### PR TITLE
mo5_cass: Metadata cleaning

### DIFF
--- a/hash/mo5_cass.xml
+++ b/hash/mo5_cass.xml
@@ -13,7 +13,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Adresse des Fichiers .bin sur Disques</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1353">
 				<rom name="adresse des fichiers .bin sur disques (198x)(-)(fr)(pd).k7" size="1353" crc="e10868f3" sha1="8fc1312a2a3ebe39d7304fbda55ff16ef3fa674c"/>
@@ -25,7 +24,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Adresses SAVEM sur MO5</description>
 		<year>198?</year>
 		<publisher>Deplombsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="2650">
 				<rom name="adresses savem sur mo5 (198x)(deplombsoft)(fr)(pd).k7" size="2650" crc="4151bfff" sha1="5fe6c210e413ba85a5d837a6cdce3c5a9cf852f8"/>
@@ -37,7 +35,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Affine</description>
 		<year>1984</year>
 		<publisher>USTL</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11696">
 				<rom name="affine (1984)(ustl)(fr).k7" size="11696" crc="63de1c17" sha1="13ee8e24528d1aecbd5bc8481f0fc7f179f44ef9"/>
@@ -49,7 +46,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides Editeur</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6211025">
 				<rom name="androides editeur (1985)(infogrames)(fr).wav" size="6211025" crc="d9da60fa" sha1="014361f8d1afa8e46964d2b98ddf2184f43faf96"/>
@@ -58,10 +54,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="andredita" cloneof="andredit">
-		<description>Androides Editeur (Alt)</description>
+		<description>Androides Editeur (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18508">
 				<rom name="androides editeur (1985)(infogrames)(fr)[b].k7" size="18508" crc="e942f534" sha1="fc1b3dc5d814f0f0ab0afedf546bb92311529f94"/>
@@ -70,10 +65,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="andreditb" cloneof="andredit">
-		<description>Androides Editeur (Alt 2)</description>
+		<description>Androides Editeur (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18508">
 				<rom name="editeur (1986)(infogrames)(fr)[b].k7" size="18508" crc="5fbd30b0" sha1="dc5232ebf5ccf39268849b215ad1b974f8f15736"/>
@@ -99,7 +93,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Animatix</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28272">
 				<rom name="animatix (1985)(infogrames)(fr).k7" size="28272" crc="e532ad03" sha1="455f3cbbd4e2f5008d1b7010fc4aec212c99a169"/>
@@ -108,10 +101,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="animatixa" cloneof="animatix">
-		<description>Animatix (Alt)</description>
+		<description>Animatix (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28272">
 				<rom name="animatix (1985)(infogrames)(fr)[a].k7" size="28272" crc="bdefdf08" sha1="b93e4e1ef4716aac2bda3ba34af3c8be5ec79e90"/>
@@ -120,10 +112,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="animatixb" cloneof="animatix">
-		<description>Animatix (Alt 2)</description>
+		<description>Animatix (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28272">
 				<rom name="animatix_mo5.k7" size="28272" crc="154f3f2c" sha1="37a645520504111d763f4b1c2859a05e85ffb628"/>
@@ -136,7 +127,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with LOADM"/>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11612">
 				<rom name="assdesass version k7 (1985)(infogrames)(fr)[loadm].k7" size="11612" crc="f451771a" sha1="664a979ff36869761522bb7d1a56f11a08742fec"/>
@@ -145,11 +135,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="assdesasa" cloneof="assdesas">
-		<description>Assdesass - version K7 (Alt)</description>
+		<description>Assdesass - version K7 (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with LOADM"/>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11612">
 				<rom name="assdesass version k7 (1985)(infogrames)(fr)[a][loadm].k7" size="11612" crc="eb6fd52d" sha1="25f239cf8d78102d76a277630aee7ee6241a7e53"/>
@@ -158,11 +147,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="assdesasb" cloneof="assdesas">
-		<description>Assdesass - version K7 (Alt 2)</description>
+		<description>Assdesass - version K7 (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with LOADM"/>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11612">
 				<rom name="assdesass_mo5.k7" size="11612" crc="04da328e" sha1="840975a41d5003e3b08b525746563ef02007c934"/>
@@ -174,7 +162,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Astro-Couple</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29753">
 				<rom name="astro-couple (answare) (elizabeth tessier) (1985) (mo5 k7).k7" size="29753" crc="17dad983" sha1="24e4d56155062272d524a7ca2d16ebcf462eed4c"/>
@@ -186,7 +173,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Biorythmes</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15302">
 				<rom name="biorythmes (1984)(answare)(fr).k7" size="15302" crc="63e22a77" sha1="ab14b381916b260eefc1ba4071c4fc01bc90f2b1"/>
@@ -195,10 +181,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="biorythma" cloneof="biorythm">
-		<description>Biorythmes (Alt)</description>
+		<description>Biorythmes (alt)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15302">
 				<rom name="biorythmes (answare) (1984).k7" size="15302" crc="ad687f26" sha1="45adab914791b6309957ca1b90db20c5774e1845"/>
@@ -207,10 +192,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="biorythmb" cloneof="biorythm">
-		<description>Biorythmes (Alt 2)</description>
+		<description>Biorythmes (alt 2)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15302">
 				<rom name="biorythmes_mo5.k7" size="15302" crc="bdabf4b8" sha1="a16fcb78f903b24af305a4f686b78d73afe13bc2"/>
@@ -222,7 +206,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Budget Familial (Free Game Blot)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16821">
 				<rom name="budget familial (1984)(free game blot)(fr).k7" size="16821" crc="227bad83" sha1="5f7b9940dfc359c6c1e7399495657409ebd1e930"/>
@@ -231,10 +214,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="budgetf1a" cloneof="budgetf1">
-		<description>Budget Familial (Free Game Blot) (Alt)</description>
+		<description>Budget Familial (Free Game Blot) (alt)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16821">
 				<rom name="budget familial (1984)(free game blot)(fr)[a].k7" size="16821" crc="48e6f366" sha1="73de447c747790ef57628c8be0d8f4c3f03baa5d"/>
@@ -243,10 +225,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="budgetf1b" cloneof="budgetf1">
-		<description>Budget Familial (Free Game Blot) (Alt 2)</description>
+		<description>Budget Familial (Free Game Blot) (alt 2)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16821">
 				<rom name="budget-familial-free-game-blot_mo5.k7" size="16821" crc="7f357742" sha1="1a07c9ae88d925e3112a9bb4c7f665ede11fe850"/>
@@ -258,7 +239,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Budget Familial (Loriciels)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17035">
 				<rom name="budget-familial-loriciels_mo5.k7" size="17035" crc="4083f4d1" sha1="1ab1cf25b115e5545463fbf74a025f328985a37c"/>
@@ -270,7 +250,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carte du Ciel</description>
 		<year>1983</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29208">
 				<rom name="carte du ciel (1983)(answare)(fr)(m3).k7" size="29208" crc="a279d8ef" sha1="c2f3123b6c4ed336d3150b518f6719f62b21b4ee"/>
@@ -279,10 +258,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cartciela" cloneof="cartciel">
-		<description>Carte du Ciel (Alt)</description>
+		<description>Carte du Ciel (alt)</description>
 		<year>1983</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29208">
 				<rom name="carte du ciel (1983)(answare)(fr)(m3)[a].k7" size="29208" crc="cde121ba" sha1="0b38a94f3a52ce178977473f6acadb8d928b0275"/>
@@ -291,10 +269,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cartcielb" cloneof="cartciel">
-		<description>Carte du Ciel (Alt 2)</description>
+		<description>Carte du Ciel (alt 2)</description>
 		<year>1983</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29208">
 				<rom name="carte du ciel (1983)(answare)(fr)(m3)[a2].k7" size="29208" crc="ee0a486e" sha1="0aeb4b8a601d3ecd210ee3d15da7779bb6d5db21"/>
@@ -303,10 +280,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cartcielc" cloneof="cartciel">
-		<description>Carte du Ciel (Alt 3)</description>
+		<description>Carte du Ciel (alt 3)</description>
 		<year>1983</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29208">
 				<rom name="carte-du-ciel_mo5.k7" size="29208" crc="29450504" sha1="df8950868f079fe4d1e545302e39fdd5e8956797"/>
@@ -318,7 +294,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cartoon Maker</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48638">
 				<rom name="cartoon maker (1985)(free game blot)(fr).k7" size="48638" crc="8a40800f" sha1="475f45149a10ff007ef0b4334b0015bd859da9cc"/>
@@ -327,10 +302,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cartoonma" cloneof="cartoonm">
-		<description>Cartoon Maker (Alt)</description>
+		<description>Cartoon Maker (alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48638">
 				<rom name="cartoon maker (1985)(free game blot)(fr)[a].k7" size="48638" crc="afe94d58" sha1="db2cebbf17a65bcf6015f29ef634216de9f88120"/>
@@ -339,10 +313,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cartoonmb" cloneof="cartoonm">
-		<description>Cartoon Maker (Alt 2)</description>
+		<description>Cartoon Maker (alt 2)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48638">
 				<rom name="cartoon-maker_mo5.k7" size="48638" crc="b704c02c" sha1="537d07e69afb9c2daf78aa27929ddd871e660f24"/>
@@ -354,7 +327,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Catalog</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="2213">
 				<rom name="catalog (198x)(-)(pd).k7" size="2213" crc="3b9fb1b0" sha1="3471ce6641f02c2e417ef992298d976887ee316d"/>
@@ -366,7 +338,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Chardata</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="899">
 				<rom name="chardata (198x)(-)(pd).k7" size="899" crc="2619447a" sha1="16d0e09b0626546ccb178cca1a70f1f428c083a5"/>
@@ -378,7 +349,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Commande du Robot Youpi (v1.1)</description>
 		<year>1985</year>
 		<publisher>JD Productique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10511">
 				<rom name="commande du robot youpi v1.1 (1985)(jd productique)(fr).k7" size="10511" crc="340c2d5f" sha1="3e74f4da8655e0a84d2d8e47e0ac951ad0422b03"/>
@@ -390,7 +360,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Conte</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26311">
 				<rom name="conte (1985)(lambert, alain)(fr).k7" size="26311" crc="46675110" sha1="4a8dfa2fa9a247e1bac77ac02d8396c6a80d09ae"/>
@@ -399,10 +368,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="contea" cloneof="conte">
-		<description>Conte (Alt)</description>
+		<description>Conte (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26311">
 				<rom name="conte (1985)(lambert, alain)(fr)[a].k7" size="26311" crc="68e9e7b6" sha1="84ff859c8f16f74fa2b15171b061fe2dc3648293"/>
@@ -411,10 +379,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="conteb" cloneof="conte">
-		<description>Conte (Alt 2)</description>
+		<description>Conte (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26311">
 				<rom name="conte (1985)(lambert, alain)(fr)[a2].k7" size="26311" crc="927ab799" sha1="017a9850a5db7ba85986a1f83ca1301c5cc713b7"/>
@@ -423,10 +390,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="contec" cloneof="conte">
-		<description>Conte (Alt 3)</description>
+		<description>Conte (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26311">
 				<rom name="conte_mo5.k7" size="26311" crc="41481f4d" sha1="e0ff080f783c4b10fdb3027c0e7798132dbf2eb5"/>
@@ -438,7 +404,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Conte (Hacked by Christophe Lesur)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26766">
 				<rom name="conte (1985-05-26)(lambert, alain)(fr)[h lesur, c.].k7" size="26766" crc="fc76d616" sha1="41645e3ab08c0e63636b798dd43c81ccc4b264fc"/>
@@ -450,7 +415,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Conversion Images</description>
 		<year>198?</year>
 		<publisher>Edouard Foller</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1332">
 				<rom name="conversion images (198x)(foller, edouard)(fr).k7" size="1332" crc="b0d132cf" sha1="db1ac6ab2813f2f702f8a0ab420fd05af303cf67"/>
@@ -462,7 +426,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Copie de Fichiers Data</description>
 		<year>198?</year>
 		<publisher>Deplombsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1987">
 				<rom name="copie de fichiers data (198x)(deplombsoft)(fr)(pd).k7" size="1987" crc="b18d4c14" sha1="650fcf550c6954eec67b19a0be499393a2ca0768"/>
@@ -474,7 +437,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Courrier</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22397">
 				<rom name="courrier (answare) (inconnus) (1984) (mo5).k7" size="22397" crc="bf5dada6" sha1="f01886c81c363c01baf52bd161116087c986d012"/>
@@ -486,7 +448,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Creadata</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1438">
 				<rom name="creadata (198x)(-)(fr)(pd).k7" size="1438" crc="be0ca07f" sha1="aa2490fef1ba8d6e588795fcfd483adc494bb06f"/>
@@ -498,7 +459,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Decode</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="474">
 				<rom name="decode (198x)(-)(fr)(pd).k7" size="474" crc="149174be" sha1="b347eb90e21eab6818c498e8c52b4e7844c5141a"/>
@@ -510,7 +470,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Deper</description>
 		<year>198?</year>
 		<publisher>Deplombsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="658">
 				<rom name="deper (198x)(deplombsoft)(fr)(pd).k7" size="658" crc="6f4b8245" sha1="5d6d4994755f84bbe7cc84904e345562b5b536fd"/>
@@ -519,10 +478,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="depera" cloneof="deper">
-		<description>Deper (Alt)</description>
+		<description>Deper (alt)</description>
 		<year>198?</year>
 		<publisher>Deplombsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="658">
 				<rom name="deper (198x)(deplombsoft)(fr)(pd)[a].k7" size="658" crc="239eda82" sha1="b06f7a5cc3cfb3e03823904a17d71aaef5c53cb9"/>
@@ -535,7 +493,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
 		<info name="usage" value="Load with LOADM&quot;&quot;,&amp;H9000,R"/>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="3411">
@@ -563,11 +520,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="desassema" cloneof="desassem">
-		<description>Desassembleur - Dump et Patch (v4.0, Alt Tape 1)</description>
+		<description>Desassembleur - Dump et Patch (v4.0, alt tape 1)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
 		<info name="usage" value="Load with LOADM&quot;&quot;,&amp;H9000,R"/>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="3411">
@@ -595,11 +551,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="desassemb" cloneof="desassem">
-		<description>Desassembleur - Dump et Patch (v4.0, Alt 2 Tape 1)</description>
+		<description>Desassembleur - Dump et Patch (v4.0, alt 2 tape 1)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
 		<info name="usage" value="Load with LOADM&quot;&quot;,&amp;H9000,R"/>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="3411">
@@ -630,7 +585,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Destruc</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="684">
 				<rom name="destruc (198x)(-)(fr)(pd).k7" size="684" crc="0c8ea976" sha1="1476a46bea59cf1f472b91b5fe863d29d26a56ce"/>
@@ -642,7 +596,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dump</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1642">
 				<rom name="dump (198x)(-)(pd)(fr).k7" size="1642" crc="0e22d2db" sha1="01c04c3c91b807e1e9b07e94aa20725874f6fb00"/>
@@ -654,7 +607,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Einstein1</description>
 		<year>198?</year>
 		<publisher>Soft &amp; Micro</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10962">
 				<rom name="einstein1 (198x)(soft &amp; micro)(fr).k7" size="10962" crc="1fd19569" sha1="0b605f229cd4ab90c3836b45ef6817bb5066e9c2"/>
@@ -663,10 +615,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="einsteina" cloneof="einstein">
-		<description>Einstein1 (Alt)</description>
+		<description>Einstein1 (alt)</description>
 		<year>198?</year>
 		<publisher>Soft &amp; Micro</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10962">
 				<rom name="einstein1 (198x)(soft &amp; micro)(fr)[a].k7" size="10962" crc="343a7613" sha1="003099c54303f72ed77e8484317eb62715296334"/>
@@ -675,10 +626,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="einsteinb" cloneof="einstein">
-		<description>Einstein1 (Alt 2)</description>
+		<description>Einstein1 (alt 2)</description>
 		<year>198?</year>
 		<publisher>Soft &amp; Micro</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10962">
 				<rom name="einstein_mo5.k7" size="10962" crc="4d7232a0" sha1="617f33d2927780bd359e08fc537bdbb15f794989"/>
@@ -690,7 +640,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Epargne - Emprunt</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19726">
 				<rom name="EE 5010.k7" size="19726" crc="b1115202" sha1="1ddf059adbe9a4d91653eb02d9a24b47c0cb6b8a"/>
@@ -702,7 +651,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Extension Basic (Hebdogiciel no. 118)</description>
 		<year>1986</year>
 		<publisher>Francis Malard - Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15757">
 				<rom name="extbas[mo5].k7" size="15757" crc="eaa71694" sha1="b746a21e6bf4acdfe03bc780a4d7e377251440d0"/>
@@ -714,7 +662,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Extension Basic MO5</description>
 		<year>1986</year>
 		<publisher>D.G. Vevy</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3801">
 				<rom name="extension basic mo5 (1986)(vevy, d.g.)(fr).k7" size="3801" crc="e77097d0" sha1="fc90b13a3214f075b8c4e9777376fa07894db849"/>
@@ -723,10 +670,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="xbasmo5a" cloneof="xbasmo5">
-		<description>Extension Basic MO5 (Alt)</description>
+		<description>Extension Basic MO5 (alt)</description>
 		<year>1986</year>
 		<publisher>D.G. Vevy</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7699">
 				<rom name="extension basic mo5 (1986)(vevy, d.g.)(fr)[a].k7" size="7699" crc="3e8f1bba" sha1="0e1c084269c6695e9c3899b8c411cef6e3b1dd58"/>
@@ -738,7 +684,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Forth</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="11674312">
@@ -754,10 +699,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="fortha" cloneof="forth">
-		<description>Forth (Single Tape)</description>
+		<description>Forth (single tape)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25367">
 				<rom name="forth mo5 (1985-04)(loriciels)(fr).k7" size="25367" crc="f068355e" sha1="31bf85d0b3cdb4b9291d99a3e0910c30956c4fb7"/>
@@ -766,10 +710,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="forthb" cloneof="forth">
-		<description>Forth (Single Tape, Alt)</description>
+		<description>Forth (single tape, alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25367">
 				<rom name="forth-mo5_mo5.k7" size="25367" crc="6aba6864" sha1="484fd4d57d9dfb061e67d1631efebad92d02cc7f"/>
@@ -778,10 +721,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="forthc" cloneof="forth">
-		<description>Forth (Single Tape, Alt 2)</description>
+		<description>Forth (single tape, alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12688478">
 				<rom name="forth mo5 (1985-04)(loriciels)(fr).wav" size="12688478" crc="a8cfbb98" sha1="ce713a7412e8d8fb4278e461236304ccdec6de4c"/>
@@ -790,10 +732,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="forthd" cloneof="forth">
-		<description>Forth (Single Tape, Alt 3)</description>
+		<description>Forth (single tape, alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14228450">
 				<rom name="forth-mo5_mo5.wav" size="14228450" crc="4e4df37b" sha1="b543267b987c09382ff03be4191135bab6cbed1e"/>
@@ -805,7 +746,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Frises</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18741">
 				<rom name="frises (1985)(cedic-nathan)(fr).k7" size="18741" crc="b5a4c4f1" sha1="99865cf7dd639a1d4756bd7ca8a3636fe6c86aa7"/>
@@ -817,7 +757,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gestion Imprimante</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="2029">
 				<rom name="gestion imprimante (198x)(-)(fr)(pd).k7" size="2029" crc="9cb63e6d" sha1="a3325e57c820ae86ce25851ade156c34540322a9"/>
@@ -829,7 +768,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Histogrammes</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14447">
 				<rom name="histogrammes (1985)(fil)(fr).k7" size="14447" crc="6f367ab2" sha1="d74a5b9471b06d8af26df3e9d1c9de9fb260a05b"/>
@@ -841,7 +779,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Identif</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="629">
 				<rom name="identif (198x)(-)(pd)(fr).k7" size="629" crc="72556033" sha1="092138eb2613882ed4b9754b98fdd3edaf84783f"/>
@@ -850,10 +787,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="identifa" cloneof="identif">
-		<description>Identif (Alt)</description>
+		<description>Identif (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="629">
 				<rom name="identif (198x)(-)(pd)(fr)[a].k7" size="629" crc="3937a9bd" sha1="99a73867f8d50d1aa5dc85bec47b31b4e3b6b1e4"/>
@@ -865,7 +801,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>C.A.O. - Conception Assistee par Ordinateur</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="83053">
 				<rom name="j'apprends le c.a.o. (1985)(loriciels)(fr).k7" size="83053" crc="150c4e84" sha1="a194253eb18abb393166297f20112505901c27b4"/>
@@ -874,10 +809,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="caoa" cloneof="cao">
-		<description>C.A.O. - Conception Assistee par Ordinateur (Alt)</description>
+		<description>C.A.O. - Conception Assistee par Ordinateur (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="60275">
 				<rom name="j'apprends le c.a.o. (1985)(loriciels)(fr)[a].k7" size="60275" crc="e653fc33" sha1="feeb0b210f4e3b562ff3cb37c8048e47ef61f09a"/>
@@ -886,10 +820,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="caob" cloneof="cao">
-		<description>C.A.O. - Conception Assistee par Ordinateur (Alt 2)</description>
+		<description>C.A.O. - Conception Assistee par Ordinateur (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="83053">
 				<rom name="c.a.o. conception assistee par ordinateur (loriciels) (j.p. h., p. w.) (1985) (mo5).k7" size="83053" crc="6dd269e6" sha1="e398742949a95507ab4da669c5815b0a4ea21871"/>
@@ -901,7 +834,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Je Dessine</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10078">
 				<rom name="je dessine (1984)(vifi-nathan)(fr).k7" size="10078" crc="f6c23f22" sha1="be3176a555011a61852dfa039b15f4ac2ae2db45"/>
@@ -913,7 +845,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Liratt</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3464">
 				<rom name="liratt (198x)(-)(fr)(pd).k7" size="3464" crc="faa75cb5" sha1="b3c403e3c75011908898b35e24c9c4b8b4ba3305"/>
@@ -925,7 +856,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Lirfic</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1632">
 				<rom name="lirfic (198x)(-)(fr)(pd).k7" size="1632" crc="55472e7b" sha1="62f6021a9a1f97941b7f3142b142f3075cb0efbc"/>
@@ -937,7 +867,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Machine a Ecrire</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14904">
 				<rom name="machine a ecrire (198x)(-)(fr)(pd).k7" size="14904" crc="9df3fb90" sha1="ec0adeb40ab4954019a19f6b8a5954fad2263f9d"/>
@@ -949,7 +878,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mcass</description>
 		<year>1985</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3674">
 				<rom name="mcass (1985)(-)(pd).k7" size="3674" crc="59f704a3" sha1="66d5690ad3dd1239b8dc130c94375bd128d1e7b5"/>
@@ -961,7 +889,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mdsk</description>
 		<year>1985</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3674">
 				<rom name="mdsk (1985)(-)(pd).k7" size="3674" crc="b03ea7d5" sha1="711e4accefb890aae8c17246e162b6842b724745"/>
@@ -973,7 +900,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>MO 4 Paint</description>
 		<year>2013</year>
 		<publisher>Dominique Contant</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="10080">
@@ -992,7 +918,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Modifatt</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1739">
 				<rom name="modifatt (198x)(-)(fr)(pd).k7" size="1739" crc="71012d1d" sha1="be707137e66f42660431448f4ff11551d8ed4af6"/>
@@ -1004,7 +929,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Moniteur Desassembleur</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9153">
 				<rom name="moniteur desassembleur (198x)(-)(fr)(pd).k7" size="9153" crc="31ddc7b8" sha1="ce7085403da4e723c7b7b4e6fa1e87ca43c0bc8c"/>
@@ -1016,7 +940,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Moniteur pour MO5</description>
 		<year>1985</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5873">
 				<rom name="moniteur pour mo5 (1985-10-26)(-)(fr)(pd).k7" size="5873" crc="6a7b1a72" sha1="d2ad889c19148490a8368ecd8a7f6482fa88c353"/>
@@ -1028,7 +951,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Morse</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18447">
 				<rom name="morse (1985)(free game blot)(fr).k7" size="18447" crc="e1b254f0" sha1="8b267907e9ef14c439b781727e44d50c007c4e56"/>
@@ -1040,7 +962,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Odin (v2.1)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18278">
 				<rom name="odin v2.1 (1984-09)(loriciels)(fr).k7" size="18278" crc="eabf738b" sha1="d97469b29f9acc8ffec6aa6793b5906a7ba4219d"/>
@@ -1049,10 +970,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="odina" cloneof="odin">
-		<description>Odin (v2.1, Alt)</description>
+		<description>Odin (v2.1, alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18270">
 				<rom name="odin_mo5.k7" size="18270" crc="3b9e20b8" sha1="13bb2b5b80fc1ce846a6b1b787c0c2969ed6f813"/>
@@ -1064,7 +984,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ordi Tierce</description>
 		<year>1984</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16978">
 				<rom name="ordi tierce (cobrasoft) (michel fernandez) (1984) (mo5 k7).k7" size="16978" crc="b5f6840e" sha1="f88b4f22c70de2f90e9494234f8fa1efea312c91"/>
@@ -1076,7 +995,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>PAINTX</description>
 		<year>2013</year>
 		<publisher>Dominique Contant</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="10178">
@@ -1095,7 +1013,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pascal Base (v1)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28323">
 				<rom name="pascal base v1 (1985)(free game blot)(fr).k7" size="28323" crc="3ba67057" sha1="67f58b470bb4b17f185dd3e28f23277a68e08437"/>
@@ -1104,10 +1021,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pascalba" cloneof="pascalb">
-		<description>Pascal Base (v1, Alt)</description>
+		<description>Pascal Base (v1, alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29283">
 				<rom name="pascal base v1 (1985)(free game blot)(fr)[a].k7" size="29283" crc="018d17f9" sha1="f8f2fc57f463184b6b9137b8d9bf160cddba84f8"/>
@@ -1116,10 +1032,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pascalbb" cloneof="pascalb">
-		<description>Pascal Base (v1, Alt 2)</description>
+		<description>Pascal Base (v1, alt 2)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29283">
 				<rom name="pascal base v1 (1985)(free game blot)(fr)[a2].k7" size="29283" crc="b8691f9b" sha1="65e252da597bc7f1795eb71e266061f505f618d8"/>
@@ -1128,10 +1043,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pascalbc" cloneof="pascalb">
-		<description>Pascal Base (v1, Alt 3)</description>
+		<description>Pascal Base (v1, alt 3)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29283">
 				<rom name="pascal-base_mo5.k7" size="29283" crc="7aba80c5" sha1="8075d73244071f59ca279a06eb53bcd3d8624a69"/>
@@ -1143,7 +1057,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Phone8</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1220">
 				<rom name="phone8 (198x)(-)(fr)(pd).k7" size="1220" crc="c900f763" sha1="67fb019685e5820117ebe917b43a051906e07ea3"/>
@@ -1155,7 +1068,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Picture Print</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="327">
 				<rom name="picture print (198x)(-)(fr)(pd).k7" size="327" crc="844b3f1d" sha1="e355f3f85679660f6b6a02e173b5905151a9e36e"/>
@@ -1167,7 +1079,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pro23</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="627">
 				<rom name="pro23 (198x)(-)(pd)(fr).k7" size="627" crc="83695f82" sha1="e1cb102f9d6ef2beed189ebeb30aee0c2809b32a"/>
@@ -1179,7 +1090,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Protege</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="464">
 				<rom name="protege (198x)(-)(fr)(pd).k7" size="464" crc="fee5a8de" sha1="da3bd934c8a0b439372f0d262391416cb38d8d67"/>
@@ -1188,10 +1098,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="protegea" cloneof="protege">
-		<description>Protege (Alt)</description>
+		<description>Protege (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="464">
 				<rom name="protege (198x)(-)(fr)(pd)[a].k7" size="464" crc="138a5b01" sha1="e6785d4c8dbbc85c1cd52b158ab7f1872bc37792"/>
@@ -1203,7 +1112,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Resolution de Systemes d'Equations</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9347">
 				<rom name="resolution de systemes d'equations (198x)(-)(fr)(pd).k7" size="9347" crc="fb20f885" sha1="4820e6e58ad11b1166f64fd80a232e8c58fbd11e"/>
@@ -1215,7 +1123,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scrutdsk</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="975">
 				<rom name="scrutdsk (198x)(-)(fr)(pd).k7" size="975" crc="7f2faf8a" sha1="f53ea8c63934f2a05cca4076d44e64afd90d17a3"/>
@@ -1224,10 +1131,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="scrutdska" cloneof="scrutdsk">
-		<description>Scrutdsk (Alt)</description>
+		<description>Scrutdsk (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="911">
 				<rom name="scrutdsk (198x)(-)(fr)(pd)[a].k7" size="911" crc="b9d459d0" sha1="a29b680cb826abca0546085e5989f8a3bb49aa28"/>
@@ -1239,7 +1145,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scrutmo5</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="2717">
 				<rom name="scrutmo5 (198x)(-)(fr)(pd).k7" size="2717" crc="79c7b651" sha1="be5bd3db928b1d31dfc7e40e5fe1bc8ff5273d08"/>
@@ -1251,7 +1156,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDANIM7</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1136">
 				<rom name="sdanim7_mo5.k7" size="1136" crc="d1e44340" sha1="0abb060e2beff82a0f05d4b9798f411ee5ad49fc"/>
@@ -1263,7 +1167,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDLOADM5</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5020424">
 				<rom name="sdloadm5 - chargement rapide de programmes mo5 par carte sd (dcsoft) (2013) (daniel coulom).wav" size="5020424" crc="b02df181" sha1="7fc8a4666c7fd4c77c4af8c251ad06924870c9b6"/>
@@ -1272,10 +1175,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sdloadm5a" cloneof="sdloadm5">
-		<description>SDLOADM5 (Alt)</description>
+		<description>SDLOADM5 (alt)</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10535">
 				<rom name="sdloadm5 - chargement rapide de programmes mo5 par carte sd (dcsoft) (2013) (daniel coulom).k7" size="10535" crc="2e7646e9" sha1="4cac5bb8fe75da076fe90e4c017c0d6b6dbabd15"/>
@@ -1287,7 +1189,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDLOADM6</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5660684">
 				<rom name="sdloadm6 - chargement rapide de programmes mo5 par carte sd (dcsoft) (2013) (daniel coulom).wav" size="5660684" crc="7610f11d" sha1="4fedc69c084a2d0769c4fa38274ea58327e984b2"/>
@@ -1296,10 +1197,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sdloadm6a" cloneof="sdloadm6">
-		<description>SDLOADM6 (Alt)</description>
+		<description>SDLOADM6 (alt)</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12470">
 				<rom name="sdloadm6 - chargement rapide de programmes mo5 par carte sd (dcsoft) (2013) (daniel coulom).k7" size="12470" crc="4c8d1647" sha1="16bfb1f76ee968547d3c949947429e17af8fefbc"/>
@@ -1311,7 +1211,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDMEMO5 - Chargement MEMO5</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1732">
 				<rom name="sdmemo5 - chargement memo5 (dcsoft) (2013) (daniel coulom) (mo5).k7" size="1732" crc="df4d8faa" sha1="ec249cf539306f9a7c7f4bd9d2ac999745bfa7c8"/>
@@ -1323,7 +1222,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDMOANIM</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1740">
 				<rom name="sdmoanim - simon's cat (dcsoft) (2013) (daniel coulom) (mo5).k7" size="1740" crc="f5c5d823" sha1="d6dafbfd13de150382a2b007c88b5dcde8c752e2"/>
@@ -1335,7 +1233,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDMOPLAY</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="2513">
 				<rom name="sdmoplay - stan getz (dcsoft) (2013) (daniel coulom) (mo5).k7" size="2513" crc="ed25fe02" sha1="ef68e3bc08ae18299a26456dea5cfaa56567a62f"/>
@@ -1347,7 +1244,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDPLAY44 (2015.09.24)</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="802">
 				<rom name="sdplay44_mo5.k7" size="802" crc="e4cc8474" sha1="aba947be8c5b58ae366b1ffb9e16f13ac2e7fa5e"/>
@@ -1359,7 +1255,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDPLAY44 (2015.09.07)</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="802">
 				<rom name="sdplay44_mo5 [a].k7" size="802" crc="73f591a1" sha1="72cca02406826f574b3ba82a1187db2b1394c3f5"/>
@@ -1371,7 +1266,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Story Board</description>
 		<year>198?</year>
 		<publisher>Langage et Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13678">
 				<rom name="story board (198x)(langage et informatique)(fr).k7" size="13678" crc="3c20bcda" sha1="18fa5906c42db1197696cee99278d260bd86c2c3"/>
@@ -1380,10 +1274,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="storybrda" cloneof="storybrd">
-		<description>Story Board (Alt)</description>
+		<description>Story Board (alt)</description>
 		<year>198?</year>
 		<publisher>Langage et Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13678">
 				<rom name="story board (198x)(langage et informatique)(fr)[a].k7" size="13678" crc="47cc3c8a" sha1="a0a56f61bd07574e5a0fc59639cd90269cb2963f"/>
@@ -1392,10 +1285,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="storybrdb" cloneof="storybrd">
-		<description>Story Board (Alt 2)</description>
+		<description>Story Board (alt 2)</description>
 		<year>198?</year>
 		<publisher>Langage et Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13678">
 				<rom name="story-board_mo5.k7" size="13678" crc="6cd28e8f" sha1="91ca6384bfb1bc00fc9f9cd0c1047d2e30de8d8a"/>
@@ -1407,7 +1299,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SUPBAS</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5575">
 				<rom name="supbas.k7" size="5575" crc="9c3b4895" sha1="404a5da42b310874e808b38dd2ef2fa36a89de89"/>
@@ -1419,7 +1310,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>T2</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6645">
 				<rom name="t2 (198x)(-)(fr)(pd)[b].k7" size="6645" crc="1ecfb660" sha1="eea25d57840f9cc929d23232645bba6dd7b4c30a"/>
@@ -1431,7 +1321,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>TESTRAM5 - Controle de la RAM du MO5</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass2" interface="mo_cass">
 			<dataarea name="cass" size="820394">
 				<rom name="testram5 - controle de la ram du mo5 (dcsoft) (2013) (daniel coulom) (mo5).wav" size="820394" crc="fb3dc1e8" sha1="9a862487ff0518916b7b8c17db36d3d8d3d7f65b"/>
@@ -1440,10 +1329,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="testram5a" cloneof="testram5">
-		<description>TESTRAM5 - Controle de la RAM du MO5 (Alt)</description>
+		<description>TESTRAM5 - Controle de la RAM du MO5 (alt)</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1252">
 				<rom name="testram5 - controle de la ram du mo5 (dcsoft) (2013) (daniel coulom) (mo5).k7" size="1252" crc="a20a9b92" sha1="9641af5dc8e088aa27eab718cd40ffd06f1754fe"/>
@@ -1455,7 +1343,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Triangle Quelconque</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8061">
 				<rom name="triangle quelconque (198x)(-)(fr)(pd).k7" size="8061" crc="cd8857f0" sha1="f83ea4ca2935decc958155c4c8750e64e8b414c9"/>
@@ -1468,7 +1355,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1987</year>
 		<publisher>Loic Bried</publisher>
 		<info name="usage" value="Load with LOADM&quot;&quot;,,R"/>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22718">
 				<rom name="vision (1987)(bried, loic)(fr)[loadm'''',,r].k7" size="22718" crc="84b3b882" sha1="f539f6c33dd73f8b7a95afe39d9a7322f2e96073"/>
@@ -1480,7 +1366,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vision (Loic Bried) (No Title Screen)</description>
 		<year>1987</year>
 		<publisher>Loic Bried</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27021">
 				<rom name="vision (1987)(bried, loic)(fr)[m title screen].k7" size="27021" crc="41db9a2a" sha1="d253c43264ffb5cfb6aa2d1b34bca0b3559a2baa"/>
@@ -1493,7 +1378,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
 		<info name="alt_title" value="Vox Basic"/>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11817">
 				<rom name="vox - synthetiseur vocal (1984)(ere informatique)(fr).k7" size="11817" crc="5187bf2d" sha1="d548a4604b88cd054de5c96deb226ab78c129b62"/>
@@ -1502,11 +1386,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="voxa" cloneof="vox">
-		<description>Vox - Synthetiseur Vocal (Alt)</description>
+		<description>Vox - Synthetiseur Vocal (alt)</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
 		<info name="alt_title" value="Vox Basic"/>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12596">
 				<rom name="vox - synthetiseur vocal (1984)(ere informatique)(fr)[a].k7" size="12596" crc="5c7b83bc" sha1="205fc87aece3314d3fbb6c4de7c1a339aae7fc75"/>
@@ -1515,11 +1398,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="voxb" cloneof="vox">
-		<description>Vox - Synthetiseur Vocal (Alt 2)</description>
+		<description>Vox - Synthetiseur Vocal (alt 2)</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
 		<info name="alt_title" value="Vox Basic"/>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12596">
 				<rom name="vox - synthetiseur vocal (1984)(ere informatique)(fr)[a2].k7" size="12596" crc="3f162733" sha1="72da3719193ed258c5e741c658fe2aee04d465f8"/>
@@ -1528,11 +1410,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="voxc" cloneof="vox">
-		<description>Vox - Synthetiseur Vocal (Alt 3)</description>
+		<description>Vox - Synthetiseur Vocal (alt 3)</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
 		<info name="alt_title" value="Vox Basic"/>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12596">
 				<rom name="vox-basic_mo5.k7" size="12596" crc="cf3bb219" sha1="ee77c2625c7edb30995d05f20cf463010addabde"/>
@@ -1546,7 +1427,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Depart</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3203">
 				<rom name="depart (198x)(-)(fr)(pd).k7" size="3203" crc="97eb412f" sha1="4b7cf09eb7681c7712e7c8274fbd07263e956bd3"/>
@@ -1560,7 +1440,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volumes 4 &amp; 5 - Le Groupe Nominal 1 &amp; 2</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="192047">
 				<rom name="anglais - volumes 4 &amp; 5 - le groupe nominal 1 &amp; 2 (1984)(vifi-nathan)(fr).k7" size="192047" crc="b81c7f1d" sha1="f9fa511be63c28f07377725409f6ab13c9d5c464"/>
@@ -1569,10 +1448,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="anglai45a" cloneof="anglai45">
-		<description>Anglais - Volumes 4 &amp; 5 - Le Groupe Nominal 1 &amp; 2 (Alt)</description>
+		<description>Anglais - Volumes 4 &amp; 5 - Le Groupe Nominal 1 &amp; 2 (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="192047">
 				<rom name="anglais - volumes 4 &amp; 5 - le groupe nominal 1 &amp; 2 (1984)(vifi-nathan)(fr)[a].k7" size="192047" crc="1a6d0e3c" sha1="d97cc7948e2bc3f17a9b918c349142b2f5f30163"/>
@@ -1581,10 +1459,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="anglai45b" cloneof="anglai45">
-		<description>Anglais - Volumes 4 &amp; 5 - Le Groupe Nominal 1 &amp; 2 (Alt 2)</description>
+		<description>Anglais - Volumes 4 &amp; 5 - Le Groupe Nominal 1 &amp; 2 (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="192047">
 				<rom name="anglais - volumes 4 &amp; 5 - le groupe nominal 1 &amp; 2 (1984)(vifi-nathan)(fr)[a2].k7" size="192047" crc="9e5eac82" sha1="bae22b9a185e2d502f297f6ad1a1dab2ff0a1bfa"/>
@@ -1596,7 +1473,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Diamant &amp; Fractions</description>
 		<year>1986</year>
 		<publisher>Christophe Lesur</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47564">
 				<rom name="diamant &amp; fractions (1986-11)(lesur, christophe)(fr).k7" size="47564" crc="fb724d6d" sha1="d666ca471ae07f67f83eddd915a0aa93fafa8d68"/>
@@ -1608,7 +1484,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'orthographe</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44542">
 				<rom name="francecm.k7" size="44542" crc="591986a9" sha1="39e3c0c87827fcadd442198475a2b368e20cd90f"/>
@@ -1620,7 +1495,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Identite</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19742">
 				<rom name="identite (1985-09-13)(ustl - irem)(fr).k7" size="19742" crc="a67cdd78" sha1="f9e037f009ddae800485b916b59031e92641ad1d"/>
@@ -1632,7 +1506,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Invasion des Chiffres &amp; Multiplication</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36897">
 				<rom name="mathematiques calculs - invasion des chiffres &amp; multiplication (1984)(nathan ecoles)(fr).k7" size="36897" crc="7fa05154" sha1="add9be7ea8f1813eaa1e523104c75b52f59b4b3e"/>
@@ -1641,10 +1514,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="calccmp1a" cloneof="calccmp1">
-		<description>Mathematiques Calculs - Invasion des Chiffres &amp; Multiplication (Alt)</description>
+		<description>Mathematiques Calculs - Invasion des Chiffres &amp; Multiplication (alt)</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36897">
 				<rom name="mathematiques calculs - invasion des chiffres &amp; multiplication (1984)(nathan ecoles)(fr)[a].k7" size="36897" crc="867b66da" sha1="75e8e7a724dddc747cfa490058cb07de6f66aa40"/>
@@ -1656,7 +1528,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Ranger des Nombres &amp; Carre Magique</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36531">
 				<rom name="mathematiques calculs - ranger des nombres &amp; carre magique (1985)(nathan ecoles)(fr).k7" size="36531" crc="7b3217f7" sha1="7862247dce27d72a206e561ecb16ce14ab1bb558"/>
@@ -1665,10 +1536,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="calccmp2a" cloneof="calccmp2">
-		<description>Mathematiques Calculs - Ranger des Nombres &amp; Carre Magique (Alt)</description>
+		<description>Mathematiques Calculs - Ranger des Nombres &amp; Carre Magique (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36531">
 				<rom name="mathematiques calculs - ranger des nombres &amp; carre magique (1985)(nathan ecoles)(fr)[a].k7" size="36531" crc="a908ff95" sha1="5698595df94df4edf7bc3412aa1e969cef8199aa"/>
@@ -1680,7 +1550,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Avant et Apres &amp; Combinaisons</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36024">
 				<rom name="mathematiques ce - rangements et reperages - avant et apres &amp; combinaisons (1985)(vifi-nathan)(fr).k7" size="36024" crc="54aee51f" sha1="1fcc54102adf8dd2144b207d7eb8b5fe8256d6cf"/>
@@ -1689,10 +1558,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecomp1a" cloneof="cecomp1">
-		<description>Mathematiques CE - Rangements et Reperages - Avant et Apres &amp; Combinaisons (Alt)</description>
+		<description>Mathematiques CE - Rangements et Reperages - Avant et Apres &amp; Combinaisons (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36024">
 				<rom name="mathematiques ce - rangements et reperages - avant et apres &amp; combinaisons (1985)(vifi-nathan)(fr)[a].k7" size="36024" crc="d6292de3" sha1="bcb996d405b33f01d05923bf39471a9ba5979d99"/>
@@ -1704,7 +1572,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Produits et Surfaces &amp; Quadrillage</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41424">
 				<rom name="mathematiques ce - rangements et reperages - produits et surfaces &amp; quadrillage (1985)(vifi-nathan)(fr).k7" size="41424" crc="4ce1f661" sha1="0611e3b55ae1f8086bf308f5d3f6c6a6e99c25d3"/>
@@ -1713,10 +1580,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecomp2a" cloneof="cecomp2">
-		<description>Mathematiques CE - Rangements et Reperages - Produits et Surfaces &amp; Quadrillage (Alt)</description>
+		<description>Mathematiques CE - Rangements et Reperages - Produits et Surfaces &amp; Quadrillage (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41424">
 				<rom name="mathematiques ce - rangements et reperages - produits et surfaces &amp; quadrillage (1985)(vifi-nathan)(fr)[a].k7" size="41424" crc="7796bbe6" sha1="d1ec8c4d54995de304129ae2a380ea5944962800"/>
@@ -1728,7 +1594,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Angles &amp; Golf</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42446">
 				<rom name="mathematiques ce-cm - geometrie - angles &amp; golf (1985)(vifi-nathan)(fr).k7" size="42446" crc="66fc1f87" sha1="044036b0678d38af8b24b8e1c0e7d44d47468040"/>
@@ -1737,10 +1602,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmcmp1a" cloneof="cecmcmp1">
-		<description>Mathematiques CE/CM - Geometrie - Angles &amp; Golf (Alt)</description>
+		<description>Mathematiques CE/CM - Geometrie - Angles &amp; Golf (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42446">
 				<rom name="mathematiques ce-cm - geometrie - angles &amp; golf (1985)(vifi-nathan)(fr)[a].k7" size="42446" crc="ea910101" sha1="09e05d1617fb30168ffc0fd79a057ea2c358c523"/>
@@ -1752,7 +1616,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Droites &amp; Triangles et Quadrilateres</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38100">
 				<rom name="mathematiques ce-cm - geometrie - droites &amp; triangles et quadrilateres (1985)(vifi-nathan)(fr).k7" size="38100" crc="b951f141" sha1="3e97223b105ce9cb83eb5699a73a3f5047cafcac"/>
@@ -1764,7 +1627,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="77023">
 				<rom name="mathcecm.k5" size="77023" crc="e1bf143f" sha1="8e0570e71585d3a8a84f1579d03ddef4bc448b2c"/>
@@ -1776,7 +1638,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="40411">
@@ -1792,10 +1653,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmcompa" cloneof="cmcomp">
-		<description>Mathematiques CM - Mesures et Grandeurs (Alt)</description>
+		<description>Mathematiques CM - Mesures et Grandeurs (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="40411">
@@ -1811,10 +1671,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmcompb" cloneof="cmcomp">
-		<description>Mathematiques CM - Mesures et Grandeurs (Alt 2)</description>
+		<description>Mathematiques CM - Mesures et Grandeurs (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40411">
 				<rom name="maths-cm-mesures-et-grandeurs-1_mo5.k7" size="40411" crc="78fe7659" sha1="c26c403baffc6c429f4215f5ab750a12853a4284"/>
@@ -1831,7 +1690,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Division &amp; Addition-Soustraction Express</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30930">
 				<rom name="mathematiques cm1 - division &amp; addition-soustraction express (1985)(nathan ecoles)(fr).k7" size="30930" crc="7c26e821" sha1="de5c44ebf363fa18faaa3ce97393c278ec226560"/>
@@ -1843,7 +1701,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Orde de Grandeur &amp; Lecture-Ecriture d'Un Nombre</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33083">
 				<rom name="mathematiques cm1 - orde de grandeur &amp; lecture-ecriture d'un nombre (1985)(nathan ecoles)(fr).k7" size="33083" crc="bcbeab0c" sha1="8bd396c8728c7ecd7c6445ca20bb6f26e11e663b"/>
@@ -1852,10 +1709,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cm1cmp2a" cloneof="cm1cmp2">
-		<description>Mathematiques CM1 - Orde de Grandeur &amp; Lecture-Ecriture d'Un Nombre (Alt)</description>
+		<description>Mathematiques CM1 - Orde de Grandeur &amp; Lecture-Ecriture d'Un Nombre (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33083">
 				<rom name="mathematiques cm1 - orde de grandeur &amp; lecture-ecriture d'un nombre (1985)(nathan ecoles)(fr)[a].k7" size="33083" crc="3106eec0" sha1="1c7af212234f691fd75d8e2dee3ae601c2fd107a"/>
@@ -1867,7 +1723,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Moins, Autant, Plus &amp; Compter</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36083">
 				<rom name="mathematiques cp - chiffres et formes - moins, autant, plus &amp; compter (1985)(vifi-nathan)(fr).k7" size="36083" crc="a620fcad" sha1="5e197adb6fe073393eb90ac853dcb577a9015cd6"/>
@@ -1876,10 +1731,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcomp1a" cloneof="cpcomp1">
-		<description>Mathematiques CP - Chiffres et Formes - Moins, Autant, Plus &amp; Compter (Alt)</description>
+		<description>Mathematiques CP - Chiffres et Formes - Moins, Autant, Plus &amp; Compter (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36083">
 				<rom name="mathematiques cp - chiffres et formes - moins, autant, plus &amp; compter (1985)(vifi-nathan)(fr)[a].k7" size="36083" crc="b22b1c2e" sha1="1c341bda8b7b07a61df7d134a6c4ad280b36baf3"/>
@@ -1891,7 +1745,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Promenade &amp; Puzzle</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46563">
 				<rom name="mathematiques cp - chiffres et formes - promenade &amp; puzzle (1985)(vifi-nathan)(fr).k7" size="46563" crc="16e7ac55" sha1="e65f929fcc240fa38b43cc7c5555247b9903f42c"/>
@@ -1900,10 +1753,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcomp2a" cloneof="cpcomp2">
-		<description>Mathematiques CP - Chiffres et Formes - Promenade &amp; Puzzle (Alt)</description>
+		<description>Mathematiques CP - Chiffres et Formes - Promenade &amp; Puzzle (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46563">
 				<rom name="mathematiques cp - chiffres et formes - promenade &amp; puzzle (1985)(vifi-nathan)(fr)[a].k7" size="46563" crc="09199eee" sha1="fbe4a1ec6284acf4dfe7e69bb32e62c01ea14e73"/>
@@ -1915,7 +1767,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Frises &amp; Symetries et Translations</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38270">
 				<rom name="mathematiques cp-ce - tables et frises - frises &amp; symetries et translations (1985)(vifi-nathan)(fr).k7" size="38270" crc="d5ecfdfc" sha1="d6dbb268df9eca03e699d5aec59f862557c37b43"/>
@@ -1924,10 +1775,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcecmp1a" cloneof="cpcecmp1">
-		<description>Mathematiques CP/CE - Tables et Frises - Frises &amp; Symetries et Translations (Alt)</description>
+		<description>Mathematiques CP/CE - Tables et Frises - Frises &amp; Symetries et Translations (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38270">
 				<rom name="mathematiques cp-ce - tables et frises - frises &amp; symetries et translations (1985)(vifi-nathan)(fr)[a].k7" size="38270" crc="28815d52" sha1="3608c7739735c4d255b7d4447b1395dc374335b0"/>
@@ -1939,7 +1789,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Tables d'Operations &amp; Classement</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39916">
 				<rom name="mathematiques cp-ce - tables et frises - tables d'operations &amp; classement (1985)(vifi-nathan)(fr).k7" size="39916" crc="1ded18f0" sha1="abd3f2ee0bbab55104a289a310f55155b4ab24f3"/>
@@ -1948,10 +1797,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcecmp2a" cloneof="cpcecmp2">
-		<description>Mathematiques CP/CE - Tables et Frises - Tables d'Operations &amp; Classement (Alt)</description>
+		<description>Mathematiques CP/CE - Tables et Frises - Tables d'Operations &amp; Classement (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39916">
 				<rom name="mathematiques cp-ce - tables et frises - tables d'operations &amp; classement (1985)(vifi-nathan)(fr)[a].k7" size="39916" crc="bac9a9df" sha1="b71685d4ae97096ecd203bdde2168ce05688e89b"/>
@@ -1963,7 +1811,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Programmes ludo-educatifs pour MO5 (07-08-2015)</description>
 		<year>2015</year>
 		<publisher>dcmoto.free.fr</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="106199">
 				<rom name="programmes-ludo-educatifs_mo5.k7" size="106199" crc="51c78d31" sha1="ae44f032e226037d90652aa4b7a50878f79382c6"/>
@@ -1975,7 +1822,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Programmes ludo-educatifs pour MO5 (27-07-2015)</description>
 		<year>2015</year>
 		<publisher>dcmoto.free.fr</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="70342">
 				<rom name="programmes-ludo-educatifs_mo5 [a].k7" size="70342" crc="649b6870" sha1="bb2b452884598ef7684577682380d6b6edd14ca4"/>
@@ -1989,7 +1835,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 1</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43925">
 				<rom name="classiques volume 1 (1987)(titus software)(fr).k7" size="43925" crc="c5c67830" sha1="8c6c33e2d7d37be65e401e801fe32607e9201e1d"/>
@@ -1998,10 +1843,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="classiq1a" cloneof="classiq1">
-		<description>Classiques Volume 1 (Alt)</description>
+		<description>Classiques Volume 1 (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43925">
 				<rom name="classiques volume 1 (1987)(titus software)(fr)[a].k7" size="43925" crc="85481850" sha1="1568d128b1ffa9a1bd635427214dc519f734c534"/>
@@ -2010,10 +1854,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="classiq1b" cloneof="classiq1">
-		<description>Classiques Volume 1 (Alt 2)</description>
+		<description>Classiques Volume 1 (alt 2)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43764">
 				<rom name="classiques volume 1 (1987)(titus software)(fr)[a2].k7" size="43764" crc="72961a1e" sha1="00324e1dda29bffb8e01746f0290658c7d556844"/>
@@ -2022,10 +1865,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="classiq1c" cloneof="classiq1">
-		<description>Classiques Volume 1 (Alt 3)</description>
+		<description>Classiques Volume 1 (alt 3)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46533">
 				<rom name="classiques1.k7" size="46533" crc="862029bb" sha1="f11a215ecc24ecdb2b5fe5f7d9788797f577afa9"/>
@@ -2037,7 +1879,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 2</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43204">
 				<rom name="classiques volume 2 (1987)(titus software)(fr).k7" size="43204" crc="050c1fcb" sha1="48bf8a01a0b556a03384c03d79c735c672e99e25"/>
@@ -2046,10 +1887,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="classiq2a" cloneof="classiq2">
-		<description>Classiques Volume 2 (Alt)</description>
+		<description>Classiques Volume 2 (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43204">
 				<rom name="classiques volume 2 (1987)(titus software)(fr)[a].k7" size="43204" crc="54645b20" sha1="7b97870a2a134338319df10357bf85d38eaab4f4"/>
@@ -2058,10 +1898,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="classiq2b" cloneof="classiq2">
-		<description>Classiques Volume 2 (Alt 2)</description>
+		<description>Classiques Volume 2 (alt 2)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46949">
 				<rom name="classiques2.k7" size="46949" crc="8d9fcc0a" sha1="9b9b0908ef1659084179a990198d7381d86dd3c4"/>
@@ -2073,7 +1912,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 3</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41009">
 				<rom name="classiques volume 3 (1987)(titus software)(fr).k7" size="41009" crc="29e7e8be" sha1="e575deab2ddd03133d8b4e162af0eb8bde8f7c4b"/>
@@ -2082,10 +1920,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="classiq3a" cloneof="classiq3">
-		<description>Classiques Volume 3 (Alt)</description>
+		<description>Classiques Volume 3 (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41009">
 				<rom name="classiques volume 3 (1987)(titus software)(fr)[a].k7" size="41009" crc="70ad6a47" sha1="5e3957e007cf7375b21251fb617db41f14ef9c63"/>
@@ -2094,10 +1931,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="classiq3b" cloneof="classiq3">
-		<description>Classiques Volume 3 (Alt 2)</description>
+		<description>Classiques Volume 3 (alt 2)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41009">
 				<rom name="classiques-vol3_mo5.k7" size="41009" crc="df561f49" sha1="5b25824471fb404a47943402a9b10770fe0e0782"/>
@@ -2109,7 +1945,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 4</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40699">
 				<rom name="classiques volume 4 (1987)(titus software)(fr).k7" size="40699" crc="c4ce7938" sha1="d17c74bc4078684e051ab6d7f2e818dd649fe098"/>
@@ -2118,10 +1953,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="classiq4a" cloneof="classiq4">
-		<description>Classiques Volume 4 (Alt)</description>
+		<description>Classiques Volume 4 (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40699">
 				<rom name="classiques volume 4 (1987)(titus software)(fr)[a].k7" size="40699" crc="0b036946" sha1="14eb82079900512d15955c82a43ea33053dc76b7"/>
@@ -2130,10 +1964,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="classiq4b" cloneof="classiq4">
-		<description>Classiques Volume 4 (Alt 2)</description>
+		<description>Classiques Volume 4 (alt 2)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40699">
 				<rom name="classiques-vol4_mo5.k7" size="40699" crc="7b3883af" sha1="8ee5e9a47032b078278f6d89983f379131aa3180"/>
@@ -2145,7 +1978,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coffret Cadeau</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Monopoly"/>
 			<dataarea name="cass" size="50613">
@@ -2164,7 +1996,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Hits de Loriciels 1</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36266">
 				<rom name="les hits de loriciels 1 (loriciels) (pascal pellier) (1985) (mo5).k7" size="36266" crc="ded80996" sha1="fe3e080599518eb998ff4e8dc1c6eaa1260b7c5d"/>
@@ -2173,10 +2004,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="hitsloria" cloneof="hitslori">
-		<description>Les Hits de Loriciels 1 (Alt)</description>
+		<description>Les Hits de Loriciels 1 (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36266">
 				<rom name="pulsar-eliminator-yeti_mo5.k7" size="36266" crc="fb045064" sha1="0a3bed6f6fc788570cd1366da623d9c9f3f057a6"/>
@@ -2188,7 +2018,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Hits d'Ocean</description>
 		<year>1986</year>
 		<publisher>Micromania</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="154263">
@@ -2231,7 +2060,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeux BASIC de Magazines</description>
 		<year>1985</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="15062">
@@ -2247,10 +2075,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeuxbmaga" cloneof="jeuxbmag">
-		<description>Jeux BASIC de Magazines (Alt)</description>
+		<description>Jeux BASIC de Magazines (alt)</description>
 		<year>1985</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="15062">
@@ -2269,7 +2096,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeux sur TO7 et MO5</description>
 		<year>1986</year>
 		<publisher>Sybex</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="87825">
 				<rom name="jeux sur to7 et mo5 (sybex) (georges fagot-barraly) (1986) (mo k7).k7" size="87825" crc="29712630" sha1="26229f1850f936a4ba61c81032e8fb620341a818"/>
@@ -2281,7 +2107,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mallette de Jeu Thomson</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Arkanoid)"/>
 			<dataarea name="cass" size="27667">
@@ -2312,7 +2137,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>MO5 Compilation Disk</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47432">
 				<rom name="mo5 compilation disk (198x) (pd).k7" size="47432" crc="4f7b87d3" sha1="5a585d6681d87c32678eb66f6f543147c58e814c"/>
@@ -2336,7 +2160,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Super Hits de Thomson</description>
 		<year>1986</year>
 		<publisher>Micromania</publisher>
-
 		<part name="cass1" interface="mo_cass"> <!-- dupe of hitocean tape2 -->
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="145397">
@@ -2367,7 +2190,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Telerama no.1</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6248">
 				<rom name="telerama no.1 (1984)(vifi-nathan)(fr)[isola].k7" size="6248" crc="bdbec1c0" sha1="3d2591b58fd4458f25133f438bb8416e6b4e1b6c"/>
@@ -2379,7 +2201,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Telerama no.2</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13474">
 				<rom name="telerama no. 2 (nathan) (alain rigolot, andre deledicq, etc.) (1984) (mo5).k7" size="13474" crc="d40ee451" sha1="87ea753de094dc2601f3ce4ef03b113ec8a0cc00"/>
@@ -2393,7 +2214,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Departge</description>
 		<year>1986</year>
 		<publisher>Ecole Jules Ferry</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3485">
 				<rom name="departge (1986)(ecole jules ferry)(pd).k7" size="3485" crc="14d6b9f9" sha1="7675429741b0556eb9c2f078288b7b254e7ccb2b"/>
@@ -2407,7 +2227,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Theogiciels Loisir 1</description>
 		<year>1984</year>
 		<publisher>Micropresse</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32678">
 				<rom name="theogiciels loisir 1 (1984)(micropresse)(fr).k7" size="32678" crc="e86097a1" sha1="c8f56fbf174068f466f3baf01832fc3fe74b5315"/>
@@ -2416,10 +2235,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="theogic1a" cloneof="theogic1">
-		<description>Theogiciels Loisir 1 (Alt)</description>
+		<description>Theogiciels Loisir 1 (alt)</description>
 		<year>1984</year>
 		<publisher>Micropresse</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32678">
 				<rom name="theogiciels-loisir-1_mo5.k7" size="32678" crc="1b46d826" sha1="acf16e3b46384091b32042f86725d19ef586ac32"/>
@@ -2447,7 +2265,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Hello World!</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="101">
 				<rom name="hello.k7" size="101" crc="d85c5606" sha1="a1e59379afc184420801a23b8a63143f3c4ef071"/>
@@ -2461,7 +2278,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>A.G.D.</description>
 		<year>1984</year>
 		<publisher>Gameco</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8910">
 				<rom name="a.g.d. (1984)(gameco)(fr).k7" size="8910" crc="18d3da95" sha1="7f6e255e1056f1644bafefbaedb85e022786e431"/>
@@ -2470,10 +2286,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="agda" cloneof="agd">
-		<description>A.G.D. (Alt)</description>
+		<description>A.G.D. (alt)</description>
 		<year>1984</year>
 		<publisher>Gameco</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8910">
 				<rom name="a.g.d. (1984)(gameco)(fr)[a].k7" size="8910" crc="20868f22" sha1="f72725b259a5f32eb8460c1426368e27b8ba12a7"/>
@@ -2482,10 +2297,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="agdb" cloneof="agd">
-		<description>A.G.D. (Alt 2)</description>
+		<description>A.G.D. (alt 2)</description>
 		<year>1984</year>
 		<publisher>Gameco</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8910">
 				<rom name="agd_mo5.k7" size="8910" crc="bb2729f8" sha1="8494ebbf208ca6a5a22d65cbd2649fc1179ea761"/>
@@ -2497,7 +2311,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Algebre</description>
 		<year>1986</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25047">
 				<rom name="algebre (nathan) (jean-philippe et stephane rethore) (1986) (mo5).k7" size="25047" crc="7477c9c3" sha1="69ead6612f0689d73c4e6634957afcd5313d9056"/>
@@ -2509,7 +2322,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Amperemetre</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12896">
 				<rom name="amperemetre (198x)(cndp)(fr).k7" size="12896" crc="8208c043" sha1="69c6b9c50d9808424478947774463e3e41267b8e"/>
@@ -2521,7 +2333,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volume 1 - Tests de Niveau</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="32580">
@@ -2540,7 +2351,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volume 2 - Le Systeme Verbal 1</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="74268">
@@ -2559,7 +2369,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volume 3 - Le Systeme Verbal 2</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="52134">
@@ -2578,7 +2387,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volume 4 - Le Groupe Nominal 1</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="49475">
@@ -2597,7 +2405,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volume 5 - Le Groupe Nominal 2</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="46219">
@@ -2616,7 +2423,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Apprends-moi a Ecrire</description>
 		<year>198?</year>
 		<publisher>Cedic/Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="26763">
@@ -2635,7 +2441,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ardoise Magique</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10006">
 				<rom name="ardoise magique (198x)(-)(fr).k7" size="10006" crc="956fcb98" sha1="aa05aee8d564f73c97965ef3031d00f281375314"/>
@@ -2644,10 +2449,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ardoisea" cloneof="ardoise">
-		<description>Ardoise Magique (Alt)</description>
+		<description>Ardoise Magique (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10006">
 				<rom name="ardoise magique (198x)(-)(fr)[a].k7" size="10006" crc="93ea2c87" sha1="cae3c885b8d9a7cb8602ce5360af39b7557fb9af"/>
@@ -2656,10 +2460,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ardoiseb" cloneof="ardoise">
-		<description>Ardoise Magique (Alt 2)</description>
+		<description>Ardoise Magique (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10006">
 				<rom name="ardoise-magique_mo5.k7" size="10006" crc="7850dc19" sha1="dc55e69a7f782cbf164e94967501ea38c164ac1a"/>
@@ -2671,7 +2474,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ascens</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22793">
 				<rom name="ascens (1985-09-13)(ustl - irem)(fr).k7" size="22793" crc="069d4255" sha1="4b2be81db4cf87c21171536444df936dc9b835c4"/>
@@ -2683,7 +2485,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Attrape Mots</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18889">
 				<rom name="attrape mots (no man's land) (inconnus) (1984) (mo5 k7).k7" size="18889" crc="3195f5d0" sha1="4c8326ddb8b39029e83fd64368b0a8bbbedc137b"/>
@@ -2695,7 +2496,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Auto-Initiation au Basic MO5</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="57753">
@@ -2711,10 +2511,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initbmo5a" cloneof="initbmo5">
-		<description>Auto-Initiation au Basic MO5 (Alt)</description>
+		<description>Auto-Initiation au Basic MO5 (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="57753">
@@ -2730,10 +2529,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initbmo5b" cloneof="initbmo5">
-		<description>Auto-Initiation au Basic MO5 (Single Tape)</description>
+		<description>Auto-Initiation au Basic MO5 (single tape)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="134878">
 				<rom name="auto-initiation au basic mo5 (1984)(to tek)(fr)[m single tape].k7" size="134878" crc="c196fee7" sha1="48bb180edd5537fb560eac930a46b847bb1e2eed"/>
@@ -2742,10 +2540,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initbmo5c" cloneof="initbmo5">
-		<description>Auto-Initiation au Basic MO5 (Single Tape, Alt)</description>
+		<description>Auto-Initiation au Basic MO5 (single tape, alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="134878">
 				<rom name="auto-initiation au basic mo5 (1984)(to tek)(fr)[m2 single tape].k7" size="134878" crc="cbf7aa55" sha1="9acc12c2c54c75bd1c303d0dfde2b15dc98b7d7d"/>
@@ -2757,7 +2554,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Auto-Initiation au Basic MO5 - Version NanoReseau</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="165822">
 				<rom name="auto-initiation au basic mo5 - version nanoreseau (1984)(to tek)(fr).k7" size="165822" crc="30515b15" sha1="436ba645018cfce3e720ae33e76196e168953a82"/>
@@ -2766,10 +2562,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initbmo5na" cloneof="initbmo5">
-		<description>Auto-Initiation au Basic MO5 - Version NanoReseau (Alt)</description>
+		<description>Auto-Initiation au Basic MO5 - Version NanoReseau (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="165822">
 				<rom name="auto-initiation au basic mo5 - version nanoreseau (1984)(to tek)(fr)[a].k7" size="165822" crc="f9352a2d" sha1="069e6a6819ff3c891538e1a4fe9cfc59708c2c8c"/>
@@ -2778,10 +2573,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initbmo5nb" cloneof="initbmo5">
-		<description>Auto-Initiation au Basic MO5 - Version NanoReseau (Alt 2)</description>
+		<description>Auto-Initiation au Basic MO5 - Version NanoReseau (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="165822">
 				<rom name="auto-initiation au basic mo5 - version nanoreseau (1984)(to tek)(fr)[a2].k7" size="165822" crc="9bbfe4db" sha1="256fbffac7282446a8eb2d60f153336abfce5da3"/>
@@ -2793,7 +2587,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Baladins</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13825">
 				<rom name="baladins (198x)(cndp)(fr).k7" size="13825" crc="9862f766" sha1="2dec8b788b329c0247a27e84638e0dbf0e922297"/>
@@ -2805,7 +2598,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Calcul Mental (CNDP)</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13168">
 				<rom name="calcul mental (1984)(cndp)(fr).k7" size="13168" crc="ae9ab28c" sha1="9306f2eef3a2b5484df82691f2e9a8241a455eb6"/>
@@ -2817,7 +2609,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Calcul Mental (Loriciels)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19978">
 				<rom name="calcul mental (1984-07)(loriciels)(fr).k7" size="19978" crc="d4bc25c9" sha1="f76d6c8feeb190dab44fe6398e67438fded8ed9c"/>
@@ -2826,10 +2617,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="calcmnt2a" cloneof="calcmnt2">
-		<description>Calcul Mental (Loriciels, Alt)</description>
+		<description>Calcul Mental (Loriciels, alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19978">
 				<rom name="calcul mental (1984-07)(loriciels)(fr)[a].k7" size="19978" crc="6dd827a3" sha1="f1882761aebb11b00edd0df287f08e6f61ac0670"/>
@@ -2838,7 +2628,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="calcmnt2b" cloneof="calcmnt2">
-		<description>Calcul Mental (Loriciels, Alt 2)</description>
+		<description>Calcul Mental (Loriciels, alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
 
@@ -2853,7 +2643,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Calcul Rapide</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9667">
 				<rom name="calcul rapide (1984)(no man's land)(fr).k7" size="9667" crc="cc27835f" sha1="401d705f363bb8d75cac588bc1dd4b836dd17a52"/>
@@ -2865,7 +2654,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Calculs Numeriques</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25040">
 				<rom name="calculs numeriques (1985)(vifi-nathan)(fr).k7" size="25040" crc="30f1a612" sha1="f7e6b4a6e960d3567de1673115e6c9473c0d6585"/>
@@ -2877,7 +2665,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cara</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9667">
 				<rom name="cara (no man's land) (inconnus) (1984) (mo5 k7).k7" size="9667" crc="eaaff390" sha1="2a520f825bb768ee68bd7fdbe31004e3f7f8c84b"/>
@@ -2889,7 +2676,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carre Magique</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6766">
 				<rom name="carre magique (198x)(cndp)(fr).k7" size="6766" crc="e1bd12da" sha1="db77bf57eb968b00bf1c3cce4405be8eb4849bfb"/>
@@ -2901,7 +2687,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cartable Francais</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29838">
 				<rom name="cartable-francais-1_mo5.k7" size="29838" crc="5625d6c9" sha1="cce2057129bbc889a6062a9bd85191d136e2562b"/>
@@ -2918,7 +2703,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carte d'Europe</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22824">
 				<rom name="carte d'europe (1985)(vifi-nathan)(fr).k7" size="22824" crc="2f93bfbd" sha1="49d4ffec325c8e72402b15c97f3c43118f90a579"/>
@@ -2927,10 +2711,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="carteuroa" cloneof="carteuro">
-		<description>Carte d'Europe (Alt)</description>
+		<description>Carte d'Europe (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22824">
 				<rom name="carte d'europe (1985)(vifi-nathan)(fr)[a].k7" size="22824" crc="08876575" sha1="c702eba07c99f4a2e9b752d8727c31f456f180e8"/>
@@ -2939,10 +2722,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="carteurob" cloneof="carteuro">
-		<description>Carte d'Europe (Alt 2)</description>
+		<description>Carte d'Europe (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22824">
 				<rom name="carte d'europe (1985)(vifi-nathan)(fr)[a2].k7" size="22824" crc="bf1caf1f" sha1="76077ef9c014547507d4b8443a2e0b5c4043adeb"/>
@@ -2951,10 +2733,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="carteuroc" cloneof="carteuro">
-		<description>Carte d'Europe (Alt 3)</description>
+		<description>Carte d'Europe (alt 3)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23287">
 				<rom name="carte d'europe (nathan) (1985) (alain beck) (mo5).k7" size="23287" crc="05fedff8" sha1="ece0ac8e0552667e42a3bfec82aee8e5cb006354"/>
@@ -2975,10 +2756,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cartefraa" cloneof="cartefra">
-		<description>La Carte de France (Alt)</description>
+		<description>La Carte de France (alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34179">
 				<rom name="carte de france, la (1983)(vifi-nathan)(fr)[a].k7" size="34179" crc="8fa0e9a9" sha1="2e4f00d2996091a371821686e903949bc6ebf5c3"/>
@@ -2987,10 +2767,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cartefrab" cloneof="cartefra">
-		<description>La Carte de France (Alt 2)</description>
+		<description>La Carte de France (alt 2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34179">
 				<rom name="carte de france, la (1983)(vifi-nathan)(fr)[a2].k7" size="34179" crc="ac6f5ad1" sha1="12ddc64c89f07cf244fcccb96cae724f185ed6da"/>
@@ -2999,10 +2778,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cartefrac" cloneof="cartefra">
-		<description>La Carte de France (Alt 3)</description>
+		<description>La Carte de France (alt 3)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34171">
 				<rom name="carte de france, la (1983)(vifi-nathan)(fr)[a3].k7" size="34171" crc="4b1a3ec3" sha1="7e7dd3ae1db517266149350d49d50df90e6a08b0"/>
@@ -3014,7 +2792,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Chiffres et les Lettres</description>
 		<year>198?</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10647">
 				<rom name="chiffres et des lettres, des (198x)(vifi-nathan)(fr).k7" size="10647" crc="7f29764d" sha1="e9f0fe34904d86ef5b9f424783b4f6092b9fb405"/>
@@ -3023,10 +2800,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="chiffleta" cloneof="chifflet">
-		<description>Les Chiffres et les Lettres (Alt)</description>
+		<description>Les Chiffres et les Lettres (alt)</description>
 		<year>198?</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8951">
 				<rom name="chiffres et des lettres, des (198x)(vifi-nathan)(fr)[a].k7" size="8951" crc="75684270" sha1="a588b5013b0598460f074f7cd75eb797bbfe6747"/>
@@ -3035,10 +2811,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="chiffletb" cloneof="chifflet">
-		<description>Les Chiffres et les Lettres (Alt 2)</description>
+		<description>Les Chiffres et les Lettres (alt 2)</description>
 		<year>198?</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8951">
 				<rom name="chiffres et des lettres, des (198x)(vifi-nathan)(fr)[a2].k7" size="8951" crc="931965bd" sha1="df277e59c29d6bab5afa2eb0f15c432824c0f5ac"/>
@@ -3047,10 +2822,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="chiffletc" cloneof="chifflet">
-		<description>Les Chiffres et les Lettres (Alt 3)</description>
+		<description>Les Chiffres et les Lettres (alt 3)</description>
 		<year>198?</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8951">
 				<rom name="des-chiffres-et-des-lettres_mo5.k7" size="8951" crc="a8b1f28d" sha1="c7716d3b3a4400336568362aab88b1262055dea1"/>
@@ -3062,7 +2836,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cible</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10287">
 				<rom name="cible (1984-10-20)(cndp)(fr).k7" size="10287" crc="7d6246a0" sha1="f472074d4e36fe90d036b8aee5773a22d3aac917"/>
@@ -3074,7 +2847,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Compte est Rond</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17467">
 				<rom name="compte est rond, le (1984)(hatier)(fr)(m3).k7" size="17467" crc="e239e303" sha1="68505d4dc95bbd18f51e35bf86f07f05594fe7ce"/>
@@ -3083,10 +2855,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="compteroa" cloneof="comptero">
-		<description>Le Compte est Rond (Alt)</description>
+		<description>Le Compte est Rond (alt)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17467">
 				<rom name="compte est rond, le (1984)(hatier)(fr)(m3)[a].k7" size="17467" crc="97d1a12a" sha1="73acbd346d9890c11dec480a7cae924d8f45b117"/>
@@ -3095,10 +2866,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="compterob" cloneof="comptero">
-		<description>Le Compte est Rond (Alt 2)</description>
+		<description>Le Compte est Rond (alt 2)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17467">
 				<rom name="compte est rond, le (1984)(hatier)(fr)(m3)[a2].k7" size="17467" crc="bb810063" sha1="135b672c73c54004638bb4a3690b5b0b53e00972"/>
@@ -3107,10 +2877,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="compteroc" cloneof="comptero">
-		<description>Le Compte est Rond (Alt 3)</description>
+		<description>Le Compte est Rond (alt 3)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17467">
 				<rom name="le-compte-est-rond_mo5.k7" size="17467" crc="c5821f49" sha1="07174d12e35bfeb03df6f0e881c20935ef4b9227"/>
@@ -3122,7 +2891,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Concours d'Algebre</description>
 		<year>198?</year>
 		<publisher>C. &amp; D. Missenard</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20757">
 				<rom name="concours d'algebre (198x)(missenard, c. &amp; d.)(fr)(pd).k7" size="20757" crc="dfc92e55" sha1="d3d20b3ec4012746a3838402db2e50c747564b83"/>
@@ -3134,7 +2902,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Concours de Geometrie</description>
 		<year>198?</year>
 		<publisher>C. &amp; D. Missenard</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22661">
 				<rom name="concours de geometrie (198x)(missenard, c. &amp; d.)(fr)(pd).k7" size="22661" crc="e5c01e63" sha1="725c68bfe61c69a7ee36cf573dbe3d3fe915bc50"/>
@@ -3146,7 +2913,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Conjugaichouette</description>
 		<year>1984</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="57789">
 				<rom name="conjugaichouette, la (1984)(edil)(fr).k7" size="57789" crc="6f6157fd" sha1="05ef5b244bc553eedb85c66beb1ba6305ceb7a83"/>
@@ -3158,7 +2924,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Corps Humain</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64831">
 				<rom name="corps humain, le (1985)(infogrames)(fr).k7" size="64831" crc="d55feaed" sha1="388bef1d3e5b51a1351dfadf2f80d50c79214d13"/>
@@ -3167,10 +2932,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="corpshuma" cloneof="corpshum">
-		<description>Le Corps Humain (Alt)</description>
+		<description>Le Corps Humain (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64831">
 				<rom name="corps humain, le (1985)(infogrames)(fr)[a].k7" size="64831" crc="afe3b3e8" sha1="0e2f2ac8c2d8637a15b8a7d1b84695360844f945"/>
@@ -3179,10 +2943,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="corpshumb" cloneof="corpshum">
-		<description>Le Corps Humain (Alt 2)</description>
+		<description>Le Corps Humain (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64831">
 				<rom name="corps humain, le (1985)(infogrames)(fr)[a2].k7" size="64831" crc="85fd4d3c" sha1="60913fc8b76b72c4a8b12adddc7ce5e25b205874"/>
@@ -3191,10 +2954,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="corpshumc" cloneof="corpshum">
-		<description>Le Corps Humain (Alt 3)</description>
+		<description>Le Corps Humain (alt 3)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64831">
 				<rom name="le-corps-humain_mo5.k7" size="64831" crc="ae94c971" sha1="1b87e1353f25b9654968f280dd8c13feb88db694"/>
@@ -3206,7 +2968,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Course aux Lettres</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12829">
 				<rom name="cyprien dans la course aux lettres (1984-07)(loriciels)(fr).k7" size="12829" crc="165464f6" sha1="cb4f77d55e9bceb9b2a3cdbdf5594c9ec35a2e70"/>
@@ -3215,10 +2976,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coursleta" cloneof="courslet">
-		<description>Course aux Lettres (Alt)</description>
+		<description>Course aux Lettres (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15062">
 				<rom name="cyprien dans la course aux lettres (1984-07)(loriciels)(fr)[a].k7" size="15062" crc="9426ef51" sha1="e8585096863cf7ccf94fbca3e6936d64d7546564"/>
@@ -3227,10 +2987,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coursletb" cloneof="courslet">
-		<description>Course aux Lettres (Alt 2)</description>
+		<description>Course aux Lettres (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12829">
 				<rom name="cyprien dans la course aux lettres (1984-07)(loriciels)(fr)[a2].k7" size="12829" crc="dc136386" sha1="d642068db0ae11dba251ae8d8b2fa90766a0cf06"/>
@@ -3239,10 +2998,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coursletc" cloneof="courslet">
-		<description>Course aux Lettres (Alt 3)</description>
+		<description>Course aux Lettres (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12829">
 				<rom name="cyprien dans la course aux lettres (1984-07)(loriciels)(fr)[a3].k7" size="12829" crc="4a1c472c" sha1="fb36978f12a5d388e4b4f5fb87daf04497c8e3ee"/>
@@ -3251,10 +3009,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coursletd" cloneof="courslet">
-		<description>Course aux Lettres (Alt 4)</description>
+		<description>Course aux Lettres (alt 4)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12829">
 				<rom name="course-aux-lettres_mo5.k7" size="12829" crc="6bbc4c3d" sha1="b924ccf8096ef5cc2fca734ecc1d545ec14cd071"/>
@@ -3266,7 +3023,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cubomagique</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="cubomagique (1984)(hatier)(fr).k7" size="12668" crc="59b956dd" sha1="4ed85707363dfe9e7bd6e09609f2ea3d0d8a4959"/>
@@ -3275,10 +3031,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cubomagia" cloneof="cubomagi">
-		<description>Cubomagique (Alt)</description>
+		<description>Cubomagique (alt)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="cubomagique (1984)(hatier)(fr)[a].k7" size="12668" crc="04b70f94" sha1="3cbc83f0cca9afd47a34c04fab2c69ca83ef8f34"/>
@@ -3287,10 +3042,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cubomagib" cloneof="cubomagi">
-		<description>Cubomagique (Alt 2)</description>
+		<description>Cubomagique (alt 2)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="cubomagique (1984)(hatier)(fr)[a2].k7" size="12668" crc="3c89b6a9" sha1="28091646af44b8cb24d637e7d79745bbf28d17bf"/>
@@ -3299,10 +3053,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cubomagic" cloneof="cubomagi">
-		<description>Cubomagique (Alt 3)</description>
+		<description>Cubomagique (alt 3)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="cubomagique_mo5.k7" size="12668" crc="c8b2cffd" sha1="9f5e0a8a37cbf5a91b40c8ebaca91e87810364f5"/>
@@ -3314,7 +3067,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Cuisine Francaise</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="62273042">
 				<rom name="la cuisine francaise (free game blot) (alain guiri) (1985) (mo5).wav" size="62273042" crc="42999f30" sha1="eeef46ec0b61f9919afa65d79fe7d92aadfa6cdb"/>
@@ -3323,10 +3075,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cuisinfra" cloneof="cuisinfr">
-		<description>La Cuisine Francaise (Alt)</description>
+		<description>La Cuisine Francaise (alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="144783">
 				<rom name="la cuisine francaise (free game blot) (alain guiri) (1985) (mo5).k7" size="144783" crc="bf0430a9" sha1="62e639b1b43bb0e44121c84a4f02862a047b85ca"/>
@@ -3335,10 +3086,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cuisinfrb" cloneof="cuisinfr">
-		<description>La Cuisine Francaise (Alt 2)</description>
+		<description>La Cuisine Francaise (alt 2)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64037042">
 				<rom name="la-cuisine-francaise_mo5.wav" size="64037042" crc="807b0793" sha1="db48e1bb97c55c0fc0da6090d2ec2656afdf49d0"/>
@@ -3350,7 +3100,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dactylographie</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27687">
 				<rom name="dactylographie (fil) (henri rolland) (1985) (mo5 k7).k7" size="27687" crc="287d9d54" sha1="3e2637255e289d0e5d12de3094795b3f274a0348"/>
@@ -3362,7 +3111,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Defi</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6367">
 				<rom name="defi (1984-10-20)(cndp)(fr).k7" size="6367" crc="2359b8a1" sha1="9a20acf4e86b8e375d6a31097a9fe7fb4c3969af"/>
@@ -3374,7 +3122,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Devin</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7513">
 				<rom name="devin (1984-10-20)(cndp)(fr).k7" size="7513" crc="93a30388" sha1="3657aff0de0c08cd44185b35db93bb707d5a4a82"/>
@@ -3386,7 +3133,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dialogue avec une Sauterelle</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18068">
 				<rom name="dialogue avec une sauterelle (1983)(vifi-nathan)(fr).k7" size="18068" crc="b01f54cc" sha1="a0b05c2fbeda995ffe20c8058f2d0dc089dcebb6"/>
@@ -3395,10 +3141,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sauterela" cloneof="sauterel">
-		<description>Dialogue avec une Sauterelle (Alt)</description>
+		<description>Dialogue avec une Sauterelle (alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23463">
 				<rom name="dialogue avec une sauterelle (nathan) (bernard delarue) (1983) (mo5).k7" size="23463" crc="d412723c" sha1="dcf6f195c1e72a470ed042cc50052e5c3592bd31"/>
@@ -3410,7 +3155,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didact-English - BTS Communication</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43810">
 				<rom name="didact-english - bts communication (1987)(carraz editions)(fr)(en-fr).k7" size="43810" crc="94909c92" sha1="e0164444846fc869360f5bc143d2de396ff50d8c"/>
@@ -3419,10 +3163,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="btscomma" cloneof="btscomm">
-		<description>Didact-English - BTS Communication (Alt)</description>
+		<description>Didact-English - BTS Communication (alt)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43702">
 				<rom name="didact-english - bts communication (1987)(carraz editions)(fr)(en-fr)[a].k7" size="43702" crc="03d99146" sha1="44fd162726a6725f4814f1d613f822c4f57db996"/>
@@ -3431,10 +3174,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="btscommb" cloneof="btscomm">
-		<description>Didact-English - BTS Communication (Alt 2)</description>
+		<description>Didact-English - BTS Communication (alt 2)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43702">
 				<rom name="didact-english-bts-communication_mo5.k7" size="43702" crc="c42f6e14" sha1="f741fa882df64831ff5336c3c3d63eadbb6c8aa1"/>
@@ -3446,7 +3188,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didact-English - BTS Electronique</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43702">
 				<rom name="didact-english - bts electronique (1987)(carraz editions)(fr)(en-fr).k7" size="43702" crc="8608df7a" sha1="d33e3aaf2b42cc3240ac4ba2abae2c063c95ad08"/>
@@ -3455,10 +3196,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="btselecta" cloneof="btselect">
-		<description>Didact-English - BTS Electronique (Alt)</description>
+		<description>Didact-English - BTS Electronique (alt)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43810">
 				<rom name="didact-english - bts electronique (1987)(carraz editions)(fr)(en-fr)[a].k7" size="43810" crc="13627d76" sha1="491be2709eb96b7754e157ac59411876ddd4031f"/>
@@ -3467,10 +3207,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="btselectb" cloneof="btselect">
-		<description>Didact-English - BTS Electronique (Alt 2)</description>
+		<description>Didact-English - BTS Electronique (alt 2)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43810">
 				<rom name="didact-english-bts-electronique_mo5.k7" size="43810" crc="403e005f" sha1="a9ddb3d7d8ff3f52b9d8f5ac999068163aacbe1a"/>
@@ -3482,7 +3221,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didactimath 4eme Volume 1</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="65578">
 				<rom name="didactimath 4eme (1985)(edil)(fr).k7" size="65578" crc="f29a7944" sha1="f7f185d09f367a27c2d3bbdf12686200b809e9f8"/>
@@ -3491,10 +3229,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="didact41a" cloneof="didact41">
-		<description>Didactimath 4eme Volume 1 (Alt)</description>
+		<description>Didactimath 4eme Volume 1 (alt)</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66134">
 				<rom name="didactimath 4eme (1985)(edil)(fr)[a].k7" size="66134" crc="0c0c48f7" sha1="5e3655b1be12ff1f1b80d5dd521f6e83b19f0137"/>
@@ -3503,10 +3240,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="didact41b" cloneof="didact41">
-		<description>Didactimath 4eme Volume 1 (Alt 2)</description>
+		<description>Didactimath 4eme Volume 1 (alt 2)</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="65578">
 				<rom name="didactimath 4eme (1985)(edil)(fr)[a2].k7" size="65578" crc="196e6c91" sha1="77a0b8fd41bcf1c54aee91876c2bf3e374290c00"/>
@@ -3518,7 +3254,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didactimath 4eme Volume 2</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56090">
 				<rom name="didactimath 4eme volume 2 (edil) (j.f reygnier) (1985) (mo5 k7).k7" size="56090" crc="1ec032df" sha1="7f6a1a9f61feebdc43ee8fd5f9014477c251983b"/>
@@ -3530,7 +3265,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didactimath 5eme</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="54495">
 				<rom name="didactimath 5eme (1985)(edil)(fr).k7" size="54495" crc="7ef04078" sha1="b877bdf0c2a95a9471159bd3539aa3fee47e951f"/>
@@ -3542,7 +3276,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Divisibilite</description>
 		<year>198?</year>
 		<publisher>CDDP</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5869">
 				<rom name="divisibilite (198x)(cddp)(fr).k7" size="5869" crc="d63d11e9" sha1="9e3a8dca6dee8e012a3e4d69a6b5cc08913d3739"/>
@@ -3554,7 +3287,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Educatif 4 Mathasard</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19971">
 				<rom name="educatif 4 mathasard (cobrasoft) (jean biron) (1985) (mo5 k7).k7" size="19971" crc="6340a783" sha1="16e18b6fa017c2052c8350b4930a1449069109b1"/>
@@ -3566,7 +3298,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Educatif 5</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16373">
 				<rom name="educatif 5 (cobrasoft) (franck megel) (1985) (mo5 k7).k7" size="16373" crc="a54efc5b" sha1="4be9413fa83e1acf53a983b360cd6a7ac0a1471f"/>
@@ -3578,7 +3309,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Educatif 8 Cours'Auto</description>
 		<year>1986</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12049">
 				<rom name="educatif 8 cours'auto (cobrasoft) (jean-pierre latuilliere) (1986) (mo5 k7).k7" size="12049" crc="4f2ad469" sha1="bab00216883a85643444f47b2971a442620a5afd"/>
@@ -3590,7 +3320,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Electricite</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32798">
 				<rom name="electricite (1984)(cndp)(fr).k7" size="32798" crc="d87adb2c" sha1="167da598a88eb62f4845745923eb505ff52966ea"/>
@@ -3602,7 +3331,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Emploi du Subjonctif</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3292">
 				<rom name="emploi du subjonctif (198x)(cndp)(fr).k7" size="3292" crc="19474090" sha1="9fd6f9b913d7150c5bcbd19613afcdc133c7509a"/>
@@ -3614,7 +3342,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>En Allant a l'Ecole Cycliste</description>
 		<year>1985</year>
 		<publisher>Cedic</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="40484">
@@ -3633,7 +3360,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ensemble Z</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25071">
 				<rom name="ensemble z (198x)(-)(fr).k7" size="25071" crc="0f9034b6" sha1="7160dff3cb1a4e1520f7d30aa55b00df4cfefb0e"/>
@@ -3645,7 +3371,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Entrainement au Calcul</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="4504">
@@ -3712,7 +3437,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Equations</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25400">
 				<rom name="equations (198x)(-)(fr).k7" size="25400" crc="2e0bd6c0" sha1="6846317f2beb81ded4c364f139a176e0d9f26bc4"/>
@@ -3724,7 +3448,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Equations Inequations</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45435">
 				<rom name="equations inequations (nathan) (jean-paul germond) (1985) (mo5).k7" size="45435" crc="10dfdd50" sha1="57562c55763962b5b32f6a755bfad3b78fc09407"/>
@@ -3736,7 +3459,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Equations de Droites</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37661">
 				<rom name="equations de droites (1986)(fil)(fr).k7" size="37661" crc="c90d0234" sha1="a8e5a0a8c8357d5f84f5619d37a9b8742fcd9cbf"/>
@@ -3748,7 +3470,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Equichim</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26075">
 				<rom name="equichim (198x)(cndp)(fr).k7" size="26075" crc="d594d2af" sha1="6137467f55eadc03c33c99495be15877966c78a7"/>
@@ -3760,7 +3481,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Escalier pour l'Infini</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16989">
 				<rom name="escalier pour l'infini (198x)(cndp)(fr).k7" size="16989" crc="5c199b72" sha1="cc481b38a145fbe1520b0ed540855de6ecb2665a"/>
@@ -3772,7 +3492,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Espagnol</description>
 		<year>198?</year>
 		<publisher>Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="145944">
@@ -3794,10 +3513,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="espagnola" cloneof="espagnol">
-		<description>Espagnol (Single Tape)</description>
+		<description>Espagnol (single tape)</description>
 		<year>198?</year>
 		<publisher>Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="646500">
 				<rom name="espagnol (198x)(nathan)(fr)[m single tape].k7" size="646500" crc="aac5f591" sha1="29dedaca5a5d594a58e64a2e4871f20ef7b43d84"/>
@@ -3806,10 +3524,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="espagnolb" cloneof="espagnol">
-		<description>Espagnol (Single Tape, Alt)</description>
+		<description>Espagnol (single tape, alt)</description>
 		<year>198?</year>
 		<publisher>Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="646500">
 				<rom name="espagnol (198x)(nathan)(fr)[m single tape][a].k7" size="646500" crc="8d0fdca2" sha1="53c3e6c56fff5e6d0fb59a02f8f6019eb45dc016"/>
@@ -3818,10 +3535,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="espagnolc" cloneof="espagnol">
-		<description>Espagnol (Single Tape, Alt 2)</description>
+		<description>Espagnol (single tape, alt 2)</description>
 		<year>198?</year>
 		<publisher>Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="646500">
 				<rom name="espagnol_mo5.k7" size="646500" crc="02227edc" sha1="108f5edc0b6241849fcbd9ce88f673d8f5b9c159"/>
@@ -3833,7 +3549,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Etude de la Vitesse Instantanee</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16689">
 				<rom name="etude de la vitesse instantanee (1984)(cndp)(fr).k7" size="16689" crc="8de38047" sha1="23fd24e6d64d8bd87c36c8f2d07e23359b5db872"/>
@@ -3845,7 +3560,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Faire le Point Bac Maths (v1.2)</description>
 		<year>1985</year>
 		<publisher>Ediciel Hachette</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="61779">
 				<rom name="faire le point bac maths v1.2 (1985)(ediciel hachette)(fr).k7" size="61779" crc="a683a428" sha1="57b46b8b684aa5a492ec550a57ce2921781b2f63"/>
@@ -3857,7 +3571,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Faire le Point Bac Maths (v1.1)</description>
 		<year>1985</year>
 		<publisher>Ediciel Hachette</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41398">
 				<rom name="faire le point bac maths v1.1 (1985)(ediciel hachette)(fr).k7" size="41398" crc="5ef7e0d5" sha1="0f0f5c8ef5a55396946757489fed807d4be3bb25"/>
@@ -3869,7 +3582,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Feu Vert</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14640">
 				<rom name="feu vert (1985)(vifi-nathan)(fr).k7" size="14640" crc="705d8a4d" sha1="c1eece8eca1d4cb272eb3b4a47dcf69bebe38d0b"/>
@@ -3881,7 +3593,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Fichier des Animaux</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3980">
 				<rom name="fichier des animaux (198x)(cndp)(fr).k7" size="3980" crc="a5ed9f3e" sha1="73673f32151b7436580931ff9d9794ea900b3713"/>
@@ -3893,7 +3604,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Forget Me Not</description>
 		<year>1985</year>
 		<publisher>Ediciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="15710">
@@ -3912,7 +3622,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 1 - Accord Parfait</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51010">
 				<rom name="francais ce - grammaire et orthographe 1 - accord parfait (1985)(vifi-nathan)(fr).k7" size="51010" crc="7fe3aad7" sha1="a4d98607deb58982485c6208032ca62425ecdbfb"/>
@@ -3921,10 +3630,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ceaccpara" cloneof="ceaccpar">
-		<description>Francais CE - Grammaire et Orthographe 1 - Accord Parfait (Alt)</description>
+		<description>Francais CE - Grammaire et Orthographe 1 - Accord Parfait (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51010">
 				<rom name="francais ce - grammaire et orthographe 1 - accord parfait (1985)(vifi-nathan)(fr)[a].k7" size="51010" crc="3e29979a" sha1="3d7315fb45162ecba898792d0923a70d21e9a466"/>
@@ -3933,7 +3641,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ceaccparb" cloneof="ceaccpar">
-		<description>Francais CE - Grammaire et Orthographe 1 - Accord Parfait (WAV Format)</description>
+		<description>Francais CE - Grammaire et Orthographe 1 - Accord Parfait (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
 
@@ -3948,7 +3656,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 1 - Mot Croises-Images</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36042">
 				<rom name="francais ce - grammaire et orthographe 1 - mot croises-images (1985)(vifi-nathan).k7" size="36042" crc="fa6f9cbc" sha1="b4cf11c9ffadf72b43fc65105a9725d0a4dd27f4"/>
@@ -3957,10 +3664,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cemotcrsa" cloneof="cemotcrs">
-		<description>Francais CE - Grammaire et Orthographe 1 - Mot Croises-Images (Alt)</description>
+		<description>Francais CE - Grammaire et Orthographe 1 - Mot Croises-Images (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36042">
 				<rom name="francais ce - grammaire et orthographe 1 - mot croises-images (1985)(vifi-nathan)[a].k7" size="36042" crc="4862c190" sha1="fb28dda697e4032c09d897eb0be93b58afbebfe2"/>
@@ -3969,10 +3675,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cemotcrsb" cloneof="cemotcrs">
-		<description>Francais CE - Grammaire et Orthographe 1 - Mot Croises-Images (Alt 2)</description>
+		<description>Francais CE - Grammaire et Orthographe 1 - Mot Croises-Images (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36042">
 				<rom name="francais - grammaire et orthographe (1) - ce (nathan) (inconnus) (1985) (mo5).k7" size="36042" crc="2db70f1d" sha1="299bd1ad46100305c5b6b78c8cd153277b478cfe"/>
@@ -3981,10 +3686,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cemotcrsc" cloneof="cemotcrs">
-		<description>Francais CE - Grammaire et Orthographe 1 - Mot Croises-Images (WAV Format)</description>
+		<description>Francais CE - Grammaire et Orthographe 1 - Mot Croises-Images (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21211150">
 				<rom name="francais ce - grammaire et orthographe 1 - mot croises-images (1985)(vifi-nathan).wav" size="21211150" crc="826aa79c" sha1="5f7e17ff3dfcb7a417e0b5d19523f6388c329d9a"/>
@@ -3996,7 +3700,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 3 - Conjucalc</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35710">
 				<rom name="francais ce - grammaire et orthographe 3 - conjucalc (1985)(vifi-nathan)(fr).k7" size="35710" crc="0e0061df" sha1="8f7e871d3d87b491f109a62c9f2bd6223a86e3dd"/>
@@ -4005,10 +3708,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecnjclca" cloneof="cecnjclc">
-		<description>Francais CE - Grammaire et Orthographe 3 - Conjucalc (Alt)</description>
+		<description>Francais CE - Grammaire et Orthographe 3 - Conjucalc (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35710">
 				<rom name="francais ce - grammaire et orthographe 3 - conjucalc (1985)(vifi-nathan)(fr)[a].k7" size="35710" crc="5326b62c" sha1="48b0c68546001ebbcf5ad9b08e3e1b61e05fbcb9"/>
@@ -4017,10 +3719,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecnjclcb" cloneof="cecnjclc">
-		<description>Francais CE - Grammaire et Orthographe 3 - Conjucalc (WAV Format)</description>
+		<description>Francais CE - Grammaire et Orthographe 3 - Conjucalc (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13335810">
 				<rom name="francais ce - grammaire et orthographe 3 - conjucalc (1985)(vifi-nathan)(fr).wav" size="13335810" crc="6e8d1b5f" sha1="68eeb667f4d05a65beab3d84defc94961f1bc3e4"/>
@@ -4032,7 +3733,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 3 - Graphix</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37812">
 				<rom name="francais ce - grammaire et orthographe 3 - graphix (1985)(vifi-nathan)(fr).k7" size="37812" crc="c3d2e2ee" sha1="c3f25c0412958857b91411e444df7e82c85764e0"/>
@@ -4041,10 +3741,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cegraphxa" cloneof="cegraphx">
-		<description>Francais CE - Grammaire et Orthographe 3 - Graphix (Alt)</description>
+		<description>Francais CE - Grammaire et Orthographe 3 - Graphix (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37812">
 				<rom name="francais ce - grammaire et orthographe 3 - graphix (1985)(vifi-nathan)(fr)[a].k7" size="37812" crc="d4e95bfa" sha1="a093de95aba973781081e2fcc50c0417af79d8be"/>
@@ -4053,10 +3752,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cegraphxb" cloneof="cegraphx">
-		<description>Francais CE - Grammaire et Orthographe 3 - Graphix (WAV Formatv)</description>
+		<description>Francais CE - Grammaire et Orthographe 3 - Graphix (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14016184">
 				<rom name="francais ce - grammaire et orthographe 3 - graphix (1985)(vifi-nathan)(fr).wav" size="14016184" crc="67ed1958" sha1="5dd3fb3f73dca990fedd8815a713ed09acb8304f"/>
@@ -4068,7 +3766,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 4 - Accord, D'Accord!</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44408">
 				<rom name="francais ce - grammaire et orthographe 4 - accord, d'accord (1985)(vifi-nathan)(fr).k7" size="44408" crc="dc7ffcb6" sha1="affe06b34bc7e0c2d7bce8de28fe3c2c168affae"/>
@@ -4077,10 +3774,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ceaccorda" cloneof="ceaccord">
-		<description>Francais CE - Grammaire et Orthographe 4 - Accord, D'Accord! (Alt)</description>
+		<description>Francais CE - Grammaire et Orthographe 4 - Accord, D'Accord! (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44408">
 				<rom name="francais ce - grammaire et orthographe 4 - accord, d'accord (1985)(vifi-nathan)(fr)[a].k7" size="44408" crc="9a40841a" sha1="8d535ead9d7f2e6dc2ea218d250095f3ac431f15"/>
@@ -4089,10 +3785,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ceaccordb" cloneof="ceaccord">
-		<description>Francais CE - Grammaire et Orthographe 4 - Accord, D'Accord! (WAV Format)</description>
+		<description>Francais CE - Grammaire et Orthographe 4 - Accord, D'Accord! (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16133872">
 				<rom name="francais ce - grammaire et orthographe 4 - accord, d'accord (1985)(vifi-nathan)(fr).wav" size="16133872" crc="20478ed3" sha1="106de7af77fdc30cd1f90f5a06b2f9d727996703"/>
@@ -4104,7 +3799,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 4 - Bourse aux Voyelles</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21534">
 				<rom name="francais ce - grammaire et orthographe 4 - bourse aux voyelles (1985)(vifi-nathan)(fr).k7" size="21534" crc="b06b3273" sha1="8f29e8f779b58f54993de3538d422884d388b4c6"/>
@@ -4113,10 +3807,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ceboursea" cloneof="cebourse">
-		<description>Francais CE - Grammaire et Orthographe 4 - Bourse aux Voyelles (Alt)</description>
+		<description>Francais CE - Grammaire et Orthographe 4 - Bourse aux Voyelles (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21534">
 				<rom name="francais ce - grammaire et orthographe 4 - bourse aux voyelles (1985)(vifi-nathan)(fr)[a].k7" size="21534" crc="3fb292fe" sha1="d178730a348f0a72cf6c29fb16b3429a4ff0ec93"/>
@@ -4125,10 +3818,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cebourseb" cloneof="cebourse">
-		<description>Francais CE - Grammaire et Orthographe 4 - Bourse aux Voyelles (WAV Format)</description>
+		<description>Francais CE - Grammaire et Orthographe 4 - Bourse aux Voyelles (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8775976">
 				<rom name="francais ce - grammaire et orthographe 4 - bourse aux voyelles (1985)(vifi-nathan)(fr).wav" size="8775976" crc="d26f003d" sha1="1d9180b3319a540fc84f1b53a2aa6070d8258549"/>
@@ -4140,7 +3832,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Atelier</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21541">
 				<rom name="francais ce-cm - aide a l'orthographe - atelier (1985)(vifi-nathan)(fr).k7" size="21541" crc="831103a5" sha1="61ff3534a110f7608cc73751e45b51d590b1b3de"/>
@@ -4149,10 +3840,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmatela" cloneof="cecmatel">
-		<description>Francais CE/CM - Aide a l'Orthographe - Atelier (Alt)</description>
+		<description>Francais CE/CM - Aide a l'Orthographe - Atelier (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21541">
 				<rom name="francais ce-cm - aide a l'orthographe - atelier (1985)(vifi-nathan)(fr)[a].k7" size="21541" crc="fb99998a" sha1="ebb67973c107c569a31bac7e31e4fc23364990e4"/>
@@ -4161,10 +3851,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmatelb" cloneof="cecmatel">
-		<description>Francais CE/CM - Aide a l'Orthographe - Atelier (WAV Format)</description>
+		<description>Francais CE/CM - Aide a l'Orthographe - Atelier (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8782618">
 				<rom name="francais ce-cm - aide a l'orthographe - atelier (1985)(vifi-nathan)(fr).wav" size="8782618" crc="94675e77" sha1="6a7ce7c71a5e493831725ddc028ce0213b746894"/>
@@ -4176,7 +3865,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Deviner</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38532">
 				<rom name="francais ce-cm - aide a l'orthographe - deviner (1985)(vifi-nathan)(fr).k7" size="38532" crc="3e22d589" sha1="dbce12b1d76e2769dff065403c2a65005f0847c1"/>
@@ -4185,10 +3873,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmdevia" cloneof="cecmdevi">
-		<description>Francais CE/CM - Aide a l'Orthographe - Deviner (Alt)</description>
+		<description>Francais CE/CM - Aide a l'Orthographe - Deviner (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38532">
 				<rom name="francais ce-cm - aide a l'orthographe - deviner (1985)(vifi-nathan)(fr)[a].k7" size="38532" crc="f1b96b74" sha1="10b1593d07d58eaafad584b2972b4ec9caa3c6f6"/>
@@ -4197,10 +3884,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmdevib" cloneof="cecmdevi">
-		<description>Francais CE/CM - Aide a l'Orthographe - Deviner (Alt 2)</description>
+		<description>Francais CE/CM - Aide a l'Orthographe - Deviner (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38532">
 				<rom name="deviner_mo5.k7" size="38532" crc="1626faa7" sha1="fe133c854d50b453e57144d6551727582027a67f"/>
@@ -4209,10 +3895,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmdevic" cloneof="cecmdevi">
-		<description>Francais CE/CM - Aide a l'Orthographe - Deviner (WAV Format)</description>
+		<description>Francais CE/CM - Aide a l'Orthographe - Deviner (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14220234">
 				<rom name="francais ce-cm - aide a l'orthographe - deviner (1985)(vifi-nathan)(fr).wav" size="14220234" crc="77c4ecd4" sha1="d1fcd421c73c787e286bc29eacd75dbc202a93c9"/>
@@ -4224,7 +3909,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Invasion</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23023">
 				<rom name="francais ce-cm - aide a l'orthographe - invasion (1985)(vifi-nathan)(fr).k7" size="23023" crc="3037704f" sha1="dc9a83872cc1565391903ba0368fe13d8a4287f6"/>
@@ -4233,10 +3917,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecminvaa" cloneof="cecminva">
-		<description>Francais CE/CM - Aide a l'Orthographe - Invasion (Alt)</description>
+		<description>Francais CE/CM - Aide a l'Orthographe - Invasion (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23023">
 				<rom name="francais ce-cm - aide a l'orthographe - invasion (1985)(vifi-nathan)(fr)[a].k7" size="23023" crc="e154aab5" sha1="66857d4bb89211e03db963913b8b6d741ba4c99f"/>
@@ -4245,10 +3928,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecminvab" cloneof="cecminva">
-		<description>Francais CE/CM - Aide a l'Orthographe - Invasion (WAV Format)</description>
+		<description>Francais CE/CM - Aide a l'Orthographe - Invasion (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9035838">
 				<rom name="francais ce-cm - aide a l'orthographe - invasion (1985)(vifi-nathan)(fr).wav" size="9035838" crc="f8ae381c" sha1="1e2dc70fdea17dc09832db116a809f223c7cd500"/>
@@ -4260,7 +3942,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Ponctuation</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26113">
 				<rom name="francais ce-cm - aide a l'orthographe - ponctuation (1985)(vifi-nathan)(fr).k7" size="26113" crc="daae6a2c" sha1="2a0739c35dfce259cb2096fe0861e61f6c6df772"/>
@@ -4269,10 +3950,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmponca" cloneof="cecmponc">
-		<description>Francais CE/CM - Aide a l'Orthographe - Ponctuation (Alt)</description>
+		<description>Francais CE/CM - Aide a l'Orthographe - Ponctuation (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26113">
 				<rom name="francais ce-cm - aide a l'orthographe - ponctuation (1985)(vifi-nathan)(fr)[a].k7" size="26113" crc="0eff2492" sha1="cb7ddf62e595fab4b0569c44e6f05b3a85d3c00c"/>
@@ -4281,10 +3961,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmponcb" cloneof="cecmponc">
-		<description>Francais CE/CM - Aide a l'Orthographe - Ponctuation (WAV Format)</description>
+		<description>Francais CE/CM - Aide a l'Orthographe - Ponctuation (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10244384">
 				<rom name="francais ce-cm - aide a l'orthographe - ponctuation (1985)(vifi-nathan)(fr).wav" size="10244384" crc="797f78ec" sha1="495da2de7ca4a7c1a70b6eada4915b6e74fa20af"/>
@@ -4296,7 +3975,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE1 - Grammaire et Orthographe - Conjugaison</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37191">
 				<rom name="francais ce1 - grammaire et orthographe - conjugaison (1985)(vifi-nathan)(fr).k7" size="37191" crc="b95dc84f" sha1="91ca1b69f362f7c783c44f221c77fadfa6114428"/>
@@ -4305,10 +3983,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ce1conjua" cloneof="ce1conju">
-		<description>Francais CE1 - Grammaire et Orthographe - Conjugaison (Alt)</description>
+		<description>Francais CE1 - Grammaire et Orthographe - Conjugaison (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37191">
 				<rom name="francais ce1 - grammaire et orthographe - conjugaison (1985)(vifi-nathan)(fr)[a].k7" size="37191" crc="e1ca9ef2" sha1="a5ec01e109adf77219f2011a91fa308365ee3520"/>
@@ -4317,10 +3994,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ce1conjub" cloneof="ce1conju">
-		<description>Francais CE1 - Grammaire et Orthographe - Conjugaison (WAV Format)</description>
+		<description>Francais CE1 - Grammaire et Orthographe - Conjugaison (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13819460">
 				<rom name="francais ce1 - grammaire et orthographe - conjugaison (1985)(vifi-nathan)(fr).wav" size="13819460" crc="9ba443f7" sha1="08a2cbb386f1d7e21d11f2434e12c3bb2c7a7645"/>
@@ -4332,7 +4008,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE1 - Grammaire et Orthographe - Devine</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23403">
 				<rom name="francais ce1 - grammaire et orthographe - devine (1985)(vifi-nathan)(fr).k7" size="23403" crc="baa9e78b" sha1="7bad5f1f2be2bd9dc5646970f959f60593c2e0f9"/>
@@ -4341,10 +4016,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ce1devina" cloneof="ce1devin">
-		<description>Francais CE1 - Grammaire et Orthographe - Devine (Alt)</description>
+		<description>Francais CE1 - Grammaire et Orthographe - Devine (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23403">
 				<rom name="francais ce1 - grammaire et orthographe - devine (1985)(vifi-nathan)(fr)[a].k7" size="23403" crc="7028b303" sha1="c09b9fba711653b083cddbeedba1a32615d7043f"/>
@@ -4353,10 +4027,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ce1devinb" cloneof="ce1devin">
-		<description>Francais CE1 - Grammaire et Orthographe - Devine (WAV Format)</description>
+		<description>Francais CE1 - Grammaire et Orthographe - Devine (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9377254">
 				<rom name="francais ce1 - grammaire et orthographe - devine (1985)(vifi-nathan)(fr).wav" size="9377254" crc="cef1b360" sha1="e3eaf1750492dc9883701ddc658a333a41b1dffa"/>
@@ -4368,7 +4041,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 1 - Chenille Savante</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32612">
 				<rom name="francais cm - grammaire et vocabulaire 1 - chenille savante (1985)(vifi-nathan)(fr).k7" size="32612" crc="576c619b" sha1="8be1062568a2f197217d2ebb8abb848390438811"/>
@@ -4377,10 +4049,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmchenila" cloneof="cmchenil">
-		<description>Francais CM - Grammaire et Vocabulaire 1 - Chenille Savante (Alt)</description>
+		<description>Francais CM - Grammaire et Vocabulaire 1 - Chenille Savante (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32612">
 				<rom name="francais cm - grammaire et vocabulaire 1 - chenille savante (1985)(vifi-nathan)(fr)[a].k7" size="32612" crc="63a37dc8" sha1="2b5de1a9998290327308c9088e3982fc0b7d9df9"/>
@@ -4389,10 +4060,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmchenilb" cloneof="cmchenil">
-		<description>Francais CM - Grammaire et Vocabulaire 1 - Chenille Savante (WAV Format)</description>
+		<description>Francais CM - Grammaire et Vocabulaire 1 - Chenille Savante (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12336420">
 				<rom name="francais cm - grammaire et vocabulaire 1 - chenille savante (1985)(vifi-nathan)(fr).wav" size="12336420" crc="ea589dd1" sha1="01985da82bd62dc20bb10dfe740dff7048b2797d"/>
@@ -4404,7 +4074,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 1 - La Phrase et ses Constituants</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45314">
 				<rom name="francais cm - grammaire et vocabulaire 1 - la phrase et ses constituants (1985)(vifi-nathan)(fr).k7" size="45314" crc="947f23f1" sha1="0c7f66431bcd4e667be0ecf185f1e5e949bd21da"/>
@@ -4413,10 +4082,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmconstia" cloneof="cmconsti">
-		<description>Francais CM - Grammaire et Vocabulaire 1 - La Phrase et ses Constituants (Alt)</description>
+		<description>Francais CM - Grammaire et Vocabulaire 1 - La Phrase et ses Constituants (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45314">
 				<rom name="francais cm - grammaire et vocabulaire 1 - la phrase et ses constituants (1985)(vifi-nathan)(fr)[a].k7" size="45314" crc="57558954" sha1="1bb2da442e6f49256321132086693b5c4bd9ed78"/>
@@ -4425,10 +4093,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmconstib" cloneof="cmconsti">
-		<description>Francais CM - Grammaire et Vocabulaire 1 - La Phrase et ses Constituants (WAV Format)</description>
+		<description>Francais CM - Grammaire et Vocabulaire 1 - La Phrase et ses Constituants (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16640680">
 				<rom name="francais cm - grammaire et vocabulaire 1 - la phrase et ses constituants (1985)(vifi-nathan)(fr).wav" size="16640680" crc="9d99876f" sha1="f2a42130e92a03e1ddf1fd8ba13ef1bf4807ec24"/>
@@ -4440,7 +4107,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 2 - Classement Alphabetique</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25801">
 				<rom name="francais cm - grammaire et vocabulaire 2 - classement alphabetique (1985)(vifi-nathan)(fr).k7" size="25801" crc="17b338cc" sha1="6a8fcc965b64644730d3ab020835c4f12a0d6eee"/>
@@ -4449,10 +4115,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmclassea" cloneof="cmclasse">
-		<description>Francais CM - Grammaire et Vocabulaire 2 - Classement Alphabetique (Alt)</description>
+		<description>Francais CM - Grammaire et Vocabulaire 2 - Classement Alphabetique (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25801">
 				<rom name="francais cm - grammaire et vocabulaire 2 - classement alphabetique (1985)(vifi-nathan)(fr)[a].k7" size="25801" crc="5b3a9f04" sha1="03625491fd01bd83d978d995ee922cd6414c83fb"/>
@@ -4461,10 +4126,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmclasseb" cloneof="cmclasse">
-		<description>Francais CM - Grammaire et Vocabulaire 2 - Classement Alphabetique (WAV Format)</description>
+		<description>Francais CM - Grammaire et Vocabulaire 2 - Classement Alphabetique (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10150460">
 				<rom name="francais cm - grammaire et vocabulaire 2 - classement alphabetique (1985)(vifi-nathan)(fr).wav" size="10150460" crc="f3b8bc5c" sha1="138da5aa6f998a882b0db1673e9b1b0f3ae006ac"/>
@@ -4476,7 +4140,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 2 - Pronoms</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35571">
 				<rom name="francais cm - grammaire et vocabulaire 2 - pronoms (1985)(vifi-nathan)(fr).k7" size="35571" crc="a05dbf35" sha1="af673a4399fffe21ab00ca17a1c133637066a8bc"/>
@@ -4485,10 +4148,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmpronoma" cloneof="cmpronom">
-		<description>Francais CM - Grammaire et Vocabulaire 2 - Pronoms (Alt)</description>
+		<description>Francais CM - Grammaire et Vocabulaire 2 - Pronoms (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35571">
 				<rom name="francais cm - grammaire et vocabulaire 2 - pronoms (1985)(vifi-nathan)(fr)[a].k7" size="35571" crc="64c8c004" sha1="daf91640be5e5093071e25a530511269c42b4e66"/>
@@ -4497,10 +4159,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmpronomb" cloneof="cmpronom">
-		<description>Francais CM - Grammaire et Vocabulaire 2 - Pronoms (WAV Format)</description>
+		<description>Francais CM - Grammaire et Vocabulaire 2 - Pronoms (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13293086">
 				<rom name="francais cm - grammaire et vocabulaire 2 - pronoms (1985)(vifi-nathan)(fr).wav" size="13293086" crc="ba01857c" sha1="1904695ac2b2da21231ee0e9f4671ca4179a4064"/>
@@ -4512,7 +4173,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Vocabulaire et Orthographe - A Demi Mot</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25082">
 				<rom name="francais cm - vocabulaire et orthographe - a demi mot (1985)(vifi-nathan)(fr).k7" size="25082" crc="fe3e42b8" sha1="cfdfae72561e81a814872e2050854bae380e0bce"/>
@@ -4521,10 +4181,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmdemimoa" cloneof="cmdemimo">
-		<description>Francais CM - Vocabulaire et Orthographe - A Demi Mot (Alt)</description>
+		<description>Francais CM - Vocabulaire et Orthographe - A Demi Mot (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25069">
 				<rom name="francais cm - vocabulaire et orthographe - a demi mot (1985)(vifi-nathan)(fr)[a].k7" size="25069" crc="89a28d2b" sha1="fb8670f9127c090c0b51df4812cb59f1f832b853"/>
@@ -4533,10 +4192,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmdemimob" cloneof="cmdemimo">
-		<description>Francais CM - Vocabulaire et Orthographe - A Demi Mot (Alt 2)</description>
+		<description>Francais CM - Vocabulaire et Orthographe - A Demi Mot (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25069">
 				<rom name="francais cm - vocabulaire et orthographe - a demi mot (1985)(vifi-nathan)(fr)[a2].k7" size="25069" crc="63911d1a" sha1="3a518ad376a968276813ea9d88f8289f49af4ddd"/>
@@ -4548,7 +4206,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Vocabulaire et Orthographe 1 - A.P.I.</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42796">
 				<rom name="francais cm - vocabulaire et orthographe 1 - a.p.i. (1985)(vifi-nathan)(fr).k7" size="42796" crc="74afe34b" sha1="d54d3118b7fa49aa560f5607670eba8aa7061416"/>
@@ -4557,10 +4214,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmapia" cloneof="cmapi">
-		<description>Francais CM - Vocabulaire et Orthographe 1 - A.P.I. (Alt)</description>
+		<description>Francais CM - Vocabulaire et Orthographe 1 - A.P.I. (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42796">
 				<rom name="francais cm - vocabulaire et orthographe 1 - a.p.i. (1985)(vifi-nathan)(fr)[a].k7" size="42796" crc="fccf946a" sha1="4a30d38fd14661aa2c560d8a5c95e7a18030ad03"/>
@@ -4572,7 +4228,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM2/6eme - Vocabulaire et Orthographe - Memotex</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25821">
 				<rom name="francais cm2-6eme - vocabulaire et orthographe - memotex (1985)(vifi-nathan)(fr).k7" size="25821" crc="f3004420" sha1="dc5e2094a697afc27f194e16d9e58e5668c0e756"/>
@@ -4581,10 +4236,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cm26memoa" cloneof="cm26memo">
-		<description>Francais CM2/6eme - Vocabulaire et Orthographe - Memotex (Alt)</description>
+		<description>Francais CM2/6eme - Vocabulaire et Orthographe - Memotex (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25821">
 				<rom name="francais cm2-6eme - vocabulaire et orthographe - memotex (1985)(vifi-nathan)(fr)[a].k7" size="25821" crc="6d6929a3" sha1="7cc2706f1e568a040d7f02b6028117898e623ee9"/>
@@ -4596,7 +4250,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM2/6eme - Vocabulaire et Orthographe - Synonymes</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36064">
 				<rom name="francais cm2-6eme - vocabulaire et orthographe - synonymes (1985)(vifi-nathan)(fr).k7" size="36064" crc="d28941fe" sha1="27294f972cdffa838093da7ce81d961870a2c34c"/>
@@ -4605,10 +4258,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cm26synoa" cloneof="cm26syno">
-		<description>Francais CM2/6eme - Vocabulaire et Orthographe - Synonymes (Alt)</description>
+		<description>Francais CM2/6eme - Vocabulaire et Orthographe - Synonymes (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36064">
 				<rom name="francais cm2-6eme - vocabulaire et orthographe - synonymes (1985)(vifi-nathan)(fr)[a].k7" size="36064" crc="7fe2c0d8" sha1="16752d3c6e001aa35fc9cc0033e7cb29757d50bc"/>
@@ -4620,7 +4272,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture - Famille</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23733">
 				<rom name="francais cp - aide a la lecture - famille (1985)(vifi-nathan)(fr).k7" size="23733" crc="addeb7b0" sha1="c38899e5c425f611bfb6d4097d8fda23ee9b3171"/>
@@ -4629,10 +4280,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpfamilea" cloneof="cpfamile">
-		<description>Francais CP - Aide a la Lecture - Famille (Alt)</description>
+		<description>Francais CP - Aide a la Lecture - Famille (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23733">
 				<rom name="francais cp - aide a la lecture - famille (1985)(vifi-nathan)(fr)[b].k7" size="23733" crc="b5875730" sha1="967bb6a26a45567b132fcbfdb94117dd6b198e7e"/>
@@ -4644,7 +4294,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture - Famille (No Loader Screen)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16509">
 				<rom name="francais cp - aide a la lecture - famille (1985)(vifi-nathan)(fr)[m title screen].k7" size="16509" crc="1c412ad7" sha1="12238763c947966f973ced9e44e43c07b7d775aa"/>
@@ -4653,10 +4302,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpfamilec" cloneof="cpfamile">
-		<description>Francais CP - Aide a la Lecture - Famille (WAV Format)</description>
+		<description>Francais CP - Aide a la Lecture - Famille (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9482440">
 				<rom name="francais cp - aide a la lecture - famille (1985)(vifi-nathan)(fr).wav" size="9482440" crc="9f759cf5" sha1="8f152776b62f59b343d8b02c4206a55f4e7c7da2"/>
@@ -4668,7 +4316,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture - Lecture</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35942">
 				<rom name="francais cp - aide a la lecture - lecture (1985)(vifi-nathan)(fr).k7" size="35942" crc="4e67bbd3" sha1="d851d4ab00c95973e05cc6c4b3c724b262c4439a"/>
@@ -4677,10 +4324,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cplectura" cloneof="cplectur">
-		<description>Francais CP - Aide a la Lecture - Lecture (Alt)</description>
+		<description>Francais CP - Aide a la Lecture - Lecture (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35942">
 				<rom name="francais cp - aide a la lecture - lecture (1985)(vifi-nathan)(fr)[a].k7" size="35942" crc="0a0678d2" sha1="fd7ccca8b0393548d37e20b31698374d33806bd2"/>
@@ -4689,10 +4335,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cplecturb" cloneof="cplectur">
-		<description>Francais CP - Aide a la Lecture - Lecture (WAV Format)</description>
+		<description>Francais CP - Aide a la Lecture - Lecture (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13409050">
 				<rom name="francais cp - aide a la lecture - lecture (1985)(vifi-nathan)(fr).wav" size="13409050" crc="f9e72d6c" sha1="55722181a13e00d388fa39c5d8d77794ae2ccd99"/>
@@ -4704,7 +4349,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture 2 - Loto</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38621">
 				<rom name="francais cp - aide a la lecture 2 - loto (1985)(vifi-nathan)(fr).k7" size="38621" crc="7f59ee17" sha1="98fffee48b92980eecbd0672904483db6dec32b4"/>
@@ -4713,10 +4357,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cplotoa" cloneof="cploto">
-		<description>Francais CP - Aide a la Lecture 2 - Loto (Alt)</description>
+		<description>Francais CP - Aide a la Lecture 2 - Loto (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38621">
 				<rom name="francais cp - aide a la lecture 2 - loto (1985)(vifi-nathan)(fr)[a].k7" size="38621" crc="063a1b26" sha1="dda94a4273a2df59072502e0dae058a016f70d59"/>
@@ -4725,10 +4368,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cplotob" cloneof="cploto">
-		<description>Francais CP - Aide a la Lecture 2 - Loto (WAV Format)</description>
+		<description>Francais CP - Aide a la Lecture 2 - Loto (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14221462">
 				<rom name="francais cp - aide a la lecture 2 - loto (1985)(vifi-nathan)(fr).wav" size="14221462" crc="7d248459" sha1="997aba34d0eb77f24816e579b7e07c76fb3fc7db"/>
@@ -4740,7 +4382,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture 2 - Memo-Jeu</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38006">
 				<rom name="francais cp - aide a la lecture 2 - memo-jeu (1985)(vifi-nathan)(fr).k7" size="38006" crc="c2379b74" sha1="8cab874f7a5c1622969e036fa2318c2b3cc03951"/>
@@ -4749,10 +4390,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpmemojea" cloneof="cpmemoje">
-		<description>Francais CP - Aide a la Lecture 2 - Memo-Jeu (Alt)</description>
+		<description>Francais CP - Aide a la Lecture 2 - Memo-Jeu (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38006">
 				<rom name="francais cp - aide a la lecture 2 - memo-jeu (1985)(vifi-nathan)(fr)[a].k7" size="38006" crc="2c5b66b0" sha1="03a3466a68d0cdf614991c7fd53a43c83565a0de"/>
@@ -4761,10 +4401,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpmemojeb" cloneof="cpmemoje">
-		<description>Francais CP - Aide a la Lecture 2 - Memo-Jeu (WAV Format)</description>
+		<description>Francais CP - Aide a la Lecture 2 - Memo-Jeu (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14026558">
 				<rom name="francais cp - aide a la lecture 2 - memo-jeu (1985)(vifi-nathan)(fr).wav" size="14026558" crc="bf71660e" sha1="90a82f9d5d68b5d333614024bb8d3367548e6a9d"/>
@@ -4776,7 +4415,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Alerte</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39363">
 				<rom name="francais cp-ce - aide a la lecture - alerte (1985)(vifi-nathan)(fr).k7" size="39363" crc="1c35e13d" sha1="58285fce34b6f31f449891cb13a88390204daf28"/>
@@ -4785,10 +4423,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcealera" cloneof="cpcealer">
-		<description>Francais CP/CE - Aide a la Lecture - Alerte (Alt)</description>
+		<description>Francais CP/CE - Aide a la Lecture - Alerte (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39363">
 				<rom name="francais cp-ce - aide a la lecture - alerte (1985)(vifi-nathan)(fr)[a].k7" size="39363" crc="daf8f473" sha1="ee001e316ff7e289857c16001ed03e562e6c2462"/>
@@ -4797,10 +4434,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcealerb" cloneof="cpcealer">
-		<description>Francais CP/CE - Aide a la Lecture - Alerte (WAV Format)</description>
+		<description>Francais CP/CE - Aide a la Lecture - Alerte (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16564786">
 				<rom name="francais cp-ce - aide a la lecture - alerte (1985)(vifi-nathan)(fr).wav" size="16564786" crc="bf83816d" sha1="b89b80081334e52a0b4c97d8f36223fd8ae748dd"/>
@@ -4812,7 +4448,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Memot</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32904">
 				<rom name="francais cp-ce - aide a la lecture - memot (1985)(nathan ecoles)(fr).k7" size="32904" crc="f2d93334" sha1="07dd3c2b9b0155df759d4912938215e7a6800c36"/>
@@ -4821,10 +4456,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcememoa" cloneof="cpcememo">
-		<description>Francais CP/CE - Aide a la Lecture - Memot (Alt)</description>
+		<description>Francais CP/CE - Aide a la Lecture - Memot (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32904">
 				<rom name="francais cp-ce - aide a la lecture - memot (1985)(nathan ecoles)(fr)[a].k7" size="32904" crc="7c07c6f8" sha1="022e49524be64061f11d1fcdad932e40a7cbf5f1"/>
@@ -4833,10 +4467,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcememob" cloneof="cpcememo">
-		<description>Francais CP/CE - Aide a la Lecture - Memot (WAV Format)</description>
+		<description>Francais CP/CE - Aide a la Lecture - Memot (WAV format)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12413154">
 				<rom name="francais cp-ce - aide a la lecture - memot (1985)(nathan ecoles)(fr).wav" size="12413154" crc="4599421f" sha1="f93c12529952f7234f9bf287886d0b32e22ca2f8"/>
@@ -4848,7 +4481,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Pelmel</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32459">
 				<rom name="francais cp-ce - aide a la lecture - pelmel (1985)(vifi-nathan)(fr).k7" size="32459" crc="24893889" sha1="8047c7a9ef350bba7ece31514fc3b39483b17cac"/>
@@ -4857,10 +4489,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcepelma" cloneof="cpcepelm">
-		<description>Francais CP/CE - Aide a la Lecture - Pelmel (Alt)</description>
+		<description>Francais CP/CE - Aide a la Lecture - Pelmel (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32459">
 				<rom name="francais cp-ce - aide a la lecture - pelmel (1985)(vifi-nathan)(fr)[a].k7" size="32459" crc="6c634188" sha1="6c453eb4485414c0d495f3c6a4d997194c4bb3b2"/>
@@ -4869,10 +4500,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcepelmb" cloneof="cpcepelm">
-		<description>Francais CP/CE - Aide a la Lecture - Pelmel (WAV Format)</description>
+		<description>Francais CP/CE - Aide a la Lecture - Pelmel (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12298936">
 				<rom name="francais cp-ce - aide a la lecture - pelmel (1985)(vifi-nathan)(fr).wav" size="12298936" crc="ba711f1d" sha1="2e64137bb984b1fa2e1318a3f14339f5db1e476a"/>
@@ -4884,7 +4514,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Radar</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26855">
 				<rom name="francais cp-ce - aide a la lecture - radar (1985)(vifi-nathan)(fr).k7" size="26855" crc="27c24c49" sha1="5eab2df27abb6999ea10d4f59e47c0897f41fed2"/>
@@ -4893,10 +4522,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpceradaa" cloneof="cpcerada">
-		<description>Francais CP/CE - Aide a la Lecture - Radar (Alt)</description>
+		<description>Francais CP/CE - Aide a la Lecture - Radar (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26855">
 				<rom name="francais cp-ce - aide a la lecture - radar (1985)(vifi-nathan)(fr)[a].k7" size="26855" crc="20022dcc" sha1="1a82b6ea61f3b2dd21c5a0ed96b27652b9138669"/>
@@ -4905,10 +4533,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpceradab" cloneof="cpcerada">
-		<description>Francais CP/CE - Aide a la Lecture - Radar (WAV Format)</description>
+		<description>Francais CP/CE - Aide a la Lecture - Radar (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10498248">
 				<rom name="francais cp-ce - aide a la lecture - radar (1985)(vifi-nathan)(fr).wav" size="10498248" crc="78238813" sha1="0f7010e9b137f189bcd26ccfdb5ce090b2c4af94"/>
@@ -4920,7 +4547,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Frontier</description>
 		<year>198?</year>
 		<publisher>CDDP</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3875">
 				<rom name="frontier (198x)(cddp)(fr)[b].k7" size="3875" crc="fbe181d2" sha1="94da3bd62fb9a7307f45af7e0522888d685baf0f"/>
@@ -4932,7 +4558,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Geometre 5eme</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="71304">
 				<rom name="geometre 5eme, le (1985)(edil)(fr).k7" size="71304" crc="feee5f4f" sha1="d5cdcbddaa99797cb3a216e9da08ae06fd76ccd1"/>
@@ -4944,7 +4569,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Geometrie</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32484">
 				<rom name="geometrie (1985)(vifi-nathan)(fr).k7" size="32484" crc="8dc36435" sha1="c3f758fdecc4b0799c24b9e8c97a2b6ae2ea1a59"/>
@@ -4956,7 +4580,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Grsang</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23601">
 				<rom name="grsang (198x)(cndp)(fr).k7" size="23601" crc="930d4e3c" sha1="f9a70938f1d2be59866e0746002096d4657f3674"/>
@@ -4968,7 +4591,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Histoire de France</description>
 		<year>1985</year>
 		<publisher>MPS Diffusion</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="30187">
@@ -4984,10 +4606,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="histfrnca" cloneof="histfrnc">
-		<description>Histoire de France (Single Tape)</description>
+		<description>Histoire de France (single tape)</description>
 		<year>1985</year>
 		<publisher>MPS Diffusion</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="164845">
 				<rom name="histoire de france (1985)(mps diffusion)(fr).k7" size="164845" crc="4768face" sha1="8973cc4144ba4e1f7865fe8b55f79386ce1a835f"/>
@@ -4996,10 +4617,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="histfrncb" cloneof="histfrnc">
-		<description>Histoire de France (Single Tape, Alt)</description>
+		<description>Histoire de France (single tape, alt)</description>
 		<year>1985</year>
 		<publisher>MPS Diffusion</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="137533">
 				<rom name="histoire de france (1985)(mps diffusion)(fr)[a].k7" size="137533" crc="34a5a4bd" sha1="8c4215f75017d60b1d423856e16aa38b13d93837"/>
@@ -5008,10 +4628,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="histfrncc" cloneof="histfrnc">
-		<description>Histoire de France (Single Tape, Alt 2)</description>
+		<description>Histoire de France (single tape, alt 2)</description>
 		<year>1985</year>
 		<publisher>MPS Diffusion</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="137533">
 				<rom name="histoire de france (1985)(mps diffusion)(fr)[a2].k7" size="137533" crc="ceb99826" sha1="a956fff2b87f64c4b49da79a3ccc20de64dff816"/>
@@ -5020,10 +4639,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="histfrncd" cloneof="histfrnc">
-		<description>Histoire de France (Single Tape, Alt 3)</description>
+		<description>Histoire de France (single tape, alt 3)</description>
 		<year>1985</year>
 		<publisher>MPS Diffusion</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="137533">
 				<rom name="histoire de france (mps diffusion) (gerard tramier) (1985) (mo5).k7" size="137533" crc="064e26f5" sha1="80cd9c9e879c76d0757e35f85e90cb65359ad39a"/>
@@ -5035,7 +4653,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Horloge</description>
 		<year>1984</year>
 		<publisher>USTL</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8693">
 				<rom name="horloge (1984)(ustl)(fr).k7" size="8693" crc="e8a2c3b6" sha1="7e22948b0e2216f74dd30238a0797f2867c9e23f"/>
@@ -5047,7 +4664,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Image et Signes</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="26161">
@@ -5066,7 +4682,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Inequations</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25881">
 				<rom name="inequations (198x)(-)(fr).k7" size="25881" crc="98e4c723" sha1="b1d8189f51f8aae5d23aaeb3fe5946f43685a207"/>
@@ -5078,7 +4693,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Initiation au Basic</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="50882">
@@ -5106,10 +4720,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initbasa" cloneof="initbas">
-		<description>Initiation au Basic (Alt)</description>
+		<description>Initiation au Basic (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="50866">
@@ -5137,10 +4750,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initbasb" cloneof="initbas">
-		<description>Initiation au Basic (Alt 2)</description>
+		<description>Initiation au Basic (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="50866">
@@ -5168,10 +4780,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initbasc" cloneof="initbas">
-		<description>Initiation au Basic (Alt 3)</description>
+		<description>Initiation au Basic (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="50866">
@@ -5199,10 +4810,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initbasd" cloneof="initbas">
-		<description>Initiation au Basic (Alt 4)</description>
+		<description>Initiation au Basic (alt 4)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="50866">
@@ -5233,7 +4843,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Einfuehrung in Basic (Ger)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="51623">
@@ -5264,7 +4873,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Initiation aux Echecs</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40029">
 				<rom name="initiation aux echecs (1984)(vifi-nathan)(fr).k7" size="40029" crc="cb04da54" sha1="003b441627a52b288ab1c1c80c947290ea5d8621"/>
@@ -5273,10 +4881,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initechea" cloneof="initeche">
-		<description>Initiation aux Echecs (Alt)</description>
+		<description>Initiation aux Echecs (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40029">
 				<rom name="initiation aux echecs (1984)(vifi-nathan)(fr)[b title screen].k7" size="40029" crc="44c70ab1" sha1="7bfad9a19f3bdf2c1faa69f7972d363011adfe0b"/>
@@ -5285,10 +4892,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initecheb" cloneof="initeche">
-		<description>Initiation aux Echecs (Alt 2)</description>
+		<description>Initiation aux Echecs (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40029">
 				<rom name="initiation aux echecs (1984)(vifi-nathan)(fr)[a].k7" size="40029" crc="8e912a0e" sha1="45f4599df9e12507bbf7d1c4949fca7a8ffe90b7"/>
@@ -5297,10 +4903,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="initechec" cloneof="initeche">
-		<description>Initiation aux Echecs (Alt 3)</description>
+		<description>Initiation aux Echecs (alt 3)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40029">
 				<rom name="initiation-aux-echecs_mo5.k7" size="40029" crc="44a50c33" sha1="801bf4f452849db8610508cd5f25bf727d268779"/>
@@ -5312,7 +4917,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>J'entends</description>
 		<year>1984</year>
 		<publisher>Ediciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="34901">
@@ -5331,7 +4935,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jauge</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11107">
 				<rom name="jauge (1984-10-20)(cndp)(fr).k7" size="11107" crc="25955a0a" sha1="294e9b08be558afa9a7da0a33be2bac2b7b48d7e"/>
@@ -5343,7 +4946,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Je Lis, J'Ecris</description>
 		<year>1984</year>
 		<publisher>Ediciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="29902">
@@ -5362,7 +4964,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Je Tu Il</description>
 		<year>1986</year>
 		<publisher>Ediciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51405">
 				<rom name="je tu il (1986)(ediciel)(fr).k7" size="51405" crc="153c8f28" sha1="825899a852eb28b1341e84e9395c6ec57a62e5eb"/>
@@ -5371,10 +4972,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jetuila" cloneof="jetuil">
-		<description>Je Tu Il (Alt)</description>
+		<description>Je Tu Il (alt)</description>
 		<year>1986</year>
 		<publisher>Ediciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51405">
 				<rom name="je tu il (1986)(ediciel)(fr)[a].k7" size="51405" crc="bd49b89b" sha1="5291ff791b6e186208c6d1494d462a9211e50e39"/>
@@ -5383,10 +4983,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jetuilb" cloneof="jetuil">
-		<description>Je Tu Il (Alt 2)</description>
+		<description>Je Tu Il (alt 2)</description>
 		<year>1986</year>
 		<publisher>Ediciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51405">
 				<rom name="je-tu-il_mo5.k7" size="51405" crc="34aaa3cf" sha1="45b0a62c4aeb5d0d210fc093562885851bc0debd"/>
@@ -5398,7 +4997,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Jeu de Boole</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18388">
 				<rom name="jeu de boole, le (1984)(hatier)(fr)(m3).k7" size="18388" crc="0d5335b3" sha1="0cc58c35e2c443ce44f011e882b8ba5fc95de13e"/>
@@ -5407,10 +5005,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeuboolea" cloneof="jeuboole">
-		<description>Le Jeu de Boole (Alt)</description>
+		<description>Le Jeu de Boole (alt)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18388">
 				<rom name="jeu-de-boole_mo5.k7" size="18388" crc="b4453083" sha1="41c93e5a21f55cc61ce562d412ff54be677cd6da"/>
@@ -5436,7 +5033,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu des Planetes</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11570">
 				<rom name="jeu des planetes (198x)(-)(fr).k7" size="11570" crc="cba4dfa1" sha1="2327d7aa274745f3204aebaa0a6a455619203b38"/>
@@ -5445,10 +5041,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeuplanea" cloneof="jeuplane">
-		<description>Jeu des Planetes (Alt)</description>
+		<description>Jeu des Planetes (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11570">
 				<rom name="jeu des planetes (198x)(-)(fr)[a].k7" size="11570" crc="a51022c0" sha1="05c743a26dbd46ce42922b038ec0f1f8ebc69333"/>
@@ -5457,10 +5052,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeuplaneb" cloneof="jeuplane">
-		<description>Jeu des Planetes (Alt 2)</description>
+		<description>Jeu des Planetes (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11570">
 				<rom name="jeu-des-planetes_mo5.k7" size="11570" crc="2db0a0bc" sha1="8a3584af8d2a13bf12f5eba1b87bc7891367ebac"/>
@@ -5472,7 +5066,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu du Dictionnaire</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7117">
 				<rom name="jeu du dictionnaire (198x)(cndp)(fr).k7" size="7117" crc="e10943d0" sha1="7f6faddd6477584396346e9f664103d978a2323a"/>
@@ -5484,7 +5077,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeux de Kim</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8553">
 				<rom name="jeux de kim (1984)(no man's land)(fr).k7" size="8553" crc="743f0ea7" sha1="2760ce060344408ff955065252a8783b6d30bcde"/>
@@ -5493,10 +5085,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeuxkima" cloneof="jeuxkim">
-		<description>Jeux de Kim (Alt)</description>
+		<description>Jeux de Kim (alt)</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8553">
 				<rom name="jeux de kim (1984)(no man's land)(fr)[a].k7" size="8553" crc="e8383ac8" sha1="1b44f73eeacb6595512cc444f9dc797a8aedf84a"/>
@@ -5508,7 +5099,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Kim</description>
 		<year>1984</year>
 		<publisher>Mo Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9420">
 				<rom name="kim (no man's land) (inconnus) (1984) (mo5 k7).k7" size="9420" crc="0c72cc99" sha1="cb7c494648f87518c6320bd6f9055918314426a5"/>
@@ -5520,7 +5110,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Lis, Lisons, Lisez...</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="65073">
@@ -5545,7 +5134,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>LOGO Sans Peine</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40898">
 				<rom name="logo sans peine (nathan) (1985) (mo5).k7" size="40898" crc="fc82e45e" sha1="e630a71372fcce29a101e83e3b515bfd5e9e0997"/>
@@ -5554,10 +5142,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="logospeia" cloneof="logospei">
-		<description>LOGO Sans Peine (Alt?)</description>
+		<description>LOGO Sans Peine (alt?)</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20558">
 				<rom name="logo-sans-peine-2_mo5.k7" size="20558" crc="926dacde" sha1="0005279fa943eed30114d74a4586ce68a8f75f2a"/>
@@ -5569,7 +5156,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ludo Algebre</description>
 		<year>1985</year>
 		<publisher>Edumicro</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21412">
 				<rom name="ludo algebre (1985)(edumicro)(fr).k7" size="21412" crc="032aeb7c" sha1="ea53974a2e885e35ed8a85cbcf2d35874d54b620"/>
@@ -5581,7 +5167,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ludo OP1</description>
 		<year>1985</year>
 		<publisher>Edumicro</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17382">
 				<rom name="ludo op1 (1985)(edumicro)(fr).k7" size="17382" crc="e5a7e6af" sha1="7e973a9e51809ceb24fd6beffa8cef7879dc93fb"/>
@@ -5593,7 +5178,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Carre Magique</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16092">
 				<rom name="mathematiques calculs - carre magique (1984)(nathan ecoles)(fr).k7" size="16092" crc="70f9326d" sha1="c88afea281a71c2b17666eff999cf0f2556367d5"/>
@@ -5602,10 +5186,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="calccarra" cloneof="calccarr">
-		<description>Mathematiques Calculs - Carre Magique (Alt)</description>
+		<description>Mathematiques Calculs - Carre Magique (alt)</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16078">
 				<rom name="mathematiques calculs - carre magique (1984)(nathan ecoles)(fr)[a].k7" size="16078" crc="e08f3298" sha1="30a663987d7b1ab37271859690ae084e33617772"/>
@@ -5614,10 +5197,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="calccarrb" cloneof="calccarr">
-		<description>Mathematiques Calculs - Carre Magique (Alt 2)</description>
+		<description>Mathematiques Calculs - Carre Magique (alt 2)</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16078">
 				<rom name="mathematiques calculs - carre magique (1984)(nathan ecoles)(fr)[a2].k7" size="16078" crc="8c8083f3" sha1="a215e53276674e5668c5a639ebbd5cbbf6796599"/>
@@ -5626,10 +5208,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="calccarrc" cloneof="calccarr">
-		<description>Mathematiques Calculs - Carre Magique (Alt 3)</description>
+		<description>Mathematiques Calculs - Carre Magique (alt 3)</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16078">
 				<rom name="mathematiques calculs - carre magique (1984)(nathan ecoles)(fr)[a3].k7" size="16078" crc="7777f8ce" sha1="6b08bde3d2fd8b2bae5e3595d5efd4196c5a9fa4"/>
@@ -5638,10 +5219,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="calccarrd" cloneof="calccarr">
-		<description>Mathematiques Calculs - Carre Magique (Alt 4)</description>
+		<description>Mathematiques Calculs - Carre Magique (alt 4)</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16078">
 				<rom name="maths-calculs-carre-magique_mo5.k7" size="16078" crc="0826714d" sha1="41b2e3aba631b84d0691f961d18f358bbe86dedb"/>
@@ -5653,7 +5233,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Invasion des Chiffres</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18746">
 				<rom name="mathematiques calculs - invasion des chiffres (1984)(nathan ecoles)(fr).k7" size="18746" crc="29d8eff5" sha1="4f95959aff95dbbc21cb3090612bce251b2887a6"/>
@@ -5665,7 +5244,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Multiplication</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15630">
 				<rom name="mathematiques calculs - multiplication (1985)(cedic-nathan)(fr)[m title screen].k7" size="15630" crc="2d02db0e" sha1="815e91c44d1b0284df2431190221ea9844956176"/>
@@ -5677,7 +5255,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Ranger des Nombres</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17442">
 				<rom name="mathematiques calculs - ranger des nombres (1985)(cedic-nathan)(fr)[m title screen].k7" size="17442" crc="31538754" sha1="c46258d66f78c27ac089990fe4b1ff88b0251d56"/>
@@ -5689,7 +5266,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Avant et Apres</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15608">
 				<rom name="mathematiques ce - rangements et reperages - avant et apres (1985)(vifi-nathan)(fr).k7" size="15608" crc="a8d775d9" sha1="60362c2461878a6d622e5e65c298047f9e5d28a5"/>
@@ -5698,10 +5274,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ceavanta" cloneof="ceavant">
-		<description>Mathematiques CE - Rangements et Reperages - Avant et Apres (Alt)</description>
+		<description>Mathematiques CE - Rangements et Reperages - Avant et Apres (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15608">
 				<rom name="maths-ce-avant-et-apres_mo5.k7" size="15608" crc="ccf0d850" sha1="e00c6157e71bafe4e23eda07d10e3e38a7b4af7a"/>
@@ -5713,7 +5288,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Combinaisons</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20416">
 				<rom name="mathematiques ce - rangements et reperages - combinaisons (1985)(vifi-nathan)(fr).k7" size="20416" crc="6df32a25" sha1="2db76500e564925dced102ae98eaf020f378f0f5"/>
@@ -5722,10 +5296,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecombina" cloneof="cecombin">
-		<description>Mathematiques CE - Rangements et Reperages - Combinaisons (Alt)</description>
+		<description>Mathematiques CE - Rangements et Reperages - Combinaisons (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20416">
 				<rom name="maths-ce-combinaisons_mo5.k7" size="20416" crc="92112f13" sha1="5272151cfc4b59de00bc21f806f5ef632377f3ad"/>
@@ -5737,7 +5310,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Produits et Surfaces</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18884">
 				<rom name="mathematiques ce - rangements et reperages - produits et surfaces (1985)(vifi-nathan)(fr).k7" size="18884" crc="ab4a6419" sha1="5bd26f3adde6102c590fd54b6962f74c654950cc"/>
@@ -5746,10 +5318,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ceproduia" cloneof="ceprodui">
-		<description>Mathematiques CE - Rangements et Reperages - Produits et Surfaces (Alt)</description>
+		<description>Mathematiques CE - Rangements et Reperages - Produits et Surfaces (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18884">
 				<rom name="maths-ce-produits-et-surfaces_mo5.k7" size="18884" crc="95220122" sha1="a92a2f4e46b166490754a473b2e6c32086f9aa3a"/>
@@ -5761,7 +5332,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Quadrillage</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22540">
 				<rom name="mathematiques ce - rangements et reperages - quadrillage (1985)(vifi-nathan)(fr).k7" size="22540" crc="3908f783" sha1="da84227e962dc5d0845c7926cb667297766fc314"/>
@@ -5770,10 +5340,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cequadria" cloneof="cequadri">
-		<description>Mathematiques CE - Rangements et Reperages - Quadrillage (Alt)</description>
+		<description>Mathematiques CE - Rangements et Reperages - Quadrillage (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22540">
 				<rom name="maths-ce-quadrillage_mo5.k7" size="22540" crc="6d4a8d0a" sha1="b08cc5fc58b019ca2c0aa311e05009791f2a34f7"/>
@@ -5785,7 +5354,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Angles</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21148">
 				<rom name="mathematiques ce-cm - geometrie - angles (1985)(vifi-nathan)(fr).k7" size="21148" crc="3ff35d7d" sha1="6902b8f581cb3e4bea7fd9ccd92c0b0ea0637711"/>
@@ -5794,10 +5362,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmangla" cloneof="cecmangl">
-		<description>Mathematiques CE/CM - Geometrie - Angles (Alt)</description>
+		<description>Mathematiques CE/CM - Geometrie - Angles (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20602">
 				<rom name="mathematiques ce-cm - geometrie - angles (1985)(vifi-nathan)(fr)[a].k7" size="20602" crc="7d18210b" sha1="007426b468473a2962d393e62cca722ee5449281"/>
@@ -5806,10 +5373,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmanglb" cloneof="cecmangl">
-		<description>Mathematiques CE/CM - Geometrie - Angles (Alt 2)</description>
+		<description>Mathematiques CE/CM - Geometrie - Angles (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38923">
 				<rom name="mathematiques ce-cm - geometrie - angles (1985)(vifi-nathan)(fr)[a2].k7" size="38923" crc="d3115664" sha1="a6106da534247f666999808ba7674fcb05309b42"/>
@@ -5818,10 +5384,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmanglc" cloneof="cecmangl">
-		<description>Mathematiques CE/CM - Geometrie - Angles (Alt 3)</description>
+		<description>Mathematiques CE/CM - Geometrie - Angles (alt 3)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20602">
 				<rom name="maths-ce-cm-angles_mo5.k7" size="20602" crc="5dde4a8c" sha1="597f39aa0e75f0ce766759c0bc4b68487b1b1b5d"/>
@@ -5833,7 +5398,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Droites</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16167">
 				<rom name="mathematiques ce-cm - geometrie - droites (1985)(vifi-nathan)(fr).k7" size="16167" crc="aa6280d2" sha1="e711d44519e1d6297e4681616db909e7fccb3366"/>
@@ -5842,10 +5406,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmdroia" cloneof="cecmdroi">
-		<description>Mathematiques CE/CM - Geometrie - Droites (Alt)</description>
+		<description>Mathematiques CE/CM - Geometrie - Droites (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38100">
 				<rom name="mathematiques ce-cm - geometrie - droites (1985)(vifi-nathan)(fr)[a].k7" size="38100" crc="39d95f6c" sha1="4d56b355aff6ce565d12ffb11d1a763a670ab123"/>
@@ -5854,10 +5417,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmdroib" cloneof="cecmdroi">
-		<description>Mathematiques CE/CM - Geometrie - Droites (Alt 2)</description>
+		<description>Mathematiques CE/CM - Geometrie - Droites (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38100">
 				<rom name="mathematiques ce-cm - geometrie - droites (1985)(vifi-nathan)(fr)[b].k7" size="38100" crc="d18e11bd" sha1="aad4ca12a5f1e627bfdde7da1d552f7e306ec462"/>
@@ -5866,10 +5428,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmdroic" cloneof="cecmdroi">
-		<description>Mathematiques CE/CM - Geometrie - Droites (Alt 3)</description>
+		<description>Mathematiques CE/CM - Geometrie - Droites (alt 3)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16167">
 				<rom name="maths-ce-cm-droites_mo5.k7" size="16167" crc="8986fe15" sha1="50e1ca43bdb0b441d3d95e96f694011a1927a470"/>
@@ -5881,7 +5442,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Golf</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21844">
 				<rom name="mathematiques ce-cm - geometrie - golf (1985)(vifi-nathan)(fr).k7" size="21844" crc="9a7c4259" sha1="a616be5a79141d2898d2d4d124404520b9d0ea2d"/>
@@ -5890,10 +5450,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmgolfa" cloneof="cecmgolf">
-		<description>Mathematiques CE/CM - Geometrie - Golf (Alt)</description>
+		<description>Mathematiques CE/CM - Geometrie - Golf (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21844">
 				<rom name="maths-ce-cm-golf_mo5.k7" size="21844" crc="e100f09f" sha1="ad295dc9fc986cd9bcc04bbf7505a032b419419b"/>
@@ -5905,7 +5464,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Golf (No Loader Screen)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15753">
 				<rom name="mathematiques ce-cm - geometrie - golf (1985)(vifi-nathan)(fr)[m title screen].k7" size="15753" crc="3b887c4b" sha1="40ea0c508477be65186518875fda4962a91528c6"/>
@@ -5917,7 +5475,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Triangles et Quadrilateres</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21933">
 				<rom name="mathematiques ce-cm - geometrie - triangles et quadrilateres (1985)(vifi-nathan)(fr).k7" size="21933" crc="f5194aa4" sha1="a1a765422ef691e7721b67bad1c9b4442bc81b0e"/>
@@ -5926,10 +5483,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmtriaa" cloneof="cecmtria">
-		<description>Mathematiques CE/CM - Geometrie - Triangles et Quadrilateres (Alt)</description>
+		<description>Mathematiques CE/CM - Geometrie - Triangles et Quadrilateres (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21933">
 				<rom name="maths-ce-cm--triangles-et-quadrilateres_mo5.k7" size="21933" crc="3ccc632c" sha1="5fcb7ad36f7c56ec34662664baf2f12bc3b05a14"/>
@@ -5941,7 +5497,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs - Aires et Volumes</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18670">
 				<rom name="mathematiques cm - mesures et grandeurs - aires et volumes (1985)(vifi-nathan)(fr).k7" size="18670" crc="04a61aa5" sha1="3c564c4becc2f60994a39e22832505b44880c9d1"/>
@@ -5953,7 +5508,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs - Changement d'Unites</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15993">
 				<rom name="maths-cm-changement-d-unites_mo5.k7" size="15993" crc="0c6eafee" sha1="2725d652842ff68123cc9ed26c073e4a9503d905"/>
@@ -5965,7 +5519,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs - Linearite</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22277">
 				<rom name="maths-cm-linearite_mo5.k7" size="22277" crc="1192ecae" sha1="fb697f1d846e011fea06fd2bebcde8f26b31c211"/>
@@ -5977,7 +5530,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs - Mesure du Temps</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16768">
 				<rom name="maths-cm-mesure-du-temps_mo5.k7" size="16768" crc="c83b775a" sha1="e96e1dc1b98ab106e04ec22661623beda3c7edd6"/>
@@ -5989,7 +5541,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs - Mesure du Temps (No Loader Screen)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16252">
 				<rom name="mathematiques cm - mesures et grandeurs - mesure du temps (1985)(vifi-nathan)(fr)[m title screen].k7" size="16252" crc="36d056f7" sha1="5d34d966981df2d84067bddf21ffb8a3e8cdc305"/>
@@ -6001,7 +5552,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Addition-Soustraction Express</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14327">
 				<rom name="mathematiques cm1 - addition-soustraction express (1985)(nathan ecoles)(fr).k7" size="14327" crc="277d3db5" sha1="79c576f9b501854a831f4f480ecdea8b585b7f7c"/>
@@ -6010,10 +5560,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cm1adsoua" cloneof="cm1adsou">
-		<description>Mathematiques CM1 - Addition-Soustraction Express (Alt)</description>
+		<description>Mathematiques CM1 - Addition-Soustraction Express (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14327">
 				<rom name="maths-cm1-addition-soustraction_mo5.k7" size="14327" crc="077912c5" sha1="627abc5e2b6fb7ed4a09e85fd4f2964651880591"/>
@@ -6025,7 +5574,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Division</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17174">
 				<rom name="mathematiques cm1 - division (1985)(nathan ecoles)(fr).k7" size="17174" crc="eea631e2" sha1="2535d842beb34884b8702faf9fe40bdd1ea052ab"/>
@@ -6034,10 +5582,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cm1divisa" cloneof="cm1divis">
-		<description>Mathematiques CM1 - Division (Alt)</description>
+		<description>Mathematiques CM1 - Division (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30930">
 				<rom name="mathematiques cm1 - division (1985)(nathan ecoles)(fr)[a].k7" size="30930" crc="07ec1940" sha1="87ac2a9481296f54af5d88f4ee23a79697f53402"/>
@@ -6046,10 +5593,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cm1divisb" cloneof="cm1divis">
-		<description>Mathematiques CM1 - Division (Alt 2)</description>
+		<description>Mathematiques CM1 - Division (alt 2)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17159">
 				<rom name="mathematiques cm1 - division (1985)(nathan ecoles)(fr)[a2].k7" size="17159" crc="806a11c6" sha1="fa3af0afab0e01f573c6d9cd3322c1c1cb62a70f"/>
@@ -6058,10 +5604,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cm1divisc" cloneof="cm1divis">
-		<description>Mathematiques CM1 - Division (Alt 3)</description>
+		<description>Mathematiques CM1 - Division (alt 3)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17159">
 				<rom name="maths-cm1-division_mo5.k7" size="17159" crc="43b7df58" sha1="8d8d00a04f793040946accb120b3283b0eb0ff5d"/>
@@ -6073,7 +5618,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Lecture et Ecriture d'Un Nombre</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16630">
 				<rom name="mathematiques cm1 - lecture-ecriture d'un nombre (1985)(nathan ecoles)(fr).k7" size="16630" crc="d9437fa5" sha1="9f74fa60cc4705dd5254b5b5eafe5ec5d8ccbea4"/>
@@ -6082,10 +5626,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cm1lececa" cloneof="cm1lecec">
-		<description>Mathematiques CM1 - Lecture et Ecriture d'Un Nombre (Alt)</description>
+		<description>Mathematiques CM1 - Lecture et Ecriture d'Un Nombre (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16630">
 				<rom name="mathematiques cm1 - lecture et ecriture d'un nombre (nathan) (inconnus) (1985) (mo5).k7" size="16630" crc="16402d91" sha1="529b905ee80738b413dfcfb52178d3d7e69e3f80"/>
@@ -6097,7 +5640,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Orde de Grandeur</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17014">
 				<rom name="mathematiques cm1 - orde de grandeur (1985)(nathan ecoles)(fr).k7" size="17014" crc="e2b124c2" sha1="0cd2f285ec0af04861afaabba7a037c9e1650c99"/>
@@ -6106,10 +5648,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cm1ordea" cloneof="cm1orde">
-		<description>Mathematiques CM1 - Orde de Grandeur (Alt)</description>
+		<description>Mathematiques CM1 - Orde de Grandeur (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16453">
 				<rom name="mathematiques cm1 - orde de grandeur (1985)(nathan ecoles)(fr)[a].k7" size="16453" crc="5b98a889" sha1="be920641ca2f3ed58f7e6eb490549ef090bc6db2"/>
@@ -6118,10 +5659,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cm1ordeb" cloneof="cm1orde">
-		<description>Mathematiques CM1 - Orde de Grandeur (Alt 2)</description>
+		<description>Mathematiques CM1 - Orde de Grandeur (alt 2)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16453">
 				<rom name="mathematiques cm1 - ordre de grandeur (nathan) (inconnus) (1985) (mo5).k7" size="16453" crc="6e4b8cd3" sha1="809f32cb0546e719c30e0f727089c87384bf0ab4"/>
@@ -6133,7 +5673,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Compter</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19908">
 				<rom name="mathematiques cp - chiffres et formes - compter (1985)(vifi-nathan)(fr).k7" size="19908" crc="9e772d00" sha1="04811e1e762d4cc6005c807121e1ea623f1c08e5"/>
@@ -6142,10 +5681,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcomptea" cloneof="cpcompte">
-		<description>Mathematiques CP - Chiffres et Formes - Compter (Alt)</description>
+		<description>Mathematiques CP - Chiffres et Formes - Compter (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19908">
 				<rom name="maths-cp-compter_mo5.k7" size="19908" crc="dc581763" sha1="4ac54e019bece7f323d2cd836bc142bf98b19868"/>
@@ -6157,7 +5695,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Moins, Autant, Plus</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16175">
 				<rom name="mathematiques cp - chiffres et formes - moins, autant, plus (1985)(vifi-nathan)(fr).k7" size="16175" crc="ff762614" sha1="735bcc3a34ba0cdf95977a18c8855876203f65a6"/>
@@ -6166,10 +5703,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpmoinsa" cloneof="cpmoins">
-		<description>Mathematiques CP - Chiffres et Formes - Moins, Autant, Plus (Alt)</description>
+		<description>Mathematiques CP - Chiffres et Formes - Moins, Autant, Plus (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16175">
 				<rom name="maths-cp-moins-autant-plus_mo5.k7" size="16175" crc="dfd2bdb6" sha1="b8c85ac93eacdfa5386dcd72c82cd22d7a1949b9"/>
@@ -6181,7 +5717,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Promenade</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24021">
 				<rom name="mathematiques cp - chiffres et formes - promenade (1985)(vifi-nathan)(fr).k7" size="24021" crc="08470258" sha1="3dc096b3474f724c3f8d6101cd5b8cfe5fc971c3"/>
@@ -6190,10 +5725,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cppromena" cloneof="cppromen">
-		<description>Mathematiques CP - Chiffres et Formes - Promenade (Alt)</description>
+		<description>Mathematiques CP - Chiffres et Formes - Promenade (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24021">
 				<rom name="maths-cp-promenade_mo5.k7" size="24021" crc="c9a3d471" sha1="70b63da53adf43acee466f00d0efb4070f15a94b"/>
@@ -6205,7 +5739,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Puzzle</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22542">
 				<rom name="mathematiques cp - chiffres et formes - puzzle (1985)(vifi-nathan)(fr).k7" size="22542" crc="87a57a88" sha1="4bdac464c9b0df9b8d1ec92c841f946ba76bc70e"/>
@@ -6214,10 +5747,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cppuzzlea" cloneof="cppuzzle">
-		<description>Mathematiques CP - Chiffres et Formes - Puzzle (Alt)</description>
+		<description>Mathematiques CP - Chiffres et Formes - Puzzle (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22542">
 				<rom name="maths-cp-puzzle_mo5.k7" size="22542" crc="7d892822" sha1="c7876280509c3b6c5bb7ab0194e9f316757fa2ac"/>
@@ -6229,7 +5761,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Classement</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23060">
 				<rom name="mathematiques cp-ce - tables et frises - classement (1985)(vifi-nathan)(fr).k7" size="23060" crc="a8e056e4" sha1="88379fb6c7768845a68e020a1cc9830fe903709a"/>
@@ -6238,10 +5769,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpceclasa" cloneof="cpceclas">
-		<description>Mathematiques CP/CE - Tables et Frises - Classement (Alt)</description>
+		<description>Mathematiques CP/CE - Tables et Frises - Classement (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23060">
 				<rom name="maths-cp-ce-classement_mo5.k7" size="23060" crc="f1da96ca" sha1="9369d2dd4f1f0a6b86632f126af7d0c6ff6be8ca"/>
@@ -6253,7 +5783,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Frises</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22337">
 				<rom name="mathematiques cp-ce - tables et frises - frises (1985)(vifi-nathan)(fr).k7" size="22337" crc="9a7b6616" sha1="90761b0bbfd48f5d234eab6a4fb59f52b20344e7"/>
@@ -6262,10 +5791,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcefrisa" cloneof="cpcefris">
-		<description>Mathematiques CP/CE - Tables et Frises - Frises (Alt)</description>
+		<description>Mathematiques CP/CE - Tables et Frises - Frises (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22337">
 				<rom name="maths-cp-ce-frises_mo5.k7" size="22337" crc="b3fb307c" sha1="c1df6e93be0a83f183dca514dd87504b16718290"/>
@@ -6277,7 +5805,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Symetries et Translations</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15933">
 				<rom name="mathematiques cp-ce - tables et frises - symetries et translations (1985)(vifi-nathan)(fr).k7" size="15933" crc="c87d004c" sha1="40979e81b6f77ed88df59178157a80d6838ac28e"/>
@@ -6286,10 +5813,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcesymea" cloneof="cpcesyme">
-		<description>Mathematiques CP/CE - Tables et Frises - Symetries et Translations (Alt)</description>
+		<description>Mathematiques CP/CE - Tables et Frises - Symetries et Translations (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15933">
 				<rom name="maths-cp-ce-symetries-et-translations_mo5.k7" size="15933" crc="e1290c26" sha1="e8c98c8ce90837e04935d6e7e9fece9c3bfbdc66"/>
@@ -6301,7 +5827,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Tables d'Operations</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16856">
 				<rom name="mathematiques cp-ce - tables et frises - tables d'operations (1985)(vifi-nathan)(fr).k7" size="16856" crc="1b22bf70" sha1="a19dc3d5fff87ff79dd73eadc309e9e9f9893ea5"/>
@@ -6310,10 +5835,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpcetabla" cloneof="cpcetabl">
-		<description>Mathematiques CP/CE - Tables et Frises - Tables d'Operations (Alt)</description>
+		<description>Mathematiques CP/CE - Tables et Frises - Tables d'Operations (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16856">
 				<rom name="maths-cp-ce-tables-d-operations_mo5.k7" size="16856" crc="3a734320" sha1="d4ae11245f25b7828bb50eb67b5f1c6e92edb246"/>
@@ -6325,7 +5849,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Melodimus</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23170">
 				<rom name="melodimus (1984)(logimus)(fr).k7" size="23170" crc="d2cf4e4f" sha1="10981af3ce5d7090dd7bba2314b07076cc2c4604"/>
@@ -6334,10 +5857,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="melodimua" cloneof="melodimu">
-		<description>Melodimus (Alt)</description>
+		<description>Melodimus (alt)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23161">
 				<rom name="melodimus (1984)(logimus)(fr)[a].k7" size="23161" crc="07f172d0" sha1="d82e7dddaa645dc24544f0c1b2c6cf633632f1a6"/>
@@ -6346,10 +5868,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="melodimub" cloneof="melodimu">
-		<description>Melodimus (Alt 2)</description>
+		<description>Melodimus (alt 2)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23161">
 				<rom name="melodimus (1984)(logimus)(fr)[a2].k7" size="23161" crc="0c8aff43" sha1="ea39a3eaf44fdf70828c3b8125e4ac900b60002e"/>
@@ -6358,10 +5879,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="melodimuc" cloneof="melodimu">
-		<description>Melodimus (Alt 3)</description>
+		<description>Melodimus (alt 3)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23161">
 				<rom name="melodimus (1984)(logimus)(fr)[a3].k7" size="23161" crc="6d3fd719" sha1="b581afa6a0007c24d2cb95b1256c5fe044b600e8"/>
@@ -6370,10 +5890,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="melodimud" cloneof="melodimu">
-		<description>Melodimus (Alt 4)</description>
+		<description>Melodimus (alt 4)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23161">
 				<rom name="melodimus_mo5.k7" size="23161" crc="63efacb7" sha1="58bbe1d244f826a351b2fa043b3f92f0d701e5d4"/>
@@ -6385,7 +5904,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Micro-Processeur</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46082">
 				<rom name="micro-processeur, le (1985)(vifi-nathan)(fr).k7" size="46082" crc="661d43d6" sha1="bc7327e80a5c1139b0ea52dd8b5cc39ccddc25e7"/>
@@ -6394,10 +5912,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="microproa" cloneof="micropro">
-		<description>Le Micro-Processeur (Alt)</description>
+		<description>Le Micro-Processeur (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46082">
 				<rom name="microprocesseur_mo5.k7" size="46082" crc="2c10af1b" sha1="10c316bb957114c312bf228100afb9b0bf003239"/>
@@ -6409,7 +5926,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Microscillo</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23382">
 				<rom name="microscillo (1984)(infogrames)(fr).k7" size="23382" crc="3b429a24" sha1="9605d4bc7d51d839a1817286edb05284123ad7a3"/>
@@ -6418,10 +5934,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="microscia" cloneof="microsci">
-		<description>Microscillo (Alt)</description>
+		<description>Microscillo (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23382">
 				<rom name="microscillo (1984)(infogrames)(fr)[a].k7" size="23382" crc="cff9fc8f" sha1="b80a8093558b770ffa63b0d9aa41e548dfb1b001"/>
@@ -6430,10 +5945,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="microscib" cloneof="microsci">
-		<description>Microscillo (Alt 2)</description>
+		<description>Microscillo (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23382">
 				<rom name="microscillo_mo5.k7" size="23382" crc="4ebe8ba8" sha1="d8a44759f664106ba5530bbf6342767fa9867218"/>
@@ -6445,7 +5959,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Minotaure</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15576">
 				<rom name="minotaure, le (1984)(hatier)(fr).k7" size="15576" crc="d5a10e54" sha1="c1c2812dce713a0ecce4bf48a20796d942fbe067"/>
@@ -6454,10 +5967,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="minotaura" cloneof="minotaur">
-		<description>Le Minotaure (Alt)</description>
+		<description>Le Minotaure (alt)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15346">
 				<rom name="minotaure, le (1984)(hatier)(fr)[a].k7" size="15346" crc="af73a382" sha1="bc63c4b8e7ffdfc208d4e8b99454ae2fa9856506"/>
@@ -6466,10 +5978,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="minotaurb" cloneof="minotaur">
-		<description>Le Minotaure (Alt 2)</description>
+		<description>Le Minotaure (alt 2)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15444">
 				<rom name="minotaure, le (1984)(hatier)(fr)[a2].k7" size="15444" crc="eca56be7" sha1="52321808b17f8dce5ec1ab9f3ab550a9ff36acb6"/>
@@ -6478,10 +5989,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="minotaurc" cloneof="minotaur">
-		<description>Le Minotaure (Alt 3)</description>
+		<description>Le Minotaure (alt 3)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15444">
 				<rom name="minotaure, le (1984)(hatier)(fr)[a3].k7" size="15444" crc="3de436ca" sha1="8abdb485f1462217279443a623617e6e5eff4d81"/>
@@ -6490,10 +6000,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="minotaurd" cloneof="minotaur">
-		<description>Le Minotaure (Alt 4)</description>
+		<description>Le Minotaure (alt 4)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15444">
 				<rom name="minotaure, le (1984)(hatier)(fr)[a4].k7" size="15444" crc="d4a9fa6a" sha1="15eca81ec9997760cb3fe7112753361d7152c000"/>
@@ -6502,10 +6011,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="minotaure" cloneof="minotaur">
-		<description>Le Minotaure (Alt 5)</description>
+		<description>Le Minotaure (alt 5)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15444">
 				<rom name="minotaure, le (1984)(hatier)(fr)[a5].k7" size="15444" crc="febb076b" sha1="1ea37bae11e7b42a74d60da6161f9ef67960e418"/>
@@ -6517,7 +6025,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>MO5BOOT - MO5SD Bootstrap Loader</description>
 		<year>2012</year>
 		<publisher>Daniel Coulom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4587974">
 				<rom name="mo5boot.wav" size="4587974" crc="8c442ed2" sha1="b5d7a24d7c9e4f0dccfcd7220e970d9c01a1fd36"/>
@@ -6529,7 +6036,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mongolfiere</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15076">
 				<rom name="mongolfiere (1985)(cedic-nathan)(fr).k7" size="15076" crc="329ad3d8" sha1="6c80292c2f165fba4980a4e3fb74d7373a3831d0"/>
@@ -6541,7 +6047,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mosaique</description>
 		<year>198?</year>
 		<publisher>Edumicro</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10572">
 				<rom name="mosaique (198x)(edumicro)(fr).k7" size="10572" crc="0ea45252" sha1="2228ff1075f81729c20d4f87d8f64964067a9d23"/>
@@ -6550,10 +6055,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="mosaiquea" cloneof="mosaique">
-		<description>Mosaique (Alt)</description>
+		<description>Mosaique (alt)</description>
 		<year>198?</year>
 		<publisher>Edumicro</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10572">
 				<rom name="mosaique (198x)(edumicro)(fr)[a].k7" size="10572" crc="a412b5d1" sha1="1e2aca1208ea4cbec19604d335bdc26ecbe19fd5"/>
@@ -6562,10 +6066,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="mosaiqueb" cloneof="mosaique">
-		<description>Mosaique (Alt 2)</description>
+		<description>Mosaique (alt 2)</description>
 		<year>198?</year>
 		<publisher>Edumicro</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10572">
 				<rom name="mosaique_mo5.k7" size="10572" crc="1eeaa4f3" sha1="8e8c83c997eda14933ae546fc9197721e818ee09"/>
@@ -6577,7 +6080,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Un Mot pour le Compte</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13726">
 				<rom name="mot pour le compte, un (1983)(vifi-nathan)(fr).k7" size="13726" crc="3ce78dfc" sha1="b416c03e93bde26766445048ece2c2c8b7d18c87"/>
@@ -6589,7 +6091,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mpendu</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17203">
 				<rom name="mpendu (1984-10-20)(cndp)(fr).k7" size="17203" crc="bd27b69a" sha1="b16bf7124aac01bfbeaed9a33328ef97c1741d4c"/>
@@ -6601,7 +6102,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Multiplications Casse-Tete</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39458">
 				<rom name="multiplications casse-tete (1984)(vifi-nathan)(fr).k7" size="39458" crc="dfca6a0d" sha1="85c2ceb9ef72deedac184610a56256067976ebe7"/>
@@ -6610,10 +6110,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="casstetea" cloneof="casstete">
-		<description>Multiplications Casse-Tete (Alt)</description>
+		<description>Multiplications Casse-Tete (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30967">
 				<rom name="multiplications casse-tete (1984)(vifi-nathan)(fr)[a].k7" size="30967" crc="5b9b7f54" sha1="1c04543a349e81094805bbc9e569c63cf277b21d"/>
@@ -6625,7 +6124,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Navire</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17419">
 				<rom name="navire (1985-09-13)(ustl - irem)(fr).k7" size="17419" crc="2621e3c2" sha1="66a2d7b4f74580d43f2cff33573413855b0ff0dc"/>
@@ -6637,7 +6135,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Nombre Cache Ou...</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18346">
 				<rom name="nombre cache ou..., le (198x)(-)(pd)(fr).k7" size="18346" crc="a93cb758" sha1="bf998bd15f7ed091fa58ea2c6dff9a740b1e37e9"/>
@@ -6649,7 +6146,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Nouvel Espagnol sans Peine</description>
 		<year>1985</year>
 		<publisher>Assimil</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="81819">
@@ -6677,10 +6173,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="nouvespaa" cloneof="nouvespa">
-		<description>Le Nouvel Espagnol sans Peine (Alt)</description>
+		<description>Le Nouvel Espagnol sans Peine (alt)</description>
 		<year>1985</year>
 		<publisher>Assimil</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="81819">
@@ -6708,10 +6203,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="nouvespab" cloneof="nouvespa">
-		<description>Le Nouvel Espagnol sans Peine (Alt 2)</description>
+		<description>Le Nouvel Espagnol sans Peine (alt 2)</description>
 		<year>1985</year>
 		<publisher>Assimil</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="81819">
@@ -6739,10 +6233,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="nouvespac" cloneof="nouvespa">
-		<description>Le Nouvel Espagnol sans Peine (Single Tape)</description>
+		<description>Le Nouvel Espagnol sans Peine (single tape)</description>
 		<year>1985</year>
 		<publisher>Assimil</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="646500">
 				<rom name="nouvel espagnol sans peine, le (1985)(assimil)(fr)[m single tape].k7" size="646500" crc="19c2cf4d" sha1="de5dbe92c5ffc94de3091709964d5df47000639e"/>
@@ -6754,7 +6247,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ordidactic</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9984">
 				<rom name="ordidactic (1984)(ere informatique)(fr).k7" size="9984" crc="5a30eb5d" sha1="1808811fdeea045f20c28a5e912d9d5e6b69fdcc"/>
@@ -6763,10 +6255,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ordidacta" cloneof="ordidact">
-		<description>Ordidactic (Alt)</description>
+		<description>Ordidactic (alt)</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9984">
 				<rom name="ordidactic (1984)(ere informatique)(fr)[a].k7" size="9984" crc="4ddfc641" sha1="47ac44d9ab74f3fc6fef79f877c3897622b34391"/>
@@ -6775,10 +6266,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ordidactb" cloneof="ordidact">
-		<description>Ordidactic (Alt 2)</description>
+		<description>Ordidactic (alt 2)</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9984">
 				<rom name="ordidactic (1984)(ere informatique)(fr)[a2].k7" size="9984" crc="5af0f767" sha1="50e66d51f1bd0eb7d0bf8f680b229769f30c4b9c"/>
@@ -6787,10 +6277,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ordidactc" cloneof="ordidact">
-		<description>Ordidactic (Alt 3)</description>
+		<description>Ordidactic (alt 3)</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9984">
 				<rom name="ordidactic_mo5.k7" size="9984" crc="041256ef" sha1="131a087809fa7b5dc69274af6dbf6495854d1bf9"/>
@@ -6802,7 +6291,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Ordifables</description>
 		<year>1985</year>
 		<publisher>Larousse</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="24325">
@@ -6821,7 +6309,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orthocrack 1 - Masculin-Feminin</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19853">
 				<rom name="orthocrack 1 - masculin-feminin (1984)(hatier)(fr).k7" size="19853" crc="82863ff1" sha1="5d7fb7ba716ec72a45f062707d6462d5e1bee60f"/>
@@ -6833,7 +6320,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orthocrack 2 - Singulier-Pluriel</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22416">
 				<rom name="orthocrack 2 - singulier-pluriel (1984)(hatier)(fr).k7" size="22416" crc="0dc0de3c" sha1="419de49061bc683afe0c2a10ed3cfabc5a9b472d"/>
@@ -6845,7 +6331,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orthocrack 3 - Present de l'Indicatif</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24791">
 				<rom name="orthocrack 3 - present de l'indicatif (1984)(hatier)(fr).k7" size="24791" crc="3c84453d" sha1="feb3eedc04fc97274a0f14fa6782b3118d3f61f9"/>
@@ -6857,7 +6342,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orthographe Lexicale</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="332492">
 				<rom name="orthographe lexicale (1984)(cndp)(fr).k7" size="332492" crc="5aa6ab58" sha1="e194ee6aa46f97a573657994b4d7f14e8f9dd684"/>
@@ -6866,10 +6350,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ogralexia" cloneof="ogralexi">
-		<description>Orthographe Lexicale (Alt)</description>
+		<description>Orthographe Lexicale (alt)</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="332492">
 				<rom name="orthographe lexicale (1984)(cndp)(fr)[a].k7" size="332492" crc="66c86c7b" sha1="5b5f8f4f1537823c2b98bb797dc006ddf5a084e0"/>
@@ -6878,10 +6361,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ogralexib" cloneof="ogralexi">
-		<description>Orthographe Lexicale (Alt 2)</description>
+		<description>Orthographe Lexicale (alt 2)</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="332492">
 				<rom name="orthographe lexicale (1984)(cndp)(fr)[a2].k7" size="332492" crc="58fcbf49" sha1="cba97ce508c7d9d5bb3ed524eebb13748b5e74da"/>
@@ -6890,10 +6372,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ogralexic" cloneof="ogralexi">
-		<description>Orthographe Lexicale (Alt 3)</description>
+		<description>Orthographe Lexicale (alt 3)</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="332492">
 				<rom name="orthographe-lexicale_mo5.k7" size="332492" crc="f26772d1" sha1="3176520b6e4378dbec466020ae6e585ba37ef97e"/>
@@ -6905,7 +6386,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pays du Monde</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66841">
 				<rom name="pays du monde (1986)(infogrames)(fr).k7" size="66841" crc="8c86a5a2" sha1="bcdd23d086bbda1c60533448758e8e3396f111e1"/>
@@ -6917,7 +6397,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Paysage a,b,c</description>
 		<year>1985</year>
 		<publisher>Jeriko</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30030">
 				<rom name="paysage-abc_mo5.k7" size="30030" crc="8fb12caa" sha1="4885a6e7a491a8c21bd46d728ff7d3b51fc9aba1"/>
@@ -6929,7 +6408,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Pendu</description>
 		<year>1982</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16431">
 				<rom name="pendu, le (1982)(cndp)(fr).k7" size="16431" crc="618ba2e3" sha1="10770aebe04a83273280b6783f609daca8c3b7a7"/>
@@ -6941,7 +6419,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Phases de la Lune</description>
 		<year>1988</year>
 		<publisher>C. Prevost</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3589">
 				<rom name="les phases de la lune (c. prevost) (1988) (mo5).k7" size="3589" crc="4556cb2d" sha1="0ba6cfdfb470b8d090ace29eea07725e0de6d6c7"/>
@@ -6950,10 +6427,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="phaslunea" cloneof="phaslune">
-		<description>Les Phases de la Lune (Alt)</description>
+		<description>Les Phases de la Lune (alt)</description>
 		<year>1988</year>
 		<publisher>C. Prevost</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3589">
 				<rom name="les-phases-de-la-lune_mo5.k7" size="3589" crc="630217f4" sha1="0396917da5ff4e735905eb2207c9a6318a1f7a09"/>
@@ -6965,7 +6441,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pique-Fiche</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33989">
 				<rom name="pique-fiche (1984)(hatier)(fr).k7" size="33989" crc="51e37e48" sha1="95457135ef9e0a0ad438da398e8c266a7166e408"/>
@@ -6974,10 +6449,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="piquefica" cloneof="piquefic">
-		<description>Pique-Fiche (WAV Format)</description>
+		<description>Pique-Fiche (WAV format)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20023982">
 				<rom name="pique-fiche (1984)(hatier)(fr).wav" size="20023982" crc="d6e7376d" sha1="5540efb58420c69aa4428879946a3ae175287be2"/>
@@ -6989,7 +6463,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pluriel des Noms Simples</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3185">
 				<rom name="pluriel des noms simples (198x)(cndp)(fr).k7" size="3185" crc="6c6ba04d" sha1="75c400dac1f692c877d396556d16d5dcd903d3e0"/>
@@ -7001,7 +6474,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pourcentages</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11543">
 				<rom name="pourcentages (198x)(-)(fr)(pd)[b].k7" size="11543" crc="bc0a3d98" sha1="5fe303ab20394b74d7e6f9c4ca2866cc45aa0923"/>
@@ -7013,7 +6485,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Premiers pas vers le Basic</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="90200">
@@ -7035,10 +6506,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="premvrs1a" cloneof="premvrs1">
-		<description>Premiers pas vers le Basic (Alt)</description>
+		<description>Premiers pas vers le Basic (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="90200">
@@ -7060,10 +6530,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="premvrs1b" cloneof="premvrs1">
-		<description>Premiers pas vers le Basic (Alt 2)</description>
+		<description>Premiers pas vers le Basic (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="90220">
@@ -7088,7 +6557,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Preterite Star</description>
 		<year>1984</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34666">
 				<rom name="preterite star (1984)(edil)(fr)(en-fr)[b2].k7" size="34666" crc="763e0544" sha1="9df621f94efedc6cc98269b015f4784726647552"/>
@@ -7114,7 +6582,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Prologic</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26032">
 				<rom name="prologic (1985)(fil)(fr).k7" size="26032" crc="2c60ec93" sha1="be2ec2b3d8769401dc8649c26fba2667a5fe0138"/>
@@ -7126,7 +6593,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Proportions</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11074">
 				<rom name="proportions (19xx)(-)(fr).k7" size="11074" crc="164d4f12" sha1="2a8dcd300e1b994218a7a126f78b4ac7d068e4d1"/>
@@ -7138,7 +6604,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pythagore</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25004">
 				<rom name="pythagore (1984)(hatier)(fr).k7" size="25004" crc="8306dbad" sha1="d279b8e0c3e6ea35204cf7cc3d8daa89264544ca"/>
@@ -7150,7 +6615,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Repere</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19735">
 				<rom name="repere (1985-09-13)(ustl - irem)(fr).k7" size="19735" crc="96f8d319" sha1="eacdec7ffc9a5e5b1c58b0ed5aa732cb6220b523"/>
@@ -7162,7 +6626,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Ronde de l'Eau</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13692">
 				<rom name="la ronde de l'eau (fil) (jean moreau) (1985) (mo5 k7).k7" size="13692" crc="f6bdd61b" sha1="2e435fbd5c01c01a425b3788e8e0104c7f531289"/>
@@ -7174,7 +6637,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rythmamus (v2)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23920">
 				<rom name="rythmamus v2 (1984)(logimus)(fr).k7" size="23920" crc="0d714436" sha1="276e3517ab75aa411972e9a425fdd68fa099f1f0"/>
@@ -7183,10 +6645,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="rythmamua" cloneof="rythmamu">
-		<description>Rythmamus (v2, Alt)</description>
+		<description>Rythmamus (v2, alt)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23912">
 				<rom name="rythmamus v2 (1984)(logimus)(fr)[a].k7" size="23912" crc="56bd12e7" sha1="1a95d5207ba82479c00ac6b298e70e5d31f15002"/>
@@ -7195,10 +6656,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="rythmamub" cloneof="rythmamu">
-		<description>Rythmamus (v2, Alt 2)</description>
+		<description>Rythmamus (v2, alt 2)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23912">
 				<rom name="rythmamus v2 (1984)(logimus)(fr)[a2].k7" size="23912" crc="6696f0f3" sha1="319ef7b619b6130bf8929f6ef7a00401ea9f94ac"/>
@@ -7207,10 +6667,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="rythmamuc" cloneof="rythmamu">
-		<description>Rythmamus (v2, Alt 3)</description>
+		<description>Rythmamus (v2, alt 3)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23912">
 				<rom name="rythmamus v2 (1984)(logimus)(fr)[a3].k7" size="23912" crc="d2a02cdc" sha1="21a4020d4f670e3a0931a883bbdcb981d9960071"/>
@@ -7219,10 +6678,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="rythmamud" cloneof="rythmamu">
-		<description>Rythmamus (v2, Alt 4)</description>
+		<description>Rythmamus (v2, alt 4)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23912">
 				<rom name="rythmamus_mo5.k7" size="23912" crc="48f1570c" sha1="6e627e6f3484209f71fa86e02f1598270cf47f16"/>
@@ -7234,7 +6692,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>S.O.S. - J'apprends le Morse (v2.3)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18447">
 				<rom name="s.o.s. - j'apprends le morse v2.3 (1985)(free game blot)(fr).k7" size="18447" crc="49d5c2ed" sha1="c75f01ffc1eb4cec49c59d431b654c850f57a433"/>
@@ -7243,10 +6700,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sosa" cloneof="sos">
-		<description>S.O.S. - J'apprends le Morse (v2.3, Alt)</description>
+		<description>S.O.S. - J'apprends le Morse (v2.3, alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18447">
 				<rom name="sos-morse_mo5.k7" size="18447" crc="ef0256c7" sha1="2ee6501bd48bb280842b1b475efb5024ffa5fb80"/>
@@ -7258,7 +6714,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Secrets au Pays des Mots</description>
 		<year>1984</year>
 		<publisher>Marcel &amp; Christian</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="62812">
 				<rom name="secrets au pays des mots (marcel &amp; christian) (christian camier, marcel halberstam) (1984) (mo5 k7).k7" size="62812" crc="9f28afea" sha1="86a1640514ea3169cba5366df4b9faf3874b5913"/>
@@ -7270,7 +6725,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sich Vorstellen</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40475">
 				<rom name="sich vorstellen (1985)(fil)(fr)(de-fr).k7" size="40475" crc="239d78b7" sha1="cbf5bfa6f395eff52cd405c0ad4f9690a383532d"/>
@@ -7279,10 +6733,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sichvorsa" cloneof="sichvors">
-		<description>Sich Vorstellen (Alt)</description>
+		<description>Sich Vorstellen (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33915">
 				<rom name="sich vorstellen (1985)(fil)(fr)(de-fr)[a].k7" size="33915" crc="27297d31" sha1="f699ddce0a4ba4b5175b707985c4b2e00d6a7af3"/>
@@ -7291,10 +6744,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sichvorsb" cloneof="sichvors">
-		<description>Sich Vorstellen (Alt 2)</description>
+		<description>Sich Vorstellen (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33915">
 				<rom name="sich vorstellen (1985)(fil)(fr)(de-fr)[a2].k7" size="33915" crc="e70cee30" sha1="e6e6496c4a92b56b5b64bcde72b9739b37d2d74a"/>
@@ -7303,10 +6755,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sichvorsc" cloneof="sichvors">
-		<description>Sich Vorstellen (Alt 3)</description>
+		<description>Sich Vorstellen (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33915">
 				<rom name="sich vorstellen (1985)(fil)(fr)(de-fr)[a3].k7" size="33915" crc="440a777e" sha1="4f2a5c9578b1ed4b5ad32721f279fc5334bbbd18"/>
@@ -7315,10 +6766,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sichvorsd" cloneof="sichvors">
-		<description>Sich Vorstellen (Alt 4)</description>
+		<description>Sich Vorstellen (alt 4)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33915">
 				<rom name="sich-vorstellen_mo5.k7" size="33915" crc="9c3dab63" sha1="8aabd6c4a4974d48d5a3ccdbfba328f8c64a0ed6"/>
@@ -7330,7 +6780,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Des Signes dans l'Espace</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="57602">
 				<rom name="signes dans l'espace, des (1983)(vifi-nathan)(fr).k7" size="57602" crc="4ce1aa84" sha1="57a0403ebdf79242a15b8187e8037b8e9cafe314"/>
@@ -7339,10 +6788,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="signespaa" cloneof="signespa">
-		<description>Des Signes dans l'Espace (Alt)</description>
+		<description>Des Signes dans l'Espace (alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="58709">
 				<rom name="signes dans l'espace, des (1983)(vifi-nathan)(fr)[a].k7" size="58709" crc="20a86cf0" sha1="74814169a818fd2c3a79c191a221b3ba8c06ca58"/>
@@ -7351,10 +6799,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="signespab" cloneof="signespa">
-		<description>Des Signes dans l'Espace (Alt 2)</description>
+		<description>Des Signes dans l'Espace (alt 2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="58709">
 				<rom name="signes dans l'espace, des (1983)(vifi-nathan)(fr)[a2].k7" size="58709" crc="71727121" sha1="518ed54173cdd324d09120b48619287fba2688eb"/>
@@ -7363,10 +6810,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="signespac" cloneof="signespa">
-		<description>Des Signes dans l'Espace (Alt 3)</description>
+		<description>Des Signes dans l'Espace (alt 3)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="58709">
 				<rom name="des-signes-dans-l-espace_mo5.k7" size="58709" crc="d52260a6" sha1="3719dd5616f4369af267603690320c337fef5542"/>
@@ -7378,7 +6824,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Simulation de l'Evolution d'Un Objet dans un Champ de Gravitation</description>
 		<year>1985</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6448">
 				<rom name="simulation de l'evolution d'un objet dans un champ de gravitation (1985)(cndp)(fr).k7" size="6448" crc="efd8dbde" sha1="e75c456de67c902ece54ad26fdbd90108d449845"/>
@@ -7390,7 +6835,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sujet/Complement</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="17887928">
@@ -7406,10 +6850,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sujeta" cloneof="sujet">
-		<description>Sujet/Complement (Alt)</description>
+		<description>Sujet/Complement (alt)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="18417128">
@@ -7425,10 +6868,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sujetb" cloneof="sujet">
-		<description>Sujet/Complement (Alt 2)</description>
+		<description>Sujet/Complement (alt 2)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="48084">
@@ -7447,7 +6889,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Thermo</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17305">
 				<rom name="thermo (1985-09-13)(ustl - irem)(fr).k7" size="17305" crc="8d1dbaea" sha1="a2cdb6c373af9ad1a2e9bcb9342be13f727ea73b"/>
@@ -7459,7 +6900,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tissage</description>
 		<year>1985</year>
 		<publisher>Jean-Louis Sauzade</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14572">
 				<rom name="tissage (1985)(sauzade, jean-louis)(fr).k7" size="14572" crc="dab19d7c" sha1="ed41ad6812c0e3481f328c9dda5a715d0f528230"/>
@@ -7468,10 +6908,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="tissagea" cloneof="tissage">
-		<description>Tissage (Alt)</description>
+		<description>Tissage (alt)</description>
 		<year>1985</year>
 		<publisher>Jean-Louis Sauzade</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14572">
 				<rom name="tissage (1985)(sauzade, jean-louis)(fr)[a].k7" size="14572" crc="27a0430f" sha1="e720aa40b3260b3c7a92624ac1d9b30fe59b6060"/>
@@ -7480,10 +6919,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="tissageb" cloneof="tissage">
-		<description>Tissage (Alt 2)</description>
+		<description>Tissage (alt 2)</description>
 		<year>1985</year>
 		<publisher>Jean-Louis Sauzade</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14572">
 				<rom name="tissage_mo5.k7" size="14572" crc="9027ae52" sha1="3e6538ee43dbde842ffa56105d6c920dbffffbf2"/>
@@ -7495,7 +6933,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>TO7/MO5 a l'ecole</description>
 		<year>1985</year>
 		<publisher>Ediciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="109945">
@@ -7514,7 +6951,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vecteurs</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17156">
 				<rom name="vecteurs (1985-09-13)(ustl - irem)(fr).k7" size="17156" crc="c4a826c4" sha1="566cdc405a1156c38c411011f24ac12c422ad324"/>
@@ -7526,7 +6962,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vin sur Vin</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64693">
 				<rom name="vin sur vin (infogrames) (francois-xavier liagre) (imagiciel) (1984) (mo5).k7" size="64693" crc="b718404c" sha1="54193a8488b73accec3c8982da43f362f21dcce4"/>
@@ -7538,7 +6973,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Voici Mona Lisa</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49569">
 				<rom name="voici mona lisa (fil) (t. hatt) (1985) (mo5).k7" size="49569" crc="aa9c3050" sha1="7da3e20934305d1d15cb3f52c9cdcbf96c3b78e4"/>
@@ -7550,7 +6984,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wormy - Junior Computhink</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29109">
 				<rom name="wormy - junior computhink (1984)(hatier)(fr).k7" size="29109" crc="0a61be8e" sha1="1f699f2ae1fb76c538f684d500a45b2af13671f1"/>
@@ -7562,7 +6995,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Zorro</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12380">
 				<rom name="zorro (1985)(fil)(fr).k7" size="12380" crc="1aa537b1" sha1="ca7abe52e5da5c00f60db8e47e080f8fbb6bb999"/>
@@ -7576,7 +7008,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1000 Bornes</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17282">
 				<rom name="1000 bornes (1985)(free game blot)(fr).k7" size="17282" crc="8aea8e72" sha1="ee9bd7d9d94b7d38386cb91f6a128468fd2848a1"/>
@@ -7585,10 +7016,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="1000borna" cloneof="1000born">
-		<description>1000 Bornes (Alt)</description>
+		<description>1000 Bornes (alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17282">
 				<rom name="1000 bornes (1985)(free game blot)(fr)[a].k7" size="17282" crc="9d9a85a4" sha1="0e3eebce9b2d9146fe987525ba6daf5324608ae4"/>
@@ -7597,10 +7027,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="1000bornb" cloneof="1000born">
-		<description>1000 Bornes (Alt 2)</description>
+		<description>1000 Bornes (alt 2)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20114">
 				<rom name="1000 bornes (1985)(free game blot)[b].k7" size="20114" crc="21a22390" sha1="ad36270d8e3ad39047882812d6e250609d6608c5"/>
@@ -7609,10 +7038,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="1000bornc" cloneof="1000born">
-		<description>1000 Bornes (Alt 3)</description>
+		<description>1000 Bornes (alt 3)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20114">
 				<rom name="1000born.k7" size="20114" crc="bce22550" sha1="2698aad5742ecbdff0e5242c057dd179cfc09a48"/>
@@ -7621,10 +7049,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="1000bornd" cloneof="1000born">
-		<description>1000 Bornes (Alt 4)</description>
+		<description>1000 Bornes (alt 4)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17282">
 				<rom name="1000-bornes_mo5.k7" size="17282" crc="824ca054" sha1="b389df64c2b480dc68521296c0b4fde3f7b1dd22"/>
@@ -7636,7 +7063,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1789</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="73427">
@@ -7664,10 +7090,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="1789a" cloneof="1789">
-		<description>1789 (Alt)</description>
+		<description>1789 (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="73427">
@@ -7695,10 +7120,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="1789b" cloneof="1789">
-		<description>1789 (Alt 2)</description>
+		<description>1789 (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="73427">
 				<rom name="1789-1a_mo5.k7" size="73427" crc="e983601f" sha1="25b6efe4ab9b1ec34b91beb8ca4952e7e2a83361"/>
@@ -7725,7 +7149,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1815 (v2)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51930">
 				<rom name="1815 (198x)(cobra soft)(fr)[m mo5 2nd generation].k7" size="51930" crc="24352377" sha1="d5ad5df2c3aa336c55392df6d0a4e78ed069fd04"/>
@@ -7734,10 +7157,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="1815a" cloneof="1815">
-		<description>1815 (v2, Alt)</description>
+		<description>1815 (v2, alt)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51930">
 				<rom name="1815-v2_mo5.k7" size="51930" crc="c5fe5afa" sha1="1f2a266032f53f8fd28de0d260659accfc2a76c5"/>
@@ -7749,7 +7171,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1815 (v1)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51930">
 				<rom name="1815 (198x)(cobra soft)(fr).k7" size="51930" crc="31d12880" sha1="e6bd987a4a1504073477fa1410cfec5a4a86a8ed"/>
@@ -7758,10 +7179,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="18151a" cloneof="1815">
-		<description>1815 (v1, Alt)</description>
+		<description>1815 (v1, alt)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51930">
 				<rom name="1815-v1_mo5.k7" size="51930" crc="d01a510d" sha1="4066fc300a1bf994b7e6493790193fb6205cd998"/>
@@ -7783,10 +7203,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="3dfighta" cloneof="3dfight" supported="no">
-		<description>3D Fight (Alt)</description>
+		<description>3D Fight (alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34140">
 				<rom name="3d fight (1986)(loriciels)(fr)[b].k7" size="34140" crc="cdf97c00" sha1="1c84928b851be97c9e5de4e6cad685be1176949f"/>
@@ -7796,10 +7215,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="3dfightb" cloneof="3dfight" supported="no">
-		<description>3D Fight (Alt 2)</description>
+		<description>3D Fight (alt 2)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34140">
 				<rom name="3d fight (1986)(loriciels)(fr)[b2].k7" size="34140" crc="3a2dac6c" sha1="8b07249e4f452902ea2dcaffe1f8f6e3d86bf1d2"/>
@@ -7809,10 +7227,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="3dfightc" cloneof="3dfight" supported="no">
-		<description>3D Fight (Alt 3)</description>
+		<description>3D Fight (alt 3)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34138">
 				<rom name="3d fight (1986)(loriciels)(fr)[b3].k7" size="34138" crc="e7aafe23" sha1="4e6c9af428ca6144c2afcc6340aa6806a91677d3" status="baddump" />
@@ -7822,10 +7239,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="3dfightd" cloneof="3dfight" supported="no">
-		<description>3D Fight (Alt 4)</description>
+		<description>3D Fight (alt 4)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34140">
 				<rom name="3dfight-mo5 (k7).k7" size="34140" crc="4f41f172" sha1="8c8c1da7d48efbd92fb623d87342b3437d049419"/>
@@ -7837,7 +7253,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3D Sub</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48209">
 				<rom name="3d sub (1985)(loriciels)(fr).k7" size="48209" crc="b252051a" sha1="2e76c80ab61d353499ecda0344cddd13b9a965e2"/>
@@ -7846,10 +7261,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="3dsuba" cloneof="3dsub">
-		<description>3D Sub (Alt)</description>
+		<description>3D Sub (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48209">
 				<rom name="3d sub (1985)(loriciels)(fr)[a].k7" size="48209" crc="03850f6d" sha1="320b8207c09cf22fd2208526356b880070e2f523"/>
@@ -7858,10 +7272,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="3dsubb" cloneof="3dsub">
-		<description>3D Sub (Alt 2)</description>
+		<description>3D Sub (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48209">
 				<rom name="3d sub (1985)(loriciels)(fr)[a2].k7" size="48209" crc="e798db13" sha1="b1c21423a9cfe81918e5c058a3999ec01dfdbe7c"/>
@@ -7870,10 +7283,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="3dsubc" cloneof="3dsub">
-		<description>3D Sub (Alt 3)</description>
+		<description>3D Sub (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48209">
 				<rom name="3dsub_mo5.k7" size="48209" crc="5d9ecc70" sha1="a48f0cbb4e15755db0a8af988d2b5fca1d3eff52"/>
@@ -7885,7 +7297,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le 5eme Axe</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17284022">
 				<rom name="5eme axe, le (1985)(loriciels)(fr).wav" size="17284022" crc="a89e15ad" sha1="6128230563aad0fe7db0b6341eb7c657dc9f45da"/>
@@ -7894,10 +7305,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="5emeaxea" cloneof="5emeaxe">
-		<description>Le 5eme Axe (Alt)</description>
+		<description>Le 5eme Axe (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18873460">
 				<rom name="le-5eme-axe_mo5.wav" size="18873460" crc="d2eaa0e0" sha1="3e2defbe430895598d8140ccae4beb5c1b682a44"/>
@@ -7907,10 +7317,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="5emeaxeb" cloneof="5emeaxe" supported="no">
-		<description>Le 5eme Axe (Alt 2)</description>
+		<description>Le 5eme Axe (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52998">
 				<rom name="5eme axe, le (1985)(loriciels)(fr)[b].k7" size="52998" crc="c33e0138" sha1="f9dfd3b737a010cc1d4ee5cb61ee035e7312fc37"/>
@@ -7920,10 +7329,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="5emeaxec" cloneof="5emeaxe" supported="no">
-		<description>Le 5eme Axe (Alt 3)</description>
+		<description>Le 5eme Axe (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52998">
 				<rom name="5eme axe, le (1985)(loriciels)(fr)[b2].k7" size="52998" crc="7de608b7" sha1="ca43ab608a18e88463925ddb8005543149381e76"/>
@@ -7933,10 +7341,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="5emeaxed" cloneof="5emeaxe" supported="no">
-		<description>Le 5eme Axe (Alt 4)</description>
+		<description>Le 5eme Axe (alt 4)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52998">
 				<rom name="5eme axe (1985)(loriciels)[b].k7" size="52998" crc="844284dc" sha1="608fd89dc7609a212a3694467dff92deee90f1b4"/>
@@ -7946,10 +7353,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="5emeaxee" cloneof="5emeaxe" supported="no">
-		<description>Le 5eme Axe (Alt 5)</description>
+		<description>Le 5eme Axe (alt 5)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52998">
 				<rom name="le-5eme-axe_mo5.k7" size="52998" crc="6e3757f4" sha1="d03dbb177c2f36e3d3928b5b1b16dc7740e7c55a"/>
@@ -7961,7 +7367,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les 7 Magiciens</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17281">
 				<rom name="7 magiciens, les (1984)(to tek)(fr)(m5).k7" size="17281" crc="1d047ddf" sha1="6835342e7b32a437f7d200f4960c09ba26b92770"/>
@@ -7970,10 +7375,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="7magicia" cloneof="7magici">
-		<description>Les 7 Magiciens (Alt)</description>
+		<description>Les 7 Magiciens (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17281">
 				<rom name="7 magiciens, les (1984)(to tek)(fr)(m5)[a].k7" size="17281" crc="ee12a6a7" sha1="2da128ec05812779c73f533e1c901b43af01cccf"/>
@@ -7982,10 +7386,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="7magicib" cloneof="7magici">
-		<description>Les 7 Magiciens (Alt 2)</description>
+		<description>Les 7 Magiciens (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17281">
 				<rom name="7 magiciens, les (1984)(to tek)(fr)(m5)[a2].k7" size="17281" crc="85c3b805" sha1="ebeeddcb3ed85f40f93f79771f61123efa36da8f"/>
@@ -7994,10 +7397,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="7magicic" cloneof="7magici">
-		<description>Les 7 Magiciens (Alt 3)</description>
+		<description>Les 7 Magiciens (alt 3)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17281">
 				<rom name="les-7-magiciens_mo5.k7" size="17281" crc="cc2da4b3" sha1="d7fc3f4f93db9f158444e63b9c052f54043bb6e8"/>
@@ -8009,7 +7411,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Une Affaire en Or</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20893">
 				<rom name="affaire en or, une (198x)(free game blot)(fr).k7" size="20893" crc="e9a2e04d" sha1="bc980a2c16e225f1916f35752df46bd38e0b8fd4"/>
@@ -8018,10 +7419,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="affairora" cloneof="affairor">
-		<description>Une Affaire en Or (Alt)</description>
+		<description>Une Affaire en Or (alt)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22126">
 				<rom name="affaire en or, une (198x)(free game blot)(fr)[a].k7" size="22126" crc="8092be60" sha1="6f5394ad34d8540743db0e773c94f1e8d2b14b67"/>
@@ -8030,10 +7430,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="affairorb" cloneof="affairor">
-		<description>Une Affaire en Or (Alt 2)</description>
+		<description>Une Affaire en Or (alt 2)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22126">
 				<rom name="affaire en or, une (198x)(free game blot)(fr)[a2].k7" size="22126" crc="5db06513" sha1="0bf36e2ebd8bd797cc4aaefa4af3e0492f320bd3"/>
@@ -8042,10 +7441,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="affairorc" cloneof="affairor">
-		<description>Une Affaire en Or (Alt 3)</description>
+		<description>Une Affaire en Or (alt 3)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22126">
 				<rom name="une-affaire-en-or_mo5.k7" size="22126" crc="f73278b0" sha1="a29c753083ab69993e3062ac7fa946c346db8e16"/>
@@ -8058,7 +7456,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Affaire Sydney</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51542">
 				<rom name="affaire sydney, l' (1986)(infogrames)(fr)[b].k7" size="51542" crc="c2b26fc3" sha1="4f7a2bb01d0b7ac02e65de5cbf2d12bd4573e6f2"/>
@@ -8068,10 +7465,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="sydneya" cloneof="sydney" supported="no">
-		<description>L'Affaire Sydney (Alt)</description>
+		<description>L'Affaire Sydney (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51542">
 				<rom name="l'affaire sydney (infogrames) (gilles blancon) (1986).k7" size="51542" crc="d31b7c17" sha1="2485cbd8409b6d884b0c285a420e520c70152d41"/>
@@ -8081,10 +7477,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="sydneyb" cloneof="sydney" supported="no">
-		<description>L'Affaire Sydney (Alt 2)</description>
+		<description>L'Affaire Sydney (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="53222">
 				<rom name="l-affaire-sydney_mo5.k7" size="53222" crc="5d68b3e1" sha1="8785280916a547302e3eb1627cce6abc75c2b36f"/>
@@ -8097,7 +7492,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Affaire Vera Cruz</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48020">
 				<rom name="affaire vera cruz, l' (1986)(infogrames)(fr)[b].k7" size="48020" crc="b3ab84b5" sha1="b6fa3123deb445f70a3d91eaaaddf753b02b2205"/>
@@ -8107,10 +7501,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="veracruza" cloneof="veracruz" supported="no">
-		<description>L'Affaire Vera Cruz (Alt)</description>
+		<description>L'Affaire Vera Cruz (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48020">
 				<rom name="l'affaire vera cruz (infogrames) (gilles blancon) (1986).k7" size="48020" crc="f56dea4d" sha1="6998669fbe4861f5b479106ccbb8ca21849284d0"/>
@@ -8120,10 +7513,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="veracruzb" cloneof="veracruz" supported="no">
-		<description>L'Affaire Vera Cruz (Alt 2)</description>
+		<description>L'Affaire Vera Cruz (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49700">
 				<rom name="l-affaire-vera-cruz_mo5.k7" size="49700" crc="e6049712" sha1="9883f0a3061945703dc3c984fb168617ee6db59e"/>
@@ -8135,7 +7527,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Aigle d'Or</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40931">
 				<rom name="aigle d'or, l' (1985-02)(loriciels)(fr).k7" size="40931" crc="081bd8c9" sha1="dc2bb411ee0aeca0a5b47c465b0a8d163af67661"/>
@@ -8144,10 +7535,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="aigleora" cloneof="aigleor">
-		<description>L'Aigle d'Or (Alt)</description>
+		<description>L'Aigle d'Or (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43298">
 				<rom name="aigle d'or, l' (1985-02)(loriciels)(fr)[a].k7" size="43298" crc="f6f7a72b" sha1="5c813dcb0d68df02c557c3916ec5b8741a736d37"/>
@@ -8156,10 +7546,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="aigleorb" cloneof="aigleor">
-		<description>L'Aigle d'Or (Alt 2)</description>
+		<description>L'Aigle d'Or (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43298">
 				<rom name="aigle d'or, l' (1985-02)(loriciels)(fr)[a2].k7" size="43298" crc="37a13834" sha1="367e8980820b41602495bdd89694feb599661f48"/>
@@ -8168,10 +7557,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="aigleorc" cloneof="aigleor">
-		<description>L'Aigle d'Or (Alt 3)</description>
+		<description>L'Aigle d'Or (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40923">
 				<rom name="aigle d'or, l' (1985-02)(loriciels)(fr)[a3].k7" size="40923" crc="4db05ae8" sha1="b2dc7ca59204a0d136d06f654ee472feee208e5a"/>
@@ -8183,7 +7571,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Air Attack</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51108">
 				<rom name="air attack (1985)(loriciels)(fr).k7" size="51108" crc="721e741c" sha1="a19f999bcc02fa414a01dc6a6290747b734dba97"/>
@@ -8192,10 +7579,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="aattacka" cloneof="aattack">
-		<description>Air Attack (Alt)</description>
+		<description>Air Attack (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51363">
 				<rom name="air attack (1985)(loriciels)(fr)[a].k7" size="51363" crc="892d1c07" sha1="deb60e3c1605f1241199dd0046b321e8aa832f81"/>
@@ -8204,10 +7590,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="aattackb" cloneof="aattack">
-		<description>Air Attack (Alt 2)</description>
+		<description>Air Attack (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51363">
 				<rom name="air attack (1985)(loriciels)(fr)[a2].k7" size="51363" crc="1a586b9d" sha1="9ff613d51692b313f747fc88e92a2b5257908228"/>
@@ -8216,10 +7601,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="aattackc" cloneof="aattack">
-		<description>Air Attack (Alt 3)</description>
+		<description>Air Attack (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51571">
 				<rom name="air attack (microids) (m. beziat, e. grassiano) (1985) (mo5).k7" size="51571" crc="e744467e" sha1="99e4c18ec110b1c3d44850940d8a1d4d6edf0254"/>
@@ -8231,7 +7615,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Albatros</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4403">
 				<rom name="albatros, l' (198x)(-)(fr).k7" size="4403" crc="2832af9c" sha1="b2a70bd5a0c1b567927888b72afa419be867179c"/>
@@ -8240,10 +7623,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="albatrosa" cloneof="albatros">
-		<description>L'Albatros (Alt)</description>
+		<description>L'Albatros (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4403">
 				<rom name="albatros, l' (198x)(-)(fr)[a].k7" size="4403" crc="53717a18" sha1="04203937f43e470ebb41f3a6f0d652f65c84c565"/>
@@ -8252,10 +7634,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="albatrosb" cloneof="albatros">
-		<description>L'Albatros (Alt 2)</description>
+		<description>L'Albatros (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4403">
 				<rom name="l-albatros_mo5.k7" size="4403" crc="3d445d5a" sha1="7cc88b3ef47d60aaab05a582ada6a063b414972c"/>
@@ -8267,7 +7648,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>America's Cup</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39920">
 				<rom name="america's cup (1986)(free game blot)(fr).k7" size="39920" crc="87c6d3cc" sha1="eefd8915bff39b52b6ae76836adc2c8c002246e7"/>
@@ -8276,10 +7656,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="americaca" cloneof="americac">
-		<description>America's Cup (Alt)</description>
+		<description>America's Cup (alt)</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39920">
 				<rom name="america's cup (1986)(free game blot)(fr)[a].k7" size="39920" crc="5a2944e2" sha1="34d40c4d6d7693cc0d7eb9f091075f6b98a2fa13"/>
@@ -8291,7 +7670,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6616646">
 				<rom name="androides (1985)(infogrames)(fr)[loadm'''',,r].wav" size="6616646" crc="399a1429" sha1="0e44c0ef4a311cf55de4ffb67f121ec4678a3fe6"/>
@@ -8301,10 +7679,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="androida" cloneof="android" supported="no">
-		<description>Androides (Alt)</description>
+		<description>Androides (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17705">
 				<rom name="androides (1985)(infogrames)(fr).k7" size="17705" crc="e43f1253" sha1="651b27edec2a1cc29aad6b3fe44d90e6df466666"/>
@@ -8314,10 +7691,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="androidb" cloneof="android" supported="no">
-		<description>Androides (Alt 2)</description>
+		<description>Androides (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18257">
 				<rom name="androides (1985)(infogrames)(fr)[a].k7" size="18257" crc="0dedd2dc" sha1="c53e3e91fdf0f622a5091d9130b8148b41a47835"/>
@@ -8327,10 +7703,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="androidc" cloneof="android" supported="no">
-		<description>Androides (Alt 3)</description>
+		<description>Androides (alt 3)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18255">
 				<rom name="androides (1985)(infogrames)(fr)[b2].k7" size="18255" crc="7c03d67a" sha1="3d72861598e72fcec4dc234b90e306723d00afaf"/>
@@ -8340,10 +7715,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="androidd" cloneof="android" supported="no">
-		<description>Androides (Alt 4)</description>
+		<description>Androides (alt 4)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18255">
 				<rom name="androides (1985)(infogrames)(fr)[b3].k7" size="18255" crc="91d613f9" sha1="d1f0c1794bc2a4eb80e86fde448e6d57be77aa25"/>
@@ -8356,7 +7730,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides (Bad?)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18255">
 				<rom name="androides (1985)(infogrames)(fr)[b].k7" size="18255" crc="e0163b6d" sha1="573083d2b38f2743a72417ff489f97b8493e91c3" status="baddump" />
@@ -8368,7 +7741,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Araignees</description>
 		<year>1985</year>
 		<publisher>Microtom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5702">
 				<rom name="araignees (1985)(microtom)(fr)(pd).k7" size="5702" crc="78db2fe3" sha1="3a917432d1e01654a62e2fb9edbf00d8e9454c8f"/>
@@ -8377,10 +7749,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="araigneea" cloneof="araignee">
-		<description>Araignees (Alt)</description>
+		<description>Araignees (alt)</description>
 		<year>1985</year>
 		<publisher>Microtom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6014">
 				<rom name="araignees (1985)(microtom)(fr)(pd)[a].k7" size="6014" crc="f3ed32e8" sha1="46138fca03737608f3a56f65b7e5fc4e139a4901"/>
@@ -8389,10 +7760,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="araigneeb" cloneof="araignee">
-		<description>Araignees (Alt 2)</description>
+		<description>Araignees (alt 2)</description>
 		<year>1985</year>
 		<publisher>Microtom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6014">
 				<rom name="araignees (1985)(microtom)(fr)(pd)[a2].k7" size="6014" crc="26fa4d20" sha1="61f12afb40361d785696e5d153b5631db975aacc"/>
@@ -8401,10 +7771,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="araigneec" cloneof="araignee">
-		<description>Araignees (Alt 3)</description>
+		<description>Araignees (alt 3)</description>
 		<year>1985</year>
 		<publisher>Microtom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6014">
 				<rom name="araignees_mo5.k7" size="6014" crc="776d4b00" sha1="f17990c75247d50f7c734dbfe9b771a03371c65b"/>
@@ -8416,7 +7785,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arkanoid</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29054">
 				<rom name="arkanoid (1987)(fil)(fr).k7" size="29054" crc="8f6b0676" sha1="af1dae5512bb1bd3d87c2b2c6fcd06d845c5c4ce"/>
@@ -8425,10 +7793,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="arkanoida" cloneof="arkanoid">
-		<description>Arkanoid (Alt)</description>
+		<description>Arkanoid (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29054">
 				<rom name="arkanoid (1987)(fil)(fr)[a].k7" size="29054" crc="e3fe50d0" sha1="d8e43fbf1320fa93d3844aff0ef65c27f32fb9d9"/>
@@ -8437,10 +7804,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="arkanoidb" cloneof="arkanoid">
-		<description>Arkanoid (Alt 2)</description>
+		<description>Arkanoid (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29054">
 				<rom name="arkanoid (fil) (james higgins) (1987) (mo5).k7" size="29054" crc="76e7a3e3" sha1="1cb9d8cb1f82510a62b0b221bc95830a1d5c495d"/>
@@ -8452,7 +7818,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arkanoid (Trained +2 by Yoan Roiu)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28975">
 				<rom name="arkanoid (1987)(fil)(fr)[t +2 yoan riou].k7" size="28975" crc="dbb3683e" sha1="6594f562feca732862d533d7932852439d1960e4"/>
@@ -8464,7 +7829,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Armada</description>
 		<year>1984</year>
 		<publisher>Langage et Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6033">
 				<rom name="armada (langage et informatique) (j. salon) (1984) (mo5).k7" size="6033" crc="bff29785" sha1="e6fbe8a35fc894379f2cfcba24f4bcf1dcb93f42"/>
@@ -8476,7 +7840,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arsene Lapin</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33520">
 				<rom name="arsene lapin (1984)(infogrames)(fr).k7" size="33520" crc="a43d80f1" sha1="8528b1eeaaac687ceff577c5468839c7b71ca7a2"/>
@@ -8485,10 +7848,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="arslapina" cloneof="arslapin">
-		<description>Arsene Lapin (Alt)</description>
+		<description>Arsene Lapin (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33520">
 				<rom name="arsene lapin (1984)(infogrames)(fr)[a].k7" size="33520" crc="1f660955" sha1="6401b1683958045ef1116b826e6cbaf56a9bc8a6"/>
@@ -8497,10 +7859,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="arslapinb" cloneof="arslapin">
-		<description>Arsene Lapin (Alt 2)</description>
+		<description>Arsene Lapin (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33520">
 				<rom name="arsene-lapin_mo5.k7" size="33520" crc="c767e17f" sha1="d87a531792930b06f2df0033a2731766d6e12d03"/>
@@ -8512,7 +7873,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Asterix et la Potion Magique</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45106">
 				<rom name="asterix et la potion magique (198x)(fil)(fr).k7" size="45106" crc="916d74de" sha1="1ada057a26fdfc0137d6ecd94b1a709b898a5444"/>
@@ -8521,10 +7881,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="asterixa" cloneof="asterix">
-		<description>Asterix et la Potion Magique (Alt)</description>
+		<description>Asterix et la Potion Magique (alt)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47655">
 				<rom name="asterix et la potion magique (198x)(fil)(fr)[a].k7" size="47655" crc="493fba03" sha1="512ec0b610b969ca802cdbd5dd64f6f5b9c14f03"/>
@@ -8533,10 +7892,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="asterixb" cloneof="asterix">
-		<description>Asterix et la Potion Magique (Alt 2)</description>
+		<description>Asterix et la Potion Magique (alt 2)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47655">
 				<rom name="asterix et la potion magique (198x)(fil)(fr)[a2].k7" size="47655" crc="45a93e6d" sha1="392f16b2db949f8239e01534f0cc7e68e009846c"/>
@@ -8545,10 +7903,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="asterixc" cloneof="asterix">
-		<description>Asterix et la Potion Magique (Alt 3)</description>
+		<description>Asterix et la Potion Magique (alt 3)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47655">
 				<rom name="asterix-et-la-potion-magique_mo5.k7" size="47655" crc="23a6a1ba" sha1="2d1293ef935c38b71a4fdded6568c4d2950828b9"/>
@@ -8560,7 +7917,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Astromus</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24649">
 				<rom name="astromus (1984)(logimus)(fr).k7" size="24649" crc="bf8a905a" sha1="d5a3f48bd1046b66b975eab6c6e7739142ab9d4a"/>
@@ -8569,10 +7925,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="astromusa" cloneof="astromus">
-		<description>Astromus (Alt)</description>
+		<description>Astromus (alt)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24768">
 				<rom name="astromus (1984)(logimus)(fr)[a].k7" size="24768" crc="741b3c57" sha1="92b5655f7e2cacba31417c45575439742ec8adf9"/>
@@ -8581,10 +7936,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="astromusb" cloneof="astromus">
-		<description>Astromus (Alt 2)</description>
+		<description>Astromus (alt 2)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24768">
 				<rom name="astromus (1984)(logimus)(fr)[a2].k7" size="24768" crc="e5933eaf" sha1="e863671ff5b60bc1f5dc39c98305d1888815fd91"/>
@@ -8593,10 +7947,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="astromusc" cloneof="astromus">
-		<description>Astromus (Alt 3)</description>
+		<description>Astromus (alt 3)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24768">
 				<rom name="astromus (1984)(logimus)(fr)[a3].k7" size="24768" crc="b30d392d" sha1="102d49e4475318883597e58d9d496db6c086d951"/>
@@ -8605,10 +7958,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="astromusd" cloneof="astromus">
-		<description>Astromus (Alt 4)</description>
+		<description>Astromus (alt 4)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24768">
 				<rom name="astromus_mo5.k7" size="24768" crc="4c316117" sha1="17ce1273360281d0fb9bcec0ff11a1c7df9b62ba"/>
@@ -8620,7 +7972,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Atlantis</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43299">
 				<rom name="atlantis (cobrasoft) (serge querne) (1985) (mo5 k7).k7" size="43299" crc="77d11762" sha1="e961a1f745a258ce6f4093b332be82e19b15fdd5"/>
@@ -8632,7 +7983,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Atomik</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31457">
 				<rom name="atomik (1987)(fil)(fr).k7" size="31457" crc="715fe631" sha1="9d6ad879c1404bb5df0a71e001410d5a75ad882b"/>
@@ -8641,10 +7991,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="atomika" cloneof="atomik">
-		<description>Atomik (Alt)</description>
+		<description>Atomik (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31709">
 				<rom name="atomik (1987)(fil)(fr)[a].k7" size="31709" crc="5e149fea" sha1="325b8c042a90a455322384421550ac7bf7f3fbcd"/>
@@ -8653,10 +8002,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="atomikb" cloneof="atomik">
-		<description>Atomik (Alt 2)</description>
+		<description>Atomik (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31709">
 				<rom name="atomik (1987)(fil)(fr)[a2].k7" size="31709" crc="509545e4" sha1="44304d62b231c3747655fdead89bfec0e0e2ebb0"/>
@@ -8665,10 +8013,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="atomikc" cloneof="atomik">
-		<description>Atomik (Alt 3)</description>
+		<description>Atomik (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31709">
 				<rom name="atomik_mo5.k7" size="31709" crc="1c68f03b" sha1="a202e3afacdc1b305fc0b2d9ab963e60030e2cbc"/>
@@ -8680,7 +8027,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Avenger</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51067">
 				<rom name="avenger (1986)(fil)(fr).k7" size="51067" crc="4187026a" sha1="a96685478a82e7f42e88a7d341e192c3749b07d5"/>
@@ -8689,10 +8035,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="avengera" cloneof="avenger">
-		<description>Avenger (Alt)</description>
+		<description>Avenger (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51354">
 				<rom name="avenger (1986)(fil)(fr)[a].k7" size="51354" crc="fef353b6" sha1="cfe2d7ffbc697e998c95d8775855dcfcc56ddb05"/>
@@ -8701,10 +8046,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="avengerb" cloneof="avenger">
-		<description>Avenger (Alt 2)</description>
+		<description>Avenger (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51354">
 				<rom name="avenger (1986)(fil)(fr)[a2].k7" size="51354" crc="f097faa8" sha1="633e56b52ee2ff433a4386b9172e463a432c8336"/>
@@ -8713,10 +8057,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="avengerc" cloneof="avenger">
-		<description>Avenger (Alt 3)</description>
+		<description>Avenger (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51354">
 				<rom name="avenger_mo5.k7" size="51354" crc="77a91490" sha1="0167c7f3efa47a966439019c075c4b7d88af765b"/>
@@ -8725,10 +8068,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="avengerd" cloneof="avenger">
-		<description>Avenger (Alt 4?)</description>
+		<description>Avenger (alt 4?)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="55046">
 				<rom name="avenger.k7" size="55046" crc="c92ccf6f" sha1="a80661b4c023d0df7eff72d8a598b74d36883fdc"/>
@@ -8740,7 +8082,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Backgammon</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17693">
 				<rom name="backgammon (1984)(vifi-nathan)(fr).k7" size="17693" crc="8dc00333" sha1="8e042ac6aa0a49bfd914d1dcecf47a5a8c593f3b"/>
@@ -8749,10 +8090,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="backgamma" cloneof="backgamm">
-		<description>Backgammon (Alt)</description>
+		<description>Backgammon (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17693">
 				<rom name="backgammon (1984)(vifi-nathan)(fr)[a].k7" size="17693" crc="b9d931e6" sha1="1604e9d1ff8fe9ff9d149b450027c6636e113034"/>
@@ -8761,10 +8101,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="backgammb" cloneof="backgamm">
-		<description>Backgammon (Alt 2)</description>
+		<description>Backgammon (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17693">
 				<rom name="backgammon (1984)(vifi-nathan)(fr)[a2].k7" size="17693" crc="1641bae4" sha1="ff805139f8317a365661abfbff0bae6ce98ba92e"/>
@@ -8773,10 +8112,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="backgammc" cloneof="backgamm">
-		<description>Backgammon (Alt 3)</description>
+		<description>Backgammon (alt 3)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17693">
 				<rom name="backgammon_mo5.k7" size="17693" crc="2dc3ff38" sha1="a02875395ba52aed2a6fb6b952bdc20a8f3acfda"/>
@@ -8788,7 +8126,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Bagh Chal</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16637">
 				<rom name="bag chal ou la tactique du tigre, le (1985)(free game blot)(fr).k7" size="16637" crc="679f75e9" sha1="918da48e861974d5f745e9ca2824ca2c5fe285d2"/>
@@ -8797,10 +8134,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="baghchala" cloneof="baghchal">
-		<description>Le Bagh Chal (Alt)</description>
+		<description>Le Bagh Chal (alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16637">
 				<rom name="bag chal ou la tactique du tigre, le (1985)(free game blot)(fr)[a].k7" size="16637" crc="d6711009" sha1="cf5c163a07968bec5c6804e9a7f397db36f2236d"/>
@@ -8809,10 +8145,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="baghchalb" cloneof="baghchal">
-		<description>Le Bagh Chal (Alt 2)</description>
+		<description>Le Bagh Chal (alt 2)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16637">
 				<rom name="le-bagh-chal_mo5.k7" size="16637" crc="efb45946" sha1="51515251d8251ba832068cef200f956c56a7ad82"/>
@@ -8824,7 +8159,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balade en Ballon</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28289">
 				<rom name="balade en ballon (1985)(sprites)(fr).k7" size="28289" crc="874da006" sha1="2e6b1e056e8260bd4edf0e450615664da0e32665"/>
@@ -8833,10 +8167,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="baladbala" cloneof="baladbal">
-		<description>Balade en Ballon (Alt)</description>
+		<description>Balade en Ballon (alt)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28289">
 				<rom name="balade en ballon (1985)(sprites)(fr)[a].k7" size="28289" crc="90c5f03f" sha1="c85cc608b03737c3369e0857975950ee7d81772f"/>
@@ -8845,10 +8178,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="baladbalb" cloneof="baladbal">
-		<description>Balade en Ballon (Alt 2)</description>
+		<description>Balade en Ballon (alt 2)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28289">
 				<rom name="balade en ballon (1985)(sprites)(fr)[a2].k7" size="28289" crc="f09cf0d3" sha1="4f205ff4c48a383f9585ab57c793b3b878918e31"/>
@@ -8857,10 +8189,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="baladbalc" cloneof="baladbal">
-		<description>Balade en Ballon (Alt 3)</description>
+		<description>Balade en Ballon (alt 3)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36193">
 				<rom name="balade en ballon (sprites) (gilbert berot) (1985) (mo5).k7" size="36193" crc="1ca943d7" sha1="dd5db3935dc41e8c942fd1fc16870cd9c13fa663"/>
@@ -8872,7 +8203,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ball Trap</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21651">
 				<rom name="ball trap (sprites) (1985) (mo5).k7" size="21651" crc="930f2c09" sha1="cd9a69578a557f165a9ed59ad7c7c4a750d605ef"/>
@@ -8884,7 +8214,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balthazar</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43445">
 				<rom name="balthazar (1987)(titus software)(fr).k7" size="43445" crc="eb8d52ef" sha1="1fcb6f63627a976e57550280fd25bdf60cf350a3"/>
@@ -8893,10 +8222,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="balthazaa" cloneof="balthaza">
-		<description>Balthazar (Alt)</description>
+		<description>Balthazar (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43604">
 				<rom name="balthazar (1987)(titus software)(fr)[a].k7" size="43604" crc="ebba62fe" sha1="c98a6e6c84790a5b3e775ee6ec97cb740f9cc8d7"/>
@@ -8905,10 +8233,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="balthazab" cloneof="balthaza">
-		<description>Balthazar (Alt 2)</description>
+		<description>Balthazar (alt 2)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43604">
 				<rom name="balthazar (1987)(titus software)(fr)[a2].k7" size="43604" crc="89e842d0" sha1="3200ab019faadb838741a9899294584be71df603"/>
@@ -8917,10 +8244,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="balthazac" cloneof="balthaza">
-		<description>Balthazar (Alt 3)</description>
+		<description>Balthazar (alt 3)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43604">
 				<rom name="balthazar_mo5.k7" size="43604" crc="e76630c3" sha1="d3b6197caa684c1c61c147717537be63fbbe73d0"/>
@@ -8932,7 +8258,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Barry McGuigan Championship Boxing</description>
 		<year>198?</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35419">
 				<rom name="barry mcguigan championship boxing (198x)(microids)(fr).k7" size="35419" crc="8085d757" sha1="bc670d997ff6fc38e2027437b3fcf338d93cb5f8"/>
@@ -8941,10 +8266,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="barrymcga" cloneof="barrymcg">
-		<description>Barry McGuigan Championship Boxing (Alt)</description>
+		<description>Barry McGuigan Championship Boxing (alt)</description>
 		<year>198?</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35634">
 				<rom name="barry mcguigan championship boxing (198x)(microids)(fr)[a].k7" size="35634" crc="bf63f92f" sha1="233988a7ea077e3bdeb515ea45b61a983b6a627d"/>
@@ -8953,10 +8277,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="barrymcgb" cloneof="barrymcg">
-		<description>Barry McGuigan Championship Boxing (Alt 2)</description>
+		<description>Barry McGuigan Championship Boxing (alt 2)</description>
 		<year>198?</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35634">
 				<rom name="barry mcguigan championship boxing (198x)(microids)(fr)[a2].k7" size="35634" crc="96a37b54" sha1="af0963bcbdbbb36fb33bbf98da71b49aab7e9363"/>
@@ -8968,7 +8291,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Beach-Head</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27830">
 				<rom name="bh 1055 face b.k7" size="27830" crc="9a1a11e0" sha1="4e77b5723cd4dc48b37c5d11f94e51cae74b42fb"/>
@@ -8977,10 +8299,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="beacheada" cloneof="beachead">
-		<description>Beach-Head (Alt)</description>
+		<description>Beach-Head (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27830">
 				<rom name="bh 1055 face b [a].k7" size="27830" crc="63d330b4" sha1="4625a2b3e5d864e62c1346cb0e2267cc15d8729a"/>
@@ -8989,10 +8310,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="beacheadb" cloneof="beachead">
-		<description>Beach-Head (Alt 2)</description>
+		<description>Beach-Head (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27830">
 				<rom name="bh 1055 face b [a2].k7" size="27830" crc="66865526" sha1="85b9d09806ab3d176f586267a3170ca7fd921026"/>
@@ -9001,10 +8321,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="beacheadc" cloneof="beachead">
-		<description>Beach-Head (Alt 3)</description>
+		<description>Beach-Head (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27830">
 				<rom name="beach-head_mo5.k7" size="27830" crc="5eeab28e" sha1="827ef11f95d27fdcd1e983e8849013be8aeb9597"/>
@@ -9016,7 +8335,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bidul</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11007">
 				<rom name="bidul (1984)(infogrames)(fr).k7" size="11007" crc="fd4507d8" sha1="a137be097293cef9a7ab61c993483539240f96ca"/>
@@ -9025,10 +8343,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="bidula" cloneof="bidul">
-		<description>Bidul (Alt)</description>
+		<description>Bidul (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11007">
 				<rom name="bidul (1984)(infogrames)(fr)[a].k7" size="11007" crc="0478846e" sha1="b5ecf776c79545704c4851b61ebfaefc46093438"/>
@@ -9037,10 +8354,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="bidulb" cloneof="bidul">
-		<description>Bidul (Alt 2)</description>
+		<description>Bidul (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11007">
 				<rom name="bidul_mo5.k7" size="11007" crc="bc8ce84f" sha1="ca864e43da54724d99c171b115456c1dab5412a2"/>
@@ -9052,7 +8368,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Billard Americain (Hebdogiciel no. 84)</description>
 		<year>1985</year>
 		<publisher>Jean-Pierre Quelo - Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7562">
 				<rom name="billardamericain.k7" size="7562" crc="fa85bb96" sha1="5b53f1fedc7fe0fc6b6447968ac7ddd0b33bc83f"/>
@@ -9064,7 +8379,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blitz Krieg</description>
 		<year>198?</year>
 		<publisher>Francis Malard</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13372">
 				<rom name="blitz krieg (198x)(malard, francis)(fr)(pd).k7" size="13372" crc="148c5dfc" sha1="281a17443e11dbd61df6d31978149590cf4eb9aa"/>
@@ -9073,10 +8387,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="blitzkrga" cloneof="blitzkrg">
-		<description>Blitz Krieg (Alt)</description>
+		<description>Blitz Krieg (alt)</description>
 		<year>198?</year>
 		<publisher>Francis Malard</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13372">
 				<rom name="blitz krieg (198x)(malard, francis)(fr)(pd)[a].k7" size="13372" crc="6b9d8774" sha1="e2dd865e005d3755b16b53772114c112ec343b7e"/>
@@ -9085,10 +8398,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="blitzkrgb" cloneof="blitzkrg">
-		<description>Blitz Krieg (Alt 2)</description>
+		<description>Blitz Krieg (alt 2)</description>
 		<year>198?</year>
 		<publisher>Francis Malard</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13372">
 				<rom name="blitz krieg (198x)(malard, francis)(fr)(pd)[a2].k7" size="13372" crc="e00d806d" sha1="8bf4b8f984dbc2f3869da3bcbc8a294802f037aa"/>
@@ -9097,10 +8409,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="blitzkrgc" cloneof="blitzkrg">
-		<description>Blitz Krieg (Alt 3)</description>
+		<description>Blitz Krieg (alt 3)</description>
 		<year>198?</year>
 		<publisher>Francis Malard</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13372">
 				<rom name="blitz-krieg_mo5.k7" size="13372" crc="2a5dbd34" sha1="c692550ba2332c84f7e8426e6498d067376b3426"/>
@@ -9112,7 +8423,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blue War</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38315">
 				<rom name="blue war - le bateau (1986)(free game blot)(fr).k7" size="38315" crc="94f07b56" sha1="aa6c2ad03e17ffb190816e14a0d83641eacbedaf"/>
@@ -9121,10 +8431,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="bluewara" cloneof="bluewar">
-		<description>Blue War (Alt)</description>
+		<description>Blue War (alt)</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38315">
 				<rom name="blue war (1986)(free game blot).k7" size="38315" crc="4aca3466" sha1="36cb790e3cd1da59b8080b314f366c1fda5a379d"/>
@@ -9133,10 +8442,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="bluewarb" cloneof="bluewar">
-		<description>Blue War (Alt 2)</description>
+		<description>Blue War (alt 2)</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38315">
 				<rom name="blue-war_mo5.k7" size="38315" crc="c8c191f3" sha1="b6877f6e764b71475447b449e5cdeab3bff29efe"/>
@@ -9148,7 +8456,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bomber</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8391">
 				<rom name="bomber (1986)(hebdogiciel)(fr)(pd).k7" size="8391" crc="cb84e6fa" sha1="ef3aba24162a7c04f8acf38ad84573b717bdbcef"/>
@@ -9157,10 +8464,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="bombera" cloneof="bomber">
-		<description>Bomber (Alt)</description>
+		<description>Bomber (alt)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8391">
 				<rom name="bomber (1986)(hebdogiciel)(fr)(pd)[a].k7" size="8391" crc="c6e47553" sha1="da680c3578d5725b99ba1af93cd14ee2bd83bc60"/>
@@ -9169,10 +8475,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="bomberb" cloneof="bomber">
-		<description>Bomber (Alt 2)</description>
+		<description>Bomber (alt 2)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8391">
 				<rom name="bomber (19xx)(hebdogiciel)(pd).k7" size="8391" crc="1add4de5" sha1="c3b9d3387816b197e9f43614baaf594dc38c6be2"/>
@@ -9181,10 +8486,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="bomberc" cloneof="bomber">
-		<description>Bomber (Alt 3)</description>
+		<description>Bomber (alt 3)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8391">
 				<rom name="bomber_mo5.k7" size="8391" crc="95f3827c" sha1="dd0ffc030abf049dc8e104dd4666f2a22317e734"/>
@@ -9196,7 +8500,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Boufy</description>
 		<year>198?</year>
 		<publisher>Merien Ronan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17772">
 				<rom name="boufy (198x)(ronan, merien)(fr).k7" size="17772" crc="7bc2a8f3" sha1="65e05499d33549d2f8f8d1f53c353418aa6040bf"/>
@@ -9205,10 +8508,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="boufya" cloneof="boufy">
-		<description>Boufy (Alt)</description>
+		<description>Boufy (alt)</description>
 		<year>198?</year>
 		<publisher>Merien Ronan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17772">
 				<rom name="boufy (198x)(ronan, merien)(fr)[a].k7" size="17772" crc="33f797d0" sha1="5ef2bc17b5c76fbb75ce29d68123edc6ffc68b38"/>
@@ -9217,10 +8519,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="boufyb" cloneof="boufy">
-		<description>Boufy (Alt 2)</description>
+		<description>Boufy (alt 2)</description>
 		<year>198?</year>
 		<publisher>Merien Ronan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17772">
 				<rom name="boufy_mo5.k7" size="17772" crc="8fb23f19" sha1="5413ce0370a2dbe03ba91ce1e99e6661970a7773"/>
@@ -9232,7 +8533,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bowling Fou</description>
 		<year>1985</year>
 		<publisher>Brunosoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14379">
 				<rom name="bowling fou (1985)(brunosoft)(fr).k7" size="14379" crc="7c9a0275" sha1="fce9d946d4d94d92f88c9ebdb700d55f56c19788"/>
@@ -9241,10 +8541,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="bowlfoua" cloneof="bowlfou">
-		<description>Bowling Fou (Alt)</description>
+		<description>Bowling Fou (alt)</description>
 		<year>1985</year>
 		<publisher>Brunosoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14379">
 				<rom name="bowling fou (1985)(brunosoft)(fr)[a].k7" size="14379" crc="1ad8eba2" sha1="fb2d9e107d3d3d25e8339af66a9411bb479e0328"/>
@@ -9253,10 +8552,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="bowlfoub" cloneof="bowlfou">
-		<description>Bowling Fou (Alt 2)</description>
+		<description>Bowling Fou (alt 2)</description>
 		<year>1985</year>
 		<publisher>Brunosoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14379">
 				<rom name="bowling-fou_mo5.k7" size="14379" crc="7c9f1588" sha1="da5fc718bf9b1a87e7846676f11c6a7b9ce0d6c4"/>
@@ -9268,7 +8566,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Brain Power</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="82480">
 				<rom name="brain power (1987)(softbook)(fr).k7" size="82480" crc="40ae75c7" sha1="3c65d21cfbe0c1e99ba80edd82cf381e05cf9bf1"/>
@@ -9277,10 +8574,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="brainpwra" cloneof="brainpwr">
-		<description>Brain Power (Alt)</description>
+		<description>Brain Power (alt)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="82480">
 				<rom name="brain power (1987)(softbook)(fr)[a].k7" size="82480" crc="6e6ff441" sha1="231e9e4f3f8734210299253cd2c7fc39920aee8d"/>
@@ -9289,10 +8585,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="brainpwrb" cloneof="brainpwr">
-		<description>Brain Power (Alt 2)</description>
+		<description>Brain Power (alt 2)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="82472">
 				<rom name="brain power (softbook) (inconnus) (1987) (mo5).k7" size="82472" crc="6dd1baef" sha1="2e23334926675bc15cd7370ff62ab9154a25371a"/>
@@ -9301,10 +8596,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="brainpwrc" cloneof="brainpwr">
-		<description>Brain Power (WAV Format)</description>
+		<description>Brain Power (WAV format)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24431561">
 				<rom name="brain power (1987)(softbook)(fr).wav" size="24431561" crc="f2cb42e9" sha1="a9aa9c1cdcb6753aa878d2fcc897d69732e7ac8e"/>
@@ -9317,7 +8611,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Brigade du Feu</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32679">
 				<rom name="brigade du feu (1985)(coktel vision)(fr)[b].k7" size="32679" crc="f1f96c4f" sha1="57fe6203a07135e181bc1992af8a7c47a6ca9ffc"/>
@@ -9329,7 +8622,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Buds</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20544">
 				<rom name="buds (1984)(to tek)(fr).k7" size="20544" crc="fadb00d9" sha1="76d8c8cfb6974fc3b0a1c17917a774c5c7c87e3e"/>
@@ -9338,10 +8630,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="budsa" cloneof="buds">
-		<description>Buds (Alt)</description>
+		<description>Buds (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20544">
 				<rom name="buds (1984)(to tek)(fr)[a].k7" size="20544" crc="82b8008c" sha1="714e11d5edb254e6371dfebbbc8ceb5bd5630f91"/>
@@ -9350,10 +8641,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="budsb" cloneof="buds">
-		<description>Buds (Alt 2)</description>
+		<description>Buds (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20544">
 				<rom name="buds (1984)(to tek)(fr)[a2].k7" size="20544" crc="cb9b5def" sha1="3de499300342c6b1d19fca44a4a4f0635e9c5e54"/>
@@ -9362,10 +8652,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="budsc" cloneof="buds">
-		<description>Buds (Alt 3)</description>
+		<description>Buds (alt 3)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20544">
 				<rom name="buds_mo5.k7" size="20544" crc="516619f1" sha1="4bc1d367374dd7d4f91025b19857eb51e8ccde99"/>
@@ -9377,7 +8666,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bus</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6074">
 				<rom name="bus (1986-09-09)(rubier, javier marco)(es).k7" size="6074" crc="82b8c659" sha1="536cdb142bbb0ef03eab698a489e8c757372afc7"/>
@@ -9386,10 +8674,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="busa" cloneof="bus">
-		<description>Bus (Alt)</description>
+		<description>Bus (alt)</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6074">
 				<rom name="bus (1986-09-09)(marco rubio, javier)(es)[a].k7" size="6074" crc="cb1a6000" sha1="d421eafdc14a8250d59f753890c20d723c86e2d6"/>
@@ -9398,10 +8685,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="busb" cloneof="bus">
-		<description>Bus (Alt 2)</description>
+		<description>Bus (alt 2)</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6074">
 				<rom name="bus_mo5.k7" size="6074" crc="173de304" sha1="9e7bbb9fa99be77afe613460d09e2cf5eb712213"/>
@@ -9413,7 +8699,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Business+</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23433">
 				<rom name="business+ (1986)(fil)(fr).k7" size="23433" crc="649af866" sha1="02dba608ae005066eadbe4bafdf2243185ddc1f8"/>
@@ -9422,10 +8707,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="businessa" cloneof="business">
-		<description>Business+ (Alt)</description>
+		<description>Business+ (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23433">
 				<rom name="business+ (1986)(fil)(fr)[m title screen].k7" size="23433" crc="b5201026" sha1="25c5132904c4d87a4a2288e61d29cf5fbb4929f9"/>
@@ -9434,10 +8718,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="businessb" cloneof="business">
-		<description>Business+ (Alt 2)</description>
+		<description>Business+ (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23433">
 				<rom name="business+ (1986)(fil)(fr)[m2 title screen].k7" size="23433" crc="d18e7673" sha1="efe6d334f5dfd4b7270a457ae77a0436fbd2a802"/>
@@ -9446,10 +8729,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="businessc" cloneof="business">
-		<description>Business+ (Alt 3)</description>
+		<description>Business+ (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23433">
 				<rom name="business_mo5.k7" size="23433" crc="f532244f" sha1="e7bf82c3b358b6cb9f87abb7fc9cf4e5fbbddd55"/>
@@ -9461,7 +8743,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cap Horn</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23932">
 				<rom name="cap horn (198x)(coktel vision)(fr).k7" size="23932" crc="94f6a28a" sha1="dcbd9972305d1c5af77d91dbe655f4724c3146ad"/>
@@ -9470,10 +8751,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="caphorna" cloneof="caphorn">
-		<description>Cap Horn (Alt)</description>
+		<description>Cap Horn (alt)</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23932">
 				<rom name="cap horn (198x)(coktel vision)(fr)[a].k7" size="23932" crc="46309d45" sha1="0931ee2d67ba2a69af18a8e70056741c50207837"/>
@@ -9482,10 +8762,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="caphornb" cloneof="caphorn">
-		<description>Cap Horn (Alt 2)</description>
+		<description>Cap Horn (alt 2)</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23932">
 				<rom name="cap horn (198x)(coktel vision)(fr)[a2].k7" size="23932" crc="1a27e819" sha1="5c0a2ba962ef19a938f3a4c09238bcbdc8804c15"/>
@@ -9494,10 +8773,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="caphornc" cloneof="caphorn">
-		<description>Cap Horn (Alt 3)</description>
+		<description>Cap Horn (alt 3)</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23932">
 				<rom name="cap-horn_mo5.k7" size="23932" crc="7bb19291" sha1="2570884ce3cca47455a86e701f982a551d168d3a"/>
@@ -9509,7 +8787,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cap sur Dakar</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44826">
 				<rom name="cap sur dakar (1985)(coktel vision)(fr).k7" size="44826" crc="e244996e" sha1="3433fae662a328d24412f44895d8f65582ccdf62"/>
@@ -9518,10 +8795,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="capdakara" cloneof="capdakar">
-		<description>Cap sur Dakar (Alt)</description>
+		<description>Cap sur Dakar (alt)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44991">
 				<rom name="cap sur dakar (1985)(coktel vision)(fr)[a].k7" size="44991" crc="35023a2a" sha1="1c9f5a17528b05e5c807909c316f6696f851af8a"/>
@@ -9530,10 +8806,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="capdakarb" cloneof="capdakar">
-		<description>Cap sur Dakar (Alt 2)</description>
+		<description>Cap sur Dakar (alt 2)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44991">
 				<rom name="cap sur dakar (1985)(coktel vision)(fr)[a2].k7" size="44991" crc="7629d1b3" sha1="6a73c465e76d2fce7df1021c4c059e2a572417d9"/>
@@ -9542,10 +8817,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="capdakarc" cloneof="capdakar">
-		<description>Cap sur Dakar (Alt 3)</description>
+		<description>Cap sur Dakar (alt 3)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44991">
 				<rom name="cap sur dakar (coktel vision) (inconnus) (1985) (mo5).k7" size="44991" crc="df787752" sha1="7c776aeb2e0fdb8931da3b38cfaa7277ad86d9c9"/>
@@ -9557,7 +8831,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cassebrique</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8762">
 				<rom name="cassebrique (1986-04-01)(hebdogiciel)(fr)(pd).k7" size="8762" crc="707a1fdc" sha1="28b457ccd8e66967d5532fb0e39ef4b003320ff0"/>
@@ -9566,10 +8839,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cassebrqa" cloneof="cassebrq">
-		<description>Cassebrique (Alt)</description>
+		<description>Cassebrique (alt)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8762">
 				<rom name="cassebrique (1986-04-01)(hebdogiciel)(fr)(pd)[a].k7" size="8762" crc="8df2a959" sha1="12f7abad21ad732d20f6f4c73c5a955ace825a0f"/>
@@ -9578,10 +8850,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cassebrqb" cloneof="cassebrq">
-		<description>Cassebrique (Alt 2)</description>
+		<description>Cassebrique (alt 2)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8762">
 				<rom name="cassebrique (1986-04-01)(hebdogiciel)(fr)(pd)[a2].k7" size="8762" crc="63b04169" sha1="4f1eb6d1ae79811ef189cf9b5bef16a7141e8d14"/>
@@ -9590,10 +8861,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cassebrqc" cloneof="cassebrq">
-		<description>Cassebrique (Alt 3)</description>
+		<description>Cassebrique (alt 3)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8762">
 				<rom name="cassebrique_mo5.k7" size="8762" crc="74844fad" sha1="27672a113b08c81621c43972ce963f11e8594541"/>
@@ -9605,7 +8875,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Catapulte</description>
 		<year>1984</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7258">
 				<rom name="catapulte (1984)(hebdogiciel)(fr)(pd).k7" size="7258" crc="b372519e" sha1="a481634016c21fcab76f36ab3a4c24a4b96fef40"/>
@@ -9614,10 +8883,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="catapulta" cloneof="catapult">
-		<description>Catapulte (Alt)</description>
+		<description>Catapulte (alt)</description>
 		<year>1984</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7258">
 				<rom name="catapulte_mo5.k7" size="7258" crc="925b8e09" sha1="2bd7655584eb996f47355e732c2d13617de445f9"/>
@@ -9629,7 +8897,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Categoric</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32809">
 				<rom name="categoric (1984)(no man's land)(fr).k7" size="32809" crc="582e7ea4" sha1="a551635fdea1e80b99eedc644863ee2ad49fb07d"/>
@@ -9638,10 +8905,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="categoria" cloneof="categori">
-		<description>Categoric (Alt)</description>
+		<description>Categoric (alt)</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32809">
 				<rom name="categoric (1984)(no man's land)(fr)[a].k7" size="32809" crc="0c7edfc9" sha1="34bd445945741f5196f85067633bec5c3da3993e"/>
@@ -9650,10 +8916,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="categorib" cloneof="categori">
-		<description>Categoric (Alt 2)</description>
+		<description>Categoric (alt 2)</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32809">
 				<rom name="categoric_mo5.k7" size="32809" crc="59d197ae" sha1="62e5ff02d1bee7191b062d724b9cdbdf4ed16895"/>
@@ -9665,7 +8930,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Cavernes de Thenebe</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="71428">
 				<rom name="cavernes de thenebe, les (198x)(softbook)(fr).k7" size="71428" crc="58b12548" sha1="991c4de9752f17d8061fd3a70ed67100300d1aae"/>
@@ -9674,10 +8938,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="thenebea" cloneof="thenebe">
-		<description>Les Cavernes de Thenebe (Alt)</description>
+		<description>Les Cavernes de Thenebe (alt)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="71428">
 				<rom name="cavernes de thenebe, les (198x)(softbook)(fr)[a].k7" size="71428" crc="4c134f51" sha1="6155013daf0c4d043fec42bcdffc8391a081b6a9"/>
@@ -9686,10 +8949,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="thenebeb" cloneof="thenebe">
-		<description>Les Cavernes de Thenebe (Alt 2)</description>
+		<description>Les Cavernes de Thenebe (alt 2)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="71428">
 				<rom name="les-cavernes-de-thenebe_mo5.k7" size="71428" crc="5756b36a" sha1="4ff6f1c3934a4e67bf5476ec1b5baa2a7cdf9715"/>
@@ -9701,7 +8963,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Challenge Voile</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22569">
 				<rom name="challenge voile (1984-10)(loriciels)(fr).k7" size="22569" crc="e066303c" sha1="880363b1cf293e8f7d0a9cf6a60c1d5bb4c4cb00"/>
@@ -9710,10 +8971,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="chalvoila" cloneof="chalvoil">
-		<description>Challenge Voile (Alt)</description>
+		<description>Challenge Voile (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22569">
 				<rom name="challenge voile (1984-10)(loriciels)(fr)[a].k7" size="22569" crc="4a7b05a7" sha1="cb8a631595126c7914634430133e62532fc12a76"/>
@@ -9722,10 +8982,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="chalvoilb" cloneof="chalvoil">
-		<description>Challenge Voile (Alt 2)</description>
+		<description>Challenge Voile (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22569">
 				<rom name="challenge-voile_mo5.k7" size="22569" crc="b5f3083a" sha1="68a7f6905b95cbc94aa34d2451def292e2cdb576"/>
@@ -9737,7 +8996,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Chasseur Omega</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6479">
 				<rom name="chasseur omega (1983)(infogrames)(fr).k7" size="6479" crc="0f5e91d5" sha1="7ff3a845709cd36fccce9b83c662eeca27c1e04b"/>
@@ -9746,10 +9004,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="chasomega" cloneof="chasomeg">
-		<description>Chasseur Omega (Alt)</description>
+		<description>Chasseur Omega (alt)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6479">
 				<rom name="chasseur omega (1983)(infogrames)(fr)[a].k7" size="6479" crc="d942ff44" sha1="c1caa863d7f99e1c4ddb38fe0ccfaa131cfc88c1"/>
@@ -9758,10 +9015,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="chasomegb" cloneof="chasomeg">
-		<description>Chasseur Omega (Alt 2)</description>
+		<description>Chasseur Omega (alt 2)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6479">
 				<rom name="chasseur-omega_mo5.k7" size="6479" crc="cb83d621" sha1="949b4606f0c773b002de5d441b57bcf0d8f3c6e1"/>
@@ -9773,7 +9029,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Chateau de la Mort</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23249">
 				<rom name="chateau de la mort, le (1985)(cobrasoft)(fr).k7" size="23249" crc="6dcf3f7c" sha1="ec7eccae1f627965e25bbaa49e731bcf60922776"/>
@@ -9785,7 +9040,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Chateau Noir et Dragons Rouges</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32232">
 				<rom name="chateau noir et dragons rouges (1985)(vifi-nathan)(fr).k7" size="32232" crc="9b7d8e91" sha1="af0e2420e9b4d9f6e478461c398e6b9a308cf13e"/>
@@ -9794,10 +9048,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="chatnoira" cloneof="chatnoir">
-		<description>Chateau Noir et Dragons Rouges (Alt)</description>
+		<description>Chateau Noir et Dragons Rouges (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32190">
 				<rom name="chateau noir et dragons rouges (1985)(vifi-nathan)(fr)[a].k7" size="32190" crc="2a3ac61e" sha1="6e0ba65b5bdc6f78ac3b2cc856f88d3adbb9b84e"/>
@@ -9806,10 +9059,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="chatnoirb" cloneof="chatnoir">
-		<description>Chateau Noir et Dragons Rouges (Alt 2)</description>
+		<description>Chateau Noir et Dragons Rouges (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32190">
 				<rom name="chateau noir et dragons rouges (1985)(vifi-nathan)(fr)[a2].k7" size="32190" crc="600d19db" sha1="38f011355f8eba39d37b5c1960833c7ea62cae70"/>
@@ -9818,10 +9070,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="chatnoirc" cloneof="chatnoir">
-		<description>Chateau Noir et Dragons Rouges (Alt 3)</description>
+		<description>Chateau Noir et Dragons Rouges (alt 3)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32190">
 				<rom name="chateau-noir-et-dragons-rouges_mo5.k7" size="32190" crc="905afad0" sha1="e75cb2022bc1ab3a82e1202f4ceed32b067f469d"/>
@@ -9833,7 +9084,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Clinique du Docteur Spounz (Hebdogiciel no. 77-78)</description>
 		<year>1985</year>
 		<publisher>Jean-Yves Le Friec - Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28417">
 				<rom name="spounz1_mo5.k7" size="28417" crc="8e24d10a" sha1="c8933480e885e9f344e0c99dc5e0ffa406e78890"/>
@@ -9845,7 +9095,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cocotte</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16168">
 				<rom name="cocotte (1985)(fil)(fr).k7" size="16168" crc="599cfd41" sha1="093801baaf2d94fe6a8d90d7d9a68a11378a19ca"/>
@@ -9857,7 +9106,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coliseum</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51399">
 				<rom name="coliseum (1985)(loriciels)(fr).k7" size="51399" crc="16142072" sha1="a9f2489ebae1638de7973d38b447a751433c682c"/>
@@ -9866,10 +9114,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coliseuma" cloneof="coliseum">
-		<description>Coliseum (Alt)</description>
+		<description>Coliseum (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51790">
 				<rom name="coliseum (1985)(loriciels)(fr)[a].k7" size="51790" crc="2845ba3f" sha1="f85325d5d70c8d75a543d5bbf9993e822d6c6728"/>
@@ -9878,10 +9125,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coliseumb" cloneof="coliseum">
-		<description>Coliseum (Alt 2)</description>
+		<description>Coliseum (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51790">
 				<rom name="coliseum (1985)(loriciels)(fr)[a2].k7" size="51790" crc="4d0e0266" sha1="bbd41b8045b5e50c1c6d750f1acd997edc5c3e20"/>
@@ -9890,10 +9136,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coliseumc" cloneof="coliseum">
-		<description>Coliseum (Alt 3)</description>
+		<description>Coliseum (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51790">
 				<rom name="coliseum_mo5.k7" size="51790" crc="0eceaee4" sha1="fc72b4e409dcf204e05406c71a773510196058db"/>
@@ -9905,7 +9150,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coloric</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5718">
 				<rom name="coloric (1984)(free game blot)(fr).k7" size="5718" crc="6a5a221e" sha1="af65ba7cff2923975c4ba353568e145a0233582b"/>
@@ -9914,10 +9158,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="colorica" cloneof="coloric">
-		<description>Coloric (Alt)</description>
+		<description>Coloric (alt)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5718">
 				<rom name="coloric (1984)(free game blot)(fr)[a].k7" size="5718" crc="8fd53734" sha1="305f2a9c044fdecaab706e69ff9519d1370f75c8"/>
@@ -9926,10 +9169,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coloricb" cloneof="coloric">
-		<description>Coloric (Alt 2)</description>
+		<description>Coloric (alt 2)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5718">
 				<rom name="coloric_mo5.k7" size="5718" crc="30af55d8" sha1="915d4534f0f1eefe9ef4121155536445e0eb2bc0"/>
@@ -9941,7 +9183,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Contes de Monte-Crypto</description>
 		<year>1988</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48697">
 				<rom name="les-contes-de-monte-crypto_mo5.k7" size="48697" crc="2745fdc3" sha1="f546f545b69154d56e5b3c1bcf3330fc8202c0ac"/>
@@ -9950,10 +9191,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="montecrya" cloneof="montecry">
-		<description>Les Contes de Monte-Crypto (WAV Format)</description>
+		<description>Les Contes de Monte-Crypto (WAV format)</description>
 		<year>1988</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26906246">
 				<rom name="les-contes-de-monte-crypto_mo5.wav" size="26906246" crc="00b2162b" sha1="0369c7662e116ba89aa3970291e9b62720ccc757"/>
@@ -9965,7 +9205,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coq Inn</description>
 		<year>1984</year>
 		<publisher>VIFI International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51550">
 				<rom name="coq inn (1984)(vifi)(fr).k7" size="51550" crc="3836a66e" sha1="1fec9c768a60d91093a2a6fe5efd562f5c10c622"/>
@@ -9974,10 +9213,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coqinna" cloneof="coqinn">
-		<description>Coq Inn (Alt)</description>
+		<description>Coq Inn (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51550">
 				<rom name="coq inn (1984)(vifi)(fr)[a].k7" size="51550" crc="e519c464" sha1="2c3bd27b4c7faa0f515ceeb37e0e8cef067e1843"/>
@@ -9986,10 +9224,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coqinnb" cloneof="coqinn">
-		<description>Coq Inn (Alt 2)</description>
+		<description>Coq Inn (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51550">
 				<rom name="coq inn (1984)(vifi)(fr)[a2].k7" size="51550" crc="35300727" sha1="f1b96d280dae37bbaaaa5159f4ae40c476077e30"/>
@@ -9998,10 +9235,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coqinnc" cloneof="coqinn">
-		<description>Coq Inn (Alt 3)</description>
+		<description>Coq Inn (alt 3)</description>
 		<year>1984</year>
 		<publisher>VIFI International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51550">
 				<rom name="coq-inn_mo5.k7" size="51550" crc="df5fda6f" sha1="2fd7292412f8b8e6861a9f307461829f46555aa3"/>
@@ -10013,7 +9249,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crocky II</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17362">
 				<rom name="crocky ii (1984-09)(loriciels)(fr).k7" size="17362" crc="dac3535e" sha1="d2c5b4504c8023f28aeccfd1d3c7c1ce9cc1bc37"/>
@@ -10022,10 +9257,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="crocky2a" cloneof="crocky2">
-		<description>Crocky II (Alt)</description>
+		<description>Crocky II (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18625">
 				<rom name="crocky ii (1984-09)(loriciels)(fr)[a].k7" size="18625" crc="e9676d11" sha1="82a6f679aee2e4bc6cf925d3031b1fd703b73db4"/>
@@ -10034,10 +9268,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="crocky2b" cloneof="crocky2">
-		<description>Crocky II (Alt 2)</description>
+		<description>Crocky II (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18351">
 				<rom name="crocky ii (1984-09)(loriciels)(fr)[a2].k7" size="18351" crc="572b69b1" sha1="ffb8ca6d5a04e3926dab23624fc77d20852c0709"/>
@@ -10046,10 +9279,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="crocky2c" cloneof="crocky2">
-		<description>Crocky II (Alt 3)</description>
+		<description>Crocky II (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18351">
 				<rom name="crocky ii (1984-09)(loriciels)(fr)[a3].k7" size="18351" crc="79362686" sha1="963dc2e4769c3bded10ae8b9cdbff102d1be3bd1"/>
@@ -10058,10 +9290,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="crocky2d" cloneof="crocky2">
-		<description>Crocky II (Alt 4)</description>
+		<description>Crocky II (alt 4)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18351">
 				<rom name="crocky2_mo5.k7" size="18351" crc="78239c38" sha1="97a1be678b12f765bc11990f7fa34e685bda6ae5"/>
@@ -10073,7 +9304,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crystann</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34573">
 				<rom name="crystann (1985)(loriciels)(fr).k7" size="34573" crc="6f9713b3" sha1="98982871dc763a489553888cda262c319824be3b"/>
@@ -10082,10 +9312,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="crystanna" cloneof="crystann">
-		<description>Crystann (Alt)</description>
+		<description>Crystann (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34573">
 				<rom name="crystann (1985)(loriciels)(fr)[a].k7" size="34573" crc="f4ce7eb3" sha1="835c477081db62c6fad01f2318c130c0226a3421"/>
@@ -10094,10 +9323,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="crystannb" cloneof="crystann">
-		<description>Crystann (Alt 2)</description>
+		<description>Crystann (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34573">
 				<rom name="crystann (1985)(loriciels)(fr)[a2].k7" size="34573" crc="d1ea604d" sha1="dc6eee21e0f2b32ff00b408a5d9943f74c7b30c9"/>
@@ -10106,10 +9334,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="crystannc" cloneof="crystann">
-		<description>Crystann (Alt 3)</description>
+		<description>Crystann (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34570">
 				<rom name="crystann_mo5.k7" size="34570" crc="5de8dd28" sha1="68d5a42f51720e60c3cee54dab6df20faafced44"/>
@@ -10118,10 +9345,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="crystannd" cloneof="crystann">
-		<description>Crystann (WAV Format)</description>
+		<description>Crystann (WAV format)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10086740">
 				<rom name="crystann (1985)(loriciels)(fr).wav" size="10086740" crc="92177192" sha1="b85904e3bfd6bcd421d61576ea6d986a181e4168"/>
@@ -10130,10 +9356,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="crystanne" cloneof="crystann">
-		<description>Crystann (WAV Format, Alt)</description>
+		<description>Crystann (WAV format, alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11812490">
 				<rom name="crystann_mo5.wav" size="11812490" crc="aa4a6579" sha1="c30252d9badf126b9a2fbcf5c856f1a5ec41b7bb"/>
@@ -10145,7 +9370,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cyberlab</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16330">
 				<rom name="cyberlab (1984)(to tek)(fr).k7" size="16330" crc="40bcac29" sha1="a581167d4d243c1c6de29a75c23baa447c9a73ea"/>
@@ -10154,10 +9378,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cyberlaba" cloneof="cyberlab">
-		<description>Cyberlab (Alt)</description>
+		<description>Cyberlab (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16330">
 				<rom name="cyberlab (1984)(to tek)(fr)[a].k7" size="16330" crc="752306cd" sha1="627345a94d11bdbd71290f37fc1a3fa246040184"/>
@@ -10166,10 +9389,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cyberlabb" cloneof="cyberlab">
-		<description>Cyberlab (Alt 2)</description>
+		<description>Cyberlab (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16330">
 				<rom name="cyberlab_mo5.k7" size="16330" crc="5ddac57d" sha1="77d7c6503eeef29fc732de6d7ece74fd12069dad"/>
@@ -10178,10 +9400,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cyberlabc" cloneof="cyberlab">
-		<description>Cyberlab (WAV Format)</description>
+		<description>Cyberlab (WAV format)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6199752">
 				<rom name="cyberlab (1984)(to tek)(fr).wav" size="6199752" crc="06f90469" sha1="77522e995394097ffe6547890ab8229d358cce0e"/>
@@ -10190,10 +9411,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cyberlabd" cloneof="cyberlab">
-		<description>Cyberlab (WAV Format, Alt)</description>
+		<description>Cyberlab (WAV format, alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7113392">
 				<rom name="cyberlab_mo5.wav" size="7113392" crc="59da3141" sha1="6680b31c83f6fd7dd494108dfbb8786df1ae1153"/>
@@ -10205,7 +9425,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dakar 4x4</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47183">
 				<rom name="dakar 4x4 (1987)(coktel vision)(fr)[a].k7" size="47183" crc="3c58aec7" sha1="bbe2ad5820fe962922a00ae9af6ec26d884218fc"/>
@@ -10214,10 +9433,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="dakar4x4a" cloneof="dakar4x4">
-		<description>Dakar 4x4 (Alt)</description>
+		<description>Dakar 4x4 (alt)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47183">
 				<rom name="dakar 4x4 (1987)(coktel vision)(fr)[a2].k7" size="47183" crc="6f6214ad" sha1="a72f46d4cac299458ac9f8b71bb4bf720f6fb2c7"/>
@@ -10226,10 +9444,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="dakar4x4b" cloneof="dakar4x4">
-		<description>Dakar 4x4 (Alt 2)</description>
+		<description>Dakar 4x4 (alt 2)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47183">
 				<rom name="dakar-4x4_mo5.k7" size="47183" crc="9b345f91" sha1="eaf2cb84eb431347bb255e75052b1d369fe79140"/>
@@ -10238,10 +9455,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="dakar4x4c" cloneof="dakar4x4">
-		<description>Dakar 4x4 (No Title Screen)</description>
+		<description>Dakar 4x4 (no title screen)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29592">
 				<rom name="dakar 4x4 (1987)(coktel vision)(fr)[m title screen].k7" size="29592" crc="0c1ba7db" sha1="59672953158e76f1e8d0212b12f7bdf6672fc57e"/>
@@ -10250,10 +9466,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="dakar4x4d" cloneof="dakar4x4">
-		<description>Dakar 4x4 (No Title Screen, Alt)</description>
+		<description>Dakar 4x4 (no title screen, alt)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29592">
 				<rom name="dakar 4x4 (1987)(coktel vision)(fr).k7" size="29592" crc="63cb7ecf" sha1="1d3ea4f1ebb8ba81f2282c61267dd2f1c8771849"/>
@@ -10265,7 +9480,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dakar Moto</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47458">
 				<rom name="dakar moto (198x)(coktel vision)(fr).k7" size="47458" crc="172bcbda" sha1="51d6c9ce37b4d00ac87a291fa6f2ab37f3f3e764"/>
@@ -10274,10 +9488,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="dakarmota" cloneof="dakarmot">
-		<description>Dakar Moto (Alt)</description>
+		<description>Dakar Moto (alt)</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47458">
 				<rom name="dakar moto (198x)(coktel vision)(fr)[a].k7" size="47458" crc="737d21fd" sha1="4d4643acf53c6a74aeab8758089a9986d2b4a7c8"/>
@@ -10289,7 +9502,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Delos Attack</description>
 		<year>1989</year>
 		<publisher>Christophe Lesur</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7383">
 				<rom name="delos attack (1989)(lesur, christophe)(fr).k7" size="7383" crc="477d97f3" sha1="4c2e4f7213fb6f5153b6ff282879ad1155893036"/>
@@ -10301,7 +9513,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Devant Derriere</description>
 		<year>198?</year>
 		<publisher>Francoise Monnet</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19942">
 				<rom name="devant derriere (198x)(monnet, francoise)(fr).k7" size="19942" crc="7f0a32b4" sha1="1fd766bd9d1d3b729739278947177ec8f1cb9257"/>
@@ -10313,7 +9524,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dianne</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="dianne - mission rubidiums (1985)(loriciels - novasoft)(fr).k7" size="34587" crc="38f4d036" sha1="49b9d488e15f41f16d72b4d47f313f7819f457a0"/>
@@ -10322,10 +9532,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="diannea" cloneof="dianne">
-		<description>Dianne (Alt)</description>
+		<description>Dianne (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="dianne - mission rubidiums (1985)(loriciels - novasoft)(fr)[a].k7" size="34587" crc="1f3b7fd3" sha1="e09b0572b7a7c5d5096d99bc109c0a7ddf80f639"/>
@@ -10334,10 +9543,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="dianneb" cloneof="dianne">
-		<description>Dianne (Alt 2)</description>
+		<description>Dianne (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="dianne - mission rubidiums (1985)(loriciels - novasoft)(fr)[a2].k7" size="34587" crc="bd48dcac" sha1="604858c56f229979cf079aa279406b6adc5feedd"/>
@@ -10346,10 +9554,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="diannec" cloneof="dianne">
-		<description>Dianne (Alt 3)</description>
+		<description>Dianne (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="dianne-mission-rubidiums_mo5.k7" size="34587" crc="047bbfb2" sha1="64ccc717ad9c43aefa4a81f8c71fc37094aebf57"/>
@@ -10361,7 +9568,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Dieux du Stade</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26031">
 				<rom name="dieux du stade, les (1988)(infogrames)(fr).k7" size="26031" crc="3ad54b8d" sha1="f2efda9e92fea10c0addad12e37f96be78d07f2e"/>
@@ -10370,10 +9576,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="dieuxstaa" cloneof="dieuxsta">
-		<description>Les Dieux du Stade (Alt)</description>
+		<description>Les Dieux du Stade (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26031">
 				<rom name="dieux du stade, les (1988)(infogrames)(fr)[a].k7" size="26031" crc="487df22d" sha1="44d7e521e8191b6048f100a2a6520be9e306a7ae"/>
@@ -10382,10 +9587,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="dieuxstab" cloneof="dieuxsta">
-		<description>Les Dieux du Stade (Alt 2)</description>
+		<description>Les Dieux du Stade (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26031">
 				<rom name="les dieux du stade (infogrames) (william hennebois) (1985) (mo5) (v1).k7" size="26031" crc="4f2c1612" sha1="00a608f511ec39ad60ad3e9211cc0ab3d967ba87"/>
@@ -10394,10 +9598,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="dieuxstac" cloneof="dieuxsta">
-		<description>Les Dieux du Stade (Alt 3)</description>
+		<description>Les Dieux du Stade (alt 3)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25625">
 				<rom name="les dieux du stade (infogrames) (william hennebois) (1985) (mo5) (v2).k7" size="25625" crc="bdf9ba3f" sha1="2ea2ace76e673565fbc599d9cb5836391f9fb725"/>
@@ -10409,7 +9612,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Dieux du Stade II</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26220155">
 				<rom name="dieux du stade ii, les (1986)(infogrames)(fr)[loadm].wav" size="26220155" crc="12565f24" sha1="d9c002208e546b63c697b96f1bec1ed3bcd31fea"/>
@@ -10419,10 +9621,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="dieuxst2a" cloneof="dieuxst2" supported="no">
-		<description>Les Dieux du Stade II (Alt)</description>
+		<description>Les Dieux du Stade II (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="120702">
 				<rom name="dieux du stade ii, les (1986)(infogrames)(fr)[b].k7" size="120702" crc="a172406f" sha1="4f0c05d5d461b93bdba8b442b77b187005dbb0fe"/>
@@ -10432,10 +9633,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="dieuxst2b" cloneof="dieuxst2" supported="no">
-		<description>Les Dieux du Stade II (Alt 2)</description>
+		<description>Les Dieux du Stade II (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="120702">
 				<rom name="les dieux du stade 2 (infogrames) (kamel bala) (1986).k7" size="120702" crc="3584c1ab" sha1="1659eb80ccfdb3f06b31a9a1009ec4ecf909e5f0"/>
@@ -10445,10 +9645,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="dieuxst2c" cloneof="dieuxst2" supported="no">
-		<description>Les Dieux du Stade II (Alt 3)</description>
+		<description>Les Dieux du Stade II (alt 3)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="125502">
 				<rom name="les-dieux-du-stade-2_mo5.k7" size="125502" crc="5629181b" sha1="2480d8f4689352bd8237635a01708a630ef63b31"/>
@@ -10461,7 +9660,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dossier Boerhaave</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66662">
 				<rom name="dossier boerhaave (1986)(infogrames)(fr)[copy protection].k7" size="66662" crc="5f837876" sha1="58026b7f41b28dd4d5a5d832e04493de87a0d607"/>
@@ -10471,10 +9669,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="boerhaava" cloneof="boerhaav" supported="no">
-		<description>Dossier Boerhaave (Alt)</description>
+		<description>Dossier Boerhaave (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66662">
 				<rom name="dossier boerhaave (1986)(infogrames)[b].k7" size="66662" crc="c2a4f6dd" sha1="b71b32b307fc6ca1c2f1a38452cf4b86e34c31e0"/>
@@ -10484,10 +9681,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="boerhaavb" cloneof="boerhaav" supported="no">
-		<description>Dossier Boerhaave (Alt 2)</description>
+		<description>Dossier Boerhaave (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66662">
 				<rom name="dossier boerhaave (1986)(infogrames)[b2].k7" size="66662" crc="c1765672" sha1="3d0a26015823e602826c77475f6b37357fd27495"/>
@@ -10497,10 +9693,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="boerhaavc" cloneof="boerhaav" supported="no">
-		<description>Dossier Boerhaave (Alt 3)</description>
+		<description>Dossier Boerhaave (alt 3)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="69062">
 				<rom name="dossier-boerhaave_mo5.k7" size="69062" crc="3bf0c14a" sha1="0ca9960bf6a6da3a053ca4a9360bfece9373afcb"/>
@@ -10512,7 +9707,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dossier Boerhaave (Hacked)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66662">
 				<rom name="dossier boerhaave (1986)(infogrames)(fr)[h dcmo5, dcmo6].k7" size="66662" crc="3fd48b69" sha1="0d140083454e93efd61ce25afd49b55d53b53dcc"/>
@@ -10524,7 +9718,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dossier Boerhaave (Hacked 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66662">
 				<rom name="dossier boerhaave (1986)(infogrames)(fr)[h dcmo5].k7" size="66662" crc="bfada424" sha1="b58935978d126093576e13ee216724fe8e40ddd0"/>
@@ -10543,9 +9736,8 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 			</dataarea>
 		</part>
 	</software>
-
 	<software name="dribblea" cloneof="dribble">
-		<description>Dribble (Alt)</description>
+		<description>Dribble (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
 
@@ -10557,10 +9749,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="dribbleb" cloneof="dribble">
-		<description>Dribble (Alt 2)</description>
+		<description>Dribble (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9364">
 				<rom name="dribble_mo5.k7" size="9364" crc="91d2b3ee" sha1="d965c58ca85388194ea433feace56b299e3ee833"/>
@@ -10572,7 +9763,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Duel au Colorado</description>
 		<year>1986</year>
 		<publisher>Chip</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35669">
 				<rom name="duel au colorado (198x)(chip)(fr).k7" size="35669" crc="e80a25dc" sha1="ee4462e9937c7a0cf19da512ff40c769a8a90e64"/>
@@ -10581,10 +9771,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coloradoa" cloneof="colorado">
-		<description>Duel au Colorado (Alt)</description>
+		<description>Duel au Colorado (alt)</description>
 		<year>1986</year>
 		<publisher>Chip</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35842">
 				<rom name="duel au colorado (198x)(chip)(fr)[a].k7" size="35842" crc="55d42177" sha1="ab490640d2c34acf49ef6c311051ba5945ff6f4e"/>
@@ -10593,10 +9782,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coloradob" cloneof="colorado">
-		<description>Duel au Colorado (Alt 2)</description>
+		<description>Duel au Colorado (alt 2)</description>
 		<year>1986</year>
 		<publisher>Chip</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35842">
 				<rom name="duel au colorado (198x)(chip)(fr)[a2].k7" size="35842" crc="67149e61" sha1="e0600b1cc41c11be58275cc80d6b9333d5cf2fc7"/>
@@ -10605,10 +9793,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="coloradoc" cloneof="colorado">
-		<description>Duel au Colorado (Alt 3)</description>
+		<description>Duel au Colorado (alt 3)</description>
 		<year>1986</year>
 		<publisher>Chip</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35842">
 				<rom name="duel-au-colorado_mo5.k7" size="35842" crc="f04b687d" sha1="57a2e36b43e454e4726c4621feb77b69525c1bcf"/>
@@ -10620,7 +9807,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Echecs (v3.7)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14919">
 				<rom name="echecs v3.7 (198x)(cobra soft)(fr).k7" size="14919" crc="7a58f536" sha1="c5f98e6ba55e6c5114eb40b8a468934061d7524b"/>
@@ -10629,10 +9815,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="echecsa" cloneof="echecs">
-		<description>Echecs (v3.7, Alt)</description>
+		<description>Echecs (v3.7, alt)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15076">
 				<rom name="echecs v3.7 (198x)(cobrasoft)(fr)[a].k7" size="15076" crc="443e6ef3" sha1="a1f17dfb6fce3103b12fc6d26f7cc5b73b859bf3"/>
@@ -10641,10 +9826,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="echecsb" cloneof="echecs">
-		<description>Echecs (v3.7, Alt 2)</description>
+		<description>Echecs (v3.7, alt 2)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15076">
 				<rom name="echecs v3.7 (198x)(cobrasoft)(fr)[a2].k7" size="15076" crc="6d83b77d" sha1="317c5a4dfd0f53f4c523d9d310e3c3307ad52205"/>
@@ -10653,10 +9837,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="echecsc" cloneof="echecs">
-		<description>Echecs (v3.7, Alt 3)</description>
+		<description>Echecs (v3.7, alt 3)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15076">
 				<rom name="echecs-3-7_mo5.k7" size="15076" crc="8cf1d227" sha1="f36a5d71f2a2cca853b274d182d70ef4dadb799c"/>
@@ -10668,7 +9851,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Eliminator</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3129695">
 				<rom name="eliminator (1984)(loriciels)(fr).wav" size="3129695" crc="5caf9f32" sha1="d203cff44126245eae8fa1728d6a4a35309d44c3"/>
@@ -10678,10 +9860,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="eliminata" cloneof="eliminat" supported="no">
-		<description>Eliminator (Alt)</description>
+		<description>Eliminator (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9478">
 				<rom name="eliminator (1984)(loriciels)(fr)[b2].k7" size="9478" crc="5d54aa79" sha1="56a19211c31d3d20332a62cd7953f25ca8ed2ac8"/>
@@ -10691,10 +9872,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="eliminatb" cloneof="eliminat" supported="no">
-		<description>Eliminator (Alt 2)</description>
+		<description>Eliminator (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9478">
 				<rom name="eliminator (1984)(loriciels)(fr)[b3].k7" size="9478" crc="5d521fe8" sha1="d22753dbe9029d0db5b59f59b63c2bfe87915901"/>
@@ -10704,10 +9884,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="eliminatc" cloneof="eliminat" supported="no">
-		<description>Eliminator (Alt 3)</description>
+		<description>Eliminator (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9224">
 				<rom name="eliminator_mo5.k7" size="9224" crc="299c1d12" sha1="cd463b4d28046dcd46cf3496ad9ebe277e7cf5d8"/>
@@ -10717,10 +9896,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="eliminatd" cloneof="eliminat" supported="no">
-		<description>Eliminator (Alt 4)</description>
+		<description>Eliminator (alt 4)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9224">
 				<rom name="eliminator_a_mo5.k7" size="9224" crc="cc9586bb" sha1="e257a8f82c33a1b178e75f83747e32789b29df20"/>
@@ -10729,10 +9907,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="eliminate" cloneof="eliminat">
-		<description>Eliminator (Cracked?)</description>
+		<description>Eliminator (cracked?)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9480">
 				<rom name="eliminator (1984)(loriciels)(fr).k7" size="9480" crc="9a380faf" sha1="efa716fa809dd60b114012b4cec6730c17d49a4c"/>
@@ -10760,7 +9937,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Empire</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44884">
 				<rom name="empire (1985-04)(loriciels)(fr)[b].k7" size="44884" crc="2317ddaa" sha1="839b08823de130d117d24af79681603df571c3d8"/>
@@ -10770,10 +9946,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="empirea" cloneof="empire" supported="no">
-		<description>Empire (Alt)</description>
+		<description>Empire (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44884">
 				<rom name="empire (1985-04)(loriciels)(fr)[b2].k7" size="44884" crc="a70fe2dc" sha1="bd3ed979bac6977c5dff0c7ee4d67b1f87fde47c"/>
@@ -10783,10 +9958,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="empireb" cloneof="empire" supported="no">
-		<description>Empire (Alt 2)</description>
+		<description>Empire (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44884">
 				<rom name="empire_mo5.k7" size="44884" crc="4dfb8745" sha1="9e21dc5a0345c2d0442145000dbecea3b9ee092d"/>
@@ -10798,7 +9972,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Enduro Racer</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45296">
 				<rom name="enduro racer (1988)(fil)(fr).k7" size="45296" crc="de053935" sha1="eb511a397aa5d57e6c3a23fd8190cdbe5a908b5c"/>
@@ -10807,10 +9980,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="enduroa" cloneof="enduro">
-		<description>Enduro Racer (Alt)</description>
+		<description>Enduro Racer (alt)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45465">
 				<rom name="enduro racer (1988)(fil)(fr)[a].k7" size="45465" crc="afeb5f4f" sha1="e466f99d82287e8e60ae57c211468128fb6d9674"/>
@@ -10819,10 +9991,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="endurob" cloneof="enduro">
-		<description>Enduro Racer (Alt 2)</description>
+		<description>Enduro Racer (alt 2)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45465">
 				<rom name="enduro racer (1988)(fil)(fr)[a2].k7" size="45465" crc="8580b00f" sha1="88ca964cd4334c63e8007323cfe9bb6b2d3843a2"/>
@@ -10831,10 +10002,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="enduroc" cloneof="enduro">
-		<description>Enduro Racer (Alt 3)</description>
+		<description>Enduro Racer (alt 3)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45465">
 				<rom name="enduro-racer_mo5.k7" size="45465" crc="524b098b" sha1="8d52903943e46d1a02147e29986079ef947839ba"/>
@@ -10860,7 +10030,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Energic</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25710">
 				<rom name="energic (198x)(dechelette, guy)(fr).k7" size="25710" crc="689d6117" sha1="ff0cdc34d82b52ea27667a0e8af5fc1a2184a781"/>
@@ -10869,10 +10038,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="energica" cloneof="energic">
-		<description>Energic (Alt)</description>
+		<description>Energic (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26368">
 				<rom name="energic (198x)(dechelette, guy)(fr)[a].k7" size="26368" crc="7d9efba7" sha1="a86513c0e5e2806aa323c9108e0c4c808c522c00"/>
@@ -10881,10 +10049,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="energicb" cloneof="energic">
-		<description>Energic (Alt 2)</description>
+		<description>Energic (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26368">
 				<rom name="energic (1985)(hebdogiciel)(fr)[a2].k7" size="26368" crc="f86707ba" sha1="006f8393b46f92e83c17f23e0509f1e85663fc48"/>
@@ -10893,10 +10060,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="energicc" cloneof="energic">
-		<description>Energic (Alt 3)</description>
+		<description>Energic (alt 3)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26368">
 				<rom name="energic (1985)(hebdogiciel)(fr)[a3].k7" size="26368" crc="ba7be5dd" sha1="74d3b058ac9ea773602b8d1287363b3effa27bc4"/>
@@ -10905,10 +10071,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="energicd" cloneof="energic">
-		<description>Energic (Alt 4)</description>
+		<description>Energic (alt 4)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26368">
 				<rom name="energic_mo5.k7" size="26368" crc="a6690205" sha1="4737a63e5e4d6da211c7aedbbe8e137a4f0730b4"/>
@@ -10920,7 +10085,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Enigmatika</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="20856">
@@ -10954,10 +10118,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="enigmatia" cloneof="enigmati">
-		<description>Enigmatika (Alt Tapes 1-4)</description>
+		<description>Enigmatika (alt tapes 1-4)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="20856">
@@ -10994,7 +10157,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Enquetes de M. Theophile</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47964">
 				<rom name="enquetes de m. theophile, les (1984)(hatier)(fr).k7" size="47964" crc="ad7f394f" sha1="0294d81d6fb342c1c3da3c0d381a779ffff6d3cb"/>
@@ -11006,7 +10168,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Erebus</description>
 		<year>198?</year>
 		<publisher>EH Services</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="93933">
 				<rom name="erebus (198x)(eh services).k7" size="93933" crc="87f297b7" sha1="75269f36afe3b60debc005abce46bc318fca70b9"/>
@@ -11015,10 +10176,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="erebusa" cloneof="erebus">
-		<description>Erebus (Alt)</description>
+		<description>Erebus (alt)</description>
 		<year>198?</year>
 		<publisher>EH Services</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="93933">
 				<rom name="erebus (198x)(eh services)[a].k7" size="93933" crc="95a10b9e" sha1="c2d25b757f49da2d7d18802f44f675ccb6faf11f"/>
@@ -11027,10 +10187,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="erebusb" cloneof="erebus">
-		<description>Erebus (Alt 2)</description>
+		<description>Erebus (alt 2)</description>
 		<year>198?</year>
 		<publisher>EH Services</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="93933">
 				<rom name="erebus_mo5.k7" size="93933" crc="3738fe9f" sha1="14dba07e8205c5c6b73dcad5c2b0137f953ab29e"/>
@@ -11042,7 +10201,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Evade de Tapiocatraz</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40775">
 				<rom name="evade de tapiocatraz, l' (1986)(ere informatique)(fr).k7" size="40775" crc="518dbd6a" sha1="0a4fdbf93a96b8ea3a50f96b27a5287b43b000d7"/>
@@ -11051,10 +10209,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="evadetapa" cloneof="evadetap">
-		<description>L'Evade de Tapiocatraz (Alt)</description>
+		<description>L'Evade de Tapiocatraz (alt)</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40775">
 				<rom name="l-evade-de-tapiocatraz_mo5.k7" size="40775" crc="0dce570c" sha1="fccdd4f8cf86cdc55aea2f6d30218c682fc452e0"/>
@@ -11066,7 +10223,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Extra-Mission</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10602">
 				<rom name="extra-mission (shift-edition) (philippe baroin) (1985) (mo5 k7).k7" size="10602" crc="277e656b" sha1="567e0d9492067be5aca41b2a2f73c07287b1b49e"/>
@@ -11078,7 +10234,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>F15 Strike Eagle</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27898">
 				<rom name="f15 strike eagle (1987)(fil)(fr).k7" size="27898" crc="9caa4e16" sha1="09bdec308f00357b89de078aff7a87c0ad27b70e"/>
@@ -11087,10 +10242,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="f15strika" cloneof="f15strik">
-		<description>F15 Strike Eagle (Alt)</description>
+		<description>F15 Strike Eagle (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28038">
 				<rom name="f15 strike eagle (1987)(fil)(fr)[a].k7" size="28038" crc="1d4a7cc0" sha1="9c34b6bc4b98b2d9a14187d800b07652f0a3ecd0"/>
@@ -11099,10 +10253,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="f15strikb" cloneof="f15strik">
-		<description>F15 Strike Eagle (Alt 2)</description>
+		<description>F15 Strike Eagle (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28038">
 				<rom name="f15 strike eagle (1987)(fil)(fr)[a2].k7" size="28038" crc="fbfe24dd" sha1="6d79bef494af65e29b56f7fdbe52320b7d40d238"/>
@@ -11111,10 +10264,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="f15strikc" cloneof="f15strik">
-		<description>F15 Strike Eagle (Alt 3)</description>
+		<description>F15 Strike Eagle (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28038">
 				<rom name="f15-strike-eagle_mo5.k7" size="28038" crc="5714f7f7" sha1="e132cd4d271eb62d63e21c959b69cc2b06409f80"/>
@@ -11126,7 +10278,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>FBI</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20396">
 				<rom name="fbi (1984)(infogrames)(fr).k7" size="20396" crc="0ca3dd5d" sha1="f140c04ae38d3cb16f881cf46f3d60eccfbc40ec"/>
@@ -11135,10 +10286,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="fbia" cloneof="fbi">
-		<description>FBI (Alt)</description>
+		<description>FBI (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21306">
 				<rom name="fbi (1984)(infogrames)(fr)[a].k7" size="21306" crc="3c276fa5" sha1="b1ea672ee1b0be83f44a534849209befb3beec2a"/>
@@ -11147,10 +10297,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="fbib" cloneof="fbi">
-		<description>FBI (Alt 2)</description>
+		<description>FBI (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21306">
 				<rom name="fbi (1984)(infogrames)(fr)[a2].k7" size="21306" crc="15936f44" sha1="01ababd6d840ada8a8cfae173800a3143e31b0fa"/>
@@ -11159,10 +10308,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="fbic" cloneof="fbi">
-		<description>FBI (Alt 3)</description>
+		<description>FBI (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21306">
 				<rom name="fbi.k5" size="21306" crc="de356375" sha1="d5f1f93c12a5f48394ca4a0fcd05375918aea0fe"/>
@@ -11171,10 +10319,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="fbid" cloneof="fbi">
-		<description>FBI (Alt 4)</description>
+		<description>FBI (alt 4)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21083">
 				<rom name="fbi_mo5.k7" size="21083" crc="13912bd8" sha1="2ad5db80a84b31681b03cbd38c0122b42521c2b5"/>
@@ -11186,7 +10333,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Felonies</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="82242">
 				<rom name="felonies (1986)(ere informatique)(fr)[b].k7" size="82242" crc="e705bae9" sha1="9840aae261ea8df490167445ea0e69633a7214c1"/>
@@ -11195,10 +10341,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="feloniesa" cloneof="felonies">
-		<description>Felonies (Alt)</description>
+		<description>Felonies (alt)</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="87465">
 				<rom name="felonies (1986)(ere informatique)(fr)[b2].k7" size="87465" crc="55b97461" sha1="44b97642cc200732828108d6c2fc83612e35e045"/>
@@ -11207,10 +10352,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="feloniesb" cloneof="felonies">
-		<description>Felonies (Alt 2)</description>
+		<description>Felonies (alt 2)</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="87465">
 				<rom name="felonies (1986) (ere informatique) [a1].k7" size="87465" crc="61745d72" sha1="5593a1eafff0dbe3a3b49960a128ad564379363f"/>
@@ -11219,10 +10363,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="feloniesc" cloneof="felonies">
-		<description>Felonies (Alt 3)</description>
+		<description>Felonies (alt 3)</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="87465">
 				<rom name="felonies (ere) (guy bec) (1986).k7" size="87465" crc="826a8a69" sha1="ea3f9d4145fedcc32e31b951c23553f082ec9b75"/>
@@ -11234,7 +10377,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flash Point</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49843">
 				<rom name="flash point (1987)(fil)(fr).k7" size="49843" crc="8bb39efa" sha1="bd1c2d9c53b843ab6cd2111fd720e47ec1a6fc49"/>
@@ -11243,10 +10385,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="flashpnta" cloneof="flashpnt">
-		<description>Flash Point (Alt)</description>
+		<description>Flash Point (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49843">
 				<rom name="flash point (1987)(fil)(fr)[a].k7" size="49843" crc="bd2041ee" sha1="a51bab0fdbc787c5e3038518ffddfff2383547c7"/>
@@ -11255,10 +10396,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="flashpntb" cloneof="flashpnt">
-		<description>Flash Point (Alt 2)</description>
+		<description>Flash Point (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49843">
 				<rom name="flash-point_mo5.k7" size="49843" crc="f95e42a6" sha1="3d3f01f715a5ff52393673c5afa221cc47c206b3"/>
@@ -11270,7 +10410,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flipper</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42892">
 				<rom name="flipper (1984-10)(loriciels)(fr).k7" size="42892" crc="086cee71" sha1="1d14f5bd3b0bacf51296b2a399f594aca9500115"/>
@@ -11279,10 +10418,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="flippera" cloneof="flipper">
-		<description>Flipper (Alt)</description>
+		<description>Flipper (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42892">
 				<rom name="flipper (1984-10)(loriciels)(fr)[a].k7" size="42892" crc="51fbbb08" sha1="de4553aaf6d64a8cb82dfbc74b56af2a5f1befcb"/>
@@ -11291,10 +10429,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="flipperb" cloneof="flipper">
-		<description>Flipper (Alt 2)</description>
+		<description>Flipper (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42892">
 				<rom name="flipper (1984-10)(loriciels)(fr)[a2].k7" size="42892" crc="8ec31bae" sha1="1e739a36bdc3cd12a2b82076c9cf930452151fdd"/>
@@ -11303,10 +10440,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="flipperc" cloneof="flipper">
-		<description>Flipper (Alt 3)</description>
+		<description>Flipper (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42866">
 				<rom name="flipper_mo5.k7" size="42866" crc="5fa07901" sha1="319891503838abd90e646a92dfc23a09e6f38f3a"/>
@@ -11315,10 +10451,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="flipperd" cloneof="flipper">
-		<description>Flipper (WAV Format)</description>
+		<description>Flipper (WAV format)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13303304">
 				<rom name="flipper (1984-10)(loriciels)(fr).wav" size="13303304" crc="411bdac1" sha1="15a9231147bfda321232e63bc8a92b6e6cad8247"/>
@@ -11331,7 +10466,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Football</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21679">
 				<rom name="football (1987)(infogrames)[b].k7" size="21679" crc="493f4579" sha1="b65afaaf1055444538ccfaa7880ab9f2ed091e3c"/>
@@ -11341,10 +10475,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="footballa" cloneof="football" supported="no">
-		<description>Football (Alt)</description>
+		<description>Football (alt)</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21679">
 				<rom name="football (infogrames) (1987).k7" size="21679" crc="243be34e" sha1="c9e0d33cddd110918c3312411d200432d0718a46"/>
@@ -11354,10 +10487,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="footballb" cloneof="football" supported="no">
-		<description>Football (Alt 2)</description>
+		<description>Football (alt 2)</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22879">
 				<rom name="football_mo5.k7" size="22879" crc="c262341b" sha1="117f543fdd7b4abdaa17c976875b928955b65601"/>
@@ -11369,7 +10501,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Formule 1</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68525">
 				<rom name="formule 1 (1987)(fil)(fr).k7" size="68525" crc="c41cf39b" sha1="2a499eb490c048a418226edd14dd27caceb7af66"/>
@@ -11378,10 +10509,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="formule1a" cloneof="formule1">
-		<description>Formule 1 (Alt)</description>
+		<description>Formule 1 (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68789">
 				<rom name="formule 1 (1987)(fil)(fr)[a].k7" size="68789" crc="e257747d" sha1="6ba813b62d266b583ca44c929cf6757072fce9c1"/>
@@ -11390,10 +10520,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="formule1b" cloneof="formule1">
-		<description>Formule 1 (Alt 2)</description>
+		<description>Formule 1 (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68789">
 				<rom name="formule 1 (1987)(fil)(fr)[a2].k7" size="68789" crc="458699e6" sha1="1f4de6ed59843d531953309d0f8e255064f196ce"/>
@@ -11402,10 +10531,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="formule1c" cloneof="formule1">
-		<description>Formule 1 (Alt 3)</description>
+		<description>Formule 1 (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68789">
 				<rom name="formule-1_mo5.k7" size="68789" crc="a8866410" sha1="745384f0a36cc0c72f91adcf354386858dc1c65d"/>
@@ -11417,7 +10545,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Fox</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21858">
 				<rom name="fox (1985)(shift-edition)(fr).k7" size="21858" crc="b5ba1fa6" sha1="ac87b0daa3dc911446ca0b574a69c0c8a668291f"/>
@@ -11426,10 +10553,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="foxa" cloneof="fox">
-		<description>Fox (Alt)</description>
+		<description>Fox (alt)</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21858">
 				<rom name="fox (1985)(shift-edition)(fr)[a2].k7" size="21858" crc="2d5ea3b0" sha1="cb4bd1f17eed81a11f97c530837cbe63046aa2f0"/>
@@ -11441,7 +10567,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Fox (No BASIC Loader)</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22549">
 				<rom name="fox (1985)(shift-edition)(fr)[a no basic loader].k7" size="22549" crc="e5f36182" sha1="eb421269e4d8356a90e8ead60b33ca725af5569a"/>
@@ -11450,10 +10575,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="foxc" cloneof="fox">
-		<description>Fox (No BASIC Loader, Alt)</description>
+		<description>Fox (No BASIC Loader, alt)</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22549">
 				<rom name="fox (1985)(shift-edition)(fr)[b].k7" size="22549" crc="8a55398a" sha1="17e43edeb3e74e243442455105ccfddbff633d10"/>
@@ -11465,7 +10589,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Fox (Hebdogiciel no. 146)</description>
 		<year>1986</year>
 		<publisher>Pascal Gabriel - Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14946">
 				<rom name="fox[mo5].k7" size="14946" crc="8c198443" sha1="26918a0723225e68a6a328ff0eb001c2146924ed"/>
@@ -11477,7 +10600,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Galaxie Perdue</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22792">
 				<rom name="galaxie perdue (sprites) (1985) (mo5).k7" size="22792" crc="e2fc3ff0" sha1="304af14145edc352aa401dc780ab50cadb951bc8"/>
@@ -11489,7 +10611,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Game Over</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="57052">
 				<rom name="game over (1987)(fil)(fr).k7" size="57052" crc="63a9553a" sha1="eb14d8649da945b0e1bf3df357bca735cf4256f2"/>
@@ -11498,10 +10619,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="gameovera" cloneof="gameover">
-		<description>Game Over (Alt)</description>
+		<description>Game Over (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56731">
 				<rom name="game over (1987)(fil)(fr)[a].k7" size="56731" crc="12d185cf" sha1="489efa465f7773ccb9e0747ec6031f708658ea2d"/>
@@ -11510,10 +10630,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="gameoverb" cloneof="gameover">
-		<description>Game Over (Alt 2)</description>
+		<description>Game Over (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="57052">
 				<rom name="game over (1987)(fil)(fr)[a2].k7" size="57052" crc="f8dfc124" sha1="46b0184eb4053e188af84e8e1fc0cc412b330fd9"/>
@@ -11525,7 +10644,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le General</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47922">
 				<rom name="general, le (198x)(loriciels)(fr).k7" size="47922" crc="265ce965" sha1="df06a23292206190f4ee84819309acc415b1b3c7"/>
@@ -11534,10 +10652,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="generala" cloneof="general">
-		<description>Le General (Alt)</description>
+		<description>Le General (alt)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48396">
 				<rom name="general, le (198x)(loriciels)(fr)[a].k7" size="48396" crc="1a3d884f" sha1="7a46b64a8e09cac9f7ebfb705ffee95bfda9b6c6"/>
@@ -11546,10 +10663,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="generalb" cloneof="general">
-		<description>Le General (Alt 2)</description>
+		<description>Le General (alt 2)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48396">
 				<rom name="general, le (198x)(loriciels)(fr)[a2].k7" size="48396" crc="67f1e951" sha1="a2a407fdb306b191b0e8b3931f7e8716d623e17c"/>
@@ -11558,10 +10674,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="generalc" cloneof="general">
-		<description>Le General (Alt 3)</description>
+		<description>Le General (alt 3)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48396">
 				<rom name="le-general_mo5.k7" size="48396" crc="ce7e2b63" sha1="0550a69a4c41c980a843b20e9267616b0150077c"/>
@@ -11573,7 +10688,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Geodyssee</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33735">
 				<rom name="geodyssee (1985)(coktel vision)(fr).k7" size="33735" crc="3fe2dbf3" sha1="de7303824d1d75b387bc87f30fcf5f73f44f5fd4"/>
@@ -11582,10 +10696,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="geodyseea" cloneof="geodysee">
-		<description>Geodyssee (Alt)</description>
+		<description>Geodyssee (alt)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33735">
 				<rom name="geodyssee (1985)(coktel vision)(fr)[a].k7" size="33735" crc="cda51e01" sha1="8b6d967660c38a6edede67b45232200fbafddf49"/>
@@ -11594,10 +10707,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="geodyseeb" cloneof="geodysee">
-		<description>Geodyssee (Alt 2)</description>
+		<description>Geodyssee (alt 2)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33735">
 				<rom name="geodyssee (1985)(coktel vision)(fr)[a2].k7" size="33735" crc="2db636af" sha1="e8543417c3a8667768b761c61f61a4e15ccf7b6e"/>
@@ -11606,10 +10718,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="geodyseec" cloneof="geodysee">
-		<description>Geodyssee (Alt 3)</description>
+		<description>Geodyssee (alt 3)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33735">
 				<rom name="geodyssee_mo5.k7" size="33735" crc="9a7ae807" sha1="ebc0a7546561d9e8b9d8c9c1371d1eac40ac6da3"/>
@@ -11622,7 +10733,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Geste d'Artillac</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="21188">
@@ -11645,10 +10755,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="gestearta" cloneof="gesteart" supported="no">
-		<description>La Geste d'Artillac (Alt)</description>
+		<description>La Geste d'Artillac (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="21180">
@@ -11671,10 +10780,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="gesteartb" cloneof="gesteart" supported="no">
-		<description>La Geste d'Artillac (Single Tape)</description>
+		<description>La Geste d'Artillac (single tape)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="215555">
 				<rom name="geste d'artillac, la (1985)(infogrames)(fr).k7" size="215555" crc="7055ba87" sha1="cc761ea5808609ff28602977b19358513264230f"/>
@@ -11684,10 +10792,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="gesteartc" cloneof="gesteart" supported="no">
-		<description>La Geste d'Artillac (Single Tape, Alt)</description>
+		<description>La Geste d'Artillac (single tape, alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="215754">
 				<rom name="geste d'artillac, la (1985)(infogrames)(fr)[a].k7" size="215754" crc="83e03fe8" sha1="ec02c9088bb54da3bd3adc747835226afe084b5f"/>
@@ -11697,10 +10804,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="gesteartd" cloneof="gesteart" supported="no">
-		<description>La Geste d'Artillac (Single Tape, Alt 2)</description>
+		<description>La Geste d'Artillac (single tape, alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="215520">
 				<rom name="geste d'artillac, la (1985)(infogrames)(fr)[a2].k7" size="215520" crc="edee005c" sha1="5835d9cc4cd69add07d8a398111cc60692c056f4"/>
@@ -11712,7 +10818,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ghostbusters</description>
 		<year>1989</year>
 		<publisher>Christophe Lesur</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10948">
 				<rom name="ghostbusters (1989-08)(lesur, christophe)(fr)[load twice].k7" size="10948" crc="d66aea27" sha1="490618148c5bc70d99c2e079736d08bfd0748e07"/>
@@ -11724,7 +10829,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Glouton</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4283">
 				<rom name="glouton (1986)(hebdogiciel)(fr).k7" size="4283" crc="68d02f32" sha1="91be61be3f055c65a33e2cca5c743f31770212a3"/>
@@ -11733,10 +10837,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="gloutona" cloneof="glouton">
-		<description>Glouton (Alt)</description>
+		<description>Glouton (alt)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4283">
 				<rom name="glouton (1986)(hebdogiciel)(fr)[a].k7" size="4283" crc="1ee0e62f" sha1="ed227607c43050a4168b88ed19a65252d89718f9"/>
@@ -11745,10 +10848,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="gloutonb" cloneof="glouton">
-		<description>Glouton (Alt 2)</description>
+		<description>Glouton (alt 2)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4283">
 				<rom name="glouton_mo5.k7" size="4283" crc="18bbe7da" sha1="09347863050549a444ac1f2e9929ccc50ff0ce8a"/>
@@ -11760,7 +10862,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Graal</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="60337">
@@ -11779,7 +10880,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Grand Siecle</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="77123">
@@ -11798,7 +10898,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Granulus (Hebdogiciel no. 152)</description>
 		<year>1986</year>
 		<publisher>Emerich Fernandes - Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12667">
 				<rom name="granulus[mo5].k7" size="12667" crc="2d036233" sha1="52adad91e120339be7f4e91e8a500780b7e18b95"/>
@@ -11810,7 +10909,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gravitron</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9077">
 				<rom name="gravitron (1985)(fil)(fr).k7" size="9077" crc="b8e1c174" sha1="893e7da70c13373902b101bfbc00095ff058316e"/>
@@ -11819,10 +10917,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="gravitroa" cloneof="gravitro">
-		<description>Gravitron (Alt)</description>
+		<description>Gravitron (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10885">
 				<rom name="gravitron (1985)(fil)(fr)[a].k7" size="10885" crc="0c6ed22d" sha1="632cc9865ad963be54950dd518561877a7cc4285"/>
@@ -11831,10 +10928,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="gravitrob" cloneof="gravitro">
-		<description>Gravitron (Alt 2)</description>
+		<description>Gravitron (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9059">
 				<rom name="gravitron (1985)(fil)(fr)[a2].k7" size="9059" crc="7b60c492" sha1="5626103a00c0aacae6df57ea324a0d823377b77d"/>
@@ -11843,10 +10939,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="gravitroc" cloneof="gravitro">
-		<description>Gravitron (Alt 3)</description>
+		<description>Gravitron (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9059">
 				<rom name="gravitron (1985)(fil)(fr)[a3].k7" size="9059" crc="1e6771db" sha1="fc62c55847671f4fd22c4f1048c4203dad55a734"/>
@@ -11855,10 +10950,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="gravitrod" cloneof="gravitro">
-		<description>Gravitron (Alt 4)</description>
+		<description>Gravitron (alt 4)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9015">
 				<rom name="gravitron_mo5.k7" size="9015" crc="cb1463f5" sha1="6ff96e6d1382d0756f21949dd3ba1bf652e0b1b5"/>
@@ -11870,7 +10964,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Green Beret</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33241">
 				<rom name="green beret (1986)(fil)(fr).k7" size="33241" crc="0f93b01f" sha1="30b07f962e703ff461685df47916c80caa13d75c"/>
@@ -11879,10 +10972,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="greenbera" cloneof="greenber">
-		<description>Green Beret (Alt)</description>
+		<description>Green Beret (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33383">
 				<rom name="green beret (1986)(fil)(fr)[a].k7" size="33383" crc="97b9f662" sha1="5fa5da2ac499cc4050ce3336ecb1f3f1640c7742"/>
@@ -11891,10 +10983,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="greenberb" cloneof="greenber">
-		<description>Green Beret (Alt 2)</description>
+		<description>Green Beret (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33383">
 				<rom name="green beret (1986)(fil)(fr)[a2].k7" size="33383" crc="c36c5b39" sha1="7d45c53f5b73425d7c15d1d4ea86650a0375a42e"/>
@@ -11903,10 +10994,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="greenberc" cloneof="greenber">
-		<description>Green Beret (Alt 3)</description>
+		<description>Green Beret (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33383">
 				<rom name="green-beret_mo5.k7" size="33383" crc="07790323" sha1="d8eac58827067a80e9d8d36f4823e83257cef5c9"/>
@@ -11918,7 +11008,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Grignote II</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3030">
 				<rom name="grignote ii, la (1985)(dcsoft)(fr).k7" size="3030" crc="61f0d851" sha1="885e53a5e8a6b490b0f5b190d1a22f03898bddb4"/>
@@ -11927,10 +11016,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="grignot2a" cloneof="grignot2">
-		<description>La Grignote II (Alt)</description>
+		<description>La Grignote II (alt)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3030">
 				<rom name="grignote ii, la (1985)(dcsoft)(fr)[a].k7" size="3030" crc="cd51fb54" sha1="d4a012e8b26462a8d56d2be552e3581ecf483e6a"/>
@@ -11939,10 +11027,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="grignot2b" cloneof="grignot2">
-		<description>La Grignote II (Alt 2)</description>
+		<description>La Grignote II (alt 2)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3030">
 				<rom name="grignote ii, la (1985)(dcsoft)(fr)[a2].k7" size="3030" crc="c935cf4e" sha1="e66d7d425c508957fee02aeef37c6351e1856812"/>
@@ -11951,10 +11038,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="grignot2c" cloneof="grignot2">
-		<description>La Grignote II (Alt 3)</description>
+		<description>La Grignote II (alt 3)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3030">
 				<rom name="la-grignote-2_mo5.k7" size="3030" crc="f8523444" sha1="2ef2523d7c3407ec4fc03a5b4a3a726918e4a78c"/>
@@ -11966,7 +11052,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Guerres Spaciales (Hebdogiciel no. 132/134)</description>
 		<year>1986</year>
 		<publisher>Michael Escoffier - Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52932">
 				<rom name="guerresspatiales_jeu_[mo5].k7" size="52932" crc="0482b67b" sha1="be18a883a341e3c84d8c3e23c241e1b98d6b3b18"/>
@@ -11983,7 +11068,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gulpy la Chenille Gourmand</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8832">
 				<rom name="gulpy la chenille gourmand (1986)(microtom)(fr).k7" size="8832" crc="8d95638d" sha1="1253c40e7429fcfd03f8f805010ad01d3654875a"/>
@@ -11992,10 +11076,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="gulpya" cloneof="gulpy">
-		<description>Gulpy la Chenille Gourmand (Alt)</description>
+		<description>Gulpy la Chenille Gourmand (alt)</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8832">
 				<rom name="gulpy la chenille gourmand (1986)(microtom)(fr)[a].k7" size="8832" crc="72e41d56" sha1="0387794a269f0e45322ec821bd0640ffeb8babc4"/>
@@ -12004,10 +11087,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="gulpyb" cloneof="gulpy">
-		<description>Gulpy la Chenille Gourmand (Alt 2)</description>
+		<description>Gulpy la Chenille Gourmand (alt 2)</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8832">
 				<rom name="gulpy_mo5.k7" size="8832" crc="16034446" sha1="f682b897f928e860716e547db94edf938db393cb"/>
@@ -12019,7 +11101,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Hacker</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48516">
 				<rom name="hacker (1986)(loriciels)(fr)(en-fr).k7" size="48516" crc="dc3e9851" sha1="a1be7693bcca86ba90b966bca766ed412566b68e"/>
@@ -12028,10 +11109,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="hackera" cloneof="hacker">
-		<description>Hacker (Alt)</description>
+		<description>Hacker (alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48516">
 				<rom name="hacker (1986)(loriciels)(fr)(en-fr)[a].k7" size="48516" crc="e48d049b" sha1="50e0c0d361bba9f48d8e294163acc3c9a53128ed"/>
@@ -12040,10 +11120,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="hackerb" cloneof="hacker">
-		<description>Hacker (Alt 2)</description>
+		<description>Hacker (alt 2)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48516">
 				<rom name="hacker (loriciels) (steve cartwright (activision), alain fernandes) (1986) (mo5).k7" size="48516" crc="f98d6c1d" sha1="241c2945ca2fec532b9a1a227090af0b3460e362"/>
@@ -12055,7 +11134,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Heritage</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11348766">
 				<rom name="heritage, l' (1986)(infogrames)(fr)[loadm'''',,r].wav" size="11348766" crc="827aa00b" sha1="f2f405b8fbcd68981cc948e940ddaf3de50824e2"/>
@@ -12065,10 +11143,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="heritagea" cloneof="heritage" supported="no">
-		<description>L'Heritage (Alt)</description>
+		<description>L'Heritage (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41201">
 				<rom name="heritage ii, l' (1986)(infogrames)(fr)[b].k7" size="41201" crc="febe0967" sha1="ce3aea2e355d3ea83952aa2e760025d649ee9519"/>
@@ -12078,10 +11155,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="heritageb" cloneof="heritage" supported="no">
-		<description>L'Heritage (Alt 2)</description>
+		<description>L'Heritage (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39521">
 				<rom name="heritage ii, l' (1986)(infogrames)(fr)[b2].k7" size="39521" crc="d97ddd1b" sha1="8e43c7cb4686f9936bb79141303a7b9e7d7543f5"/>
@@ -12091,10 +11167,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="heritagec" cloneof="heritage" supported="no">
-		<description>L'Heritage (Alt 3)</description>
+		<description>L'Heritage (alt 3)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39521">
 				<rom name="l'heritage ii (infogrames) (pierre bayle) (1986).k7" size="39521" crc="a89f246a" sha1="510da52b000f095b15b4b6817361f1c064a47fb5"/>
@@ -12106,7 +11181,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>HMS Cobra - Convois pour Mourmansk</description>
 		<year>1987</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="67369">
 				<rom name="hms cobra - convois pour mourmansk (198x)(cobra soft)(fr).k7" size="67369" crc="2cc96102" sha1="481f09e264792fa5d240b11af498717d48ee15f8"/>
@@ -12115,10 +11189,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="hmscobraa" cloneof="hmscobra">
-		<description>HMS Cobra - Convois pour Mourmansk (Alt)</description>
+		<description>HMS Cobra - Convois pour Mourmansk (alt)</description>
 		<year>1987</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="67642">
 				<rom name="hms cobra - convois pour mourmansk (198x)(cobra soft)(fr)[a].k7" size="67642" crc="7d7de536" sha1="58e21aa023a7637f388ecbfd6dae83676f34ffd1"/>
@@ -12127,10 +11200,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="hmscobrab" cloneof="hmscobra">
-		<description>HMS Cobra - Convois pour Mourmansk (Alt 2)</description>
+		<description>HMS Cobra - Convois pour Mourmansk (alt 2)</description>
 		<year>1987</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="67642">
 				<rom name="hms cobra - convois pour mourmansk (198x)(cobra soft)(fr)[a2].k7" size="67642" crc="b40a1915" sha1="5e96dc44cfdaa1de17420e0e2d6b1e3f3ef8bfa2"/>
@@ -12139,10 +11211,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="hmscobrac" cloneof="hmscobra">
-		<description>HMS Cobra - Convois pour Mourmansk (Alt 3)</description>
+		<description>HMS Cobra - Convois pour Mourmansk (alt 3)</description>
 		<year>1987</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="67642">
 				<rom name="hms-cobra_mo5.k7" size="67642" crc="993f90ca" sha1="aba526cc46a2baf9d650fe2a7c0f98dcab9504bc"/>
@@ -12154,7 +11225,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>I.L. l'Intrus</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21355">
 				<rom name="i.l. l'intrus (1984)(infogrames)(fr).k7" size="21355" crc="bedc32cb" sha1="84d8e4347766eb4eb5805077cec4cc7879538e92"/>
@@ -12163,10 +11233,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ilintrusa" cloneof="ilintrus">
-		<description>I.L. l'Intrus (Alt)</description>
+		<description>I.L. l'Intrus (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21355">
 				<rom name="i.l. l'intrus (1984)(infogrames)(fr)[a].k7" size="21355" crc="31c30473" sha1="ef4970d60f5f096d8c0c4c7a112fcd546a7d41ed"/>
@@ -12175,10 +11244,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="ilintrusb" cloneof="ilintrus">
-		<description>I.L. l'Intrus (Alt 2)</description>
+		<description>I.L. l'Intrus (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21355">
 				<rom name="il-l-intrus_mo5.k7" size="21355" crc="568ce583" sha1="a35548f086c181454b84ca6570e9cb37959fd973"/>
@@ -12190,7 +11258,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Imperialis</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24396">
 				<rom name="imperialis (198x)(coktel vision)(fr).k7" size="24396" crc="b3845223" sha1="253e72b378b34c84f54f2ae1d8588c3a770bddfc"/>
@@ -12199,10 +11266,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="imperiala" cloneof="imperial">
-		<description>Imperialis (Alt)</description>
+		<description>Imperialis (alt)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24396">
 				<rom name="imperialis (1986)(coktel vision)(fr)[a].k7" size="24396" crc="052df47f" sha1="ee0a60a1da53eb2d6c60999dde58a91933ee840c"/>
@@ -12211,10 +11277,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="imperialb" cloneof="imperial">
-		<description>Imperialis (Alt 2)</description>
+		<description>Imperialis (alt 2)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24396">
 				<rom name="imperialis (1986)(coktel vision)(fr)[a2].k7" size="24396" crc="3917df65" sha1="adfd6477ef2168b082483551562d1df7147330fa"/>
@@ -12223,10 +11288,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="imperialc" cloneof="imperial">
-		<description>Imperialis (Alt 3)</description>
+		<description>Imperialis (alt 3)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24396">
 				<rom name="imperialis_mo5.k7" size="24396" crc="dc0c0fe0" sha1="21b31a6d7f3ce7c47b80b6f05c63570e095f92ff"/>
@@ -12238,7 +11302,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>In Ex</description>
 		<year>198?</year>
 		<publisher>Francoise Monnet</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13280">
 				<rom name="in ex (198x)(monnet, francoise)(fr).k7" size="13280" crc="32895237" sha1="700dfcbb48f348827347058da82ab20a0ed7127a"/>
@@ -12250,7 +11313,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Indiana</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24199">
 				<rom name="indiana (1985)(hebdogiciel)(fr).k7" size="24199" crc="20d4a6f3" sha1="5705637ddfcfd47bcb1e134e979e194aa57151d5"/>
@@ -12259,10 +11321,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="indianaa" cloneof="indiana">
-		<description>Indiana (Alt)</description>
+		<description>Indiana (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24199">
 				<rom name="indiana (1985)(hebdogiciel)(fr)[a].k7" size="24199" crc="decaf303" sha1="0bf232dbaca006b7d7678c88ed306bb7859eb6ee"/>
@@ -12271,10 +11332,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="indianab" cloneof="indiana">
-		<description>Indiana (Alt 2)</description>
+		<description>Indiana (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24199">
 				<rom name="indiana_mo5.k7" size="24199" crc="eec6a987" sha1="d9ff0704528f446e559a04820b76a3f66720bb81"/>
@@ -12286,7 +11346,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Indiana (No Title Screen)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21952">
 				<rom name="indiana (1985)(hebdogiciel)(fr)[m title screen].k7" size="21952" crc="b6a31c35" sha1="57b5fb44208c94d1f3381735b6af938ad1a62f9f"/>
@@ -12298,7 +11357,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Indiana Thom</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24966">
 				<rom name="indiana thom (sprites) (1985) (mo5).k7" size="24966" crc="20e883b1" sha1="f69bfa2dbfb181004705624863b3170be057f150"/>
@@ -12310,7 +11368,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Infierno</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39069">
 				<rom name="infierno (1986-07-16)(rubio, javier marco &amp; escudero, angelines rubio)(es).k7" size="39069" crc="36ea0239" sha1="144c1a763fa888f8dd2464772de58436ed3d1e09"/>
@@ -12319,10 +11376,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="infiernoa" cloneof="infierno">
-		<description>Infierno (Alt)</description>
+		<description>Infierno (alt)</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39069">
 				<rom name="infierno (1986-07-16)(rubio, javier marco &amp; escudero, angelines rubio)(es)[a].k7" size="39069" crc="90f3f15b" sha1="287a9a7478063e25726bdf96deaa0e920724d9de"/>
@@ -12331,10 +11387,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="infiernob" cloneof="infierno">
-		<description>Infierno (Alt 2)</description>
+		<description>Infierno (alt 2)</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39069">
 				<rom name="infierno_mo5.k7" size="39069" crc="0c9cb158" sha1="b505a27b4e813b457eedf1a53c7c21ba592e9d20"/>
@@ -12346,7 +11401,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Inspecteur Gadget</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64132">
 				<rom name="inspecteur gadget (1984)(vifi-nathan)(fr).k7" size="64132" crc="aad19502" sha1="6447041fe47666604c18ec44f10e3019c5a88e15"/>
@@ -12355,10 +11409,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="inspgadga" cloneof="inspgadg">
-		<description>Inspecteur Gadget (Alt)</description>
+		<description>Inspecteur Gadget (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64132">
 				<rom name="inspecteur gadget (1984)(vifi-nathan)(fr)[a].k7" size="64132" crc="b0b6eb61" sha1="131763241f2b1d8e2ab24f63a9ceb10f3d841544"/>
@@ -12367,10 +11420,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="inspgadgb" cloneof="inspgadg">
-		<description>Inspecteur Gadget (Alt 2)</description>
+		<description>Inspecteur Gadget (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64132">
 				<rom name="inspecteur-gadget_mo5.k7" size="64132" crc="0a3a0d54" sha1="ae1f539382bfce1f1af1a2c2b145656e0c459a27"/>
@@ -12382,7 +11434,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Intox &amp; Zoe</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32509">
 				<rom name="intox &amp; zoe (1984-08)(loriciels - tf01)(fr).k7" size="32509" crc="a831ec58" sha1="f5b24f4c73c33b9e6edd4f131a775f8d22c520ea"/>
@@ -12391,10 +11442,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="intoxzoea" cloneof="intoxzoe">
-		<description>Intox &amp; Zoe (Alt)</description>
+		<description>Intox &amp; Zoe (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32501">
 				<rom name="intox &amp; zoe (1984-08)(loriciels - tf01)(fr)[b2].k7" size="32501" crc="38c0b137" sha1="383421a8d01e5faf04e5b753cb1560e0e40fbd67"/>
@@ -12403,10 +11453,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="intoxzoeb" cloneof="intoxzoe">
-		<description>Intox &amp; Zoe (Alt 2)</description>
+		<description>Intox &amp; Zoe (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32501">
 				<rom name="intox-et-zoe_mo5.k7" size="32501" crc="3d3febf8" sha1="b17e0cf7a8904cb5afa68a9ebb0ba90be56184da"/>
@@ -12419,7 +11468,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Intox &amp; Zoe (Protected)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32501">
 				<rom name="intox &amp; zoe (1984-08)(loriciels - tf01)(fr)[b].k7" size="32501" crc="170361b6" sha1="510a7106e83cfcf4e9b3f9287e1c7faf7c4847e8"/>
@@ -12431,7 +11479,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Intrus</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16791">
 				<rom name="l'intrus (sprites) (pascal pommier) (1985) (mo5).k7" size="16791" crc="54b53b35" sha1="32e5654453f1c911546c53e11f197a162cdde7d1"/>
@@ -12443,7 +11490,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Invasion</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7691">
 				<rom name="invasion (1985)(infogrames)(fr).k7" size="7691" crc="36a9384b" sha1="47bd732186010f80c70a7726942fb58eb8c060f3"/>
@@ -12452,10 +11498,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="invasiona" cloneof="invasion">
-		<description>Invasion (Alt)</description>
+		<description>Invasion (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7691">
 				<rom name="invasion (1985)(infogrames)(fr)[a].k7" size="7691" crc="844e1def" sha1="70673d1e33abcf8f026e2315d4c4708778d8fce8"/>
@@ -12464,10 +11509,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="invasionb" cloneof="invasion">
-		<description>Invasion (Alt 2)</description>
+		<description>Invasion (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7691">
 				<rom name="invasion_mo5.k7" size="7691" crc="7626a8e3" sha1="0d46e1448de00c61e57a5f45fec5f118972325e2"/>
@@ -12479,7 +11523,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Isabelle et le Dragon</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20234">
 				<rom name="isabelle et le dragon (1985)(hebdogiciel)(fr)(pd).k7" size="20234" crc="dacd4a41" sha1="0d5abaf03560f31298b2da1922e114311c776138"/>
@@ -12488,10 +11531,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="isabellea" cloneof="isabelle">
-		<description>Isabelle et le Dragon (Alt)</description>
+		<description>Isabelle et le Dragon (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20234">
 				<rom name="isabelle et le dragon (1985)(hebdogiciel)(fr)(pd)[a].k7" size="20234" crc="c4f3bbe3" sha1="3589f3287327f60e3b276caef39f822e3369fd97"/>
@@ -12500,10 +11542,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="isabelleb" cloneof="isabelle">
-		<description>Isabelle et le Dragon (Alt 2)</description>
+		<description>Isabelle et le Dragon (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20234">
 				<rom name="isabelle et le dragon (19xx)(hebdogiciel)(pd).k7" size="20234" crc="2d19f913" sha1="66f2d528e22364f980f5d9556840b3db6d0c27e9"/>
@@ -12512,10 +11553,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="isabellec" cloneof="isabelle">
-		<description>Isabelle et le Dragon (Alt 3)</description>
+		<description>Isabelle et le Dragon (alt 3)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20234">
 				<rom name="isabelle-et-le-dragon_mo5.k7" size="20234" crc="3cbca6a4" sha1="98a2a5e426e1121adf26c8a9999c8156d3bebc1a"/>
@@ -12527,7 +11567,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Island</description>
 		<year>1984</year>
 		<publisher>Micro Application - Informatics</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32502">
 				<rom name="island (1984)(micro application - informatics)(fr).k7" size="32502" crc="95740fd4" sha1="a99a6f3404710b1e7a88b2a2f0607b806d0ae228"/>
@@ -12536,10 +11575,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="islanda" cloneof="island">
-		<description>Island (Alt)</description>
+		<description>Island (alt)</description>
 		<year>1984</year>
 		<publisher>Micro Application - Informatics</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32502">
 				<rom name="island (1984)(micro application - informatics)(fr)[a].k7" size="32502" crc="c7952c4e" sha1="008915bba8acabadc22cea8e71498f1b6129cdc9"/>
@@ -12548,10 +11586,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="islandb" cloneof="island">
-		<description>Island (Alt 2)</description>
+		<description>Island (alt 2)</description>
 		<year>1984</year>
 		<publisher>Micro Application - Informatics</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32502">
 				<rom name="island (1984)(micro application - informatics)(fr)[a2].k7" size="32502" crc="21850d19" sha1="43a31718b7ca7211e76f40fc8db7543cd55cc011"/>
@@ -12560,10 +11597,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="islandc" cloneof="island">
-		<description>Island (Alt 3)</description>
+		<description>Island (alt 3)</description>
 		<year>1984</year>
 		<publisher>Micro Application - Informatics</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32502">
 				<rom name="island_mo5.k7" size="32502" crc="1987ecaa" sha1="6e48857b4915e61afcf6f23b517c648ccc2500cf"/>
@@ -12575,7 +11611,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>James Debug - Le Grand Saut</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45944">
 				<rom name="james debug - le grand saut (1987)(coktel vision)(fr).k7" size="45944" crc="0bb9d507" sha1="b85e96dc9aabcfb06c5efb852032a79c6bd2fd72"/>
@@ -12584,10 +11619,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jamesdeba" cloneof="jamesdeb">
-		<description>James Debug - Le Grand Saut (Alt)</description>
+		<description>James Debug - Le Grand Saut (alt)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45944">
 				<rom name="james debug - le grand saut (1987)(coktel vision)(fr)[a].k7" size="45944" crc="bcb85934" sha1="00fb5d6a5f6c4ee9f72ab26ec84cbede076f43c5"/>
@@ -12599,7 +11633,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu de Dames</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="jeu de dames (1984-07)(loriciels)(fr).k7" size="12668" crc="cfc445b1" sha1="fe4e01cf88a6e70308a64a54a292985f87f04f61"/>
@@ -12608,10 +11641,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeudamesa" cloneof="jeudames">
-		<description>Jeu de Dames (Alt)</description>
+		<description>Jeu de Dames (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="jeu de dames (1984-07)(loriciels)(fr)[a].k7" size="12668" crc="5554f495" sha1="f1a6bc270829494223aa2129e81c80461af2500e"/>
@@ -12620,10 +11652,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeudamesb" cloneof="jeudames">
-		<description>Jeu de Dames (Alt 2)</description>
+		<description>Jeu de Dames (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="jeu-de-dames_mo5.k7" size="12668" crc="908daafa" sha1="673b04e3b862b268a21681652afb6cd393f8adda"/>
@@ -12635,7 +11666,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu de Dames Americain</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11985">
 				<rom name="jeu de dames americain (1987)(fil)(fr).k7" size="11985" crc="6fbe9e56" sha1="526bb3c616bf8263d86ad41aedb1e4ec6ba95d35"/>
@@ -12644,10 +11674,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeudameaa" cloneof="jeudamea">
-		<description>Jeu de Dames Americain (Alt)</description>
+		<description>Jeu de Dames Americain (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11985">
 				<rom name="jeu de dames americain (1987)(fil)(fr)[a].k7" size="11985" crc="6e7c4698" sha1="7cf13cdd01f55ba271cacfbb61c6fa640d40abbe"/>
@@ -12656,10 +11685,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeudameab" cloneof="jeudamea">
-		<description>Jeu de Dames Americain (Alt 2)</description>
+		<description>Jeu de Dames Americain (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11985">
 				<rom name="jeu de dames americain (1987)(fil)(fr)[a2].k7" size="11985" crc="19796d72" sha1="9d6368634863577476918c60566720f57bd063d6"/>
@@ -12668,10 +11696,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeudameac" cloneof="jeudamea">
-		<description>Jeu de Dames Americain (Alt 3)</description>
+		<description>Jeu de Dames Americain (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11985">
 				<rom name="draughts_mo5.k7" size="11985" crc="c2c4ae54" sha1="04b4002e60df40df177eb758c2825d483d0c0a45"/>
@@ -12683,7 +11710,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Jeu des Marelles</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30298">
 				<rom name="jeu des marelles, le (198x)(free game blot)(fr).k7" size="30298" crc="bde59900" sha1="d2e866fcb2df6bde1d76eb974c32be7c0061b3b6"/>
@@ -12692,10 +11718,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="marellesa" cloneof="marelles">
-		<description>Le Jeu des Marelles (Alt)</description>
+		<description>Le Jeu des Marelles (alt)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30298">
 				<rom name="jeu des marelles, le (198x)(free game blot)(fr)[a].k7" size="30298" crc="e81a18df" sha1="edc6c937fe4d354985661fd90cef0e2a49067d83"/>
@@ -12704,10 +11729,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="marellesb" cloneof="marelles">
-		<description>Le Jeu des Marelles (Alt 2)</description>
+		<description>Le Jeu des Marelles (alt 2)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30298">
 				<rom name="le jeu des marelles (free game blot) (reiner ost) (mo5).k7" size="30298" crc="e848867d" sha1="f8ebef41e026e71a7d1c20e819422d376166058f"/>
@@ -12719,7 +11743,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Jeu des Petits Chevaux</description>
 		<year>198?</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12710">
 				<rom name="jeu des petits chevaux, le (198x)(edil)(fr).k7" size="12710" crc="6374534c" sha1="707ef589e9f8361134a255b7df0d1d206a9c5407"/>
@@ -12731,7 +11754,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu Meteo</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5580">
 				<rom name="jeu meteo (198x)(-)(fr).k7" size="5580" crc="4a944ec7" sha1="2bd2dcb472fdcab1c066ec381ee414ad0aed1632"/>
@@ -12740,10 +11762,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeumeteoa" cloneof="jeumeteo">
-		<description>Jeu Meteo (Alt)</description>
+		<description>Jeu Meteo (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5580">
 				<rom name="jeu meteo (198x)(-)(fr)[a].k7" size="5580" crc="9dd9992c" sha1="32cb989f96d7d5a1fdff703d596260ceb7c9fabb"/>
@@ -12752,10 +11773,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeumeteob" cloneof="jeumeteo">
-		<description>Jeu Meteo (Alt 2)</description>
+		<description>Jeu Meteo (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5745">
 				<rom name="jeu meteo (198x)(-)(fr)[a2].k7" size="5745" crc="54e451fd" sha1="e82860454636f5c43740fb5c03ff9f79e2f2671d"/>
@@ -12764,10 +11784,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeumeteoc" cloneof="jeumeteo">
-		<description>Jeu Meteo (Alt 3)</description>
+		<description>Jeu Meteo (alt 3)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5580">
 				<rom name="jeu-meteo_mo5.k7" size="5580" crc="f6e169ff" sha1="ae36db5c1b02db6f2d03d40355c324d9498b0a17"/>
@@ -12779,7 +11798,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Jeux de Maitre Jacques</description>
 		<year>1984</year>
 		<publisher>Micro Application</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13592">
 				<rom name="les jeux de maitre jacques (micro application) (jacques lebbe) (1984) (mo5).k7" size="13592" crc="80bb25f4" sha1="dc1e9491b483f904ab6aea89a9a67e85e97d3800"/>
@@ -12791,7 +11809,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Judoka</description>
 		<year>1985</year>
 		<publisher>VIFI International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36361">
 				<rom name="judoka (1985)(vifi)(fr).k7" size="36361" crc="1d805f09" sha1="b3d52e9c1d328cb25173480ad455bb7f35f0bbfe"/>
@@ -12803,7 +11820,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jump for Survival</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22703">
 				<rom name="jump-for-survival_mo5.k7" size="22703" crc="3cb828b9" sha1="6c1ed7ef786c79484148ca0ce0d08e91ad363266"/>
@@ -12815,7 +11831,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jungle Hero</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="92170">
 				<rom name="jungle hero (198x)(softbook)(fr).k7" size="92170" crc="8cb49839" sha1="ccec5ece656d490e3292124139cda6de3f26e7b9"/>
@@ -12824,10 +11839,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jungheroa" cloneof="junghero">
-		<description>Jungle Hero (Alt)</description>
+		<description>Jungle Hero (alt)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="92170">
 				<rom name="jungle hero (198x)(softbook)(fr)[a].k7" size="92170" crc="ab608ac2" sha1="487da0ade89659c93ff493bf9eddf20352923d39"/>
@@ -12836,10 +11850,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jungherob" cloneof="junghero">
-		<description>Jungle Hero (Alt 2)</description>
+		<description>Jungle Hero (alt 2)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="92170">
 				<rom name="jungle hero (198x)(softbook)(fr)[a2].k7" size="92170" crc="cd8e3050" sha1="c54695890f367875c469db2d16fc5b2c7675c804"/>
@@ -12848,10 +11861,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jungheroc" cloneof="junghero">
-		<description>Jungle Hero (Alt 3)</description>
+		<description>Jungle Hero (alt 3)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="92170">
 				<rom name="jungle-hero_mo5.k7" size="92170" crc="4a4f2f83" sha1="02f9f231b3f63351cf7581d89c81ba0ca526451e"/>
@@ -12863,7 +11875,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Kanicula</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14293">
 				<rom name="kanicula (1984)(to tek)(fr).k7" size="14293" crc="b4efadc2" sha1="bdacf13288271e740f186b091370e861cce5a115"/>
@@ -12872,10 +11883,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="kaniculaa" cloneof="kanicula">
-		<description>Kanicula (Alt)</description>
+		<description>Kanicula (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14293">
 				<rom name="kanicula (1984)(to tek)(fr)[a].k7" size="14293" crc="ca61905d" sha1="484b0ba291cbeb5553f7b8895a4df539386d7449"/>
@@ -12884,10 +11894,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="kaniculab" cloneof="kanicula">
-		<description>Kanicula (Alt 2)</description>
+		<description>Kanicula (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14293">
 				<rom name="kanicula (1984)(to tek)(fr)[a2].k7" size="14293" crc="e71c0c9a" sha1="15539ca522395d1004b45bf1d6f8e68bd04a7e3e"/>
@@ -12896,10 +11905,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="kaniculac" cloneof="kanicula">
-		<description>Kanicula (Alt 3)</description>
+		<description>Kanicula (alt 3)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14293">
 				<rom name="kanicula_mo5.k7" size="14293" crc="a58ff181" sha1="dfeac1fa7ab5274c2392baa16e3baac48a8458c4"/>
@@ -12911,7 +11919,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Karate</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11312405">
 				<rom name="karate (1985)(infogrames)[loadm'''',,r].wav" size="11312405" crc="c8c268fc" sha1="bd792e0e96f7f0a6578a8dc6a7f66f92cb8b51f7"/>
@@ -12920,10 +11927,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="karatea" cloneof="karate">
-		<description>Karate (Alt)</description>
+		<description>Karate (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34853">
 				<rom name="karate (1985)(infogrames)(fr)[loadm].k7" size="34853" crc="5557eaa4" sha1="e09f8f22d075ee5a89c77efe5e26f9d5aca2f8c1"/>
@@ -12932,10 +11938,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="karateb" cloneof="karate">
-		<description>Karate (Alt 2)</description>
+		<description>Karate (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33912">
 				<rom name="karate (1985)(infogrames)(fr)[a][loadm].k7" size="33912" crc="f9a5b85a" sha1="bf564d54fd836e9fbe87c4871b1eaacc530625a8"/>
@@ -12944,10 +11949,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="karatec" cloneof="karate">
-		<description>Karate (Alt 3)</description>
+		<description>Karate (alt 3)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33912">
 				<rom name="karate (1985)(infogrames)(fr)[a2][loadm].k7" size="33912" crc="7cf35047" sha1="b0b6a5688abd38b8791ff406a7de759bbc7579f9"/>
@@ -12956,10 +11960,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="karated" cloneof="karate">
-		<description>Karate (Alt 4)</description>
+		<description>Karate (alt 4)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33912">
 				<rom name="karate (1985)(infogrames)(fr)[a3][loadm].k7" size="33912" crc="a28c199b" sha1="6f082fe1ab6825899a95603d27932d41f32ab859"/>
@@ -12968,10 +11971,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="karatee" cloneof="karate">
-		<description>Karate (Alt 5)</description>
+		<description>Karate (alt 5)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33912">
 				<rom name="karate_mo5.k7" size="33912" crc="0306544c" sha1="885ef795c3c57c6dc6366e766b91ab8ba841477b"/>
@@ -12983,7 +11985,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Karate (BASIC Loader)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36725">
 				<rom name="karate (1985)(infogrames)(fr)[b].k7" size="36725" crc="34c629d4" sha1="6185db96da92ba2c3f1a021ca48454ce921681bd"/>
@@ -12995,7 +11996,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Khronos</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48948">
 				<rom name="khronos (1986)(coktel vision)(fr).k7" size="48948" crc="f8730104" sha1="a16291123b7953b8a3f142d91f4ba8e584ecfd08"/>
@@ -13004,10 +12004,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="khronosa" cloneof="khronos">
-		<description>Khronos (Alt)</description>
+		<description>Khronos (alt)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49187">
 				<rom name="khronos (1986)(coktel vision)(fr)[a].k7" size="49187" crc="9134df59" sha1="642c29f1628dbf4be1d5eff1e9f72eb5d092a13b"/>
@@ -13016,10 +12015,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="khronosb" cloneof="khronos">
-		<description>Khronos (Alt 2)</description>
+		<description>Khronos (alt 2)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49187">
 				<rom name="khronos (1986)(coktel vision)(fr)[a2].k7" size="49187" crc="32041430" sha1="3066a87778a416e0c8a5765dfb71f8d7bf73ecee"/>
@@ -13028,10 +12026,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="khronosc" cloneof="khronos">
-		<description>Khronos (Alt 3)</description>
+		<description>Khronos (alt 3)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49187">
 				<rom name="khronos_mo5.k7" size="49187" crc="59fffdf1" sha1="13c930e6f415b804077df0e96f7d2c7236e64928"/>
@@ -13043,7 +12040,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Krakout</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45889">
 				<rom name="krakout (1987)(fil)(fr).k7" size="45889" crc="748c99be" sha1="0af603e6c4522dd5bd01e08ddbbfa229e211782e"/>
@@ -13052,10 +12048,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="krakouta" cloneof="krakout">
-		<description>Krakout (Alt)</description>
+		<description>Krakout (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46166">
 				<rom name="krakout (1987)(fil)(fr)[a].k7" size="46166" crc="6b06330e" sha1="a4eeeeec30afca893fc4edbf9703da0aee96815a"/>
@@ -13064,10 +12059,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="krakoutb" cloneof="krakout">
-		<description>Krakout (Alt 2)</description>
+		<description>Krakout (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46166">
 				<rom name="krakout (1987)(fil)(fr)[a2].k7" size="46166" crc="0ac9b5bb" sha1="75c2cecb03135658168beb00bfc5c073c4bcb36e"/>
@@ -13076,10 +12070,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="krakoutc" cloneof="krakout">
-		<description>Krakout (Alt 3)</description>
+		<description>Krakout (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46166">
 				<rom name="krakout_mo5.k7" size="46166" crc="5ed303f1" sha1="93aa11375f5961437743a369708d96972a79a663"/>
@@ -13091,7 +12084,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Kung Fou</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="54716">
 				<rom name="kung fou (1987)(softbook)(fr).k7" size="54716" crc="3de15f6b" sha1="7b80154f3ad6031a8f1d33e2888a0e9db6c3da19"/>
@@ -13100,10 +12092,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="kungfoua" cloneof="kungfou">
-		<description>Kung Fou (Alt)</description>
+		<description>Kung Fou (alt)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="54716">
 				<rom name="kung-fou_mo5.k7" size="54716" crc="10e31e72" sha1="393b76cf0b885d74986597b6914b7dfcef2e0382"/>
@@ -13115,7 +12106,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6654">
 				<rom name="labyrinthe (1986)(dcsoft)(fr)(pd).k7" size="6654" crc="83a76d0c" sha1="f0a19c460d2aab3973df2a01a7bdab8f5e6d4b46"/>
@@ -13124,10 +12114,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="labyrinta" cloneof="labyrint">
-		<description>Labyrinthe (Alt)</description>
+		<description>Labyrinthe (alt)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6654">
 				<rom name="labyrinthe (1986)(dcsoft)(fr)(pd)[a].k7" size="6654" crc="67e65574" sha1="4882f71fe9c6f13e108b0fa277fb4bd88c9742c5"/>
@@ -13136,10 +12125,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="labyrintb" cloneof="labyrint">
-		<description>Labyrinthe (Alt 2)</description>
+		<description>Labyrinthe (alt 2)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6654">
 				<rom name="labyrinthe (1986)(dcsoft)(fr)(pd)[a2].k7" size="6654" crc="b7138668" sha1="a741bd12d858e73205200ae6fd78d51fbc4713b8"/>
@@ -13148,10 +12136,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="labyrintc" cloneof="labyrint">
-		<description>Labyrinthe (Alt 3)</description>
+		<description>Labyrinthe (alt 3)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6654">
 				<rom name="labyrinthe_mo5.k7" size="6654" crc="202f2840" sha1="a4ba6b4bb6f0baeb76961059814282364242c71e"/>
@@ -13163,7 +12150,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe Survie</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10455">
 				<rom name="labyrinthe survie (1984)(vifi-nathan)(fr).k7" size="10455" crc="3550e148" sha1="52655416d5d0650ea93d789d66b918bbb32eecfb"/>
@@ -13172,10 +12158,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="labyrinsa" cloneof="labyrins">
-		<description>Labyrinthe Survie (Alt)</description>
+		<description>Labyrinthe Survie (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16559">
 				<rom name="labyrinthe survie (1984)(vifi-nathan)(fr)[a].k7" size="16559" crc="6e662977" sha1="14d187be5d08c082108f0c9a13fe548c1af864c8"/>
@@ -13184,10 +12169,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="labyrinsb" cloneof="labyrins">
-		<description>Labyrinthe Survie (Alt 2)</description>
+		<description>Labyrinthe Survie (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16559">
 				<rom name="labyrinthe-survie_mo5.k7" size="16559" crc="17c92688" sha1="3754de4974ad859b306819a57d51721e28bb03c7"/>
@@ -13213,7 +12197,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Las Vegas</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="55339">
@@ -13232,7 +12215,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Las Vegas (Split Side A)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A Part 1"/>
 			<dataarea name="cass" size="33674">
@@ -13254,10 +12236,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="lasvegasb" cloneof="lasvegas">
-		<description>Las Vegas (Single Tape)</description>
+		<description>Las Vegas (single tape)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85282">
 				<rom name="las vegas (1985)(infogrames)(fr).k7" size="85282" crc="c9fcd41b" sha1="036e68f4b86b4ddfa85434008c8b11acff76d169"/>
@@ -13266,10 +12247,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="lasvegasc" cloneof="lasvegas">
-		<description>Las Vegas (Single Tape, Alt)</description>
+		<description>Las Vegas (single tape, alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85282">
 				<rom name="las vegas (1985)(infogrames)(fr)[a].k7" size="85282" crc="876c5d31" sha1="24aeff0f55975fb6697ef5ab8c439adb3aab6083"/>
@@ -13278,10 +12258,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="lasvegasd" cloneof="lasvegas">
-		<description>Las Vegas (Single Tape, Alt 2)</description>
+		<description>Las Vegas (single tape, alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85282">
 				<rom name="las vegas (infogrames) (pierre bayle, roger granier) (1985) (mo6).k7" size="85282" crc="c49ffbb2" sha1="f3beb79d7ea838baac9bebb072b3242b835df350"/>
@@ -13290,10 +12269,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="lasvegase" cloneof="lasvegas">
-		<description>Las Vegas (Single Tape, Alt 3)</description>
+		<description>Las Vegas (single tape, alt 3)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85282">
 				<rom name="las vegas (fr) (infogrames) (pierre bayle) (1985) (lasvegasmo6).k7" size="85282" crc="8a0f7298" sha1="8e9de8be151009fdfd1f4fda0a98083c1da1f6ae"/>
@@ -13302,10 +12280,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="lasvegasf" cloneof="lasvegas" supported="no">
-		<description>Las Vegas (KCI Format)</description>
+		<description>Las Vegas (KCI format)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="701846">
@@ -13321,10 +12298,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="lasvegasg" cloneof="lasvegas" supported="no">
-		<description>Las Vegas (WAV Format)</description>
+		<description>Las Vegas (WAV format)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21625964">
 				<rom name="las-vegas-a_mo5.wav" size="21625964" crc="f3756a41" sha1="3d2c1152b75d493d8b364198383db776ab2ebbaf"/>
@@ -13341,7 +12317,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Lorann</description>
 		<year>1985</year>
 		<publisher>Novasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38582">
 				<rom name="lorann (1985)(novasoft)(fr).k7" size="38582" crc="1c7fd158" sha1="1dc0412a93a175039588e1801316b057897e7285"/>
@@ -13350,10 +12325,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="loranna" cloneof="lorann">
-		<description>Lorann (Alt)</description>
+		<description>Lorann (alt)</description>
 		<year>1985</year>
 		<publisher>Novasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38582">
 				<rom name="lorann (1985)(novasoft)(fr)[a].k7" size="38582" crc="097d7664" sha1="9c027569f722d8573c9086b0297a850b34619f39"/>
@@ -13362,10 +12336,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="lorannb" cloneof="lorann">
-		<description>Lorann (Alt 2)</description>
+		<description>Lorann (alt 2)</description>
 		<year>1985</year>
 		<publisher>Novasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38582">
 				<rom name="lorann (1985)(novasoft)(fr)[a2].k7" size="38582" crc="83fc8f85" sha1="e6f648ac1e4dee89c3b7b4482416360473152c6b"/>
@@ -13374,10 +12347,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="lorannc" cloneof="lorann">
-		<description>Lorann (Alt 3)</description>
+		<description>Lorann (alt 3)</description>
 		<year>1985</year>
 		<publisher>Novasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38582">
 				<rom name="lorann-mo5.k7" size="38582" crc="9c6c2c11" sha1="3782f15ad90d4640702fe18ded845257b9c5815b"/>
@@ -13389,7 +12361,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Magic</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44972">
 				<rom name="magic (1987)(titus software)(fr)(en-fr).k7" size="44972" crc="aed97f08" sha1="b1b163fd466129d1cc0dc5f98b68cd76c1787b01"/>
@@ -13398,10 +12369,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="magica" cloneof="magic">
-		<description>Magic (Alt)</description>
+		<description>Magic (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44972">
 				<rom name="magic_mo5.k7" size="44972" crc="75269635" sha1="d9ffd2e90d530f456635b72684dcab6b5e14b40b"/>
@@ -13413,7 +12383,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Maison Hantee</description>
 		<year>198?</year>
 		<publisher>Lilian Pigallio</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34616">
 				<rom name="maison hantee, la (198x)(pigallio, lilian)(fr).k7" size="34616" crc="4ddccac4" sha1="51f6c809bb32e4c492cb92fe7f7ee28ca627f81d"/>
@@ -13422,10 +12391,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="maisonhaa" cloneof="maisonha">
-		<description>La Maison Hantee (Alt)</description>
+		<description>La Maison Hantee (alt)</description>
 		<year>198?</year>
 		<publisher>Lilian Pigallio</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34616">
 				<rom name="maison hantee, la (198x)(pigallio, lilian)(fr)[a].k7" size="34616" crc="c79c688f" sha1="7f4715544876ea4f620141eed3e0cf6ed02e770c"/>
@@ -13434,10 +12402,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="maisonhab" cloneof="maisonha">
-		<description>La Maison Hantee (Alt 2)</description>
+		<description>La Maison Hantee (alt 2)</description>
 		<year>198?</year>
 		<publisher>Lilian Pigallio</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34616">
 				<rom name="maison hantee, la (198x)(pigallio, lilian)(fr)[a2].k7" size="34616" crc="8672623c" sha1="ef73d84017ebbaf09b7a6664db76140412a39f48"/>
@@ -13446,10 +12413,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="maisonhac" cloneof="maisonha">
-		<description>La Maison Hantee (Alt 3)</description>
+		<description>La Maison Hantee (alt 3)</description>
 		<year>198?</year>
 		<publisher>Lilian Pigallio</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34616">
 				<rom name="la-maison-hantee_mo5.k7" size="34616" crc="88bb4711" sha1="10c9bb32b10bd1ff89cd20ceaa00e7daf77a608c"/>
@@ -13461,7 +12427,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Malediction de Thaar</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38316">
 				<rom name="malediction de thaar, la (1986)(coktel vision)(fr).k7" size="38316" crc="4ca7dbfd" sha1="1e7b432a504e3c380908fcf3760bf921276001d1"/>
@@ -13470,10 +12435,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="malthaara" cloneof="malthaar">
-		<description>La Malediction de Thaar (Alt)</description>
+		<description>La Malediction de Thaar (alt)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38458">
 				<rom name="malediction de thaar, la (1986)(coktel vision)(fr)[a].k7" size="38458" crc="9e841d02" sha1="42aa8debb2423797db1b6ec014fdfa17ce831b81"/>
@@ -13482,10 +12446,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="malthaarb" cloneof="malthaar">
-		<description>La Malediction de Thaar (Alt 2)</description>
+		<description>La Malediction de Thaar (alt 2)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38458">
 				<rom name="malediction de thaar, la (1986)(coktel vision)(fr)[a2].k7" size="38458" crc="d7b17373" sha1="ea19a02bc4db6dfa165c3711a357b4851fbd819c"/>
@@ -13494,10 +12457,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="malthaarc" cloneof="malthaar">
-		<description>La Malediction de Thaar (Alt 3)</description>
+		<description>La Malediction de Thaar (alt 3)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38458">
 				<rom name="la-malediction-de-thaar_mo5.k7" size="38458" crc="94208b9c" sha1="12783baadc3a38920a16487ab8529fa94d15f4c2"/>
@@ -13510,7 +12472,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mandragore</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Jeu)"/>
 			<dataarea name="cass" size="41969">
@@ -13526,10 +12487,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="mandragoa" cloneof="mandrago">
-		<description>Mandragore (Alt, Tape 2 Split)</description>
+		<description>Mandragore (alt, tape 2 split)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Jeu)"/>
 			<dataarea name="cass" size="40521">
@@ -13551,10 +12511,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="mandragob" cloneof="mandrago">
-		<description>Mandragore (Single Tape)</description>
+		<description>Mandragore (single tape)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="150395">
 				<rom name="mandragore (1984)(infogrames)(fr).k7" size="150395" crc="307edecf" sha1="ee09e016830f8781a8fce8906b57dd915f2fa532"/>
@@ -13563,10 +12522,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="mandragoc" cloneof="mandrago">
-		<description>Mandragore (Single Tape, Alt)</description>
+		<description>Mandragore (single tape, alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="150395">
 				<rom name="mandragore (1984)(infogrames)(fr)[a].k7" size="150395" crc="1167e991" sha1="cfa380867df3216b189bc8bd6a419edfc1472140"/>
@@ -13578,7 +12536,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Marathon Cosmique</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24081">
 				<rom name="marathon cosmique (1985)(hebdogiciel)(fr)(pd).k7" size="24081" crc="f2debb3f" sha1="95278cfe7cc74ca1413abe52e5a1e0e96d62cdfe"/>
@@ -13587,10 +12544,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="marathona" cloneof="marathon">
-		<description>Marathon Cosmique (Alt)</description>
+		<description>Marathon Cosmique (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24081">
 				<rom name="marathon cosmique (1985)(hebdogiciel)(fr)(pd)[a].k7" size="24081" crc="5df90a41" sha1="6655e0355d3a7aff289ba1712319089f66801df1"/>
@@ -13599,10 +12555,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="marathonb" cloneof="marathon">
-		<description>Marathon Cosmique (Alt 2)</description>
+		<description>Marathon Cosmique (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24081">
 				<rom name="marathon cosmique (1985)(hebdogiciel)(fr)(pd)[a2].k7" size="24081" crc="09c999cd" sha1="cb0e86a1ce57eb97c0bd03a25bed6afb1a41cd07"/>
@@ -13611,10 +12566,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="marathonc" cloneof="marathon">
-		<description>Marathon Cosmique (Alt 3)</description>
+		<description>Marathon Cosmique (alt 3)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24081">
 				<rom name="marathon-cosmique_mo5.k7" size="24081" crc="5544ee55" sha1="0e2f360e4fbaa291c5e5af63e2749d0ddd2f3bfd"/>
@@ -13626,7 +12580,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Masque du Graille</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32003">
 				<rom name="masque du graille, le (198x)(-)(fr).k7" size="32003" crc="5e5776c3" sha1="395dab202391233021b60854d9862def052a1986"/>
@@ -13635,10 +12588,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="masqgraia" cloneof="masqgrai">
-		<description>Le Masque du Graille (Alt)</description>
+		<description>Le Masque du Graille (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32003">
 				<rom name="masque du graille, le (19xx)(-)(fr).k7" size="32003" crc="d5457a41" sha1="62a3e2b189ad07fe78bb6df49b30bd71c7c696aa"/>
@@ -13647,10 +12599,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="masqgraib" cloneof="masqgrai">
-		<description>Le Masque du Graille (Alt 2)</description>
+		<description>Le Masque du Graille (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32003">
 				<rom name="le-masque-du-graille_mo5.k7" size="32003" crc="58ee5e18" sha1="c9c5a11e37875fe2595cac780ff4fd1bdf974839"/>
@@ -13662,7 +12613,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Megawatt</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="53035">
@@ -13678,10 +12628,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="megawatta" cloneof="megawatt">
-		<description>Megawatt (Single Tape)</description>
+		<description>Megawatt (single tape)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="106070">
 				<rom name="megawatt (1987)(softbook)(fr).k7" size="106070" crc="3cd6d9bc" sha1="1bcbe6bfa11dc3bff8d3289203ca492a5b22d3dd"/>
@@ -13690,10 +12639,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="megawattb" cloneof="megawatt">
-		<description>Megawatt (Single Tape, Alt)</description>
+		<description>Megawatt (single tape, alt)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="106070">
 				<rom name="megawatt (1987)(softbook)(fr)(tape 1 of 2)[a].k7" size="106070" crc="dda95749" sha1="7f240d9a1f6a93bc2da931b75c3271b3ee4778f7"/>
@@ -13702,10 +12650,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="megawattc" cloneof="megawatt">
-		<description>Megawatt (Single Tape, Alt 2)</description>
+		<description>Megawatt (single tape, alt 2)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="106070">
 				<rom name="megawatt_mo5.k7" size="106070" crc="d9d33582" sha1="624f6a94c1bfc81e0c6202cdacb836f8a3bdcc84"/>
@@ -13717,7 +12664,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Memo7</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6853">
 				<rom name="memo7 (1983)(vifi-nathan)(fr).k7" size="6853" crc="a966b643" sha1="a91d9b804b9cbbab9783a5567a217d819459b7e6"/>
@@ -13726,10 +12672,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="memo7a" cloneof="memo7">
-		<description>Memo7 (Alt)</description>
+		<description>Memo7 (alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6853">
 				<rom name="memo7 (1983)(vifi-nathan)(fr)[a].k7" size="6853" crc="8066ad81" sha1="c68b5d8dbb8446b925062888b69d5e6e8752f45a"/>
@@ -13738,10 +12683,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="memo7b" cloneof="memo7">
-		<description>Memo7 (Alt 2)</description>
+		<description>Memo7 (alt 2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6853">
 				<rom name="memo7_mo5.k7" size="6853" crc="45e92614" sha1="111e9d8e1bbb7faf54ba784e6f9060493db9091e"/>
@@ -13753,7 +12697,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Memory</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13947">
 				<rom name="memory (1985)(dcsoft)(fr)(pd).k7" size="13947" crc="bc853288" sha1="96ce3dd1e9d8c7f3b59b79ba22df03c2d38aad0f"/>
@@ -13762,10 +12705,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="memorya" cloneof="memory">
-		<description>Memory (Alt)</description>
+		<description>Memory (alt)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13947">
 				<rom name="memory (1985)(dcsoft)(fr)(pd)[a].k7" size="13947" crc="1d677ffc" sha1="58c54335ebc62008f13910375b4b186a93d35489"/>
@@ -13774,10 +12716,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="memoryb" cloneof="memory">
-		<description>Memory (Alt 2)</description>
+		<description>Memory (alt 2)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13947">
 				<rom name="memory (1985)(dcsoft)(fr)(pd)[a2].k7" size="13947" crc="cce44972" sha1="c2d11758452fa38bdba29f42cce0a22d87899ba6"/>
@@ -13786,10 +12727,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="memoryc" cloneof="memory">
-		<description>Memory (Alt 3)</description>
+		<description>Memory (alt 3)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13947">
 				<rom name="memory_mo5.k7" size="13947" crc="5b6c1e09" sha1="8358c49d4e5022b3a8324d93c84bdf58a8ba19e2"/>
@@ -13801,7 +12741,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mes Premiers Mots Croises (v1.2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19166">
 				<rom name="mes premiers mots croises v1.2 (1983)(vifi-nathan)(fr).k7" size="19166" crc="a923a0e2" sha1="f656cd62e4aa26399f85bc1315bbb9ad68e761f1"/>
@@ -13810,10 +12749,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="premmotsa" cloneof="premmots">
-		<description>Mes Premiers Mots Croises (v1.2, Alt)</description>
+		<description>Mes Premiers Mots Croises (v1.2, alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19174">
 				<rom name="mes premiers mots croises v1.2 (1983)(vifi-nathan)(fr)[a].k7" size="19174" crc="a47eab9a" sha1="f9c2704d776cc142c19d2628944f0c613914af54"/>
@@ -13822,10 +12760,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="premmotsb" cloneof="premmots">
-		<description>Mes Premiers Mots Croises (v1.2, Alt 2)</description>
+		<description>Mes Premiers Mots Croises (v1.2, alt 2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19158">
 				<rom name="mes premiers mots croises v1.2 (1983)(vifi-nathan)(fr)[a2].k7" size="19158" crc="f71828c9" sha1="db52c96453b9ea6617373517c6f5f1c4099cff40"/>
@@ -13834,10 +12771,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="premmotsc" cloneof="premmots">
-		<description>Mes Premiers Mots Croises (v1.2, Alt 3)</description>
+		<description>Mes Premiers Mots Croises (v1.2, alt 3)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19158">
 				<rom name="mes premiers mots croises v1.2 (1983)(vifi-nathan)(fr)[a3].k7" size="19158" crc="7a698b2a" sha1="4f358c51d3a48c91ed4914aed84db3368d79cfe7"/>
@@ -13846,10 +12782,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="premmotsd" cloneof="premmots">
-		<description>Mes Premiers Mots Croises (v1.2, Alt 4)</description>
+		<description>Mes Premiers Mots Croises (v1.2, alt 4)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19158">
 				<rom name="mes-premiers-mots-croises-2_mo5.k7" size="19158" crc="04a404a5" sha1="d317fb06a0cdc71b744d023d40694e7e9bbe640a"/>
@@ -13861,7 +12796,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mes Premiers Mots Croises (v1.1)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21236">
 				<rom name="mes premiers mots croises v1.1 (1983)(vifi-nathan)(fr).k7" size="21236" crc="39acbb41" sha1="3f252773b7ca6e80f12782f95c163006484edc48"/>
@@ -13870,10 +12804,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="premmots11a" cloneof="premmots">
-		<description>Mes Premiers Mots Croises (v1.1, Alt)</description>
+		<description>Mes Premiers Mots Croises (v1.1, alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21236">
 				<rom name="mes premiers mots croises v1.1 (1983)(vifi-nathan)(fr)[a].k7" size="21236" crc="456bb1cb" sha1="073d145eae2afcf4ebf11dd6e03362e70939c019"/>
@@ -13882,10 +12815,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="premmots11b" cloneof="premmots">
-		<description>Mes Premiers Mots Croises (v1.1, Alt 2)</description>
+		<description>Mes Premiers Mots Croises (v1.1, alt 2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21236">
 				<rom name="mes premiers mots croises v1.1 (1983)(vifi-nathan)(fr)[a2].k7" size="21236" crc="3f7a8a1c" sha1="a271135f145fae67234b3a4b98c26a30864b5787"/>
@@ -13894,10 +12826,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="premmots11c" cloneof="premmots">
-		<description>Mes Premiers Mots Croises (v1.1, Alt 3)</description>
+		<description>Mes Premiers Mots Croises (v1.1, alt 3)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21236">
 				<rom name="mes-premiers-mots-croises-1_mo5.k7" size="21236" crc="f846b07b" sha1="9efd28546d343fa4655903b7bdc4ed41ce488036"/>
@@ -13909,7 +12840,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Metallurgiste</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7250">
 				<rom name="metallurgiste, le (198x)(-)(fr).k7" size="7250" crc="8a29a426" sha1="ce72564d67963a5fe183fa7d25bb7df2aad61406"/>
@@ -13918,10 +12848,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="metalurga" cloneof="metalurg">
-		<description>Le Metallurgiste (Alt)</description>
+		<description>Le Metallurgiste (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7250">
 				<rom name="metallurgiste, le (198x)(-)(fr)[a].k7" size="7250" crc="f8f12b49" sha1="1ce8629b030c4ac5efd102d4f2cec39377401151"/>
@@ -13930,10 +12859,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="metalurgb" cloneof="metalurg">
-		<description>Le Metallurgiste (Alt 2)</description>
+		<description>Le Metallurgiste (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7250">
 				<rom name="le-metallurgiste_mo5.k7" size="7250" crc="67363111" sha1="4f59cb5b09d944dc8fc1a984178da94fc3d9b5b8"/>
@@ -13945,7 +12873,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Meteo-7</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10641">
 				<rom name="meteo-7 (1984)(infogrames)(fr).k7" size="10641" crc="71b24444" sha1="9bb0c7c70ce9733782a753ff903569c3dbd97bd0"/>
@@ -13954,10 +12881,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="meteo7a" cloneof="meteo7">
-		<description>Meteo-7 (Alt)</description>
+		<description>Meteo-7 (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11009">
 				<rom name="meteo-7 (1984)(infogrames)(fr)[a].k7" size="11009" crc="7afbf3df" sha1="a7c69a6daa381b56a9de931caae3337ee8dd23a7"/>
@@ -13966,10 +12892,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="meteo7b" cloneof="meteo7">
-		<description>Meteo-7 (Alt 2)</description>
+		<description>Meteo-7 (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11009">
 				<rom name="meteo-7 (1984)(infogrames)(fr)[a2].k7" size="11009" crc="0b6c16d1" sha1="c84f02bac9f4ebd2ff1a4d351b74a3dc106061cd"/>
@@ -13978,10 +12903,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="meteo7c" cloneof="meteo7">
-		<description>Meteo-7 (Alt 3)</description>
+		<description>Meteo-7 (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11009">
 				<rom name="meteo-7 (infogrames) (eric mottet) (1984) (mo5).k7" size="11009" crc="0a7fc71e" sha1="1535ffcbce2deed542bff24a2618f04808070b4e"/>
@@ -13993,7 +12917,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Metro</description>
 		<year>1984</year>
 		<publisher>Logimicro</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22570">
 				<rom name="metro (logimicro) (inconnus) (1984) (mo5 k7).k7" size="22570" crc="fc3b163e" sha1="55fd16f2c17dd6b062e6d5a939da24e22459126e"/>
@@ -14005,7 +12928,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Meurtre a Grande Vitesse</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37294">
 				<rom name="meurtre a grande vitesse (1985)(cobrasoft)(fr).k7" size="37294" crc="5538505e" sha1="f0a4b68fff941abcdc54942e4d3ee820a82e1350"/>
@@ -14014,10 +12936,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="grandvita" cloneof="grandvit">
-		<description>Meurtre a Grande Vitesse (Alt)</description>
+		<description>Meurtre a Grande Vitesse (alt)</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37294">
 				<rom name="meurtre-a-grande-vitesse_mo5.k7" size="37294" crc="68062e31" sha1="744282f141e52422b9edb4033f7869736272d40a"/>
@@ -14029,7 +12950,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Meurtres sur l'Atlantique</description>
 		<year>1986</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="79652">
 				<rom name="meurtres sur l'atlantique (1986)(cobrasoft)(fr).k7" size="79652" crc="3497f137" sha1="af5e5f77128dbf896c4852bc921d019a796ec2bd"/>
@@ -14038,10 +12958,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="meurtatla" cloneof="meurtatl">
-		<description>Meurtres sur l'Atlantique (Alt)</description>
+		<description>Meurtres sur l'Atlantique (alt)</description>
 		<year>1986</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="79652">
 				<rom name="meurtres-sur-l-atlantique_mo5.k7" size="79652" crc="43e601c1" sha1="e0ed59ade9834ca9afdca954b557ab8648ff8284"/>
@@ -14053,7 +12972,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Microjeux</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37778">
 				<rom name="microjeux (nathan) (a. deledicq, j. delcourt, j.p. duclos, j.b. touchard, s. pouts lajus) (1985) (mo5).k7" size="37778" crc="40b0e2e0" sha1="e0b9772a12bf23a87cecb771944f1aff640505f6"/>
@@ -14065,7 +12983,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Micro Scrabble</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31042">
 				<rom name="micro scrabble (1985)(leisure genius)(fr).k7" size="31042" crc="6e782698" sha1="39029e11d31eecfe4e73b9f80257af930c8bbbef"/>
@@ -14074,10 +12991,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="scrabblea" cloneof="scrabble">
-		<description>Micro Scrabble (Alt)</description>
+		<description>Micro Scrabble (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32905">
 				<rom name="micro scrabble (1985)(leisure genius)(fr)[a].k7" size="32905" crc="1b95b892" sha1="26b0e5e7e99ad8d2b040d8ced820b0fca19aecb2"/>
@@ -14086,10 +13002,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="scrabbleb" cloneof="scrabble">
-		<description>Micro Scrabble (Alt 2)</description>
+		<description>Micro Scrabble (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32905">
 				<rom name="micro scrabble (1985)(leisure genius)(fr)[a2].k7" size="32905" crc="7879651a" sha1="b4b6fee4b9585839b1377251a14100c44000d308"/>
@@ -14098,10 +13013,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="scrabblec" cloneof="scrabble">
-		<description>Micro Scrabble (Alt 3)</description>
+		<description>Micro Scrabble (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32905">
 				<rom name="micro-scrabble (fil) (inconnus) (1985) (mo5).k7" size="32905" crc="eda702e7" sha1="5ea64e9b920b4248e9847d5a9542bd6e5cd446f3"/>
@@ -14113,7 +13027,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Millionnaire</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27457">
 				<rom name="le millionnaire (ere informatique) (m. de guilhermier) (1984) (mo5).k7" size="27457" crc="f33a9946" sha1="b0ca4d1ed17693c64bf775efb1ba3fa5462d2ae6"/>
@@ -14125,7 +13038,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Mine aux Diamants</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6428104">
 				<rom name="mine aux diamants, la (1986)(infogrames)(fr)[loadm'''',,r].wav" size="6428104" crc="d624e8de" sha1="71b3f92e7fc39f073dec76f6a538062791a01b19"/>
@@ -14135,10 +13047,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="minediama" cloneof="minediam" supported="no">
-		<description>La Mine aux Diamants (Alt)</description>
+		<description>La Mine aux Diamants (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31374">
 				<rom name="mine aux diamants, la (1986)(infogrames)(fr)[b].k7" size="31374" crc="769a6c35" sha1="96aafb1de83658b4a22d2c05d6b6c15d88c59852"/>
@@ -14148,10 +13059,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="minediamb" cloneof="minediam" supported="no">
-		<description>La Mine aux Diamants (Alt 2)</description>
+		<description>La Mine aux Diamants (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32814">
 				<rom name="la-mine-aux-diamants_mo5.k7" size="32814" crc="e8ff0fec" sha1="334596efc6fcdac5aeafed8389167514b94350c2"/>
@@ -14163,7 +13073,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Minotaure 3D</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17448">
 				<rom name="minotaure 3d (1985-04)(loriciels)(fr).k7" size="17448" crc="3e58ae7e" sha1="dd33aaa61b9f930065c798cc82f3d6df131d9fb9"/>
@@ -14172,10 +13081,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="minota3da" cloneof="minota3d">
-		<description>Minotaure 3D (Alt)</description>
+		<description>Minotaure 3D (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17448">
 				<rom name="minotaure 3d (1985-04)(loriciels)(fr)[a].k7" size="17448" crc="0b0cd2c2" sha1="6497366b897e303c1c770b1a21d10ede3837ffc2"/>
@@ -14184,10 +13092,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="minota3db" cloneof="minota3d">
-		<description>Minotaure 3D (Alt 2)</description>
+		<description>Minotaure 3D (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17448">
 				<rom name="minotaure-3d_mo5.k7" size="17448" crc="63ebba37" sha1="f9cb640426669d2388b9c0ac9045ed145c578dec"/>
@@ -14196,10 +13103,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="minota3dc" cloneof="minota3d">
-		<description>Minotaure 3D (Cracked)</description>
+		<description>Minotaure 3D (cracked)</description>
 		<year>1985</year>
 		<publisher>&lt;bootleg (Christophe Lesur)&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17390">
 				<rom name="minotaure 3d (1985-04)(loriciels)(fr)[cr lesur, christophe].k7" size="17390" crc="6e6d9bee" sha1="deb43479782d27e31f1ca939b923a17d5c1686aa"/>
@@ -14211,7 +13117,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission Delta</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39540">
 				<rom name="mission delta (1984)(ere informatique)(fr).k7" size="39540" crc="33b19f83" sha1="af35538639ecc8f1c9715da41de8e626555fde83"/>
@@ -14223,7 +13128,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission Ninja (Hebdogiciel no. 150-151)</description>
 		<year>1986</year>
 		<publisher>Frederic Nguyen - Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21909">
 				<rom name="missionninja[mo5].k7" size="21909" crc="48564151" sha1="8ed3d2d1a04926aba22f88ecf56dce6d528fdc51"/>
@@ -14235,7 +13139,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission pas Possible</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24176">
 				<rom name="mission pas possible (198x)(infogrames)(fr).k7" size="24176" crc="6913053b" sha1="245583df89886107468ab472e4e6c59f74ba9fe2"/>
@@ -14244,10 +13147,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="misspossa" cloneof="missposs">
-		<description>Mission pas Possible (Alt)</description>
+		<description>Mission pas Possible (alt)</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24317">
 				<rom name="mission pas possible (198x)(infogrames)(fr)[a].k7" size="24317" crc="1d168e2d" sha1="44a06df875d1a353debc8a49a4520b179cb73fb4"/>
@@ -14256,10 +13158,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="misspossb" cloneof="missposs">
-		<description>Mission pas Possible (Alt 2)</description>
+		<description>Mission pas Possible (alt 2)</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24317">
 				<rom name="mission pas possible (198x)(infogrames)(fr)[a2].k7" size="24317" crc="fee22459" sha1="5423329c8dee6b5e1084475e3356b1eb80e7b72d"/>
@@ -14268,10 +13169,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="misspossc" cloneof="missposs">
-		<description>Mission pas Possible (Alt 3)</description>
+		<description>Mission pas Possible (alt 3)</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24317">
 				<rom name="mission-pas-possible_mo5.k7" size="24317" crc="68124cab" sha1="a67d6658ec24eb0e897b05d9a0b37f456ec720eb"/>
@@ -14283,7 +13183,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission U-72</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24065">
 				<rom name="mission u-72 (1986)(hebdogiciel)(fr)(pd).k7" size="24065" crc="c974f5e7" sha1="eb85334da37a4815f07c06da3adf95f7de99e723"/>
@@ -14292,10 +13191,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="missu72a" cloneof="missu72">
-		<description>Mission U-72 (Alt)</description>
+		<description>Mission U-72 (alt)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24065">
 				<rom name="mission u-72 (1986)(hebdogiciel)(fr)(pd)[a].k7" size="24065" crc="1ed6ecfe" sha1="0bef5365d211c6b9a0c6324817ee3acccffd80b6"/>
@@ -14304,10 +13202,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="missu72b" cloneof="missu72">
-		<description>Mission U-72 (Alt 2)</description>
+		<description>Mission U-72 (alt 2)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24065">
 				<rom name="mission u72 (19xx)(hebdogiciel)(pd).k7" size="24065" crc="7711543f" sha1="61bbf749774c0bbabf54b86320d423481cadf1f4"/>
@@ -14316,10 +13213,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="missu72c" cloneof="missu72">
-		<description>Mission U-72 (Alt 3)</description>
+		<description>Mission U-72 (alt 3)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24065">
 				<rom name="mission-u72_mo5.k7" size="24065" crc="c0d2bc4f" sha1="5e84e8271d392965ea72e39015b2262cc235e1d0"/>
@@ -14331,7 +13227,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Missions en Rafale</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31529">
 				<rom name="missions en rafale (1987)(fil)(fr)(en-fr).k7" size="31529" crc="21f3d27b" sha1="cfe5559f7a6c889b348fbae2cb18034def0527a3"/>
@@ -14340,10 +13235,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="missrafaa" cloneof="missrafa">
-		<description>Missions en Rafale (Alt)</description>
+		<description>Missions en Rafale (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31647">
 				<rom name="missions en rafale (1987)(fil)(fr)(en-fr)[a].k7" size="31647" crc="90d4c6d4" sha1="7e1ea6821f0e2fcd8cc48ec4b33dae841d50dc22"/>
@@ -14352,10 +13246,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="missrafab" cloneof="missrafa">
-		<description>Missions en Rafale (Alt 2)</description>
+		<description>Missions en Rafale (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31647">
 				<rom name="missions en rafale (1987)(fil)(fr)(en-fr)[a2].k7" size="31647" crc="ae2a1d1c" sha1="d6a835dbedb4ebcaf56469c3dc9f3a844abb12d9"/>
@@ -14364,10 +13257,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="missrafac" cloneof="missrafa">
-		<description>Missions en Rafale (Alt 3)</description>
+		<description>Missions en Rafale (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31647">
 				<rom name="missions-en-rafale_mo5.k7" size="31647" crc="d25f2210" sha1="33402314809901760e52e29adc5a5ff69eb141da"/>
@@ -14379,7 +13271,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monopolic</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19234">
 				<rom name="monopolic (198x)(free game blot)(fr).k7" size="19234" crc="ed06ee0f" sha1="4fd7b46921c40ce1fb4804c33e4e4ea2158d38f2"/>
@@ -14388,10 +13279,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="monopolca" cloneof="monopolc">
-		<description>Monopolic (Alt)</description>
+		<description>Monopolic (alt)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19300">
 				<rom name="monopolic (198x)(free game blot)(fr)[a].k7" size="19300" crc="4fbaf91f" sha1="ddd3eff3f8b85268654a2b1170036fb71a62af8e"/>
@@ -14400,10 +13290,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="monopolcb" cloneof="monopolc">
-		<description>Monopolic (Alt 2)</description>
+		<description>Monopolic (alt 2)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19300">
 				<rom name="monopolic (198x)(free game blot)(fr)[a2].k7" size="19300" crc="7ed9aca9" sha1="17ba802e77eb9aec717ea75ad57fac2f2c55855b"/>
@@ -14412,10 +13301,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="monopolcc" cloneof="monopolc">
-		<description>Monopolic (Alt 3)</description>
+		<description>Monopolic (alt 3)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19300">
 				<rom name="monopolic_a_mo5.k7" size="19300" crc="4f48f72f" sha1="4cdee680ea72f3bada4053d1c31080b8d973d875"/>
@@ -14427,7 +13315,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monopolic (Ger)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19806">
 				<rom name="monopolic version allemande (free game blot) (inconnus) (1985) (mo5 k7).k7" size="19806" crc="d572573d" sha1="048c2799bb0a27a40a78e0128468a590f29b3562"/>
@@ -14439,7 +13326,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monopoly</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47640">
 				<rom name="monopoly (1985)(leisure genius)(fr).k7" size="47640" crc="119a4016" sha1="259cc1050fb79c7def770f2d75f4efe213dfa211"/>
@@ -14448,10 +13334,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="monopolya" cloneof="monopoly">
-		<description>Monopoly (Alt)</description>
+		<description>Monopoly (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="50613">
 				<rom name="monopoly (1985)(leisure genius)(fr)[a].k7" size="50613" crc="7341e02d" sha1="40ae6932119a4e68b74c4cd78b8ce86a6aa29e7e"/>
@@ -14460,10 +13345,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="monopolyb" cloneof="monopoly">
-		<description>Monopoly (Alt 2)</description>
+		<description>Monopoly (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="50613">
 				<rom name="monopoly (1985)(leisure genius)(fr)[a2].k7" size="50613" crc="347699e3" sha1="94a9c0dd5cc8ee740a1cc81f69fccf5f55bdc3e5"/>
@@ -14475,7 +13359,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monster Mine</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12777">
 				<rom name="monster mine (1985)(fil)(fr).k7" size="12777" crc="7f14dc07" sha1="57966a88c1655100fe856f9c4cf0fff1cd709143"/>
@@ -14484,10 +13367,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="monstmina" cloneof="monstmin">
-		<description>Monster Mine (Alt)</description>
+		<description>Monster Mine (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10512">
 				<rom name="monster mine (1985)(fil)(fr)[a].k7" size="10512" crc="19d00d1c" sha1="4abb82b4c448bdb9fc61e3dc86ad0693fc532d4c"/>
@@ -14496,10 +13378,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="monstminb" cloneof="monstmin">
-		<description>Monster Mine (Alt 2)</description>
+		<description>Monster Mine (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10512">
 				<rom name="monster mine (fil) (inconnus) (1986) (mo5).k7" size="10512" crc="7acf4032" sha1="1a2a1f9ce33f0901447e6c73c5c367ccfe5e18a6"/>
@@ -14511,7 +13392,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monte Carlo</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="53439">
 				<rom name="monte carlo (1984-06)(loriciels)(fr).k7" size="53439" crc="331bc6d6" sha1="4f5533f5b8f532b6178e3aff352699d05c9900b6"/>
@@ -14520,10 +13400,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="montecara" cloneof="montecar">
-		<description>Monte Carlo (Alt)</description>
+		<description>Monte Carlo (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="53806">
 				<rom name="monte carlo (1984-06)(loriciels)(fr)[a].k7" size="53806" crc="60e5d723" sha1="6d806b2d8c9a900db959acf74b8067e12998ddff"/>
@@ -14532,10 +13411,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="montecarb" cloneof="montecar">
-		<description>Monte Carlo (Alt 2)</description>
+		<description>Monte Carlo (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="53806">
 				<rom name="monte carlo (1984-06)(loriciels)(fr)[a2].k7" size="53806" crc="99d926fb" sha1="89e2284faed0c9a57c34ff386ddb80b300b7e965"/>
@@ -14544,10 +13422,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="montecarc" cloneof="montecar">
-		<description>Monte Carlo (Alt 3)</description>
+		<description>Monte Carlo (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="53806">
 				<rom name="monte-carlo_mo5.k7" size="53806" crc="e3434e18" sha1="cb672466560093627b9b08f5be87cf73d94e6b3e"/>
@@ -14559,7 +13436,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Mystere de Ming-Fonko</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22627">
 				<rom name="mystere de ming-fonko, le (1986)(hebdogiciel)(fr).k7" size="22627" crc="cda89980" sha1="e0ae7fb0c9c25af2da2b2290843ea662bee6888d"/>
@@ -14568,10 +13444,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="mingfonka" cloneof="mingfonk">
-		<description>Le Mystere de Ming-Fonko (Alt)</description>
+		<description>Le Mystere de Ming-Fonko (alt)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22627">
 				<rom name="mystere de ming-fonko, le (1986)(hebdogiciel)(fr)[a].k7" size="22627" crc="6efd1312" sha1="358255a95cfcb704ca48db61af68c5b6bd82dc5e"/>
@@ -14580,10 +13455,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="mingfonkb" cloneof="mingfonk">
-		<description>Le Mystere de Ming-Fonko (Alt 2)</description>
+		<description>Le Mystere de Ming-Fonko (alt 2)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22627">
 				<rom name="le-mystere-de-ming-fonko_mo5.k7" size="22627" crc="04e7cf1f" sha1="24f4fe20bb3f58132fe935649487fa83ce7864bf"/>
@@ -14595,7 +13469,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Mystere de Paris</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="54883">
 				<rom name="mystere de paris, le (198x)(coktel vision)(fr).k7" size="54883" crc="7bfacd9b" sha1="506760fa52500ef6d72cad5860f0e96cdd7934b1"/>
@@ -14607,7 +13480,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Night Flight</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4220">
 				<rom name="night flight (198x)(-)(fr).k7" size="4220" crc="f3c5c3a5" sha1="c4425da64f9fb0519f987224b8f5979c27cc50dc"/>
@@ -14616,10 +13488,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="nightflia" cloneof="nightfli">
-		<description>Night Flight (Alt)</description>
+		<description>Night Flight (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4220">
 				<rom name="night-flight_mo5.k7" size="4220" crc="5b05d310" sha1="2b6ca43ddf1dbe9c242e95a1d9912b27887d9cb0"/>
@@ -14631,7 +13502,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Nuit des Templiers</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29627">
 				<rom name="nuit des templiers, la (1986)(fil)(fr).k7" size="29627" crc="dd32e370" sha1="b306ee9b37cad495c35ba485114fcd1ba498598c"/>
@@ -14640,10 +13510,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="nuittempa" cloneof="nuittemp">
-		<description>La Nuit des Templiers (Alt)</description>
+		<description>La Nuit des Templiers (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29601">
 				<rom name="nuit des templiers, la (1986)(fil)(fr)[a].k7" size="29601" crc="be987305" sha1="230bb7b0f8cfc0e78df725d8da1c5e1dfe1cb08b"/>
@@ -14652,10 +13521,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="nuittempb" cloneof="nuittemp">
-		<description>La Nuit des Templiers (Alt 2)</description>
+		<description>La Nuit des Templiers (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29601">
 				<rom name="nuit des templiers, la (1986)(fil)(fr)[a2].k7" size="29601" crc="ca29d433" sha1="2346418e00a548fb090858bcabaade50a888c0c0"/>
@@ -14664,10 +13532,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="nuittempc" cloneof="nuittemp">
-		<description>La Nuit des Templiers (Alt 3)</description>
+		<description>La Nuit des Templiers (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30157">
 				<rom name="la-nuit-des-templiers_mo5.k7" size="30157" crc="e46f90dc" sha1="7242de9b6542e0d63698775b211e4dbcb1bcdbb5"/>
@@ -14679,7 +13546,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Numero 10</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22420">
 				<rom name="numero 10 (1985)(fil)(fr).k7" size="22420" crc="382a11bb" sha1="9c0eadfbabd4a69a40de3e30fbfb44a6d6620d77"/>
@@ -14688,10 +13554,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="numero10a" cloneof="numero10">
-		<description>Numero 10 (Alt)</description>
+		<description>Numero 10 (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22556">
 				<rom name="numero 10 (1985)(fil)(fr)[a].k7" size="22556" crc="879f4f6a" sha1="870b2c1323ace86a53154731e64314beb856c729"/>
@@ -14700,10 +13565,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="numero10b" cloneof="numero10">
-		<description>Numero 10 (Alt 2)</description>
+		<description>Numero 10 (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22556">
 				<rom name="numero 10 (1985)(fil)(fr)[a2].k7" size="22556" crc="86c6a70b" sha1="ea8544b73a115a1d4fc6023f7122d5c53e4e1c73"/>
@@ -14712,10 +13576,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="numero10c" cloneof="numero10">
-		<description>Numero 10 (Alt 3)</description>
+		<description>Numero 10 (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23112">
 				<rom name="numero 10 (1985)(fil)(fr)[a3].k7" size="23112" crc="d5b8141c" sha1="fd763513334974535c21ba5626ab7111004fd57b"/>
@@ -14724,10 +13587,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="numero10d" cloneof="numero10">
-		<description>Numero 10 (Alt 4)</description>
+		<description>Numero 10 (alt 4)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22556">
 				<rom name="numero 10 (1985)(fil)(fr)[a4].k7" size="22556" crc="225e2ef9" sha1="b8d6eb45d10e486378b5d3479a8e5cfbc9a0aca4"/>
@@ -14739,7 +13601,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Numero 10 Special - Coupe du Monde 86</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25209">
 				<rom name="numero 10 version speciale - mexico 86 (1985)(fil)(fr).k7" size="25209" crc="908ffd25" sha1="9a5da1ba8d5617de896aa458a8fa8c18b46550d9"/>
@@ -14748,10 +13609,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="num10c86a" cloneof="numero10">
-		<description>Numero 10 Special - Coupe du Monde 86 (Alt)</description>
+		<description>Numero 10 Special - Coupe du Monde 86 (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25335">
 				<rom name="numero 10 version speciale - mexico 86 (1985)(fil)(fr)[a].k7" size="25335" crc="d31e4e3e" sha1="2c0c26d626fb64b66b683a5283159783a8870c7f"/>
@@ -14760,10 +13620,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="num10c86b" cloneof="numero10">
-		<description>Numero 10 Special - Coupe du Monde 86 (Alt 2)</description>
+		<description>Numero 10 Special - Coupe du Monde 86 (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25335">
 				<rom name="numero 10 version speciale - mexico 86 (1985)(fil)(fr)[a2].k7" size="25335" crc="ad7f9339" sha1="9dd06ef46d39948ee6faf4a48996e992c7523e54"/>
@@ -14772,10 +13631,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="num10c86c" cloneof="numero10">
-		<description>Numero 10 Special - Coupe du Monde 86 (Alt 3)</description>
+		<description>Numero 10 Special - Coupe du Monde 86 (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25335">
 				<rom name="numero-10-mexico-86_mo5.k7" size="25335" crc="386eb042" sha1="a88aab29dc5362618c0da157b2d8c3b7b4d5edd2"/>
@@ -14787,7 +13645,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Oceania</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35514">
 				<rom name="oceania (1985)(microids)(fr).k7" size="35514" crc="b560cbd3" sha1="f576f2f362cae24f9ee7e661030cae94e38a74ab"/>
@@ -14796,10 +13653,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="oceaniaa" cloneof="oceania">
-		<description>Oceania (Alt)</description>
+		<description>Oceania (alt)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35514">
 				<rom name="oceania (1985)(microids)(fr)[a].k7" size="35514" crc="14d31dfb" sha1="07b08d7bc37173d05fcff8610d68171e36314481"/>
@@ -14808,10 +13664,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="oceaniab" cloneof="oceania">
-		<description>Oceania (Alt 2)</description>
+		<description>Oceania (alt 2)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35514">
 				<rom name="oceania_mo5.k7" size="35514" crc="60187ed0" sha1="43aa94157e7ada1189fa2fc1db5f36c9395b0ee1"/>
@@ -14823,7 +13678,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Octogonus</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18875">
 				<rom name="octogonus (1984)(to tek)(fr).k7" size="18875" crc="a775a5c5" sha1="e870d146e92447b6cb958cad774b53d5b69246ca"/>
@@ -14832,10 +13686,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="octogonua" cloneof="octogonu">
-		<description>Octogonus (Alt)</description>
+		<description>Octogonus (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18867">
 				<rom name="octogonus (1984)(to tek)(fr)[a].k7" size="18867" crc="78aea91b" sha1="8621d68f8113a79b5d0eadc17358e6272dc712b4"/>
@@ -14844,10 +13697,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="octogonub" cloneof="octogonu">
-		<description>Octogonus (Alt 2)</description>
+		<description>Octogonus (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18875">
 				<rom name="octogonus (1984)(to tek)(fr)[a2].k7" size="18875" crc="d929be26" sha1="2b429dded85a293cd0b543f7d21d7e44c492fb20"/>
@@ -14859,7 +13711,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Omega - Planete Invisible</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="117798">
 				<rom name="omega planete invisible (198x)(infogrames)(fr)[loadm'''',,r].k7" size="117798" crc="b9d1844c" sha1="6c16468769ed3f93bf54d7f20ebd67896c04a8c7"/>
@@ -14868,10 +13719,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="omegaa" cloneof="omega">
-		<description>Omega - Planete Invisible (Alt)</description>
+		<description>Omega - Planete Invisible (alt)</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="117798">
 				<rom name="omega-planete-invisible_mo5.k7" size="117798" crc="a6fdf4b5" sha1="29730071773c8500fa6eec07f413af1466f39efe"/>
@@ -14883,7 +13733,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Operation Nemo</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35953">
 				<rom name="operation-nemo_mo5.k7" size="35953" crc="8d82d85b" sha1="24e50996101c2dfc568a0124daaaf0be30aca990"/>
@@ -14895,7 +13744,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orbital Mission</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22964">
 				<rom name="orbital mission (1986)(coktel vision)(it).k7" size="22964" crc="532e9dd2" sha1="d9f178b12671bf5e4f215b981149a890f22c4f38"/>
@@ -14904,10 +13752,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="orbitala" cloneof="orbital">
-		<description>Orbital Mission (Alt)</description>
+		<description>Orbital Mission (alt)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22964">
 				<rom name="orbital mission (1986)(coktel vision)(it)[a].k7" size="22964" crc="89ac58dc" sha1="3edb74c091e49521355765d6120a2a1109301cb2"/>
@@ -14916,10 +13763,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="orbitalb" cloneof="orbital">
-		<description>Orbital Mission (Alt 2)</description>
+		<description>Orbital Mission (alt 2)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22964">
 				<rom name="orbital-mission_mo5.k7" size="22964" crc="786c158f" sha1="438c54bc1a2e8afeb2236b14e6b870e22b9bc895"/>
@@ -14931,7 +13777,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pac-man</description>
 		<year>1986</year>
 		<publisher>Theophile</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7861">
 				<rom name="pac-man (1986)(theophile)(fr).k7" size="7861" crc="2586c1ae" sha1="553f05238285e087e6e95382bb7dcb19aa421353"/>
@@ -14943,7 +13788,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pac-man (v2)</description>
 		<year>1998</year>
 		<publisher>Remi Coulom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16476">
 				<rom name="pac-man v2 (1998-06-06)(coulom, remi)(fr)(pd).k7" size="16476" crc="95918135" sha1="387f222d77f3d66a45ee11d7cada57f7a2213bfe"/>
@@ -14952,10 +13796,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pacman2a" cloneof="pacman">
-		<description>Pac-man (v2, Alt)</description>
+		<description>Pac-man (v2, alt)</description>
 		<year>1998</year>
 		<publisher>Remi Coulom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16476">
 				<rom name="pac-man v2 (1998-06-06)(coulom, remi)(fr)(pd)[a].k7" size="16476" crc="1156970c" sha1="ac3a5b24c2163923297066587f944cd5897e5c7e"/>
@@ -14964,10 +13807,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pacman2b" cloneof="pacman">
-		<description>Pac-man (v2, Alt 2)</description>
+		<description>Pac-man (v2, alt 2)</description>
 		<year>1998</year>
 		<publisher>Remi Coulom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16476">
 				<rom name="pac-man v2 (1998-06-06)(coulom, remi)(fr)(pd)[a2].k7" size="16476" crc="bea92e79" sha1="bea357d58beca5e6e25082268b07eeca28128651"/>
@@ -14976,10 +13818,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pacman2c" cloneof="pacman">
-		<description>Pac-man (v2, Alt 3)</description>
+		<description>Pac-man (v2, alt 3)</description>
 		<year>1998</year>
 		<publisher>Remi Coulom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16476">
 				<rom name="pacman-2_mo5.k7" size="16476" crc="6d6e0cd2" sha1="1d302e63b2dcdb565eb1e20d2d4d1b5c1cd9d5a9"/>
@@ -14991,7 +13832,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pancho</description>
 		<year>1984</year>
 		<publisher>Micro Application</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14466">
 				<rom name="pancho_mo5.k7" size="14466" crc="c3fb5e9d" sha1="89113d091dd4a829692c5a323124d7dc2320d045"/>
@@ -15003,7 +13843,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Paris 92 - Jeux Olympiques</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26714">
 				<rom name="paris 92 - jeux olympiques (infogrames) (william hennebois) (1986) (mo5 k7).k7" size="26714" crc="90e9c71a" sha1="f8fe66b728e0eb3f7ae1fa13ada942a640af9669"/>
@@ -15015,7 +13854,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pilot</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10247">
 				<rom name="pilot (1984)(infogrames)(fr).k7" size="10247" crc="4041249c" sha1="b3e831583582642c503f93b1a53c3b61af5c1bc8"/>
@@ -15024,10 +13862,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pilota" cloneof="pilot">
-		<description>Pilot (Alt)</description>
+		<description>Pilot (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10247">
 				<rom name="pilot (1984)(infogrames)(fr)[a].k7" size="10247" crc="676a8559" sha1="58def35057b8e5cc283ea214ddd1c4f14f8d413b"/>
@@ -15036,10 +13873,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pilotb" cloneof="pilot">
-		<description>Pilot (Alt 2)</description>
+		<description>Pilot (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10247">
 				<rom name="pilot (infogrames) (gilles blanchard) (1984) (mo5) (v1).k7" size="10247" crc="1602899e" sha1="17c70d9447dd88ec589242424b76f14e13c42d9f"/>
@@ -15048,10 +13884,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pilotc" cloneof="pilot">
-		<description>Pilot (Alt 3)</description>
+		<description>Pilot (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8512">
 				<rom name="pilot (infogrames) (gilles blanchard) (1984) (mo5) (v2).k7" size="8512" crc="0cd75373" sha1="8d0e9b054950c19a79e646fdc43dec1bde4c5e6c"/>
@@ -15063,7 +13898,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pingo</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7261">
 				<rom name="pingo (1983)(infogrames)(fr).k7" size="7261" crc="2aba1f9d" sha1="d5de23ed51ec35f0e68de00bc1c301d6758c8d42"/>
@@ -15072,10 +13906,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pingoa" cloneof="pingo">
-		<description>Pingo (Alt)</description>
+		<description>Pingo (alt)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7261">
 				<rom name="pingo (1983)(infogrames)(fr)[a].k7" size="7261" crc="effd9280" sha1="8d21486058fd1c6944e2ea55dbec3f9b4152f1ae"/>
@@ -15084,10 +13917,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pingob" cloneof="pingo">
-		<description>Pingo (Alt 2)</description>
+		<description>Pingo (alt 2)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7261">
 				<rom name="pingo_mo5.k7" size="7261" crc="bcd83c9d" sha1="68a6ca51d1ec5962520d8b585df93b1454846e6c"/>
@@ -15099,7 +13931,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Piramide</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68600">
 				<rom name="piramide (1987-06-21)(rubio, javier marco)(es).k7" size="68600" crc="ef81427c" sha1="cefbfee2e10babc7ac2759177b044984cd5d00a6"/>
@@ -15108,10 +13939,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="piramidea" cloneof="piramide">
-		<description>Piramide (Alt)</description>
+		<description>Piramide (alt)</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68600">
 				<rom name="piramide (1987-06-21)(rubio, javier marco)(es)[a].k7" size="68600" crc="55c5d062" sha1="832067ee451d9cfbf5ea8b923c0389a146a8ef6d"/>
@@ -15120,10 +13950,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="piramideb" cloneof="piramide">
-		<description>Piramide (Alt 2)</description>
+		<description>Piramide (alt 2)</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68600">
 				<rom name="piramide_mo5.k7" size="68600" crc="36cb6c03" sha1="b3cba5352a5850d9eb0cc9b87e77c370ea869df2"/>
@@ -15135,7 +13964,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Planete Inconnue</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39713">
 				<rom name="planete inconnue, la (198x)(fil)(fr).k7" size="39713" crc="63e2792e" sha1="3046be2a4c886a1b903325d0b23c32a48a8f90c8"/>
@@ -15144,10 +13972,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="planetina" cloneof="planetin">
-		<description>La Planete Inconnue (Alt)</description>
+		<description>La Planete Inconnue (alt)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39948">
 				<rom name="planete inconnue, la (198x)(fil)(fr)[a].k7" size="39948" crc="00412721" sha1="8c0921e64368c4af76f364c7daa9d692bf8edc09"/>
@@ -15156,10 +13983,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="planetinb" cloneof="planetin">
-		<description>La Planete Inconnue (Alt 2)</description>
+		<description>La Planete Inconnue (alt 2)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39948">
 				<rom name="planete inconnue, la (198x)(fil)(fr)[a2].k7" size="39948" crc="5ecdd2f5" sha1="505b28b53918497c67492f31f7f05526e75f4753"/>
@@ -15168,10 +13994,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="planetinc" cloneof="planetin">
-		<description>La Planete Inconnue (Alt 3)</description>
+		<description>La Planete Inconnue (alt 3)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39948">
 				<rom name="la-planete-inconnue_mo5.k7" size="39948" crc="b3e1893d" sha1="d600797908eacb2e8fee3e7fac617e9203897d73"/>
@@ -15197,7 +14022,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Plus Beau Puzzle</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22702">
 				<rom name="plus beau puzzle, le (1985)(cedic-nathan)(fr).k7" size="22702" crc="088cbdb2" sha1="d89a747bf4a71111688b18fd6b0cb142d015e6f5"/>
@@ -15209,7 +14033,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Plymouth-Newport</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32273">
 				<rom name="plymouth-newport (sprites) (pascal pommier) (1985) (mo5).k7" size="32273" crc="43446fc3" sha1="3750daa66a0a4d422c181133d0a80568ab14e24b"/>
@@ -15221,7 +14044,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Poker</description>
 		<year>1986</year>
 		<publisher>Gasoline Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39838">
 				<rom name="poker (1986)(gasoline software)(fr).k7" size="39838" crc="750288c3" sha1="d7049045a824f9d0fa6612f760e8986b456e31ca"/>
@@ -15230,10 +14052,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pokera" cloneof="poker">
-		<description>Poker (Alt)</description>
+		<description>Poker (alt)</description>
 		<year>1986</year>
 		<publisher>Gasoline Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39838">
 				<rom name="poker (1986)(gasoline software)(fr)[a].k7" size="39838" crc="21718b85" sha1="7c002500a67af2a4b4a73784189f5a632bfd918f"/>
@@ -15242,10 +14063,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pokerb" cloneof="poker">
-		<description>Poker (Alt 2)</description>
+		<description>Poker (alt 2)</description>
 		<year>1986</year>
 		<publisher>Gasoline Software</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39838">
 				<rom name="poker_mo5.k7" size="39838" crc="0296f0b8" sha1="c313ade08b3ffd2a7ee1602a6293cf30872c8eb9"/>
@@ -15257,7 +14077,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pole Position (Hebdogiciel no. 119-120)</description>
 		<year>1986</year>
 		<publisher>Thierry Dugnolle - Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22508">
 				<rom name="pole_position[mo5].k7" size="22508" crc="9db7e095" sha1="3fa87f3703691b2e473afa92d6d954de0175be92"/>
@@ -15269,7 +14088,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Politik Poker</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28819">
 				<rom name="politik poker (infogrames) (roger granier, pierre bayle) (1986) (mo5 k7).k7" size="28819" crc="50037baa" sha1="f5f068093480cc5453e22296e1f56fd962ba13f2"/>
@@ -15281,7 +14099,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Politique Economique</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19274">
 				<rom name="politique economique (1984)(answare)(fr).k7" size="19274" crc="26123c55" sha1="5ebdae6fd0c091f00f59aa9ce826262580fb1fb9"/>
@@ -15290,10 +14107,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="poliecona" cloneof="poliecon">
-		<description>Politique Economique (Alt)</description>
+		<description>Politique Economique (alt)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19339">
 				<rom name="politique economique (1984)(answare)(fr)[a].k7" size="19339" crc="707739fb" sha1="d6c1b4288c060d0cdb46dde32aa59948ea6af29d"/>
@@ -15302,10 +14118,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="polieconb" cloneof="poliecon">
-		<description>Politique Economique (Alt 2)</description>
+		<description>Politique Economique (alt 2)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19339">
 				<rom name="politique economique (1984)(answare)(fr)[a2].k7" size="19339" crc="fa023222" sha1="a347291df0ba770f5f6e8aba90dbea9ae390ad7b"/>
@@ -15314,10 +14129,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="polieconc" cloneof="poliecon">
-		<description>Politique Economique (Alt 3)</description>
+		<description>Politique Economique (alt 3)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19339">
 				<rom name="politique-economique_mo5.k7" size="19339" crc="522b637f" sha1="b3ea75967a6e240764a3b2875cf5bcf96d419ae9"/>
@@ -15329,7 +14143,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pop Pop</description>
 		<year>1985</year>
 		<publisher>Minipuce</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15016">
 				<rom name="pop pop (1985)(minipuce)(fr).k7" size="15016" crc="66bd3e82" sha1="82b8cbb746e0fbeaab921c040d61d1418b473df2"/>
@@ -15341,7 +14154,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Popeye</description>
 		<year>1986</year>
 		<publisher>Christophe Lesur</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4219">
 				<rom name="popeye (1986-09)(lesur, christophe)(fr)(pd).k7" size="4219" crc="08032eff" sha1="67e184db55a55108cbd1e93d4a1733ac71ec21ad"/>
@@ -15353,7 +14165,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Portrait (Hebdogiciel no. 53)</description>
 		<year>1984</year>
 		<publisher>Alain van Puymbroeck - Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10813">
 				<rom name="portrait[mo5].k7" size="10813" crc="d21907d1" sha1="314c5bc4909f522cc0a6078189f603e3e8446e19"/>
@@ -15365,7 +14176,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Poseidon</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34250">
 				<rom name="poseidon (1986)(coktel vision)(fr).k7" size="34250" crc="3951bd6a" sha1="8b46025f85cfb0f7c7c5351ccac6d0a69ca13b02"/>
@@ -15374,10 +14184,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="poseidona" cloneof="poseidon">
-		<description>Poseidon (Alt)</description>
+		<description>Poseidon (alt)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34250">
 				<rom name="poseidon (1986)(coktel vision)(fr)[a].k7" size="34250" crc="76cc2fc7" sha1="192610b42aa831c1d538dbaf5abc41051904df2a"/>
@@ -15386,10 +14195,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="poseidonb" cloneof="poseidon">
-		<description>Poseidon (Alt 2)</description>
+		<description>Poseidon (alt 2)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34250">
 				<rom name="poseidon (1986)(coktel vision)(fr)[a2].k7" size="34250" crc="0f506d49" sha1="941716d2ef23e02453a70b42916daba8552d5c09"/>
@@ -15398,10 +14206,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="poseidonc" cloneof="poseidon">
-		<description>Poseidon (Alt 3)</description>
+		<description>Poseidon (alt 3)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34250">
 				<rom name="poseidon_mo5.k7" size="34250" crc="884e20a5" sha1="b4ca5ce50bb5fe39235118a39d2a26174a59f951"/>
@@ -15413,7 +14220,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pour 20 Millions de Dollars</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="87266">
 				<rom name="pour 20 millions de dollars (198x)(softbook)(fr).k7" size="87266" crc="448d6b10" sha1="282b990e47530b854f7178281964e697bde17184"/>
@@ -15422,10 +14228,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="20mildola" cloneof="20mildol">
-		<description>Pour 20 Millions de Dollars (Alt)</description>
+		<description>Pour 20 Millions de Dollars (alt)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85846">
 				<rom name="pour 20 millions de dollars (198x)(softbook)(fr)[a].k7" size="85846" crc="62bc8723" sha1="9bd08fe321f200040903653f2098835e854efe88"/>
@@ -15434,10 +14239,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="20mildolb" cloneof="20mildol">
-		<description>Pour 20 Millions de Dollars (Alt 2)</description>
+		<description>Pour 20 Millions de Dollars (alt 2)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85846">
 				<rom name="pour 20 millions de dollars (198x)(softbook)(fr)[a2].k7" size="85846" crc="64b077de" sha1="22f5d4d306a42cfc39634ab472b389c7fb313081"/>
@@ -15446,10 +14250,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="20mildolc" cloneof="20mildol">
-		<description>Pour 20 Millions de Dollars (Alt 3)</description>
+		<description>Pour 20 Millions de Dollars (alt 3)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85846">
 				<rom name="pour-20-millions-de-dollars_mo5.k7" size="85846" crc="6cd3940d" sha1="f5d09af57efd49651299dcfc0d3ad3c3f0cd3ed1"/>
@@ -15461,7 +14264,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pouss Ball</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22592">
 				<rom name="pouss ball (1984)(to tek)(fr).k7" size="22592" crc="b56afeea" sha1="5391a3b187a7d7bf65343158121481ef06706e30"/>
@@ -15470,10 +14272,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pousballa" cloneof="pousball">
-		<description>Pouss Ball (Alt)</description>
+		<description>Pouss Ball (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22592">
 				<rom name="pouss ball (1984)(to tek)(fr)[a].k7" size="22592" crc="9a0ba535" sha1="53416a04eaca2f28792dbe024672987069a087e5"/>
@@ -15482,10 +14283,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pousballb" cloneof="pousball">
-		<description>Pouss Ball (Alt 2)</description>
+		<description>Pouss Ball (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22592">
 				<rom name="poussball_mo5.k7" size="22592" crc="d0f05d25" sha1="4a070ab1034d8806885fed4bd894020f834f6973"/>
@@ -15497,7 +14297,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pouvoir</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9610622">
 				<rom name="pouvoir_mo5.wav" size="9610622" crc="3e461021" sha1="47556ad5f1d905d79139e27f0a2fac16d51731cb"/>
@@ -15506,10 +14305,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pouvoira" cloneof="pouvoir">
-		<description>Pouvoir (Alt)</description>
+		<description>Pouvoir (alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26494">
 				<rom name="pouvoir_mo5.k7" size="26494" crc="7af5e073" sha1="eae176ed9f9e943eda92337269ac7fe12e21acb4"/>
@@ -15521,7 +14319,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Puissance 4</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5540">
 				<rom name="puissance 4 (1985)(dcsoft)(fr)(pd).k7" size="5540" crc="3e4e2c1d" sha1="d7152c7ff730cf1ceda1cc6f2df2cb5f40f3417c"/>
@@ -15530,10 +14327,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="puisanc4a" cloneof="puisanc4">
-		<description>Puissance 4 (Alt)</description>
+		<description>Puissance 4 (alt)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5540">
 				<rom name="puissance 4 (1985)(dcsoft)(fr)(pd)[a].k7" size="5540" crc="b868a4ef" sha1="2231549f02bb6d40fe88379a0b7995f5d722dd40"/>
@@ -15542,10 +14338,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="puisanc4b" cloneof="puisanc4">
-		<description>Puissance 4 (Alt 2)</description>
+		<description>Puissance 4 (alt 2)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5540">
 				<rom name="puissance 4 (1985)(dcsoft)(fr)(pd)[a2].k7" size="5540" crc="d8250cc1" sha1="ff720d898e208640e6282a1b9eebade8c57557df"/>
@@ -15554,10 +14349,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="puisanc4c" cloneof="puisanc4">
-		<description>Puissance 4 (Alt 3)</description>
+		<description>Puissance 4 (alt 3)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5540">
 				<rom name="puissance-4_mo5.k7" size="5540" crc="c7373fee" sha1="a27401290f6121a21ee82bc91541a4caac6157d6"/>
@@ -15569,7 +14363,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pulsar II</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4228064">
 				<rom name="pulsar ii (1984)(loriciels)(fr).wav" size="4228064" crc="7ce22be6" sha1="be0a2adf281c9da8269f0ad045606cbeda6546c4"/>
@@ -15578,10 +14371,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="pulsar2a" cloneof="pulsar2">
-		<description>Pulsar II (Alt)</description>
+		<description>Pulsar II (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4541588">
 				<rom name="pulsar ii (loriciels) (pascal pellier) (1984) (mo5).wav" size="4541588" crc="bd5b56cf" sha1="e7d2520b0729ca1f84ab473b7ea3d59811210346"/>
@@ -15591,10 +14383,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="pulsar2b" cloneof="pulsar2" supported="no">
-		<description>Pulsar II (Alt 2)</description>
+		<description>Pulsar II (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13278">
 				<rom name="pulsar ii (1984)(loriciels)(fr)[b2].k7" size="13278" crc="4c8cd8b3" sha1="eed998f78c2be6605676df7fff1d0385fdf5a615"/>
@@ -15604,10 +14395,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="pulsar2c" cloneof="pulsar2" supported="no">
-		<description>Pulsar II (Alt 3)</description>
+		<description>Pulsar II (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13278">
 				<rom name="pulsar ii (1984)(loriciels)(fr)[b3].k7" size="13278" crc="f36800e7" sha1="d9ea99f841c83561d3908b95558a27f8931ca3e5"/>
@@ -15617,10 +14407,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="pulsar2d" cloneof="pulsar2" supported="no">
-		<description>Pulsar II (Alt 4)</description>
+		<description>Pulsar II (alt 4)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12970">
 				<rom name="pulsar-2_mo5.k7" size="12970" crc="92619200" sha1="794437ad91db0c965ffde106b2519f527ccb2fbc"/>
@@ -15630,10 +14419,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="pulsar2e" cloneof="pulsar2" supported="no">
-		<description>Pulsar II (Alt 5)</description>
+		<description>Pulsar II (alt 5)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12970">
 				<rom name="pulsar-2_a_mo5.k7" size="12970" crc="a86358c5" sha1="620af3cc56be55f7d2c4f6c1d8c42f22533a39f1"/>
@@ -15643,10 +14431,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- This loads and runs in MAME but not in dcmoto!!! -->
 	<software name="pulsar2f" cloneof="pulsar2">
-		<description>Pulsar II (Cracked?)</description>
+		<description>Pulsar II (cracked?)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13280">
 				<rom name="pulsar ii (1984)(loriciels)(fr)[b].k7" size="13280" crc="0ddae936" sha1="1b4551dbca7ddf529d3e9a0543e0363723b3e4bb"/>
@@ -15658,7 +14445,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>PV 2000</description>
 		<year>1983</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10959">
 				<rom name="pv 2000 (totek) (philippe descamps, marc rolin) (1983) (mo5).k7" size="10959" crc="3c31e81c" sha1="17f89db63c08bc101030591f6634699b7802a149"/>
@@ -15670,7 +14456,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Qrisp</description>
 		<year>198?</year>
 		<publisher>ERE Informatique</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20328">
 				<rom name="qrisp (198x)(ere informatique)(fr).k7" size="20328" crc="2b4c0c65" sha1="d21a18c774c4cd09155804c86988c1ff611b5bfd"/>
@@ -15682,7 +14467,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Quadrille</description>
 		<year>198?</year>
 		<publisher>Francoise Monnet</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23480">
 				<rom name="quadrille (198x)(monnet, francoise)(fr).k7" size="23480" crc="4cb17b98" sha1="b9a7cfa354f09308a41b2a6d3c536a79edc58bb4"/>
@@ -15694,7 +14478,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Quaero</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11734">
 				<rom name="quaero (1985)(hebdogiciel)(fr)(pd).k7" size="11734" crc="085eb80f" sha1="924b82edf68ffb8b7af80038cf1edfc36efc542e"/>
@@ -15703,10 +14486,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="quaeroa" cloneof="quaero">
-		<description>Quaero (Alt)</description>
+		<description>Quaero (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11734">
 				<rom name="quaero (1985)(hebdogiciel)(fr)(pd)[a].k7" size="11734" crc="92ecfcd1" sha1="e43f6ce483558a4133ebbfa42beaa46dee4556fc"/>
@@ -15715,10 +14497,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="quaerob" cloneof="quaero">
-		<description>Quaero (Alt 2)</description>
+		<description>Quaero (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11734">
 				<rom name="quaero_mo5.k7" size="11734" crc="20403e0d" sha1="78a7d1f2a92213724c95467726af8e93dd31a69d"/>
@@ -15730,7 +14511,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Quiliquili</description>
 		<year>1986</year>
 		<publisher>Clap 54</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16830">
 				<rom name="quiliquili (1986)(clap 54)(fr).k7" size="16830" crc="df3c4de6" sha1="4cd0df8a7f4778f113b1adacb2de70b0f31e51a3"/>
@@ -15739,10 +14519,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="quiliquia" cloneof="quiliqui">
-		<description>Quiliquili (Alt)</description>
+		<description>Quiliquili (alt)</description>
 		<year>1986</year>
 		<publisher>Clap 54</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16830">
 				<rom name="quiliquili (1986)(clap 54)(fr)[a].k7" size="16830" crc="f3069ef8" sha1="a0b2d46ce1cac5d291ffade262e00906f582d944"/>
@@ -15751,10 +14530,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="quiliquib" cloneof="quiliqui">
-		<description>Quiliquili (Alt 2)</description>
+		<description>Quiliquili (alt 2)</description>
 		<year>1986</year>
 		<publisher>Clap 54</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16830">
 				<rom name="quiliquili_mo5.k7" size="16830" crc="c7b811df" sha1="1e5405546a804cc1848a7d0690240636f21fe0a9"/>
@@ -15766,7 +14544,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Raid sur Tenere</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25913">
 				<rom name="raid sur tenere (198x)(coktel vision)(fr).k7" size="25913" crc="50dafb37" sha1="f70cf849ee0f830c6820fb45a24769cbb0ec015a"/>
@@ -15778,7 +14555,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Regates</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13361">
 				<rom name="regates (1985)(vifi-nathan)(fr).k7" size="13361" crc="ba429324" sha1="57687dc6a54e7d7a93d622f322f34b76db68773e"/>
@@ -15790,7 +14566,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Renegade</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="92246">
@@ -15806,10 +14581,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="renegadea" cloneof="renegade">
-		<description>Renegade (Single Tape)</description>
+		<description>Renegade (single tape)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="153707">
 				<rom name="renegade (1988)(wise owl software)(fr).k7" size="153707" crc="310d59dd" sha1="8fd8c5212672d26d7480c60c286bfa39e913c9ba"/>
@@ -15818,10 +14592,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="renegadeb" cloneof="renegade">
-		<description>Renegade (Single Tape, Alt)</description>
+		<description>Renegade (single tape, alt)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="153707">
 				<rom name="renegade (1988)(wise owl software)(fr)[a].k7" size="153707" crc="e53ca403" sha1="f4c78e74bba10e24b9d6ceae0c4832b8dc9683dd"/>
@@ -15830,10 +14603,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="renegadec" cloneof="renegade">
-		<description>Renegade (Single Tape, Alt 2)</description>
+		<description>Renegade (single tape, alt 2)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="153707">
 				<rom name="renegade_mo5.k7" size="153707" crc="bbc07dca" sha1="2cf7a3356bb601fd36130710081cdde91ebc4ce0"/>
@@ -15845,7 +14617,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Reverse</description>
 		<year>198?</year>
 		<publisher>Daniel Coulom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6680">
 				<rom name="reverse (198x)(coulom, daniel)(fr)(pd).k7" size="6680" crc="2eb32be5" sha1="ab8e48321bd3671421a0370c294ff990745dde65"/>
@@ -15854,10 +14625,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="reversea" cloneof="reverse">
-		<description>Reverse (Alt)</description>
+		<description>Reverse (alt)</description>
 		<year>198?</year>
 		<publisher>Daniel Coulom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6680">
 				<rom name="reverse (198x)(coulom, daniel)(fr)(pd)[a].k7" size="6680" crc="6fb4479c" sha1="34baa9f778a8c67d5e677f1b94420c0422af43d8"/>
@@ -15866,10 +14636,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="reverseb" cloneof="reverse">
-		<description>Reverse (Alt 2)</description>
+		<description>Reverse (alt 2)</description>
 		<year>198?</year>
 		<publisher>Daniel Coulom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6680">
 				<rom name="reverse (198x)(coulom, daniel)(fr)(pd)[a2].k7" size="6680" crc="444208a5" sha1="0da75b34531a9e3def9e22a5485c5e82c404b3ef"/>
@@ -15878,10 +14647,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="reversec" cloneof="reverse">
-		<description>Reverse (Alt 3)</description>
+		<description>Reverse (alt 3)</description>
 		<year>198?</year>
 		<publisher>Daniel Coulom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6680">
 				<rom name="reverse_mo5.k7" size="6680" crc="a6aaf38f" sha1="7b7c85eeb44d00ceb57405a8df758dd293ddc053"/>
@@ -15907,7 +14675,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Revolution</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="62439">
@@ -15926,7 +14693,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rodeo</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43463">
 				<rom name="rodeo (1985)(microids)(fr).k7" size="43463" crc="eadd7429" sha1="c54e3706d83d93460741d260edd05a3270c2d890"/>
@@ -15935,10 +14701,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="rodeoa" cloneof="rodeo">
-		<description>Rodeo (Alt)</description>
+		<description>Rodeo (alt)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43463">
 				<rom name="rodeo (1985)(microids)(fr)[a].k7" size="43463" crc="40c2a295" sha1="b1296ee918becb7d779d8267db87392971d4da43"/>
@@ -15947,10 +14712,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="rodeob" cloneof="rodeo">
-		<description>Rodeo (Alt 2)</description>
+		<description>Rodeo (alt 2)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43463">
 				<rom name="rodeo_mo5.k7" size="43463" crc="d962d926" sha1="0792928c874712a1a356b61deb4d5c0f7d9dcf32"/>
@@ -15962,7 +14726,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Roger et Paulo</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11223">
 				<rom name="roger et paulo (1984)(infogrames)(fr).k7" size="11223" crc="291bc52b" sha1="81439adb4bc1bfe7bc386aa2e239317f2cc2b21b"/>
@@ -15971,10 +14734,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="rogerpaua" cloneof="rogerpau">
-		<description>Roger et Paulo (Alt)</description>
+		<description>Roger et Paulo (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10236">
 				<rom name="roger et paulo (1984)(infogrames)(fr)[loadm'''',,r].k7" size="10236" crc="92680468" sha1="f8d3c1143c88c3ad026b810a96790ddc285d53e3"/>
@@ -15983,10 +14745,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="rogerpaub" cloneof="rogerpau">
-		<description>Roger et Paulo (Alt 2)</description>
+		<description>Roger et Paulo (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10236">
 				<rom name="roger et paulo (1984)(infogrames)(fr)[a][loadm'''',,r].k7" size="10236" crc="bb93ca23" sha1="ce64fd4013b2511f3b600fa35934acd223740d03"/>
@@ -15995,10 +14756,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="rogerpauc" cloneof="rogerpau">
-		<description>Roger et Paulo (Alt 3)</description>
+		<description>Roger et Paulo (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10236">
 				<rom name="roger-et-paulo_mo5.k7" size="10236" crc="a3f0fd0f" sha1="ebfb6a5644f69b239fbc3ed90e70a7d9608d394e"/>
@@ -16010,7 +14770,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rotor-War</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17516">
 				<rom name="rotor-war (1984)(vifi-nathan)(fr).k7" size="17516" crc="eb093e0d" sha1="aa809dfb7e4696e324358f7dbee6f95b3b019047"/>
@@ -16022,7 +14781,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Runway</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13785">
 				<rom name="runway (1986)(fil)(fr).k7" size="13785" crc="52734da0" sha1="a2705561abbc9678aa539310ff2610cf2ce1a807"/>
@@ -16031,10 +14789,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="runwaya" cloneof="runway">
-		<description>Runway (Alt)</description>
+		<description>Runway (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14718">
 				<rom name="runway (1986)(fil)(fr)[a].k7" size="14718" crc="b45b3982" sha1="a178943eb8f8234557d3b5e53b269d36bddcb65f"/>
@@ -16043,10 +14800,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="runwayb" cloneof="runway">
-		<description>Runway (Alt 2)</description>
+		<description>Runway (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14718">
 				<rom name="runway (1986)(fil)(fr)[a2].k7" size="14718" crc="f6e859ab" sha1="659716a727a90fc9a53d60233192db9deaafe8fd"/>
@@ -16055,10 +14811,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="runwayc" cloneof="runway">
-		<description>Runway (Alt 3)</description>
+		<description>Runway (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14718">
 				<rom name="runway_mo5.k7" size="14718" crc="d4d5914e" sha1="e4aef09030f7e38a935e69cb078145280bae498f"/>
@@ -16070,7 +14825,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Runway II</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24533">
 				<rom name="runway ii (1986)(fil)(fr).k7" size="24533" crc="0db773af" sha1="e82c6160471af0c244612acfd679dba56eae2147"/>
@@ -16079,10 +14833,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="runway2a" cloneof="runway2">
-		<description>Runway II (Alt)</description>
+		<description>Runway II (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24533">
 				<rom name="runway ii (1986)(fil)(fr)[a].k7" size="24533" crc="4493ffb0" sha1="bdfeeb4e59b98b1d48b54d865c13ddf6c31209be"/>
@@ -16091,10 +14844,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="runway2b" cloneof="runway2">
-		<description>Runway II (Alt 2)</description>
+		<description>Runway II (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24533">
 				<rom name="runway ii (1986)(fil)(fr)[a2].k7" size="24533" crc="84ff2800" sha1="2a9e51e33a6233715b5829f941aeb86dfb095efb"/>
@@ -16103,10 +14855,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="runway2c" cloneof="runway2">
-		<description>Runway II (Alt 3)</description>
+		<description>Runway II (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24533">
 				<rom name="runway2_mo5.k7" size="24533" crc="4bfbefc2" sha1="6117d903a4c2ebe88d70a8a6c9108822d804d95a"/>
@@ -16118,7 +14869,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>San Pablo</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19531">
 				<rom name="san pablo (1985)(coktel vision)(fr).k7" size="19531" crc="d26cb2e7" sha1="027a131353c06ef448fc06dfaabd09cc2d7501af"/>
@@ -16127,10 +14877,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sanpabloa" cloneof="sanpablo">
-		<description>San Pablo (Alt)</description>
+		<description>San Pablo (alt)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19531">
 				<rom name="san pablo (1985)(coktel vision)(fr)[a].k7" size="19531" crc="798fdba5" sha1="bfcfb30e09b2f4ec706ce60acd3811d28da07a40"/>
@@ -16139,10 +14888,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sanpablob" cloneof="sanpablo">
-		<description>San Pablo (Alt 2)</description>
+		<description>San Pablo (alt 2)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19531">
 				<rom name="san-pablo_mo5.k7" size="19531" crc="c1757c21" sha1="c6b68473f3731811090e0dd4a23d58023077ac62"/>
@@ -16154,7 +14902,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Saphir</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Jeu)"/>
 			<dataarea name="cass" size="8191020">
@@ -16171,10 +14918,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="saphira" cloneof="saphir" supported="no">
-		<description>Saphir (Alt)</description>
+		<description>Saphir (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Jeu)"/>
 			<dataarea name="cass" size="33196">
@@ -16190,10 +14936,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="saphirb" cloneof="saphir">
-		<description>Saphir (Single Tape)</description>
+		<description>Saphir (single tape)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11803923">
 				<rom name="saphir (1986)(infogrames)(fr)[loadm].wav" size="11803923" crc="fca17c56" sha1="5aa446aa5bb9f15a66cb0bc79eb039a4399f16de"/>
@@ -16203,10 +14948,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="saphirc" cloneof="saphir" supported="no">
-		<description>Saphir (Single Tape, Alt)</description>
+		<description>Saphir (single tape, alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56101">
 				<rom name="saphir &amp; editeur (1986)(infogrames)(fr)[b].k7" size="56101" crc="0f4b3056" sha1="4b9c44737195a013e6441d2b09b042020fd6efd5"/>
@@ -16216,10 +14960,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="saphird" cloneof="saphir" supported="no">
-		<description>Saphir (Single Tape, Alt 2)</description>
+		<description>Saphir (single tape, alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56101">
 				<rom name="saphir + editeur (infogrames) (eric szymkowiak) (1986).k7" size="56101" crc="adf19594" sha1="6e189b3d32ca9342f7dce5963077737068d38961"/>
@@ -16228,10 +14971,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="saphire" cloneof="saphir" supported="no">
-		<description>Saphir (Single Tape, KCI Format)</description>
+		<description>Saphir (single tape, KCI format)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="363927">
 				<rom name="saphir.kci" size="363927" crc="d0f9f566" sha1="369c9c87f868bdab0436eff32faf34fe4138bd60"/>
@@ -16243,7 +14985,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sapiens</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10082726">
 				<rom name="sapiens (1986)(loriciels)(fr)[loadm].wav" size="10082726" crc="a210104e" sha1="bbfe7a84be958ce9269a74c427833e719a613167"/>
@@ -16253,10 +14994,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="sapiensa" cloneof="sapiens" supported="no">
-		<description>Sapiens (Alt)</description>
+		<description>Sapiens (alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31495">
 				<rom name="sapiens (1986)(loriciels)(fr)[b2].k7" size="31495" crc="1cace75a" sha1="75ea385e7f5079e3ace43f8b42453fa8d6f96b88"/>
@@ -16266,10 +15006,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="sapiensb" cloneof="sapiens" supported="no">
-		<description>Sapiens (Alt 2)</description>
+		<description>Sapiens (alt 2)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31495">
 				<rom name="sapiens (1986)(loriciels)(fr)[b3].k7" size="31495" crc="32ea16b0" sha1="0d7fd5c29619e07ce5ede54d81a2af3c75f5a468"/>
@@ -16279,10 +15018,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="sapiensc" cloneof="sapiens" supported="no">
-		<description>Sapiens (Alt 3)</description>
+		<description>Sapiens (alt 3)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31495">
 				<rom name="sapiens_mo5.k7" size="31495" crc="dfea9834" sha1="f38b6dab501698fb9fdee230c09adbd0f1e52bb6"/>
@@ -16291,10 +15029,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sapiensd" cloneof="sapiens" supported="no">
-		<description>Sapiens (KCI Format)</description>
+		<description>Sapiens (KCI format)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="298033">
 				<rom name="sapiens.kci" size="298033" crc="ccdb0c93" sha1="4f2a45b7ae65a36b97fe98fdb89ba0e52878c5f1"/>
@@ -16332,7 +15069,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scarfinger</description>
 		<year>1985</year>
 		<publisher>Nice Ideas</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24255">
 				<rom name="scarfinger - la moto infernale (1985)(nice ideas)(fr).k7" size="24255" crc="fde44192" sha1="1db8b99840b844f78e183075ecb4c0c8a2fa40c0"/>
@@ -16341,10 +15077,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="scarfinga" cloneof="scarfing">
-		<description>Scarfinger (Alt)</description>
+		<description>Scarfinger (alt)</description>
 		<year>1985</year>
 		<publisher>Nice Ideas</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24255">
 				<rom name="scarfinger_mo5.k7" size="24255" crc="3d57b84e" sha1="57dfab3e8b9459b5dcf5c5658d7cb540a09b4825"/>
@@ -16356,7 +15091,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scrontch</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5968">
 				<rom name="scrontch (1984)(vifi-nathan)(fr)(en)[loadm'''',,r].k7" size="5968" crc="bb5ee50b" sha1="96dfa23fde2c614031b5a089c805c4335d12cc5b"/>
@@ -16365,10 +15099,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="scrontcha" cloneof="scrontch">
-		<description>Scrontch (Alt)</description>
+		<description>Scrontch (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6045">
 				<rom name="scrontch (1984)(vifi-nathan)(fr)(en)[a][loadm'''',,r].k7" size="6045" crc="0ae4f424" sha1="77dbd00e2ab30ebc0ae0f9841a28a68f8dc9e939"/>
@@ -16377,7 +15110,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="scrontchb" cloneof="scrontch">
-		<description>Scrontch (Alt 2)</description>
+		<description>Scrontch (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
 
@@ -16389,10 +15122,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="scrontchc" cloneof="scrontch">
-		<description>Scrontch (Alt 3)</description>
+		<description>Scrontch (alt 3)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6045">
 				<rom name="scrontch_mo5.k7" size="6045" crc="d6687ffc" sha1="e81b040f759844a19d58db91eb315f4ab3559213"/>
@@ -16404,7 +15136,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Securite Social - En Jeu</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43548">
 				<rom name="securite social, la - en jeu (198x)(-)(fr).k7" size="43548" crc="86a705d1" sha1="afdf13ed806032066733f1fd8dc711bbd94bef1c"/>
@@ -16416,7 +15147,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Slap-Fight</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="121867">
 				<rom name="slap-fight (1987)(fil)(fr).k7" size="121867" crc="90e03f9d" sha1="dbe21619091c0e3805374be5614104889235140c"/>
@@ -16425,10 +15155,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="slapfigha" cloneof="slapfigh">
-		<description>Slap-Fight (Alt)</description>
+		<description>Slap-Fight (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="122285">
 				<rom name="slap-fight (1987)(fil)(fr)[a].k7" size="122285" crc="c158c277" sha1="f49cb3cf0800f83a594ca566aab82d5d32c171f8"/>
@@ -16437,10 +15166,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="slapfighb" cloneof="slapfigh">
-		<description>Slap-Fight (Alt 2)</description>
+		<description>Slap-Fight (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="122285">
 				<rom name="slap-fight (1987)(fil)(fr)[a2].k7" size="122285" crc="a57a907d" sha1="5d488edcd88a9e5edafecd7d0683a337ceecadf0"/>
@@ -16449,10 +15177,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="slapfighc" cloneof="slapfigh">
-		<description>Slap-Fight (Alt 3)</description>
+		<description>Slap-Fight (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="122285">
 				<rom name="slap-fight_mo5.k7" size="122285" crc="b5e8996c" sha1="988b5a62d5ea883222d2599e53f0e788c6e2dc19"/>
@@ -16464,7 +15191,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Smurfy</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22954">
 				<rom name="smurfy (sprites) (pascal pommier) (1985) (mo5).k7" size="22954" crc="8f73b256" sha1="9c4a9dae08a56a64f87fdbd54759321883fc5b0f"/>
@@ -16476,7 +15202,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Soleil Noir</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36599">
 				<rom name="soleil noir (1985)(microids)(fr).k7" size="36599" crc="84bb3fca" sha1="f532da673ec977d185f9e88d3e6b8020315f5ea8"/>
@@ -16485,10 +15210,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="solnoira" cloneof="solnoir">
-		<description>Soleil Noir (Alt)</description>
+		<description>Soleil Noir (alt)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36599">
 				<rom name="soleil noir (1985)(microids)(fr)[a].k7" size="36599" crc="cba29eb2" sha1="56c1723c1858d83f69815118c879d99d2e21164f"/>
@@ -16497,10 +15221,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="solnoirb" cloneof="solnoir">
-		<description>Soleil Noir (Alt 2)</description>
+		<description>Soleil Noir (alt 2)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36599">
 				<rom name="soleil-noir_mo5.k7" size="36599" crc="7dca1672" sha1="d02512d4a9db24078bad2f046f59abf0f18debcb"/>
@@ -16512,7 +15235,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sorcery</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8536324">
 				<rom name="sorcery (1986)(virgin games)(fr)[loadm].wav" size="8536324" crc="3bdf44a0" sha1="23e128094e819ffe5a4f48df0fc8cf8b79e68143"/>
@@ -16522,10 +15244,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="sorcerya" cloneof="sorcery" supported="no">
-		<description>Sorcery (Alt)</description>
+		<description>Sorcery (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38574">
 				<rom name="sorcery (1986)(virgin games)[b].k7" size="38574" crc="97c831e2" sha1="e468a4029d250f5591ae9e7600f85d32fc2b7364"/>
@@ -16535,10 +15256,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="sorceryb" cloneof="sorcery" supported="no">
-		<description>Sorcery (Alt 2)</description>
+		<description>Sorcery (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38574">
 				<rom name="sorcery (infogrames) (1986).k7" size="38574" crc="c7f9be83" sha1="093f4b55fb52021ced817c3b0c1873b49960da97"/>
@@ -16550,7 +15270,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sorciere</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7935">
 				<rom name="sorciere (198x)(-)(fr).k7" size="7935" crc="d890d005" sha1="b21051e2f88347fbdd9a4daeb06c82af276bedc9"/>
@@ -16559,10 +15278,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sorcierea" cloneof="sorciere">
-		<description>Sorciere (Alt)</description>
+		<description>Sorciere (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7935">
 				<rom name="sorciere (198x)(-)(fr)[a].k7" size="7935" crc="890c6735" sha1="4f294aa9f859a396955593bc85ffa8f24de66d9b"/>
@@ -16571,10 +15289,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sorciereb" cloneof="sorciere">
-		<description>Sorciere (Alt 2)</description>
+		<description>Sorciere (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7935">
 				<rom name="sorciere_mo5.k7" size="7935" crc="982ee6db" sha1="98e5ade2cd52991e65ddab8c9cd56b78f80b1605"/>
@@ -16586,7 +15303,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sortileges</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7165687">
 				<rom name="sortileges (1986)(infogrames)(fr)[loadm].wav" size="7165687" crc="7fa2080f" sha1="f1b837bbb4a383863493062a8dcbc9a12a3b82b0"/>
@@ -16596,10 +15312,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="sortilega" cloneof="sortileg" supported="no">
-		<description>Sortileges (Alt)</description>
+		<description>Sortileges (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30438">
 				<rom name="sortileges (1986)(infogrames)[b].k7" size="30438" crc="54114675" sha1="33bccf09eec4da5ca1e636e8c9625071533622ce"/>
@@ -16609,10 +15324,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="sortilegb" cloneof="sortileg" supported="no">
-		<description>Sortileges (Alt 2)</description>
+		<description>Sortileges (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30438">
 				<rom name="sortileges (infogrames) (william hennebois) (1986).k7" size="30438" crc="6e479d64" sha1="ff995ce534a8efdbd20ceae504b9432e25c819c2"/>
@@ -16622,10 +15336,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="sortilegc" cloneof="sortileg" supported="no">
-		<description>Sortileges (Alt 3)</description>
+		<description>Sortileges (alt 3)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31630">
 				<rom name="sortileges_mo5.k7" size="31630" crc="3c9d5430" sha1="4611f6aceabdc666529305f93d41341dc021a5d9"/>
@@ -16634,10 +15347,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sortilegd" cloneof="sortileg" supported="no">
-		<description>Sortileges (KCI Format)</description>
+		<description>Sortileges (KCI format)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="278906">
 				<rom name="sortil.kci" size="278906" crc="84d54397" sha1="8a74f5495a9995a02afdb2a8ae4781581e49f456"/>
@@ -16663,7 +15375,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SOS Space</description>
 		<year>198?</year>
 		<publisher>Minipuce</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29862">
 				<rom name="sos space (minipuce) (e. marquis) (mo5).k7" size="29862" crc="106343ae" sha1="26c9209c6a15f7ef2e9b26c3c4383dcad7394ceb"/>
@@ -16675,7 +15386,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Space Shuttle Simulator</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43741">
 				<rom name="space shuttle simulator (1984)(loriciels)(fr).k7" size="43741" crc="c9bee86e" sha1="519e6086b5a619b589b4bcfeed598e545cca471d"/>
@@ -16684,10 +15394,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="spaceshua" cloneof="spaceshu">
-		<description>Space Shuttle Simulator (Alt)</description>
+		<description>Space Shuttle Simulator (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43741">
 				<rom name="space shuttle simulator (1984)(loriciels)(fr)[a].k7" size="43741" crc="742ae0f6" sha1="87ab3f7e458d9ca810473a50d97e1acd09f3370d"/>
@@ -16696,10 +15405,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="spaceshub" cloneof="spaceshu">
-		<description>Space Shuttle Simulator (Alt 2)</description>
+		<description>Space Shuttle Simulator (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43741">
 				<rom name="space-shuttle-simulator_mo5.k7" size="43741" crc="f8a9981a" sha1="d4a71057389741bb78bb16d679388d9f5a1f1231"/>
@@ -16711,7 +15419,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Speedway</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45158">
 				<rom name="speedway (1986)(free game blot)(fr).k7" size="45158" crc="b16cabad" sha1="0a83cc3272ea70f0335f4033721a33e131363eb2"/>
@@ -16720,10 +15427,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="speedwaya" cloneof="speedway">
-		<description>Speedway (Alt)</description>
+		<description>Speedway (alt)</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45158">
 				<rom name="speedway_mo5.k7" size="45158" crc="d2aafe9d" sha1="44efc4df62e8a753a5a2bb6ad53d6adfa0b42bcf"/>
@@ -16735,7 +15441,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Spix</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8965">
 				<rom name="spix (1984)(infogrames)(fr).k7" size="8965" crc="82469825" sha1="8e992c79e49db77505eb131c2ffc3ecfa6d60a8d"/>
@@ -16744,10 +15449,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="spixa" cloneof="spix">
-		<description>Spix (Alt)</description>
+		<description>Spix (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8965">
 				<rom name="spix (1984)(infogrames)(fr)[a].k7" size="8965" crc="8acabb9f" sha1="c0ec3bb304ea6975994226cc29282538661d7dec"/>
@@ -16756,10 +15460,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="spixb" cloneof="spix">
-		<description>Spix (Alt 2)</description>
+		<description>Spix (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8965">
 				<rom name="spix (1984)(infogrames)(fr)[a2].k7" size="8965" crc="80345da8" sha1="e7c06bb3cbbb615008e562fa22d97fb93d268fb5"/>
@@ -16768,10 +15471,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="spixc" cloneof="spix">
-		<description>Spix (Alt 3)</description>
+		<description>Spix (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8957">
 				<rom name="spix (infogrames) (patrick princ) (1984) (mo5).k7" size="8957" crc="dc398e7b" sha1="2622216cc87c472c51d6b53b56e5503769ff3d08"/>
@@ -16783,7 +15485,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sports d'Ete</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="251178">
 				<rom name="sports d'ete (1988)(wise owl software)(fr).k7" size="251178" crc="bbb4207a" sha1="d55397200b0e75198d1aa3f5acc9fcec9b498fa2"/>
@@ -16792,10 +15493,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sportetea" cloneof="sportete">
-		<description>Sports d'Ete (Alt)</description>
+		<description>Sports d'Ete (alt)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="252915">
 				<rom name="sports d'ete (1988)(wise owl software)(fr)[a].k7" size="252915" crc="3dccad4c" sha1="fb31c3ce4ae6524108bab5ce6a8ced805bbab3d7"/>
@@ -16804,10 +15504,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sporteteb" cloneof="sportete">
-		<description>Sports d'Ete (Alt 2)</description>
+		<description>Sports d'Ete (alt 2)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="252915">
 				<rom name="sports d'ete (1988)(wise owl software)(fr)[a2].k7" size="252915" crc="4d93a8b5" sha1="4073d432fa048a019aa484afa3f7fb1c6dd27aa4"/>
@@ -16816,10 +15515,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sportetec" cloneof="sportete">
-		<description>Sports d'Ete (Alt 3)</description>
+		<description>Sports d'Ete (alt 3)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="252915">
 				<rom name="sports-d-ete_mo5.k7" size="252915" crc="685ce251" sha1="62bb3c583e96cd66ddf5038da112f992bb453cbd"/>
@@ -16831,7 +15529,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Stanley</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34271">
 				<rom name="stanley (1984)(loriciels)(fr).k7" size="34271" crc="8c816f23" sha1="acdc5d90f631d2cd37e67ab983f81d9b6c3810f0"/>
@@ -16840,10 +15537,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="stanleya" cloneof="stanley">
-		<description>Stanley (Alt)</description>
+		<description>Stanley (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33854">
 				<rom name="stanley (1984)(loriciels)(fr)[loadm'''',,r].k7" size="33854" crc="8edfa6d1" sha1="57aa2daa69c92d813c6d3ea8bf69dd6400f27f3d"/>
@@ -16852,10 +15548,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="stanleyb" cloneof="stanley">
-		<description>Stanley (Alt 2)</description>
+		<description>Stanley (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33854">
 				<rom name="stanley_mo5.k7" size="33854" crc="f0495429" sha1="8c8fe950342a2e987cc58fd5ef034235c6ee2685"/>
@@ -16867,7 +15562,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Starwar</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6511">
 				<rom name="starwar (198x)(-)(fr)(pd).k7" size="6511" crc="7fc70fd4" sha1="c3b54781cfa41afd107edcde609eafeeecf6cb07"/>
@@ -16879,7 +15573,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Stone Zone</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56086">
 				<rom name="stone zone (198x)(softbook)(fr).k7" size="56086" crc="6041c841" sha1="01cf5f9dfd961eb165f9ce2604a04159e3f3159c"/>
@@ -16888,10 +15581,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="stonezona" cloneof="stonezon">
-		<description>Stone Zone (Alt)</description>
+		<description>Stone Zone (alt)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56361">
 				<rom name="stone zone (198x)(softbook)(fr)[a].k7" size="56361" crc="49cbdc43" sha1="4f856040b1b51c937a69eaca31caa626e8fb6cdc"/>
@@ -16900,10 +15592,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="stonezonb" cloneof="stonezon">
-		<description>Stone Zone (Alt 2)</description>
+		<description>Stone Zone (alt 2)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56086">
 				<rom name="stone zone (198x)(softbook)(fr)[a3].k7" size="56086" crc="cea94e71" sha1="0b4fb05830b3651cf6592b1a9c3259114285bc79"/>
@@ -16912,10 +15603,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="stonezonc" cloneof="stonezon">
-		<description>Stone Zone (Alt 3)</description>
+		<description>Stone Zone (alt 3)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56086">
 				<rom name="stone-zone_mo5.k7" size="56086" crc="a3034f53" sha1="de6d159a1639827f51b8e807ebb5c874086ba663"/>
@@ -16927,7 +15617,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Strip 21</description>
 		<year>198?</year>
 		<publisher>Patrick Lahbib</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14616">
 				<rom name="strip 21 (198x)(lahbib, patrick)(fr)(pd).k7" size="14616" crc="a192c936" sha1="385a55231c599260d88308189e573f2f1cce3bc5"/>
@@ -16936,10 +15625,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="strip21a" cloneof="strip21">
-		<description>Strip 21 (Alt)</description>
+		<description>Strip 21 (alt)</description>
 		<year>198?</year>
 		<publisher>Patrick Lahbib</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14616">
 				<rom name="strip 21 (198x)(lahbib, patrick)(fr)(pd)[a].k7" size="14616" crc="6e3954ca" sha1="c66ddd65dbd35c9a61c2caf2c1d6fd1060e19d2a"/>
@@ -16948,10 +15636,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="strip21b" cloneof="strip21">
-		<description>Strip 21 (Alt 2)</description>
+		<description>Strip 21 (alt 2)</description>
 		<year>198?</year>
 		<publisher>Patrick Lahbib</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14616">
 				<rom name="strip 21 (198x)(lahbib, patrick)(fr)(pd)[a2].k7" size="14616" crc="fbbe83d8" sha1="464027591fb5c04904dfc3bed51ef1cdd102b58e"/>
@@ -16960,10 +15647,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="strip21c" cloneof="strip21">
-		<description>Strip 21 (Alt 3)</description>
+		<description>Strip 21 (alt 3)</description>
 		<year>198?</year>
 		<publisher>Patrick Lahbib</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14616">
 				<rom name="strip-21_mo5.k7" size="14616" crc="347350c8" sha1="6e4cfd1791acdd21d1b491a2358d54818f24a817"/>
@@ -16975,7 +15661,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Jimmie</description>
 		<year>1985</year>
 		<publisher>Minipuce</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13437">
 				<rom name="super jimmie (1985)(minipuce - microstory)(fr).k7" size="13437" crc="8d6bb6f1" sha1="b03ae3a8a7b750ca52a016c31c4b2435cf2e1286"/>
@@ -16984,10 +15669,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sjimmiea" cloneof="sjimmie">
-		<description>Super Jimmie (Alt)</description>
+		<description>Super Jimmie (alt)</description>
 		<year>1985</year>
 		<publisher>Minipuce</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13437">
 				<rom name="super jimmie (1985)(minipuce - microstory)(fr)[a].k7" size="13437" crc="70865577" sha1="3e389970e29a0378145fd8411c5c35d4556798a2"/>
@@ -16996,10 +15680,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sjimmieb" cloneof="sjimmie">
-		<description>Super Jimmie (Alt 2)</description>
+		<description>Super Jimmie (alt 2)</description>
 		<year>1985</year>
 		<publisher>Minipuce</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13437">
 				<rom name="super-jimmie_mo5.k7" size="13437" crc="24bac33e" sha1="e30298c66f5b1b14be578a948d5c4ca183585bcc"/>
@@ -17011,7 +15694,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Tennis (FIL)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28837">
 				<rom name="super tennis (1986)(fil)(fr).k7" size="28837" crc="db897a55" sha1="57adbc98788885cb5b0bf9fdd387c8bfc53acfb6"/>
@@ -17020,10 +15702,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="stennisa" cloneof="stennis">
-		<description>Super Tennis (FIL) (Alt)</description>
+		<description>Super Tennis (FIL) (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28837">
 				<rom name="super tennis (1986)(fil)(fr)[a].k7" size="28837" crc="4dc65f05" sha1="8d61e10b68f69e26c7122905e0050d5ca222620b"/>
@@ -17035,7 +15716,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Tennis (Answare)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28860">
 				<rom name="super tennis (1985)(answare)(fr).k7" size="28860" crc="576d1b89" sha1="cc07f4155b96e4687cd8858b4acc24d4c2d96be5"/>
@@ -17044,10 +15724,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="stennisc" cloneof="stennis">
-		<description>Super Tennis (Answare) (Alt)</description>
+		<description>Super Tennis (Answare) (alt)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29026">
 				<rom name="super tennis (1985)(answare)(fr)[a].k7" size="29026" crc="ba7cd618" sha1="c18925f6c4afd717dbec12bcbf4b3bfdc23b6dd4"/>
@@ -17056,10 +15735,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="stennisd" cloneof="stennis">
-		<description>Super Tennis (Answare) (Alt 2)</description>
+		<description>Super Tennis (Answare) (alt 2)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29026">
 				<rom name="super tennis (1985)(answare)(fr)[a2].k7" size="29026" crc="5836d549" sha1="882463e38fa53d0c8c1ae568af20425d03050951"/>
@@ -17068,10 +15746,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="stennise" cloneof="stennis">
-		<description>Super Tennis (Answare) (Alt 3)</description>
+		<description>Super Tennis (Answare) (alt 3)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29026">
 				<rom name="super tennis (1985)(answare)(fr)[a3].k7" size="29026" crc="ca8c3f01" sha1="9bf4240aeeab756e26bdb16364151b380765cf2c"/>
@@ -17083,7 +15760,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sympuz</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11208">
 				<rom name="sympuz (1984)(no man's land)(fr).k7" size="11208" crc="3e987359" sha1="c43a092ca471e96ea312daba9736d369a3ff09e7"/>
@@ -17092,10 +15768,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sympuza" cloneof="sympuz">
-		<description>Sympuz (Alt)</description>
+		<description>Sympuz (alt)</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11208">
 				<rom name="sympuz (1984)(no man's land)(fr)[a].k7" size="11208" crc="9d532407" sha1="cdcdd88a70826c66ecc5a51c5bc81dc6016010a3"/>
@@ -17104,10 +15779,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sympuzb" cloneof="sympuz">
-		<description>Sympuz (Alt 2)</description>
+		<description>Sympuz (alt 2)</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11208">
 				<rom name="sympuz_mo5.k7" size="11208" crc="b947a134" sha1="0b617dbeba4c299c845c98e65587997cb9d37a7c"/>
@@ -17120,7 +15794,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>T.N.T.</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="55605">
 				<rom name="t.n.t. (1986)(infogrames)[b].k7" size="55605" crc="64f6ceb6" sha1="fb4619847ddc9195098f1d82c0fa1b4aaeeac6b6"/>
@@ -17130,10 +15803,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="tnta" cloneof="tnt" supported="no">
-		<description>T.N.T. (Alt)</description>
+		<description>T.N.T. (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="58245">
 				<rom name="tnt_mo5.k7" size="58245" crc="547c9006" sha1="fae130ef5e7fff367de81284c100b6132dbf45a7"/>
@@ -17145,7 +15817,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Taquin+</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21838">
 				<rom name="taquin+ (1984)(to tek)(fr).k7" size="21838" crc="86ad5b9f" sha1="85d99b12995f15a31d75f54cdffb0b84874fc222"/>
@@ -17154,10 +15825,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="taquina" cloneof="taquin">
-		<description>Taquin+ (Alt)</description>
+		<description>Taquin+ (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21830">
 				<rom name="taquin+ (1984)(to tek)(fr)[a].k7" size="21830" crc="8a9dfb76" sha1="92bdf546c1a1ed7adfe56ba5f8b72b0941d48f09"/>
@@ -17166,10 +15836,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="taquinb" cloneof="taquin">
-		<description>Taquin+ (Alt 2)</description>
+		<description>Taquin+ (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21830">
 				<rom name="taquin+ (1984)(to tek)(fr)[a2].k7" size="21830" crc="2c7e046e" sha1="ccfe99360a12268e3bfa2aa9cabb7cbe00cbb54b"/>
@@ -17178,10 +15847,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="taquinc" cloneof="taquin">
-		<description>Taquin+ (Alt 3)</description>
+		<description>Taquin+ (alt 3)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21830">
 				<rom name="taquin_mo5.k7" size="21830" crc="e1107ad6" sha1="9d425d107dfc426ba3732116c8a6a0f9982b9414"/>
@@ -17193,7 +15861,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tarot</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22061">
 				<rom name="tarot (1986-08)(dcsoft)(fr)(pd).k7" size="22061" crc="a27dfbfc" sha1="205b8c70b2743782bf171e02c0f386e9d4e14a0d"/>
@@ -17202,10 +15869,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="tarota" cloneof="tarot">
-		<description>Tarot (Alt)</description>
+		<description>Tarot (alt)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22061">
 				<rom name="tarot (1986-08)(dcsoft)(fr)(pd)[a].k7" size="22061" crc="8e4c2f29" sha1="06b30ffe464dd38c48706527a092cf433e4c5c50"/>
@@ -17214,10 +15880,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="tarotb" cloneof="tarot">
-		<description>Tarot (Alt 2)</description>
+		<description>Tarot (alt 2)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22061">
 				<rom name="tarot (1986-08)(dcsoft)(fr)(pd)[a2].k7" size="22061" crc="ff8f1c85" sha1="bcb1a503cc20a3cc9fee7b630801fcab53b713ea"/>
@@ -17226,10 +15891,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="tarotc" cloneof="tarot">
-		<description>Tarot (Alt 3)</description>
+		<description>Tarot (alt 3)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22061">
 				<rom name="dctarot_mo5.k7" size="22061" crc="e4724dde" sha1="4ce27f9cda1664afc15afa3cb63d34e4ddb6282d"/>
@@ -17241,7 +15905,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Teledomino</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10862">
 				<rom name="teledomino (1986)(microtom)(fr).k7" size="10862" crc="9d03b185" sha1="e3767a3dc87b3429959cc0c019738923853e2b74"/>
@@ -17250,10 +15913,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="teledomia" cloneof="teledomi">
-		<description>Teledomino (Alt)</description>
+		<description>Teledomino (alt)</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10862">
 				<rom name="teledomino (1986)(microtom)(fr)[a].k7" size="10862" crc="45b2a033" sha1="d80bda73fc36a0333e29319dd3e325efa1aefd7c"/>
@@ -17262,10 +15924,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="teledomib" cloneof="teledomi">
-		<description>Teledomino (Alt 2)</description>
+		<description>Teledomino (alt 2)</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10862">
 				<rom name="teledomino_mo5.k7" size="10862" crc="64dca519" sha1="75ca377bf5a0e5cfaa173745e1fd04054acd8fad"/>
@@ -17277,7 +15938,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Temple de Quauthli</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="49705">
@@ -17293,10 +15953,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="quauthlia" cloneof="quauthli">
-		<description>Le Temple de Quauthli (Single Tape)</description>
+		<description>Le Temple de Quauthli (single tape)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="83468">
 				<rom name="temple de quauthli, le (1986)(loriciels)(fr).k7" size="83468" crc="db0a84e2" sha1="74d86b5cef08348062628e9a721572ff04a8d1b2"/>
@@ -17305,10 +15964,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="quauthlib" cloneof="quauthli">
-		<description>Le Temple de Quauthli (Single Tape, Alt)</description>
+		<description>Le Temple de Quauthli (single tape, alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="83468">
 				<rom name="temple de quauthli, le (1986)(loriciels)(fr)[a].k7" size="83468" crc="52954732" sha1="f7be813a845a57f319023d015d8f3b607935230d"/>
@@ -17317,10 +15975,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="quauthlic" cloneof="quauthli">
-		<description>Le Temple de Quauthli (Single Tape, Alt 2)</description>
+		<description>Le Temple de Quauthli (single tape, alt 2)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="83468">
 				<rom name="le-temple-de-quauhtli_mo5.k7" size="83468" crc="82585fa4" sha1="43b13cb72a6468e882a581e8df5a965d546c11c9"/>
@@ -17332,7 +15989,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Territoire</description>
 		<year>1985</year>
 		<publisher>Logimicro</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52326">
 				<rom name="territoire (logimicro) (inconnus) (1985) (mo5 k7).k7" size="52326" crc="7f405c64" sha1="b6a99ffe498ce502011cc21ca24e250747560d65"/>
@@ -17344,7 +16000,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tetris</description>
 		<year>1989</year>
 		<publisher>Gilles Daurat</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3677">
 				<rom name="tetris gd (1989)(daurat, gilles)(fr).k7" size="3677" crc="d649962b" sha1="cb513d05fe730faea537ab10a2e1869635a161d3"/>
@@ -17353,10 +16008,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="tetrisa" cloneof="tetris">
-		<description>Tetris (Alt)</description>
+		<description>Tetris (alt)</description>
 		<year>1989</year>
 		<publisher>Gilles Daurat</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3677">
 				<rom name="tetris-gd_mo5.k7" size="3677" crc="3201586d" sha1="6c14f2247aad169bf57620e5f8af8b864d643f48"/>
@@ -17368,7 +16022,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Thesaurus</description>
 		<year>198?</year>
 		<publisher>Minipuce</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="72028">
 				<rom name="thesaurus (198x)(minipuce)(fr).k7" size="72028" crc="b542a958" sha1="a5a30a2b65dbcbc204fc11ea4fb97610b7978b57"/>
@@ -17377,10 +16030,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="thesaurua" cloneof="thesauru">
-		<description>Thesaurus (Alt)</description>
+		<description>Thesaurus (alt)</description>
 		<year>198?</year>
 		<publisher>Minipuce</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="72028">
 				<rom name="thesaurus_mo5.k7" size="72028" crc="b213ef3a" sha1="2530226053ac661e146bfe3ee3af70a36613790d"/>
@@ -17392,7 +16044,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Third World War</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7954">
 				<rom name="third world war (198x)(free game blot)(fr).k7" size="7954" crc="ec519f11" sha1="1cbaaf71f113a064fa781606bfa72e386530d4bb"/>
@@ -17401,10 +16052,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="thirdwara" cloneof="thirdwar">
-		<description>Third World War (Alt)</description>
+		<description>Third World War (alt)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7174">
 				<rom name="third world war (198x)(free game blot)(fr)[a].k7" size="7174" crc="0cd75a0c" sha1="3bc771e318b4bee2e1bbfdee74319b399eff6e9b"/>
@@ -17413,10 +16063,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="thirdwarb" cloneof="thirdwar">
-		<description>Third World War (Alt 2)</description>
+		<description>Third World War (alt 2)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7174">
 				<rom name="third world war (198x)(free game blot)(fr)[a2].k7" size="7174" crc="c8acc05e" sha1="04088f525531120bb4e9b4cbc1a995e38b80f742"/>
@@ -17425,10 +16074,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="thirdwarc" cloneof="thirdwar">
-		<description>Third World War (Alt 3)</description>
+		<description>Third World War (alt 3)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7174">
 				<rom name="world-war3_mo5.k7" size="7174" crc="efe98dc9" sha1="2f5435b62d001b1a88b3b12aad31faeaa703394a"/>
@@ -17440,7 +16088,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Thom-Puzz</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18000">
 				<rom name="thom-puzz (1984)(no man's land)(fr).k7" size="18000" crc="7640f5d7" sha1="956980dabf5ee8878d50ba23f8f9807c2d945247"/>
@@ -17452,7 +16099,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tic-Tac</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31007">
 				<rom name="tic-tac (1984)(loriciels)(fr).k7" size="31007" crc="e3cc6585" sha1="a2ccb6c411cbfd52789fd7bfe5dfbd0c13b6a950"/>
@@ -17461,10 +16107,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="tictaca" cloneof="tictac">
-		<description>Tic-Tac (Alt)</description>
+		<description>Tic-Tac (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31007">
 				<rom name="tic-tac (1984)(loriciels)(fr)[a].k7" size="31007" crc="b9d2757c" sha1="3ae7602847c6df499231a583884d39f0cce6eb10"/>
@@ -17473,10 +16118,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="tictacb" cloneof="tictac">
-		<description>Tic-Tac (Alt 2)</description>
+		<description>Tic-Tac (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31007">
 				<rom name="tic-tac_mo5.k7" size="31007" crc="dbf60d2e" sha1="ffb5d07350664da9cfda7e562302f137f01766bb"/>
@@ -17488,7 +16132,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Top Gun</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36652">
 				<rom name="top gun (1987)(fil)(fr).k7" size="36652" crc="a951b8c7" sha1="e628e5a4e41419188250a44bce4434e0e2064687"/>
@@ -17497,10 +16140,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="topguna" cloneof="topgun">
-		<description>Top Gun (Alt)</description>
+		<description>Top Gun (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36898">
 				<rom name="top gun (1987)(fil)(fr)[a].k7" size="36898" crc="6cd09338" sha1="7c95e03d340a416d83aba91848c63ee83ad269d2"/>
@@ -17509,10 +16151,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="topgunb" cloneof="topgun">
-		<description>Top Gun (Alt 2)</description>
+		<description>Top Gun (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36898">
 				<rom name="top gun (1987)(fil)(fr)[a2].k7" size="36898" crc="66fd03d8" sha1="579b4febef16fe4755095cac4aeea13aedd4ec10"/>
@@ -17521,10 +16162,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="topgunc" cloneof="topgun">
-		<description>Top Gun (Alt 3)</description>
+		<description>Top Gun (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36898">
 				<rom name="top-gun_mo5.k7" size="36898" crc="dde9599d" sha1="483aaafa32144e9590d89892179036bd319b521d"/>
@@ -17536,7 +16176,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Top-Chrono</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36316">
 				<rom name="top-chrono (1985)(loriciels)(fr).k7" size="36316" crc="0cc96513" sha1="524d179d3f1bfb66b843851a5efa70e418638e83"/>
@@ -17545,10 +16184,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="topchrona" cloneof="topchron">
-		<description>Top-Chrono (Alt)</description>
+		<description>Top-Chrono (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34609">
 				<rom name="top-chrono (1985)(loriciels)(fr)[a].k7" size="34609" crc="a6a025f2" sha1="b0f48a6adb344a0c0848b1ac004968b050e63c04"/>
@@ -17557,10 +16195,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="topchronb" cloneof="topchron">
-		<description>Top-Chrono (Alt 2)</description>
+		<description>Top-Chrono (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36325">
 				<rom name="top-chrono (1985)(loriciels)(fr)[a2].k7" size="36325" crc="10be2f49" sha1="9ae47d51ac004840ea29d275bca0706f8bd478ed"/>
@@ -17569,10 +16206,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="topchronc" cloneof="topchron">
-		<description>Top-Chrono (Alt 3)</description>
+		<description>Top-Chrono (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36325">
 				<rom name="top-chrono (1985)(loriciels)(fr)[a3].k7" size="36325" crc="6e036ec0" sha1="6d9c2818e9534a113326bb415b652bc4bbe09c00"/>
@@ -17581,10 +16217,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="topchrond" cloneof="topchron">
-		<description>Top-Chrono (Alt 4)</description>
+		<description>Top-Chrono (alt 4)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36325">
 				<rom name="top-chrono_mo5.k7" size="36325" crc="4836284e" sha1="78e4fed788f1925f50296c9965dfe53071b1562c"/>
@@ -17596,7 +16231,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Torann - Mission Blue 5</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="torann - mission blue 5 (198x)(loriciels)(fr).k7" size="34587" crc="d9b72731" sha1="acaf497b5cd8035e5cada8691c8826a3a7aed9da"/>
@@ -17605,10 +16239,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="toranna" cloneof="torann">
-		<description>Torann - Mission Blue 5 (Alt)</description>
+		<description>Torann - Mission Blue 5 (alt)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="torann - mission blue 5 (198x)(loriciels)(fr)[a].k7" size="34587" crc="fe7888d4" sha1="13b48d25631b49d16cb46c8e28c4fe068cbcef51"/>
@@ -17617,10 +16250,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="torannb" cloneof="torann">
-		<description>Torann - Mission Blue 5 (Alt 2)</description>
+		<description>Torann - Mission Blue 5 (alt 2)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="torann - mission blue 5 (198x)(loriciels)(fr)[a2].k7" size="34587" crc="5c0b2bab" sha1="fa791d16f0e2d9fda4b840431a6a48272507b4d3"/>
@@ -17629,10 +16261,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="torannc" cloneof="torann">
-		<description>Torann - Mission Blue 5 (Alt 3)</description>
+		<description>Torann - Mission Blue 5 (alt 3)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="torann-mission-blue_mo5.k7" size="34587" crc="e53848b5" sha1="8a9787cbca6f6d59f43a9462a4d655f330db1256"/>
@@ -17644,7 +16275,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tout Schuss</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="221948">
 				<rom name="tout schuss (1987)(fil)(fr).k7" size="221948" crc="0e3904a1" sha1="35cbeb09e27eb4c7b80adeb4e85b8d7c7c979ab2"/>
@@ -17653,10 +16283,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="toutschua" cloneof="toutschu">
-		<description>Tout Schuss (Alt)</description>
+		<description>Tout Schuss (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="221948">
 				<rom name="tout schuss (1987)(fil)(fr)[a].k7" size="221948" crc="aea059ca" sha1="a7bb455001606a720b587bbade897ca88bce8312"/>
@@ -17665,10 +16294,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="toutschub" cloneof="toutschu">
-		<description>Tout Schuss (Alt 2)</description>
+		<description>Tout Schuss (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="221948">
 				<rom name="tout-schuss_mo5.k7" size="221948" crc="aabb8c77" sha1="44b78489c6dfc01b8bae501f434febe3c03a7741"/>
@@ -17680,7 +16308,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Toutankhamon</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40660">
 				<rom name="toutankhamon (1985)(no man's land)(fr).k7" size="40660" crc="3567168d" sha1="2717d5e11ec122acfab80528ccc5a5372ca6bed5"/>
@@ -17689,10 +16316,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="toutankha" cloneof="toutankh">
-		<description>Toutankhamon (Alt)</description>
+		<description>Toutankhamon (alt)</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40855">
 				<rom name="toutankhamon (1985)(no man's land)(fr)[a].k7" size="40855" crc="b8f9ac86" sha1="6594265a109a436f72d1e80f18f0332550c08b9c"/>
@@ -17701,10 +16327,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="toutankhb" cloneof="toutankh">
-		<description>Toutankhamon (Alt 2)</description>
+		<description>Toutankhamon (alt 2)</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40855">
 				<rom name="toutankhamon (1985)(no man's land)(fr)[a2].k7" size="40855" crc="c48c4959" sha1="5744e001dc6cb66c6e6ce2d4f49e0b9ce438c5a2"/>
@@ -17713,10 +16338,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="toutankhc" cloneof="toutankh">
-		<description>Toutankhamon (Alt 3)</description>
+		<description>Toutankhamon (alt 3)</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40855">
 				<rom name="toutankhamon_mo5.k7" size="40855" crc="32adab50" sha1="80131f8e2f37e29dd3382d3042e85e63701a7e8c"/>
@@ -17728,7 +16352,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Tresor du Pirate</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21830">
 				<rom name="tresor du pirate, le (1984)(free game blot)(fr).k7" size="21830" crc="95582d2c" sha1="babdf940db6730f11e4e068bcd61086a2322a2fb"/>
@@ -17737,10 +16360,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="trespira" cloneof="trespir">
-		<description>Le Tresor du Pirate (Alt)</description>
+		<description>Le Tresor du Pirate (alt)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23091">
 				<rom name="tresor du pirate, le (1984)(free game blot)(fr)[a].k7" size="23091" crc="07336cbf" sha1="846d0411c1b28e79f1c4191968b308281c4a562f"/>
@@ -17749,10 +16371,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="trespirb" cloneof="trespir">
-		<description>Le Tresor du Pirate (Alt 2)</description>
+		<description>Le Tresor du Pirate (alt 2)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23091">
 				<rom name="tresor du pirate, le (1984)(free game blot)(fr)[a2].k7" size="23091" crc="ebd6ee58" sha1="b9e06d353b4262155a1dcf4ebb5e8f4eb380fc3f"/>
@@ -17761,10 +16382,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="trespirc" cloneof="trespir">
-		<description>Le Tresor du Pirate (Alt 3)</description>
+		<description>Le Tresor du Pirate (alt 3)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23091">
 				<rom name="le-tresor-du-pirate_mo5.k7" size="23091" crc="58d0ddee" sha1="3d60caa6cffb3f25313650dc1e13b916ec272bd5"/>
@@ -17776,7 +16396,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Troff</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6461">
 				<rom name="troff (1983)(infogrames)(fr).k7" size="6461" crc="e733c8fe" sha1="2128fb4ef61ee4f5f13729b85590ed37a07863b0"/>
@@ -17785,10 +16404,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="troffa" cloneof="troff">
-		<description>Troff (Alt)</description>
+		<description>Troff (alt)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5676">
 				<rom name="troff (1983)(infogrames)(fr)[a].k7" size="5676" crc="c379c8f3" sha1="39bf4130679112c646f80b9774ea1184d41a2785"/>
@@ -17797,10 +16415,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="troffb" cloneof="troff">
-		<description>Troff (Alt 2)</description>
+		<description>Troff (alt 2)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5676">
 				<rom name="troff (1983)(infogrames)(fr)[a2].k7" size="5676" crc="2d927325" sha1="5c4d0083917e1862fab2357a04051b6f50008302"/>
@@ -17809,10 +16426,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="troffc" cloneof="troff">
-		<description>Troff (Alt 3)</description>
+		<description>Troff (alt 3)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5676">
 				<rom name="troff_mo5.k7" size="5676" crc="881633ce" sha1="ff06edc4b4bca255f55437872c4f86f316304aa3"/>
@@ -17825,7 +16441,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tyrann</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40753">
 				<rom name="tyrann (1985)(norsoft)(fr)[1st generation mo5].k7" size="40753" crc="ee1fccf2" sha1="a229c6cecb1dad618c4d0c4c7e099e0aeb3333c3"/>
@@ -17835,10 +16450,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection?, works in dcmoto -->
 	<software name="tyranna" cloneof="tyrann" supported="no">
-		<description>Tyrann (Alt)</description>
+		<description>Tyrann (alt)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40753">
 				<rom name="tyrann (1985)(norsoft)(fr)[2nd generation mo5].k7" size="40753" crc="d1b5ca52" sha1="d9d8db32295df1eb8dbf8c2e54b49e563adf4a6e"/>
@@ -17848,10 +16462,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection?, works in dcmoto -->
 	<software name="tyrannb" cloneof="tyrann" supported="no">
-		<description>Tyrann (Alt 2)</description>
+		<description>Tyrann (alt 2)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40753">
 				<rom name="tyrann (1985)(norsoft)(fr)[b2].k7" size="40753" crc="09371720" sha1="5bb82a9494d1c7eafa23983382ef9c3f3572b25e"/>
@@ -17861,10 +16474,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection?, works in dcmoto -->
 	<software name="tyrannc" cloneof="tyrann" supported="no">
-		<description>Tyrann (Alt 3)</description>
+		<description>Tyrann (alt 3)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40753">
 				<rom name="tyrann-v1_mo5.k7" size="40753" crc="84de926d" sha1="9e26136d2fdee303e920ed8516ae12c547acd0cb"/>
@@ -17874,10 +16486,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection?, works in dcmoto -->
 	<software name="tyrannd" cloneof="tyrann" supported="no">
-		<description>Tyrann (Alt 4)</description>
+		<description>Tyrann (alt 4)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40753">
 				<rom name="tyrann-v2_mo5.k7" size="40753" crc="bb7494cd" sha1="f901743aa1ee4ddcc13f61a1a6cf7aea3fec290e"/>
@@ -17887,10 +16498,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection?, fails to load in dcmoto -->
 	<software name="tyranne" cloneof="tyrann" supported="no">
-		<description>Tyrann (Alt 5)</description>
+		<description>Tyrann (alt 5)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40668">
 				<rom name="tyrann (1985)(norsoft)(fr)[b].k7" size="40668" crc="99decafb" sha1="932b015db5e8ea89d84e413daeb56212abdb0877"/>
@@ -17902,7 +16512,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Usine Infernale</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12532">
 				<rom name="l'usine infernale (shift-edition) (philippe baroin) (1985) (mo5 k7).k7" size="12532" crc="a33bb9b9" sha1="ebf558890535ce0d022d21ca0c931e1c5f928569"/>
@@ -17914,7 +16523,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vampire</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8410873">
 				<rom name="vampire (198x)(infogrames)(fr).wav" size="8410873" crc="1e162d3a" sha1="2728b7d0e0a9bd6dc45b70359f0d32f680ddd916"/>
@@ -17924,10 +16532,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="vampirea" cloneof="vampire" supported="no">
-		<description>Vampire (Alt)</description>
+		<description>Vampire (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40145">
 				<rom name="vampire (1986)(infogrames)(fr)[b2].k7" size="40145" crc="78e4ec64" sha1="5f6a5b8e40fa842581f70099f9c289e035284ddf"/>
@@ -17937,10 +16544,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="vampireb" cloneof="vampire" supported="no">
-		<description>Vampire (Alt 2)</description>
+		<description>Vampire (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40145">
 				<rom name="vampire (infogrames) (alain vialon) (1986).k7" size="40145" crc="8b80f156" sha1="cc6ecd48dd1dd7e4419af59fb5839a9062fe0d40"/>
@@ -17950,10 +16556,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="vampirec" cloneof="vampire" supported="no">
-		<description>Vampire (Alt 3)</description>
+		<description>Vampire (alt 3)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41345">
 				<rom name="vampire (infogrames) (alain vialon, philippe nottoli, dominique girou) (1986) (mo5).k7" size="41345" crc="9d4208af" sha1="5f2e7cd93c313a1129f30df40b6ebf2420e10f51"/>
@@ -17979,7 +16584,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vision (Loriciels)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31220">
 				<rom name="vision (1984)(loriciels)(fr).k7" size="31220" crc="5ed7733c" sha1="e0b84034a4a486bb758c856e35f5f0d248de7289"/>
@@ -17988,10 +16592,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="visiona" cloneof="vision">
-		<description>Vision (Loriciels) (Alt)</description>
+		<description>Vision (Loriciels) (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31220">
 				<rom name="vision (1984)(loriciels)(fr)[a].k7" size="31220" crc="e3e37c89" sha1="d3f56689989b794c51b98853917db75db06b31c6"/>
@@ -18000,10 +16603,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="visionb" cloneof="vision">
-		<description>Vision (Loriciels) (Alt 2)</description>
+		<description>Vision (Loriciels) (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31220">
 				<rom name="vision_mo5.k7" size="31220" crc="76132c32" sha1="2998c7dc19befb45eab47eb5dada51f21a4eb422"/>
@@ -18015,7 +16617,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vol Solo</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23772">
 				<rom name="vol solo (1985)(fil)(fr).k7" size="23772" crc="23a1aaaa" sha1="b955649085090cad2737094479947099cef36dd4"/>
@@ -18024,10 +16625,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="volsoloa" cloneof="volsolo">
-		<description>Vol Solo (Alt)</description>
+		<description>Vol Solo (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25305">
 				<rom name="vol solo (1985)(fil)(fr)[a].k7" size="25305" crc="f7217934" sha1="f0134fe65a7956c3870b63699d44774913fb3e38"/>
@@ -18036,10 +16636,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="volsolob" cloneof="volsolo">
-		<description>Vol Solo (Alt 2)</description>
+		<description>Vol Solo (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25305">
 				<rom name="vol solo (1985)(fil)(fr)[a2].k7" size="25305" crc="09976ba4" sha1="c198556a61eaa797cf494f1c5253279b71eca06a"/>
@@ -18048,10 +16647,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="volsoloc" cloneof="volsolo">
-		<description>Vol Solo (Alt 3)</description>
+		<description>Vol Solo (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25305">
 				<rom name="vol-solo_mo5.k7" size="25305" crc="37bbbe43" sha1="088c3b1e72991a863b27ddd664bbc223eeb87413"/>
@@ -18060,10 +16658,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="volsolod" cloneof="volsolo">
-		<description>Vol Solo (WAV Format)</description>
+		<description>Vol Solo (WAV format)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8365890">
 				<rom name="vol solo (1985)(fil)(fr).wav" size="8365890" crc="0b498fb5" sha1="7f50709ed798acd440d2193e1e361a939e052e96"/>
@@ -18075,7 +16672,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Votez pour Moi</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31541">
 				<rom name="votez pour moi (1985)(answare)(fr).k7" size="31541" crc="bd51f0d3" sha1="8f6fceba282c66227b165ccb77ea49494f1bfc3e"/>
@@ -18084,10 +16680,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="votezmoia" cloneof="votezmoi">
-		<description>Votez pour Moi (Alt)</description>
+		<description>Votez pour Moi (alt)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31720">
 				<rom name="votez pour moi (1985)(answare)(fr)[a].k7" size="31720" crc="8f986024" sha1="b7972b96a10508572d29d670635ec52e40ff58d1"/>
@@ -18096,10 +16691,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="votezmoib" cloneof="votezmoi">
-		<description>Votez pour Moi (Alt 2)</description>
+		<description>Votez pour Moi (alt 2)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31720">
 				<rom name="votez pour moi (1985)(answare)(fr)[a2].k7" size="31720" crc="bda8aca6" sha1="cff7b24ca6e655fd2838347321ef4761366f98da"/>
@@ -18108,10 +16702,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="votezmoic" cloneof="votezmoi">
-		<description>Votez pour Moi (Alt 3)</description>
+		<description>Votez pour Moi (alt 3)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31720">
 				<rom name="votez-pour-moi_mo5.k7" size="31720" crc="3a31452c" sha1="892c508cf11196be3f5460c3e23944c757bb2857"/>
@@ -18123,7 +16716,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Voyage au Centre du MO5</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26793">
 				<rom name="voyage au centre du mo5 (1985)(hebdogiciel)(fr)(pd).k7" size="26793" crc="7cbae7aa" sha1="594c9cb18b4b1d86db205acb0711e530bf7fe4b8"/>
@@ -18132,10 +16724,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="centrmo5a" cloneof="centrmo5">
-		<description>Voyage au Centre du MO5 (Alt)</description>
+		<description>Voyage au Centre du MO5 (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26793">
 				<rom name="voyage au centre du mo5 (1985)(hebdogiciel)(fr)(pd)[a2].k7" size="26793" crc="57f3b37f" sha1="47f0e6984df04be38d9456e4d96e1c07db413181"/>
@@ -18144,10 +16735,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="centrmo5b" cloneof="centrmo5">
-		<description>Voyage au Centre du MO5 (Alt 2)</description>
+		<description>Voyage au Centre du MO5 (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26793">
 				<rom name="voyage au centre du mo5 (1985)(hebdogiciel)(fr)(pd)[a3].k7" size="26793" crc="d4d5f41c" sha1="66103e2e06aeb32a1b583cb2f39b8502b585c63d"/>
@@ -18156,10 +16746,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="centrmo5c" cloneof="centrmo5">
-		<description>Voyage au Centre du MO5 (Alt 3)</description>
+		<description>Voyage au Centre du MO5 (alt 3)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26793">
 				<rom name="voyage-au-coeur-du-mo5_mo5.k7" size="26793" crc="dfe31c6d" sha1="3536ac68762478e9ecce10979045a517851c7273"/>
@@ -18171,7 +16760,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Voyage au Centre du MO5 (No Title Screen)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10462">
 				<rom name="voyage au centre du mo5 (1985)(hebdogiciel)(fr)(pd)[a title screen].k7" size="10462" crc="48581305" sha1="fdc786827d5fba4fb2e2965ee59702bb89d92bcd"/>
@@ -18183,7 +16771,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>The Way of the Tiger</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="104264">
 				<rom name="way of the tiger, the (1986)(fil)(fr).k7" size="104264" crc="ad7347c6" sha1="873d7be358d4dbe75530e181e89d09f9520b1971"/>
@@ -18192,10 +16779,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="waytigera" cloneof="waytiger">
-		<description>The Way of the Tiger (Alt)</description>
+		<description>The Way of the Tiger (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="104264">
 				<rom name="way of the tiger, the (1986)(fil)(fr)[a].k7" size="104264" crc="1591e7a7" sha1="85ee56dbaad0d7e0b242f0135fc238b5d1debd1f"/>
@@ -18204,10 +16790,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="waytigerb" cloneof="waytiger">
-		<description>The Way of the Tiger (Alt 2)</description>
+		<description>The Way of the Tiger (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="104264">
 				<rom name="way of the tiger, the (1986)(fil)(fr)[a2].k7" size="104264" crc="67ffb579" sha1="2d42e09d7bdee669477a90efcb7c76597b09ece2"/>
@@ -18216,10 +16801,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="waytigerc" cloneof="waytiger">
-		<description>The Way of the Tiger (Alt 3)</description>
+		<description>The Way of the Tiger (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="104264">
 				<rom name="the-way-of-the-tiger_mo5.k7" size="104264" crc="3e41520a" sha1="818d46be345f591d94ee40933c036acc5691e46d"/>
@@ -18231,7 +16815,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Westbank</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29030">
 				<rom name="westbank (1987-06-28)(rubio, javier marco - escudero, angelines rubio)(es).k7" size="29030" crc="7a484754" sha1="2862a7d6bf39a360f1f5713fa06f40d2e03f2a23"/>
@@ -18240,10 +16823,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="westbanka" cloneof="westbank">
-		<description>Westbank (Alt)</description>
+		<description>Westbank (alt)</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29030">
 				<rom name="westbank (1987-06-28)(rubio, javier marco - escudero, angelines rubio)(es)[a].k7" size="29030" crc="5c11384a" sha1="1be315d2b64eea0a6aa93c7457984cb761348257"/>
@@ -18252,10 +16834,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="westbankb" cloneof="westbank">
-		<description>Westbank (Alt 2)</description>
+		<description>Westbank (alt 2)</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29030">
 				<rom name="westbank_mo5.k7" size="29030" crc="2808b2fa" sha1="bab30feb9b510f3427a9d78f527e6a7822525c92"/>
@@ -18267,7 +16848,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wild Boy</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6262">
 				<rom name="wild boy (19xx)(-)(fr).k7" size="6262" crc="ff160c9f" sha1="3c0d96fb964d0295674b786d04b4661077fb6564"/>
@@ -18276,10 +16856,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="wildboya" cloneof="wildboy">
-		<description>Wild Boy (Alt)</description>
+		<description>Wild Boy (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6262">
 				<rom name="wildboy_mo5.k7" size="6262" crc="c243e802" sha1="0cd24ab769bb0c04a1f31dddbb01ebcd9f807319"/>
@@ -18291,7 +16870,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wizball</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="57925">
 				<rom name="wizball (1988)(fil)(fr).k7" size="57925" crc="5b6aa9f3" sha1="eb82fbead4806be1049a633394696a9de6bac3c6"/>
@@ -18300,10 +16878,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="wizballa" cloneof="wizball">
-		<description>Wizball (Alt)</description>
+		<description>Wizball (alt)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="61286">
 				<rom name="wizball (1988)(fil)(fr)[a].k7" size="61286" crc="7b4993e4" sha1="bbb622b913db2f3693453c7842eaca9f7764d4e8"/>
@@ -18312,10 +16889,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="wizballb" cloneof="wizball">
-		<description>Wizball (Alt 2)</description>
+		<description>Wizball (alt 2)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="61286">
 				<rom name="wizball (1988)(fil)(fr)[a2].k7" size="61286" crc="a9364da0" sha1="07e3a51c29a378d43e694714a2d2a5aed66051a9"/>
@@ -18324,10 +16900,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="wizballc" cloneof="wizball">
-		<description>Wizball (Alt 3)</description>
+		<description>Wizball (alt 3)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="61286">
 				<rom name="wizball_mo5.k7" size="61286" crc="28d37c3a" sha1="690ed611c767bb63541038a55c8fa44de85e3d3a"/>
@@ -18339,7 +16914,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>X-Ray</description>
 		<year>1986</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11606858">
 				<rom name="x-ray_mo5.wav" size="11606858" crc="8ccdf8dd" sha1="f9ff59e87300664e33cd3417e8abc3ef9efe1625"/>
@@ -18348,10 +16922,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="xraya" cloneof="xray">
-		<description>X-Ray (Alt)</description>
+		<description>X-Ray (alt)</description>
 		<year>1986</year>
 		<publisher>Microids</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35051">
 				<rom name="x-ray_mo5.k7" size="35051" crc="f8a9199c" sha1="53600b7a0d2058a62bc25f1dd162f417f0b424df"/>
@@ -18363,7 +16936,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Y</description>
 		<year>1988</year>
 		<publisher>G. Fetis</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18514">
 				<rom name="y (1988)(fetis, g.).k7" size="18514" crc="b211bcc7" sha1="5d4dd7187d71e6601a3b9194f35e980448dd8ea0"/>
@@ -18375,7 +16947,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yahtzee</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10652">
 				<rom name="yahtzee (1985)(hebdogiciel)(fr)(pd).k7" size="10652" crc="cca6d3d0" sha1="23ca2b6b0d08f21c32d446067fa879e07659bc76"/>
@@ -18384,10 +16955,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="yahtzeea" cloneof="yahtzee">
-		<description>Yahtzee (Alt)</description>
+		<description>Yahtzee (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10652">
 				<rom name="yahtzee (1985)(hebdogiciel)(fr)(pd)[a].k7" size="10652" crc="e6bff0ae" sha1="53a8903623cdac5787126979f13a3dd6fc7a3b9d"/>
@@ -18396,10 +16966,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="yahtzeeb" cloneof="yahtzee">
-		<description>Yahtzee (Alt 2)</description>
+		<description>Yahtzee (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10652">
 				<rom name="yahtzee (1985)(hebdogiciel)(fr)(pd)[a2].k7" size="10652" crc="a3942d56" sha1="353cc6f72a67458f749b5a461d99da4bca9f7331"/>
@@ -18408,10 +16977,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="yahtzeec" cloneof="yahtzee">
-		<description>Yahtzee (Alt 3)</description>
+		<description>Yahtzee (alt 3)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10652">
 				<rom name="yahtzee_mo5.k7" size="10652" crc="301d7fa6" sha1="27086960d8d52df51a38c92574a53e2546f790b0"/>
@@ -18423,7 +16991,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yeti</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4474808">
 				<rom name="yeti (1984)(loriciels)(fr).wav" size="4474808" crc="dd65a22d" sha1="0fd108081cb70f1aa696f573a255a848ed63040f"/>
@@ -18433,10 +17000,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="yetia" cloneof="yeti" supported="no">
-		<description>Yeti (Alt)</description>
+		<description>Yeti (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13510">
 				<rom name="yeti (1984)(loriciels)(fr)[b3].k7" size="13510" crc="a6be8075" sha1="7ac9be6a94ed3c5c7e686b54df776f00d0a81d51"/>
@@ -18446,10 +17012,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="yetib" cloneof="yeti" supported="no">
-		<description>Yeti (Alt 2)</description>
+		<description>Yeti (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13510">
 				<rom name="yeti (1984)(loriciels)(fr)[b4].k7" size="13510" crc="9646972a" sha1="91376ce256eb381fe85b381c003fc7ff25aba339"/>
@@ -18459,10 +17024,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="yetic" cloneof="yeti" supported="no">
-		<description>Yeti (Alt 3)</description>
+		<description>Yeti (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13510">
 				<rom name="yeti_mo5.k7" size="13510" crc="a8806b5c" sha1="acb283a375878e353031e3cfdae996f0102e0e1a"/>
@@ -18472,10 +17036,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="yetid" cloneof="yeti" supported="no">
-		<description>Yeti (Alt 4)</description>
+		<description>Yeti (alt 4)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13510">
 				<rom name="yeti_a_mo5.k7" size="13510" crc="abc1f165" sha1="bcec9d2f74577de51246ae39d683a7709e665a88"/>
@@ -18515,7 +17078,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yie Ar Kung Fu II</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32886">
 				<rom name="yie ar kung fu ii (1986)(fil)(fr)(en-fr).k7" size="32886" crc="574d042c" sha1="64ec01fde551fb3ae9b6a5f47ed1b50c89c46a36"/>
@@ -18524,10 +17086,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="yiear2a" cloneof="yiear2">
-		<description>Yie Ar Kung Fu II (Alt)</description>
+		<description>Yie Ar Kung Fu II (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33041">
 				<rom name="yie ar kung fu ii (1986)(fil)(fr)(en-fr)[a].k7" size="33041" crc="01431c54" sha1="62c77ba28bda6b0847ba429fa243aa5ada0cbb34"/>
@@ -18536,10 +17097,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="yiear2b" cloneof="yiear2">
-		<description>Yie Ar Kung Fu II (Alt 2)</description>
+		<description>Yie Ar Kung Fu II (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33041">
 				<rom name="yie ar kung fu ii (1986)(fil)(fr)(en-fr)[a2].k7" size="33041" crc="04516810" sha1="0fa25862702c024da5454d6cf882c1409f05e3f3"/>
@@ -18548,10 +17108,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="yiear2c" cloneof="yiear2">
-		<description>Yie Ar Kung Fu II (Alt 3)</description>
+		<description>Yie Ar Kung Fu II (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33041">
 				<rom name="yie-ar-kung-fu_mo5.k7" size="33041" crc="c6c47c35" sha1="73daa439a7dbe950ec1d1ab4b616d1155f81b42e"/>

--- a/hash/mo5_cass.xml
+++ b/hash/mo5_cass.xml
@@ -13,6 +13,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Adresse des Fichiers .bin sur Disques</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1353">
 				<rom name="adresse des fichiers .bin sur disques (198x)(-)(fr)(pd).k7" size="1353" crc="e10868f3" sha1="8fc1312a2a3ebe39d7304fbda55ff16ef3fa674c"/>
@@ -24,6 +25,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Adresses SAVEM sur MO5</description>
 		<year>198?</year>
 		<publisher>Deplombsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="2650">
 				<rom name="adresses savem sur mo5 (198x)(deplombsoft)(fr)(pd).k7" size="2650" crc="4151bfff" sha1="5fe6c210e413ba85a5d837a6cdce3c5a9cf852f8"/>
@@ -35,6 +37,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Affine</description>
 		<year>1984</year>
 		<publisher>USTL</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11696">
 				<rom name="affine (1984)(ustl)(fr).k7" size="11696" crc="63de1c17" sha1="13ee8e24528d1aecbd5bc8481f0fc7f179f44ef9"/>
@@ -46,6 +49,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides Editeur</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6211025">
 				<rom name="androides editeur (1985)(infogrames)(fr).wav" size="6211025" crc="d9da60fa" sha1="014361f8d1afa8e46964d2b98ddf2184f43faf96"/>
@@ -57,6 +61,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides Editeur (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18508">
 				<rom name="androides editeur (1985)(infogrames)(fr)[b].k7" size="18508" crc="e942f534" sha1="fc1b3dc5d814f0f0ab0afedf546bb92311529f94"/>
@@ -68,6 +73,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides Editeur (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18508">
 				<rom name="editeur (1986)(infogrames)(fr)[b].k7" size="18508" crc="5fbd30b0" sha1="dc5232ebf5ccf39268849b215ad1b974f8f15736"/>
@@ -93,6 +99,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Animatix</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28272">
 				<rom name="animatix (1985)(infogrames)(fr).k7" size="28272" crc="e532ad03" sha1="455f3cbbd4e2f5008d1b7010fc4aec212c99a169"/>
@@ -104,6 +111,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Animatix (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28272">
 				<rom name="animatix (1985)(infogrames)(fr)[a].k7" size="28272" crc="bdefdf08" sha1="b93e4e1ef4716aac2bda3ba34af3c8be5ec79e90"/>
@@ -115,6 +123,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Animatix (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28272">
 				<rom name="animatix_mo5.k7" size="28272" crc="154f3f2c" sha1="37a645520504111d763f4b1c2859a05e85ffb628"/>
@@ -127,6 +136,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with LOADM"/>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11612">
 				<rom name="assdesass version k7 (1985)(infogrames)(fr)[loadm].k7" size="11612" crc="f451771a" sha1="664a979ff36869761522bb7d1a56f11a08742fec"/>
@@ -139,6 +149,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with LOADM"/>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11612">
 				<rom name="assdesass version k7 (1985)(infogrames)(fr)[a][loadm].k7" size="11612" crc="eb6fd52d" sha1="25f239cf8d78102d76a277630aee7ee6241a7e53"/>
@@ -151,6 +162,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with LOADM"/>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11612">
 				<rom name="assdesass_mo5.k7" size="11612" crc="04da328e" sha1="840975a41d5003e3b08b525746563ef02007c934"/>
@@ -162,6 +174,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Astro-Couple</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29753">
 				<rom name="astro-couple (answare) (elizabeth tessier) (1985) (mo5 k7).k7" size="29753" crc="17dad983" sha1="24e4d56155062272d524a7ca2d16ebcf462eed4c"/>
@@ -173,6 +186,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Biorythmes</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15302">
 				<rom name="biorythmes (1984)(answare)(fr).k7" size="15302" crc="63e22a77" sha1="ab14b381916b260eefc1ba4071c4fc01bc90f2b1"/>
@@ -184,6 +198,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Biorythmes (alt)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15302">
 				<rom name="biorythmes (answare) (1984).k7" size="15302" crc="ad687f26" sha1="45adab914791b6309957ca1b90db20c5774e1845"/>
@@ -195,6 +210,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Biorythmes (alt 2)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15302">
 				<rom name="biorythmes_mo5.k7" size="15302" crc="bdabf4b8" sha1="a16fcb78f903b24af305a4f686b78d73afe13bc2"/>
@@ -206,6 +222,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Budget Familial (Free Game Blot)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16821">
 				<rom name="budget familial (1984)(free game blot)(fr).k7" size="16821" crc="227bad83" sha1="5f7b9940dfc359c6c1e7399495657409ebd1e930"/>
@@ -217,6 +234,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Budget Familial (Free Game Blot) (alt)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16821">
 				<rom name="budget familial (1984)(free game blot)(fr)[a].k7" size="16821" crc="48e6f366" sha1="73de447c747790ef57628c8be0d8f4c3f03baa5d"/>
@@ -228,6 +246,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Budget Familial (Free Game Blot) (alt 2)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16821">
 				<rom name="budget-familial-free-game-blot_mo5.k7" size="16821" crc="7f357742" sha1="1a07c9ae88d925e3112a9bb4c7f665ede11fe850"/>
@@ -239,6 +258,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Budget Familial (Loriciels)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17035">
 				<rom name="budget-familial-loriciels_mo5.k7" size="17035" crc="4083f4d1" sha1="1ab1cf25b115e5545463fbf74a025f328985a37c"/>
@@ -250,6 +270,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carte du Ciel</description>
 		<year>1983</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29208">
 				<rom name="carte du ciel (1983)(answare)(fr)(m3).k7" size="29208" crc="a279d8ef" sha1="c2f3123b6c4ed336d3150b518f6719f62b21b4ee"/>
@@ -261,6 +282,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carte du Ciel (alt)</description>
 		<year>1983</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29208">
 				<rom name="carte du ciel (1983)(answare)(fr)(m3)[a].k7" size="29208" crc="cde121ba" sha1="0b38a94f3a52ce178977473f6acadb8d928b0275"/>
@@ -272,6 +294,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carte du Ciel (alt 2)</description>
 		<year>1983</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29208">
 				<rom name="carte du ciel (1983)(answare)(fr)(m3)[a2].k7" size="29208" crc="ee0a486e" sha1="0aeb4b8a601d3ecd210ee3d15da7779bb6d5db21"/>
@@ -283,6 +306,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carte du Ciel (alt 3)</description>
 		<year>1983</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29208">
 				<rom name="carte-du-ciel_mo5.k7" size="29208" crc="29450504" sha1="df8950868f079fe4d1e545302e39fdd5e8956797"/>
@@ -294,6 +318,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cartoon Maker</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48638">
 				<rom name="cartoon maker (1985)(free game blot)(fr).k7" size="48638" crc="8a40800f" sha1="475f45149a10ff007ef0b4334b0015bd859da9cc"/>
@@ -305,6 +330,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cartoon Maker (alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48638">
 				<rom name="cartoon maker (1985)(free game blot)(fr)[a].k7" size="48638" crc="afe94d58" sha1="db2cebbf17a65bcf6015f29ef634216de9f88120"/>
@@ -316,6 +342,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cartoon Maker (alt 2)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48638">
 				<rom name="cartoon-maker_mo5.k7" size="48638" crc="b704c02c" sha1="537d07e69afb9c2daf78aa27929ddd871e660f24"/>
@@ -327,6 +354,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Catalog</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="2213">
 				<rom name="catalog (198x)(-)(pd).k7" size="2213" crc="3b9fb1b0" sha1="3471ce6641f02c2e417ef992298d976887ee316d"/>
@@ -338,6 +366,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Chardata</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="899">
 				<rom name="chardata (198x)(-)(pd).k7" size="899" crc="2619447a" sha1="16d0e09b0626546ccb178cca1a70f1f428c083a5"/>
@@ -349,6 +378,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Commande du Robot Youpi (v1.1)</description>
 		<year>1985</year>
 		<publisher>JD Productique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10511">
 				<rom name="commande du robot youpi v1.1 (1985)(jd productique)(fr).k7" size="10511" crc="340c2d5f" sha1="3e74f4da8655e0a84d2d8e47e0ac951ad0422b03"/>
@@ -360,6 +390,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Conte</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26311">
 				<rom name="conte (1985)(lambert, alain)(fr).k7" size="26311" crc="46675110" sha1="4a8dfa2fa9a247e1bac77ac02d8396c6a80d09ae"/>
@@ -371,6 +402,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Conte (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26311">
 				<rom name="conte (1985)(lambert, alain)(fr)[a].k7" size="26311" crc="68e9e7b6" sha1="84ff859c8f16f74fa2b15171b061fe2dc3648293"/>
@@ -382,6 +414,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Conte (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26311">
 				<rom name="conte (1985)(lambert, alain)(fr)[a2].k7" size="26311" crc="927ab799" sha1="017a9850a5db7ba85986a1f83ca1301c5cc713b7"/>
@@ -393,6 +426,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Conte (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26311">
 				<rom name="conte_mo5.k7" size="26311" crc="41481f4d" sha1="e0ff080f783c4b10fdb3027c0e7798132dbf2eb5"/>
@@ -401,9 +435,11 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="conted" cloneof="conte">
-		<description>Conte (Hacked by Christophe Lesur)</description>
+		<description>Conte (hacked)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+		<info name="hacked" value="Christophe Lesur" />
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26766">
 				<rom name="conte (1985-05-26)(lambert, alain)(fr)[h lesur, c.].k7" size="26766" crc="fc76d616" sha1="41645e3ab08c0e63636b798dd43c81ccc4b264fc"/>
@@ -415,6 +451,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Conversion Images</description>
 		<year>198?</year>
 		<publisher>Edouard Foller</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1332">
 				<rom name="conversion images (198x)(foller, edouard)(fr).k7" size="1332" crc="b0d132cf" sha1="db1ac6ab2813f2f702f8a0ab420fd05af303cf67"/>
@@ -426,6 +463,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Copie de Fichiers Data</description>
 		<year>198?</year>
 		<publisher>Deplombsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1987">
 				<rom name="copie de fichiers data (198x)(deplombsoft)(fr)(pd).k7" size="1987" crc="b18d4c14" sha1="650fcf550c6954eec67b19a0be499393a2ca0768"/>
@@ -437,6 +475,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Courrier</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22397">
 				<rom name="courrier (answare) (inconnus) (1984) (mo5).k7" size="22397" crc="bf5dada6" sha1="f01886c81c363c01baf52bd161116087c986d012"/>
@@ -448,6 +487,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Creadata</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1438">
 				<rom name="creadata (198x)(-)(fr)(pd).k7" size="1438" crc="be0ca07f" sha1="aa2490fef1ba8d6e588795fcfd483adc494bb06f"/>
@@ -459,6 +499,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Decode</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="474">
 				<rom name="decode (198x)(-)(fr)(pd).k7" size="474" crc="149174be" sha1="b347eb90e21eab6818c498e8c52b4e7844c5141a"/>
@@ -470,6 +511,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Deper</description>
 		<year>198?</year>
 		<publisher>Deplombsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="658">
 				<rom name="deper (198x)(deplombsoft)(fr)(pd).k7" size="658" crc="6f4b8245" sha1="5d6d4994755f84bbe7cc84904e345562b5b536fd"/>
@@ -481,6 +523,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Deper (alt)</description>
 		<year>198?</year>
 		<publisher>Deplombsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="658">
 				<rom name="deper (198x)(deplombsoft)(fr)(pd)[a].k7" size="658" crc="239eda82" sha1="b06f7a5cc3cfb3e03823904a17d71aaef5c53cb9"/>
@@ -493,6 +536,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
 		<info name="usage" value="Load with LOADM&quot;&quot;,&amp;H9000,R"/>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="3411">
@@ -524,6 +568,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
 		<info name="usage" value="Load with LOADM&quot;&quot;,&amp;H9000,R"/>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="3411">
@@ -555,6 +600,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
 		<info name="usage" value="Load with LOADM&quot;&quot;,&amp;H9000,R"/>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="3411">
@@ -585,6 +631,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Destruc</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="684">
 				<rom name="destruc (198x)(-)(fr)(pd).k7" size="684" crc="0c8ea976" sha1="1476a46bea59cf1f472b91b5fe863d29d26a56ce"/>
@@ -596,6 +643,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dump</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1642">
 				<rom name="dump (198x)(-)(pd)(fr).k7" size="1642" crc="0e22d2db" sha1="01c04c3c91b807e1e9b07e94aa20725874f6fb00"/>
@@ -607,6 +655,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Einstein1</description>
 		<year>198?</year>
 		<publisher>Soft &amp; Micro</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10962">
 				<rom name="einstein1 (198x)(soft &amp; micro)(fr).k7" size="10962" crc="1fd19569" sha1="0b605f229cd4ab90c3836b45ef6817bb5066e9c2"/>
@@ -618,6 +667,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Einstein1 (alt)</description>
 		<year>198?</year>
 		<publisher>Soft &amp; Micro</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10962">
 				<rom name="einstein1 (198x)(soft &amp; micro)(fr)[a].k7" size="10962" crc="343a7613" sha1="003099c54303f72ed77e8484317eb62715296334"/>
@@ -629,6 +679,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Einstein1 (alt 2)</description>
 		<year>198?</year>
 		<publisher>Soft &amp; Micro</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10962">
 				<rom name="einstein_mo5.k7" size="10962" crc="4d7232a0" sha1="617f33d2927780bd359e08fc537bdbb15f794989"/>
@@ -640,6 +691,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Epargne - Emprunt</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19726">
 				<rom name="EE 5010.k7" size="19726" crc="b1115202" sha1="1ddf059adbe9a4d91653eb02d9a24b47c0cb6b8a"/>
@@ -651,6 +703,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Extension Basic (Hebdogiciel no. 118)</description>
 		<year>1986</year>
 		<publisher>Francis Malard - Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15757">
 				<rom name="extbas[mo5].k7" size="15757" crc="eaa71694" sha1="b746a21e6bf4acdfe03bc780a4d7e377251440d0"/>
@@ -662,6 +715,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Extension Basic MO5</description>
 		<year>1986</year>
 		<publisher>D.G. Vevy</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3801">
 				<rom name="extension basic mo5 (1986)(vevy, d.g.)(fr).k7" size="3801" crc="e77097d0" sha1="fc90b13a3214f075b8c4e9777376fa07894db849"/>
@@ -673,6 +727,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Extension Basic MO5 (alt)</description>
 		<year>1986</year>
 		<publisher>D.G. Vevy</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7699">
 				<rom name="extension basic mo5 (1986)(vevy, d.g.)(fr)[a].k7" size="7699" crc="3e8f1bba" sha1="0e1c084269c6695e9c3899b8c411cef6e3b1dd58"/>
@@ -684,6 +739,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Forth</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="11674312">
@@ -702,6 +758,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Forth (single tape)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25367">
 				<rom name="forth mo5 (1985-04)(loriciels)(fr).k7" size="25367" crc="f068355e" sha1="31bf85d0b3cdb4b9291d99a3e0910c30956c4fb7"/>
@@ -713,6 +770,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Forth (single tape, alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25367">
 				<rom name="forth-mo5_mo5.k7" size="25367" crc="6aba6864" sha1="484fd4d57d9dfb061e67d1631efebad92d02cc7f"/>
@@ -724,6 +782,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Forth (single tape, alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12688478">
 				<rom name="forth mo5 (1985-04)(loriciels)(fr).wav" size="12688478" crc="a8cfbb98" sha1="ce713a7412e8d8fb4278e461236304ccdec6de4c"/>
@@ -735,6 +794,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Forth (single tape, alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14228450">
 				<rom name="forth-mo5_mo5.wav" size="14228450" crc="4e4df37b" sha1="b543267b987c09382ff03be4191135bab6cbed1e"/>
@@ -746,6 +806,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Frises</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18741">
 				<rom name="frises (1985)(cedic-nathan)(fr).k7" size="18741" crc="b5a4c4f1" sha1="99865cf7dd639a1d4756bd7ca8a3636fe6c86aa7"/>
@@ -757,6 +818,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gestion Imprimante</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="2029">
 				<rom name="gestion imprimante (198x)(-)(fr)(pd).k7" size="2029" crc="9cb63e6d" sha1="a3325e57c820ae86ce25851ade156c34540322a9"/>
@@ -768,6 +830,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Histogrammes</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14447">
 				<rom name="histogrammes (1985)(fil)(fr).k7" size="14447" crc="6f367ab2" sha1="d74a5b9471b06d8af26df3e9d1c9de9fb260a05b"/>
@@ -779,6 +842,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Identif</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="629">
 				<rom name="identif (198x)(-)(pd)(fr).k7" size="629" crc="72556033" sha1="092138eb2613882ed4b9754b98fdd3edaf84783f"/>
@@ -790,6 +854,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Identif (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="629">
 				<rom name="identif (198x)(-)(pd)(fr)[a].k7" size="629" crc="3937a9bd" sha1="99a73867f8d50d1aa5dc85bec47b31b4e3b6b1e4"/>
@@ -801,6 +866,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>C.A.O. - Conception Assistee par Ordinateur</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="83053">
 				<rom name="j'apprends le c.a.o. (1985)(loriciels)(fr).k7" size="83053" crc="150c4e84" sha1="a194253eb18abb393166297f20112505901c27b4"/>
@@ -812,6 +878,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>C.A.O. - Conception Assistee par Ordinateur (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="60275">
 				<rom name="j'apprends le c.a.o. (1985)(loriciels)(fr)[a].k7" size="60275" crc="e653fc33" sha1="feeb0b210f4e3b562ff3cb37c8048e47ef61f09a"/>
@@ -823,6 +890,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>C.A.O. - Conception Assistee par Ordinateur (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="83053">
 				<rom name="c.a.o. conception assistee par ordinateur (loriciels) (j.p. h., p. w.) (1985) (mo5).k7" size="83053" crc="6dd269e6" sha1="e398742949a95507ab4da669c5815b0a4ea21871"/>
@@ -834,6 +902,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Je Dessine</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10078">
 				<rom name="je dessine (1984)(vifi-nathan)(fr).k7" size="10078" crc="f6c23f22" sha1="be3176a555011a61852dfa039b15f4ac2ae2db45"/>
@@ -845,6 +914,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Liratt</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3464">
 				<rom name="liratt (198x)(-)(fr)(pd).k7" size="3464" crc="faa75cb5" sha1="b3c403e3c75011908898b35e24c9c4b8b4ba3305"/>
@@ -856,6 +926,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Lirfic</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1632">
 				<rom name="lirfic (198x)(-)(fr)(pd).k7" size="1632" crc="55472e7b" sha1="62f6021a9a1f97941b7f3142b142f3075cb0efbc"/>
@@ -867,6 +938,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Machine a Ecrire</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14904">
 				<rom name="machine a ecrire (198x)(-)(fr)(pd).k7" size="14904" crc="9df3fb90" sha1="ec0adeb40ab4954019a19f6b8a5954fad2263f9d"/>
@@ -878,6 +950,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mcass</description>
 		<year>1985</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3674">
 				<rom name="mcass (1985)(-)(pd).k7" size="3674" crc="59f704a3" sha1="66d5690ad3dd1239b8dc130c94375bd128d1e7b5"/>
@@ -889,6 +962,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mdsk</description>
 		<year>1985</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3674">
 				<rom name="mdsk (1985)(-)(pd).k7" size="3674" crc="b03ea7d5" sha1="711e4accefb890aae8c17246e162b6842b724745"/>
@@ -900,6 +974,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>MO 4 Paint</description>
 		<year>2013</year>
 		<publisher>Dominique Contant</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="10080">
@@ -918,6 +993,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Modifatt</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1739">
 				<rom name="modifatt (198x)(-)(fr)(pd).k7" size="1739" crc="71012d1d" sha1="be707137e66f42660431448f4ff11551d8ed4af6"/>
@@ -929,6 +1005,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Moniteur Desassembleur</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9153">
 				<rom name="moniteur desassembleur (198x)(-)(fr)(pd).k7" size="9153" crc="31ddc7b8" sha1="ce7085403da4e723c7b7b4e6fa1e87ca43c0bc8c"/>
@@ -940,6 +1017,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Moniteur pour MO5</description>
 		<year>1985</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5873">
 				<rom name="moniteur pour mo5 (1985-10-26)(-)(fr)(pd).k7" size="5873" crc="6a7b1a72" sha1="d2ad889c19148490a8368ecd8a7f6482fa88c353"/>
@@ -951,6 +1029,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Morse</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18447">
 				<rom name="morse (1985)(free game blot)(fr).k7" size="18447" crc="e1b254f0" sha1="8b267907e9ef14c439b781727e44d50c007c4e56"/>
@@ -962,6 +1041,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Odin (v2.1)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18278">
 				<rom name="odin v2.1 (1984-09)(loriciels)(fr).k7" size="18278" crc="eabf738b" sha1="d97469b29f9acc8ffec6aa6793b5906a7ba4219d"/>
@@ -973,6 +1053,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Odin (v2.1, alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18270">
 				<rom name="odin_mo5.k7" size="18270" crc="3b9e20b8" sha1="13bb2b5b80fc1ce846a6b1b787c0c2969ed6f813"/>
@@ -984,6 +1065,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ordi Tierce</description>
 		<year>1984</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16978">
 				<rom name="ordi tierce (cobrasoft) (michel fernandez) (1984) (mo5 k7).k7" size="16978" crc="b5f6840e" sha1="f88b4f22c70de2f90e9494234f8fa1efea312c91"/>
@@ -995,6 +1077,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>PAINTX</description>
 		<year>2013</year>
 		<publisher>Dominique Contant</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="10178">
@@ -1013,6 +1096,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pascal Base (v1)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28323">
 				<rom name="pascal base v1 (1985)(free game blot)(fr).k7" size="28323" crc="3ba67057" sha1="67f58b470bb4b17f185dd3e28f23277a68e08437"/>
@@ -1024,6 +1108,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pascal Base (v1, alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29283">
 				<rom name="pascal base v1 (1985)(free game blot)(fr)[a].k7" size="29283" crc="018d17f9" sha1="f8f2fc57f463184b6b9137b8d9bf160cddba84f8"/>
@@ -1035,6 +1120,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pascal Base (v1, alt 2)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29283">
 				<rom name="pascal base v1 (1985)(free game blot)(fr)[a2].k7" size="29283" crc="b8691f9b" sha1="65e252da597bc7f1795eb71e266061f505f618d8"/>
@@ -1046,6 +1132,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pascal Base (v1, alt 3)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29283">
 				<rom name="pascal-base_mo5.k7" size="29283" crc="7aba80c5" sha1="8075d73244071f59ca279a06eb53bcd3d8624a69"/>
@@ -1057,6 +1144,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Phone8</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1220">
 				<rom name="phone8 (198x)(-)(fr)(pd).k7" size="1220" crc="c900f763" sha1="67fb019685e5820117ebe917b43a051906e07ea3"/>
@@ -1068,6 +1156,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Picture Print</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="327">
 				<rom name="picture print (198x)(-)(fr)(pd).k7" size="327" crc="844b3f1d" sha1="e355f3f85679660f6b6a02e173b5905151a9e36e"/>
@@ -1079,6 +1168,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pro23</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="627">
 				<rom name="pro23 (198x)(-)(pd)(fr).k7" size="627" crc="83695f82" sha1="e1cb102f9d6ef2beed189ebeb30aee0c2809b32a"/>
@@ -1090,6 +1180,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Protege</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="464">
 				<rom name="protege (198x)(-)(fr)(pd).k7" size="464" crc="fee5a8de" sha1="da3bd934c8a0b439372f0d262391416cb38d8d67"/>
@@ -1101,6 +1192,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Protege (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="464">
 				<rom name="protege (198x)(-)(fr)(pd)[a].k7" size="464" crc="138a5b01" sha1="e6785d4c8dbbc85c1cd52b158ab7f1872bc37792"/>
@@ -1112,6 +1204,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Resolution de Systemes d'Equations</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9347">
 				<rom name="resolution de systemes d'equations (198x)(-)(fr)(pd).k7" size="9347" crc="fb20f885" sha1="4820e6e58ad11b1166f64fd80a232e8c58fbd11e"/>
@@ -1123,6 +1216,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scrutdsk</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="975">
 				<rom name="scrutdsk (198x)(-)(fr)(pd).k7" size="975" crc="7f2faf8a" sha1="f53ea8c63934f2a05cca4076d44e64afd90d17a3"/>
@@ -1134,6 +1228,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scrutdsk (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="911">
 				<rom name="scrutdsk (198x)(-)(fr)(pd)[a].k7" size="911" crc="b9d459d0" sha1="a29b680cb826abca0546085e5989f8a3bb49aa28"/>
@@ -1145,6 +1240,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scrutmo5</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="2717">
 				<rom name="scrutmo5 (198x)(-)(fr)(pd).k7" size="2717" crc="79c7b651" sha1="be5bd3db928b1d31dfc7e40e5fe1bc8ff5273d08"/>
@@ -1156,6 +1252,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDANIM7</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1136">
 				<rom name="sdanim7_mo5.k7" size="1136" crc="d1e44340" sha1="0abb060e2beff82a0f05d4b9798f411ee5ad49fc"/>
@@ -1167,6 +1264,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDLOADM5</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5020424">
 				<rom name="sdloadm5 - chargement rapide de programmes mo5 par carte sd (dcsoft) (2013) (daniel coulom).wav" size="5020424" crc="b02df181" sha1="7fc8a4666c7fd4c77c4af8c251ad06924870c9b6"/>
@@ -1178,6 +1276,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDLOADM5 (alt)</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10535">
 				<rom name="sdloadm5 - chargement rapide de programmes mo5 par carte sd (dcsoft) (2013) (daniel coulom).k7" size="10535" crc="2e7646e9" sha1="4cac5bb8fe75da076fe90e4c017c0d6b6dbabd15"/>
@@ -1189,6 +1288,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDLOADM6</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5660684">
 				<rom name="sdloadm6 - chargement rapide de programmes mo5 par carte sd (dcsoft) (2013) (daniel coulom).wav" size="5660684" crc="7610f11d" sha1="4fedc69c084a2d0769c4fa38274ea58327e984b2"/>
@@ -1200,6 +1300,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDLOADM6 (alt)</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12470">
 				<rom name="sdloadm6 - chargement rapide de programmes mo5 par carte sd (dcsoft) (2013) (daniel coulom).k7" size="12470" crc="4c8d1647" sha1="16bfb1f76ee968547d3c949947429e17af8fefbc"/>
@@ -1211,6 +1312,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDMEMO5 - Chargement MEMO5</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1732">
 				<rom name="sdmemo5 - chargement memo5 (dcsoft) (2013) (daniel coulom) (mo5).k7" size="1732" crc="df4d8faa" sha1="ec249cf539306f9a7c7f4bd9d2ac999745bfa7c8"/>
@@ -1222,6 +1324,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDMOANIM</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1740">
 				<rom name="sdmoanim - simon's cat (dcsoft) (2013) (daniel coulom) (mo5).k7" size="1740" crc="f5c5d823" sha1="d6dafbfd13de150382a2b007c88b5dcde8c752e2"/>
@@ -1233,6 +1336,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDMOPLAY</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="2513">
 				<rom name="sdmoplay - stan getz (dcsoft) (2013) (daniel coulom) (mo5).k7" size="2513" crc="ed25fe02" sha1="ef68e3bc08ae18299a26456dea5cfaa56567a62f"/>
@@ -1244,6 +1348,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDPLAY44 (2015.09.24)</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="802">
 				<rom name="sdplay44_mo5.k7" size="802" crc="e4cc8474" sha1="aba947be8c5b58ae366b1ffb9e16f13ac2e7fa5e"/>
@@ -1255,6 +1360,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDPLAY44 (2015.09.07)</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="802">
 				<rom name="sdplay44_mo5 [a].k7" size="802" crc="73f591a1" sha1="72cca02406826f574b3ba82a1187db2b1394c3f5"/>
@@ -1266,6 +1372,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Story Board</description>
 		<year>198?</year>
 		<publisher>Langage et Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13678">
 				<rom name="story board (198x)(langage et informatique)(fr).k7" size="13678" crc="3c20bcda" sha1="18fa5906c42db1197696cee99278d260bd86c2c3"/>
@@ -1277,6 +1384,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Story Board (alt)</description>
 		<year>198?</year>
 		<publisher>Langage et Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13678">
 				<rom name="story board (198x)(langage et informatique)(fr)[a].k7" size="13678" crc="47cc3c8a" sha1="a0a56f61bd07574e5a0fc59639cd90269cb2963f"/>
@@ -1288,6 +1396,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Story Board (alt 2)</description>
 		<year>198?</year>
 		<publisher>Langage et Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13678">
 				<rom name="story-board_mo5.k7" size="13678" crc="6cd28e8f" sha1="91ca6384bfb1bc00fc9f9cd0c1047d2e30de8d8a"/>
@@ -1299,6 +1408,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SUPBAS</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5575">
 				<rom name="supbas.k7" size="5575" crc="9c3b4895" sha1="404a5da42b310874e808b38dd2ef2fa36a89de89"/>
@@ -1310,6 +1420,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>T2</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6645">
 				<rom name="t2 (198x)(-)(fr)(pd)[b].k7" size="6645" crc="1ecfb660" sha1="eea25d57840f9cc929d23232645bba6dd7b4c30a"/>
@@ -1321,6 +1432,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>TESTRAM5 - Controle de la RAM du MO5</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass2" interface="mo_cass">
 			<dataarea name="cass" size="820394">
 				<rom name="testram5 - controle de la ram du mo5 (dcsoft) (2013) (daniel coulom) (mo5).wav" size="820394" crc="fb3dc1e8" sha1="9a862487ff0518916b7b8c17db36d3d8d3d7f65b"/>
@@ -1332,6 +1444,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>TESTRAM5 - Controle de la RAM du MO5 (alt)</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="1252">
 				<rom name="testram5 - controle de la ram du mo5 (dcsoft) (2013) (daniel coulom) (mo5).k7" size="1252" crc="a20a9b92" sha1="9641af5dc8e088aa27eab718cd40ffd06f1754fe"/>
@@ -1343,6 +1456,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Triangle Quelconque</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8061">
 				<rom name="triangle quelconque (198x)(-)(fr)(pd).k7" size="8061" crc="cd8857f0" sha1="f83ea4ca2935decc958155c4c8750e64e8b414c9"/>
@@ -1355,6 +1469,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1987</year>
 		<publisher>Loic Bried</publisher>
 		<info name="usage" value="Load with LOADM&quot;&quot;,,R"/>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22718">
 				<rom name="vision (1987)(bried, loic)(fr)[loadm'''',,r].k7" size="22718" crc="84b3b882" sha1="f539f6c33dd73f8b7a95afe39d9a7322f2e96073"/>
@@ -1363,9 +1478,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="visionlba" cloneof="visionlb">
-		<description>Vision (Loic Bried) (No Title Screen)</description>
+		<description>Vision (Loic Bried) (no title screen)</description>
 		<year>1987</year>
 		<publisher>Loic Bried</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27021">
 				<rom name="vision (1987)(bried, loic)(fr)[m title screen].k7" size="27021" crc="41db9a2a" sha1="d253c43264ffb5cfb6aa2d1b34bca0b3559a2baa"/>
@@ -1378,6 +1494,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
 		<info name="alt_title" value="Vox Basic"/>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11817">
 				<rom name="vox - synthetiseur vocal (1984)(ere informatique)(fr).k7" size="11817" crc="5187bf2d" sha1="d548a4604b88cd054de5c96deb226ab78c129b62"/>
@@ -1390,6 +1507,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
 		<info name="alt_title" value="Vox Basic"/>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12596">
 				<rom name="vox - synthetiseur vocal (1984)(ere informatique)(fr)[a].k7" size="12596" crc="5c7b83bc" sha1="205fc87aece3314d3fbb6c4de7c1a339aae7fc75"/>
@@ -1402,6 +1520,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
 		<info name="alt_title" value="Vox Basic"/>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12596">
 				<rom name="vox - synthetiseur vocal (1984)(ere informatique)(fr)[a2].k7" size="12596" crc="3f162733" sha1="72da3719193ed258c5e741c658fe2aee04d465f8"/>
@@ -1414,6 +1533,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
 		<info name="alt_title" value="Vox Basic"/>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12596">
 				<rom name="vox-basic_mo5.k7" size="12596" crc="cf3bb219" sha1="ee77c2625c7edb30995d05f20cf463010addabde"/>
@@ -1427,6 +1547,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Depart</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3203">
 				<rom name="depart (198x)(-)(fr)(pd).k7" size="3203" crc="97eb412f" sha1="4b7cf09eb7681c7712e7c8274fbd07263e956bd3"/>
@@ -1440,6 +1561,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volumes 4 &amp; 5 - Le Groupe Nominal 1 &amp; 2</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="192047">
 				<rom name="anglais - volumes 4 &amp; 5 - le groupe nominal 1 &amp; 2 (1984)(vifi-nathan)(fr).k7" size="192047" crc="b81c7f1d" sha1="f9fa511be63c28f07377725409f6ab13c9d5c464"/>
@@ -1451,6 +1573,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volumes 4 &amp; 5 - Le Groupe Nominal 1 &amp; 2 (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="192047">
 				<rom name="anglais - volumes 4 &amp; 5 - le groupe nominal 1 &amp; 2 (1984)(vifi-nathan)(fr)[a].k7" size="192047" crc="1a6d0e3c" sha1="d97cc7948e2bc3f17a9b918c349142b2f5f30163"/>
@@ -1462,6 +1585,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volumes 4 &amp; 5 - Le Groupe Nominal 1 &amp; 2 (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="192047">
 				<rom name="anglais - volumes 4 &amp; 5 - le groupe nominal 1 &amp; 2 (1984)(vifi-nathan)(fr)[a2].k7" size="192047" crc="9e5eac82" sha1="bae22b9a185e2d502f297f6ad1a1dab2ff0a1bfa"/>
@@ -1473,6 +1597,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Diamant &amp; Fractions</description>
 		<year>1986</year>
 		<publisher>Christophe Lesur</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47564">
 				<rom name="diamant &amp; fractions (1986-11)(lesur, christophe)(fr).k7" size="47564" crc="fb724d6d" sha1="d666ca471ae07f67f83eddd915a0aa93fafa8d68"/>
@@ -1484,6 +1609,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'orthographe</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44542">
 				<rom name="francecm.k7" size="44542" crc="591986a9" sha1="39e3c0c87827fcadd442198475a2b368e20cd90f"/>
@@ -1495,6 +1621,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Identite</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19742">
 				<rom name="identite (1985-09-13)(ustl - irem)(fr).k7" size="19742" crc="a67cdd78" sha1="f9e037f009ddae800485b916b59031e92641ad1d"/>
@@ -1506,6 +1633,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Invasion des Chiffres &amp; Multiplication</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36897">
 				<rom name="mathematiques calculs - invasion des chiffres &amp; multiplication (1984)(nathan ecoles)(fr).k7" size="36897" crc="7fa05154" sha1="add9be7ea8f1813eaa1e523104c75b52f59b4b3e"/>
@@ -1517,6 +1645,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Invasion des Chiffres &amp; Multiplication (alt)</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36897">
 				<rom name="mathematiques calculs - invasion des chiffres &amp; multiplication (1984)(nathan ecoles)(fr)[a].k7" size="36897" crc="867b66da" sha1="75e8e7a724dddc747cfa490058cb07de6f66aa40"/>
@@ -1528,6 +1657,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Ranger des Nombres &amp; Carre Magique</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36531">
 				<rom name="mathematiques calculs - ranger des nombres &amp; carre magique (1985)(nathan ecoles)(fr).k7" size="36531" crc="7b3217f7" sha1="7862247dce27d72a206e561ecb16ce14ab1bb558"/>
@@ -1539,6 +1669,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Ranger des Nombres &amp; Carre Magique (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36531">
 				<rom name="mathematiques calculs - ranger des nombres &amp; carre magique (1985)(nathan ecoles)(fr)[a].k7" size="36531" crc="a908ff95" sha1="5698595df94df4edf7bc3412aa1e969cef8199aa"/>
@@ -1550,6 +1681,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Avant et Apres &amp; Combinaisons</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36024">
 				<rom name="mathematiques ce - rangements et reperages - avant et apres &amp; combinaisons (1985)(vifi-nathan)(fr).k7" size="36024" crc="54aee51f" sha1="1fcc54102adf8dd2144b207d7eb8b5fe8256d6cf"/>
@@ -1561,6 +1693,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Avant et Apres &amp; Combinaisons (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36024">
 				<rom name="mathematiques ce - rangements et reperages - avant et apres &amp; combinaisons (1985)(vifi-nathan)(fr)[a].k7" size="36024" crc="d6292de3" sha1="bcb996d405b33f01d05923bf39471a9ba5979d99"/>
@@ -1572,6 +1705,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Produits et Surfaces &amp; Quadrillage</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41424">
 				<rom name="mathematiques ce - rangements et reperages - produits et surfaces &amp; quadrillage (1985)(vifi-nathan)(fr).k7" size="41424" crc="4ce1f661" sha1="0611e3b55ae1f8086bf308f5d3f6c6a6e99c25d3"/>
@@ -1583,6 +1717,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Produits et Surfaces &amp; Quadrillage (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41424">
 				<rom name="mathematiques ce - rangements et reperages - produits et surfaces &amp; quadrillage (1985)(vifi-nathan)(fr)[a].k7" size="41424" crc="7796bbe6" sha1="d1ec8c4d54995de304129ae2a380ea5944962800"/>
@@ -1594,6 +1729,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Angles &amp; Golf</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42446">
 				<rom name="mathematiques ce-cm - geometrie - angles &amp; golf (1985)(vifi-nathan)(fr).k7" size="42446" crc="66fc1f87" sha1="044036b0678d38af8b24b8e1c0e7d44d47468040"/>
@@ -1605,6 +1741,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Angles &amp; Golf (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42446">
 				<rom name="mathematiques ce-cm - geometrie - angles &amp; golf (1985)(vifi-nathan)(fr)[a].k7" size="42446" crc="ea910101" sha1="09e05d1617fb30168ffc0fd79a057ea2c358c523"/>
@@ -1616,6 +1753,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Droites &amp; Triangles et Quadrilateres</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38100">
 				<rom name="mathematiques ce-cm - geometrie - droites &amp; triangles et quadrilateres (1985)(vifi-nathan)(fr).k7" size="38100" crc="b951f141" sha1="3e97223b105ce9cb83eb5699a73a3f5047cafcac"/>
@@ -1627,6 +1765,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="77023">
 				<rom name="mathcecm.k5" size="77023" crc="e1bf143f" sha1="8e0570e71585d3a8a84f1579d03ddef4bc448b2c"/>
@@ -1638,6 +1777,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="40411">
@@ -1656,6 +1796,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="40411">
@@ -1674,6 +1815,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40411">
 				<rom name="maths-cm-mesures-et-grandeurs-1_mo5.k7" size="40411" crc="78fe7659" sha1="c26c403baffc6c429f4215f5ab750a12853a4284"/>
@@ -1690,6 +1832,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Division &amp; Addition-Soustraction Express</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30930">
 				<rom name="mathematiques cm1 - division &amp; addition-soustraction express (1985)(nathan ecoles)(fr).k7" size="30930" crc="7c26e821" sha1="de5c44ebf363fa18faaa3ce97393c278ec226560"/>
@@ -1701,6 +1844,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Orde de Grandeur &amp; Lecture-Ecriture d'Un Nombre</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33083">
 				<rom name="mathematiques cm1 - orde de grandeur &amp; lecture-ecriture d'un nombre (1985)(nathan ecoles)(fr).k7" size="33083" crc="bcbeab0c" sha1="8bd396c8728c7ecd7c6445ca20bb6f26e11e663b"/>
@@ -1712,6 +1856,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Orde de Grandeur &amp; Lecture-Ecriture d'Un Nombre (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33083">
 				<rom name="mathematiques cm1 - orde de grandeur &amp; lecture-ecriture d'un nombre (1985)(nathan ecoles)(fr)[a].k7" size="33083" crc="3106eec0" sha1="1c7af212234f691fd75d8e2dee3ae601c2fd107a"/>
@@ -1723,6 +1868,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Moins, Autant, Plus &amp; Compter</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36083">
 				<rom name="mathematiques cp - chiffres et formes - moins, autant, plus &amp; compter (1985)(vifi-nathan)(fr).k7" size="36083" crc="a620fcad" sha1="5e197adb6fe073393eb90ac853dcb577a9015cd6"/>
@@ -1734,6 +1880,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Moins, Autant, Plus &amp; Compter (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36083">
 				<rom name="mathematiques cp - chiffres et formes - moins, autant, plus &amp; compter (1985)(vifi-nathan)(fr)[a].k7" size="36083" crc="b22b1c2e" sha1="1c341bda8b7b07a61df7d134a6c4ad280b36baf3"/>
@@ -1745,6 +1892,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Promenade &amp; Puzzle</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46563">
 				<rom name="mathematiques cp - chiffres et formes - promenade &amp; puzzle (1985)(vifi-nathan)(fr).k7" size="46563" crc="16e7ac55" sha1="e65f929fcc240fa38b43cc7c5555247b9903f42c"/>
@@ -1756,6 +1904,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Promenade &amp; Puzzle (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46563">
 				<rom name="mathematiques cp - chiffres et formes - promenade &amp; puzzle (1985)(vifi-nathan)(fr)[a].k7" size="46563" crc="09199eee" sha1="fbe4a1ec6284acf4dfe7e69bb32e62c01ea14e73"/>
@@ -1767,6 +1916,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Frises &amp; Symetries et Translations</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38270">
 				<rom name="mathematiques cp-ce - tables et frises - frises &amp; symetries et translations (1985)(vifi-nathan)(fr).k7" size="38270" crc="d5ecfdfc" sha1="d6dbb268df9eca03e699d5aec59f862557c37b43"/>
@@ -1778,6 +1928,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Frises &amp; Symetries et Translations (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38270">
 				<rom name="mathematiques cp-ce - tables et frises - frises &amp; symetries et translations (1985)(vifi-nathan)(fr)[a].k7" size="38270" crc="28815d52" sha1="3608c7739735c4d255b7d4447b1395dc374335b0"/>
@@ -1789,6 +1940,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Tables d'Operations &amp; Classement</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39916">
 				<rom name="mathematiques cp-ce - tables et frises - tables d'operations &amp; classement (1985)(vifi-nathan)(fr).k7" size="39916" crc="1ded18f0" sha1="abd3f2ee0bbab55104a289a310f55155b4ab24f3"/>
@@ -1800,6 +1952,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Tables d'Operations &amp; Classement (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39916">
 				<rom name="mathematiques cp-ce - tables et frises - tables d'operations &amp; classement (1985)(vifi-nathan)(fr)[a].k7" size="39916" crc="bac9a9df" sha1="b71685d4ae97096ecd203bdde2168ce05688e89b"/>
@@ -1811,6 +1964,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Programmes ludo-educatifs pour MO5 (07-08-2015)</description>
 		<year>2015</year>
 		<publisher>dcmoto.free.fr</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="106199">
 				<rom name="programmes-ludo-educatifs_mo5.k7" size="106199" crc="51c78d31" sha1="ae44f032e226037d90652aa4b7a50878f79382c6"/>
@@ -1822,6 +1976,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Programmes ludo-educatifs pour MO5 (27-07-2015)</description>
 		<year>2015</year>
 		<publisher>dcmoto.free.fr</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="70342">
 				<rom name="programmes-ludo-educatifs_mo5 [a].k7" size="70342" crc="649b6870" sha1="bb2b452884598ef7684577682380d6b6edd14ca4"/>
@@ -1835,6 +1990,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 1</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43925">
 				<rom name="classiques volume 1 (1987)(titus software)(fr).k7" size="43925" crc="c5c67830" sha1="8c6c33e2d7d37be65e401e801fe32607e9201e1d"/>
@@ -1846,6 +2002,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 1 (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43925">
 				<rom name="classiques volume 1 (1987)(titus software)(fr)[a].k7" size="43925" crc="85481850" sha1="1568d128b1ffa9a1bd635427214dc519f734c534"/>
@@ -1857,6 +2014,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 1 (alt 2)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43764">
 				<rom name="classiques volume 1 (1987)(titus software)(fr)[a2].k7" size="43764" crc="72961a1e" sha1="00324e1dda29bffb8e01746f0290658c7d556844"/>
@@ -1868,6 +2026,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 1 (alt 3)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46533">
 				<rom name="classiques1.k7" size="46533" crc="862029bb" sha1="f11a215ecc24ecdb2b5fe5f7d9788797f577afa9"/>
@@ -1879,6 +2038,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 2</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43204">
 				<rom name="classiques volume 2 (1987)(titus software)(fr).k7" size="43204" crc="050c1fcb" sha1="48bf8a01a0b556a03384c03d79c735c672e99e25"/>
@@ -1890,6 +2050,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 2 (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43204">
 				<rom name="classiques volume 2 (1987)(titus software)(fr)[a].k7" size="43204" crc="54645b20" sha1="7b97870a2a134338319df10357bf85d38eaab4f4"/>
@@ -1901,6 +2062,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 2 (alt 2)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46949">
 				<rom name="classiques2.k7" size="46949" crc="8d9fcc0a" sha1="9b9b0908ef1659084179a990198d7381d86dd3c4"/>
@@ -1912,6 +2074,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 3</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41009">
 				<rom name="classiques volume 3 (1987)(titus software)(fr).k7" size="41009" crc="29e7e8be" sha1="e575deab2ddd03133d8b4e162af0eb8bde8f7c4b"/>
@@ -1923,6 +2086,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 3 (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41009">
 				<rom name="classiques volume 3 (1987)(titus software)(fr)[a].k7" size="41009" crc="70ad6a47" sha1="5e3957e007cf7375b21251fb617db41f14ef9c63"/>
@@ -1934,6 +2098,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 3 (alt 2)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41009">
 				<rom name="classiques-vol3_mo5.k7" size="41009" crc="df561f49" sha1="5b25824471fb404a47943402a9b10770fe0e0782"/>
@@ -1945,6 +2110,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 4</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40699">
 				<rom name="classiques volume 4 (1987)(titus software)(fr).k7" size="40699" crc="c4ce7938" sha1="d17c74bc4078684e051ab6d7f2e818dd649fe098"/>
@@ -1956,6 +2122,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 4 (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40699">
 				<rom name="classiques volume 4 (1987)(titus software)(fr)[a].k7" size="40699" crc="0b036946" sha1="14eb82079900512d15955c82a43ea33053dc76b7"/>
@@ -1967,6 +2134,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Classiques Volume 4 (alt 2)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40699">
 				<rom name="classiques-vol4_mo5.k7" size="40699" crc="7b3883af" sha1="8ee5e9a47032b078278f6d89983f379131aa3180"/>
@@ -1978,6 +2146,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coffret Cadeau</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Monopoly"/>
 			<dataarea name="cass" size="50613">
@@ -1996,6 +2165,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Hits de Loriciels 1</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36266">
 				<rom name="les hits de loriciels 1 (loriciels) (pascal pellier) (1985) (mo5).k7" size="36266" crc="ded80996" sha1="fe3e080599518eb998ff4e8dc1c6eaa1260b7c5d"/>
@@ -2007,6 +2177,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Hits de Loriciels 1 (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36266">
 				<rom name="pulsar-eliminator-yeti_mo5.k7" size="36266" crc="fb045064" sha1="0a3bed6f6fc788570cd1366da623d9c9f3f057a6"/>
@@ -2018,6 +2189,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Hits d'Ocean</description>
 		<year>1986</year>
 		<publisher>Micromania</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="154263">
@@ -2060,6 +2232,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeux BASIC de Magazines</description>
 		<year>1985</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="15062">
@@ -2078,6 +2251,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeux BASIC de Magazines (alt)</description>
 		<year>1985</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="15062">
@@ -2096,6 +2270,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeux sur TO7 et MO5</description>
 		<year>1986</year>
 		<publisher>Sybex</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="87825">
 				<rom name="jeux sur to7 et mo5 (sybex) (georges fagot-barraly) (1986) (mo k7).k7" size="87825" crc="29712630" sha1="26229f1850f936a4ba61c81032e8fb620341a818"/>
@@ -2107,6 +2282,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mallette de Jeu Thomson</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Arkanoid)"/>
 			<dataarea name="cass" size="27667">
@@ -2137,6 +2313,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>MO5 Compilation Disk</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47432">
 				<rom name="mo5 compilation disk (198x) (pd).k7" size="47432" crc="4f7b87d3" sha1="5a585d6681d87c32678eb66f6f543147c58e814c"/>
@@ -2160,6 +2337,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Super Hits de Thomson</description>
 		<year>1986</year>
 		<publisher>Micromania</publisher>
+
 		<part name="cass1" interface="mo_cass"> <!-- dupe of hitocean tape2 -->
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="145397">
@@ -2190,6 +2368,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Telerama no.1</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6248">
 				<rom name="telerama no.1 (1984)(vifi-nathan)(fr)[isola].k7" size="6248" crc="bdbec1c0" sha1="3d2591b58fd4458f25133f438bb8416e6b4e1b6c"/>
@@ -2201,6 +2380,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Telerama no.2</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13474">
 				<rom name="telerama no. 2 (nathan) (alain rigolot, andre deledicq, etc.) (1984) (mo5).k7" size="13474" crc="d40ee451" sha1="87ea753de094dc2601f3ce4ef03b113ec8a0cc00"/>
@@ -2214,6 +2394,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Departge</description>
 		<year>1986</year>
 		<publisher>Ecole Jules Ferry</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3485">
 				<rom name="departge (1986)(ecole jules ferry)(pd).k7" size="3485" crc="14d6b9f9" sha1="7675429741b0556eb9c2f078288b7b254e7ccb2b"/>
@@ -2227,6 +2408,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Theogiciels Loisir 1</description>
 		<year>1984</year>
 		<publisher>Micropresse</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32678">
 				<rom name="theogiciels loisir 1 (1984)(micropresse)(fr).k7" size="32678" crc="e86097a1" sha1="c8f56fbf174068f466f3baf01832fc3fe74b5315"/>
@@ -2238,6 +2420,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Theogiciels Loisir 1 (alt)</description>
 		<year>1984</year>
 		<publisher>Micropresse</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32678">
 				<rom name="theogiciels-loisir-1_mo5.k7" size="32678" crc="1b46d826" sha1="acf16e3b46384091b32042f86725d19ef586ac32"/>
@@ -2265,6 +2448,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Hello World!</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="101">
 				<rom name="hello.k7" size="101" crc="d85c5606" sha1="a1e59379afc184420801a23b8a63143f3c4ef071"/>
@@ -2278,6 +2462,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>A.G.D.</description>
 		<year>1984</year>
 		<publisher>Gameco</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8910">
 				<rom name="a.g.d. (1984)(gameco)(fr).k7" size="8910" crc="18d3da95" sha1="7f6e255e1056f1644bafefbaedb85e022786e431"/>
@@ -2289,6 +2474,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>A.G.D. (alt)</description>
 		<year>1984</year>
 		<publisher>Gameco</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8910">
 				<rom name="a.g.d. (1984)(gameco)(fr)[a].k7" size="8910" crc="20868f22" sha1="f72725b259a5f32eb8460c1426368e27b8ba12a7"/>
@@ -2300,6 +2486,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>A.G.D. (alt 2)</description>
 		<year>1984</year>
 		<publisher>Gameco</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8910">
 				<rom name="agd_mo5.k7" size="8910" crc="bb2729f8" sha1="8494ebbf208ca6a5a22d65cbd2649fc1179ea761"/>
@@ -2311,6 +2498,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Algebre</description>
 		<year>1986</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25047">
 				<rom name="algebre (nathan) (jean-philippe et stephane rethore) (1986) (mo5).k7" size="25047" crc="7477c9c3" sha1="69ead6612f0689d73c4e6634957afcd5313d9056"/>
@@ -2322,6 +2510,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Amperemetre</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12896">
 				<rom name="amperemetre (198x)(cndp)(fr).k7" size="12896" crc="8208c043" sha1="69c6b9c50d9808424478947774463e3e41267b8e"/>
@@ -2333,6 +2522,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volume 1 - Tests de Niveau</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="32580">
@@ -2351,6 +2541,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volume 2 - Le Systeme Verbal 1</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="74268">
@@ -2369,6 +2560,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volume 3 - Le Systeme Verbal 2</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="52134">
@@ -2387,6 +2579,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volume 4 - Le Groupe Nominal 1</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="49475">
@@ -2405,6 +2598,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Anglais - Volume 5 - Le Groupe Nominal 2</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="46219">
@@ -2423,6 +2617,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Apprends-moi a Ecrire</description>
 		<year>198?</year>
 		<publisher>Cedic/Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="26763">
@@ -2441,6 +2636,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ardoise Magique</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10006">
 				<rom name="ardoise magique (198x)(-)(fr).k7" size="10006" crc="956fcb98" sha1="aa05aee8d564f73c97965ef3031d00f281375314"/>
@@ -2452,6 +2648,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ardoise Magique (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10006">
 				<rom name="ardoise magique (198x)(-)(fr)[a].k7" size="10006" crc="93ea2c87" sha1="cae3c885b8d9a7cb8602ce5360af39b7557fb9af"/>
@@ -2463,6 +2660,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ardoise Magique (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10006">
 				<rom name="ardoise-magique_mo5.k7" size="10006" crc="7850dc19" sha1="dc55e69a7f782cbf164e94967501ea38c164ac1a"/>
@@ -2474,6 +2672,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ascens</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22793">
 				<rom name="ascens (1985-09-13)(ustl - irem)(fr).k7" size="22793" crc="069d4255" sha1="4b2be81db4cf87c21171536444df936dc9b835c4"/>
@@ -2485,6 +2684,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Attrape Mots</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18889">
 				<rom name="attrape mots (no man's land) (inconnus) (1984) (mo5 k7).k7" size="18889" crc="3195f5d0" sha1="4c8326ddb8b39029e83fd64368b0a8bbbedc137b"/>
@@ -2496,6 +2696,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Auto-Initiation au Basic MO5</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="57753">
@@ -2514,6 +2715,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Auto-Initiation au Basic MO5 (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="57753">
@@ -2532,6 +2734,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Auto-Initiation au Basic MO5 (single tape)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="134878">
 				<rom name="auto-initiation au basic mo5 (1984)(to tek)(fr)[m single tape].k7" size="134878" crc="c196fee7" sha1="48bb180edd5537fb560eac930a46b847bb1e2eed"/>
@@ -2543,6 +2746,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Auto-Initiation au Basic MO5 (single tape, alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="134878">
 				<rom name="auto-initiation au basic mo5 (1984)(to tek)(fr)[m2 single tape].k7" size="134878" crc="cbf7aa55" sha1="9acc12c2c54c75bd1c303d0dfde2b15dc98b7d7d"/>
@@ -2554,6 +2758,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Auto-Initiation au Basic MO5 - Version NanoReseau</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="165822">
 				<rom name="auto-initiation au basic mo5 - version nanoreseau (1984)(to tek)(fr).k7" size="165822" crc="30515b15" sha1="436ba645018cfce3e720ae33e76196e168953a82"/>
@@ -2565,6 +2770,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Auto-Initiation au Basic MO5 - Version NanoReseau (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="165822">
 				<rom name="auto-initiation au basic mo5 - version nanoreseau (1984)(to tek)(fr)[a].k7" size="165822" crc="f9352a2d" sha1="069e6a6819ff3c891538e1a4fe9cfc59708c2c8c"/>
@@ -2576,6 +2782,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Auto-Initiation au Basic MO5 - Version NanoReseau (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="165822">
 				<rom name="auto-initiation au basic mo5 - version nanoreseau (1984)(to tek)(fr)[a2].k7" size="165822" crc="9bbfe4db" sha1="256fbffac7282446a8eb2d60f153336abfce5da3"/>
@@ -2587,6 +2794,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Baladins</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13825">
 				<rom name="baladins (198x)(cndp)(fr).k7" size="13825" crc="9862f766" sha1="2dec8b788b329c0247a27e84638e0dbf0e922297"/>
@@ -2598,6 +2806,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Calcul Mental (CNDP)</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13168">
 				<rom name="calcul mental (1984)(cndp)(fr).k7" size="13168" crc="ae9ab28c" sha1="9306f2eef3a2b5484df82691f2e9a8241a455eb6"/>
@@ -2609,6 +2818,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Calcul Mental (Loriciels)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19978">
 				<rom name="calcul mental (1984-07)(loriciels)(fr).k7" size="19978" crc="d4bc25c9" sha1="f76d6c8feeb190dab44fe6398e67438fded8ed9c"/>
@@ -2620,6 +2830,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Calcul Mental (Loriciels, alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19978">
 				<rom name="calcul mental (1984-07)(loriciels)(fr)[a].k7" size="19978" crc="6dd827a3" sha1="f1882761aebb11b00edd0df287f08e6f61ac0670"/>
@@ -2643,6 +2854,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Calcul Rapide</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9667">
 				<rom name="calcul rapide (1984)(no man's land)(fr).k7" size="9667" crc="cc27835f" sha1="401d705f363bb8d75cac588bc1dd4b836dd17a52"/>
@@ -2654,6 +2866,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Calculs Numeriques</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25040">
 				<rom name="calculs numeriques (1985)(vifi-nathan)(fr).k7" size="25040" crc="30f1a612" sha1="f7e6b4a6e960d3567de1673115e6c9473c0d6585"/>
@@ -2665,6 +2878,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cara</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9667">
 				<rom name="cara (no man's land) (inconnus) (1984) (mo5 k7).k7" size="9667" crc="eaaff390" sha1="2a520f825bb768ee68bd7fdbe31004e3f7f8c84b"/>
@@ -2676,6 +2890,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carre Magique</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6766">
 				<rom name="carre magique (198x)(cndp)(fr).k7" size="6766" crc="e1bd12da" sha1="db77bf57eb968b00bf1c3cce4405be8eb4849bfb"/>
@@ -2687,6 +2902,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cartable Francais</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29838">
 				<rom name="cartable-francais-1_mo5.k7" size="29838" crc="5625d6c9" sha1="cce2057129bbc889a6062a9bd85191d136e2562b"/>
@@ -2703,6 +2919,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carte d'Europe</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22824">
 				<rom name="carte d'europe (1985)(vifi-nathan)(fr).k7" size="22824" crc="2f93bfbd" sha1="49d4ffec325c8e72402b15c97f3c43118f90a579"/>
@@ -2714,6 +2931,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carte d'Europe (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22824">
 				<rom name="carte d'europe (1985)(vifi-nathan)(fr)[a].k7" size="22824" crc="08876575" sha1="c702eba07c99f4a2e9b752d8727c31f456f180e8"/>
@@ -2725,6 +2943,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carte d'Europe (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22824">
 				<rom name="carte d'europe (1985)(vifi-nathan)(fr)[a2].k7" size="22824" crc="bf1caf1f" sha1="76077ef9c014547507d4b8443a2e0b5c4043adeb"/>
@@ -2736,6 +2955,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Carte d'Europe (alt 3)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23287">
 				<rom name="carte d'europe (nathan) (1985) (alain beck) (mo5).k7" size="23287" crc="05fedff8" sha1="ece0ac8e0552667e42a3bfec82aee8e5cb006354"/>
@@ -2759,6 +2979,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Carte de France (alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34179">
 				<rom name="carte de france, la (1983)(vifi-nathan)(fr)[a].k7" size="34179" crc="8fa0e9a9" sha1="2e4f00d2996091a371821686e903949bc6ebf5c3"/>
@@ -2770,6 +2991,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Carte de France (alt 2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34179">
 				<rom name="carte de france, la (1983)(vifi-nathan)(fr)[a2].k7" size="34179" crc="ac6f5ad1" sha1="12ddc64c89f07cf244fcccb96cae724f185ed6da"/>
@@ -2781,6 +3003,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Carte de France (alt 3)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34171">
 				<rom name="carte de france, la (1983)(vifi-nathan)(fr)[a3].k7" size="34171" crc="4b1a3ec3" sha1="7e7dd3ae1db517266149350d49d50df90e6a08b0"/>
@@ -2792,6 +3015,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Chiffres et les Lettres</description>
 		<year>198?</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10647">
 				<rom name="chiffres et des lettres, des (198x)(vifi-nathan)(fr).k7" size="10647" crc="7f29764d" sha1="e9f0fe34904d86ef5b9f424783b4f6092b9fb405"/>
@@ -2803,6 +3027,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Chiffres et les Lettres (alt)</description>
 		<year>198?</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8951">
 				<rom name="chiffres et des lettres, des (198x)(vifi-nathan)(fr)[a].k7" size="8951" crc="75684270" sha1="a588b5013b0598460f074f7cd75eb797bbfe6747"/>
@@ -2814,6 +3039,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Chiffres et les Lettres (alt 2)</description>
 		<year>198?</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8951">
 				<rom name="chiffres et des lettres, des (198x)(vifi-nathan)(fr)[a2].k7" size="8951" crc="931965bd" sha1="df277e59c29d6bab5afa2eb0f15c432824c0f5ac"/>
@@ -2825,6 +3051,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Chiffres et les Lettres (alt 3)</description>
 		<year>198?</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8951">
 				<rom name="des-chiffres-et-des-lettres_mo5.k7" size="8951" crc="a8b1f28d" sha1="c7716d3b3a4400336568362aab88b1262055dea1"/>
@@ -2836,6 +3063,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cible</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10287">
 				<rom name="cible (1984-10-20)(cndp)(fr).k7" size="10287" crc="7d6246a0" sha1="f472074d4e36fe90d036b8aee5773a22d3aac917"/>
@@ -2847,6 +3075,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Compte est Rond</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17467">
 				<rom name="compte est rond, le (1984)(hatier)(fr)(m3).k7" size="17467" crc="e239e303" sha1="68505d4dc95bbd18f51e35bf86f07f05594fe7ce"/>
@@ -2858,6 +3087,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Compte est Rond (alt)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17467">
 				<rom name="compte est rond, le (1984)(hatier)(fr)(m3)[a].k7" size="17467" crc="97d1a12a" sha1="73acbd346d9890c11dec480a7cae924d8f45b117"/>
@@ -2869,6 +3099,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Compte est Rond (alt 2)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17467">
 				<rom name="compte est rond, le (1984)(hatier)(fr)(m3)[a2].k7" size="17467" crc="bb810063" sha1="135b672c73c54004638bb4a3690b5b0b53e00972"/>
@@ -2880,6 +3111,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Compte est Rond (alt 3)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17467">
 				<rom name="le-compte-est-rond_mo5.k7" size="17467" crc="c5821f49" sha1="07174d12e35bfeb03df6f0e881c20935ef4b9227"/>
@@ -2891,6 +3123,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Concours d'Algebre</description>
 		<year>198?</year>
 		<publisher>C. &amp; D. Missenard</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20757">
 				<rom name="concours d'algebre (198x)(missenard, c. &amp; d.)(fr)(pd).k7" size="20757" crc="dfc92e55" sha1="d3d20b3ec4012746a3838402db2e50c747564b83"/>
@@ -2902,6 +3135,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Concours de Geometrie</description>
 		<year>198?</year>
 		<publisher>C. &amp; D. Missenard</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22661">
 				<rom name="concours de geometrie (198x)(missenard, c. &amp; d.)(fr)(pd).k7" size="22661" crc="e5c01e63" sha1="725c68bfe61c69a7ee36cf573dbe3d3fe915bc50"/>
@@ -2913,6 +3147,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Conjugaichouette</description>
 		<year>1984</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="57789">
 				<rom name="conjugaichouette, la (1984)(edil)(fr).k7" size="57789" crc="6f6157fd" sha1="05ef5b244bc553eedb85c66beb1ba6305ceb7a83"/>
@@ -2924,6 +3159,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Corps Humain</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64831">
 				<rom name="corps humain, le (1985)(infogrames)(fr).k7" size="64831" crc="d55feaed" sha1="388bef1d3e5b51a1351dfadf2f80d50c79214d13"/>
@@ -2935,6 +3171,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Corps Humain (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64831">
 				<rom name="corps humain, le (1985)(infogrames)(fr)[a].k7" size="64831" crc="afe3b3e8" sha1="0e2f2ac8c2d8637a15b8a7d1b84695360844f945"/>
@@ -2946,6 +3183,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Corps Humain (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64831">
 				<rom name="corps humain, le (1985)(infogrames)(fr)[a2].k7" size="64831" crc="85fd4d3c" sha1="60913fc8b76b72c4a8b12adddc7ce5e25b205874"/>
@@ -2957,6 +3195,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Corps Humain (alt 3)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64831">
 				<rom name="le-corps-humain_mo5.k7" size="64831" crc="ae94c971" sha1="1b87e1353f25b9654968f280dd8c13feb88db694"/>
@@ -2968,6 +3207,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Course aux Lettres</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12829">
 				<rom name="cyprien dans la course aux lettres (1984-07)(loriciels)(fr).k7" size="12829" crc="165464f6" sha1="cb4f77d55e9bceb9b2a3cdbdf5594c9ec35a2e70"/>
@@ -2979,6 +3219,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Course aux Lettres (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15062">
 				<rom name="cyprien dans la course aux lettres (1984-07)(loriciels)(fr)[a].k7" size="15062" crc="9426ef51" sha1="e8585096863cf7ccf94fbca3e6936d64d7546564"/>
@@ -2990,6 +3231,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Course aux Lettres (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12829">
 				<rom name="cyprien dans la course aux lettres (1984-07)(loriciels)(fr)[a2].k7" size="12829" crc="dc136386" sha1="d642068db0ae11dba251ae8d8b2fa90766a0cf06"/>
@@ -3001,6 +3243,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Course aux Lettres (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12829">
 				<rom name="cyprien dans la course aux lettres (1984-07)(loriciels)(fr)[a3].k7" size="12829" crc="4a1c472c" sha1="fb36978f12a5d388e4b4f5fb87daf04497c8e3ee"/>
@@ -3012,6 +3255,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Course aux Lettres (alt 4)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12829">
 				<rom name="course-aux-lettres_mo5.k7" size="12829" crc="6bbc4c3d" sha1="b924ccf8096ef5cc2fca734ecc1d545ec14cd071"/>
@@ -3023,6 +3267,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cubomagique</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="cubomagique (1984)(hatier)(fr).k7" size="12668" crc="59b956dd" sha1="4ed85707363dfe9e7bd6e09609f2ea3d0d8a4959"/>
@@ -3034,6 +3279,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cubomagique (alt)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="cubomagique (1984)(hatier)(fr)[a].k7" size="12668" crc="04b70f94" sha1="3cbc83f0cca9afd47a34c04fab2c69ca83ef8f34"/>
@@ -3045,6 +3291,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cubomagique (alt 2)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="cubomagique (1984)(hatier)(fr)[a2].k7" size="12668" crc="3c89b6a9" sha1="28091646af44b8cb24d637e7d79745bbf28d17bf"/>
@@ -3056,6 +3303,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cubomagique (alt 3)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="cubomagique_mo5.k7" size="12668" crc="c8b2cffd" sha1="9f5e0a8a37cbf5a91b40c8ebaca91e87810364f5"/>
@@ -3067,6 +3315,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Cuisine Francaise</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="62273042">
 				<rom name="la cuisine francaise (free game blot) (alain guiri) (1985) (mo5).wav" size="62273042" crc="42999f30" sha1="eeef46ec0b61f9919afa65d79fe7d92aadfa6cdb"/>
@@ -3078,6 +3327,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Cuisine Francaise (alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="144783">
 				<rom name="la cuisine francaise (free game blot) (alain guiri) (1985) (mo5).k7" size="144783" crc="bf0430a9" sha1="62e639b1b43bb0e44121c84a4f02862a047b85ca"/>
@@ -3089,6 +3339,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Cuisine Francaise (alt 2)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64037042">
 				<rom name="la-cuisine-francaise_mo5.wav" size="64037042" crc="807b0793" sha1="db48e1bb97c55c0fc0da6090d2ec2656afdf49d0"/>
@@ -3100,6 +3351,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dactylographie</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27687">
 				<rom name="dactylographie (fil) (henri rolland) (1985) (mo5 k7).k7" size="27687" crc="287d9d54" sha1="3e2637255e289d0e5d12de3094795b3f274a0348"/>
@@ -3111,6 +3363,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Defi</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6367">
 				<rom name="defi (1984-10-20)(cndp)(fr).k7" size="6367" crc="2359b8a1" sha1="9a20acf4e86b8e375d6a31097a9fe7fb4c3969af"/>
@@ -3122,6 +3375,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Devin</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7513">
 				<rom name="devin (1984-10-20)(cndp)(fr).k7" size="7513" crc="93a30388" sha1="3657aff0de0c08cd44185b35db93bb707d5a4a82"/>
@@ -3133,6 +3387,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dialogue avec une Sauterelle</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18068">
 				<rom name="dialogue avec une sauterelle (1983)(vifi-nathan)(fr).k7" size="18068" crc="b01f54cc" sha1="a0b05c2fbeda995ffe20c8058f2d0dc089dcebb6"/>
@@ -3144,6 +3399,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dialogue avec une Sauterelle (alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23463">
 				<rom name="dialogue avec une sauterelle (nathan) (bernard delarue) (1983) (mo5).k7" size="23463" crc="d412723c" sha1="dcf6f195c1e72a470ed042cc50052e5c3592bd31"/>
@@ -3155,6 +3411,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didact-English - BTS Communication</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43810">
 				<rom name="didact-english - bts communication (1987)(carraz editions)(fr)(en-fr).k7" size="43810" crc="94909c92" sha1="e0164444846fc869360f5bc143d2de396ff50d8c"/>
@@ -3166,6 +3423,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didact-English - BTS Communication (alt)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43702">
 				<rom name="didact-english - bts communication (1987)(carraz editions)(fr)(en-fr)[a].k7" size="43702" crc="03d99146" sha1="44fd162726a6725f4814f1d613f822c4f57db996"/>
@@ -3177,6 +3435,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didact-English - BTS Communication (alt 2)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43702">
 				<rom name="didact-english-bts-communication_mo5.k7" size="43702" crc="c42f6e14" sha1="f741fa882df64831ff5336c3c3d63eadbb6c8aa1"/>
@@ -3188,6 +3447,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didact-English - BTS Electronique</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43702">
 				<rom name="didact-english - bts electronique (1987)(carraz editions)(fr)(en-fr).k7" size="43702" crc="8608df7a" sha1="d33e3aaf2b42cc3240ac4ba2abae2c063c95ad08"/>
@@ -3199,6 +3459,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didact-English - BTS Electronique (alt)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43810">
 				<rom name="didact-english - bts electronique (1987)(carraz editions)(fr)(en-fr)[a].k7" size="43810" crc="13627d76" sha1="491be2709eb96b7754e157ac59411876ddd4031f"/>
@@ -3210,6 +3471,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didact-English - BTS Electronique (alt 2)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43810">
 				<rom name="didact-english-bts-electronique_mo5.k7" size="43810" crc="403e005f" sha1="a9ddb3d7d8ff3f52b9d8f5ac999068163aacbe1a"/>
@@ -3221,6 +3483,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didactimath 4eme Volume 1</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="65578">
 				<rom name="didactimath 4eme (1985)(edil)(fr).k7" size="65578" crc="f29a7944" sha1="f7f185d09f367a27c2d3bbdf12686200b809e9f8"/>
@@ -3232,6 +3495,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didactimath 4eme Volume 1 (alt)</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66134">
 				<rom name="didactimath 4eme (1985)(edil)(fr)[a].k7" size="66134" crc="0c0c48f7" sha1="5e3655b1be12ff1f1b80d5dd521f6e83b19f0137"/>
@@ -3243,6 +3507,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didactimath 4eme Volume 1 (alt 2)</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="65578">
 				<rom name="didactimath 4eme (1985)(edil)(fr)[a2].k7" size="65578" crc="196e6c91" sha1="77a0b8fd41bcf1c54aee91876c2bf3e374290c00"/>
@@ -3254,6 +3519,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didactimath 4eme Volume 2</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56090">
 				<rom name="didactimath 4eme volume 2 (edil) (j.f reygnier) (1985) (mo5 k7).k7" size="56090" crc="1ec032df" sha1="7f6a1a9f61feebdc43ee8fd5f9014477c251983b"/>
@@ -3265,6 +3531,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Didactimath 5eme</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="54495">
 				<rom name="didactimath 5eme (1985)(edil)(fr).k7" size="54495" crc="7ef04078" sha1="b877bdf0c2a95a9471159bd3539aa3fee47e951f"/>
@@ -3276,6 +3543,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Divisibilite</description>
 		<year>198?</year>
 		<publisher>CDDP</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5869">
 				<rom name="divisibilite (198x)(cddp)(fr).k7" size="5869" crc="d63d11e9" sha1="9e3a8dca6dee8e012a3e4d69a6b5cc08913d3739"/>
@@ -3287,6 +3555,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Educatif 4 Mathasard</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19971">
 				<rom name="educatif 4 mathasard (cobrasoft) (jean biron) (1985) (mo5 k7).k7" size="19971" crc="6340a783" sha1="16e18b6fa017c2052c8350b4930a1449069109b1"/>
@@ -3298,6 +3567,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Educatif 5</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16373">
 				<rom name="educatif 5 (cobrasoft) (franck megel) (1985) (mo5 k7).k7" size="16373" crc="a54efc5b" sha1="4be9413fa83e1acf53a983b360cd6a7ac0a1471f"/>
@@ -3309,6 +3579,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Educatif 8 Cours'Auto</description>
 		<year>1986</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12049">
 				<rom name="educatif 8 cours'auto (cobrasoft) (jean-pierre latuilliere) (1986) (mo5 k7).k7" size="12049" crc="4f2ad469" sha1="bab00216883a85643444f47b2971a442620a5afd"/>
@@ -3320,6 +3591,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Electricite</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32798">
 				<rom name="electricite (1984)(cndp)(fr).k7" size="32798" crc="d87adb2c" sha1="167da598a88eb62f4845745923eb505ff52966ea"/>
@@ -3331,6 +3603,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Emploi du Subjonctif</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3292">
 				<rom name="emploi du subjonctif (198x)(cndp)(fr).k7" size="3292" crc="19474090" sha1="9fd6f9b913d7150c5bcbd19613afcdc133c7509a"/>
@@ -3342,6 +3615,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>En Allant a l'Ecole Cycliste</description>
 		<year>1985</year>
 		<publisher>Cedic</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="40484">
@@ -3360,6 +3634,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ensemble Z</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25071">
 				<rom name="ensemble z (198x)(-)(fr).k7" size="25071" crc="0f9034b6" sha1="7160dff3cb1a4e1520f7d30aa55b00df4cfefb0e"/>
@@ -3371,6 +3646,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Entrainement au Calcul</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="4504">
@@ -3437,6 +3713,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Equations</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25400">
 				<rom name="equations (198x)(-)(fr).k7" size="25400" crc="2e0bd6c0" sha1="6846317f2beb81ded4c364f139a176e0d9f26bc4"/>
@@ -3448,6 +3725,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Equations Inequations</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45435">
 				<rom name="equations inequations (nathan) (jean-paul germond) (1985) (mo5).k7" size="45435" crc="10dfdd50" sha1="57562c55763962b5b32f6a755bfad3b78fc09407"/>
@@ -3459,6 +3737,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Equations de Droites</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37661">
 				<rom name="equations de droites (1986)(fil)(fr).k7" size="37661" crc="c90d0234" sha1="a8e5a0a8c8357d5f84f5619d37a9b8742fcd9cbf"/>
@@ -3470,6 +3749,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Equichim</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26075">
 				<rom name="equichim (198x)(cndp)(fr).k7" size="26075" crc="d594d2af" sha1="6137467f55eadc03c33c99495be15877966c78a7"/>
@@ -3481,6 +3761,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Escalier pour l'Infini</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16989">
 				<rom name="escalier pour l'infini (198x)(cndp)(fr).k7" size="16989" crc="5c199b72" sha1="cc481b38a145fbe1520b0ed540855de6ecb2665a"/>
@@ -3492,6 +3773,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Espagnol</description>
 		<year>198?</year>
 		<publisher>Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="145944">
@@ -3516,6 +3798,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Espagnol (single tape)</description>
 		<year>198?</year>
 		<publisher>Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="646500">
 				<rom name="espagnol (198x)(nathan)(fr)[m single tape].k7" size="646500" crc="aac5f591" sha1="29dedaca5a5d594a58e64a2e4871f20ef7b43d84"/>
@@ -3527,6 +3810,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Espagnol (single tape, alt)</description>
 		<year>198?</year>
 		<publisher>Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="646500">
 				<rom name="espagnol (198x)(nathan)(fr)[m single tape][a].k7" size="646500" crc="8d0fdca2" sha1="53c3e6c56fff5e6d0fb59a02f8f6019eb45dc016"/>
@@ -3538,6 +3822,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Espagnol (single tape, alt 2)</description>
 		<year>198?</year>
 		<publisher>Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="646500">
 				<rom name="espagnol_mo5.k7" size="646500" crc="02227edc" sha1="108f5edc0b6241849fcbd9ce88f673d8f5b9c159"/>
@@ -3549,6 +3834,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Etude de la Vitesse Instantanee</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16689">
 				<rom name="etude de la vitesse instantanee (1984)(cndp)(fr).k7" size="16689" crc="8de38047" sha1="23fd24e6d64d8bd87c36c8f2d07e23359b5db872"/>
@@ -3560,6 +3846,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Faire le Point Bac Maths (v1.2)</description>
 		<year>1985</year>
 		<publisher>Ediciel Hachette</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="61779">
 				<rom name="faire le point bac maths v1.2 (1985)(ediciel hachette)(fr).k7" size="61779" crc="a683a428" sha1="57b46b8b684aa5a492ec550a57ce2921781b2f63"/>
@@ -3571,6 +3858,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Faire le Point Bac Maths (v1.1)</description>
 		<year>1985</year>
 		<publisher>Ediciel Hachette</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41398">
 				<rom name="faire le point bac maths v1.1 (1985)(ediciel hachette)(fr).k7" size="41398" crc="5ef7e0d5" sha1="0f0f5c8ef5a55396946757489fed807d4be3bb25"/>
@@ -3582,6 +3870,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Feu Vert</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14640">
 				<rom name="feu vert (1985)(vifi-nathan)(fr).k7" size="14640" crc="705d8a4d" sha1="c1eece8eca1d4cb272eb3b4a47dcf69bebe38d0b"/>
@@ -3593,6 +3882,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Fichier des Animaux</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3980">
 				<rom name="fichier des animaux (198x)(cndp)(fr).k7" size="3980" crc="a5ed9f3e" sha1="73673f32151b7436580931ff9d9794ea900b3713"/>
@@ -3604,6 +3894,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Forget Me Not</description>
 		<year>1985</year>
 		<publisher>Ediciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="15710">
@@ -3622,6 +3913,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 1 - Accord Parfait</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51010">
 				<rom name="francais ce - grammaire et orthographe 1 - accord parfait (1985)(vifi-nathan)(fr).k7" size="51010" crc="7fe3aad7" sha1="a4d98607deb58982485c6208032ca62425ecdbfb"/>
@@ -3633,6 +3925,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 1 - Accord Parfait (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51010">
 				<rom name="francais ce - grammaire et orthographe 1 - accord parfait (1985)(vifi-nathan)(fr)[a].k7" size="51010" crc="3e29979a" sha1="3d7315fb45162ecba898792d0923a70d21e9a466"/>
@@ -3656,6 +3949,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 1 - Mot Croises-Images</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36042">
 				<rom name="francais ce - grammaire et orthographe 1 - mot croises-images (1985)(vifi-nathan).k7" size="36042" crc="fa6f9cbc" sha1="b4cf11c9ffadf72b43fc65105a9725d0a4dd27f4"/>
@@ -3667,6 +3961,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 1 - Mot Croises-Images (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36042">
 				<rom name="francais ce - grammaire et orthographe 1 - mot croises-images (1985)(vifi-nathan)[a].k7" size="36042" crc="4862c190" sha1="fb28dda697e4032c09d897eb0be93b58afbebfe2"/>
@@ -3678,6 +3973,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 1 - Mot Croises-Images (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36042">
 				<rom name="francais - grammaire et orthographe (1) - ce (nathan) (inconnus) (1985) (mo5).k7" size="36042" crc="2db70f1d" sha1="299bd1ad46100305c5b6b78c8cd153277b478cfe"/>
@@ -3689,6 +3985,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 1 - Mot Croises-Images (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21211150">
 				<rom name="francais ce - grammaire et orthographe 1 - mot croises-images (1985)(vifi-nathan).wav" size="21211150" crc="826aa79c" sha1="5f7e17ff3dfcb7a417e0b5d19523f6388c329d9a"/>
@@ -3700,6 +3997,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 3 - Conjucalc</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35710">
 				<rom name="francais ce - grammaire et orthographe 3 - conjucalc (1985)(vifi-nathan)(fr).k7" size="35710" crc="0e0061df" sha1="8f7e871d3d87b491f109a62c9f2bd6223a86e3dd"/>
@@ -3711,6 +4009,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 3 - Conjucalc (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35710">
 				<rom name="francais ce - grammaire et orthographe 3 - conjucalc (1985)(vifi-nathan)(fr)[a].k7" size="35710" crc="5326b62c" sha1="48b0c68546001ebbcf5ad9b08e3e1b61e05fbcb9"/>
@@ -3722,6 +4021,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 3 - Conjucalc (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13335810">
 				<rom name="francais ce - grammaire et orthographe 3 - conjucalc (1985)(vifi-nathan)(fr).wav" size="13335810" crc="6e8d1b5f" sha1="68eeb667f4d05a65beab3d84defc94961f1bc3e4"/>
@@ -3733,6 +4033,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 3 - Graphix</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37812">
 				<rom name="francais ce - grammaire et orthographe 3 - graphix (1985)(vifi-nathan)(fr).k7" size="37812" crc="c3d2e2ee" sha1="c3f25c0412958857b91411e444df7e82c85764e0"/>
@@ -3744,6 +4045,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 3 - Graphix (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37812">
 				<rom name="francais ce - grammaire et orthographe 3 - graphix (1985)(vifi-nathan)(fr)[a].k7" size="37812" crc="d4e95bfa" sha1="a093de95aba973781081e2fcc50c0417af79d8be"/>
@@ -3755,6 +4057,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 3 - Graphix (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14016184">
 				<rom name="francais ce - grammaire et orthographe 3 - graphix (1985)(vifi-nathan)(fr).wav" size="14016184" crc="67ed1958" sha1="5dd3fb3f73dca990fedd8815a713ed09acb8304f"/>
@@ -3766,6 +4069,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 4 - Accord, D'Accord!</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44408">
 				<rom name="francais ce - grammaire et orthographe 4 - accord, d'accord (1985)(vifi-nathan)(fr).k7" size="44408" crc="dc7ffcb6" sha1="affe06b34bc7e0c2d7bce8de28fe3c2c168affae"/>
@@ -3777,6 +4081,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 4 - Accord, D'Accord! (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44408">
 				<rom name="francais ce - grammaire et orthographe 4 - accord, d'accord (1985)(vifi-nathan)(fr)[a].k7" size="44408" crc="9a40841a" sha1="8d535ead9d7f2e6dc2ea218d250095f3ac431f15"/>
@@ -3788,6 +4093,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 4 - Accord, D'Accord! (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16133872">
 				<rom name="francais ce - grammaire et orthographe 4 - accord, d'accord (1985)(vifi-nathan)(fr).wav" size="16133872" crc="20478ed3" sha1="106de7af77fdc30cd1f90f5a06b2f9d727996703"/>
@@ -3799,6 +4105,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 4 - Bourse aux Voyelles</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21534">
 				<rom name="francais ce - grammaire et orthographe 4 - bourse aux voyelles (1985)(vifi-nathan)(fr).k7" size="21534" crc="b06b3273" sha1="8f29e8f779b58f54993de3538d422884d388b4c6"/>
@@ -3810,6 +4117,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 4 - Bourse aux Voyelles (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21534">
 				<rom name="francais ce - grammaire et orthographe 4 - bourse aux voyelles (1985)(vifi-nathan)(fr)[a].k7" size="21534" crc="3fb292fe" sha1="d178730a348f0a72cf6c29fb16b3429a4ff0ec93"/>
@@ -3821,6 +4129,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE - Grammaire et Orthographe 4 - Bourse aux Voyelles (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8775976">
 				<rom name="francais ce - grammaire et orthographe 4 - bourse aux voyelles (1985)(vifi-nathan)(fr).wav" size="8775976" crc="d26f003d" sha1="1d9180b3319a540fc84f1b53a2aa6070d8258549"/>
@@ -3832,6 +4141,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Atelier</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21541">
 				<rom name="francais ce-cm - aide a l'orthographe - atelier (1985)(vifi-nathan)(fr).k7" size="21541" crc="831103a5" sha1="61ff3534a110f7608cc73751e45b51d590b1b3de"/>
@@ -3843,6 +4153,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Atelier (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21541">
 				<rom name="francais ce-cm - aide a l'orthographe - atelier (1985)(vifi-nathan)(fr)[a].k7" size="21541" crc="fb99998a" sha1="ebb67973c107c569a31bac7e31e4fc23364990e4"/>
@@ -3854,6 +4165,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Atelier (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8782618">
 				<rom name="francais ce-cm - aide a l'orthographe - atelier (1985)(vifi-nathan)(fr).wav" size="8782618" crc="94675e77" sha1="6a7ce7c71a5e493831725ddc028ce0213b746894"/>
@@ -3865,6 +4177,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Deviner</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38532">
 				<rom name="francais ce-cm - aide a l'orthographe - deviner (1985)(vifi-nathan)(fr).k7" size="38532" crc="3e22d589" sha1="dbce12b1d76e2769dff065403c2a65005f0847c1"/>
@@ -3876,6 +4189,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Deviner (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38532">
 				<rom name="francais ce-cm - aide a l'orthographe - deviner (1985)(vifi-nathan)(fr)[a].k7" size="38532" crc="f1b96b74" sha1="10b1593d07d58eaafad584b2972b4ec9caa3c6f6"/>
@@ -3887,6 +4201,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Deviner (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38532">
 				<rom name="deviner_mo5.k7" size="38532" crc="1626faa7" sha1="fe133c854d50b453e57144d6551727582027a67f"/>
@@ -3898,6 +4213,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Deviner (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14220234">
 				<rom name="francais ce-cm - aide a l'orthographe - deviner (1985)(vifi-nathan)(fr).wav" size="14220234" crc="77c4ecd4" sha1="d1fcd421c73c787e286bc29eacd75dbc202a93c9"/>
@@ -3909,6 +4225,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Invasion</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23023">
 				<rom name="francais ce-cm - aide a l'orthographe - invasion (1985)(vifi-nathan)(fr).k7" size="23023" crc="3037704f" sha1="dc9a83872cc1565391903ba0368fe13d8a4287f6"/>
@@ -3920,6 +4237,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Invasion (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23023">
 				<rom name="francais ce-cm - aide a l'orthographe - invasion (1985)(vifi-nathan)(fr)[a].k7" size="23023" crc="e154aab5" sha1="66857d4bb89211e03db963913b8b6d741ba4c99f"/>
@@ -3931,6 +4249,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Invasion (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9035838">
 				<rom name="francais ce-cm - aide a l'orthographe - invasion (1985)(vifi-nathan)(fr).wav" size="9035838" crc="f8ae381c" sha1="1e2dc70fdea17dc09832db116a809f223c7cd500"/>
@@ -3942,6 +4261,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Ponctuation</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26113">
 				<rom name="francais ce-cm - aide a l'orthographe - ponctuation (1985)(vifi-nathan)(fr).k7" size="26113" crc="daae6a2c" sha1="2a0739c35dfce259cb2096fe0861e61f6c6df772"/>
@@ -3953,6 +4273,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Ponctuation (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26113">
 				<rom name="francais ce-cm - aide a l'orthographe - ponctuation (1985)(vifi-nathan)(fr)[a].k7" size="26113" crc="0eff2492" sha1="cb7ddf62e595fab4b0569c44e6f05b3a85d3c00c"/>
@@ -3964,6 +4285,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE/CM - Aide a l'Orthographe - Ponctuation (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10244384">
 				<rom name="francais ce-cm - aide a l'orthographe - ponctuation (1985)(vifi-nathan)(fr).wav" size="10244384" crc="797f78ec" sha1="495da2de7ca4a7c1a70b6eada4915b6e74fa20af"/>
@@ -3975,6 +4297,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE1 - Grammaire et Orthographe - Conjugaison</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37191">
 				<rom name="francais ce1 - grammaire et orthographe - conjugaison (1985)(vifi-nathan)(fr).k7" size="37191" crc="b95dc84f" sha1="91ca1b69f362f7c783c44f221c77fadfa6114428"/>
@@ -3986,6 +4309,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE1 - Grammaire et Orthographe - Conjugaison (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37191">
 				<rom name="francais ce1 - grammaire et orthographe - conjugaison (1985)(vifi-nathan)(fr)[a].k7" size="37191" crc="e1ca9ef2" sha1="a5ec01e109adf77219f2011a91fa308365ee3520"/>
@@ -3997,6 +4321,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE1 - Grammaire et Orthographe - Conjugaison (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13819460">
 				<rom name="francais ce1 - grammaire et orthographe - conjugaison (1985)(vifi-nathan)(fr).wav" size="13819460" crc="9ba443f7" sha1="08a2cbb386f1d7e21d11f2434e12c3bb2c7a7645"/>
@@ -4008,6 +4333,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE1 - Grammaire et Orthographe - Devine</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23403">
 				<rom name="francais ce1 - grammaire et orthographe - devine (1985)(vifi-nathan)(fr).k7" size="23403" crc="baa9e78b" sha1="7bad5f1f2be2bd9dc5646970f959f60593c2e0f9"/>
@@ -4019,6 +4345,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE1 - Grammaire et Orthographe - Devine (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23403">
 				<rom name="francais ce1 - grammaire et orthographe - devine (1985)(vifi-nathan)(fr)[a].k7" size="23403" crc="7028b303" sha1="c09b9fba711653b083cddbeedba1a32615d7043f"/>
@@ -4030,6 +4357,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CE1 - Grammaire et Orthographe - Devine (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9377254">
 				<rom name="francais ce1 - grammaire et orthographe - devine (1985)(vifi-nathan)(fr).wav" size="9377254" crc="cef1b360" sha1="e3eaf1750492dc9883701ddc658a333a41b1dffa"/>
@@ -4041,6 +4369,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 1 - Chenille Savante</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32612">
 				<rom name="francais cm - grammaire et vocabulaire 1 - chenille savante (1985)(vifi-nathan)(fr).k7" size="32612" crc="576c619b" sha1="8be1062568a2f197217d2ebb8abb848390438811"/>
@@ -4052,6 +4381,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 1 - Chenille Savante (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32612">
 				<rom name="francais cm - grammaire et vocabulaire 1 - chenille savante (1985)(vifi-nathan)(fr)[a].k7" size="32612" crc="63a37dc8" sha1="2b5de1a9998290327308c9088e3982fc0b7d9df9"/>
@@ -4063,6 +4393,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 1 - Chenille Savante (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12336420">
 				<rom name="francais cm - grammaire et vocabulaire 1 - chenille savante (1985)(vifi-nathan)(fr).wav" size="12336420" crc="ea589dd1" sha1="01985da82bd62dc20bb10dfe740dff7048b2797d"/>
@@ -4074,6 +4405,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 1 - La Phrase et ses Constituants</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45314">
 				<rom name="francais cm - grammaire et vocabulaire 1 - la phrase et ses constituants (1985)(vifi-nathan)(fr).k7" size="45314" crc="947f23f1" sha1="0c7f66431bcd4e667be0ecf185f1e5e949bd21da"/>
@@ -4085,6 +4417,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 1 - La Phrase et ses Constituants (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45314">
 				<rom name="francais cm - grammaire et vocabulaire 1 - la phrase et ses constituants (1985)(vifi-nathan)(fr)[a].k7" size="45314" crc="57558954" sha1="1bb2da442e6f49256321132086693b5c4bd9ed78"/>
@@ -4096,6 +4429,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 1 - La Phrase et ses Constituants (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16640680">
 				<rom name="francais cm - grammaire et vocabulaire 1 - la phrase et ses constituants (1985)(vifi-nathan)(fr).wav" size="16640680" crc="9d99876f" sha1="f2a42130e92a03e1ddf1fd8ba13ef1bf4807ec24"/>
@@ -4107,6 +4441,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 2 - Classement Alphabetique</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25801">
 				<rom name="francais cm - grammaire et vocabulaire 2 - classement alphabetique (1985)(vifi-nathan)(fr).k7" size="25801" crc="17b338cc" sha1="6a8fcc965b64644730d3ab020835c4f12a0d6eee"/>
@@ -4118,6 +4453,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 2 - Classement Alphabetique (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25801">
 				<rom name="francais cm - grammaire et vocabulaire 2 - classement alphabetique (1985)(vifi-nathan)(fr)[a].k7" size="25801" crc="5b3a9f04" sha1="03625491fd01bd83d978d995ee922cd6414c83fb"/>
@@ -4129,6 +4465,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 2 - Classement Alphabetique (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10150460">
 				<rom name="francais cm - grammaire et vocabulaire 2 - classement alphabetique (1985)(vifi-nathan)(fr).wav" size="10150460" crc="f3b8bc5c" sha1="138da5aa6f998a882b0db1673e9b1b0f3ae006ac"/>
@@ -4140,6 +4477,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 2 - Pronoms</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35571">
 				<rom name="francais cm - grammaire et vocabulaire 2 - pronoms (1985)(vifi-nathan)(fr).k7" size="35571" crc="a05dbf35" sha1="af673a4399fffe21ab00ca17a1c133637066a8bc"/>
@@ -4151,6 +4489,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 2 - Pronoms (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35571">
 				<rom name="francais cm - grammaire et vocabulaire 2 - pronoms (1985)(vifi-nathan)(fr)[a].k7" size="35571" crc="64c8c004" sha1="daf91640be5e5093071e25a530511269c42b4e66"/>
@@ -4162,6 +4501,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Grammaire et Vocabulaire 2 - Pronoms (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13293086">
 				<rom name="francais cm - grammaire et vocabulaire 2 - pronoms (1985)(vifi-nathan)(fr).wav" size="13293086" crc="ba01857c" sha1="1904695ac2b2da21231ee0e9f4671ca4179a4064"/>
@@ -4173,6 +4513,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Vocabulaire et Orthographe - A Demi Mot</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25082">
 				<rom name="francais cm - vocabulaire et orthographe - a demi mot (1985)(vifi-nathan)(fr).k7" size="25082" crc="fe3e42b8" sha1="cfdfae72561e81a814872e2050854bae380e0bce"/>
@@ -4184,6 +4525,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Vocabulaire et Orthographe - A Demi Mot (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25069">
 				<rom name="francais cm - vocabulaire et orthographe - a demi mot (1985)(vifi-nathan)(fr)[a].k7" size="25069" crc="89a28d2b" sha1="fb8670f9127c090c0b51df4812cb59f1f832b853"/>
@@ -4195,6 +4537,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Vocabulaire et Orthographe - A Demi Mot (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25069">
 				<rom name="francais cm - vocabulaire et orthographe - a demi mot (1985)(vifi-nathan)(fr)[a2].k7" size="25069" crc="63911d1a" sha1="3a518ad376a968276813ea9d88f8289f49af4ddd"/>
@@ -4206,6 +4549,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Vocabulaire et Orthographe 1 - A.P.I.</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42796">
 				<rom name="francais cm - vocabulaire et orthographe 1 - a.p.i. (1985)(vifi-nathan)(fr).k7" size="42796" crc="74afe34b" sha1="d54d3118b7fa49aa560f5607670eba8aa7061416"/>
@@ -4217,6 +4561,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM - Vocabulaire et Orthographe 1 - A.P.I. (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42796">
 				<rom name="francais cm - vocabulaire et orthographe 1 - a.p.i. (1985)(vifi-nathan)(fr)[a].k7" size="42796" crc="fccf946a" sha1="4a30d38fd14661aa2c560d8a5c95e7a18030ad03"/>
@@ -4228,6 +4573,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM2/6eme - Vocabulaire et Orthographe - Memotex</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25821">
 				<rom name="francais cm2-6eme - vocabulaire et orthographe - memotex (1985)(vifi-nathan)(fr).k7" size="25821" crc="f3004420" sha1="dc5e2094a697afc27f194e16d9e58e5668c0e756"/>
@@ -4239,6 +4585,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM2/6eme - Vocabulaire et Orthographe - Memotex (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25821">
 				<rom name="francais cm2-6eme - vocabulaire et orthographe - memotex (1985)(vifi-nathan)(fr)[a].k7" size="25821" crc="6d6929a3" sha1="7cc2706f1e568a040d7f02b6028117898e623ee9"/>
@@ -4250,6 +4597,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM2/6eme - Vocabulaire et Orthographe - Synonymes</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36064">
 				<rom name="francais cm2-6eme - vocabulaire et orthographe - synonymes (1985)(vifi-nathan)(fr).k7" size="36064" crc="d28941fe" sha1="27294f972cdffa838093da7ce81d961870a2c34c"/>
@@ -4261,6 +4609,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CM2/6eme - Vocabulaire et Orthographe - Synonymes (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36064">
 				<rom name="francais cm2-6eme - vocabulaire et orthographe - synonymes (1985)(vifi-nathan)(fr)[a].k7" size="36064" crc="7fe2c0d8" sha1="16752d3c6e001aa35fc9cc0033e7cb29757d50bc"/>
@@ -4272,6 +4621,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture - Famille</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23733">
 				<rom name="francais cp - aide a la lecture - famille (1985)(vifi-nathan)(fr).k7" size="23733" crc="addeb7b0" sha1="c38899e5c425f611bfb6d4097d8fda23ee9b3171"/>
@@ -4283,6 +4633,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture - Famille (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23733">
 				<rom name="francais cp - aide a la lecture - famille (1985)(vifi-nathan)(fr)[b].k7" size="23733" crc="b5875730" sha1="967bb6a26a45567b132fcbfdb94117dd6b198e7e"/>
@@ -4291,9 +4642,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cpfamileb" cloneof="cpfamile">
-		<description>Francais CP - Aide a la Lecture - Famille (No Loader Screen)</description>
+		<description>Francais CP - Aide a la Lecture - Famille (no loader screen)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16509">
 				<rom name="francais cp - aide a la lecture - famille (1985)(vifi-nathan)(fr)[m title screen].k7" size="16509" crc="1c412ad7" sha1="12238763c947966f973ced9e44e43c07b7d775aa"/>
@@ -4305,6 +4657,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture - Famille (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9482440">
 				<rom name="francais cp - aide a la lecture - famille (1985)(vifi-nathan)(fr).wav" size="9482440" crc="9f759cf5" sha1="8f152776b62f59b343d8b02c4206a55f4e7c7da2"/>
@@ -4316,6 +4669,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture - Lecture</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35942">
 				<rom name="francais cp - aide a la lecture - lecture (1985)(vifi-nathan)(fr).k7" size="35942" crc="4e67bbd3" sha1="d851d4ab00c95973e05cc6c4b3c724b262c4439a"/>
@@ -4327,6 +4681,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture - Lecture (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35942">
 				<rom name="francais cp - aide a la lecture - lecture (1985)(vifi-nathan)(fr)[a].k7" size="35942" crc="0a0678d2" sha1="fd7ccca8b0393548d37e20b31698374d33806bd2"/>
@@ -4338,6 +4693,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture - Lecture (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13409050">
 				<rom name="francais cp - aide a la lecture - lecture (1985)(vifi-nathan)(fr).wav" size="13409050" crc="f9e72d6c" sha1="55722181a13e00d388fa39c5d8d77794ae2ccd99"/>
@@ -4349,6 +4705,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture 2 - Loto</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38621">
 				<rom name="francais cp - aide a la lecture 2 - loto (1985)(vifi-nathan)(fr).k7" size="38621" crc="7f59ee17" sha1="98fffee48b92980eecbd0672904483db6dec32b4"/>
@@ -4360,6 +4717,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture 2 - Loto (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38621">
 				<rom name="francais cp - aide a la lecture 2 - loto (1985)(vifi-nathan)(fr)[a].k7" size="38621" crc="063a1b26" sha1="dda94a4273a2df59072502e0dae058a016f70d59"/>
@@ -4371,6 +4729,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture 2 - Loto (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14221462">
 				<rom name="francais cp - aide a la lecture 2 - loto (1985)(vifi-nathan)(fr).wav" size="14221462" crc="7d248459" sha1="997aba34d0eb77f24816e579b7e07c76fb3fc7db"/>
@@ -4382,6 +4741,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture 2 - Memo-Jeu</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38006">
 				<rom name="francais cp - aide a la lecture 2 - memo-jeu (1985)(vifi-nathan)(fr).k7" size="38006" crc="c2379b74" sha1="8cab874f7a5c1622969e036fa2318c2b3cc03951"/>
@@ -4393,6 +4753,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture 2 - Memo-Jeu (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38006">
 				<rom name="francais cp - aide a la lecture 2 - memo-jeu (1985)(vifi-nathan)(fr)[a].k7" size="38006" crc="2c5b66b0" sha1="03a3466a68d0cdf614991c7fd53a43c83565a0de"/>
@@ -4404,6 +4765,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP - Aide a la Lecture 2 - Memo-Jeu (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14026558">
 				<rom name="francais cp - aide a la lecture 2 - memo-jeu (1985)(vifi-nathan)(fr).wav" size="14026558" crc="bf71660e" sha1="90a82f9d5d68b5d333614024bb8d3367548e6a9d"/>
@@ -4415,6 +4777,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Alerte</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39363">
 				<rom name="francais cp-ce - aide a la lecture - alerte (1985)(vifi-nathan)(fr).k7" size="39363" crc="1c35e13d" sha1="58285fce34b6f31f449891cb13a88390204daf28"/>
@@ -4426,6 +4789,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Alerte (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39363">
 				<rom name="francais cp-ce - aide a la lecture - alerte (1985)(vifi-nathan)(fr)[a].k7" size="39363" crc="daf8f473" sha1="ee001e316ff7e289857c16001ed03e562e6c2462"/>
@@ -4437,6 +4801,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Alerte (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16564786">
 				<rom name="francais cp-ce - aide a la lecture - alerte (1985)(vifi-nathan)(fr).wav" size="16564786" crc="bf83816d" sha1="b89b80081334e52a0b4c97d8f36223fd8ae748dd"/>
@@ -4448,6 +4813,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Memot</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32904">
 				<rom name="francais cp-ce - aide a la lecture - memot (1985)(nathan ecoles)(fr).k7" size="32904" crc="f2d93334" sha1="07dd3c2b9b0155df759d4912938215e7a6800c36"/>
@@ -4459,6 +4825,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Memot (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32904">
 				<rom name="francais cp-ce - aide a la lecture - memot (1985)(nathan ecoles)(fr)[a].k7" size="32904" crc="7c07c6f8" sha1="022e49524be64061f11d1fcdad932e40a7cbf5f1"/>
@@ -4470,6 +4837,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Memot (WAV format)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12413154">
 				<rom name="francais cp-ce - aide a la lecture - memot (1985)(nathan ecoles)(fr).wav" size="12413154" crc="4599421f" sha1="f93c12529952f7234f9bf287886d0b32e22ca2f8"/>
@@ -4481,6 +4849,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Pelmel</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32459">
 				<rom name="francais cp-ce - aide a la lecture - pelmel (1985)(vifi-nathan)(fr).k7" size="32459" crc="24893889" sha1="8047c7a9ef350bba7ece31514fc3b39483b17cac"/>
@@ -4492,6 +4861,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Pelmel (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32459">
 				<rom name="francais cp-ce - aide a la lecture - pelmel (1985)(vifi-nathan)(fr)[a].k7" size="32459" crc="6c634188" sha1="6c453eb4485414c0d495f3c6a4d997194c4bb3b2"/>
@@ -4503,6 +4873,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Pelmel (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12298936">
 				<rom name="francais cp-ce - aide a la lecture - pelmel (1985)(vifi-nathan)(fr).wav" size="12298936" crc="ba711f1d" sha1="2e64137bb984b1fa2e1318a3f14339f5db1e476a"/>
@@ -4514,6 +4885,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Radar</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26855">
 				<rom name="francais cp-ce - aide a la lecture - radar (1985)(vifi-nathan)(fr).k7" size="26855" crc="27c24c49" sha1="5eab2df27abb6999ea10d4f59e47c0897f41fed2"/>
@@ -4525,6 +4897,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Radar (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26855">
 				<rom name="francais cp-ce - aide a la lecture - radar (1985)(vifi-nathan)(fr)[a].k7" size="26855" crc="20022dcc" sha1="1a82b6ea61f3b2dd21c5a0ed96b27652b9138669"/>
@@ -4536,6 +4909,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Francais CP/CE - Aide a la Lecture - Radar (WAV format)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10498248">
 				<rom name="francais cp-ce - aide a la lecture - radar (1985)(vifi-nathan)(fr).wav" size="10498248" crc="78238813" sha1="0f7010e9b137f189bcd26ccfdb5ce090b2c4af94"/>
@@ -4547,6 +4921,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Frontier</description>
 		<year>198?</year>
 		<publisher>CDDP</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3875">
 				<rom name="frontier (198x)(cddp)(fr)[b].k7" size="3875" crc="fbe181d2" sha1="94da3bd62fb9a7307f45af7e0522888d685baf0f"/>
@@ -4558,6 +4933,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Geometre 5eme</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="71304">
 				<rom name="geometre 5eme, le (1985)(edil)(fr).k7" size="71304" crc="feee5f4f" sha1="d5cdcbddaa99797cb3a216e9da08ae06fd76ccd1"/>
@@ -4569,6 +4945,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Geometrie</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32484">
 				<rom name="geometrie (1985)(vifi-nathan)(fr).k7" size="32484" crc="8dc36435" sha1="c3f758fdecc4b0799c24b9e8c97a2b6ae2ea1a59"/>
@@ -4580,6 +4957,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Grsang</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23601">
 				<rom name="grsang (198x)(cndp)(fr).k7" size="23601" crc="930d4e3c" sha1="f9a70938f1d2be59866e0746002096d4657f3674"/>
@@ -4591,6 +4969,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Histoire de France</description>
 		<year>1985</year>
 		<publisher>MPS Diffusion</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="30187">
@@ -4609,6 +4988,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Histoire de France (single tape)</description>
 		<year>1985</year>
 		<publisher>MPS Diffusion</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="164845">
 				<rom name="histoire de france (1985)(mps diffusion)(fr).k7" size="164845" crc="4768face" sha1="8973cc4144ba4e1f7865fe8b55f79386ce1a835f"/>
@@ -4620,6 +5000,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Histoire de France (single tape, alt)</description>
 		<year>1985</year>
 		<publisher>MPS Diffusion</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="137533">
 				<rom name="histoire de france (1985)(mps diffusion)(fr)[a].k7" size="137533" crc="34a5a4bd" sha1="8c4215f75017d60b1d423856e16aa38b13d93837"/>
@@ -4631,6 +5012,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Histoire de France (single tape, alt 2)</description>
 		<year>1985</year>
 		<publisher>MPS Diffusion</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="137533">
 				<rom name="histoire de france (1985)(mps diffusion)(fr)[a2].k7" size="137533" crc="ceb99826" sha1="a956fff2b87f64c4b49da79a3ccc20de64dff816"/>
@@ -4642,6 +5024,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Histoire de France (single tape, alt 3)</description>
 		<year>1985</year>
 		<publisher>MPS Diffusion</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="137533">
 				<rom name="histoire de france (mps diffusion) (gerard tramier) (1985) (mo5).k7" size="137533" crc="064e26f5" sha1="80cd9c9e879c76d0757e35f85e90cb65359ad39a"/>
@@ -4653,6 +5036,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Horloge</description>
 		<year>1984</year>
 		<publisher>USTL</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8693">
 				<rom name="horloge (1984)(ustl)(fr).k7" size="8693" crc="e8a2c3b6" sha1="7e22948b0e2216f74dd30238a0797f2867c9e23f"/>
@@ -4664,6 +5048,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Image et Signes</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="26161">
@@ -4682,6 +5067,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Inequations</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25881">
 				<rom name="inequations (198x)(-)(fr).k7" size="25881" crc="98e4c723" sha1="b1d8189f51f8aae5d23aaeb3fe5946f43685a207"/>
@@ -4693,6 +5079,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Initiation au Basic</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="50882">
@@ -4723,6 +5110,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Initiation au Basic (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="50866">
@@ -4753,6 +5141,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Initiation au Basic (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="50866">
@@ -4783,6 +5172,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Initiation au Basic (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="50866">
@@ -4813,6 +5203,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Initiation au Basic (alt 4)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="50866">
@@ -4843,6 +5234,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Einfuehrung in Basic (Ger)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="51623">
@@ -4873,6 +5265,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Initiation aux Echecs</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40029">
 				<rom name="initiation aux echecs (1984)(vifi-nathan)(fr).k7" size="40029" crc="cb04da54" sha1="003b441627a52b288ab1c1c80c947290ea5d8621"/>
@@ -4884,6 +5277,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Initiation aux Echecs (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40029">
 				<rom name="initiation aux echecs (1984)(vifi-nathan)(fr)[b title screen].k7" size="40029" crc="44c70ab1" sha1="7bfad9a19f3bdf2c1faa69f7972d363011adfe0b"/>
@@ -4895,6 +5289,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Initiation aux Echecs (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40029">
 				<rom name="initiation aux echecs (1984)(vifi-nathan)(fr)[a].k7" size="40029" crc="8e912a0e" sha1="45f4599df9e12507bbf7d1c4949fca7a8ffe90b7"/>
@@ -4906,6 +5301,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Initiation aux Echecs (alt 3)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40029">
 				<rom name="initiation-aux-echecs_mo5.k7" size="40029" crc="44a50c33" sha1="801bf4f452849db8610508cd5f25bf727d268779"/>
@@ -4917,6 +5313,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>J'entends</description>
 		<year>1984</year>
 		<publisher>Ediciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="34901">
@@ -4935,6 +5332,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jauge</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11107">
 				<rom name="jauge (1984-10-20)(cndp)(fr).k7" size="11107" crc="25955a0a" sha1="294e9b08be558afa9a7da0a33be2bac2b7b48d7e"/>
@@ -4946,6 +5344,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Je Lis, J'Ecris</description>
 		<year>1984</year>
 		<publisher>Ediciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="29902">
@@ -4964,6 +5363,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Je Tu Il</description>
 		<year>1986</year>
 		<publisher>Ediciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51405">
 				<rom name="je tu il (1986)(ediciel)(fr).k7" size="51405" crc="153c8f28" sha1="825899a852eb28b1341e84e9395c6ec57a62e5eb"/>
@@ -4975,6 +5375,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Je Tu Il (alt)</description>
 		<year>1986</year>
 		<publisher>Ediciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51405">
 				<rom name="je tu il (1986)(ediciel)(fr)[a].k7" size="51405" crc="bd49b89b" sha1="5291ff791b6e186208c6d1494d462a9211e50e39"/>
@@ -4986,6 +5387,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Je Tu Il (alt 2)</description>
 		<year>1986</year>
 		<publisher>Ediciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51405">
 				<rom name="je-tu-il_mo5.k7" size="51405" crc="34aaa3cf" sha1="45b0a62c4aeb5d0d210fc093562885851bc0debd"/>
@@ -4997,6 +5399,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Jeu de Boole</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18388">
 				<rom name="jeu de boole, le (1984)(hatier)(fr)(m3).k7" size="18388" crc="0d5335b3" sha1="0cc58c35e2c443ce44f011e882b8ba5fc95de13e"/>
@@ -5008,6 +5411,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Jeu de Boole (alt)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18388">
 				<rom name="jeu-de-boole_mo5.k7" size="18388" crc="b4453083" sha1="41c93e5a21f55cc61ce562d412ff54be677cd6da"/>
@@ -5033,6 +5437,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu des Planetes</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11570">
 				<rom name="jeu des planetes (198x)(-)(fr).k7" size="11570" crc="cba4dfa1" sha1="2327d7aa274745f3204aebaa0a6a455619203b38"/>
@@ -5044,6 +5449,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu des Planetes (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11570">
 				<rom name="jeu des planetes (198x)(-)(fr)[a].k7" size="11570" crc="a51022c0" sha1="05c743a26dbd46ce42922b038ec0f1f8ebc69333"/>
@@ -5055,6 +5461,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu des Planetes (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11570">
 				<rom name="jeu-des-planetes_mo5.k7" size="11570" crc="2db0a0bc" sha1="8a3584af8d2a13bf12f5eba1b87bc7891367ebac"/>
@@ -5066,6 +5473,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu du Dictionnaire</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7117">
 				<rom name="jeu du dictionnaire (198x)(cndp)(fr).k7" size="7117" crc="e10943d0" sha1="7f6faddd6477584396346e9f664103d978a2323a"/>
@@ -5077,6 +5485,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeux de Kim</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8553">
 				<rom name="jeux de kim (1984)(no man's land)(fr).k7" size="8553" crc="743f0ea7" sha1="2760ce060344408ff955065252a8783b6d30bcde"/>
@@ -5088,6 +5497,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeux de Kim (alt)</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8553">
 				<rom name="jeux de kim (1984)(no man's land)(fr)[a].k7" size="8553" crc="e8383ac8" sha1="1b44f73eeacb6595512cc444f9dc797a8aedf84a"/>
@@ -5099,6 +5509,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Kim</description>
 		<year>1984</year>
 		<publisher>Mo Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9420">
 				<rom name="kim (no man's land) (inconnus) (1984) (mo5 k7).k7" size="9420" crc="0c72cc99" sha1="cb7c494648f87518c6320bd6f9055918314426a5"/>
@@ -5110,6 +5521,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Lis, Lisons, Lisez...</description>
 		<year>1985</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="65073">
@@ -5134,6 +5546,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>LOGO Sans Peine</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40898">
 				<rom name="logo sans peine (nathan) (1985) (mo5).k7" size="40898" crc="fc82e45e" sha1="e630a71372fcce29a101e83e3b515bfd5e9e0997"/>
@@ -5145,6 +5558,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>LOGO Sans Peine (alt?)</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20558">
 				<rom name="logo-sans-peine-2_mo5.k7" size="20558" crc="926dacde" sha1="0005279fa943eed30114d74a4586ce68a8f75f2a"/>
@@ -5156,6 +5570,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ludo Algebre</description>
 		<year>1985</year>
 		<publisher>Edumicro</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21412">
 				<rom name="ludo algebre (1985)(edumicro)(fr).k7" size="21412" crc="032aeb7c" sha1="ea53974a2e885e35ed8a85cbcf2d35874d54b620"/>
@@ -5167,6 +5582,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ludo OP1</description>
 		<year>1985</year>
 		<publisher>Edumicro</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17382">
 				<rom name="ludo op1 (1985)(edumicro)(fr).k7" size="17382" crc="e5a7e6af" sha1="7e973a9e51809ceb24fd6beffa8cef7879dc93fb"/>
@@ -5178,6 +5594,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Carre Magique</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16092">
 				<rom name="mathematiques calculs - carre magique (1984)(nathan ecoles)(fr).k7" size="16092" crc="70f9326d" sha1="c88afea281a71c2b17666eff999cf0f2556367d5"/>
@@ -5189,6 +5606,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Carre Magique (alt)</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16078">
 				<rom name="mathematiques calculs - carre magique (1984)(nathan ecoles)(fr)[a].k7" size="16078" crc="e08f3298" sha1="30a663987d7b1ab37271859690ae084e33617772"/>
@@ -5200,6 +5618,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Carre Magique (alt 2)</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16078">
 				<rom name="mathematiques calculs - carre magique (1984)(nathan ecoles)(fr)[a2].k7" size="16078" crc="8c8083f3" sha1="a215e53276674e5668c5a639ebbd5cbbf6796599"/>
@@ -5211,6 +5630,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Carre Magique (alt 3)</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16078">
 				<rom name="mathematiques calculs - carre magique (1984)(nathan ecoles)(fr)[a3].k7" size="16078" crc="7777f8ce" sha1="6b08bde3d2fd8b2bae5e3595d5efd4196c5a9fa4"/>
@@ -5222,6 +5642,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Carre Magique (alt 4)</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16078">
 				<rom name="maths-calculs-carre-magique_mo5.k7" size="16078" crc="0826714d" sha1="41b2e3aba631b84d0691f961d18f358bbe86dedb"/>
@@ -5233,6 +5654,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Invasion des Chiffres</description>
 		<year>1984</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18746">
 				<rom name="mathematiques calculs - invasion des chiffres (1984)(nathan ecoles)(fr).k7" size="18746" crc="29d8eff5" sha1="4f95959aff95dbbc21cb3090612bce251b2887a6"/>
@@ -5244,6 +5666,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Multiplication</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15630">
 				<rom name="mathematiques calculs - multiplication (1985)(cedic-nathan)(fr)[m title screen].k7" size="15630" crc="2d02db0e" sha1="815e91c44d1b0284df2431190221ea9844956176"/>
@@ -5255,6 +5678,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques Calculs - Ranger des Nombres</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17442">
 				<rom name="mathematiques calculs - ranger des nombres (1985)(cedic-nathan)(fr)[m title screen].k7" size="17442" crc="31538754" sha1="c46258d66f78c27ac089990fe4b1ff88b0251d56"/>
@@ -5266,6 +5690,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Avant et Apres</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15608">
 				<rom name="mathematiques ce - rangements et reperages - avant et apres (1985)(vifi-nathan)(fr).k7" size="15608" crc="a8d775d9" sha1="60362c2461878a6d622e5e65c298047f9e5d28a5"/>
@@ -5277,6 +5702,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Avant et Apres (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15608">
 				<rom name="maths-ce-avant-et-apres_mo5.k7" size="15608" crc="ccf0d850" sha1="e00c6157e71bafe4e23eda07d10e3e38a7b4af7a"/>
@@ -5288,6 +5714,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Combinaisons</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20416">
 				<rom name="mathematiques ce - rangements et reperages - combinaisons (1985)(vifi-nathan)(fr).k7" size="20416" crc="6df32a25" sha1="2db76500e564925dced102ae98eaf020f378f0f5"/>
@@ -5299,6 +5726,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Combinaisons (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20416">
 				<rom name="maths-ce-combinaisons_mo5.k7" size="20416" crc="92112f13" sha1="5272151cfc4b59de00bc21f806f5ef632377f3ad"/>
@@ -5310,6 +5738,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Produits et Surfaces</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18884">
 				<rom name="mathematiques ce - rangements et reperages - produits et surfaces (1985)(vifi-nathan)(fr).k7" size="18884" crc="ab4a6419" sha1="5bd26f3adde6102c590fd54b6962f74c654950cc"/>
@@ -5321,6 +5750,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Produits et Surfaces (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18884">
 				<rom name="maths-ce-produits-et-surfaces_mo5.k7" size="18884" crc="95220122" sha1="a92a2f4e46b166490754a473b2e6c32086f9aa3a"/>
@@ -5332,6 +5762,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Quadrillage</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22540">
 				<rom name="mathematiques ce - rangements et reperages - quadrillage (1985)(vifi-nathan)(fr).k7" size="22540" crc="3908f783" sha1="da84227e962dc5d0845c7926cb667297766fc314"/>
@@ -5343,6 +5774,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE - Rangements et Reperages - Quadrillage (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22540">
 				<rom name="maths-ce-quadrillage_mo5.k7" size="22540" crc="6d4a8d0a" sha1="b08cc5fc58b019ca2c0aa311e05009791f2a34f7"/>
@@ -5354,6 +5786,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Angles</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21148">
 				<rom name="mathematiques ce-cm - geometrie - angles (1985)(vifi-nathan)(fr).k7" size="21148" crc="3ff35d7d" sha1="6902b8f581cb3e4bea7fd9ccd92c0b0ea0637711"/>
@@ -5365,6 +5798,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Angles (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20602">
 				<rom name="mathematiques ce-cm - geometrie - angles (1985)(vifi-nathan)(fr)[a].k7" size="20602" crc="7d18210b" sha1="007426b468473a2962d393e62cca722ee5449281"/>
@@ -5376,6 +5810,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Angles (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38923">
 				<rom name="mathematiques ce-cm - geometrie - angles (1985)(vifi-nathan)(fr)[a2].k7" size="38923" crc="d3115664" sha1="a6106da534247f666999808ba7674fcb05309b42"/>
@@ -5387,6 +5822,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Angles (alt 3)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20602">
 				<rom name="maths-ce-cm-angles_mo5.k7" size="20602" crc="5dde4a8c" sha1="597f39aa0e75f0ce766759c0bc4b68487b1b1b5d"/>
@@ -5398,6 +5834,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Droites</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16167">
 				<rom name="mathematiques ce-cm - geometrie - droites (1985)(vifi-nathan)(fr).k7" size="16167" crc="aa6280d2" sha1="e711d44519e1d6297e4681616db909e7fccb3366"/>
@@ -5409,6 +5846,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Droites (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38100">
 				<rom name="mathematiques ce-cm - geometrie - droites (1985)(vifi-nathan)(fr)[a].k7" size="38100" crc="39d95f6c" sha1="4d56b355aff6ce565d12ffb11d1a763a670ab123"/>
@@ -5420,6 +5858,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Droites (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38100">
 				<rom name="mathematiques ce-cm - geometrie - droites (1985)(vifi-nathan)(fr)[b].k7" size="38100" crc="d18e11bd" sha1="aad4ca12a5f1e627bfdde7da1d552f7e306ec462"/>
@@ -5431,6 +5870,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Droites (alt 3)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16167">
 				<rom name="maths-ce-cm-droites_mo5.k7" size="16167" crc="8986fe15" sha1="50e1ca43bdb0b441d3d95e96f694011a1927a470"/>
@@ -5442,6 +5882,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Golf</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21844">
 				<rom name="mathematiques ce-cm - geometrie - golf (1985)(vifi-nathan)(fr).k7" size="21844" crc="9a7c4259" sha1="a616be5a79141d2898d2d4d124404520b9d0ea2d"/>
@@ -5453,6 +5894,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Golf (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21844">
 				<rom name="maths-ce-cm-golf_mo5.k7" size="21844" crc="e100f09f" sha1="ad295dc9fc986cd9bcc04bbf7505a032b419419b"/>
@@ -5461,9 +5903,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cecmgolfb" cloneof="cecmgolf">
-		<description>Mathematiques CE/CM - Geometrie - Golf (No Loader Screen)</description>
+		<description>Mathematiques CE/CM - Geometrie - Golf (no loader screen)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15753">
 				<rom name="mathematiques ce-cm - geometrie - golf (1985)(vifi-nathan)(fr)[m title screen].k7" size="15753" crc="3b887c4b" sha1="40ea0c508477be65186518875fda4962a91528c6"/>
@@ -5475,6 +5918,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Triangles et Quadrilateres</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21933">
 				<rom name="mathematiques ce-cm - geometrie - triangles et quadrilateres (1985)(vifi-nathan)(fr).k7" size="21933" crc="f5194aa4" sha1="a1a765422ef691e7721b67bad1c9b4442bc81b0e"/>
@@ -5486,6 +5930,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CE/CM - Geometrie - Triangles et Quadrilateres (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21933">
 				<rom name="maths-ce-cm--triangles-et-quadrilateres_mo5.k7" size="21933" crc="3ccc632c" sha1="5fcb7ad36f7c56ec34662664baf2f12bc3b05a14"/>
@@ -5497,6 +5942,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs - Aires et Volumes</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18670">
 				<rom name="mathematiques cm - mesures et grandeurs - aires et volumes (1985)(vifi-nathan)(fr).k7" size="18670" crc="04a61aa5" sha1="3c564c4becc2f60994a39e22832505b44880c9d1"/>
@@ -5508,6 +5954,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs - Changement d'Unites</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15993">
 				<rom name="maths-cm-changement-d-unites_mo5.k7" size="15993" crc="0c6eafee" sha1="2725d652842ff68123cc9ed26c073e4a9503d905"/>
@@ -5519,6 +5966,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs - Linearite</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22277">
 				<rom name="maths-cm-linearite_mo5.k7" size="22277" crc="1192ecae" sha1="fb697f1d846e011fea06fd2bebcde8f26b31c211"/>
@@ -5530,6 +5978,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM - Mesures et Grandeurs - Mesure du Temps</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16768">
 				<rom name="maths-cm-mesure-du-temps_mo5.k7" size="16768" crc="c83b775a" sha1="e96e1dc1b98ab106e04ec22661623beda3c7edd6"/>
@@ -5538,9 +5987,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="cmmesurea" cloneof="cmmesure">
-		<description>Mathematiques CM - Mesures et Grandeurs - Mesure du Temps (No Loader Screen)</description>
+		<description>Mathematiques CM - Mesures et Grandeurs - Mesure du Temps (no loader screen)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16252">
 				<rom name="mathematiques cm - mesures et grandeurs - mesure du temps (1985)(vifi-nathan)(fr)[m title screen].k7" size="16252" crc="36d056f7" sha1="5d34d966981df2d84067bddf21ffb8a3e8cdc305"/>
@@ -5552,6 +6002,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Addition-Soustraction Express</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14327">
 				<rom name="mathematiques cm1 - addition-soustraction express (1985)(nathan ecoles)(fr).k7" size="14327" crc="277d3db5" sha1="79c576f9b501854a831f4f480ecdea8b585b7f7c"/>
@@ -5563,6 +6014,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Addition-Soustraction Express (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14327">
 				<rom name="maths-cm1-addition-soustraction_mo5.k7" size="14327" crc="077912c5" sha1="627abc5e2b6fb7ed4a09e85fd4f2964651880591"/>
@@ -5574,6 +6026,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Division</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17174">
 				<rom name="mathematiques cm1 - division (1985)(nathan ecoles)(fr).k7" size="17174" crc="eea631e2" sha1="2535d842beb34884b8702faf9fe40bdd1ea052ab"/>
@@ -5585,6 +6038,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Division (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30930">
 				<rom name="mathematiques cm1 - division (1985)(nathan ecoles)(fr)[a].k7" size="30930" crc="07ec1940" sha1="87ac2a9481296f54af5d88f4ee23a79697f53402"/>
@@ -5596,6 +6050,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Division (alt 2)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17159">
 				<rom name="mathematiques cm1 - division (1985)(nathan ecoles)(fr)[a2].k7" size="17159" crc="806a11c6" sha1="fa3af0afab0e01f573c6d9cd3322c1c1cb62a70f"/>
@@ -5607,6 +6062,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Division (alt 3)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17159">
 				<rom name="maths-cm1-division_mo5.k7" size="17159" crc="43b7df58" sha1="8d8d00a04f793040946accb120b3283b0eb0ff5d"/>
@@ -5618,6 +6074,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Lecture et Ecriture d'Un Nombre</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16630">
 				<rom name="mathematiques cm1 - lecture-ecriture d'un nombre (1985)(nathan ecoles)(fr).k7" size="16630" crc="d9437fa5" sha1="9f74fa60cc4705dd5254b5b5eafe5ec5d8ccbea4"/>
@@ -5629,6 +6086,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Lecture et Ecriture d'Un Nombre (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16630">
 				<rom name="mathematiques cm1 - lecture et ecriture d'un nombre (nathan) (inconnus) (1985) (mo5).k7" size="16630" crc="16402d91" sha1="529b905ee80738b413dfcfb52178d3d7e69e3f80"/>
@@ -5640,6 +6098,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Orde de Grandeur</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17014">
 				<rom name="mathematiques cm1 - orde de grandeur (1985)(nathan ecoles)(fr).k7" size="17014" crc="e2b124c2" sha1="0cd2f285ec0af04861afaabba7a037c9e1650c99"/>
@@ -5651,6 +6110,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Orde de Grandeur (alt)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16453">
 				<rom name="mathematiques cm1 - orde de grandeur (1985)(nathan ecoles)(fr)[a].k7" size="16453" crc="5b98a889" sha1="be920641ca2f3ed58f7e6eb490549ef090bc6db2"/>
@@ -5662,6 +6122,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CM1 - Orde de Grandeur (alt 2)</description>
 		<year>1985</year>
 		<publisher>Nathan Ecoles</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16453">
 				<rom name="mathematiques cm1 - ordre de grandeur (nathan) (inconnus) (1985) (mo5).k7" size="16453" crc="6e4b8cd3" sha1="809f32cb0546e719c30e0f727089c87384bf0ab4"/>
@@ -5673,6 +6134,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Compter</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19908">
 				<rom name="mathematiques cp - chiffres et formes - compter (1985)(vifi-nathan)(fr).k7" size="19908" crc="9e772d00" sha1="04811e1e762d4cc6005c807121e1ea623f1c08e5"/>
@@ -5684,6 +6146,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Compter (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19908">
 				<rom name="maths-cp-compter_mo5.k7" size="19908" crc="dc581763" sha1="4ac54e019bece7f323d2cd836bc142bf98b19868"/>
@@ -5695,6 +6158,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Moins, Autant, Plus</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16175">
 				<rom name="mathematiques cp - chiffres et formes - moins, autant, plus (1985)(vifi-nathan)(fr).k7" size="16175" crc="ff762614" sha1="735bcc3a34ba0cdf95977a18c8855876203f65a6"/>
@@ -5706,6 +6170,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Moins, Autant, Plus (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16175">
 				<rom name="maths-cp-moins-autant-plus_mo5.k7" size="16175" crc="dfd2bdb6" sha1="b8c85ac93eacdfa5386dcd72c82cd22d7a1949b9"/>
@@ -5717,6 +6182,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Promenade</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24021">
 				<rom name="mathematiques cp - chiffres et formes - promenade (1985)(vifi-nathan)(fr).k7" size="24021" crc="08470258" sha1="3dc096b3474f724c3f8d6101cd5b8cfe5fc971c3"/>
@@ -5728,6 +6194,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Promenade (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24021">
 				<rom name="maths-cp-promenade_mo5.k7" size="24021" crc="c9a3d471" sha1="70b63da53adf43acee466f00d0efb4070f15a94b"/>
@@ -5739,6 +6206,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Puzzle</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22542">
 				<rom name="mathematiques cp - chiffres et formes - puzzle (1985)(vifi-nathan)(fr).k7" size="22542" crc="87a57a88" sha1="4bdac464c9b0df9b8d1ec92c841f946ba76bc70e"/>
@@ -5750,6 +6218,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP - Chiffres et Formes - Puzzle (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22542">
 				<rom name="maths-cp-puzzle_mo5.k7" size="22542" crc="7d892822" sha1="c7876280509c3b6c5bb7ab0194e9f316757fa2ac"/>
@@ -5761,6 +6230,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Classement</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23060">
 				<rom name="mathematiques cp-ce - tables et frises - classement (1985)(vifi-nathan)(fr).k7" size="23060" crc="a8e056e4" sha1="88379fb6c7768845a68e020a1cc9830fe903709a"/>
@@ -5772,6 +6242,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Classement (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23060">
 				<rom name="maths-cp-ce-classement_mo5.k7" size="23060" crc="f1da96ca" sha1="9369d2dd4f1f0a6b86632f126af7d0c6ff6be8ca"/>
@@ -5783,6 +6254,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Frises</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22337">
 				<rom name="mathematiques cp-ce - tables et frises - frises (1985)(vifi-nathan)(fr).k7" size="22337" crc="9a7b6616" sha1="90761b0bbfd48f5d234eab6a4fb59f52b20344e7"/>
@@ -5794,6 +6266,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Frises (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22337">
 				<rom name="maths-cp-ce-frises_mo5.k7" size="22337" crc="b3fb307c" sha1="c1df6e93be0a83f183dca514dd87504b16718290"/>
@@ -5805,6 +6278,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Symetries et Translations</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15933">
 				<rom name="mathematiques cp-ce - tables et frises - symetries et translations (1985)(vifi-nathan)(fr).k7" size="15933" crc="c87d004c" sha1="40979e81b6f77ed88df59178157a80d6838ac28e"/>
@@ -5816,6 +6290,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Symetries et Translations (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15933">
 				<rom name="maths-cp-ce-symetries-et-translations_mo5.k7" size="15933" crc="e1290c26" sha1="e8c98c8ce90837e04935d6e7e9fece9c3bfbdc66"/>
@@ -5827,6 +6302,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Tables d'Operations</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16856">
 				<rom name="mathematiques cp-ce - tables et frises - tables d'operations (1985)(vifi-nathan)(fr).k7" size="16856" crc="1b22bf70" sha1="a19dc3d5fff87ff79dd73eadc309e9e9f9893ea5"/>
@@ -5838,6 +6314,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mathematiques CP/CE - Tables et Frises - Tables d'Operations (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16856">
 				<rom name="maths-cp-ce-tables-d-operations_mo5.k7" size="16856" crc="3a734320" sha1="d4ae11245f25b7828bb50eb67b5f1c6e92edb246"/>
@@ -5849,6 +6326,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Melodimus</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23170">
 				<rom name="melodimus (1984)(logimus)(fr).k7" size="23170" crc="d2cf4e4f" sha1="10981af3ce5d7090dd7bba2314b07076cc2c4604"/>
@@ -5860,6 +6338,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Melodimus (alt)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23161">
 				<rom name="melodimus (1984)(logimus)(fr)[a].k7" size="23161" crc="07f172d0" sha1="d82e7dddaa645dc24544f0c1b2c6cf633632f1a6"/>
@@ -5871,6 +6350,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Melodimus (alt 2)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23161">
 				<rom name="melodimus (1984)(logimus)(fr)[a2].k7" size="23161" crc="0c8aff43" sha1="ea39a3eaf44fdf70828c3b8125e4ac900b60002e"/>
@@ -5882,6 +6362,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Melodimus (alt 3)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23161">
 				<rom name="melodimus (1984)(logimus)(fr)[a3].k7" size="23161" crc="6d3fd719" sha1="b581afa6a0007c24d2cb95b1256c5fe044b600e8"/>
@@ -5893,6 +6374,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Melodimus (alt 4)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23161">
 				<rom name="melodimus_mo5.k7" size="23161" crc="63efacb7" sha1="58bbe1d244f826a351b2fa043b3f92f0d701e5d4"/>
@@ -5904,6 +6386,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Micro-Processeur</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46082">
 				<rom name="micro-processeur, le (1985)(vifi-nathan)(fr).k7" size="46082" crc="661d43d6" sha1="bc7327e80a5c1139b0ea52dd8b5cc39ccddc25e7"/>
@@ -5915,6 +6398,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Micro-Processeur (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46082">
 				<rom name="microprocesseur_mo5.k7" size="46082" crc="2c10af1b" sha1="10c316bb957114c312bf228100afb9b0bf003239"/>
@@ -5926,6 +6410,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Microscillo</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23382">
 				<rom name="microscillo (1984)(infogrames)(fr).k7" size="23382" crc="3b429a24" sha1="9605d4bc7d51d839a1817286edb05284123ad7a3"/>
@@ -5937,6 +6422,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Microscillo (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23382">
 				<rom name="microscillo (1984)(infogrames)(fr)[a].k7" size="23382" crc="cff9fc8f" sha1="b80a8093558b770ffa63b0d9aa41e548dfb1b001"/>
@@ -5948,6 +6434,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Microscillo (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23382">
 				<rom name="microscillo_mo5.k7" size="23382" crc="4ebe8ba8" sha1="d8a44759f664106ba5530bbf6342767fa9867218"/>
@@ -5959,6 +6446,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Minotaure</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15576">
 				<rom name="minotaure, le (1984)(hatier)(fr).k7" size="15576" crc="d5a10e54" sha1="c1c2812dce713a0ecce4bf48a20796d942fbe067"/>
@@ -5970,6 +6458,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Minotaure (alt)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15346">
 				<rom name="minotaure, le (1984)(hatier)(fr)[a].k7" size="15346" crc="af73a382" sha1="bc63c4b8e7ffdfc208d4e8b99454ae2fa9856506"/>
@@ -5981,6 +6470,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Minotaure (alt 2)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15444">
 				<rom name="minotaure, le (1984)(hatier)(fr)[a2].k7" size="15444" crc="eca56be7" sha1="52321808b17f8dce5ec1ab9f3ab550a9ff36acb6"/>
@@ -5992,6 +6482,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Minotaure (alt 3)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15444">
 				<rom name="minotaure, le (1984)(hatier)(fr)[a3].k7" size="15444" crc="3de436ca" sha1="8abdb485f1462217279443a623617e6e5eff4d81"/>
@@ -6003,6 +6494,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Minotaure (alt 4)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15444">
 				<rom name="minotaure, le (1984)(hatier)(fr)[a4].k7" size="15444" crc="d4a9fa6a" sha1="15eca81ec9997760cb3fe7112753361d7152c000"/>
@@ -6014,6 +6506,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Minotaure (alt 5)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15444">
 				<rom name="minotaure, le (1984)(hatier)(fr)[a5].k7" size="15444" crc="febb076b" sha1="1ea37bae11e7b42a74d60da6161f9ef67960e418"/>
@@ -6025,6 +6518,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>MO5BOOT - MO5SD Bootstrap Loader</description>
 		<year>2012</year>
 		<publisher>Daniel Coulom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4587974">
 				<rom name="mo5boot.wav" size="4587974" crc="8c442ed2" sha1="b5d7a24d7c9e4f0dccfcd7220e970d9c01a1fd36"/>
@@ -6036,6 +6530,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mongolfiere</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15076">
 				<rom name="mongolfiere (1985)(cedic-nathan)(fr).k7" size="15076" crc="329ad3d8" sha1="6c80292c2f165fba4980a4e3fb74d7373a3831d0"/>
@@ -6047,6 +6542,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mosaique</description>
 		<year>198?</year>
 		<publisher>Edumicro</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10572">
 				<rom name="mosaique (198x)(edumicro)(fr).k7" size="10572" crc="0ea45252" sha1="2228ff1075f81729c20d4f87d8f64964067a9d23"/>
@@ -6058,6 +6554,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mosaique (alt)</description>
 		<year>198?</year>
 		<publisher>Edumicro</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10572">
 				<rom name="mosaique (198x)(edumicro)(fr)[a].k7" size="10572" crc="a412b5d1" sha1="1e2aca1208ea4cbec19604d335bdc26ecbe19fd5"/>
@@ -6069,6 +6566,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mosaique (alt 2)</description>
 		<year>198?</year>
 		<publisher>Edumicro</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10572">
 				<rom name="mosaique_mo5.k7" size="10572" crc="1eeaa4f3" sha1="8e8c83c997eda14933ae546fc9197721e818ee09"/>
@@ -6080,6 +6578,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Un Mot pour le Compte</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13726">
 				<rom name="mot pour le compte, un (1983)(vifi-nathan)(fr).k7" size="13726" crc="3ce78dfc" sha1="b416c03e93bde26766445048ece2c2c8b7d18c87"/>
@@ -6091,6 +6590,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mpendu</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17203">
 				<rom name="mpendu (1984-10-20)(cndp)(fr).k7" size="17203" crc="bd27b69a" sha1="b16bf7124aac01bfbeaed9a33328ef97c1741d4c"/>
@@ -6102,6 +6602,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Multiplications Casse-Tete</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39458">
 				<rom name="multiplications casse-tete (1984)(vifi-nathan)(fr).k7" size="39458" crc="dfca6a0d" sha1="85c2ceb9ef72deedac184610a56256067976ebe7"/>
@@ -6113,6 +6614,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Multiplications Casse-Tete (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30967">
 				<rom name="multiplications casse-tete (1984)(vifi-nathan)(fr)[a].k7" size="30967" crc="5b9b7f54" sha1="1c04543a349e81094805bbc9e569c63cf277b21d"/>
@@ -6124,6 +6626,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Navire</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17419">
 				<rom name="navire (1985-09-13)(ustl - irem)(fr).k7" size="17419" crc="2621e3c2" sha1="66a2d7b4f74580d43f2cff33573413855b0ff0dc"/>
@@ -6135,6 +6638,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Nombre Cache Ou...</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18346">
 				<rom name="nombre cache ou..., le (198x)(-)(pd)(fr).k7" size="18346" crc="a93cb758" sha1="bf998bd15f7ed091fa58ea2c6dff9a740b1e37e9"/>
@@ -6146,6 +6650,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Nouvel Espagnol sans Peine</description>
 		<year>1985</year>
 		<publisher>Assimil</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="81819">
@@ -6176,6 +6681,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Nouvel Espagnol sans Peine (alt)</description>
 		<year>1985</year>
 		<publisher>Assimil</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="81819">
@@ -6206,6 +6712,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Nouvel Espagnol sans Peine (alt 2)</description>
 		<year>1985</year>
 		<publisher>Assimil</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="81819">
@@ -6236,6 +6743,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Nouvel Espagnol sans Peine (single tape)</description>
 		<year>1985</year>
 		<publisher>Assimil</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="646500">
 				<rom name="nouvel espagnol sans peine, le (1985)(assimil)(fr)[m single tape].k7" size="646500" crc="19c2cf4d" sha1="de5dbe92c5ffc94de3091709964d5df47000639e"/>
@@ -6247,6 +6755,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ordidactic</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9984">
 				<rom name="ordidactic (1984)(ere informatique)(fr).k7" size="9984" crc="5a30eb5d" sha1="1808811fdeea045f20c28a5e912d9d5e6b69fdcc"/>
@@ -6258,6 +6767,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ordidactic (alt)</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9984">
 				<rom name="ordidactic (1984)(ere informatique)(fr)[a].k7" size="9984" crc="4ddfc641" sha1="47ac44d9ab74f3fc6fef79f877c3897622b34391"/>
@@ -6269,6 +6779,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ordidactic (alt 2)</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9984">
 				<rom name="ordidactic (1984)(ere informatique)(fr)[a2].k7" size="9984" crc="5af0f767" sha1="50e66d51f1bd0eb7d0bf8f680b229769f30c4b9c"/>
@@ -6280,6 +6791,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ordidactic (alt 3)</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9984">
 				<rom name="ordidactic_mo5.k7" size="9984" crc="041256ef" sha1="131a087809fa7b5dc69274af6dbf6495854d1bf9"/>
@@ -6291,6 +6803,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Ordifables</description>
 		<year>1985</year>
 		<publisher>Larousse</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="24325">
@@ -6309,6 +6822,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orthocrack 1 - Masculin-Feminin</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19853">
 				<rom name="orthocrack 1 - masculin-feminin (1984)(hatier)(fr).k7" size="19853" crc="82863ff1" sha1="5d7fb7ba716ec72a45f062707d6462d5e1bee60f"/>
@@ -6320,6 +6834,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orthocrack 2 - Singulier-Pluriel</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22416">
 				<rom name="orthocrack 2 - singulier-pluriel (1984)(hatier)(fr).k7" size="22416" crc="0dc0de3c" sha1="419de49061bc683afe0c2a10ed3cfabc5a9b472d"/>
@@ -6331,6 +6846,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orthocrack 3 - Present de l'Indicatif</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24791">
 				<rom name="orthocrack 3 - present de l'indicatif (1984)(hatier)(fr).k7" size="24791" crc="3c84453d" sha1="feb3eedc04fc97274a0f14fa6782b3118d3f61f9"/>
@@ -6342,6 +6858,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orthographe Lexicale</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="332492">
 				<rom name="orthographe lexicale (1984)(cndp)(fr).k7" size="332492" crc="5aa6ab58" sha1="e194ee6aa46f97a573657994b4d7f14e8f9dd684"/>
@@ -6353,6 +6870,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orthographe Lexicale (alt)</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="332492">
 				<rom name="orthographe lexicale (1984)(cndp)(fr)[a].k7" size="332492" crc="66c86c7b" sha1="5b5f8f4f1537823c2b98bb797dc006ddf5a084e0"/>
@@ -6364,6 +6882,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orthographe Lexicale (alt 2)</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="332492">
 				<rom name="orthographe lexicale (1984)(cndp)(fr)[a2].k7" size="332492" crc="58fcbf49" sha1="cba97ce508c7d9d5bb3ed524eebb13748b5e74da"/>
@@ -6375,6 +6894,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orthographe Lexicale (alt 3)</description>
 		<year>1984</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="332492">
 				<rom name="orthographe-lexicale_mo5.k7" size="332492" crc="f26772d1" sha1="3176520b6e4378dbec466020ae6e585ba37ef97e"/>
@@ -6386,6 +6906,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pays du Monde</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66841">
 				<rom name="pays du monde (1986)(infogrames)(fr).k7" size="66841" crc="8c86a5a2" sha1="bcdd23d086bbda1c60533448758e8e3396f111e1"/>
@@ -6397,6 +6918,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Paysage a,b,c</description>
 		<year>1985</year>
 		<publisher>Jeriko</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30030">
 				<rom name="paysage-abc_mo5.k7" size="30030" crc="8fb12caa" sha1="4885a6e7a491a8c21bd46d728ff7d3b51fc9aba1"/>
@@ -6408,6 +6930,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Pendu</description>
 		<year>1982</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16431">
 				<rom name="pendu, le (1982)(cndp)(fr).k7" size="16431" crc="618ba2e3" sha1="10770aebe04a83273280b6783f609daca8c3b7a7"/>
@@ -6419,6 +6942,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Phases de la Lune</description>
 		<year>1988</year>
 		<publisher>C. Prevost</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3589">
 				<rom name="les phases de la lune (c. prevost) (1988) (mo5).k7" size="3589" crc="4556cb2d" sha1="0ba6cfdfb470b8d090ace29eea07725e0de6d6c7"/>
@@ -6430,6 +6954,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Phases de la Lune (alt)</description>
 		<year>1988</year>
 		<publisher>C. Prevost</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3589">
 				<rom name="les-phases-de-la-lune_mo5.k7" size="3589" crc="630217f4" sha1="0396917da5ff4e735905eb2207c9a6318a1f7a09"/>
@@ -6441,6 +6966,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pique-Fiche</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33989">
 				<rom name="pique-fiche (1984)(hatier)(fr).k7" size="33989" crc="51e37e48" sha1="95457135ef9e0a0ad438da398e8c266a7166e408"/>
@@ -6452,6 +6978,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pique-Fiche (WAV format)</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20023982">
 				<rom name="pique-fiche (1984)(hatier)(fr).wav" size="20023982" crc="d6e7376d" sha1="5540efb58420c69aa4428879946a3ae175287be2"/>
@@ -6463,6 +6990,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pluriel des Noms Simples</description>
 		<year>198?</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3185">
 				<rom name="pluriel des noms simples (198x)(cndp)(fr).k7" size="3185" crc="6c6ba04d" sha1="75c400dac1f692c877d396556d16d5dcd903d3e0"/>
@@ -6474,6 +7002,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pourcentages</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11543">
 				<rom name="pourcentages (198x)(-)(fr)(pd)[b].k7" size="11543" crc="bc0a3d98" sha1="5fe303ab20394b74d7e6f9c4ca2866cc45aa0923"/>
@@ -6485,6 +7014,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Premiers pas vers le Basic</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="90200">
@@ -6509,6 +7039,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Premiers pas vers le Basic (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="90200">
@@ -6533,6 +7064,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Premiers pas vers le Basic (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="90220">
@@ -6557,6 +7089,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Preterite Star</description>
 		<year>1984</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34666">
 				<rom name="preterite star (1984)(edil)(fr)(en-fr)[b2].k7" size="34666" crc="763e0544" sha1="9df621f94efedc6cc98269b015f4784726647552"/>
@@ -6582,6 +7115,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Prologic</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26032">
 				<rom name="prologic (1985)(fil)(fr).k7" size="26032" crc="2c60ec93" sha1="be2ec2b3d8769401dc8649c26fba2667a5fe0138"/>
@@ -6593,6 +7127,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Proportions</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11074">
 				<rom name="proportions (19xx)(-)(fr).k7" size="11074" crc="164d4f12" sha1="2a8dcd300e1b994218a7a126f78b4ac7d068e4d1"/>
@@ -6604,6 +7139,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pythagore</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25004">
 				<rom name="pythagore (1984)(hatier)(fr).k7" size="25004" crc="8306dbad" sha1="d279b8e0c3e6ea35204cf7cc3d8daa89264544ca"/>
@@ -6615,6 +7151,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Repere</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19735">
 				<rom name="repere (1985-09-13)(ustl - irem)(fr).k7" size="19735" crc="96f8d319" sha1="eacdec7ffc9a5e5b1c58b0ed5aa732cb6220b523"/>
@@ -6626,6 +7163,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Ronde de l'Eau</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13692">
 				<rom name="la ronde de l'eau (fil) (jean moreau) (1985) (mo5 k7).k7" size="13692" crc="f6bdd61b" sha1="2e435fbd5c01c01a425b3788e8e0104c7f531289"/>
@@ -6637,6 +7175,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rythmamus (v2)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23920">
 				<rom name="rythmamus v2 (1984)(logimus)(fr).k7" size="23920" crc="0d714436" sha1="276e3517ab75aa411972e9a425fdd68fa099f1f0"/>
@@ -6648,6 +7187,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rythmamus (v2, alt)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23912">
 				<rom name="rythmamus v2 (1984)(logimus)(fr)[a].k7" size="23912" crc="56bd12e7" sha1="1a95d5207ba82479c00ac6b298e70e5d31f15002"/>
@@ -6659,6 +7199,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rythmamus (v2, alt 2)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23912">
 				<rom name="rythmamus v2 (1984)(logimus)(fr)[a2].k7" size="23912" crc="6696f0f3" sha1="319ef7b619b6130bf8929f6ef7a00401ea9f94ac"/>
@@ -6670,6 +7211,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rythmamus (v2, alt 3)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23912">
 				<rom name="rythmamus v2 (1984)(logimus)(fr)[a3].k7" size="23912" crc="d2a02cdc" sha1="21a4020d4f670e3a0931a883bbdcb981d9960071"/>
@@ -6681,6 +7223,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rythmamus (v2, alt 4)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23912">
 				<rom name="rythmamus_mo5.k7" size="23912" crc="48f1570c" sha1="6e627e6f3484209f71fa86e02f1598270cf47f16"/>
@@ -6692,6 +7235,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>S.O.S. - J'apprends le Morse (v2.3)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18447">
 				<rom name="s.o.s. - j'apprends le morse v2.3 (1985)(free game blot)(fr).k7" size="18447" crc="49d5c2ed" sha1="c75f01ffc1eb4cec49c59d431b654c850f57a433"/>
@@ -6703,6 +7247,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>S.O.S. - J'apprends le Morse (v2.3, alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18447">
 				<rom name="sos-morse_mo5.k7" size="18447" crc="ef0256c7" sha1="2ee6501bd48bb280842b1b475efb5024ffa5fb80"/>
@@ -6714,6 +7259,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Secrets au Pays des Mots</description>
 		<year>1984</year>
 		<publisher>Marcel &amp; Christian</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="62812">
 				<rom name="secrets au pays des mots (marcel &amp; christian) (christian camier, marcel halberstam) (1984) (mo5 k7).k7" size="62812" crc="9f28afea" sha1="86a1640514ea3169cba5366df4b9faf3874b5913"/>
@@ -6725,6 +7271,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sich Vorstellen</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40475">
 				<rom name="sich vorstellen (1985)(fil)(fr)(de-fr).k7" size="40475" crc="239d78b7" sha1="cbf5bfa6f395eff52cd405c0ad4f9690a383532d"/>
@@ -6736,6 +7283,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sich Vorstellen (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33915">
 				<rom name="sich vorstellen (1985)(fil)(fr)(de-fr)[a].k7" size="33915" crc="27297d31" sha1="f699ddce0a4ba4b5175b707985c4b2e00d6a7af3"/>
@@ -6747,6 +7295,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sich Vorstellen (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33915">
 				<rom name="sich vorstellen (1985)(fil)(fr)(de-fr)[a2].k7" size="33915" crc="e70cee30" sha1="e6e6496c4a92b56b5b64bcde72b9739b37d2d74a"/>
@@ -6758,6 +7307,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sich Vorstellen (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33915">
 				<rom name="sich vorstellen (1985)(fil)(fr)(de-fr)[a3].k7" size="33915" crc="440a777e" sha1="4f2a5c9578b1ed4b5ad32721f279fc5334bbbd18"/>
@@ -6769,6 +7319,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sich Vorstellen (alt 4)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33915">
 				<rom name="sich-vorstellen_mo5.k7" size="33915" crc="9c3dab63" sha1="8aabd6c4a4974d48d5a3ccdbfba328f8c64a0ed6"/>
@@ -6780,6 +7331,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Des Signes dans l'Espace</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="57602">
 				<rom name="signes dans l'espace, des (1983)(vifi-nathan)(fr).k7" size="57602" crc="4ce1aa84" sha1="57a0403ebdf79242a15b8187e8037b8e9cafe314"/>
@@ -6791,6 +7343,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Des Signes dans l'Espace (alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="58709">
 				<rom name="signes dans l'espace, des (1983)(vifi-nathan)(fr)[a].k7" size="58709" crc="20a86cf0" sha1="74814169a818fd2c3a79c191a221b3ba8c06ca58"/>
@@ -6802,6 +7355,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Des Signes dans l'Espace (alt 2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="58709">
 				<rom name="signes dans l'espace, des (1983)(vifi-nathan)(fr)[a2].k7" size="58709" crc="71727121" sha1="518ed54173cdd324d09120b48619287fba2688eb"/>
@@ -6813,6 +7367,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Des Signes dans l'Espace (alt 3)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="58709">
 				<rom name="des-signes-dans-l-espace_mo5.k7" size="58709" crc="d52260a6" sha1="3719dd5616f4369af267603690320c337fef5542"/>
@@ -6824,6 +7379,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Simulation de l'Evolution d'Un Objet dans un Champ de Gravitation</description>
 		<year>1985</year>
 		<publisher>Centre National de Documentation Pedagogique (CNDP)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6448">
 				<rom name="simulation de l'evolution d'un objet dans un champ de gravitation (1985)(cndp)(fr).k7" size="6448" crc="efd8dbde" sha1="e75c456de67c902ece54ad26fdbd90108d449845"/>
@@ -6835,6 +7391,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sujet/Complement</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="17887928">
@@ -6853,6 +7410,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sujet/Complement (alt)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="18417128">
@@ -6871,6 +7429,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sujet/Complement (alt 2)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="48084">
@@ -6889,6 +7448,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Thermo</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17305">
 				<rom name="thermo (1985-09-13)(ustl - irem)(fr).k7" size="17305" crc="8d1dbaea" sha1="a2cdb6c373af9ad1a2e9bcb9342be13f727ea73b"/>
@@ -6900,6 +7460,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tissage</description>
 		<year>1985</year>
 		<publisher>Jean-Louis Sauzade</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14572">
 				<rom name="tissage (1985)(sauzade, jean-louis)(fr).k7" size="14572" crc="dab19d7c" sha1="ed41ad6812c0e3481f328c9dda5a715d0f528230"/>
@@ -6911,6 +7472,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tissage (alt)</description>
 		<year>1985</year>
 		<publisher>Jean-Louis Sauzade</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14572">
 				<rom name="tissage (1985)(sauzade, jean-louis)(fr)[a].k7" size="14572" crc="27a0430f" sha1="e720aa40b3260b3c7a92624ac1d9b30fe59b6060"/>
@@ -6922,6 +7484,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tissage (alt 2)</description>
 		<year>1985</year>
 		<publisher>Jean-Louis Sauzade</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14572">
 				<rom name="tissage_mo5.k7" size="14572" crc="9027ae52" sha1="3e6538ee43dbde842ffa56105d6c920dbffffbf2"/>
@@ -6933,6 +7496,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>TO7/MO5 a l'ecole</description>
 		<year>1985</year>
 		<publisher>Ediciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="109945">
@@ -6951,6 +7515,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vecteurs</description>
 		<year>1985</year>
 		<publisher>USTL - IREM</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17156">
 				<rom name="vecteurs (1985-09-13)(ustl - irem)(fr).k7" size="17156" crc="c4a826c4" sha1="566cdc405a1156c38c411011f24ac12c422ad324"/>
@@ -6962,6 +7527,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vin sur Vin</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64693">
 				<rom name="vin sur vin (infogrames) (francois-xavier liagre) (imagiciel) (1984) (mo5).k7" size="64693" crc="b718404c" sha1="54193a8488b73accec3c8982da43f362f21dcce4"/>
@@ -6973,6 +7539,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Voici Mona Lisa</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49569">
 				<rom name="voici mona lisa (fil) (t. hatt) (1985) (mo5).k7" size="49569" crc="aa9c3050" sha1="7da3e20934305d1d15cb3f52c9cdcbf96c3b78e4"/>
@@ -6984,6 +7551,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wormy - Junior Computhink</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29109">
 				<rom name="wormy - junior computhink (1984)(hatier)(fr).k7" size="29109" crc="0a61be8e" sha1="1f699f2ae1fb76c538f684d500a45b2af13671f1"/>
@@ -6995,6 +7563,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Zorro</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12380">
 				<rom name="zorro (1985)(fil)(fr).k7" size="12380" crc="1aa537b1" sha1="ca7abe52e5da5c00f60db8e47e080f8fbb6bb999"/>
@@ -7008,6 +7577,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1000 Bornes</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17282">
 				<rom name="1000 bornes (1985)(free game blot)(fr).k7" size="17282" crc="8aea8e72" sha1="ee9bd7d9d94b7d38386cb91f6a128468fd2848a1"/>
@@ -7019,6 +7589,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1000 Bornes (alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17282">
 				<rom name="1000 bornes (1985)(free game blot)(fr)[a].k7" size="17282" crc="9d9a85a4" sha1="0e3eebce9b2d9146fe987525ba6daf5324608ae4"/>
@@ -7030,6 +7601,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1000 Bornes (alt 2)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20114">
 				<rom name="1000 bornes (1985)(free game blot)[b].k7" size="20114" crc="21a22390" sha1="ad36270d8e3ad39047882812d6e250609d6608c5"/>
@@ -7041,6 +7613,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1000 Bornes (alt 3)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20114">
 				<rom name="1000born.k7" size="20114" crc="bce22550" sha1="2698aad5742ecbdff0e5242c057dd179cfc09a48"/>
@@ -7052,6 +7625,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1000 Bornes (alt 4)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17282">
 				<rom name="1000-bornes_mo5.k7" size="17282" crc="824ca054" sha1="b389df64c2b480dc68521296c0b4fde3f7b1dd22"/>
@@ -7063,6 +7637,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1789</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="73427">
@@ -7093,6 +7668,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1789 (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 Side A"/>
 			<dataarea name="cass" size="73427">
@@ -7123,6 +7699,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1789 (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="73427">
 				<rom name="1789-1a_mo5.k7" size="73427" crc="e983601f" sha1="25b6efe4ab9b1ec34b91beb8ca4952e7e2a83361"/>
@@ -7149,6 +7726,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1815 (v2)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51930">
 				<rom name="1815 (198x)(cobra soft)(fr)[m mo5 2nd generation].k7" size="51930" crc="24352377" sha1="d5ad5df2c3aa336c55392df6d0a4e78ed069fd04"/>
@@ -7160,6 +7738,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1815 (v2, alt)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51930">
 				<rom name="1815-v2_mo5.k7" size="51930" crc="c5fe5afa" sha1="1f2a266032f53f8fd28de0d260659accfc2a76c5"/>
@@ -7171,6 +7750,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1815 (v1)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51930">
 				<rom name="1815 (198x)(cobra soft)(fr).k7" size="51930" crc="31d12880" sha1="e6bd987a4a1504073477fa1410cfec5a4a86a8ed"/>
@@ -7182,6 +7762,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>1815 (v1, alt)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51930">
 				<rom name="1815-v1_mo5.k7" size="51930" crc="d01a510d" sha1="4066fc300a1bf994b7e6493790193fb6205cd998"/>
@@ -7206,6 +7787,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3D Fight (alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34140">
 				<rom name="3d fight (1986)(loriciels)(fr)[b].k7" size="34140" crc="cdf97c00" sha1="1c84928b851be97c9e5de4e6cad685be1176949f"/>
@@ -7218,6 +7800,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3D Fight (alt 2)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34140">
 				<rom name="3d fight (1986)(loriciels)(fr)[b2].k7" size="34140" crc="3a2dac6c" sha1="8b07249e4f452902ea2dcaffe1f8f6e3d86bf1d2"/>
@@ -7230,6 +7813,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3D Fight (alt 3)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34138">
 				<rom name="3d fight (1986)(loriciels)(fr)[b3].k7" size="34138" crc="e7aafe23" sha1="4e6c9af428ca6144c2afcc6340aa6806a91677d3" status="baddump" />
@@ -7242,6 +7826,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3D Fight (alt 4)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34140">
 				<rom name="3dfight-mo5 (k7).k7" size="34140" crc="4f41f172" sha1="8c8c1da7d48efbd92fb623d87342b3437d049419"/>
@@ -7253,6 +7838,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3D Sub</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48209">
 				<rom name="3d sub (1985)(loriciels)(fr).k7" size="48209" crc="b252051a" sha1="2e76c80ab61d353499ecda0344cddd13b9a965e2"/>
@@ -7264,6 +7850,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3D Sub (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48209">
 				<rom name="3d sub (1985)(loriciels)(fr)[a].k7" size="48209" crc="03850f6d" sha1="320b8207c09cf22fd2208526356b880070e2f523"/>
@@ -7275,6 +7862,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3D Sub (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48209">
 				<rom name="3d sub (1985)(loriciels)(fr)[a2].k7" size="48209" crc="e798db13" sha1="b1c21423a9cfe81918e5c058a3999ec01dfdbe7c"/>
@@ -7286,6 +7874,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3D Sub (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48209">
 				<rom name="3dsub_mo5.k7" size="48209" crc="5d9ecc70" sha1="a48f0cbb4e15755db0a8af988d2b5fca1d3eff52"/>
@@ -7297,6 +7886,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le 5eme Axe</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17284022">
 				<rom name="5eme axe, le (1985)(loriciels)(fr).wav" size="17284022" crc="a89e15ad" sha1="6128230563aad0fe7db0b6341eb7c657dc9f45da"/>
@@ -7308,6 +7898,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le 5eme Axe (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18873460">
 				<rom name="le-5eme-axe_mo5.wav" size="18873460" crc="d2eaa0e0" sha1="3e2defbe430895598d8140ccae4beb5c1b682a44"/>
@@ -7320,6 +7911,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le 5eme Axe (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52998">
 				<rom name="5eme axe, le (1985)(loriciels)(fr)[b].k7" size="52998" crc="c33e0138" sha1="f9dfd3b737a010cc1d4ee5cb61ee035e7312fc37"/>
@@ -7332,6 +7924,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le 5eme Axe (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52998">
 				<rom name="5eme axe, le (1985)(loriciels)(fr)[b2].k7" size="52998" crc="7de608b7" sha1="ca43ab608a18e88463925ddb8005543149381e76"/>
@@ -7344,6 +7937,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le 5eme Axe (alt 4)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52998">
 				<rom name="5eme axe (1985)(loriciels)[b].k7" size="52998" crc="844284dc" sha1="608fd89dc7609a212a3694467dff92deee90f1b4"/>
@@ -7356,6 +7950,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le 5eme Axe (alt 5)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52998">
 				<rom name="le-5eme-axe_mo5.k7" size="52998" crc="6e3757f4" sha1="d03dbb177c2f36e3d3928b5b1b16dc7740e7c55a"/>
@@ -7367,6 +7962,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les 7 Magiciens</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17281">
 				<rom name="7 magiciens, les (1984)(to tek)(fr)(m5).k7" size="17281" crc="1d047ddf" sha1="6835342e7b32a437f7d200f4960c09ba26b92770"/>
@@ -7378,6 +7974,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les 7 Magiciens (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17281">
 				<rom name="7 magiciens, les (1984)(to tek)(fr)(m5)[a].k7" size="17281" crc="ee12a6a7" sha1="2da128ec05812779c73f533e1c901b43af01cccf"/>
@@ -7389,6 +7986,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les 7 Magiciens (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17281">
 				<rom name="7 magiciens, les (1984)(to tek)(fr)(m5)[a2].k7" size="17281" crc="85c3b805" sha1="ebeeddcb3ed85f40f93f79771f61123efa36da8f"/>
@@ -7400,6 +7998,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les 7 Magiciens (alt 3)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17281">
 				<rom name="les-7-magiciens_mo5.k7" size="17281" crc="cc2da4b3" sha1="d7fc3f4f93db9f158444e63b9c052f54043bb6e8"/>
@@ -7411,6 +8010,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Une Affaire en Or</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20893">
 				<rom name="affaire en or, une (198x)(free game blot)(fr).k7" size="20893" crc="e9a2e04d" sha1="bc980a2c16e225f1916f35752df46bd38e0b8fd4"/>
@@ -7422,6 +8022,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Une Affaire en Or (alt)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22126">
 				<rom name="affaire en or, une (198x)(free game blot)(fr)[a].k7" size="22126" crc="8092be60" sha1="6f5394ad34d8540743db0e773c94f1e8d2b14b67"/>
@@ -7433,6 +8034,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Une Affaire en Or (alt 2)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22126">
 				<rom name="affaire en or, une (198x)(free game blot)(fr)[a2].k7" size="22126" crc="5db06513" sha1="0bf36e2ebd8bd797cc4aaefa4af3e0492f320bd3"/>
@@ -7444,6 +8046,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Une Affaire en Or (alt 3)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22126">
 				<rom name="une-affaire-en-or_mo5.k7" size="22126" crc="f73278b0" sha1="a29c753083ab69993e3062ac7fa946c346db8e16"/>
@@ -7456,6 +8059,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Affaire Sydney</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51542">
 				<rom name="affaire sydney, l' (1986)(infogrames)(fr)[b].k7" size="51542" crc="c2b26fc3" sha1="4f7a2bb01d0b7ac02e65de5cbf2d12bd4573e6f2"/>
@@ -7468,6 +8072,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Affaire Sydney (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51542">
 				<rom name="l'affaire sydney (infogrames) (gilles blancon) (1986).k7" size="51542" crc="d31b7c17" sha1="2485cbd8409b6d884b0c285a420e520c70152d41"/>
@@ -7480,6 +8085,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Affaire Sydney (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="53222">
 				<rom name="l-affaire-sydney_mo5.k7" size="53222" crc="5d68b3e1" sha1="8785280916a547302e3eb1627cce6abc75c2b36f"/>
@@ -7492,6 +8098,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Affaire Vera Cruz</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48020">
 				<rom name="affaire vera cruz, l' (1986)(infogrames)(fr)[b].k7" size="48020" crc="b3ab84b5" sha1="b6fa3123deb445f70a3d91eaaaddf753b02b2205"/>
@@ -7504,6 +8111,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Affaire Vera Cruz (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48020">
 				<rom name="l'affaire vera cruz (infogrames) (gilles blancon) (1986).k7" size="48020" crc="f56dea4d" sha1="6998669fbe4861f5b479106ccbb8ca21849284d0"/>
@@ -7516,6 +8124,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Affaire Vera Cruz (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49700">
 				<rom name="l-affaire-vera-cruz_mo5.k7" size="49700" crc="e6049712" sha1="9883f0a3061945703dc3c984fb168617ee6db59e"/>
@@ -7527,6 +8136,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Aigle d'Or</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40931">
 				<rom name="aigle d'or, l' (1985-02)(loriciels)(fr).k7" size="40931" crc="081bd8c9" sha1="dc2bb411ee0aeca0a5b47c465b0a8d163af67661"/>
@@ -7538,6 +8148,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Aigle d'Or (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43298">
 				<rom name="aigle d'or, l' (1985-02)(loriciels)(fr)[a].k7" size="43298" crc="f6f7a72b" sha1="5c813dcb0d68df02c557c3916ec5b8741a736d37"/>
@@ -7549,6 +8160,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Aigle d'Or (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43298">
 				<rom name="aigle d'or, l' (1985-02)(loriciels)(fr)[a2].k7" size="43298" crc="37a13834" sha1="367e8980820b41602495bdd89694feb599661f48"/>
@@ -7560,6 +8172,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Aigle d'Or (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40923">
 				<rom name="aigle d'or, l' (1985-02)(loriciels)(fr)[a3].k7" size="40923" crc="4db05ae8" sha1="b2dc7ca59204a0d136d06f654ee472feee208e5a"/>
@@ -7571,6 +8184,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Air Attack</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51108">
 				<rom name="air attack (1985)(loriciels)(fr).k7" size="51108" crc="721e741c" sha1="a19f999bcc02fa414a01dc6a6290747b734dba97"/>
@@ -7582,6 +8196,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Air Attack (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51363">
 				<rom name="air attack (1985)(loriciels)(fr)[a].k7" size="51363" crc="892d1c07" sha1="deb60e3c1605f1241199dd0046b321e8aa832f81"/>
@@ -7593,6 +8208,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Air Attack (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51363">
 				<rom name="air attack (1985)(loriciels)(fr)[a2].k7" size="51363" crc="1a586b9d" sha1="9ff613d51692b313f747fc88e92a2b5257908228"/>
@@ -7604,6 +8220,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Air Attack (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51571">
 				<rom name="air attack (microids) (m. beziat, e. grassiano) (1985) (mo5).k7" size="51571" crc="e744467e" sha1="99e4c18ec110b1c3d44850940d8a1d4d6edf0254"/>
@@ -7615,6 +8232,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Albatros</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4403">
 				<rom name="albatros, l' (198x)(-)(fr).k7" size="4403" crc="2832af9c" sha1="b2a70bd5a0c1b567927888b72afa419be867179c"/>
@@ -7626,6 +8244,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Albatros (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4403">
 				<rom name="albatros, l' (198x)(-)(fr)[a].k7" size="4403" crc="53717a18" sha1="04203937f43e470ebb41f3a6f0d652f65c84c565"/>
@@ -7637,6 +8256,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Albatros (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4403">
 				<rom name="l-albatros_mo5.k7" size="4403" crc="3d445d5a" sha1="7cc88b3ef47d60aaab05a582ada6a063b414972c"/>
@@ -7648,6 +8268,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>America's Cup</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39920">
 				<rom name="america's cup (1986)(free game blot)(fr).k7" size="39920" crc="87c6d3cc" sha1="eefd8915bff39b52b6ae76836adc2c8c002246e7"/>
@@ -7659,6 +8280,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>America's Cup (alt)</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39920">
 				<rom name="america's cup (1986)(free game blot)(fr)[a].k7" size="39920" crc="5a2944e2" sha1="34d40c4d6d7693cc0d7eb9f091075f6b98a2fa13"/>
@@ -7670,6 +8292,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6616646">
 				<rom name="androides (1985)(infogrames)(fr)[loadm'''',,r].wav" size="6616646" crc="399a1429" sha1="0e44c0ef4a311cf55de4ffb67f121ec4678a3fe6"/>
@@ -7682,6 +8305,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17705">
 				<rom name="androides (1985)(infogrames)(fr).k7" size="17705" crc="e43f1253" sha1="651b27edec2a1cc29aad6b3fe44d90e6df466666"/>
@@ -7694,6 +8318,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18257">
 				<rom name="androides (1985)(infogrames)(fr)[a].k7" size="18257" crc="0dedd2dc" sha1="c53e3e91fdf0f622a5091d9130b8148b41a47835"/>
@@ -7706,6 +8331,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides (alt 3)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18255">
 				<rom name="androides (1985)(infogrames)(fr)[b2].k7" size="18255" crc="7c03d67a" sha1="3d72861598e72fcec4dc234b90e306723d00afaf"/>
@@ -7718,6 +8344,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides (alt 4)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18255">
 				<rom name="androides (1985)(infogrames)(fr)[b3].k7" size="18255" crc="91d613f9" sha1="d1f0c1794bc2a4eb80e86fde448e6d57be77aa25"/>
@@ -7730,6 +8357,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides (Bad?)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18255">
 				<rom name="androides (1985)(infogrames)(fr)[b].k7" size="18255" crc="e0163b6d" sha1="573083d2b38f2743a72417ff489f97b8493e91c3" status="baddump" />
@@ -7741,6 +8369,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Araignees</description>
 		<year>1985</year>
 		<publisher>Microtom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5702">
 				<rom name="araignees (1985)(microtom)(fr)(pd).k7" size="5702" crc="78db2fe3" sha1="3a917432d1e01654a62e2fb9edbf00d8e9454c8f"/>
@@ -7752,6 +8381,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Araignees (alt)</description>
 		<year>1985</year>
 		<publisher>Microtom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6014">
 				<rom name="araignees (1985)(microtom)(fr)(pd)[a].k7" size="6014" crc="f3ed32e8" sha1="46138fca03737608f3a56f65b7e5fc4e139a4901"/>
@@ -7763,6 +8393,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Araignees (alt 2)</description>
 		<year>1985</year>
 		<publisher>Microtom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6014">
 				<rom name="araignees (1985)(microtom)(fr)(pd)[a2].k7" size="6014" crc="26fa4d20" sha1="61f12afb40361d785696e5d153b5631db975aacc"/>
@@ -7774,6 +8405,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Araignees (alt 3)</description>
 		<year>1985</year>
 		<publisher>Microtom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6014">
 				<rom name="araignees_mo5.k7" size="6014" crc="776d4b00" sha1="f17990c75247d50f7c734dbfe9b771a03371c65b"/>
@@ -7785,6 +8417,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arkanoid</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29054">
 				<rom name="arkanoid (1987)(fil)(fr).k7" size="29054" crc="8f6b0676" sha1="af1dae5512bb1bd3d87c2b2c6fcd06d845c5c4ce"/>
@@ -7796,6 +8429,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arkanoid (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29054">
 				<rom name="arkanoid (1987)(fil)(fr)[a].k7" size="29054" crc="e3fe50d0" sha1="d8e43fbf1320fa93d3844aff0ef65c27f32fb9d9"/>
@@ -7807,6 +8441,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arkanoid (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29054">
 				<rom name="arkanoid (fil) (james higgins) (1987) (mo5).k7" size="29054" crc="76e7a3e3" sha1="1cb9d8cb1f82510a62b0b221bc95830a1d5c495d"/>
@@ -7818,6 +8453,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arkanoid (Trained +2 by Yoan Roiu)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28975">
 				<rom name="arkanoid (1987)(fil)(fr)[t +2 yoan riou].k7" size="28975" crc="dbb3683e" sha1="6594f562feca732862d533d7932852439d1960e4"/>
@@ -7829,6 +8465,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Armada</description>
 		<year>1984</year>
 		<publisher>Langage et Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6033">
 				<rom name="armada (langage et informatique) (j. salon) (1984) (mo5).k7" size="6033" crc="bff29785" sha1="e6fbe8a35fc894379f2cfcba24f4bcf1dcb93f42"/>
@@ -7840,6 +8477,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arsene Lapin</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33520">
 				<rom name="arsene lapin (1984)(infogrames)(fr).k7" size="33520" crc="a43d80f1" sha1="8528b1eeaaac687ceff577c5468839c7b71ca7a2"/>
@@ -7851,6 +8489,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arsene Lapin (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33520">
 				<rom name="arsene lapin (1984)(infogrames)(fr)[a].k7" size="33520" crc="1f660955" sha1="6401b1683958045ef1116b826e6cbaf56a9bc8a6"/>
@@ -7862,6 +8501,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arsene Lapin (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33520">
 				<rom name="arsene-lapin_mo5.k7" size="33520" crc="c767e17f" sha1="d87a531792930b06f2df0033a2731766d6e12d03"/>
@@ -7873,6 +8513,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Asterix et la Potion Magique</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45106">
 				<rom name="asterix et la potion magique (198x)(fil)(fr).k7" size="45106" crc="916d74de" sha1="1ada057a26fdfc0137d6ecd94b1a709b898a5444"/>
@@ -7884,6 +8525,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Asterix et la Potion Magique (alt)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47655">
 				<rom name="asterix et la potion magique (198x)(fil)(fr)[a].k7" size="47655" crc="493fba03" sha1="512ec0b610b969ca802cdbd5dd64f6f5b9c14f03"/>
@@ -7895,6 +8537,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Asterix et la Potion Magique (alt 2)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47655">
 				<rom name="asterix et la potion magique (198x)(fil)(fr)[a2].k7" size="47655" crc="45a93e6d" sha1="392f16b2db949f8239e01534f0cc7e68e009846c"/>
@@ -7906,6 +8549,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Asterix et la Potion Magique (alt 3)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47655">
 				<rom name="asterix-et-la-potion-magique_mo5.k7" size="47655" crc="23a6a1ba" sha1="2d1293ef935c38b71a4fdded6568c4d2950828b9"/>
@@ -7917,6 +8561,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Astromus</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24649">
 				<rom name="astromus (1984)(logimus)(fr).k7" size="24649" crc="bf8a905a" sha1="d5a3f48bd1046b66b975eab6c6e7739142ab9d4a"/>
@@ -7928,6 +8573,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Astromus (alt)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24768">
 				<rom name="astromus (1984)(logimus)(fr)[a].k7" size="24768" crc="741b3c57" sha1="92b5655f7e2cacba31417c45575439742ec8adf9"/>
@@ -7939,6 +8585,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Astromus (alt 2)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24768">
 				<rom name="astromus (1984)(logimus)(fr)[a2].k7" size="24768" crc="e5933eaf" sha1="e863671ff5b60bc1f5dc39c98305d1888815fd91"/>
@@ -7950,6 +8597,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Astromus (alt 3)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24768">
 				<rom name="astromus (1984)(logimus)(fr)[a3].k7" size="24768" crc="b30d392d" sha1="102d49e4475318883597e58d9d496db6c086d951"/>
@@ -7961,6 +8609,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Astromus (alt 4)</description>
 		<year>1984</year>
 		<publisher>Logimus</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24768">
 				<rom name="astromus_mo5.k7" size="24768" crc="4c316117" sha1="17ce1273360281d0fb9bcec0ff11a1c7df9b62ba"/>
@@ -7972,6 +8621,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Atlantis</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43299">
 				<rom name="atlantis (cobrasoft) (serge querne) (1985) (mo5 k7).k7" size="43299" crc="77d11762" sha1="e961a1f745a258ce6f4093b332be82e19b15fdd5"/>
@@ -7983,6 +8633,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Atomik</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31457">
 				<rom name="atomik (1987)(fil)(fr).k7" size="31457" crc="715fe631" sha1="9d6ad879c1404bb5df0a71e001410d5a75ad882b"/>
@@ -7994,6 +8645,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Atomik (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31709">
 				<rom name="atomik (1987)(fil)(fr)[a].k7" size="31709" crc="5e149fea" sha1="325b8c042a90a455322384421550ac7bf7f3fbcd"/>
@@ -8005,6 +8657,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Atomik (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31709">
 				<rom name="atomik (1987)(fil)(fr)[a2].k7" size="31709" crc="509545e4" sha1="44304d62b231c3747655fdead89bfec0e0e2ebb0"/>
@@ -8016,6 +8669,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Atomik (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31709">
 				<rom name="atomik_mo5.k7" size="31709" crc="1c68f03b" sha1="a202e3afacdc1b305fc0b2d9ab963e60030e2cbc"/>
@@ -8027,6 +8681,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Avenger</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51067">
 				<rom name="avenger (1986)(fil)(fr).k7" size="51067" crc="4187026a" sha1="a96685478a82e7f42e88a7d341e192c3749b07d5"/>
@@ -8038,6 +8693,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Avenger (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51354">
 				<rom name="avenger (1986)(fil)(fr)[a].k7" size="51354" crc="fef353b6" sha1="cfe2d7ffbc697e998c95d8775855dcfcc56ddb05"/>
@@ -8049,6 +8705,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Avenger (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51354">
 				<rom name="avenger (1986)(fil)(fr)[a2].k7" size="51354" crc="f097faa8" sha1="633e56b52ee2ff433a4386b9172e463a432c8336"/>
@@ -8060,6 +8717,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Avenger (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51354">
 				<rom name="avenger_mo5.k7" size="51354" crc="77a91490" sha1="0167c7f3efa47a966439019c075c4b7d88af765b"/>
@@ -8071,6 +8729,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Avenger (alt 4?)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="55046">
 				<rom name="avenger.k7" size="55046" crc="c92ccf6f" sha1="a80661b4c023d0df7eff72d8a598b74d36883fdc"/>
@@ -8082,6 +8741,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Backgammon</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17693">
 				<rom name="backgammon (1984)(vifi-nathan)(fr).k7" size="17693" crc="8dc00333" sha1="8e042ac6aa0a49bfd914d1dcecf47a5a8c593f3b"/>
@@ -8093,6 +8753,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Backgammon (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17693">
 				<rom name="backgammon (1984)(vifi-nathan)(fr)[a].k7" size="17693" crc="b9d931e6" sha1="1604e9d1ff8fe9ff9d149b450027c6636e113034"/>
@@ -8104,6 +8765,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Backgammon (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17693">
 				<rom name="backgammon (1984)(vifi-nathan)(fr)[a2].k7" size="17693" crc="1641bae4" sha1="ff805139f8317a365661abfbff0bae6ce98ba92e"/>
@@ -8115,6 +8777,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Backgammon (alt 3)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17693">
 				<rom name="backgammon_mo5.k7" size="17693" crc="2dc3ff38" sha1="a02875395ba52aed2a6fb6b952bdc20a8f3acfda"/>
@@ -8126,6 +8789,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Bagh Chal</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16637">
 				<rom name="bag chal ou la tactique du tigre, le (1985)(free game blot)(fr).k7" size="16637" crc="679f75e9" sha1="918da48e861974d5f745e9ca2824ca2c5fe285d2"/>
@@ -8137,6 +8801,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Bagh Chal (alt)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16637">
 				<rom name="bag chal ou la tactique du tigre, le (1985)(free game blot)(fr)[a].k7" size="16637" crc="d6711009" sha1="cf5c163a07968bec5c6804e9a7f397db36f2236d"/>
@@ -8148,6 +8813,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Bagh Chal (alt 2)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16637">
 				<rom name="le-bagh-chal_mo5.k7" size="16637" crc="efb45946" sha1="51515251d8251ba832068cef200f956c56a7ad82"/>
@@ -8159,6 +8825,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balade en Ballon</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28289">
 				<rom name="balade en ballon (1985)(sprites)(fr).k7" size="28289" crc="874da006" sha1="2e6b1e056e8260bd4edf0e450615664da0e32665"/>
@@ -8170,6 +8837,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balade en Ballon (alt)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28289">
 				<rom name="balade en ballon (1985)(sprites)(fr)[a].k7" size="28289" crc="90c5f03f" sha1="c85cc608b03737c3369e0857975950ee7d81772f"/>
@@ -8181,6 +8849,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balade en Ballon (alt 2)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28289">
 				<rom name="balade en ballon (1985)(sprites)(fr)[a2].k7" size="28289" crc="f09cf0d3" sha1="4f205ff4c48a383f9585ab57c793b3b878918e31"/>
@@ -8192,6 +8861,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balade en Ballon (alt 3)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36193">
 				<rom name="balade en ballon (sprites) (gilbert berot) (1985) (mo5).k7" size="36193" crc="1ca943d7" sha1="dd5db3935dc41e8c942fd1fc16870cd9c13fa663"/>
@@ -8203,6 +8873,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ball Trap</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21651">
 				<rom name="ball trap (sprites) (1985) (mo5).k7" size="21651" crc="930f2c09" sha1="cd9a69578a557f165a9ed59ad7c7c4a750d605ef"/>
@@ -8214,6 +8885,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balthazar</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43445">
 				<rom name="balthazar (1987)(titus software)(fr).k7" size="43445" crc="eb8d52ef" sha1="1fcb6f63627a976e57550280fd25bdf60cf350a3"/>
@@ -8225,6 +8897,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balthazar (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43604">
 				<rom name="balthazar (1987)(titus software)(fr)[a].k7" size="43604" crc="ebba62fe" sha1="c98a6e6c84790a5b3e775ee6ec97cb740f9cc8d7"/>
@@ -8236,6 +8909,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balthazar (alt 2)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43604">
 				<rom name="balthazar (1987)(titus software)(fr)[a2].k7" size="43604" crc="89e842d0" sha1="3200ab019faadb838741a9899294584be71df603"/>
@@ -8247,6 +8921,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balthazar (alt 3)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43604">
 				<rom name="balthazar_mo5.k7" size="43604" crc="e76630c3" sha1="d3b6197caa684c1c61c147717537be63fbbe73d0"/>
@@ -8258,6 +8933,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Barry McGuigan Championship Boxing</description>
 		<year>198?</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35419">
 				<rom name="barry mcguigan championship boxing (198x)(microids)(fr).k7" size="35419" crc="8085d757" sha1="bc670d997ff6fc38e2027437b3fcf338d93cb5f8"/>
@@ -8269,6 +8945,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Barry McGuigan Championship Boxing (alt)</description>
 		<year>198?</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35634">
 				<rom name="barry mcguigan championship boxing (198x)(microids)(fr)[a].k7" size="35634" crc="bf63f92f" sha1="233988a7ea077e3bdeb515ea45b61a983b6a627d"/>
@@ -8280,6 +8957,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Barry McGuigan Championship Boxing (alt 2)</description>
 		<year>198?</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35634">
 				<rom name="barry mcguigan championship boxing (198x)(microids)(fr)[a2].k7" size="35634" crc="96a37b54" sha1="af0963bcbdbbb36fb33bbf98da71b49aab7e9363"/>
@@ -8291,6 +8969,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Beach-Head</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27830">
 				<rom name="bh 1055 face b.k7" size="27830" crc="9a1a11e0" sha1="4e77b5723cd4dc48b37c5d11f94e51cae74b42fb"/>
@@ -8302,6 +8981,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Beach-Head (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27830">
 				<rom name="bh 1055 face b [a].k7" size="27830" crc="63d330b4" sha1="4625a2b3e5d864e62c1346cb0e2267cc15d8729a"/>
@@ -8313,6 +8993,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Beach-Head (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27830">
 				<rom name="bh 1055 face b [a2].k7" size="27830" crc="66865526" sha1="85b9d09806ab3d176f586267a3170ca7fd921026"/>
@@ -8324,6 +9005,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Beach-Head (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27830">
 				<rom name="beach-head_mo5.k7" size="27830" crc="5eeab28e" sha1="827ef11f95d27fdcd1e983e8849013be8aeb9597"/>
@@ -8335,6 +9017,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bidul</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11007">
 				<rom name="bidul (1984)(infogrames)(fr).k7" size="11007" crc="fd4507d8" sha1="a137be097293cef9a7ab61c993483539240f96ca"/>
@@ -8346,6 +9029,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bidul (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11007">
 				<rom name="bidul (1984)(infogrames)(fr)[a].k7" size="11007" crc="0478846e" sha1="b5ecf776c79545704c4851b61ebfaefc46093438"/>
@@ -8357,6 +9041,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bidul (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11007">
 				<rom name="bidul_mo5.k7" size="11007" crc="bc8ce84f" sha1="ca864e43da54724d99c171b115456c1dab5412a2"/>
@@ -8368,6 +9053,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Billard Americain (Hebdogiciel no. 84)</description>
 		<year>1985</year>
 		<publisher>Jean-Pierre Quelo - Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7562">
 				<rom name="billardamericain.k7" size="7562" crc="fa85bb96" sha1="5b53f1fedc7fe0fc6b6447968ac7ddd0b33bc83f"/>
@@ -8379,6 +9065,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blitz Krieg</description>
 		<year>198?</year>
 		<publisher>Francis Malard</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13372">
 				<rom name="blitz krieg (198x)(malard, francis)(fr)(pd).k7" size="13372" crc="148c5dfc" sha1="281a17443e11dbd61df6d31978149590cf4eb9aa"/>
@@ -8390,6 +9077,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blitz Krieg (alt)</description>
 		<year>198?</year>
 		<publisher>Francis Malard</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13372">
 				<rom name="blitz krieg (198x)(malard, francis)(fr)(pd)[a].k7" size="13372" crc="6b9d8774" sha1="e2dd865e005d3755b16b53772114c112ec343b7e"/>
@@ -8401,6 +9089,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blitz Krieg (alt 2)</description>
 		<year>198?</year>
 		<publisher>Francis Malard</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13372">
 				<rom name="blitz krieg (198x)(malard, francis)(fr)(pd)[a2].k7" size="13372" crc="e00d806d" sha1="8bf4b8f984dbc2f3869da3bcbc8a294802f037aa"/>
@@ -8412,6 +9101,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blitz Krieg (alt 3)</description>
 		<year>198?</year>
 		<publisher>Francis Malard</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13372">
 				<rom name="blitz-krieg_mo5.k7" size="13372" crc="2a5dbd34" sha1="c692550ba2332c84f7e8426e6498d067376b3426"/>
@@ -8423,6 +9113,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blue War</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38315">
 				<rom name="blue war - le bateau (1986)(free game blot)(fr).k7" size="38315" crc="94f07b56" sha1="aa6c2ad03e17ffb190816e14a0d83641eacbedaf"/>
@@ -8434,6 +9125,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blue War (alt)</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38315">
 				<rom name="blue war (1986)(free game blot).k7" size="38315" crc="4aca3466" sha1="36cb790e3cd1da59b8080b314f366c1fda5a379d"/>
@@ -8445,6 +9137,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blue War (alt 2)</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38315">
 				<rom name="blue-war_mo5.k7" size="38315" crc="c8c191f3" sha1="b6877f6e764b71475447b449e5cdeab3bff29efe"/>
@@ -8456,6 +9149,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bomber</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8391">
 				<rom name="bomber (1986)(hebdogiciel)(fr)(pd).k7" size="8391" crc="cb84e6fa" sha1="ef3aba24162a7c04f8acf38ad84573b717bdbcef"/>
@@ -8467,6 +9161,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bomber (alt)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8391">
 				<rom name="bomber (1986)(hebdogiciel)(fr)(pd)[a].k7" size="8391" crc="c6e47553" sha1="da680c3578d5725b99ba1af93cd14ee2bd83bc60"/>
@@ -8478,6 +9173,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bomber (alt 2)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8391">
 				<rom name="bomber (19xx)(hebdogiciel)(pd).k7" size="8391" crc="1add4de5" sha1="c3b9d3387816b197e9f43614baaf594dc38c6be2"/>
@@ -8489,6 +9185,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bomber (alt 3)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8391">
 				<rom name="bomber_mo5.k7" size="8391" crc="95f3827c" sha1="dd0ffc030abf049dc8e104dd4666f2a22317e734"/>
@@ -8500,6 +9197,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Boufy</description>
 		<year>198?</year>
 		<publisher>Merien Ronan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17772">
 				<rom name="boufy (198x)(ronan, merien)(fr).k7" size="17772" crc="7bc2a8f3" sha1="65e05499d33549d2f8f8d1f53c353418aa6040bf"/>
@@ -8511,6 +9209,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Boufy (alt)</description>
 		<year>198?</year>
 		<publisher>Merien Ronan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17772">
 				<rom name="boufy (198x)(ronan, merien)(fr)[a].k7" size="17772" crc="33f797d0" sha1="5ef2bc17b5c76fbb75ce29d68123edc6ffc68b38"/>
@@ -8522,6 +9221,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Boufy (alt 2)</description>
 		<year>198?</year>
 		<publisher>Merien Ronan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17772">
 				<rom name="boufy_mo5.k7" size="17772" crc="8fb23f19" sha1="5413ce0370a2dbe03ba91ce1e99e6661970a7773"/>
@@ -8533,6 +9233,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bowling Fou</description>
 		<year>1985</year>
 		<publisher>Brunosoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14379">
 				<rom name="bowling fou (1985)(brunosoft)(fr).k7" size="14379" crc="7c9a0275" sha1="fce9d946d4d94d92f88c9ebdb700d55f56c19788"/>
@@ -8544,6 +9245,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bowling Fou (alt)</description>
 		<year>1985</year>
 		<publisher>Brunosoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14379">
 				<rom name="bowling fou (1985)(brunosoft)(fr)[a].k7" size="14379" crc="1ad8eba2" sha1="fb2d9e107d3d3d25e8339af66a9411bb479e0328"/>
@@ -8555,6 +9257,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bowling Fou (alt 2)</description>
 		<year>1985</year>
 		<publisher>Brunosoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14379">
 				<rom name="bowling-fou_mo5.k7" size="14379" crc="7c9f1588" sha1="da5fc718bf9b1a87e7846676f11c6a7b9ce0d6c4"/>
@@ -8566,6 +9269,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Brain Power</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="82480">
 				<rom name="brain power (1987)(softbook)(fr).k7" size="82480" crc="40ae75c7" sha1="3c65d21cfbe0c1e99ba80edd82cf381e05cf9bf1"/>
@@ -8577,6 +9281,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Brain Power (alt)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="82480">
 				<rom name="brain power (1987)(softbook)(fr)[a].k7" size="82480" crc="6e6ff441" sha1="231e9e4f3f8734210299253cd2c7fc39920aee8d"/>
@@ -8588,6 +9293,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Brain Power (alt 2)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="82472">
 				<rom name="brain power (softbook) (inconnus) (1987) (mo5).k7" size="82472" crc="6dd1baef" sha1="2e23334926675bc15cd7370ff62ab9154a25371a"/>
@@ -8599,6 +9305,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Brain Power (WAV format)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24431561">
 				<rom name="brain power (1987)(softbook)(fr).wav" size="24431561" crc="f2cb42e9" sha1="a9aa9c1cdcb6753aa878d2fcc897d69732e7ac8e"/>
@@ -8611,6 +9318,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Brigade du Feu</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32679">
 				<rom name="brigade du feu (1985)(coktel vision)(fr)[b].k7" size="32679" crc="f1f96c4f" sha1="57fe6203a07135e181bc1992af8a7c47a6ca9ffc"/>
@@ -8622,6 +9330,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Buds</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20544">
 				<rom name="buds (1984)(to tek)(fr).k7" size="20544" crc="fadb00d9" sha1="76d8c8cfb6974fc3b0a1c17917a774c5c7c87e3e"/>
@@ -8633,6 +9342,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Buds (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20544">
 				<rom name="buds (1984)(to tek)(fr)[a].k7" size="20544" crc="82b8008c" sha1="714e11d5edb254e6371dfebbbc8ceb5bd5630f91"/>
@@ -8644,6 +9354,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Buds (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20544">
 				<rom name="buds (1984)(to tek)(fr)[a2].k7" size="20544" crc="cb9b5def" sha1="3de499300342c6b1d19fca44a4a4f0635e9c5e54"/>
@@ -8655,6 +9366,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Buds (alt 3)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20544">
 				<rom name="buds_mo5.k7" size="20544" crc="516619f1" sha1="4bc1d367374dd7d4f91025b19857eb51e8ccde99"/>
@@ -8666,6 +9378,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bus</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6074">
 				<rom name="bus (1986-09-09)(rubier, javier marco)(es).k7" size="6074" crc="82b8c659" sha1="536cdb142bbb0ef03eab698a489e8c757372afc7"/>
@@ -8677,6 +9390,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bus (alt)</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6074">
 				<rom name="bus (1986-09-09)(marco rubio, javier)(es)[a].k7" size="6074" crc="cb1a6000" sha1="d421eafdc14a8250d59f753890c20d723c86e2d6"/>
@@ -8688,6 +9402,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Bus (alt 2)</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6074">
 				<rom name="bus_mo5.k7" size="6074" crc="173de304" sha1="9e7bbb9fa99be77afe613460d09e2cf5eb712213"/>
@@ -8699,6 +9414,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Business+</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23433">
 				<rom name="business+ (1986)(fil)(fr).k7" size="23433" crc="649af866" sha1="02dba608ae005066eadbe4bafdf2243185ddc1f8"/>
@@ -8710,6 +9426,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Business+ (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23433">
 				<rom name="business+ (1986)(fil)(fr)[m title screen].k7" size="23433" crc="b5201026" sha1="25c5132904c4d87a4a2288e61d29cf5fbb4929f9"/>
@@ -8721,6 +9438,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Business+ (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23433">
 				<rom name="business+ (1986)(fil)(fr)[m2 title screen].k7" size="23433" crc="d18e7673" sha1="efe6d334f5dfd4b7270a457ae77a0436fbd2a802"/>
@@ -8732,6 +9450,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Business+ (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23433">
 				<rom name="business_mo5.k7" size="23433" crc="f532244f" sha1="e7bf82c3b358b6cb9f87abb7fc9cf4e5fbbddd55"/>
@@ -8743,6 +9462,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cap Horn</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23932">
 				<rom name="cap horn (198x)(coktel vision)(fr).k7" size="23932" crc="94f6a28a" sha1="dcbd9972305d1c5af77d91dbe655f4724c3146ad"/>
@@ -8754,6 +9474,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cap Horn (alt)</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23932">
 				<rom name="cap horn (198x)(coktel vision)(fr)[a].k7" size="23932" crc="46309d45" sha1="0931ee2d67ba2a69af18a8e70056741c50207837"/>
@@ -8765,6 +9486,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cap Horn (alt 2)</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23932">
 				<rom name="cap horn (198x)(coktel vision)(fr)[a2].k7" size="23932" crc="1a27e819" sha1="5c0a2ba962ef19a938f3a4c09238bcbdc8804c15"/>
@@ -8776,6 +9498,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cap Horn (alt 3)</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23932">
 				<rom name="cap-horn_mo5.k7" size="23932" crc="7bb19291" sha1="2570884ce3cca47455a86e701f982a551d168d3a"/>
@@ -8787,6 +9510,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cap sur Dakar</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44826">
 				<rom name="cap sur dakar (1985)(coktel vision)(fr).k7" size="44826" crc="e244996e" sha1="3433fae662a328d24412f44895d8f65582ccdf62"/>
@@ -8798,6 +9522,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cap sur Dakar (alt)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44991">
 				<rom name="cap sur dakar (1985)(coktel vision)(fr)[a].k7" size="44991" crc="35023a2a" sha1="1c9f5a17528b05e5c807909c316f6696f851af8a"/>
@@ -8809,6 +9534,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cap sur Dakar (alt 2)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44991">
 				<rom name="cap sur dakar (1985)(coktel vision)(fr)[a2].k7" size="44991" crc="7629d1b3" sha1="6a73c465e76d2fce7df1021c4c059e2a572417d9"/>
@@ -8820,6 +9546,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cap sur Dakar (alt 3)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44991">
 				<rom name="cap sur dakar (coktel vision) (inconnus) (1985) (mo5).k7" size="44991" crc="df787752" sha1="7c776aeb2e0fdb8931da3b38cfaa7277ad86d9c9"/>
@@ -8831,6 +9558,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cassebrique</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8762">
 				<rom name="cassebrique (1986-04-01)(hebdogiciel)(fr)(pd).k7" size="8762" crc="707a1fdc" sha1="28b457ccd8e66967d5532fb0e39ef4b003320ff0"/>
@@ -8842,6 +9570,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cassebrique (alt)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8762">
 				<rom name="cassebrique (1986-04-01)(hebdogiciel)(fr)(pd)[a].k7" size="8762" crc="8df2a959" sha1="12f7abad21ad732d20f6f4c73c5a955ace825a0f"/>
@@ -8853,6 +9582,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cassebrique (alt 2)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8762">
 				<rom name="cassebrique (1986-04-01)(hebdogiciel)(fr)(pd)[a2].k7" size="8762" crc="63b04169" sha1="4f1eb6d1ae79811ef189cf9b5bef16a7141e8d14"/>
@@ -8864,6 +9594,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cassebrique (alt 3)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8762">
 				<rom name="cassebrique_mo5.k7" size="8762" crc="74844fad" sha1="27672a113b08c81621c43972ce963f11e8594541"/>
@@ -8875,6 +9606,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Catapulte</description>
 		<year>1984</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7258">
 				<rom name="catapulte (1984)(hebdogiciel)(fr)(pd).k7" size="7258" crc="b372519e" sha1="a481634016c21fcab76f36ab3a4c24a4b96fef40"/>
@@ -8886,6 +9618,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Catapulte (alt)</description>
 		<year>1984</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7258">
 				<rom name="catapulte_mo5.k7" size="7258" crc="925b8e09" sha1="2bd7655584eb996f47355e732c2d13617de445f9"/>
@@ -8897,6 +9630,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Categoric</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32809">
 				<rom name="categoric (1984)(no man's land)(fr).k7" size="32809" crc="582e7ea4" sha1="a551635fdea1e80b99eedc644863ee2ad49fb07d"/>
@@ -8908,6 +9642,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Categoric (alt)</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32809">
 				<rom name="categoric (1984)(no man's land)(fr)[a].k7" size="32809" crc="0c7edfc9" sha1="34bd445945741f5196f85067633bec5c3da3993e"/>
@@ -8919,6 +9654,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Categoric (alt 2)</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32809">
 				<rom name="categoric_mo5.k7" size="32809" crc="59d197ae" sha1="62e5ff02d1bee7191b062d724b9cdbdf4ed16895"/>
@@ -8930,6 +9666,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Cavernes de Thenebe</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="71428">
 				<rom name="cavernes de thenebe, les (198x)(softbook)(fr).k7" size="71428" crc="58b12548" sha1="991c4de9752f17d8061fd3a70ed67100300d1aae"/>
@@ -8941,6 +9678,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Cavernes de Thenebe (alt)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="71428">
 				<rom name="cavernes de thenebe, les (198x)(softbook)(fr)[a].k7" size="71428" crc="4c134f51" sha1="6155013daf0c4d043fec42bcdffc8391a081b6a9"/>
@@ -8952,6 +9690,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Cavernes de Thenebe (alt 2)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="71428">
 				<rom name="les-cavernes-de-thenebe_mo5.k7" size="71428" crc="5756b36a" sha1="4ff6f1c3934a4e67bf5476ec1b5baa2a7cdf9715"/>
@@ -8963,6 +9702,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Challenge Voile</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22569">
 				<rom name="challenge voile (1984-10)(loriciels)(fr).k7" size="22569" crc="e066303c" sha1="880363b1cf293e8f7d0a9cf6a60c1d5bb4c4cb00"/>
@@ -8974,6 +9714,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Challenge Voile (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22569">
 				<rom name="challenge voile (1984-10)(loriciels)(fr)[a].k7" size="22569" crc="4a7b05a7" sha1="cb8a631595126c7914634430133e62532fc12a76"/>
@@ -8985,6 +9726,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Challenge Voile (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22569">
 				<rom name="challenge-voile_mo5.k7" size="22569" crc="b5f3083a" sha1="68a7f6905b95cbc94aa34d2451def292e2cdb576"/>
@@ -8996,6 +9738,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Chasseur Omega</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6479">
 				<rom name="chasseur omega (1983)(infogrames)(fr).k7" size="6479" crc="0f5e91d5" sha1="7ff3a845709cd36fccce9b83c662eeca27c1e04b"/>
@@ -9007,6 +9750,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Chasseur Omega (alt)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6479">
 				<rom name="chasseur omega (1983)(infogrames)(fr)[a].k7" size="6479" crc="d942ff44" sha1="c1caa863d7f99e1c4ddb38fe0ccfaa131cfc88c1"/>
@@ -9018,6 +9762,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Chasseur Omega (alt 2)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6479">
 				<rom name="chasseur-omega_mo5.k7" size="6479" crc="cb83d621" sha1="949b4606f0c773b002de5d441b57bcf0d8f3c6e1"/>
@@ -9029,6 +9774,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Chateau de la Mort</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23249">
 				<rom name="chateau de la mort, le (1985)(cobrasoft)(fr).k7" size="23249" crc="6dcf3f7c" sha1="ec7eccae1f627965e25bbaa49e731bcf60922776"/>
@@ -9040,6 +9786,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Chateau Noir et Dragons Rouges</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32232">
 				<rom name="chateau noir et dragons rouges (1985)(vifi-nathan)(fr).k7" size="32232" crc="9b7d8e91" sha1="af0e2420e9b4d9f6e478461c398e6b9a308cf13e"/>
@@ -9051,6 +9798,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Chateau Noir et Dragons Rouges (alt)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32190">
 				<rom name="chateau noir et dragons rouges (1985)(vifi-nathan)(fr)[a].k7" size="32190" crc="2a3ac61e" sha1="6e0ba65b5bdc6f78ac3b2cc856f88d3adbb9b84e"/>
@@ -9062,6 +9810,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Chateau Noir et Dragons Rouges (alt 2)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32190">
 				<rom name="chateau noir et dragons rouges (1985)(vifi-nathan)(fr)[a2].k7" size="32190" crc="600d19db" sha1="38f011355f8eba39d37b5c1960833c7ea62cae70"/>
@@ -9073,6 +9822,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Chateau Noir et Dragons Rouges (alt 3)</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32190">
 				<rom name="chateau-noir-et-dragons-rouges_mo5.k7" size="32190" crc="905afad0" sha1="e75cb2022bc1ab3a82e1202f4ceed32b067f469d"/>
@@ -9084,6 +9834,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Clinique du Docteur Spounz (Hebdogiciel no. 77-78)</description>
 		<year>1985</year>
 		<publisher>Jean-Yves Le Friec - Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28417">
 				<rom name="spounz1_mo5.k7" size="28417" crc="8e24d10a" sha1="c8933480e885e9f344e0c99dc5e0ffa406e78890"/>
@@ -9095,6 +9846,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cocotte</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16168">
 				<rom name="cocotte (1985)(fil)(fr).k7" size="16168" crc="599cfd41" sha1="093801baaf2d94fe6a8d90d7d9a68a11378a19ca"/>
@@ -9106,6 +9858,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coliseum</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51399">
 				<rom name="coliseum (1985)(loriciels)(fr).k7" size="51399" crc="16142072" sha1="a9f2489ebae1638de7973d38b447a751433c682c"/>
@@ -9117,6 +9870,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coliseum (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51790">
 				<rom name="coliseum (1985)(loriciels)(fr)[a].k7" size="51790" crc="2845ba3f" sha1="f85325d5d70c8d75a543d5bbf9993e822d6c6728"/>
@@ -9128,6 +9882,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coliseum (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51790">
 				<rom name="coliseum (1985)(loriciels)(fr)[a2].k7" size="51790" crc="4d0e0266" sha1="bbd41b8045b5e50c1c6d750f1acd997edc5c3e20"/>
@@ -9139,6 +9894,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coliseum (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51790">
 				<rom name="coliseum_mo5.k7" size="51790" crc="0eceaee4" sha1="fc72b4e409dcf204e05406c71a773510196058db"/>
@@ -9150,6 +9906,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coloric</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5718">
 				<rom name="coloric (1984)(free game blot)(fr).k7" size="5718" crc="6a5a221e" sha1="af65ba7cff2923975c4ba353568e145a0233582b"/>
@@ -9161,6 +9918,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coloric (alt)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5718">
 				<rom name="coloric (1984)(free game blot)(fr)[a].k7" size="5718" crc="8fd53734" sha1="305f2a9c044fdecaab706e69ff9519d1370f75c8"/>
@@ -9172,6 +9930,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coloric (alt 2)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5718">
 				<rom name="coloric_mo5.k7" size="5718" crc="30af55d8" sha1="915d4534f0f1eefe9ef4121155536445e0eb2bc0"/>
@@ -9183,6 +9942,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Contes de Monte-Crypto</description>
 		<year>1988</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48697">
 				<rom name="les-contes-de-monte-crypto_mo5.k7" size="48697" crc="2745fdc3" sha1="f546f545b69154d56e5b3c1bcf3330fc8202c0ac"/>
@@ -9194,6 +9954,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Contes de Monte-Crypto (WAV format)</description>
 		<year>1988</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26906246">
 				<rom name="les-contes-de-monte-crypto_mo5.wav" size="26906246" crc="00b2162b" sha1="0369c7662e116ba89aa3970291e9b62720ccc757"/>
@@ -9205,6 +9966,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coq Inn</description>
 		<year>1984</year>
 		<publisher>VIFI International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51550">
 				<rom name="coq inn (1984)(vifi)(fr).k7" size="51550" crc="3836a66e" sha1="1fec9c768a60d91093a2a6fe5efd562f5c10c622"/>
@@ -9216,6 +9978,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coq Inn (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51550">
 				<rom name="coq inn (1984)(vifi)(fr)[a].k7" size="51550" crc="e519c464" sha1="2c3bd27b4c7faa0f515ceeb37e0e8cef067e1843"/>
@@ -9227,6 +9990,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coq Inn (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51550">
 				<rom name="coq inn (1984)(vifi)(fr)[a2].k7" size="51550" crc="35300727" sha1="f1b96d280dae37bbaaaa5159f4ae40c476077e30"/>
@@ -9238,6 +10002,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Coq Inn (alt 3)</description>
 		<year>1984</year>
 		<publisher>VIFI International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="51550">
 				<rom name="coq-inn_mo5.k7" size="51550" crc="df5fda6f" sha1="2fd7292412f8b8e6861a9f307461829f46555aa3"/>
@@ -9249,6 +10014,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crocky II</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17362">
 				<rom name="crocky ii (1984-09)(loriciels)(fr).k7" size="17362" crc="dac3535e" sha1="d2c5b4504c8023f28aeccfd1d3c7c1ce9cc1bc37"/>
@@ -9260,6 +10026,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crocky II (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18625">
 				<rom name="crocky ii (1984-09)(loriciels)(fr)[a].k7" size="18625" crc="e9676d11" sha1="82a6f679aee2e4bc6cf925d3031b1fd703b73db4"/>
@@ -9271,6 +10038,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crocky II (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18351">
 				<rom name="crocky ii (1984-09)(loriciels)(fr)[a2].k7" size="18351" crc="572b69b1" sha1="ffb8ca6d5a04e3926dab23624fc77d20852c0709"/>
@@ -9282,6 +10050,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crocky II (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18351">
 				<rom name="crocky ii (1984-09)(loriciels)(fr)[a3].k7" size="18351" crc="79362686" sha1="963dc2e4769c3bded10ae8b9cdbff102d1be3bd1"/>
@@ -9293,6 +10062,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crocky II (alt 4)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18351">
 				<rom name="crocky2_mo5.k7" size="18351" crc="78239c38" sha1="97a1be678b12f765bc11990f7fa34e685bda6ae5"/>
@@ -9304,6 +10074,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crystann</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34573">
 				<rom name="crystann (1985)(loriciels)(fr).k7" size="34573" crc="6f9713b3" sha1="98982871dc763a489553888cda262c319824be3b"/>
@@ -9315,6 +10086,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crystann (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34573">
 				<rom name="crystann (1985)(loriciels)(fr)[a].k7" size="34573" crc="f4ce7eb3" sha1="835c477081db62c6fad01f2318c130c0226a3421"/>
@@ -9326,6 +10098,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crystann (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34573">
 				<rom name="crystann (1985)(loriciels)(fr)[a2].k7" size="34573" crc="d1ea604d" sha1="dc6eee21e0f2b32ff00b408a5d9943f74c7b30c9"/>
@@ -9337,6 +10110,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crystann (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34570">
 				<rom name="crystann_mo5.k7" size="34570" crc="5de8dd28" sha1="68d5a42f51720e60c3cee54dab6df20faafced44"/>
@@ -9348,6 +10122,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crystann (WAV format)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10086740">
 				<rom name="crystann (1985)(loriciels)(fr).wav" size="10086740" crc="92177192" sha1="b85904e3bfd6bcd421d61576ea6d986a181e4168"/>
@@ -9359,6 +10134,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crystann (WAV format, alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11812490">
 				<rom name="crystann_mo5.wav" size="11812490" crc="aa4a6579" sha1="c30252d9badf126b9a2fbcf5c856f1a5ec41b7bb"/>
@@ -9370,6 +10146,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cyberlab</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16330">
 				<rom name="cyberlab (1984)(to tek)(fr).k7" size="16330" crc="40bcac29" sha1="a581167d4d243c1c6de29a75c23baa447c9a73ea"/>
@@ -9381,6 +10158,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cyberlab (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16330">
 				<rom name="cyberlab (1984)(to tek)(fr)[a].k7" size="16330" crc="752306cd" sha1="627345a94d11bdbd71290f37fc1a3fa246040184"/>
@@ -9392,6 +10170,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cyberlab (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16330">
 				<rom name="cyberlab_mo5.k7" size="16330" crc="5ddac57d" sha1="77d7c6503eeef29fc732de6d7ece74fd12069dad"/>
@@ -9403,6 +10182,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cyberlab (WAV format)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6199752">
 				<rom name="cyberlab (1984)(to tek)(fr).wav" size="6199752" crc="06f90469" sha1="77522e995394097ffe6547890ab8229d358cce0e"/>
@@ -9414,6 +10194,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Cyberlab (WAV format, alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7113392">
 				<rom name="cyberlab_mo5.wav" size="7113392" crc="59da3141" sha1="6680b31c83f6fd7dd494108dfbb8786df1ae1153"/>
@@ -9425,6 +10206,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dakar 4x4</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47183">
 				<rom name="dakar 4x4 (1987)(coktel vision)(fr)[a].k7" size="47183" crc="3c58aec7" sha1="bbe2ad5820fe962922a00ae9af6ec26d884218fc"/>
@@ -9436,6 +10218,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dakar 4x4 (alt)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47183">
 				<rom name="dakar 4x4 (1987)(coktel vision)(fr)[a2].k7" size="47183" crc="6f6214ad" sha1="a72f46d4cac299458ac9f8b71bb4bf720f6fb2c7"/>
@@ -9447,6 +10230,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dakar 4x4 (alt 2)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47183">
 				<rom name="dakar-4x4_mo5.k7" size="47183" crc="9b345f91" sha1="eaf2cb84eb431347bb255e75052b1d369fe79140"/>
@@ -9458,6 +10242,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dakar 4x4 (no title screen)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29592">
 				<rom name="dakar 4x4 (1987)(coktel vision)(fr)[m title screen].k7" size="29592" crc="0c1ba7db" sha1="59672953158e76f1e8d0212b12f7bdf6672fc57e"/>
@@ -9469,6 +10254,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dakar 4x4 (no title screen, alt)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29592">
 				<rom name="dakar 4x4 (1987)(coktel vision)(fr).k7" size="29592" crc="63cb7ecf" sha1="1d3ea4f1ebb8ba81f2282c61267dd2f1c8771849"/>
@@ -9480,6 +10266,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dakar Moto</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47458">
 				<rom name="dakar moto (198x)(coktel vision)(fr).k7" size="47458" crc="172bcbda" sha1="51d6c9ce37b4d00ac87a291fa6f2ab37f3f3e764"/>
@@ -9491,6 +10278,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dakar Moto (alt)</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47458">
 				<rom name="dakar moto (198x)(coktel vision)(fr)[a].k7" size="47458" crc="737d21fd" sha1="4d4643acf53c6a74aeab8758089a9986d2b4a7c8"/>
@@ -9502,6 +10290,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Delos Attack</description>
 		<year>1989</year>
 		<publisher>Christophe Lesur</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7383">
 				<rom name="delos attack (1989)(lesur, christophe)(fr).k7" size="7383" crc="477d97f3" sha1="4c2e4f7213fb6f5153b6ff282879ad1155893036"/>
@@ -9513,6 +10302,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Devant Derriere</description>
 		<year>198?</year>
 		<publisher>Francoise Monnet</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19942">
 				<rom name="devant derriere (198x)(monnet, francoise)(fr).k7" size="19942" crc="7f0a32b4" sha1="1fd766bd9d1d3b729739278947177ec8f1cb9257"/>
@@ -9524,6 +10314,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dianne</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="dianne - mission rubidiums (1985)(loriciels - novasoft)(fr).k7" size="34587" crc="38f4d036" sha1="49b9d488e15f41f16d72b4d47f313f7819f457a0"/>
@@ -9535,6 +10326,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dianne (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="dianne - mission rubidiums (1985)(loriciels - novasoft)(fr)[a].k7" size="34587" crc="1f3b7fd3" sha1="e09b0572b7a7c5d5096d99bc109c0a7ddf80f639"/>
@@ -9546,6 +10338,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dianne (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="dianne - mission rubidiums (1985)(loriciels - novasoft)(fr)[a2].k7" size="34587" crc="bd48dcac" sha1="604858c56f229979cf079aa279406b6adc5feedd"/>
@@ -9557,6 +10350,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dianne (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="dianne-mission-rubidiums_mo5.k7" size="34587" crc="047bbfb2" sha1="64ccc717ad9c43aefa4a81f8c71fc37094aebf57"/>
@@ -9568,6 +10362,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Dieux du Stade</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26031">
 				<rom name="dieux du stade, les (1988)(infogrames)(fr).k7" size="26031" crc="3ad54b8d" sha1="f2efda9e92fea10c0addad12e37f96be78d07f2e"/>
@@ -9579,6 +10374,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Dieux du Stade (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26031">
 				<rom name="dieux du stade, les (1988)(infogrames)(fr)[a].k7" size="26031" crc="487df22d" sha1="44d7e521e8191b6048f100a2a6520be9e306a7ae"/>
@@ -9590,6 +10386,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Dieux du Stade (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26031">
 				<rom name="les dieux du stade (infogrames) (william hennebois) (1985) (mo5) (v1).k7" size="26031" crc="4f2c1612" sha1="00a608f511ec39ad60ad3e9211cc0ab3d967ba87"/>
@@ -9601,6 +10398,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Dieux du Stade (alt 3)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25625">
 				<rom name="les dieux du stade (infogrames) (william hennebois) (1985) (mo5) (v2).k7" size="25625" crc="bdf9ba3f" sha1="2ea2ace76e673565fbc599d9cb5836391f9fb725"/>
@@ -9612,6 +10410,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Dieux du Stade II</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26220155">
 				<rom name="dieux du stade ii, les (1986)(infogrames)(fr)[loadm].wav" size="26220155" crc="12565f24" sha1="d9c002208e546b63c697b96f1bec1ed3bcd31fea"/>
@@ -9624,6 +10423,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Dieux du Stade II (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="120702">
 				<rom name="dieux du stade ii, les (1986)(infogrames)(fr)[b].k7" size="120702" crc="a172406f" sha1="4f0c05d5d461b93bdba8b442b77b187005dbb0fe"/>
@@ -9636,6 +10436,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Dieux du Stade II (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="120702">
 				<rom name="les dieux du stade 2 (infogrames) (kamel bala) (1986).k7" size="120702" crc="3584c1ab" sha1="1659eb80ccfdb3f06b31a9a1009ec4ecf909e5f0"/>
@@ -9648,6 +10449,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Dieux du Stade II (alt 3)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="125502">
 				<rom name="les-dieux-du-stade-2_mo5.k7" size="125502" crc="5629181b" sha1="2480d8f4689352bd8237635a01708a630ef63b31"/>
@@ -9660,6 +10462,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dossier Boerhaave</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66662">
 				<rom name="dossier boerhaave (1986)(infogrames)(fr)[copy protection].k7" size="66662" crc="5f837876" sha1="58026b7f41b28dd4d5a5d832e04493de87a0d607"/>
@@ -9672,6 +10475,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dossier Boerhaave (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66662">
 				<rom name="dossier boerhaave (1986)(infogrames)[b].k7" size="66662" crc="c2a4f6dd" sha1="b71b32b307fc6ca1c2f1a38452cf4b86e34c31e0"/>
@@ -9684,6 +10488,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dossier Boerhaave (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66662">
 				<rom name="dossier boerhaave (1986)(infogrames)[b2].k7" size="66662" crc="c1765672" sha1="3d0a26015823e602826c77475f6b37357fd27495"/>
@@ -9696,6 +10501,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dossier Boerhaave (alt 3)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="69062">
 				<rom name="dossier-boerhaave_mo5.k7" size="69062" crc="3bf0c14a" sha1="0ca9960bf6a6da3a053ca4a9360bfece9373afcb"/>
@@ -9704,9 +10510,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="boerhaavd" cloneof="boerhaav">
-		<description>Dossier Boerhaave (Hacked)</description>
+		<description>Dossier Boerhaave (hacked)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66662">
 				<rom name="dossier boerhaave (1986)(infogrames)(fr)[h dcmo5, dcmo6].k7" size="66662" crc="3fd48b69" sha1="0d140083454e93efd61ce25afd49b55d53b53dcc"/>
@@ -9715,9 +10522,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="boerhaave" cloneof="boerhaav">
-		<description>Dossier Boerhaave (Hacked 2)</description>
+		<description>Dossier Boerhaave (hacked 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="66662">
 				<rom name="dossier boerhaave (1986)(infogrames)(fr)[h dcmo5].k7" size="66662" crc="bfada424" sha1="b58935978d126093576e13ee216724fe8e40ddd0"/>
@@ -9736,6 +10544,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 			</dataarea>
 		</part>
 	</software>
+
 	<software name="dribblea" cloneof="dribble">
 		<description>Dribble (alt)</description>
 		<year>1985</year>
@@ -9752,6 +10561,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dribble (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9364">
 				<rom name="dribble_mo5.k7" size="9364" crc="91d2b3ee" sha1="d965c58ca85388194ea433feace56b299e3ee833"/>
@@ -9763,6 +10573,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Duel au Colorado</description>
 		<year>1986</year>
 		<publisher>Chip</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35669">
 				<rom name="duel au colorado (198x)(chip)(fr).k7" size="35669" crc="e80a25dc" sha1="ee4462e9937c7a0cf19da512ff40c769a8a90e64"/>
@@ -9774,6 +10585,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Duel au Colorado (alt)</description>
 		<year>1986</year>
 		<publisher>Chip</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35842">
 				<rom name="duel au colorado (198x)(chip)(fr)[a].k7" size="35842" crc="55d42177" sha1="ab490640d2c34acf49ef6c311051ba5945ff6f4e"/>
@@ -9785,6 +10597,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Duel au Colorado (alt 2)</description>
 		<year>1986</year>
 		<publisher>Chip</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35842">
 				<rom name="duel au colorado (198x)(chip)(fr)[a2].k7" size="35842" crc="67149e61" sha1="e0600b1cc41c11be58275cc80d6b9333d5cf2fc7"/>
@@ -9796,6 +10609,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Duel au Colorado (alt 3)</description>
 		<year>1986</year>
 		<publisher>Chip</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35842">
 				<rom name="duel-au-colorado_mo5.k7" size="35842" crc="f04b687d" sha1="57a2e36b43e454e4726c4621feb77b69525c1bcf"/>
@@ -9807,6 +10621,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Echecs (v3.7)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14919">
 				<rom name="echecs v3.7 (198x)(cobra soft)(fr).k7" size="14919" crc="7a58f536" sha1="c5f98e6ba55e6c5114eb40b8a468934061d7524b"/>
@@ -9818,6 +10633,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Echecs (v3.7, alt)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15076">
 				<rom name="echecs v3.7 (198x)(cobrasoft)(fr)[a].k7" size="15076" crc="443e6ef3" sha1="a1f17dfb6fce3103b12fc6d26f7cc5b73b859bf3"/>
@@ -9829,6 +10645,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Echecs (v3.7, alt 2)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15076">
 				<rom name="echecs v3.7 (198x)(cobrasoft)(fr)[a2].k7" size="15076" crc="6d83b77d" sha1="317c5a4dfd0f53f4c523d9d310e3c3307ad52205"/>
@@ -9840,6 +10657,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Echecs (v3.7, alt 3)</description>
 		<year>198?</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15076">
 				<rom name="echecs-3-7_mo5.k7" size="15076" crc="8cf1d227" sha1="f36a5d71f2a2cca853b274d182d70ef4dadb799c"/>
@@ -9851,6 +10669,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Eliminator</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3129695">
 				<rom name="eliminator (1984)(loriciels)(fr).wav" size="3129695" crc="5caf9f32" sha1="d203cff44126245eae8fa1728d6a4a35309d44c3"/>
@@ -9863,6 +10682,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Eliminator (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9478">
 				<rom name="eliminator (1984)(loriciels)(fr)[b2].k7" size="9478" crc="5d54aa79" sha1="56a19211c31d3d20332a62cd7953f25ca8ed2ac8"/>
@@ -9875,6 +10695,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Eliminator (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9478">
 				<rom name="eliminator (1984)(loriciels)(fr)[b3].k7" size="9478" crc="5d521fe8" sha1="d22753dbe9029d0db5b59f59b63c2bfe87915901"/>
@@ -9887,6 +10708,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Eliminator (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9224">
 				<rom name="eliminator_mo5.k7" size="9224" crc="299c1d12" sha1="cd463b4d28046dcd46cf3496ad9ebe277e7cf5d8"/>
@@ -9899,6 +10721,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Eliminator (alt 4)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9224">
 				<rom name="eliminator_a_mo5.k7" size="9224" crc="cc9586bb" sha1="e257a8f82c33a1b178e75f83747e32789b29df20"/>
@@ -9910,6 +10733,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Eliminator (cracked?)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9480">
 				<rom name="eliminator (1984)(loriciels)(fr).k7" size="9480" crc="9a380faf" sha1="efa716fa809dd60b114012b4cec6730c17d49a4c"/>
@@ -9937,6 +10761,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Empire</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44884">
 				<rom name="empire (1985-04)(loriciels)(fr)[b].k7" size="44884" crc="2317ddaa" sha1="839b08823de130d117d24af79681603df571c3d8"/>
@@ -9949,6 +10774,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Empire (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44884">
 				<rom name="empire (1985-04)(loriciels)(fr)[b2].k7" size="44884" crc="a70fe2dc" sha1="bd3ed979bac6977c5dff0c7ee4d67b1f87fde47c"/>
@@ -9961,6 +10787,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Empire (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44884">
 				<rom name="empire_mo5.k7" size="44884" crc="4dfb8745" sha1="9e21dc5a0345c2d0442145000dbecea3b9ee092d"/>
@@ -9972,6 +10799,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Enduro Racer</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45296">
 				<rom name="enduro racer (1988)(fil)(fr).k7" size="45296" crc="de053935" sha1="eb511a397aa5d57e6c3a23fd8190cdbe5a908b5c"/>
@@ -9983,6 +10811,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Enduro Racer (alt)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45465">
 				<rom name="enduro racer (1988)(fil)(fr)[a].k7" size="45465" crc="afeb5f4f" sha1="e466f99d82287e8e60ae57c211468128fb6d9674"/>
@@ -9994,6 +10823,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Enduro Racer (alt 2)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45465">
 				<rom name="enduro racer (1988)(fil)(fr)[a2].k7" size="45465" crc="8580b00f" sha1="88ca964cd4334c63e8007323cfe9bb6b2d3843a2"/>
@@ -10005,6 +10835,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Enduro Racer (alt 3)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45465">
 				<rom name="enduro-racer_mo5.k7" size="45465" crc="524b098b" sha1="8d52903943e46d1a02147e29986079ef947839ba"/>
@@ -10030,6 +10861,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Energic</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25710">
 				<rom name="energic (198x)(dechelette, guy)(fr).k7" size="25710" crc="689d6117" sha1="ff0cdc34d82b52ea27667a0e8af5fc1a2184a781"/>
@@ -10041,6 +10873,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Energic (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26368">
 				<rom name="energic (198x)(dechelette, guy)(fr)[a].k7" size="26368" crc="7d9efba7" sha1="a86513c0e5e2806aa323c9108e0c4c808c522c00"/>
@@ -10052,6 +10885,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Energic (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26368">
 				<rom name="energic (1985)(hebdogiciel)(fr)[a2].k7" size="26368" crc="f86707ba" sha1="006f8393b46f92e83c17f23e0509f1e85663fc48"/>
@@ -10063,6 +10897,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Energic (alt 3)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26368">
 				<rom name="energic (1985)(hebdogiciel)(fr)[a3].k7" size="26368" crc="ba7be5dd" sha1="74d3b058ac9ea773602b8d1287363b3effa27bc4"/>
@@ -10074,6 +10909,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Energic (alt 4)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26368">
 				<rom name="energic_mo5.k7" size="26368" crc="a6690205" sha1="4737a63e5e4d6da211c7aedbbe8e137a4f0730b4"/>
@@ -10085,6 +10921,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Enigmatika</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="20856">
@@ -10121,6 +10958,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Enigmatika (alt tapes 1-4)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="20856">
@@ -10157,6 +10995,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Enquetes de M. Theophile</description>
 		<year>1984</year>
 		<publisher>Hatier</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47964">
 				<rom name="enquetes de m. theophile, les (1984)(hatier)(fr).k7" size="47964" crc="ad7f394f" sha1="0294d81d6fb342c1c3da3c0d381a779ffff6d3cb"/>
@@ -10168,6 +11007,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Erebus</description>
 		<year>198?</year>
 		<publisher>EH Services</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="93933">
 				<rom name="erebus (198x)(eh services).k7" size="93933" crc="87f297b7" sha1="75269f36afe3b60debc005abce46bc318fca70b9"/>
@@ -10179,6 +11019,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Erebus (alt)</description>
 		<year>198?</year>
 		<publisher>EH Services</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="93933">
 				<rom name="erebus (198x)(eh services)[a].k7" size="93933" crc="95a10b9e" sha1="c2d25b757f49da2d7d18802f44f675ccb6faf11f"/>
@@ -10190,6 +11031,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Erebus (alt 2)</description>
 		<year>198?</year>
 		<publisher>EH Services</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="93933">
 				<rom name="erebus_mo5.k7" size="93933" crc="3738fe9f" sha1="14dba07e8205c5c6b73dcad5c2b0137f953ab29e"/>
@@ -10201,6 +11043,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Evade de Tapiocatraz</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40775">
 				<rom name="evade de tapiocatraz, l' (1986)(ere informatique)(fr).k7" size="40775" crc="518dbd6a" sha1="0a4fdbf93a96b8ea3a50f96b27a5287b43b000d7"/>
@@ -10212,6 +11055,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Evade de Tapiocatraz (alt)</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40775">
 				<rom name="l-evade-de-tapiocatraz_mo5.k7" size="40775" crc="0dce570c" sha1="fccdd4f8cf86cdc55aea2f6d30218c682fc452e0"/>
@@ -10223,6 +11067,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Extra-Mission</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10602">
 				<rom name="extra-mission (shift-edition) (philippe baroin) (1985) (mo5 k7).k7" size="10602" crc="277e656b" sha1="567e0d9492067be5aca41b2a2f73c07287b1b49e"/>
@@ -10234,6 +11079,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>F15 Strike Eagle</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27898">
 				<rom name="f15 strike eagle (1987)(fil)(fr).k7" size="27898" crc="9caa4e16" sha1="09bdec308f00357b89de078aff7a87c0ad27b70e"/>
@@ -10245,6 +11091,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>F15 Strike Eagle (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28038">
 				<rom name="f15 strike eagle (1987)(fil)(fr)[a].k7" size="28038" crc="1d4a7cc0" sha1="9c34b6bc4b98b2d9a14187d800b07652f0a3ecd0"/>
@@ -10256,6 +11103,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>F15 Strike Eagle (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28038">
 				<rom name="f15 strike eagle (1987)(fil)(fr)[a2].k7" size="28038" crc="fbfe24dd" sha1="6d79bef494af65e29b56f7fdbe52320b7d40d238"/>
@@ -10267,6 +11115,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>F15 Strike Eagle (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28038">
 				<rom name="f15-strike-eagle_mo5.k7" size="28038" crc="5714f7f7" sha1="e132cd4d271eb62d63e21c959b69cc2b06409f80"/>
@@ -10278,6 +11127,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>FBI</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20396">
 				<rom name="fbi (1984)(infogrames)(fr).k7" size="20396" crc="0ca3dd5d" sha1="f140c04ae38d3cb16f881cf46f3d60eccfbc40ec"/>
@@ -10289,6 +11139,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>FBI (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21306">
 				<rom name="fbi (1984)(infogrames)(fr)[a].k7" size="21306" crc="3c276fa5" sha1="b1ea672ee1b0be83f44a534849209befb3beec2a"/>
@@ -10300,6 +11151,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>FBI (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21306">
 				<rom name="fbi (1984)(infogrames)(fr)[a2].k7" size="21306" crc="15936f44" sha1="01ababd6d840ada8a8cfae173800a3143e31b0fa"/>
@@ -10311,6 +11163,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>FBI (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21306">
 				<rom name="fbi.k5" size="21306" crc="de356375" sha1="d5f1f93c12a5f48394ca4a0fcd05375918aea0fe"/>
@@ -10322,6 +11175,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>FBI (alt 4)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21083">
 				<rom name="fbi_mo5.k7" size="21083" crc="13912bd8" sha1="2ad5db80a84b31681b03cbd38c0122b42521c2b5"/>
@@ -10333,6 +11187,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Felonies</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="82242">
 				<rom name="felonies (1986)(ere informatique)(fr)[b].k7" size="82242" crc="e705bae9" sha1="9840aae261ea8df490167445ea0e69633a7214c1"/>
@@ -10344,6 +11199,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Felonies (alt)</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="87465">
 				<rom name="felonies (1986)(ere informatique)(fr)[b2].k7" size="87465" crc="55b97461" sha1="44b97642cc200732828108d6c2fc83612e35e045"/>
@@ -10355,6 +11211,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Felonies (alt 2)</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="87465">
 				<rom name="felonies (1986) (ere informatique) [a1].k7" size="87465" crc="61745d72" sha1="5593a1eafff0dbe3a3b49960a128ad564379363f"/>
@@ -10366,6 +11223,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Felonies (alt 3)</description>
 		<year>1986</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="87465">
 				<rom name="felonies (ere) (guy bec) (1986).k7" size="87465" crc="826a8a69" sha1="ea3f9d4145fedcc32e31b951c23553f082ec9b75"/>
@@ -10377,6 +11235,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flash Point</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49843">
 				<rom name="flash point (1987)(fil)(fr).k7" size="49843" crc="8bb39efa" sha1="bd1c2d9c53b843ab6cd2111fd720e47ec1a6fc49"/>
@@ -10388,6 +11247,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flash Point (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49843">
 				<rom name="flash point (1987)(fil)(fr)[a].k7" size="49843" crc="bd2041ee" sha1="a51bab0fdbc787c5e3038518ffddfff2383547c7"/>
@@ -10399,6 +11259,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flash Point (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49843">
 				<rom name="flash-point_mo5.k7" size="49843" crc="f95e42a6" sha1="3d3f01f715a5ff52393673c5afa221cc47c206b3"/>
@@ -10410,6 +11271,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flipper</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42892">
 				<rom name="flipper (1984-10)(loriciels)(fr).k7" size="42892" crc="086cee71" sha1="1d14f5bd3b0bacf51296b2a399f594aca9500115"/>
@@ -10421,6 +11283,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flipper (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42892">
 				<rom name="flipper (1984-10)(loriciels)(fr)[a].k7" size="42892" crc="51fbbb08" sha1="de4553aaf6d64a8cb82dfbc74b56af2a5f1befcb"/>
@@ -10432,6 +11295,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flipper (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42892">
 				<rom name="flipper (1984-10)(loriciels)(fr)[a2].k7" size="42892" crc="8ec31bae" sha1="1e739a36bdc3cd12a2b82076c9cf930452151fdd"/>
@@ -10443,6 +11307,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flipper (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="42866">
 				<rom name="flipper_mo5.k7" size="42866" crc="5fa07901" sha1="319891503838abd90e646a92dfc23a09e6f38f3a"/>
@@ -10454,6 +11319,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flipper (WAV format)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13303304">
 				<rom name="flipper (1984-10)(loriciels)(fr).wav" size="13303304" crc="411bdac1" sha1="15a9231147bfda321232e63bc8a92b6e6cad8247"/>
@@ -10466,6 +11332,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Football</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21679">
 				<rom name="football (1987)(infogrames)[b].k7" size="21679" crc="493f4579" sha1="b65afaaf1055444538ccfaa7880ab9f2ed091e3c"/>
@@ -10478,6 +11345,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Football (alt)</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21679">
 				<rom name="football (infogrames) (1987).k7" size="21679" crc="243be34e" sha1="c9e0d33cddd110918c3312411d200432d0718a46"/>
@@ -10490,6 +11358,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Football (alt 2)</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22879">
 				<rom name="football_mo5.k7" size="22879" crc="c262341b" sha1="117f543fdd7b4abdaa17c976875b928955b65601"/>
@@ -10501,6 +11370,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Formule 1</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68525">
 				<rom name="formule 1 (1987)(fil)(fr).k7" size="68525" crc="c41cf39b" sha1="2a499eb490c048a418226edd14dd27caceb7af66"/>
@@ -10512,6 +11382,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Formule 1 (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68789">
 				<rom name="formule 1 (1987)(fil)(fr)[a].k7" size="68789" crc="e257747d" sha1="6ba813b62d266b583ca44c929cf6757072fce9c1"/>
@@ -10523,6 +11394,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Formule 1 (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68789">
 				<rom name="formule 1 (1987)(fil)(fr)[a2].k7" size="68789" crc="458699e6" sha1="1f4de6ed59843d531953309d0f8e255064f196ce"/>
@@ -10534,6 +11406,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Formule 1 (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68789">
 				<rom name="formule-1_mo5.k7" size="68789" crc="a8866410" sha1="745384f0a36cc0c72f91adcf354386858dc1c65d"/>
@@ -10545,6 +11418,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Fox</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21858">
 				<rom name="fox (1985)(shift-edition)(fr).k7" size="21858" crc="b5ba1fa6" sha1="ac87b0daa3dc911446ca0b574a69c0c8a668291f"/>
@@ -10556,6 +11430,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Fox (alt)</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21858">
 				<rom name="fox (1985)(shift-edition)(fr)[a2].k7" size="21858" crc="2d5ea3b0" sha1="cb4bd1f17eed81a11f97c530837cbe63046aa2f0"/>
@@ -10567,6 +11442,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Fox (No BASIC Loader)</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22549">
 				<rom name="fox (1985)(shift-edition)(fr)[a no basic loader].k7" size="22549" crc="e5f36182" sha1="eb421269e4d8356a90e8ead60b33ca725af5569a"/>
@@ -10575,9 +11451,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="foxc" cloneof="fox">
-		<description>Fox (No BASIC Loader, alt)</description>
+		<description>Fox (no BASIC loader, alt)</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22549">
 				<rom name="fox (1985)(shift-edition)(fr)[b].k7" size="22549" crc="8a55398a" sha1="17e43edeb3e74e243442455105ccfddbff633d10"/>
@@ -10589,6 +11466,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Fox (Hebdogiciel no. 146)</description>
 		<year>1986</year>
 		<publisher>Pascal Gabriel - Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14946">
 				<rom name="fox[mo5].k7" size="14946" crc="8c198443" sha1="26918a0723225e68a6a328ff0eb001c2146924ed"/>
@@ -10600,6 +11478,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Galaxie Perdue</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22792">
 				<rom name="galaxie perdue (sprites) (1985) (mo5).k7" size="22792" crc="e2fc3ff0" sha1="304af14145edc352aa401dc780ab50cadb951bc8"/>
@@ -10611,6 +11490,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Game Over</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="57052">
 				<rom name="game over (1987)(fil)(fr).k7" size="57052" crc="63a9553a" sha1="eb14d8649da945b0e1bf3df357bca735cf4256f2"/>
@@ -10622,6 +11502,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Game Over (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56731">
 				<rom name="game over (1987)(fil)(fr)[a].k7" size="56731" crc="12d185cf" sha1="489efa465f7773ccb9e0747ec6031f708658ea2d"/>
@@ -10633,6 +11514,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Game Over (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="57052">
 				<rom name="game over (1987)(fil)(fr)[a2].k7" size="57052" crc="f8dfc124" sha1="46b0184eb4053e188af84e8e1fc0cc412b330fd9"/>
@@ -10644,6 +11526,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le General</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47922">
 				<rom name="general, le (198x)(loriciels)(fr).k7" size="47922" crc="265ce965" sha1="df06a23292206190f4ee84819309acc415b1b3c7"/>
@@ -10655,6 +11538,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le General (alt)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48396">
 				<rom name="general, le (198x)(loriciels)(fr)[a].k7" size="48396" crc="1a3d884f" sha1="7a46b64a8e09cac9f7ebfb705ffee95bfda9b6c6"/>
@@ -10666,6 +11550,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le General (alt 2)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48396">
 				<rom name="general, le (198x)(loriciels)(fr)[a2].k7" size="48396" crc="67f1e951" sha1="a2a407fdb306b191b0e8b3931f7e8716d623e17c"/>
@@ -10677,6 +11562,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le General (alt 3)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48396">
 				<rom name="le-general_mo5.k7" size="48396" crc="ce7e2b63" sha1="0550a69a4c41c980a843b20e9267616b0150077c"/>
@@ -10688,6 +11574,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Geodyssee</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33735">
 				<rom name="geodyssee (1985)(coktel vision)(fr).k7" size="33735" crc="3fe2dbf3" sha1="de7303824d1d75b387bc87f30fcf5f73f44f5fd4"/>
@@ -10699,6 +11586,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Geodyssee (alt)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33735">
 				<rom name="geodyssee (1985)(coktel vision)(fr)[a].k7" size="33735" crc="cda51e01" sha1="8b6d967660c38a6edede67b45232200fbafddf49"/>
@@ -10710,6 +11598,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Geodyssee (alt 2)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33735">
 				<rom name="geodyssee (1985)(coktel vision)(fr)[a2].k7" size="33735" crc="2db636af" sha1="e8543417c3a8667768b761c61f61a4e15ccf7b6e"/>
@@ -10721,6 +11610,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Geodyssee (alt 3)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33735">
 				<rom name="geodyssee_mo5.k7" size="33735" crc="9a7ae807" sha1="ebc0a7546561d9e8b9d8c9c1371d1eac40ac6da3"/>
@@ -10733,6 +11623,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Geste d'Artillac</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="21188">
@@ -10758,6 +11649,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Geste d'Artillac (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="21180">
@@ -10783,6 +11675,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Geste d'Artillac (single tape)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="215555">
 				<rom name="geste d'artillac, la (1985)(infogrames)(fr).k7" size="215555" crc="7055ba87" sha1="cc761ea5808609ff28602977b19358513264230f"/>
@@ -10795,6 +11688,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Geste d'Artillac (single tape, alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="215754">
 				<rom name="geste d'artillac, la (1985)(infogrames)(fr)[a].k7" size="215754" crc="83e03fe8" sha1="ec02c9088bb54da3bd3adc747835226afe084b5f"/>
@@ -10807,6 +11701,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Geste d'Artillac (single tape, alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="215520">
 				<rom name="geste d'artillac, la (1985)(infogrames)(fr)[a2].k7" size="215520" crc="edee005c" sha1="5835d9cc4cd69add07d8a398111cc60692c056f4"/>
@@ -10818,6 +11713,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Ghostbusters</description>
 		<year>1989</year>
 		<publisher>Christophe Lesur</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10948">
 				<rom name="ghostbusters (1989-08)(lesur, christophe)(fr)[load twice].k7" size="10948" crc="d66aea27" sha1="490618148c5bc70d99c2e079736d08bfd0748e07"/>
@@ -10829,6 +11725,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Glouton</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4283">
 				<rom name="glouton (1986)(hebdogiciel)(fr).k7" size="4283" crc="68d02f32" sha1="91be61be3f055c65a33e2cca5c743f31770212a3"/>
@@ -10840,6 +11737,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Glouton (alt)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4283">
 				<rom name="glouton (1986)(hebdogiciel)(fr)[a].k7" size="4283" crc="1ee0e62f" sha1="ed227607c43050a4168b88ed19a65252d89718f9"/>
@@ -10851,6 +11749,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Glouton (alt 2)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4283">
 				<rom name="glouton_mo5.k7" size="4283" crc="18bbe7da" sha1="09347863050549a444ac1f2e9929ccc50ff0ce8a"/>
@@ -10862,6 +11761,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Graal</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="60337">
@@ -10880,6 +11780,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Grand Siecle</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="77123">
@@ -10898,6 +11799,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Granulus (Hebdogiciel no. 152)</description>
 		<year>1986</year>
 		<publisher>Emerich Fernandes - Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12667">
 				<rom name="granulus[mo5].k7" size="12667" crc="2d036233" sha1="52adad91e120339be7f4e91e8a500780b7e18b95"/>
@@ -10909,6 +11811,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gravitron</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9077">
 				<rom name="gravitron (1985)(fil)(fr).k7" size="9077" crc="b8e1c174" sha1="893e7da70c13373902b101bfbc00095ff058316e"/>
@@ -10920,6 +11823,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gravitron (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10885">
 				<rom name="gravitron (1985)(fil)(fr)[a].k7" size="10885" crc="0c6ed22d" sha1="632cc9865ad963be54950dd518561877a7cc4285"/>
@@ -10931,6 +11835,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gravitron (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9059">
 				<rom name="gravitron (1985)(fil)(fr)[a2].k7" size="9059" crc="7b60c492" sha1="5626103a00c0aacae6df57ea324a0d823377b77d"/>
@@ -10942,6 +11847,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gravitron (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9059">
 				<rom name="gravitron (1985)(fil)(fr)[a3].k7" size="9059" crc="1e6771db" sha1="fc62c55847671f4fd22c4f1048c4203dad55a734"/>
@@ -10953,6 +11859,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gravitron (alt 4)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9015">
 				<rom name="gravitron_mo5.k7" size="9015" crc="cb1463f5" sha1="6ff96e6d1382d0756f21949dd3ba1bf652e0b1b5"/>
@@ -10964,6 +11871,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Green Beret</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33241">
 				<rom name="green beret (1986)(fil)(fr).k7" size="33241" crc="0f93b01f" sha1="30b07f962e703ff461685df47916c80caa13d75c"/>
@@ -10975,6 +11883,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Green Beret (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33383">
 				<rom name="green beret (1986)(fil)(fr)[a].k7" size="33383" crc="97b9f662" sha1="5fa5da2ac499cc4050ce3336ecb1f3f1640c7742"/>
@@ -10986,6 +11895,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Green Beret (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33383">
 				<rom name="green beret (1986)(fil)(fr)[a2].k7" size="33383" crc="c36c5b39" sha1="7d45c53f5b73425d7c15d1d4ea86650a0375a42e"/>
@@ -10997,6 +11907,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Green Beret (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33383">
 				<rom name="green-beret_mo5.k7" size="33383" crc="07790323" sha1="d8eac58827067a80e9d8d36f4823e83257cef5c9"/>
@@ -11008,6 +11919,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Grignote II</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3030">
 				<rom name="grignote ii, la (1985)(dcsoft)(fr).k7" size="3030" crc="61f0d851" sha1="885e53a5e8a6b490b0f5b190d1a22f03898bddb4"/>
@@ -11019,6 +11931,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Grignote II (alt)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3030">
 				<rom name="grignote ii, la (1985)(dcsoft)(fr)[a].k7" size="3030" crc="cd51fb54" sha1="d4a012e8b26462a8d56d2be552e3581ecf483e6a"/>
@@ -11030,6 +11943,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Grignote II (alt 2)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3030">
 				<rom name="grignote ii, la (1985)(dcsoft)(fr)[a2].k7" size="3030" crc="c935cf4e" sha1="e66d7d425c508957fee02aeef37c6351e1856812"/>
@@ -11041,6 +11955,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Grignote II (alt 3)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3030">
 				<rom name="la-grignote-2_mo5.k7" size="3030" crc="f8523444" sha1="2ef2523d7c3407ec4fc03a5b4a3a726918e4a78c"/>
@@ -11052,6 +11967,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Guerres Spaciales (Hebdogiciel no. 132/134)</description>
 		<year>1986</year>
 		<publisher>Michael Escoffier - Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52932">
 				<rom name="guerresspatiales_jeu_[mo5].k7" size="52932" crc="0482b67b" sha1="be18a883a341e3c84d8c3e23c241e1b98d6b3b18"/>
@@ -11068,6 +11984,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gulpy la Chenille Gourmand</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8832">
 				<rom name="gulpy la chenille gourmand (1986)(microtom)(fr).k7" size="8832" crc="8d95638d" sha1="1253c40e7429fcfd03f8f805010ad01d3654875a"/>
@@ -11079,6 +11996,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gulpy la Chenille Gourmand (alt)</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8832">
 				<rom name="gulpy la chenille gourmand (1986)(microtom)(fr)[a].k7" size="8832" crc="72e41d56" sha1="0387794a269f0e45322ec821bd0640ffeb8babc4"/>
@@ -11090,6 +12008,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Gulpy la Chenille Gourmand (alt 2)</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8832">
 				<rom name="gulpy_mo5.k7" size="8832" crc="16034446" sha1="f682b897f928e860716e547db94edf938db393cb"/>
@@ -11101,6 +12020,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Hacker</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48516">
 				<rom name="hacker (1986)(loriciels)(fr)(en-fr).k7" size="48516" crc="dc3e9851" sha1="a1be7693bcca86ba90b966bca766ed412566b68e"/>
@@ -11112,6 +12032,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Hacker (alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48516">
 				<rom name="hacker (1986)(loriciels)(fr)(en-fr)[a].k7" size="48516" crc="e48d049b" sha1="50e0c0d361bba9f48d8e294163acc3c9a53128ed"/>
@@ -11123,6 +12044,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Hacker (alt 2)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48516">
 				<rom name="hacker (loriciels) (steve cartwright (activision), alain fernandes) (1986) (mo5).k7" size="48516" crc="f98d6c1d" sha1="241c2945ca2fec532b9a1a227090af0b3460e362"/>
@@ -11134,6 +12056,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Heritage</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11348766">
 				<rom name="heritage, l' (1986)(infogrames)(fr)[loadm'''',,r].wav" size="11348766" crc="827aa00b" sha1="f2f405b8fbcd68981cc948e940ddaf3de50824e2"/>
@@ -11146,6 +12069,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Heritage (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41201">
 				<rom name="heritage ii, l' (1986)(infogrames)(fr)[b].k7" size="41201" crc="febe0967" sha1="ce3aea2e355d3ea83952aa2e760025d649ee9519"/>
@@ -11158,6 +12082,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Heritage (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39521">
 				<rom name="heritage ii, l' (1986)(infogrames)(fr)[b2].k7" size="39521" crc="d97ddd1b" sha1="8e43c7cb4686f9936bb79141303a7b9e7d7543f5"/>
@@ -11170,6 +12095,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Heritage (alt 3)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39521">
 				<rom name="l'heritage ii (infogrames) (pierre bayle) (1986).k7" size="39521" crc="a89f246a" sha1="510da52b000f095b15b4b6817361f1c064a47fb5"/>
@@ -11181,6 +12107,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>HMS Cobra - Convois pour Mourmansk</description>
 		<year>1987</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="67369">
 				<rom name="hms cobra - convois pour mourmansk (198x)(cobra soft)(fr).k7" size="67369" crc="2cc96102" sha1="481f09e264792fa5d240b11af498717d48ee15f8"/>
@@ -11192,6 +12119,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>HMS Cobra - Convois pour Mourmansk (alt)</description>
 		<year>1987</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="67642">
 				<rom name="hms cobra - convois pour mourmansk (198x)(cobra soft)(fr)[a].k7" size="67642" crc="7d7de536" sha1="58e21aa023a7637f388ecbfd6dae83676f34ffd1"/>
@@ -11203,6 +12131,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>HMS Cobra - Convois pour Mourmansk (alt 2)</description>
 		<year>1987</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="67642">
 				<rom name="hms cobra - convois pour mourmansk (198x)(cobra soft)(fr)[a2].k7" size="67642" crc="b40a1915" sha1="5e96dc44cfdaa1de17420e0e2d6b1e3f3ef8bfa2"/>
@@ -11214,6 +12143,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>HMS Cobra - Convois pour Mourmansk (alt 3)</description>
 		<year>1987</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="67642">
 				<rom name="hms-cobra_mo5.k7" size="67642" crc="993f90ca" sha1="aba526cc46a2baf9d650fe2a7c0f98dcab9504bc"/>
@@ -11225,6 +12155,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>I.L. l'Intrus</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21355">
 				<rom name="i.l. l'intrus (1984)(infogrames)(fr).k7" size="21355" crc="bedc32cb" sha1="84d8e4347766eb4eb5805077cec4cc7879538e92"/>
@@ -11236,6 +12167,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>I.L. l'Intrus (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21355">
 				<rom name="i.l. l'intrus (1984)(infogrames)(fr)[a].k7" size="21355" crc="31c30473" sha1="ef4970d60f5f096d8c0c4c7a112fcd546a7d41ed"/>
@@ -11247,6 +12179,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>I.L. l'Intrus (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21355">
 				<rom name="il-l-intrus_mo5.k7" size="21355" crc="568ce583" sha1="a35548f086c181454b84ca6570e9cb37959fd973"/>
@@ -11258,6 +12191,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Imperialis</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24396">
 				<rom name="imperialis (198x)(coktel vision)(fr).k7" size="24396" crc="b3845223" sha1="253e72b378b34c84f54f2ae1d8588c3a770bddfc"/>
@@ -11269,6 +12203,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Imperialis (alt)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24396">
 				<rom name="imperialis (1986)(coktel vision)(fr)[a].k7" size="24396" crc="052df47f" sha1="ee0a60a1da53eb2d6c60999dde58a91933ee840c"/>
@@ -11280,6 +12215,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Imperialis (alt 2)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24396">
 				<rom name="imperialis (1986)(coktel vision)(fr)[a2].k7" size="24396" crc="3917df65" sha1="adfd6477ef2168b082483551562d1df7147330fa"/>
@@ -11291,6 +12227,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Imperialis (alt 3)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24396">
 				<rom name="imperialis_mo5.k7" size="24396" crc="dc0c0fe0" sha1="21b31a6d7f3ce7c47b80b6f05c63570e095f92ff"/>
@@ -11302,6 +12239,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>In Ex</description>
 		<year>198?</year>
 		<publisher>Francoise Monnet</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13280">
 				<rom name="in ex (198x)(monnet, francoise)(fr).k7" size="13280" crc="32895237" sha1="700dfcbb48f348827347058da82ab20a0ed7127a"/>
@@ -11313,6 +12251,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Indiana</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24199">
 				<rom name="indiana (1985)(hebdogiciel)(fr).k7" size="24199" crc="20d4a6f3" sha1="5705637ddfcfd47bcb1e134e979e194aa57151d5"/>
@@ -11324,6 +12263,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Indiana (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24199">
 				<rom name="indiana (1985)(hebdogiciel)(fr)[a].k7" size="24199" crc="decaf303" sha1="0bf232dbaca006b7d7678c88ed306bb7859eb6ee"/>
@@ -11335,6 +12275,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Indiana (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24199">
 				<rom name="indiana_mo5.k7" size="24199" crc="eec6a987" sha1="d9ff0704528f446e559a04820b76a3f66720bb81"/>
@@ -11343,9 +12284,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="indianac" cloneof="indiana">
-		<description>Indiana (No Title Screen)</description>
+		<description>Indiana (no title screen)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21952">
 				<rom name="indiana (1985)(hebdogiciel)(fr)[m title screen].k7" size="21952" crc="b6a31c35" sha1="57b5fb44208c94d1f3381735b6af938ad1a62f9f"/>
@@ -11357,6 +12299,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Indiana Thom</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24966">
 				<rom name="indiana thom (sprites) (1985) (mo5).k7" size="24966" crc="20e883b1" sha1="f69bfa2dbfb181004705624863b3170be057f150"/>
@@ -11368,6 +12311,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Infierno</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39069">
 				<rom name="infierno (1986-07-16)(rubio, javier marco &amp; escudero, angelines rubio)(es).k7" size="39069" crc="36ea0239" sha1="144c1a763fa888f8dd2464772de58436ed3d1e09"/>
@@ -11379,6 +12323,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Infierno (alt)</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39069">
 				<rom name="infierno (1986-07-16)(rubio, javier marco &amp; escudero, angelines rubio)(es)[a].k7" size="39069" crc="90f3f15b" sha1="287a9a7478063e25726bdf96deaa0e920724d9de"/>
@@ -11390,6 +12335,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Infierno (alt 2)</description>
 		<year>1986</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39069">
 				<rom name="infierno_mo5.k7" size="39069" crc="0c9cb158" sha1="b505a27b4e813b457eedf1a53c7c21ba592e9d20"/>
@@ -11401,6 +12347,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Inspecteur Gadget</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64132">
 				<rom name="inspecteur gadget (1984)(vifi-nathan)(fr).k7" size="64132" crc="aad19502" sha1="6447041fe47666604c18ec44f10e3019c5a88e15"/>
@@ -11412,6 +12359,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Inspecteur Gadget (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64132">
 				<rom name="inspecteur gadget (1984)(vifi-nathan)(fr)[a].k7" size="64132" crc="b0b6eb61" sha1="131763241f2b1d8e2ab24f63a9ceb10f3d841544"/>
@@ -11423,6 +12371,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Inspecteur Gadget (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="64132">
 				<rom name="inspecteur-gadget_mo5.k7" size="64132" crc="0a3a0d54" sha1="ae1f539382bfce1f1af1a2c2b145656e0c459a27"/>
@@ -11434,6 +12383,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Intox &amp; Zoe</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32509">
 				<rom name="intox &amp; zoe (1984-08)(loriciels - tf01)(fr).k7" size="32509" crc="a831ec58" sha1="f5b24f4c73c33b9e6edd4f131a775f8d22c520ea"/>
@@ -11445,6 +12395,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Intox &amp; Zoe (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32501">
 				<rom name="intox &amp; zoe (1984-08)(loriciels - tf01)(fr)[b2].k7" size="32501" crc="38c0b137" sha1="383421a8d01e5faf04e5b753cb1560e0e40fbd67"/>
@@ -11456,6 +12407,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Intox &amp; Zoe (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32501">
 				<rom name="intox-et-zoe_mo5.k7" size="32501" crc="3d3febf8" sha1="b17e0cf7a8904cb5afa68a9ebb0ba90be56184da"/>
@@ -11465,9 +12417,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- protection, works in dcmoto -->
 	<software name="intoxzoec" cloneof="intoxzoe" supported="no">
-		<description>Intox &amp; Zoe (Protected)</description>
+		<description>Intox &amp; Zoe (protected)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32501">
 				<rom name="intox &amp; zoe (1984-08)(loriciels - tf01)(fr)[b].k7" size="32501" crc="170361b6" sha1="510a7106e83cfcf4e9b3f9287e1c7faf7c4847e8"/>
@@ -11479,6 +12432,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Intrus</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16791">
 				<rom name="l'intrus (sprites) (pascal pommier) (1985) (mo5).k7" size="16791" crc="54b53b35" sha1="32e5654453f1c911546c53e11f197a162cdde7d1"/>
@@ -11490,6 +12444,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Invasion</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7691">
 				<rom name="invasion (1985)(infogrames)(fr).k7" size="7691" crc="36a9384b" sha1="47bd732186010f80c70a7726942fb58eb8c060f3"/>
@@ -11501,6 +12456,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Invasion (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7691">
 				<rom name="invasion (1985)(infogrames)(fr)[a].k7" size="7691" crc="844e1def" sha1="70673d1e33abcf8f026e2315d4c4708778d8fce8"/>
@@ -11512,6 +12468,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Invasion (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7691">
 				<rom name="invasion_mo5.k7" size="7691" crc="7626a8e3" sha1="0d46e1448de00c61e57a5f45fec5f118972325e2"/>
@@ -11523,6 +12480,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Isabelle et le Dragon</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20234">
 				<rom name="isabelle et le dragon (1985)(hebdogiciel)(fr)(pd).k7" size="20234" crc="dacd4a41" sha1="0d5abaf03560f31298b2da1922e114311c776138"/>
@@ -11534,6 +12492,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Isabelle et le Dragon (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20234">
 				<rom name="isabelle et le dragon (1985)(hebdogiciel)(fr)(pd)[a].k7" size="20234" crc="c4f3bbe3" sha1="3589f3287327f60e3b276caef39f822e3369fd97"/>
@@ -11545,6 +12504,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Isabelle et le Dragon (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20234">
 				<rom name="isabelle et le dragon (19xx)(hebdogiciel)(pd).k7" size="20234" crc="2d19f913" sha1="66f2d528e22364f980f5d9556840b3db6d0c27e9"/>
@@ -11556,6 +12516,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Isabelle et le Dragon (alt 3)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20234">
 				<rom name="isabelle-et-le-dragon_mo5.k7" size="20234" crc="3cbca6a4" sha1="98a2a5e426e1121adf26c8a9999c8156d3bebc1a"/>
@@ -11567,6 +12528,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Island</description>
 		<year>1984</year>
 		<publisher>Micro Application - Informatics</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32502">
 				<rom name="island (1984)(micro application - informatics)(fr).k7" size="32502" crc="95740fd4" sha1="a99a6f3404710b1e7a88b2a2f0607b806d0ae228"/>
@@ -11578,6 +12540,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Island (alt)</description>
 		<year>1984</year>
 		<publisher>Micro Application - Informatics</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32502">
 				<rom name="island (1984)(micro application - informatics)(fr)[a].k7" size="32502" crc="c7952c4e" sha1="008915bba8acabadc22cea8e71498f1b6129cdc9"/>
@@ -11589,6 +12552,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Island (alt 2)</description>
 		<year>1984</year>
 		<publisher>Micro Application - Informatics</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32502">
 				<rom name="island (1984)(micro application - informatics)(fr)[a2].k7" size="32502" crc="21850d19" sha1="43a31718b7ca7211e76f40fc8db7543cd55cc011"/>
@@ -11600,6 +12564,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Island (alt 3)</description>
 		<year>1984</year>
 		<publisher>Micro Application - Informatics</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32502">
 				<rom name="island_mo5.k7" size="32502" crc="1987ecaa" sha1="6e48857b4915e61afcf6f23b517c648ccc2500cf"/>
@@ -11611,6 +12576,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>James Debug - Le Grand Saut</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45944">
 				<rom name="james debug - le grand saut (1987)(coktel vision)(fr).k7" size="45944" crc="0bb9d507" sha1="b85e96dc9aabcfb06c5efb852032a79c6bd2fd72"/>
@@ -11622,6 +12588,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>James Debug - Le Grand Saut (alt)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45944">
 				<rom name="james debug - le grand saut (1987)(coktel vision)(fr)[a].k7" size="45944" crc="bcb85934" sha1="00fb5d6a5f6c4ee9f72ab26ec84cbede076f43c5"/>
@@ -11633,6 +12600,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu de Dames</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="jeu de dames (1984-07)(loriciels)(fr).k7" size="12668" crc="cfc445b1" sha1="fe4e01cf88a6e70308a64a54a292985f87f04f61"/>
@@ -11644,6 +12612,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu de Dames (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="jeu de dames (1984-07)(loriciels)(fr)[a].k7" size="12668" crc="5554f495" sha1="f1a6bc270829494223aa2129e81c80461af2500e"/>
@@ -11655,6 +12624,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu de Dames (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12668">
 				<rom name="jeu-de-dames_mo5.k7" size="12668" crc="908daafa" sha1="673b04e3b862b268a21681652afb6cd393f8adda"/>
@@ -11666,6 +12636,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu de Dames Americain</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11985">
 				<rom name="jeu de dames americain (1987)(fil)(fr).k7" size="11985" crc="6fbe9e56" sha1="526bb3c616bf8263d86ad41aedb1e4ec6ba95d35"/>
@@ -11677,6 +12648,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu de Dames Americain (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11985">
 				<rom name="jeu de dames americain (1987)(fil)(fr)[a].k7" size="11985" crc="6e7c4698" sha1="7cf13cdd01f55ba271cacfbb61c6fa640d40abbe"/>
@@ -11688,6 +12660,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu de Dames Americain (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11985">
 				<rom name="jeu de dames americain (1987)(fil)(fr)[a2].k7" size="11985" crc="19796d72" sha1="9d6368634863577476918c60566720f57bd063d6"/>
@@ -11699,6 +12672,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu de Dames Americain (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11985">
 				<rom name="draughts_mo5.k7" size="11985" crc="c2c4ae54" sha1="04b4002e60df40df177eb758c2825d483d0c0a45"/>
@@ -11710,6 +12684,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Jeu des Marelles</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30298">
 				<rom name="jeu des marelles, le (198x)(free game blot)(fr).k7" size="30298" crc="bde59900" sha1="d2e866fcb2df6bde1d76eb974c32be7c0061b3b6"/>
@@ -11721,6 +12696,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Jeu des Marelles (alt)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30298">
 				<rom name="jeu des marelles, le (198x)(free game blot)(fr)[a].k7" size="30298" crc="e81a18df" sha1="edc6c937fe4d354985661fd90cef0e2a49067d83"/>
@@ -11732,6 +12708,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Jeu des Marelles (alt 2)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30298">
 				<rom name="le jeu des marelles (free game blot) (reiner ost) (mo5).k7" size="30298" crc="e848867d" sha1="f8ebef41e026e71a7d1c20e819422d376166058f"/>
@@ -11743,6 +12720,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Jeu des Petits Chevaux</description>
 		<year>198?</year>
 		<publisher>Edition Informatique Logiciel (EDIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12710">
 				<rom name="jeu des petits chevaux, le (198x)(edil)(fr).k7" size="12710" crc="6374534c" sha1="707ef589e9f8361134a255b7df0d1d206a9c5407"/>
@@ -11754,6 +12732,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu Meteo</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5580">
 				<rom name="jeu meteo (198x)(-)(fr).k7" size="5580" crc="4a944ec7" sha1="2bd2dcb472fdcab1c066ec381ee414ad0aed1632"/>
@@ -11765,6 +12744,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu Meteo (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5580">
 				<rom name="jeu meteo (198x)(-)(fr)[a].k7" size="5580" crc="9dd9992c" sha1="32cb989f96d7d5a1fdff703d596260ceb7c9fabb"/>
@@ -11776,6 +12756,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu Meteo (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5745">
 				<rom name="jeu meteo (198x)(-)(fr)[a2].k7" size="5745" crc="54e451fd" sha1="e82860454636f5c43740fb5c03ff9f79e2f2671d"/>
@@ -11787,6 +12768,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeu Meteo (alt 3)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5580">
 				<rom name="jeu-meteo_mo5.k7" size="5580" crc="f6e169ff" sha1="ae36db5c1b02db6f2d03d40355c324d9498b0a17"/>
@@ -11798,6 +12780,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Jeux de Maitre Jacques</description>
 		<year>1984</year>
 		<publisher>Micro Application</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13592">
 				<rom name="les jeux de maitre jacques (micro application) (jacques lebbe) (1984) (mo5).k7" size="13592" crc="80bb25f4" sha1="dc1e9491b483f904ab6aea89a9a67e85e97d3800"/>
@@ -11809,6 +12792,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Judoka</description>
 		<year>1985</year>
 		<publisher>VIFI International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36361">
 				<rom name="judoka (1985)(vifi)(fr).k7" size="36361" crc="1d805f09" sha1="b3d52e9c1d328cb25173480ad455bb7f35f0bbfe"/>
@@ -11820,6 +12804,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jump for Survival</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22703">
 				<rom name="jump-for-survival_mo5.k7" size="22703" crc="3cb828b9" sha1="6c1ed7ef786c79484148ca0ce0d08e91ad363266"/>
@@ -11831,6 +12816,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jungle Hero</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="92170">
 				<rom name="jungle hero (198x)(softbook)(fr).k7" size="92170" crc="8cb49839" sha1="ccec5ece656d490e3292124139cda6de3f26e7b9"/>
@@ -11842,6 +12828,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jungle Hero (alt)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="92170">
 				<rom name="jungle hero (198x)(softbook)(fr)[a].k7" size="92170" crc="ab608ac2" sha1="487da0ade89659c93ff493bf9eddf20352923d39"/>
@@ -11853,6 +12840,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jungle Hero (alt 2)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="92170">
 				<rom name="jungle hero (198x)(softbook)(fr)[a2].k7" size="92170" crc="cd8e3050" sha1="c54695890f367875c469db2d16fc5b2c7675c804"/>
@@ -11864,6 +12852,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jungle Hero (alt 3)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="92170">
 				<rom name="jungle-hero_mo5.k7" size="92170" crc="4a4f2f83" sha1="02f9f231b3f63351cf7581d89c81ba0ca526451e"/>
@@ -11875,6 +12864,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Kanicula</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14293">
 				<rom name="kanicula (1984)(to tek)(fr).k7" size="14293" crc="b4efadc2" sha1="bdacf13288271e740f186b091370e861cce5a115"/>
@@ -11886,6 +12876,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Kanicula (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14293">
 				<rom name="kanicula (1984)(to tek)(fr)[a].k7" size="14293" crc="ca61905d" sha1="484b0ba291cbeb5553f7b8895a4df539386d7449"/>
@@ -11897,6 +12888,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Kanicula (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14293">
 				<rom name="kanicula (1984)(to tek)(fr)[a2].k7" size="14293" crc="e71c0c9a" sha1="15539ca522395d1004b45bf1d6f8e68bd04a7e3e"/>
@@ -11908,6 +12900,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Kanicula (alt 3)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14293">
 				<rom name="kanicula_mo5.k7" size="14293" crc="a58ff181" sha1="dfeac1fa7ab5274c2392baa16e3baac48a8458c4"/>
@@ -11919,6 +12912,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Karate</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11312405">
 				<rom name="karate (1985)(infogrames)[loadm'''',,r].wav" size="11312405" crc="c8c268fc" sha1="bd792e0e96f7f0a6578a8dc6a7f66f92cb8b51f7"/>
@@ -11930,6 +12924,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Karate (alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34853">
 				<rom name="karate (1985)(infogrames)(fr)[loadm].k7" size="34853" crc="5557eaa4" sha1="e09f8f22d075ee5a89c77efe5e26f9d5aca2f8c1"/>
@@ -11941,6 +12936,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Karate (alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33912">
 				<rom name="karate (1985)(infogrames)(fr)[a][loadm].k7" size="33912" crc="f9a5b85a" sha1="bf564d54fd836e9fbe87c4871b1eaacc530625a8"/>
@@ -11952,6 +12948,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Karate (alt 3)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33912">
 				<rom name="karate (1985)(infogrames)(fr)[a2][loadm].k7" size="33912" crc="7cf35047" sha1="b0b6a5688abd38b8791ff406a7de759bbc7579f9"/>
@@ -11963,6 +12960,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Karate (alt 4)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33912">
 				<rom name="karate (1985)(infogrames)(fr)[a3][loadm].k7" size="33912" crc="a28c199b" sha1="6f082fe1ab6825899a95603d27932d41f32ab859"/>
@@ -11974,6 +12972,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Karate (alt 5)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33912">
 				<rom name="karate_mo5.k7" size="33912" crc="0306544c" sha1="885ef795c3c57c6dc6366e766b91ab8ba841477b"/>
@@ -11985,6 +12984,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Karate (BASIC Loader)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36725">
 				<rom name="karate (1985)(infogrames)(fr)[b].k7" size="36725" crc="34c629d4" sha1="6185db96da92ba2c3f1a021ca48454ce921681bd"/>
@@ -11996,6 +12996,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Khronos</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="48948">
 				<rom name="khronos (1986)(coktel vision)(fr).k7" size="48948" crc="f8730104" sha1="a16291123b7953b8a3f142d91f4ba8e584ecfd08"/>
@@ -12007,6 +13008,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Khronos (alt)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49187">
 				<rom name="khronos (1986)(coktel vision)(fr)[a].k7" size="49187" crc="9134df59" sha1="642c29f1628dbf4be1d5eff1e9f72eb5d092a13b"/>
@@ -12018,6 +13020,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Khronos (alt 2)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49187">
 				<rom name="khronos (1986)(coktel vision)(fr)[a2].k7" size="49187" crc="32041430" sha1="3066a87778a416e0c8a5765dfb71f8d7bf73ecee"/>
@@ -12029,6 +13032,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Khronos (alt 3)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="49187">
 				<rom name="khronos_mo5.k7" size="49187" crc="59fffdf1" sha1="13c930e6f415b804077df0e96f7d2c7236e64928"/>
@@ -12040,6 +13044,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Krakout</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45889">
 				<rom name="krakout (1987)(fil)(fr).k7" size="45889" crc="748c99be" sha1="0af603e6c4522dd5bd01e08ddbbfa229e211782e"/>
@@ -12051,6 +13056,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Krakout (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46166">
 				<rom name="krakout (1987)(fil)(fr)[a].k7" size="46166" crc="6b06330e" sha1="a4eeeeec30afca893fc4edbf9703da0aee96815a"/>
@@ -12062,6 +13068,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Krakout (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46166">
 				<rom name="krakout (1987)(fil)(fr)[a2].k7" size="46166" crc="0ac9b5bb" sha1="75c2cecb03135658168beb00bfc5c073c4bcb36e"/>
@@ -12073,6 +13080,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Krakout (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="46166">
 				<rom name="krakout_mo5.k7" size="46166" crc="5ed303f1" sha1="93aa11375f5961437743a369708d96972a79a663"/>
@@ -12084,6 +13092,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Kung Fou</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="54716">
 				<rom name="kung fou (1987)(softbook)(fr).k7" size="54716" crc="3de15f6b" sha1="7b80154f3ad6031a8f1d33e2888a0e9db6c3da19"/>
@@ -12095,6 +13104,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Kung Fou (alt)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="54716">
 				<rom name="kung-fou_mo5.k7" size="54716" crc="10e31e72" sha1="393b76cf0b885d74986597b6914b7dfcef2e0382"/>
@@ -12106,6 +13116,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6654">
 				<rom name="labyrinthe (1986)(dcsoft)(fr)(pd).k7" size="6654" crc="83a76d0c" sha1="f0a19c460d2aab3973df2a01a7bdab8f5e6d4b46"/>
@@ -12117,6 +13128,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe (alt)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6654">
 				<rom name="labyrinthe (1986)(dcsoft)(fr)(pd)[a].k7" size="6654" crc="67e65574" sha1="4882f71fe9c6f13e108b0fa277fb4bd88c9742c5"/>
@@ -12128,6 +13140,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe (alt 2)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6654">
 				<rom name="labyrinthe (1986)(dcsoft)(fr)(pd)[a2].k7" size="6654" crc="b7138668" sha1="a741bd12d858e73205200ae6fd78d51fbc4713b8"/>
@@ -12139,6 +13152,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe (alt 3)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6654">
 				<rom name="labyrinthe_mo5.k7" size="6654" crc="202f2840" sha1="a4ba6b4bb6f0baeb76961059814282364242c71e"/>
@@ -12150,6 +13164,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe Survie</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10455">
 				<rom name="labyrinthe survie (1984)(vifi-nathan)(fr).k7" size="10455" crc="3550e148" sha1="52655416d5d0650ea93d789d66b918bbb32eecfb"/>
@@ -12161,6 +13176,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe Survie (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16559">
 				<rom name="labyrinthe survie (1984)(vifi-nathan)(fr)[a].k7" size="16559" crc="6e662977" sha1="14d187be5d08c082108f0c9a13fe548c1af864c8"/>
@@ -12172,6 +13188,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe Survie (alt 2)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16559">
 				<rom name="labyrinthe-survie_mo5.k7" size="16559" crc="17c92688" sha1="3754de4974ad859b306819a57d51721e28bb03c7"/>
@@ -12197,6 +13214,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Las Vegas</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="55339">
@@ -12212,9 +13230,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="lasvegasa" cloneof="lasvegas">
-		<description>Las Vegas (Split Side A)</description>
+		<description>Las Vegas (split side A)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A Part 1"/>
 			<dataarea name="cass" size="33674">
@@ -12239,6 +13258,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Las Vegas (single tape)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85282">
 				<rom name="las vegas (1985)(infogrames)(fr).k7" size="85282" crc="c9fcd41b" sha1="036e68f4b86b4ddfa85434008c8b11acff76d169"/>
@@ -12250,6 +13270,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Las Vegas (single tape, alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85282">
 				<rom name="las vegas (1985)(infogrames)(fr)[a].k7" size="85282" crc="876c5d31" sha1="24aeff0f55975fb6697ef5ab8c439adb3aab6083"/>
@@ -12261,6 +13282,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Las Vegas (single tape, alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85282">
 				<rom name="las vegas (infogrames) (pierre bayle, roger granier) (1985) (mo6).k7" size="85282" crc="c49ffbb2" sha1="f3beb79d7ea838baac9bebb072b3242b835df350"/>
@@ -12272,6 +13294,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Las Vegas (single tape, alt 3)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85282">
 				<rom name="las vegas (fr) (infogrames) (pierre bayle) (1985) (lasvegasmo6).k7" size="85282" crc="8a0f7298" sha1="8e9de8be151009fdfd1f4fda0a98083c1da1f6ae"/>
@@ -12283,6 +13306,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Las Vegas (KCI format)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="701846">
@@ -12301,6 +13325,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Las Vegas (WAV format)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21625964">
 				<rom name="las-vegas-a_mo5.wav" size="21625964" crc="f3756a41" sha1="3d2c1152b75d493d8b364198383db776ab2ebbaf"/>
@@ -12317,6 +13342,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Lorann</description>
 		<year>1985</year>
 		<publisher>Novasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38582">
 				<rom name="lorann (1985)(novasoft)(fr).k7" size="38582" crc="1c7fd158" sha1="1dc0412a93a175039588e1801316b057897e7285"/>
@@ -12328,6 +13354,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Lorann (alt)</description>
 		<year>1985</year>
 		<publisher>Novasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38582">
 				<rom name="lorann (1985)(novasoft)(fr)[a].k7" size="38582" crc="097d7664" sha1="9c027569f722d8573c9086b0297a850b34619f39"/>
@@ -12339,6 +13366,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Lorann (alt 2)</description>
 		<year>1985</year>
 		<publisher>Novasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38582">
 				<rom name="lorann (1985)(novasoft)(fr)[a2].k7" size="38582" crc="83fc8f85" sha1="e6f648ac1e4dee89c3b7b4482416360473152c6b"/>
@@ -12350,6 +13378,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Lorann (alt 3)</description>
 		<year>1985</year>
 		<publisher>Novasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38582">
 				<rom name="lorann-mo5.k7" size="38582" crc="9c6c2c11" sha1="3782f15ad90d4640702fe18ded845257b9c5815b"/>
@@ -12361,6 +13390,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Magic</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44972">
 				<rom name="magic (1987)(titus software)(fr)(en-fr).k7" size="44972" crc="aed97f08" sha1="b1b163fd466129d1cc0dc5f98b68cd76c1787b01"/>
@@ -12372,6 +13402,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Magic (alt)</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="44972">
 				<rom name="magic_mo5.k7" size="44972" crc="75269635" sha1="d9ffd2e90d530f456635b72684dcab6b5e14b40b"/>
@@ -12383,6 +13414,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Maison Hantee</description>
 		<year>198?</year>
 		<publisher>Lilian Pigallio</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34616">
 				<rom name="maison hantee, la (198x)(pigallio, lilian)(fr).k7" size="34616" crc="4ddccac4" sha1="51f6c809bb32e4c492cb92fe7f7ee28ca627f81d"/>
@@ -12394,6 +13426,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Maison Hantee (alt)</description>
 		<year>198?</year>
 		<publisher>Lilian Pigallio</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34616">
 				<rom name="maison hantee, la (198x)(pigallio, lilian)(fr)[a].k7" size="34616" crc="c79c688f" sha1="7f4715544876ea4f620141eed3e0cf6ed02e770c"/>
@@ -12405,6 +13438,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Maison Hantee (alt 2)</description>
 		<year>198?</year>
 		<publisher>Lilian Pigallio</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34616">
 				<rom name="maison hantee, la (198x)(pigallio, lilian)(fr)[a2].k7" size="34616" crc="8672623c" sha1="ef73d84017ebbaf09b7a6664db76140412a39f48"/>
@@ -12416,6 +13450,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Maison Hantee (alt 3)</description>
 		<year>198?</year>
 		<publisher>Lilian Pigallio</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34616">
 				<rom name="la-maison-hantee_mo5.k7" size="34616" crc="88bb4711" sha1="10c9bb32b10bd1ff89cd20ceaa00e7daf77a608c"/>
@@ -12427,6 +13462,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Malediction de Thaar</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38316">
 				<rom name="malediction de thaar, la (1986)(coktel vision)(fr).k7" size="38316" crc="4ca7dbfd" sha1="1e7b432a504e3c380908fcf3760bf921276001d1"/>
@@ -12438,6 +13474,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Malediction de Thaar (alt)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38458">
 				<rom name="malediction de thaar, la (1986)(coktel vision)(fr)[a].k7" size="38458" crc="9e841d02" sha1="42aa8debb2423797db1b6ec014fdfa17ce831b81"/>
@@ -12449,6 +13486,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Malediction de Thaar (alt 2)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38458">
 				<rom name="malediction de thaar, la (1986)(coktel vision)(fr)[a2].k7" size="38458" crc="d7b17373" sha1="ea19a02bc4db6dfa165c3711a357b4851fbd819c"/>
@@ -12460,6 +13498,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Malediction de Thaar (alt 3)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38458">
 				<rom name="la-malediction-de-thaar_mo5.k7" size="38458" crc="94208b9c" sha1="12783baadc3a38920a16487ab8529fa94d15f4c2"/>
@@ -12472,6 +13511,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mandragore</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Jeu)"/>
 			<dataarea name="cass" size="41969">
@@ -12490,6 +13530,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mandragore (alt, tape 2 split)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Jeu)"/>
 			<dataarea name="cass" size="40521">
@@ -12514,6 +13555,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mandragore (single tape)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="150395">
 				<rom name="mandragore (1984)(infogrames)(fr).k7" size="150395" crc="307edecf" sha1="ee09e016830f8781a8fce8906b57dd915f2fa532"/>
@@ -12525,6 +13567,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mandragore (single tape, alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="150395">
 				<rom name="mandragore (1984)(infogrames)(fr)[a].k7" size="150395" crc="1167e991" sha1="cfa380867df3216b189bc8bd6a419edfc1472140"/>
@@ -12536,6 +13579,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Marathon Cosmique</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24081">
 				<rom name="marathon cosmique (1985)(hebdogiciel)(fr)(pd).k7" size="24081" crc="f2debb3f" sha1="95278cfe7cc74ca1413abe52e5a1e0e96d62cdfe"/>
@@ -12547,6 +13591,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Marathon Cosmique (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24081">
 				<rom name="marathon cosmique (1985)(hebdogiciel)(fr)(pd)[a].k7" size="24081" crc="5df90a41" sha1="6655e0355d3a7aff289ba1712319089f66801df1"/>
@@ -12558,6 +13603,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Marathon Cosmique (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24081">
 				<rom name="marathon cosmique (1985)(hebdogiciel)(fr)(pd)[a2].k7" size="24081" crc="09c999cd" sha1="cb0e86a1ce57eb97c0bd03a25bed6afb1a41cd07"/>
@@ -12569,6 +13615,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Marathon Cosmique (alt 3)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24081">
 				<rom name="marathon-cosmique_mo5.k7" size="24081" crc="5544ee55" sha1="0e2f360e4fbaa291c5e5af63e2749d0ddd2f3bfd"/>
@@ -12580,6 +13627,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Masque du Graille</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32003">
 				<rom name="masque du graille, le (198x)(-)(fr).k7" size="32003" crc="5e5776c3" sha1="395dab202391233021b60854d9862def052a1986"/>
@@ -12591,6 +13639,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Masque du Graille (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32003">
 				<rom name="masque du graille, le (19xx)(-)(fr).k7" size="32003" crc="d5457a41" sha1="62a3e2b189ad07fe78bb6df49b30bd71c7c696aa"/>
@@ -12602,6 +13651,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Masque du Graille (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32003">
 				<rom name="le-masque-du-graille_mo5.k7" size="32003" crc="58ee5e18" sha1="c9c5a11e37875fe2595cac780ff4fd1bdf974839"/>
@@ -12613,6 +13663,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Megawatt</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="53035">
@@ -12631,6 +13682,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Megawatt (single tape)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="106070">
 				<rom name="megawatt (1987)(softbook)(fr).k7" size="106070" crc="3cd6d9bc" sha1="1bcbe6bfa11dc3bff8d3289203ca492a5b22d3dd"/>
@@ -12642,6 +13694,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Megawatt (single tape, alt)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="106070">
 				<rom name="megawatt (1987)(softbook)(fr)(tape 1 of 2)[a].k7" size="106070" crc="dda95749" sha1="7f240d9a1f6a93bc2da931b75c3271b3ee4778f7"/>
@@ -12653,6 +13706,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Megawatt (single tape, alt 2)</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="106070">
 				<rom name="megawatt_mo5.k7" size="106070" crc="d9d33582" sha1="624f6a94c1bfc81e0c6202cdacb836f8a3bdcc84"/>
@@ -12664,6 +13718,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Memo7</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6853">
 				<rom name="memo7 (1983)(vifi-nathan)(fr).k7" size="6853" crc="a966b643" sha1="a91d9b804b9cbbab9783a5567a217d819459b7e6"/>
@@ -12675,6 +13730,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Memo7 (alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6853">
 				<rom name="memo7 (1983)(vifi-nathan)(fr)[a].k7" size="6853" crc="8066ad81" sha1="c68b5d8dbb8446b925062888b69d5e6e8752f45a"/>
@@ -12686,6 +13742,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Memo7 (alt 2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6853">
 				<rom name="memo7_mo5.k7" size="6853" crc="45e92614" sha1="111e9d8e1bbb7faf54ba784e6f9060493db9091e"/>
@@ -12697,6 +13754,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Memory</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13947">
 				<rom name="memory (1985)(dcsoft)(fr)(pd).k7" size="13947" crc="bc853288" sha1="96ce3dd1e9d8c7f3b59b79ba22df03c2d38aad0f"/>
@@ -12708,6 +13766,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Memory (alt)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13947">
 				<rom name="memory (1985)(dcsoft)(fr)(pd)[a].k7" size="13947" crc="1d677ffc" sha1="58c54335ebc62008f13910375b4b186a93d35489"/>
@@ -12719,6 +13778,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Memory (alt 2)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13947">
 				<rom name="memory (1985)(dcsoft)(fr)(pd)[a2].k7" size="13947" crc="cce44972" sha1="c2d11758452fa38bdba29f42cce0a22d87899ba6"/>
@@ -12730,6 +13790,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Memory (alt 3)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13947">
 				<rom name="memory_mo5.k7" size="13947" crc="5b6c1e09" sha1="8358c49d4e5022b3a8324d93c84bdf58a8ba19e2"/>
@@ -12741,6 +13802,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mes Premiers Mots Croises (v1.2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19166">
 				<rom name="mes premiers mots croises v1.2 (1983)(vifi-nathan)(fr).k7" size="19166" crc="a923a0e2" sha1="f656cd62e4aa26399f85bc1315bbb9ad68e761f1"/>
@@ -12752,6 +13814,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mes Premiers Mots Croises (v1.2, alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19174">
 				<rom name="mes premiers mots croises v1.2 (1983)(vifi-nathan)(fr)[a].k7" size="19174" crc="a47eab9a" sha1="f9c2704d776cc142c19d2628944f0c613914af54"/>
@@ -12763,6 +13826,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mes Premiers Mots Croises (v1.2, alt 2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19158">
 				<rom name="mes premiers mots croises v1.2 (1983)(vifi-nathan)(fr)[a2].k7" size="19158" crc="f71828c9" sha1="db52c96453b9ea6617373517c6f5f1c4099cff40"/>
@@ -12774,6 +13838,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mes Premiers Mots Croises (v1.2, alt 3)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19158">
 				<rom name="mes premiers mots croises v1.2 (1983)(vifi-nathan)(fr)[a3].k7" size="19158" crc="7a698b2a" sha1="4f358c51d3a48c91ed4914aed84db3368d79cfe7"/>
@@ -12785,6 +13850,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mes Premiers Mots Croises (v1.2, alt 4)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19158">
 				<rom name="mes-premiers-mots-croises-2_mo5.k7" size="19158" crc="04a404a5" sha1="d317fb06a0cdc71b744d023d40694e7e9bbe640a"/>
@@ -12796,6 +13862,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mes Premiers Mots Croises (v1.1)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21236">
 				<rom name="mes premiers mots croises v1.1 (1983)(vifi-nathan)(fr).k7" size="21236" crc="39acbb41" sha1="3f252773b7ca6e80f12782f95c163006484edc48"/>
@@ -12807,6 +13874,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mes Premiers Mots Croises (v1.1, alt)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21236">
 				<rom name="mes premiers mots croises v1.1 (1983)(vifi-nathan)(fr)[a].k7" size="21236" crc="456bb1cb" sha1="073d145eae2afcf4ebf11dd6e03362e70939c019"/>
@@ -12818,6 +13886,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mes Premiers Mots Croises (v1.1, alt 2)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21236">
 				<rom name="mes premiers mots croises v1.1 (1983)(vifi-nathan)(fr)[a2].k7" size="21236" crc="3f7a8a1c" sha1="a271135f145fae67234b3a4b98c26a30864b5787"/>
@@ -12829,6 +13898,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mes Premiers Mots Croises (v1.1, alt 3)</description>
 		<year>1983</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21236">
 				<rom name="mes-premiers-mots-croises-1_mo5.k7" size="21236" crc="f846b07b" sha1="9efd28546d343fa4655903b7bdc4ed41ce488036"/>
@@ -12840,6 +13910,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Metallurgiste</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7250">
 				<rom name="metallurgiste, le (198x)(-)(fr).k7" size="7250" crc="8a29a426" sha1="ce72564d67963a5fe183fa7d25bb7df2aad61406"/>
@@ -12851,6 +13922,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Metallurgiste (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7250">
 				<rom name="metallurgiste, le (198x)(-)(fr)[a].k7" size="7250" crc="f8f12b49" sha1="1ce8629b030c4ac5efd102d4f2cec39377401151"/>
@@ -12862,6 +13934,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Metallurgiste (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7250">
 				<rom name="le-metallurgiste_mo5.k7" size="7250" crc="67363111" sha1="4f59cb5b09d944dc8fc1a984178da94fc3d9b5b8"/>
@@ -12873,6 +13946,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Meteo-7</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10641">
 				<rom name="meteo-7 (1984)(infogrames)(fr).k7" size="10641" crc="71b24444" sha1="9bb0c7c70ce9733782a753ff903569c3dbd97bd0"/>
@@ -12884,6 +13958,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Meteo-7 (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11009">
 				<rom name="meteo-7 (1984)(infogrames)(fr)[a].k7" size="11009" crc="7afbf3df" sha1="a7c69a6daa381b56a9de931caae3337ee8dd23a7"/>
@@ -12895,6 +13970,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Meteo-7 (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11009">
 				<rom name="meteo-7 (1984)(infogrames)(fr)[a2].k7" size="11009" crc="0b6c16d1" sha1="c84f02bac9f4ebd2ff1a4d351b74a3dc106061cd"/>
@@ -12906,6 +13982,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Meteo-7 (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11009">
 				<rom name="meteo-7 (infogrames) (eric mottet) (1984) (mo5).k7" size="11009" crc="0a7fc71e" sha1="1535ffcbce2deed542bff24a2618f04808070b4e"/>
@@ -12917,6 +13994,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Metro</description>
 		<year>1984</year>
 		<publisher>Logimicro</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22570">
 				<rom name="metro (logimicro) (inconnus) (1984) (mo5 k7).k7" size="22570" crc="fc3b163e" sha1="55fd16f2c17dd6b062e6d5a939da24e22459126e"/>
@@ -12928,6 +14006,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Meurtre a Grande Vitesse</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37294">
 				<rom name="meurtre a grande vitesse (1985)(cobrasoft)(fr).k7" size="37294" crc="5538505e" sha1="f0a4b68fff941abcdc54942e4d3ee820a82e1350"/>
@@ -12939,6 +14018,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Meurtre a Grande Vitesse (alt)</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37294">
 				<rom name="meurtre-a-grande-vitesse_mo5.k7" size="37294" crc="68062e31" sha1="744282f141e52422b9edb4033f7869736272d40a"/>
@@ -12950,6 +14030,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Meurtres sur l'Atlantique</description>
 		<year>1986</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="79652">
 				<rom name="meurtres sur l'atlantique (1986)(cobrasoft)(fr).k7" size="79652" crc="3497f137" sha1="af5e5f77128dbf896c4852bc921d019a796ec2bd"/>
@@ -12961,6 +14042,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Meurtres sur l'Atlantique (alt)</description>
 		<year>1986</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="79652">
 				<rom name="meurtres-sur-l-atlantique_mo5.k7" size="79652" crc="43e601c1" sha1="e0ed59ade9834ca9afdca954b557ab8648ff8284"/>
@@ -12972,6 +14054,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Microjeux</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="37778">
 				<rom name="microjeux (nathan) (a. deledicq, j. delcourt, j.p. duclos, j.b. touchard, s. pouts lajus) (1985) (mo5).k7" size="37778" crc="40b0e2e0" sha1="e0b9772a12bf23a87cecb771944f1aff640505f6"/>
@@ -12983,6 +14066,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Micro Scrabble</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31042">
 				<rom name="micro scrabble (1985)(leisure genius)(fr).k7" size="31042" crc="6e782698" sha1="39029e11d31eecfe4e73b9f80257af930c8bbbef"/>
@@ -12994,6 +14078,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Micro Scrabble (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32905">
 				<rom name="micro scrabble (1985)(leisure genius)(fr)[a].k7" size="32905" crc="1b95b892" sha1="26b0e5e7e99ad8d2b040d8ced820b0fca19aecb2"/>
@@ -13005,6 +14090,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Micro Scrabble (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32905">
 				<rom name="micro scrabble (1985)(leisure genius)(fr)[a2].k7" size="32905" crc="7879651a" sha1="b4b6fee4b9585839b1377251a14100c44000d308"/>
@@ -13016,6 +14102,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Micro Scrabble (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32905">
 				<rom name="micro-scrabble (fil) (inconnus) (1985) (mo5).k7" size="32905" crc="eda702e7" sha1="5ea64e9b920b4248e9847d5a9542bd6e5cd446f3"/>
@@ -13027,6 +14114,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Millionnaire</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="27457">
 				<rom name="le millionnaire (ere informatique) (m. de guilhermier) (1984) (mo5).k7" size="27457" crc="f33a9946" sha1="b0ca4d1ed17693c64bf775efb1ba3fa5462d2ae6"/>
@@ -13038,6 +14126,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Mine aux Diamants</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6428104">
 				<rom name="mine aux diamants, la (1986)(infogrames)(fr)[loadm'''',,r].wav" size="6428104" crc="d624e8de" sha1="71b3f92e7fc39f073dec76f6a538062791a01b19"/>
@@ -13050,6 +14139,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Mine aux Diamants (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31374">
 				<rom name="mine aux diamants, la (1986)(infogrames)(fr)[b].k7" size="31374" crc="769a6c35" sha1="96aafb1de83658b4a22d2c05d6b6c15d88c59852"/>
@@ -13062,6 +14152,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Mine aux Diamants (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32814">
 				<rom name="la-mine-aux-diamants_mo5.k7" size="32814" crc="e8ff0fec" sha1="334596efc6fcdac5aeafed8389167514b94350c2"/>
@@ -13073,6 +14164,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Minotaure 3D</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17448">
 				<rom name="minotaure 3d (1985-04)(loriciels)(fr).k7" size="17448" crc="3e58ae7e" sha1="dd33aaa61b9f930065c798cc82f3d6df131d9fb9"/>
@@ -13084,6 +14176,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Minotaure 3D (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17448">
 				<rom name="minotaure 3d (1985-04)(loriciels)(fr)[a].k7" size="17448" crc="0b0cd2c2" sha1="6497366b897e303c1c770b1a21d10ede3837ffc2"/>
@@ -13095,6 +14188,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Minotaure 3D (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17448">
 				<rom name="minotaure-3d_mo5.k7" size="17448" crc="63ebba37" sha1="f9cb640426669d2388b9c0ac9045ed145c578dec"/>
@@ -13106,6 +14200,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Minotaure 3D (cracked)</description>
 		<year>1985</year>
 		<publisher>&lt;bootleg (Christophe Lesur)&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17390">
 				<rom name="minotaure 3d (1985-04)(loriciels)(fr)[cr lesur, christophe].k7" size="17390" crc="6e6d9bee" sha1="deb43479782d27e31f1ca939b923a17d5c1686aa"/>
@@ -13117,6 +14212,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission Delta</description>
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39540">
 				<rom name="mission delta (1984)(ere informatique)(fr).k7" size="39540" crc="33b19f83" sha1="af35538639ecc8f1c9715da41de8e626555fde83"/>
@@ -13128,6 +14224,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission Ninja (Hebdogiciel no. 150-151)</description>
 		<year>1986</year>
 		<publisher>Frederic Nguyen - Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21909">
 				<rom name="missionninja[mo5].k7" size="21909" crc="48564151" sha1="8ed3d2d1a04926aba22f88ecf56dce6d528fdc51"/>
@@ -13139,6 +14236,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission pas Possible</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24176">
 				<rom name="mission pas possible (198x)(infogrames)(fr).k7" size="24176" crc="6913053b" sha1="245583df89886107468ab472e4e6c59f74ba9fe2"/>
@@ -13150,6 +14248,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission pas Possible (alt)</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24317">
 				<rom name="mission pas possible (198x)(infogrames)(fr)[a].k7" size="24317" crc="1d168e2d" sha1="44a06df875d1a353debc8a49a4520b179cb73fb4"/>
@@ -13161,6 +14260,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission pas Possible (alt 2)</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24317">
 				<rom name="mission pas possible (198x)(infogrames)(fr)[a2].k7" size="24317" crc="fee22459" sha1="5423329c8dee6b5e1084475e3356b1eb80e7b72d"/>
@@ -13172,6 +14272,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission pas Possible (alt 3)</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24317">
 				<rom name="mission-pas-possible_mo5.k7" size="24317" crc="68124cab" sha1="a67d6658ec24eb0e897b05d9a0b37f456ec720eb"/>
@@ -13183,6 +14284,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission U-72</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24065">
 				<rom name="mission u-72 (1986)(hebdogiciel)(fr)(pd).k7" size="24065" crc="c974f5e7" sha1="eb85334da37a4815f07c06da3adf95f7de99e723"/>
@@ -13194,6 +14296,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission U-72 (alt)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24065">
 				<rom name="mission u-72 (1986)(hebdogiciel)(fr)(pd)[a].k7" size="24065" crc="1ed6ecfe" sha1="0bef5365d211c6b9a0c6324817ee3acccffd80b6"/>
@@ -13205,6 +14308,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission U-72 (alt 2)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24065">
 				<rom name="mission u72 (19xx)(hebdogiciel)(pd).k7" size="24065" crc="7711543f" sha1="61bbf749774c0bbabf54b86320d423481cadf1f4"/>
@@ -13216,6 +14320,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Mission U-72 (alt 3)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24065">
 				<rom name="mission-u72_mo5.k7" size="24065" crc="c0d2bc4f" sha1="5e84e8271d392965ea72e39015b2262cc235e1d0"/>
@@ -13227,6 +14332,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Missions en Rafale</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31529">
 				<rom name="missions en rafale (1987)(fil)(fr)(en-fr).k7" size="31529" crc="21f3d27b" sha1="cfe5559f7a6c889b348fbae2cb18034def0527a3"/>
@@ -13238,6 +14344,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Missions en Rafale (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31647">
 				<rom name="missions en rafale (1987)(fil)(fr)(en-fr)[a].k7" size="31647" crc="90d4c6d4" sha1="7e1ea6821f0e2fcd8cc48ec4b33dae841d50dc22"/>
@@ -13249,6 +14356,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Missions en Rafale (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31647">
 				<rom name="missions en rafale (1987)(fil)(fr)(en-fr)[a2].k7" size="31647" crc="ae2a1d1c" sha1="d6a835dbedb4ebcaf56469c3dc9f3a844abb12d9"/>
@@ -13260,6 +14368,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Missions en Rafale (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31647">
 				<rom name="missions-en-rafale_mo5.k7" size="31647" crc="d25f2210" sha1="33402314809901760e52e29adc5a5ff69eb141da"/>
@@ -13271,6 +14380,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monopolic</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19234">
 				<rom name="monopolic (198x)(free game blot)(fr).k7" size="19234" crc="ed06ee0f" sha1="4fd7b46921c40ce1fb4804c33e4e4ea2158d38f2"/>
@@ -13282,6 +14392,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monopolic (alt)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19300">
 				<rom name="monopolic (198x)(free game blot)(fr)[a].k7" size="19300" crc="4fbaf91f" sha1="ddd3eff3f8b85268654a2b1170036fb71a62af8e"/>
@@ -13293,6 +14404,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monopolic (alt 2)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19300">
 				<rom name="monopolic (198x)(free game blot)(fr)[a2].k7" size="19300" crc="7ed9aca9" sha1="17ba802e77eb9aec717ea75ad57fac2f2c55855b"/>
@@ -13304,6 +14416,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monopolic (alt 3)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19300">
 				<rom name="monopolic_a_mo5.k7" size="19300" crc="4f48f72f" sha1="4cdee680ea72f3bada4053d1c31080b8d973d875"/>
@@ -13315,6 +14428,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monopolic (Ger)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19806">
 				<rom name="monopolic version allemande (free game blot) (inconnus) (1985) (mo5 k7).k7" size="19806" crc="d572573d" sha1="048c2799bb0a27a40a78e0128468a590f29b3562"/>
@@ -13326,6 +14440,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monopoly</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="47640">
 				<rom name="monopoly (1985)(leisure genius)(fr).k7" size="47640" crc="119a4016" sha1="259cc1050fb79c7def770f2d75f4efe213dfa211"/>
@@ -13337,6 +14452,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monopoly (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="50613">
 				<rom name="monopoly (1985)(leisure genius)(fr)[a].k7" size="50613" crc="7341e02d" sha1="40ae6932119a4e68b74c4cd78b8ce86a6aa29e7e"/>
@@ -13348,6 +14464,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monopoly (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="50613">
 				<rom name="monopoly (1985)(leisure genius)(fr)[a2].k7" size="50613" crc="347699e3" sha1="94a9c0dd5cc8ee740a1cc81f69fccf5f55bdc3e5"/>
@@ -13359,6 +14476,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monster Mine</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12777">
 				<rom name="monster mine (1985)(fil)(fr).k7" size="12777" crc="7f14dc07" sha1="57966a88c1655100fe856f9c4cf0fff1cd709143"/>
@@ -13370,6 +14488,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monster Mine (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10512">
 				<rom name="monster mine (1985)(fil)(fr)[a].k7" size="10512" crc="19d00d1c" sha1="4abb82b4c448bdb9fc61e3dc86ad0693fc532d4c"/>
@@ -13381,6 +14500,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monster Mine (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10512">
 				<rom name="monster mine (fil) (inconnus) (1986) (mo5).k7" size="10512" crc="7acf4032" sha1="1a2a1f9ce33f0901447e6c73c5c367ccfe5e18a6"/>
@@ -13392,6 +14512,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monte Carlo</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="53439">
 				<rom name="monte carlo (1984-06)(loriciels)(fr).k7" size="53439" crc="331bc6d6" sha1="4f5533f5b8f532b6178e3aff352699d05c9900b6"/>
@@ -13403,6 +14524,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monte Carlo (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="53806">
 				<rom name="monte carlo (1984-06)(loriciels)(fr)[a].k7" size="53806" crc="60e5d723" sha1="6d806b2d8c9a900db959acf74b8067e12998ddff"/>
@@ -13414,6 +14536,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monte Carlo (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="53806">
 				<rom name="monte carlo (1984-06)(loriciels)(fr)[a2].k7" size="53806" crc="99d926fb" sha1="89e2284faed0c9a57c34ff386ddb80b300b7e965"/>
@@ -13425,6 +14548,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Monte Carlo (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="53806">
 				<rom name="monte-carlo_mo5.k7" size="53806" crc="e3434e18" sha1="cb672466560093627b9b08f5be87cf73d94e6b3e"/>
@@ -13436,6 +14560,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Mystere de Ming-Fonko</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22627">
 				<rom name="mystere de ming-fonko, le (1986)(hebdogiciel)(fr).k7" size="22627" crc="cda89980" sha1="e0ae7fb0c9c25af2da2b2290843ea662bee6888d"/>
@@ -13447,6 +14572,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Mystere de Ming-Fonko (alt)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22627">
 				<rom name="mystere de ming-fonko, le (1986)(hebdogiciel)(fr)[a].k7" size="22627" crc="6efd1312" sha1="358255a95cfcb704ca48db61af68c5b6bd82dc5e"/>
@@ -13458,6 +14584,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Mystere de Ming-Fonko (alt 2)</description>
 		<year>1986</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22627">
 				<rom name="le-mystere-de-ming-fonko_mo5.k7" size="22627" crc="04e7cf1f" sha1="24f4fe20bb3f58132fe935649487fa83ce7864bf"/>
@@ -13469,6 +14596,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Mystere de Paris</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="54883">
 				<rom name="mystere de paris, le (198x)(coktel vision)(fr).k7" size="54883" crc="7bfacd9b" sha1="506760fa52500ef6d72cad5860f0e96cdd7934b1"/>
@@ -13480,6 +14608,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Night Flight</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4220">
 				<rom name="night flight (198x)(-)(fr).k7" size="4220" crc="f3c5c3a5" sha1="c4425da64f9fb0519f987224b8f5979c27cc50dc"/>
@@ -13491,6 +14620,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Night Flight (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4220">
 				<rom name="night-flight_mo5.k7" size="4220" crc="5b05d310" sha1="2b6ca43ddf1dbe9c242e95a1d9912b27887d9cb0"/>
@@ -13502,6 +14632,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Nuit des Templiers</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29627">
 				<rom name="nuit des templiers, la (1986)(fil)(fr).k7" size="29627" crc="dd32e370" sha1="b306ee9b37cad495c35ba485114fcd1ba498598c"/>
@@ -13513,6 +14644,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Nuit des Templiers (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29601">
 				<rom name="nuit des templiers, la (1986)(fil)(fr)[a].k7" size="29601" crc="be987305" sha1="230bb7b0f8cfc0e78df725d8da1c5e1dfe1cb08b"/>
@@ -13524,6 +14656,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Nuit des Templiers (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29601">
 				<rom name="nuit des templiers, la (1986)(fil)(fr)[a2].k7" size="29601" crc="ca29d433" sha1="2346418e00a548fb090858bcabaade50a888c0c0"/>
@@ -13535,6 +14668,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Nuit des Templiers (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30157">
 				<rom name="la-nuit-des-templiers_mo5.k7" size="30157" crc="e46f90dc" sha1="7242de9b6542e0d63698775b211e4dbcb1bcdbb5"/>
@@ -13546,6 +14680,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Numero 10</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22420">
 				<rom name="numero 10 (1985)(fil)(fr).k7" size="22420" crc="382a11bb" sha1="9c0eadfbabd4a69a40de3e30fbfb44a6d6620d77"/>
@@ -13557,6 +14692,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Numero 10 (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22556">
 				<rom name="numero 10 (1985)(fil)(fr)[a].k7" size="22556" crc="879f4f6a" sha1="870b2c1323ace86a53154731e64314beb856c729"/>
@@ -13568,6 +14704,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Numero 10 (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22556">
 				<rom name="numero 10 (1985)(fil)(fr)[a2].k7" size="22556" crc="86c6a70b" sha1="ea8544b73a115a1d4fc6023f7122d5c53e4e1c73"/>
@@ -13579,6 +14716,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Numero 10 (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23112">
 				<rom name="numero 10 (1985)(fil)(fr)[a3].k7" size="23112" crc="d5b8141c" sha1="fd763513334974535c21ba5626ab7111004fd57b"/>
@@ -13590,6 +14728,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Numero 10 (alt 4)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22556">
 				<rom name="numero 10 (1985)(fil)(fr)[a4].k7" size="22556" crc="225e2ef9" sha1="b8d6eb45d10e486378b5d3479a8e5cfbc9a0aca4"/>
@@ -13601,6 +14740,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Numero 10 Special - Coupe du Monde 86</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25209">
 				<rom name="numero 10 version speciale - mexico 86 (1985)(fil)(fr).k7" size="25209" crc="908ffd25" sha1="9a5da1ba8d5617de896aa458a8fa8c18b46550d9"/>
@@ -13612,6 +14752,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Numero 10 Special - Coupe du Monde 86 (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25335">
 				<rom name="numero 10 version speciale - mexico 86 (1985)(fil)(fr)[a].k7" size="25335" crc="d31e4e3e" sha1="2c0c26d626fb64b66b683a5283159783a8870c7f"/>
@@ -13623,6 +14764,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Numero 10 Special - Coupe du Monde 86 (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25335">
 				<rom name="numero 10 version speciale - mexico 86 (1985)(fil)(fr)[a2].k7" size="25335" crc="ad7f9339" sha1="9dd06ef46d39948ee6faf4a48996e992c7523e54"/>
@@ -13634,6 +14776,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Numero 10 Special - Coupe du Monde 86 (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25335">
 				<rom name="numero-10-mexico-86_mo5.k7" size="25335" crc="386eb042" sha1="a88aab29dc5362618c0da157b2d8c3b7b4d5edd2"/>
@@ -13645,6 +14788,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Oceania</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35514">
 				<rom name="oceania (1985)(microids)(fr).k7" size="35514" crc="b560cbd3" sha1="f576f2f362cae24f9ee7e661030cae94e38a74ab"/>
@@ -13656,6 +14800,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Oceania (alt)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35514">
 				<rom name="oceania (1985)(microids)(fr)[a].k7" size="35514" crc="14d31dfb" sha1="07b08d7bc37173d05fcff8610d68171e36314481"/>
@@ -13667,6 +14812,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Oceania (alt 2)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35514">
 				<rom name="oceania_mo5.k7" size="35514" crc="60187ed0" sha1="43aa94157e7ada1189fa2fc1db5f36c9395b0ee1"/>
@@ -13678,6 +14824,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Octogonus</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18875">
 				<rom name="octogonus (1984)(to tek)(fr).k7" size="18875" crc="a775a5c5" sha1="e870d146e92447b6cb958cad774b53d5b69246ca"/>
@@ -13689,6 +14836,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Octogonus (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18867">
 				<rom name="octogonus (1984)(to tek)(fr)[a].k7" size="18867" crc="78aea91b" sha1="8621d68f8113a79b5d0eadc17358e6272dc712b4"/>
@@ -13700,6 +14848,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Octogonus (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18875">
 				<rom name="octogonus (1984)(to tek)(fr)[a2].k7" size="18875" crc="d929be26" sha1="2b429dded85a293cd0b543f7d21d7e44c492fb20"/>
@@ -13711,6 +14860,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Omega - Planete Invisible</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="117798">
 				<rom name="omega planete invisible (198x)(infogrames)(fr)[loadm'''',,r].k7" size="117798" crc="b9d1844c" sha1="6c16468769ed3f93bf54d7f20ebd67896c04a8c7"/>
@@ -13722,6 +14872,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Omega - Planete Invisible (alt)</description>
 		<year>198?</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="117798">
 				<rom name="omega-planete-invisible_mo5.k7" size="117798" crc="a6fdf4b5" sha1="29730071773c8500fa6eec07f413af1466f39efe"/>
@@ -13733,6 +14884,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Operation Nemo</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35953">
 				<rom name="operation-nemo_mo5.k7" size="35953" crc="8d82d85b" sha1="24e50996101c2dfc568a0124daaaf0be30aca990"/>
@@ -13744,6 +14896,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orbital Mission</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22964">
 				<rom name="orbital mission (1986)(coktel vision)(it).k7" size="22964" crc="532e9dd2" sha1="d9f178b12671bf5e4f215b981149a890f22c4f38"/>
@@ -13755,6 +14908,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orbital Mission (alt)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22964">
 				<rom name="orbital mission (1986)(coktel vision)(it)[a].k7" size="22964" crc="89ac58dc" sha1="3edb74c091e49521355765d6120a2a1109301cb2"/>
@@ -13766,6 +14920,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Orbital Mission (alt 2)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22964">
 				<rom name="orbital-mission_mo5.k7" size="22964" crc="786c158f" sha1="438c54bc1a2e8afeb2236b14e6b870e22b9bc895"/>
@@ -13777,6 +14932,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pac-man</description>
 		<year>1986</year>
 		<publisher>Theophile</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7861">
 				<rom name="pac-man (1986)(theophile)(fr).k7" size="7861" crc="2586c1ae" sha1="553f05238285e087e6e95382bb7dcb19aa421353"/>
@@ -13788,6 +14944,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pac-man (v2)</description>
 		<year>1998</year>
 		<publisher>Remi Coulom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16476">
 				<rom name="pac-man v2 (1998-06-06)(coulom, remi)(fr)(pd).k7" size="16476" crc="95918135" sha1="387f222d77f3d66a45ee11d7cada57f7a2213bfe"/>
@@ -13799,6 +14956,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pac-man (v2, alt)</description>
 		<year>1998</year>
 		<publisher>Remi Coulom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16476">
 				<rom name="pac-man v2 (1998-06-06)(coulom, remi)(fr)(pd)[a].k7" size="16476" crc="1156970c" sha1="ac3a5b24c2163923297066587f944cd5897e5c7e"/>
@@ -13810,6 +14968,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pac-man (v2, alt 2)</description>
 		<year>1998</year>
 		<publisher>Remi Coulom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16476">
 				<rom name="pac-man v2 (1998-06-06)(coulom, remi)(fr)(pd)[a2].k7" size="16476" crc="bea92e79" sha1="bea357d58beca5e6e25082268b07eeca28128651"/>
@@ -13821,6 +14980,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pac-man (v2, alt 3)</description>
 		<year>1998</year>
 		<publisher>Remi Coulom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16476">
 				<rom name="pacman-2_mo5.k7" size="16476" crc="6d6e0cd2" sha1="1d302e63b2dcdb565eb1e20d2d4d1b5c1cd9d5a9"/>
@@ -13832,6 +14992,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pancho</description>
 		<year>1984</year>
 		<publisher>Micro Application</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14466">
 				<rom name="pancho_mo5.k7" size="14466" crc="c3fb5e9d" sha1="89113d091dd4a829692c5a323124d7dc2320d045"/>
@@ -13843,6 +15004,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Paris 92 - Jeux Olympiques</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26714">
 				<rom name="paris 92 - jeux olympiques (infogrames) (william hennebois) (1986) (mo5 k7).k7" size="26714" crc="90e9c71a" sha1="f8fe66b728e0eb3f7ae1fa13ada942a640af9669"/>
@@ -13854,6 +15016,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pilot</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10247">
 				<rom name="pilot (1984)(infogrames)(fr).k7" size="10247" crc="4041249c" sha1="b3e831583582642c503f93b1a53c3b61af5c1bc8"/>
@@ -13865,6 +15028,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pilot (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10247">
 				<rom name="pilot (1984)(infogrames)(fr)[a].k7" size="10247" crc="676a8559" sha1="58def35057b8e5cc283ea214ddd1c4f14f8d413b"/>
@@ -13876,6 +15040,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pilot (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10247">
 				<rom name="pilot (infogrames) (gilles blanchard) (1984) (mo5) (v1).k7" size="10247" crc="1602899e" sha1="17c70d9447dd88ec589242424b76f14e13c42d9f"/>
@@ -13887,6 +15052,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pilot (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8512">
 				<rom name="pilot (infogrames) (gilles blanchard) (1984) (mo5) (v2).k7" size="8512" crc="0cd75373" sha1="8d0e9b054950c19a79e646fdc43dec1bde4c5e6c"/>
@@ -13898,6 +15064,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pingo</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7261">
 				<rom name="pingo (1983)(infogrames)(fr).k7" size="7261" crc="2aba1f9d" sha1="d5de23ed51ec35f0e68de00bc1c301d6758c8d42"/>
@@ -13909,6 +15076,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pingo (alt)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7261">
 				<rom name="pingo (1983)(infogrames)(fr)[a].k7" size="7261" crc="effd9280" sha1="8d21486058fd1c6944e2ea55dbec3f9b4152f1ae"/>
@@ -13920,6 +15088,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pingo (alt 2)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7261">
 				<rom name="pingo_mo5.k7" size="7261" crc="bcd83c9d" sha1="68a6ca51d1ec5962520d8b585df93b1454846e6c"/>
@@ -13931,6 +15100,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Piramide</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68600">
 				<rom name="piramide (1987-06-21)(rubio, javier marco)(es).k7" size="68600" crc="ef81427c" sha1="cefbfee2e10babc7ac2759177b044984cd5d00a6"/>
@@ -13942,6 +15112,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Piramide (alt)</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68600">
 				<rom name="piramide (1987-06-21)(rubio, javier marco)(es)[a].k7" size="68600" crc="55c5d062" sha1="832067ee451d9cfbf5ea8b923c0389a146a8ef6d"/>
@@ -13953,6 +15124,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Piramide (alt 2)</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="68600">
 				<rom name="piramide_mo5.k7" size="68600" crc="36cb6c03" sha1="b3cba5352a5850d9eb0cc9b87e77c370ea869df2"/>
@@ -13964,6 +15136,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Planete Inconnue</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39713">
 				<rom name="planete inconnue, la (198x)(fil)(fr).k7" size="39713" crc="63e2792e" sha1="3046be2a4c886a1b903325d0b23c32a48a8f90c8"/>
@@ -13975,6 +15148,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Planete Inconnue (alt)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39948">
 				<rom name="planete inconnue, la (198x)(fil)(fr)[a].k7" size="39948" crc="00412721" sha1="8c0921e64368c4af76f364c7daa9d692bf8edc09"/>
@@ -13986,6 +15160,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Planete Inconnue (alt 2)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39948">
 				<rom name="planete inconnue, la (198x)(fil)(fr)[a2].k7" size="39948" crc="5ecdd2f5" sha1="505b28b53918497c67492f31f7f05526e75f4753"/>
@@ -13997,6 +15172,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Planete Inconnue (alt 3)</description>
 		<year>198?</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39948">
 				<rom name="la-planete-inconnue_mo5.k7" size="39948" crc="b3e1893d" sha1="d600797908eacb2e8fee3e7fac617e9203897d73"/>
@@ -14022,6 +15198,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Plus Beau Puzzle</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22702">
 				<rom name="plus beau puzzle, le (1985)(cedic-nathan)(fr).k7" size="22702" crc="088cbdb2" sha1="d89a747bf4a71111688b18fd6b0cb142d015e6f5"/>
@@ -14033,6 +15210,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Plymouth-Newport</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32273">
 				<rom name="plymouth-newport (sprites) (pascal pommier) (1985) (mo5).k7" size="32273" crc="43446fc3" sha1="3750daa66a0a4d422c181133d0a80568ab14e24b"/>
@@ -14044,6 +15222,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Poker</description>
 		<year>1986</year>
 		<publisher>Gasoline Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39838">
 				<rom name="poker (1986)(gasoline software)(fr).k7" size="39838" crc="750288c3" sha1="d7049045a824f9d0fa6612f760e8986b456e31ca"/>
@@ -14055,6 +15234,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Poker (alt)</description>
 		<year>1986</year>
 		<publisher>Gasoline Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39838">
 				<rom name="poker (1986)(gasoline software)(fr)[a].k7" size="39838" crc="21718b85" sha1="7c002500a67af2a4b4a73784189f5a632bfd918f"/>
@@ -14066,6 +15246,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Poker (alt 2)</description>
 		<year>1986</year>
 		<publisher>Gasoline Software</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="39838">
 				<rom name="poker_mo5.k7" size="39838" crc="0296f0b8" sha1="c313ade08b3ffd2a7ee1602a6293cf30872c8eb9"/>
@@ -14077,6 +15258,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pole Position (Hebdogiciel no. 119-120)</description>
 		<year>1986</year>
 		<publisher>Thierry Dugnolle - Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22508">
 				<rom name="pole_position[mo5].k7" size="22508" crc="9db7e095" sha1="3fa87f3703691b2e473afa92d6d954de0175be92"/>
@@ -14088,6 +15270,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Politik Poker</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28819">
 				<rom name="politik poker (infogrames) (roger granier, pierre bayle) (1986) (mo5 k7).k7" size="28819" crc="50037baa" sha1="f5f068093480cc5453e22296e1f56fd962ba13f2"/>
@@ -14099,6 +15282,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Politique Economique</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19274">
 				<rom name="politique economique (1984)(answare)(fr).k7" size="19274" crc="26123c55" sha1="5ebdae6fd0c091f00f59aa9ce826262580fb1fb9"/>
@@ -14110,6 +15294,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Politique Economique (alt)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19339">
 				<rom name="politique economique (1984)(answare)(fr)[a].k7" size="19339" crc="707739fb" sha1="d6c1b4288c060d0cdb46dde32aa59948ea6af29d"/>
@@ -14121,6 +15306,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Politique Economique (alt 2)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19339">
 				<rom name="politique economique (1984)(answare)(fr)[a2].k7" size="19339" crc="fa023222" sha1="a347291df0ba770f5f6e8aba90dbea9ae390ad7b"/>
@@ -14132,6 +15318,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Politique Economique (alt 3)</description>
 		<year>1984</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19339">
 				<rom name="politique-economique_mo5.k7" size="19339" crc="522b637f" sha1="b3ea75967a6e240764a3b2875cf5bcf96d419ae9"/>
@@ -14143,6 +15330,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pop Pop</description>
 		<year>1985</year>
 		<publisher>Minipuce</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="15016">
 				<rom name="pop pop (1985)(minipuce)(fr).k7" size="15016" crc="66bd3e82" sha1="82b8cbb746e0fbeaab921c040d61d1418b473df2"/>
@@ -14154,6 +15342,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Popeye</description>
 		<year>1986</year>
 		<publisher>Christophe Lesur</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4219">
 				<rom name="popeye (1986-09)(lesur, christophe)(fr)(pd).k7" size="4219" crc="08032eff" sha1="67e184db55a55108cbd1e93d4a1733ac71ec21ad"/>
@@ -14165,6 +15354,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Portrait (Hebdogiciel no. 53)</description>
 		<year>1984</year>
 		<publisher>Alain van Puymbroeck - Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10813">
 				<rom name="portrait[mo5].k7" size="10813" crc="d21907d1" sha1="314c5bc4909f522cc0a6078189f603e3e8446e19"/>
@@ -14176,6 +15366,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Poseidon</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34250">
 				<rom name="poseidon (1986)(coktel vision)(fr).k7" size="34250" crc="3951bd6a" sha1="8b46025f85cfb0f7c7c5351ccac6d0a69ca13b02"/>
@@ -14187,6 +15378,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Poseidon (alt)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34250">
 				<rom name="poseidon (1986)(coktel vision)(fr)[a].k7" size="34250" crc="76cc2fc7" sha1="192610b42aa831c1d538dbaf5abc41051904df2a"/>
@@ -14198,6 +15390,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Poseidon (alt 2)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34250">
 				<rom name="poseidon (1986)(coktel vision)(fr)[a2].k7" size="34250" crc="0f506d49" sha1="941716d2ef23e02453a70b42916daba8552d5c09"/>
@@ -14209,6 +15402,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Poseidon (alt 3)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34250">
 				<rom name="poseidon_mo5.k7" size="34250" crc="884e20a5" sha1="b4ca5ce50bb5fe39235118a39d2a26174a59f951"/>
@@ -14220,6 +15414,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pour 20 Millions de Dollars</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="87266">
 				<rom name="pour 20 millions de dollars (198x)(softbook)(fr).k7" size="87266" crc="448d6b10" sha1="282b990e47530b854f7178281964e697bde17184"/>
@@ -14231,6 +15426,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pour 20 Millions de Dollars (alt)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85846">
 				<rom name="pour 20 millions de dollars (198x)(softbook)(fr)[a].k7" size="85846" crc="62bc8723" sha1="9bd08fe321f200040903653f2098835e854efe88"/>
@@ -14242,6 +15438,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pour 20 Millions de Dollars (alt 2)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85846">
 				<rom name="pour 20 millions de dollars (198x)(softbook)(fr)[a2].k7" size="85846" crc="64b077de" sha1="22f5d4d306a42cfc39634ab472b389c7fb313081"/>
@@ -14253,6 +15450,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pour 20 Millions de Dollars (alt 3)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="85846">
 				<rom name="pour-20-millions-de-dollars_mo5.k7" size="85846" crc="6cd3940d" sha1="f5d09af57efd49651299dcfc0d3ad3c3f0cd3ed1"/>
@@ -14264,6 +15462,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pouss Ball</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22592">
 				<rom name="pouss ball (1984)(to tek)(fr).k7" size="22592" crc="b56afeea" sha1="5391a3b187a7d7bf65343158121481ef06706e30"/>
@@ -14275,6 +15474,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pouss Ball (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22592">
 				<rom name="pouss ball (1984)(to tek)(fr)[a].k7" size="22592" crc="9a0ba535" sha1="53416a04eaca2f28792dbe024672987069a087e5"/>
@@ -14286,6 +15486,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pouss Ball (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22592">
 				<rom name="poussball_mo5.k7" size="22592" crc="d0f05d25" sha1="4a070ab1034d8806885fed4bd894020f834f6973"/>
@@ -14297,6 +15498,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pouvoir</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="9610622">
 				<rom name="pouvoir_mo5.wav" size="9610622" crc="3e461021" sha1="47556ad5f1d905d79139e27f0a2fac16d51731cb"/>
@@ -14308,6 +15510,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pouvoir (alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26494">
 				<rom name="pouvoir_mo5.k7" size="26494" crc="7af5e073" sha1="eae176ed9f9e943eda92337269ac7fe12e21acb4"/>
@@ -14319,6 +15522,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Puissance 4</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5540">
 				<rom name="puissance 4 (1985)(dcsoft)(fr)(pd).k7" size="5540" crc="3e4e2c1d" sha1="d7152c7ff730cf1ceda1cc6f2df2cb5f40f3417c"/>
@@ -14330,6 +15534,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Puissance 4 (alt)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5540">
 				<rom name="puissance 4 (1985)(dcsoft)(fr)(pd)[a].k7" size="5540" crc="b868a4ef" sha1="2231549f02bb6d40fe88379a0b7995f5d722dd40"/>
@@ -14341,6 +15546,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Puissance 4 (alt 2)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5540">
 				<rom name="puissance 4 (1985)(dcsoft)(fr)(pd)[a2].k7" size="5540" crc="d8250cc1" sha1="ff720d898e208640e6282a1b9eebade8c57557df"/>
@@ -14352,6 +15558,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Puissance 4 (alt 3)</description>
 		<year>1985</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5540">
 				<rom name="puissance-4_mo5.k7" size="5540" crc="c7373fee" sha1="a27401290f6121a21ee82bc91541a4caac6157d6"/>
@@ -14363,6 +15570,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pulsar II</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4228064">
 				<rom name="pulsar ii (1984)(loriciels)(fr).wav" size="4228064" crc="7ce22be6" sha1="be0a2adf281c9da8269f0ad045606cbeda6546c4"/>
@@ -14374,6 +15582,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pulsar II (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4541588">
 				<rom name="pulsar ii (loriciels) (pascal pellier) (1984) (mo5).wav" size="4541588" crc="bd5b56cf" sha1="e7d2520b0729ca1f84ab473b7ea3d59811210346"/>
@@ -14386,6 +15595,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pulsar II (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13278">
 				<rom name="pulsar ii (1984)(loriciels)(fr)[b2].k7" size="13278" crc="4c8cd8b3" sha1="eed998f78c2be6605676df7fff1d0385fdf5a615"/>
@@ -14398,6 +15608,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pulsar II (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13278">
 				<rom name="pulsar ii (1984)(loriciels)(fr)[b3].k7" size="13278" crc="f36800e7" sha1="d9ea99f841c83561d3908b95558a27f8931ca3e5"/>
@@ -14410,6 +15621,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pulsar II (alt 4)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12970">
 				<rom name="pulsar-2_mo5.k7" size="12970" crc="92619200" sha1="794437ad91db0c965ffde106b2519f527ccb2fbc"/>
@@ -14422,6 +15634,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pulsar II (alt 5)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12970">
 				<rom name="pulsar-2_a_mo5.k7" size="12970" crc="a86358c5" sha1="620af3cc56be55f7d2c4f6c1d8c42f22533a39f1"/>
@@ -14434,6 +15647,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pulsar II (cracked?)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13280">
 				<rom name="pulsar ii (1984)(loriciels)(fr)[b].k7" size="13280" crc="0ddae936" sha1="1b4551dbca7ddf529d3e9a0543e0363723b3e4bb"/>
@@ -14445,6 +15659,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>PV 2000</description>
 		<year>1983</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10959">
 				<rom name="pv 2000 (totek) (philippe descamps, marc rolin) (1983) (mo5).k7" size="10959" crc="3c31e81c" sha1="17f89db63c08bc101030591f6634699b7802a149"/>
@@ -14456,6 +15671,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Qrisp</description>
 		<year>198?</year>
 		<publisher>ERE Informatique</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="20328">
 				<rom name="qrisp (198x)(ere informatique)(fr).k7" size="20328" crc="2b4c0c65" sha1="d21a18c774c4cd09155804c86988c1ff611b5bfd"/>
@@ -14467,6 +15683,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Quadrille</description>
 		<year>198?</year>
 		<publisher>Francoise Monnet</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23480">
 				<rom name="quadrille (198x)(monnet, francoise)(fr).k7" size="23480" crc="4cb17b98" sha1="b9a7cfa354f09308a41b2a6d3c536a79edc58bb4"/>
@@ -14478,6 +15695,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Quaero</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11734">
 				<rom name="quaero (1985)(hebdogiciel)(fr)(pd).k7" size="11734" crc="085eb80f" sha1="924b82edf68ffb8b7af80038cf1edfc36efc542e"/>
@@ -14489,6 +15707,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Quaero (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11734">
 				<rom name="quaero (1985)(hebdogiciel)(fr)(pd)[a].k7" size="11734" crc="92ecfcd1" sha1="e43f6ce483558a4133ebbfa42beaa46dee4556fc"/>
@@ -14500,6 +15719,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Quaero (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11734">
 				<rom name="quaero_mo5.k7" size="11734" crc="20403e0d" sha1="78a7d1f2a92213724c95467726af8e93dd31a69d"/>
@@ -14511,6 +15731,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Quiliquili</description>
 		<year>1986</year>
 		<publisher>Clap 54</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16830">
 				<rom name="quiliquili (1986)(clap 54)(fr).k7" size="16830" crc="df3c4de6" sha1="4cd0df8a7f4778f113b1adacb2de70b0f31e51a3"/>
@@ -14522,6 +15743,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Quiliquili (alt)</description>
 		<year>1986</year>
 		<publisher>Clap 54</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16830">
 				<rom name="quiliquili (1986)(clap 54)(fr)[a].k7" size="16830" crc="f3069ef8" sha1="a0b2d46ce1cac5d291ffade262e00906f582d944"/>
@@ -14533,6 +15755,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Quiliquili (alt 2)</description>
 		<year>1986</year>
 		<publisher>Clap 54</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="16830">
 				<rom name="quiliquili_mo5.k7" size="16830" crc="c7b811df" sha1="1e5405546a804cc1848a7d0690240636f21fe0a9"/>
@@ -14544,6 +15767,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Raid sur Tenere</description>
 		<year>198?</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25913">
 				<rom name="raid sur tenere (198x)(coktel vision)(fr).k7" size="25913" crc="50dafb37" sha1="f70cf849ee0f830c6820fb45a24769cbb0ec015a"/>
@@ -14555,6 +15779,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Regates</description>
 		<year>1985</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13361">
 				<rom name="regates (1985)(vifi-nathan)(fr).k7" size="13361" crc="ba429324" sha1="57687dc6a54e7d7a93d622f322f34b76db68773e"/>
@@ -14566,6 +15791,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Renegade</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="92246">
@@ -14584,6 +15810,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Renegade (single tape)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="153707">
 				<rom name="renegade (1988)(wise owl software)(fr).k7" size="153707" crc="310d59dd" sha1="8fd8c5212672d26d7480c60c286bfa39e913c9ba"/>
@@ -14595,6 +15822,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Renegade (single tape, alt)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="153707">
 				<rom name="renegade (1988)(wise owl software)(fr)[a].k7" size="153707" crc="e53ca403" sha1="f4c78e74bba10e24b9d6ceae0c4832b8dc9683dd"/>
@@ -14606,6 +15834,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Renegade (single tape, alt 2)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="153707">
 				<rom name="renegade_mo5.k7" size="153707" crc="bbc07dca" sha1="2cf7a3356bb601fd36130710081cdde91ebc4ce0"/>
@@ -14617,6 +15846,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Reverse</description>
 		<year>198?</year>
 		<publisher>Daniel Coulom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6680">
 				<rom name="reverse (198x)(coulom, daniel)(fr)(pd).k7" size="6680" crc="2eb32be5" sha1="ab8e48321bd3671421a0370c294ff990745dde65"/>
@@ -14628,6 +15858,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Reverse (alt)</description>
 		<year>198?</year>
 		<publisher>Daniel Coulom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6680">
 				<rom name="reverse (198x)(coulom, daniel)(fr)(pd)[a].k7" size="6680" crc="6fb4479c" sha1="34baa9f778a8c67d5e677f1b94420c0422af43d8"/>
@@ -14639,6 +15870,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Reverse (alt 2)</description>
 		<year>198?</year>
 		<publisher>Daniel Coulom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6680">
 				<rom name="reverse (198x)(coulom, daniel)(fr)(pd)[a2].k7" size="6680" crc="444208a5" sha1="0da75b34531a9e3def9e22a5485c5e82c404b3ef"/>
@@ -14650,6 +15882,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Reverse (alt 3)</description>
 		<year>198?</year>
 		<publisher>Daniel Coulom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6680">
 				<rom name="reverse_mo5.k7" size="6680" crc="a6aaf38f" sha1="7b7c85eeb44d00ceb57405a8df758dd293ddc053"/>
@@ -14675,6 +15908,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Revolution</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Side A"/>
 			<dataarea name="cass" size="62439">
@@ -14693,6 +15927,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rodeo</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43463">
 				<rom name="rodeo (1985)(microids)(fr).k7" size="43463" crc="eadd7429" sha1="c54e3706d83d93460741d260edd05a3270c2d890"/>
@@ -14704,6 +15939,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rodeo (alt)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43463">
 				<rom name="rodeo (1985)(microids)(fr)[a].k7" size="43463" crc="40c2a295" sha1="b1296ee918becb7d779d8267db87392971d4da43"/>
@@ -14715,6 +15951,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rodeo (alt 2)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43463">
 				<rom name="rodeo_mo5.k7" size="43463" crc="d962d926" sha1="0792928c874712a1a356b61deb4d5c0f7d9dcf32"/>
@@ -14726,6 +15963,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Roger et Paulo</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11223">
 				<rom name="roger et paulo (1984)(infogrames)(fr).k7" size="11223" crc="291bc52b" sha1="81439adb4bc1bfe7bc386aa2e239317f2cc2b21b"/>
@@ -14737,6 +15975,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Roger et Paulo (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10236">
 				<rom name="roger et paulo (1984)(infogrames)(fr)[loadm'''',,r].k7" size="10236" crc="92680468" sha1="f8d3c1143c88c3ad026b810a96790ddc285d53e3"/>
@@ -14748,6 +15987,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Roger et Paulo (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10236">
 				<rom name="roger et paulo (1984)(infogrames)(fr)[a][loadm'''',,r].k7" size="10236" crc="bb93ca23" sha1="ce64fd4013b2511f3b600fa35934acd223740d03"/>
@@ -14759,6 +15999,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Roger et Paulo (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10236">
 				<rom name="roger-et-paulo_mo5.k7" size="10236" crc="a3f0fd0f" sha1="ebfb6a5644f69b239fbc3ed90e70a7d9608d394e"/>
@@ -14770,6 +16011,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Rotor-War</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="17516">
 				<rom name="rotor-war (1984)(vifi-nathan)(fr).k7" size="17516" crc="eb093e0d" sha1="aa809dfb7e4696e324358f7dbee6f95b3b019047"/>
@@ -14781,6 +16023,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Runway</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13785">
 				<rom name="runway (1986)(fil)(fr).k7" size="13785" crc="52734da0" sha1="a2705561abbc9678aa539310ff2610cf2ce1a807"/>
@@ -14792,6 +16035,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Runway (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14718">
 				<rom name="runway (1986)(fil)(fr)[a].k7" size="14718" crc="b45b3982" sha1="a178943eb8f8234557d3b5e53b269d36bddcb65f"/>
@@ -14803,6 +16047,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Runway (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14718">
 				<rom name="runway (1986)(fil)(fr)[a2].k7" size="14718" crc="f6e859ab" sha1="659716a727a90fc9a53d60233192db9deaafe8fd"/>
@@ -14814,6 +16059,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Runway (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14718">
 				<rom name="runway_mo5.k7" size="14718" crc="d4d5914e" sha1="e4aef09030f7e38a935e69cb078145280bae498f"/>
@@ -14825,6 +16071,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Runway II</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24533">
 				<rom name="runway ii (1986)(fil)(fr).k7" size="24533" crc="0db773af" sha1="e82c6160471af0c244612acfd679dba56eae2147"/>
@@ -14836,6 +16083,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Runway II (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24533">
 				<rom name="runway ii (1986)(fil)(fr)[a].k7" size="24533" crc="4493ffb0" sha1="bdfeeb4e59b98b1d48b54d865c13ddf6c31209be"/>
@@ -14847,6 +16095,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Runway II (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24533">
 				<rom name="runway ii (1986)(fil)(fr)[a2].k7" size="24533" crc="84ff2800" sha1="2a9e51e33a6233715b5829f941aeb86dfb095efb"/>
@@ -14858,6 +16107,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Runway II (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24533">
 				<rom name="runway2_mo5.k7" size="24533" crc="4bfbefc2" sha1="6117d903a4c2ebe88d70a8a6c9108822d804d95a"/>
@@ -14869,6 +16119,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>San Pablo</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19531">
 				<rom name="san pablo (1985)(coktel vision)(fr).k7" size="19531" crc="d26cb2e7" sha1="027a131353c06ef448fc06dfaabd09cc2d7501af"/>
@@ -14880,6 +16131,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>San Pablo (alt)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19531">
 				<rom name="san pablo (1985)(coktel vision)(fr)[a].k7" size="19531" crc="798fdba5" sha1="bfcfb30e09b2f4ec706ce60acd3811d28da07a40"/>
@@ -14891,6 +16143,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>San Pablo (alt 2)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="19531">
 				<rom name="san-pablo_mo5.k7" size="19531" crc="c1757c21" sha1="c6b68473f3731811090e0dd4a23d58023077ac62"/>
@@ -14902,6 +16155,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Saphir</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Jeu)"/>
 			<dataarea name="cass" size="8191020">
@@ -14921,6 +16175,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Saphir (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1 (Jeu)"/>
 			<dataarea name="cass" size="33196">
@@ -14939,6 +16194,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Saphir (single tape)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11803923">
 				<rom name="saphir (1986)(infogrames)(fr)[loadm].wav" size="11803923" crc="fca17c56" sha1="5aa446aa5bb9f15a66cb0bc79eb039a4399f16de"/>
@@ -14951,6 +16207,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Saphir (single tape, alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56101">
 				<rom name="saphir &amp; editeur (1986)(infogrames)(fr)[b].k7" size="56101" crc="0f4b3056" sha1="4b9c44737195a013e6441d2b09b042020fd6efd5"/>
@@ -14963,6 +16220,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Saphir (single tape, alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56101">
 				<rom name="saphir + editeur (infogrames) (eric szymkowiak) (1986).k7" size="56101" crc="adf19594" sha1="6e189b3d32ca9342f7dce5963077737068d38961"/>
@@ -14974,6 +16232,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Saphir (single tape, KCI format)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="363927">
 				<rom name="saphir.kci" size="363927" crc="d0f9f566" sha1="369c9c87f868bdab0436eff32faf34fe4138bd60"/>
@@ -14985,6 +16244,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sapiens</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10082726">
 				<rom name="sapiens (1986)(loriciels)(fr)[loadm].wav" size="10082726" crc="a210104e" sha1="bbfe7a84be958ce9269a74c427833e719a613167"/>
@@ -14997,6 +16257,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sapiens (alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31495">
 				<rom name="sapiens (1986)(loriciels)(fr)[b2].k7" size="31495" crc="1cace75a" sha1="75ea385e7f5079e3ace43f8b42453fa8d6f96b88"/>
@@ -15009,6 +16270,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sapiens (alt 2)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31495">
 				<rom name="sapiens (1986)(loriciels)(fr)[b3].k7" size="31495" crc="32ea16b0" sha1="0d7fd5c29619e07ce5ede54d81a2af3c75f5a468"/>
@@ -15021,6 +16283,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sapiens (alt 3)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31495">
 				<rom name="sapiens_mo5.k7" size="31495" crc="dfea9834" sha1="f38b6dab501698fb9fdee230c09adbd0f1e52bb6"/>
@@ -15032,6 +16295,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sapiens (KCI format)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="298033">
 				<rom name="sapiens.kci" size="298033" crc="ccdb0c93" sha1="4f2a45b7ae65a36b97fe98fdb89ba0e52878c5f1"/>
@@ -15069,6 +16333,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scarfinger</description>
 		<year>1985</year>
 		<publisher>Nice Ideas</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24255">
 				<rom name="scarfinger - la moto infernale (1985)(nice ideas)(fr).k7" size="24255" crc="fde44192" sha1="1db8b99840b844f78e183075ecb4c0c8a2fa40c0"/>
@@ -15080,6 +16345,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scarfinger (alt)</description>
 		<year>1985</year>
 		<publisher>Nice Ideas</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="24255">
 				<rom name="scarfinger_mo5.k7" size="24255" crc="3d57b84e" sha1="57dfab3e8b9459b5dcf5c5658d7cb540a09b4825"/>
@@ -15091,6 +16357,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scrontch</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5968">
 				<rom name="scrontch (1984)(vifi-nathan)(fr)(en)[loadm'''',,r].k7" size="5968" crc="bb5ee50b" sha1="96dfa23fde2c614031b5a089c805c4335d12cc5b"/>
@@ -15102,6 +16369,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scrontch (alt)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6045">
 				<rom name="scrontch (1984)(vifi-nathan)(fr)(en)[a][loadm'''',,r].k7" size="6045" crc="0ae4f424" sha1="77dbd00e2ab30ebc0ae0f9841a28a68f8dc9e939"/>
@@ -15125,6 +16393,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Scrontch (alt 3)</description>
 		<year>1984</year>
 		<publisher>VIFI-Nathan</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6045">
 				<rom name="scrontch_mo5.k7" size="6045" crc="d6687ffc" sha1="e81b040f759844a19d58db91eb315f4ab3559213"/>
@@ -15136,6 +16405,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Securite Social - En Jeu</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43548">
 				<rom name="securite social, la - en jeu (198x)(-)(fr).k7" size="43548" crc="86a705d1" sha1="afdf13ed806032066733f1fd8dc711bbd94bef1c"/>
@@ -15147,6 +16417,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Slap-Fight</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="121867">
 				<rom name="slap-fight (1987)(fil)(fr).k7" size="121867" crc="90e03f9d" sha1="dbe21619091c0e3805374be5614104889235140c"/>
@@ -15158,6 +16429,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Slap-Fight (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="122285">
 				<rom name="slap-fight (1987)(fil)(fr)[a].k7" size="122285" crc="c158c277" sha1="f49cb3cf0800f83a594ca566aab82d5d32c171f8"/>
@@ -15169,6 +16441,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Slap-Fight (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="122285">
 				<rom name="slap-fight (1987)(fil)(fr)[a2].k7" size="122285" crc="a57a907d" sha1="5d488edcd88a9e5edafecd7d0683a337ceecadf0"/>
@@ -15180,6 +16453,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Slap-Fight (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="122285">
 				<rom name="slap-fight_mo5.k7" size="122285" crc="b5e8996c" sha1="988b5a62d5ea883222d2599e53f0e788c6e2dc19"/>
@@ -15191,6 +16465,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Smurfy</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22954">
 				<rom name="smurfy (sprites) (pascal pommier) (1985) (mo5).k7" size="22954" crc="8f73b256" sha1="9c4a9dae08a56a64f87fdbd54759321883fc5b0f"/>
@@ -15202,6 +16477,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Soleil Noir</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36599">
 				<rom name="soleil noir (1985)(microids)(fr).k7" size="36599" crc="84bb3fca" sha1="f532da673ec977d185f9e88d3e6b8020315f5ea8"/>
@@ -15213,6 +16489,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Soleil Noir (alt)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36599">
 				<rom name="soleil noir (1985)(microids)(fr)[a].k7" size="36599" crc="cba29eb2" sha1="56c1723c1858d83f69815118c879d99d2e21164f"/>
@@ -15224,6 +16501,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Soleil Noir (alt 2)</description>
 		<year>1985</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36599">
 				<rom name="soleil-noir_mo5.k7" size="36599" crc="7dca1672" sha1="d02512d4a9db24078bad2f046f59abf0f18debcb"/>
@@ -15235,6 +16513,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sorcery</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8536324">
 				<rom name="sorcery (1986)(virgin games)(fr)[loadm].wav" size="8536324" crc="3bdf44a0" sha1="23e128094e819ffe5a4f48df0fc8cf8b79e68143"/>
@@ -15247,6 +16526,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sorcery (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38574">
 				<rom name="sorcery (1986)(virgin games)[b].k7" size="38574" crc="97c831e2" sha1="e468a4029d250f5591ae9e7600f85d32fc2b7364"/>
@@ -15259,6 +16539,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sorcery (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="38574">
 				<rom name="sorcery (infogrames) (1986).k7" size="38574" crc="c7f9be83" sha1="093f4b55fb52021ced817c3b0c1873b49960da97"/>
@@ -15270,6 +16551,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sorciere</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7935">
 				<rom name="sorciere (198x)(-)(fr).k7" size="7935" crc="d890d005" sha1="b21051e2f88347fbdd9a4daeb06c82af276bedc9"/>
@@ -15281,6 +16563,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sorciere (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7935">
 				<rom name="sorciere (198x)(-)(fr)[a].k7" size="7935" crc="890c6735" sha1="4f294aa9f859a396955593bc85ffa8f24de66d9b"/>
@@ -15292,6 +16575,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sorciere (alt 2)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7935">
 				<rom name="sorciere_mo5.k7" size="7935" crc="982ee6db" sha1="98e5ade2cd52991e65ddab8c9cd56b78f80b1605"/>
@@ -15303,6 +16587,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sortileges</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7165687">
 				<rom name="sortileges (1986)(infogrames)(fr)[loadm].wav" size="7165687" crc="7fa2080f" sha1="f1b837bbb4a383863493062a8dcbc9a12a3b82b0"/>
@@ -15315,6 +16600,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sortileges (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30438">
 				<rom name="sortileges (1986)(infogrames)[b].k7" size="30438" crc="54114675" sha1="33bccf09eec4da5ca1e636e8c9625071533622ce"/>
@@ -15327,6 +16613,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sortileges (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="30438">
 				<rom name="sortileges (infogrames) (william hennebois) (1986).k7" size="30438" crc="6e479d64" sha1="ff995ce534a8efdbd20ceae504b9432e25c819c2"/>
@@ -15339,6 +16626,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sortileges (alt 3)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31630">
 				<rom name="sortileges_mo5.k7" size="31630" crc="3c9d5430" sha1="4611f6aceabdc666529305f93d41341dc021a5d9"/>
@@ -15350,6 +16638,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sortileges (KCI format)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="278906">
 				<rom name="sortil.kci" size="278906" crc="84d54397" sha1="8a74f5495a9995a02afdb2a8ae4781581e49f456"/>
@@ -15375,6 +16664,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SOS Space</description>
 		<year>198?</year>
 		<publisher>Minipuce</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29862">
 				<rom name="sos space (minipuce) (e. marquis) (mo5).k7" size="29862" crc="106343ae" sha1="26c9209c6a15f7ef2e9b26c3c4383dcad7394ceb"/>
@@ -15386,6 +16676,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Space Shuttle Simulator</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43741">
 				<rom name="space shuttle simulator (1984)(loriciels)(fr).k7" size="43741" crc="c9bee86e" sha1="519e6086b5a619b589b4bcfeed598e545cca471d"/>
@@ -15397,6 +16688,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Space Shuttle Simulator (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43741">
 				<rom name="space shuttle simulator (1984)(loriciels)(fr)[a].k7" size="43741" crc="742ae0f6" sha1="87ab3f7e458d9ca810473a50d97e1acd09f3370d"/>
@@ -15408,6 +16700,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Space Shuttle Simulator (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="43741">
 				<rom name="space-shuttle-simulator_mo5.k7" size="43741" crc="f8a9981a" sha1="d4a71057389741bb78bb16d679388d9f5a1f1231"/>
@@ -15419,6 +16712,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Speedway</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45158">
 				<rom name="speedway (1986)(free game blot)(fr).k7" size="45158" crc="b16cabad" sha1="0a83cc3272ea70f0335f4033721a33e131363eb2"/>
@@ -15430,6 +16724,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Speedway (alt)</description>
 		<year>1986</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="45158">
 				<rom name="speedway_mo5.k7" size="45158" crc="d2aafe9d" sha1="44efc4df62e8a753a5a2bb6ad53d6adfa0b42bcf"/>
@@ -15441,6 +16736,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Spix</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8965">
 				<rom name="spix (1984)(infogrames)(fr).k7" size="8965" crc="82469825" sha1="8e992c79e49db77505eb131c2ffc3ecfa6d60a8d"/>
@@ -15452,6 +16748,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Spix (alt)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8965">
 				<rom name="spix (1984)(infogrames)(fr)[a].k7" size="8965" crc="8acabb9f" sha1="c0ec3bb304ea6975994226cc29282538661d7dec"/>
@@ -15463,6 +16760,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Spix (alt 2)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8965">
 				<rom name="spix (1984)(infogrames)(fr)[a2].k7" size="8965" crc="80345da8" sha1="e7c06bb3cbbb615008e562fa22d97fb93d268fb5"/>
@@ -15474,6 +16772,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Spix (alt 3)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8957">
 				<rom name="spix (infogrames) (patrick princ) (1984) (mo5).k7" size="8957" crc="dc398e7b" sha1="2622216cc87c472c51d6b53b56e5503769ff3d08"/>
@@ -15485,6 +16784,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sports d'Ete</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="251178">
 				<rom name="sports d'ete (1988)(wise owl software)(fr).k7" size="251178" crc="bbb4207a" sha1="d55397200b0e75198d1aa3f5acc9fcec9b498fa2"/>
@@ -15496,6 +16796,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sports d'Ete (alt)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="252915">
 				<rom name="sports d'ete (1988)(wise owl software)(fr)[a].k7" size="252915" crc="3dccad4c" sha1="fb31c3ce4ae6524108bab5ce6a8ced805bbab3d7"/>
@@ -15507,6 +16808,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sports d'Ete (alt 2)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="252915">
 				<rom name="sports d'ete (1988)(wise owl software)(fr)[a2].k7" size="252915" crc="4d93a8b5" sha1="4073d432fa048a019aa484afa3f7fb1c6dd27aa4"/>
@@ -15518,6 +16820,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sports d'Ete (alt 3)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="252915">
 				<rom name="sports-d-ete_mo5.k7" size="252915" crc="685ce251" sha1="62bb3c583e96cd66ddf5038da112f992bb453cbd"/>
@@ -15529,6 +16832,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Stanley</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34271">
 				<rom name="stanley (1984)(loriciels)(fr).k7" size="34271" crc="8c816f23" sha1="acdc5d90f631d2cd37e67ab983f81d9b6c3810f0"/>
@@ -15540,6 +16844,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Stanley (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33854">
 				<rom name="stanley (1984)(loriciels)(fr)[loadm'''',,r].k7" size="33854" crc="8edfa6d1" sha1="57aa2daa69c92d813c6d3ea8bf69dd6400f27f3d"/>
@@ -15551,6 +16856,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Stanley (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33854">
 				<rom name="stanley_mo5.k7" size="33854" crc="f0495429" sha1="8c8fe950342a2e987cc58fd5ef034235c6ee2685"/>
@@ -15562,6 +16868,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Starwar</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6511">
 				<rom name="starwar (198x)(-)(fr)(pd).k7" size="6511" crc="7fc70fd4" sha1="c3b54781cfa41afd107edcde609eafeeecf6cb07"/>
@@ -15573,6 +16880,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Stone Zone</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56086">
 				<rom name="stone zone (198x)(softbook)(fr).k7" size="56086" crc="6041c841" sha1="01cf5f9dfd961eb165f9ce2604a04159e3f3159c"/>
@@ -15584,6 +16892,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Stone Zone (alt)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56361">
 				<rom name="stone zone (198x)(softbook)(fr)[a].k7" size="56361" crc="49cbdc43" sha1="4f856040b1b51c937a69eaca31caa626e8fb6cdc"/>
@@ -15595,6 +16904,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Stone Zone (alt 2)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56086">
 				<rom name="stone zone (198x)(softbook)(fr)[a3].k7" size="56086" crc="cea94e71" sha1="0b4fb05830b3651cf6592b1a9c3259114285bc79"/>
@@ -15606,6 +16916,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Stone Zone (alt 3)</description>
 		<year>198?</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="56086">
 				<rom name="stone-zone_mo5.k7" size="56086" crc="a3034f53" sha1="de6d159a1639827f51b8e807ebb5c874086ba663"/>
@@ -15617,6 +16928,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Strip 21</description>
 		<year>198?</year>
 		<publisher>Patrick Lahbib</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14616">
 				<rom name="strip 21 (198x)(lahbib, patrick)(fr)(pd).k7" size="14616" crc="a192c936" sha1="385a55231c599260d88308189e573f2f1cce3bc5"/>
@@ -15628,6 +16940,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Strip 21 (alt)</description>
 		<year>198?</year>
 		<publisher>Patrick Lahbib</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14616">
 				<rom name="strip 21 (198x)(lahbib, patrick)(fr)(pd)[a].k7" size="14616" crc="6e3954ca" sha1="c66ddd65dbd35c9a61c2caf2c1d6fd1060e19d2a"/>
@@ -15639,6 +16952,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Strip 21 (alt 2)</description>
 		<year>198?</year>
 		<publisher>Patrick Lahbib</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14616">
 				<rom name="strip 21 (198x)(lahbib, patrick)(fr)(pd)[a2].k7" size="14616" crc="fbbe83d8" sha1="464027591fb5c04904dfc3bed51ef1cdd102b58e"/>
@@ -15650,6 +16964,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Strip 21 (alt 3)</description>
 		<year>198?</year>
 		<publisher>Patrick Lahbib</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="14616">
 				<rom name="strip-21_mo5.k7" size="14616" crc="347350c8" sha1="6e4cfd1791acdd21d1b491a2358d54818f24a817"/>
@@ -15661,6 +16976,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Jimmie</description>
 		<year>1985</year>
 		<publisher>Minipuce</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13437">
 				<rom name="super jimmie (1985)(minipuce - microstory)(fr).k7" size="13437" crc="8d6bb6f1" sha1="b03ae3a8a7b750ca52a016c31c4b2435cf2e1286"/>
@@ -15672,6 +16988,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Jimmie (alt)</description>
 		<year>1985</year>
 		<publisher>Minipuce</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13437">
 				<rom name="super jimmie (1985)(minipuce - microstory)(fr)[a].k7" size="13437" crc="70865577" sha1="3e389970e29a0378145fd8411c5c35d4556798a2"/>
@@ -15683,6 +17000,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Jimmie (alt 2)</description>
 		<year>1985</year>
 		<publisher>Minipuce</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13437">
 				<rom name="super-jimmie_mo5.k7" size="13437" crc="24bac33e" sha1="e30298c66f5b1b14be578a948d5c4ca183585bcc"/>
@@ -15694,6 +17012,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Tennis (FIL)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28837">
 				<rom name="super tennis (1986)(fil)(fr).k7" size="28837" crc="db897a55" sha1="57adbc98788885cb5b0bf9fdd387c8bfc53acfb6"/>
@@ -15705,6 +17024,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Tennis (FIL) (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28837">
 				<rom name="super tennis (1986)(fil)(fr)[a].k7" size="28837" crc="4dc65f05" sha1="8d61e10b68f69e26c7122905e0050d5ca222620b"/>
@@ -15716,6 +17036,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Tennis (Answare)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="28860">
 				<rom name="super tennis (1985)(answare)(fr).k7" size="28860" crc="576d1b89" sha1="cc07f4155b96e4687cd8858b4acc24d4c2d96be5"/>
@@ -15727,6 +17048,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Tennis (Answare) (alt)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29026">
 				<rom name="super tennis (1985)(answare)(fr)[a].k7" size="29026" crc="ba7cd618" sha1="c18925f6c4afd717dbec12bcbf4b3bfdc23b6dd4"/>
@@ -15738,6 +17060,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Tennis (Answare) (alt 2)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29026">
 				<rom name="super tennis (1985)(answare)(fr)[a2].k7" size="29026" crc="5836d549" sha1="882463e38fa53d0c8c1ae568af20425d03050951"/>
@@ -15749,6 +17072,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Tennis (Answare) (alt 3)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29026">
 				<rom name="super tennis (1985)(answare)(fr)[a3].k7" size="29026" crc="ca8c3f01" sha1="9bf4240aeeab756e26bdb16364151b380765cf2c"/>
@@ -15760,6 +17084,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sympuz</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11208">
 				<rom name="sympuz (1984)(no man's land)(fr).k7" size="11208" crc="3e987359" sha1="c43a092ca471e96ea312daba9736d369a3ff09e7"/>
@@ -15771,6 +17096,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sympuz (alt)</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11208">
 				<rom name="sympuz (1984)(no man's land)(fr)[a].k7" size="11208" crc="9d532407" sha1="cdcdd88a70826c66ecc5a51c5bc81dc6016010a3"/>
@@ -15782,6 +17108,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sympuz (alt 2)</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11208">
 				<rom name="sympuz_mo5.k7" size="11208" crc="b947a134" sha1="0b617dbeba4c299c845c98e65587997cb9d37a7c"/>
@@ -15794,6 +17121,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>T.N.T.</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="55605">
 				<rom name="t.n.t. (1986)(infogrames)[b].k7" size="55605" crc="64f6ceb6" sha1="fb4619847ddc9195098f1d82c0fa1b4aaeeac6b6"/>
@@ -15806,6 +17134,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>T.N.T. (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="58245">
 				<rom name="tnt_mo5.k7" size="58245" crc="547c9006" sha1="fae130ef5e7fff367de81284c100b6132dbf45a7"/>
@@ -15817,6 +17146,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Taquin+</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21838">
 				<rom name="taquin+ (1984)(to tek)(fr).k7" size="21838" crc="86ad5b9f" sha1="85d99b12995f15a31d75f54cdffb0b84874fc222"/>
@@ -15828,6 +17158,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Taquin+ (alt)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21830">
 				<rom name="taquin+ (1984)(to tek)(fr)[a].k7" size="21830" crc="8a9dfb76" sha1="92bdf546c1a1ed7adfe56ba5f8b72b0941d48f09"/>
@@ -15839,6 +17170,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Taquin+ (alt 2)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21830">
 				<rom name="taquin+ (1984)(to tek)(fr)[a2].k7" size="21830" crc="2c7e046e" sha1="ccfe99360a12268e3bfa2aa9cabb7cbe00cbb54b"/>
@@ -15850,6 +17182,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Taquin+ (alt 3)</description>
 		<year>1984</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21830">
 				<rom name="taquin_mo5.k7" size="21830" crc="e1107ad6" sha1="9d425d107dfc426ba3732116c8a6a0f9982b9414"/>
@@ -15861,6 +17194,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tarot</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22061">
 				<rom name="tarot (1986-08)(dcsoft)(fr)(pd).k7" size="22061" crc="a27dfbfc" sha1="205b8c70b2743782bf171e02c0f386e9d4e14a0d"/>
@@ -15872,6 +17206,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tarot (alt)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22061">
 				<rom name="tarot (1986-08)(dcsoft)(fr)(pd)[a].k7" size="22061" crc="8e4c2f29" sha1="06b30ffe464dd38c48706527a092cf433e4c5c50"/>
@@ -15883,6 +17218,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tarot (alt 2)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22061">
 				<rom name="tarot (1986-08)(dcsoft)(fr)(pd)[a2].k7" size="22061" crc="ff8f1c85" sha1="bcb1a503cc20a3cc9fee7b630801fcab53b713ea"/>
@@ -15894,6 +17230,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tarot (alt 3)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="22061">
 				<rom name="dctarot_mo5.k7" size="22061" crc="e4724dde" sha1="4ce27f9cda1664afc15afa3cb63d34e4ddb6282d"/>
@@ -15905,6 +17242,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Teledomino</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10862">
 				<rom name="teledomino (1986)(microtom)(fr).k7" size="10862" crc="9d03b185" sha1="e3767a3dc87b3429959cc0c019738923853e2b74"/>
@@ -15916,6 +17254,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Teledomino (alt)</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10862">
 				<rom name="teledomino (1986)(microtom)(fr)[a].k7" size="10862" crc="45b2a033" sha1="d80bda73fc36a0333e29319dd3e325efa1aefd7c"/>
@@ -15927,6 +17266,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Teledomino (alt 2)</description>
 		<year>1986</year>
 		<publisher>Microtom</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10862">
 				<rom name="teledomino_mo5.k7" size="10862" crc="64dca519" sha1="75ca377bf5a0e5cfaa173745e1fd04054acd8fad"/>
@@ -15938,6 +17278,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Temple de Quauthli</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<feature name="part_id" value="Tape 1"/>
 			<dataarea name="cass" size="49705">
@@ -15956,6 +17297,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Temple de Quauthli (single tape)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="83468">
 				<rom name="temple de quauthli, le (1986)(loriciels)(fr).k7" size="83468" crc="db0a84e2" sha1="74d86b5cef08348062628e9a721572ff04a8d1b2"/>
@@ -15967,6 +17309,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Temple de Quauthli (single tape, alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="83468">
 				<rom name="temple de quauthli, le (1986)(loriciels)(fr)[a].k7" size="83468" crc="52954732" sha1="f7be813a845a57f319023d015d8f3b607935230d"/>
@@ -15978,6 +17321,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Temple de Quauthli (single tape, alt 2)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="83468">
 				<rom name="le-temple-de-quauhtli_mo5.k7" size="83468" crc="82585fa4" sha1="43b13cb72a6468e882a581e8df5a965d546c11c9"/>
@@ -15989,6 +17333,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Territoire</description>
 		<year>1985</year>
 		<publisher>Logimicro</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="52326">
 				<rom name="territoire (logimicro) (inconnus) (1985) (mo5 k7).k7" size="52326" crc="7f405c64" sha1="b6a99ffe498ce502011cc21ca24e250747560d65"/>
@@ -16000,6 +17345,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tetris</description>
 		<year>1989</year>
 		<publisher>Gilles Daurat</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3677">
 				<rom name="tetris gd (1989)(daurat, gilles)(fr).k7" size="3677" crc="d649962b" sha1="cb513d05fe730faea537ab10a2e1869635a161d3"/>
@@ -16011,6 +17357,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tetris (alt)</description>
 		<year>1989</year>
 		<publisher>Gilles Daurat</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="3677">
 				<rom name="tetris-gd_mo5.k7" size="3677" crc="3201586d" sha1="6c14f2247aad169bf57620e5f8af8b864d643f48"/>
@@ -16022,6 +17369,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Thesaurus</description>
 		<year>198?</year>
 		<publisher>Minipuce</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="72028">
 				<rom name="thesaurus (198x)(minipuce)(fr).k7" size="72028" crc="b542a958" sha1="a5a30a2b65dbcbc204fc11ea4fb97610b7978b57"/>
@@ -16033,6 +17381,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Thesaurus (alt)</description>
 		<year>198?</year>
 		<publisher>Minipuce</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="72028">
 				<rom name="thesaurus_mo5.k7" size="72028" crc="b213ef3a" sha1="2530226053ac661e146bfe3ee3af70a36613790d"/>
@@ -16044,6 +17393,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Third World War</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7954">
 				<rom name="third world war (198x)(free game blot)(fr).k7" size="7954" crc="ec519f11" sha1="1cbaaf71f113a064fa781606bfa72e386530d4bb"/>
@@ -16055,6 +17405,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Third World War (alt)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7174">
 				<rom name="third world war (198x)(free game blot)(fr)[a].k7" size="7174" crc="0cd75a0c" sha1="3bc771e318b4bee2e1bbfdee74319b399eff6e9b"/>
@@ -16066,6 +17417,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Third World War (alt 2)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7174">
 				<rom name="third world war (198x)(free game blot)(fr)[a2].k7" size="7174" crc="c8acc05e" sha1="04088f525531120bb4e9b4cbc1a995e38b80f742"/>
@@ -16077,6 +17429,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Third World War (alt 3)</description>
 		<year>198?</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="7174">
 				<rom name="world-war3_mo5.k7" size="7174" crc="efe98dc9" sha1="2f5435b62d001b1a88b3b12aad31faeaa703394a"/>
@@ -16088,6 +17441,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Thom-Puzz</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18000">
 				<rom name="thom-puzz (1984)(no man's land)(fr).k7" size="18000" crc="7640f5d7" sha1="956980dabf5ee8878d50ba23f8f9807c2d945247"/>
@@ -16099,6 +17453,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tic-Tac</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31007">
 				<rom name="tic-tac (1984)(loriciels)(fr).k7" size="31007" crc="e3cc6585" sha1="a2ccb6c411cbfd52789fd7bfe5dfbd0c13b6a950"/>
@@ -16110,6 +17465,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tic-Tac (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31007">
 				<rom name="tic-tac (1984)(loriciels)(fr)[a].k7" size="31007" crc="b9d2757c" sha1="3ae7602847c6df499231a583884d39f0cce6eb10"/>
@@ -16121,6 +17477,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tic-Tac (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31007">
 				<rom name="tic-tac_mo5.k7" size="31007" crc="dbf60d2e" sha1="ffb5d07350664da9cfda7e562302f137f01766bb"/>
@@ -16132,6 +17489,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Top Gun</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36652">
 				<rom name="top gun (1987)(fil)(fr).k7" size="36652" crc="a951b8c7" sha1="e628e5a4e41419188250a44bce4434e0e2064687"/>
@@ -16143,6 +17501,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Top Gun (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36898">
 				<rom name="top gun (1987)(fil)(fr)[a].k7" size="36898" crc="6cd09338" sha1="7c95e03d340a416d83aba91848c63ee83ad269d2"/>
@@ -16154,6 +17513,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Top Gun (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36898">
 				<rom name="top gun (1987)(fil)(fr)[a2].k7" size="36898" crc="66fd03d8" sha1="579b4febef16fe4755095cac4aeea13aedd4ec10"/>
@@ -16165,6 +17525,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Top Gun (alt 3)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36898">
 				<rom name="top-gun_mo5.k7" size="36898" crc="dde9599d" sha1="483aaafa32144e9590d89892179036bd319b521d"/>
@@ -16176,6 +17537,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Top-Chrono</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36316">
 				<rom name="top-chrono (1985)(loriciels)(fr).k7" size="36316" crc="0cc96513" sha1="524d179d3f1bfb66b843851a5efa70e418638e83"/>
@@ -16187,6 +17549,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Top-Chrono (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34609">
 				<rom name="top-chrono (1985)(loriciels)(fr)[a].k7" size="34609" crc="a6a025f2" sha1="b0f48a6adb344a0c0848b1ac004968b050e63c04"/>
@@ -16198,6 +17561,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Top-Chrono (alt 2)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36325">
 				<rom name="top-chrono (1985)(loriciels)(fr)[a2].k7" size="36325" crc="10be2f49" sha1="9ae47d51ac004840ea29d275bca0706f8bd478ed"/>
@@ -16209,6 +17573,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Top-Chrono (alt 3)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36325">
 				<rom name="top-chrono (1985)(loriciels)(fr)[a3].k7" size="36325" crc="6e036ec0" sha1="6d9c2818e9534a113326bb415b652bc4bbe09c00"/>
@@ -16220,6 +17585,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Top-Chrono (alt 4)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="36325">
 				<rom name="top-chrono_mo5.k7" size="36325" crc="4836284e" sha1="78e4fed788f1925f50296c9965dfe53071b1562c"/>
@@ -16231,6 +17597,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Torann - Mission Blue 5</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="torann - mission blue 5 (198x)(loriciels)(fr).k7" size="34587" crc="d9b72731" sha1="acaf497b5cd8035e5cada8691c8826a3a7aed9da"/>
@@ -16242,6 +17609,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Torann - Mission Blue 5 (alt)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="torann - mission blue 5 (198x)(loriciels)(fr)[a].k7" size="34587" crc="fe7888d4" sha1="13b48d25631b49d16cb46c8e28c4fe068cbcef51"/>
@@ -16253,6 +17621,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Torann - Mission Blue 5 (alt 2)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="torann - mission blue 5 (198x)(loriciels)(fr)[a2].k7" size="34587" crc="5c0b2bab" sha1="fa791d16f0e2d9fda4b840431a6a48272507b4d3"/>
@@ -16264,6 +17633,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Torann - Mission Blue 5 (alt 3)</description>
 		<year>198?</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="34587">
 				<rom name="torann-mission-blue_mo5.k7" size="34587" crc="e53848b5" sha1="8a9787cbca6f6d59f43a9462a4d655f330db1256"/>
@@ -16275,6 +17645,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tout Schuss</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="221948">
 				<rom name="tout schuss (1987)(fil)(fr).k7" size="221948" crc="0e3904a1" sha1="35cbeb09e27eb4c7b80adeb4e85b8d7c7c979ab2"/>
@@ -16286,6 +17657,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tout Schuss (alt)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="221948">
 				<rom name="tout schuss (1987)(fil)(fr)[a].k7" size="221948" crc="aea059ca" sha1="a7bb455001606a720b587bbade897ca88bce8312"/>
@@ -16297,6 +17669,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tout Schuss (alt 2)</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="221948">
 				<rom name="tout-schuss_mo5.k7" size="221948" crc="aabb8c77" sha1="44b78489c6dfc01b8bae501f434febe3c03a7741"/>
@@ -16308,6 +17681,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Toutankhamon</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40660">
 				<rom name="toutankhamon (1985)(no man's land)(fr).k7" size="40660" crc="3567168d" sha1="2717d5e11ec122acfab80528ccc5a5372ca6bed5"/>
@@ -16319,6 +17693,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Toutankhamon (alt)</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40855">
 				<rom name="toutankhamon (1985)(no man's land)(fr)[a].k7" size="40855" crc="b8f9ac86" sha1="6594265a109a436f72d1e80f18f0332550c08b9c"/>
@@ -16330,6 +17705,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Toutankhamon (alt 2)</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40855">
 				<rom name="toutankhamon (1985)(no man's land)(fr)[a2].k7" size="40855" crc="c48c4959" sha1="5744e001dc6cb66c6e6ce2d4f49e0b9ce438c5a2"/>
@@ -16341,6 +17717,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Toutankhamon (alt 3)</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40855">
 				<rom name="toutankhamon_mo5.k7" size="40855" crc="32adab50" sha1="80131f8e2f37e29dd3382d3042e85e63701a7e8c"/>
@@ -16352,6 +17729,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Tresor du Pirate</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="21830">
 				<rom name="tresor du pirate, le (1984)(free game blot)(fr).k7" size="21830" crc="95582d2c" sha1="babdf940db6730f11e4e068bcd61086a2322a2fb"/>
@@ -16363,6 +17741,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Tresor du Pirate (alt)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23091">
 				<rom name="tresor du pirate, le (1984)(free game blot)(fr)[a].k7" size="23091" crc="07336cbf" sha1="846d0411c1b28e79f1c4191968b308281c4a562f"/>
@@ -16374,6 +17753,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Tresor du Pirate (alt 2)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23091">
 				<rom name="tresor du pirate, le (1984)(free game blot)(fr)[a2].k7" size="23091" crc="ebd6ee58" sha1="b9e06d353b4262155a1dcf4ebb5e8f4eb380fc3f"/>
@@ -16385,6 +17765,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le Tresor du Pirate (alt 3)</description>
 		<year>1984</year>
 		<publisher>Free Game Blot</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23091">
 				<rom name="le-tresor-du-pirate_mo5.k7" size="23091" crc="58d0ddee" sha1="3d60caa6cffb3f25313650dc1e13b916ec272bd5"/>
@@ -16396,6 +17777,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Troff</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6461">
 				<rom name="troff (1983)(infogrames)(fr).k7" size="6461" crc="e733c8fe" sha1="2128fb4ef61ee4f5f13729b85590ed37a07863b0"/>
@@ -16407,6 +17789,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Troff (alt)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5676">
 				<rom name="troff (1983)(infogrames)(fr)[a].k7" size="5676" crc="c379c8f3" sha1="39bf4130679112c646f80b9774ea1184d41a2785"/>
@@ -16418,6 +17801,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Troff (alt 2)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5676">
 				<rom name="troff (1983)(infogrames)(fr)[a2].k7" size="5676" crc="2d927325" sha1="5c4d0083917e1862fab2357a04051b6f50008302"/>
@@ -16429,6 +17813,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Troff (alt 3)</description>
 		<year>1983</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="5676">
 				<rom name="troff_mo5.k7" size="5676" crc="881633ce" sha1="ff06edc4b4bca255f55437872c4f86f316304aa3"/>
@@ -16441,6 +17826,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tyrann</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40753">
 				<rom name="tyrann (1985)(norsoft)(fr)[1st generation mo5].k7" size="40753" crc="ee1fccf2" sha1="a229c6cecb1dad618c4d0c4c7e099e0aeb3333c3"/>
@@ -16453,6 +17839,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tyrann (alt)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40753">
 				<rom name="tyrann (1985)(norsoft)(fr)[2nd generation mo5].k7" size="40753" crc="d1b5ca52" sha1="d9d8db32295df1eb8dbf8c2e54b49e563adf4a6e"/>
@@ -16465,6 +17852,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tyrann (alt 2)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40753">
 				<rom name="tyrann (1985)(norsoft)(fr)[b2].k7" size="40753" crc="09371720" sha1="5bb82a9494d1c7eafa23983382ef9c3f3572b25e"/>
@@ -16477,6 +17865,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tyrann (alt 3)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40753">
 				<rom name="tyrann-v1_mo5.k7" size="40753" crc="84de926d" sha1="9e26136d2fdee303e920ed8516ae12c547acd0cb"/>
@@ -16489,6 +17878,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tyrann (alt 4)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40753">
 				<rom name="tyrann-v2_mo5.k7" size="40753" crc="bb7494cd" sha1="f901743aa1ee4ddcc13f61a1a6cf7aea3fec290e"/>
@@ -16501,6 +17891,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Tyrann (alt 5)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40668">
 				<rom name="tyrann (1985)(norsoft)(fr)[b].k7" size="40668" crc="99decafb" sha1="932b015db5e8ea89d84e413daeb56212abdb0877"/>
@@ -16512,6 +17903,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Usine Infernale</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="12532">
 				<rom name="l'usine infernale (shift-edition) (philippe baroin) (1985) (mo5 k7).k7" size="12532" crc="a33bb9b9" sha1="ebf558890535ce0d022d21ca0c931e1c5f928569"/>
@@ -16523,6 +17915,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vampire</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8410873">
 				<rom name="vampire (198x)(infogrames)(fr).wav" size="8410873" crc="1e162d3a" sha1="2728b7d0e0a9bd6dc45b70359f0d32f680ddd916"/>
@@ -16535,6 +17928,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vampire (alt)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40145">
 				<rom name="vampire (1986)(infogrames)(fr)[b2].k7" size="40145" crc="78e4ec64" sha1="5f6a5b8e40fa842581f70099f9c289e035284ddf"/>
@@ -16547,6 +17941,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vampire (alt 2)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="40145">
 				<rom name="vampire (infogrames) (alain vialon) (1986).k7" size="40145" crc="8b80f156" sha1="cc6ecd48dd1dd7e4419af59fb5839a9062fe0d40"/>
@@ -16559,6 +17954,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vampire (alt 3)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="41345">
 				<rom name="vampire (infogrames) (alain vialon, philippe nottoli, dominique girou) (1986) (mo5).k7" size="41345" crc="9d4208af" sha1="5f2e7cd93c313a1129f30df40b6ebf2420e10f51"/>
@@ -16584,6 +17980,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vision (Loriciels)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31220">
 				<rom name="vision (1984)(loriciels)(fr).k7" size="31220" crc="5ed7733c" sha1="e0b84034a4a486bb758c856e35f5f0d248de7289"/>
@@ -16595,6 +17992,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vision (Loriciels) (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31220">
 				<rom name="vision (1984)(loriciels)(fr)[a].k7" size="31220" crc="e3e37c89" sha1="d3f56689989b794c51b98853917db75db06b31c6"/>
@@ -16606,6 +18004,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vision (Loriciels) (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31220">
 				<rom name="vision_mo5.k7" size="31220" crc="76132c32" sha1="2998c7dc19befb45eab47eb5dada51f21a4eb422"/>
@@ -16617,6 +18016,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vol Solo</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="23772">
 				<rom name="vol solo (1985)(fil)(fr).k7" size="23772" crc="23a1aaaa" sha1="b955649085090cad2737094479947099cef36dd4"/>
@@ -16628,6 +18028,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vol Solo (alt)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25305">
 				<rom name="vol solo (1985)(fil)(fr)[a].k7" size="25305" crc="f7217934" sha1="f0134fe65a7956c3870b63699d44774913fb3e38"/>
@@ -16639,6 +18040,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vol Solo (alt 2)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25305">
 				<rom name="vol solo (1985)(fil)(fr)[a2].k7" size="25305" crc="09976ba4" sha1="c198556a61eaa797cf494f1c5253279b71eca06a"/>
@@ -16650,6 +18052,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vol Solo (alt 3)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="25305">
 				<rom name="vol-solo_mo5.k7" size="25305" crc="37bbbe43" sha1="088c3b1e72991a863b27ddd664bbc223eeb87413"/>
@@ -16661,6 +18064,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vol Solo (WAV format)</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="8365890">
 				<rom name="vol solo (1985)(fil)(fr).wav" size="8365890" crc="0b498fb5" sha1="7f50709ed798acd440d2193e1e361a939e052e96"/>
@@ -16672,6 +18076,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Votez pour Moi</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31541">
 				<rom name="votez pour moi (1985)(answare)(fr).k7" size="31541" crc="bd51f0d3" sha1="8f6fceba282c66227b165ccb77ea49494f1bfc3e"/>
@@ -16683,6 +18088,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Votez pour Moi (alt)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31720">
 				<rom name="votez pour moi (1985)(answare)(fr)[a].k7" size="31720" crc="8f986024" sha1="b7972b96a10508572d29d670635ec52e40ff58d1"/>
@@ -16694,6 +18100,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Votez pour Moi (alt 2)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31720">
 				<rom name="votez pour moi (1985)(answare)(fr)[a2].k7" size="31720" crc="bda8aca6" sha1="cff7b24ca6e655fd2838347321ef4761366f98da"/>
@@ -16705,6 +18112,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Votez pour Moi (alt 3)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="31720">
 				<rom name="votez-pour-moi_mo5.k7" size="31720" crc="3a31452c" sha1="892c508cf11196be3f5460c3e23944c757bb2857"/>
@@ -16716,6 +18124,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Voyage au Centre du MO5</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26793">
 				<rom name="voyage au centre du mo5 (1985)(hebdogiciel)(fr)(pd).k7" size="26793" crc="7cbae7aa" sha1="594c9cb18b4b1d86db205acb0711e530bf7fe4b8"/>
@@ -16727,6 +18136,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Voyage au Centre du MO5 (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26793">
 				<rom name="voyage au centre du mo5 (1985)(hebdogiciel)(fr)(pd)[a2].k7" size="26793" crc="57f3b37f" sha1="47f0e6984df04be38d9456e4d96e1c07db413181"/>
@@ -16738,6 +18148,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Voyage au Centre du MO5 (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26793">
 				<rom name="voyage au centre du mo5 (1985)(hebdogiciel)(fr)(pd)[a3].k7" size="26793" crc="d4d5f41c" sha1="66103e2e06aeb32a1b583cb2f39b8502b585c63d"/>
@@ -16749,6 +18160,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Voyage au Centre du MO5 (alt 3)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="26793">
 				<rom name="voyage-au-coeur-du-mo5_mo5.k7" size="26793" crc="dfe31c6d" sha1="3536ac68762478e9ecce10979045a517851c7273"/>
@@ -16757,9 +18169,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="centrmo5d" cloneof="centrmo5">
-		<description>Voyage au Centre du MO5 (No Title Screen)</description>
+		<description>Voyage au Centre du MO5 (no title screen)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10462">
 				<rom name="voyage au centre du mo5 (1985)(hebdogiciel)(fr)(pd)[a title screen].k7" size="10462" crc="48581305" sha1="fdc786827d5fba4fb2e2965ee59702bb89d92bcd"/>
@@ -16771,6 +18184,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>The Way of the Tiger</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="104264">
 				<rom name="way of the tiger, the (1986)(fil)(fr).k7" size="104264" crc="ad7347c6" sha1="873d7be358d4dbe75530e181e89d09f9520b1971"/>
@@ -16782,6 +18196,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>The Way of the Tiger (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="104264">
 				<rom name="way of the tiger, the (1986)(fil)(fr)[a].k7" size="104264" crc="1591e7a7" sha1="85ee56dbaad0d7e0b242f0135fc238b5d1debd1f"/>
@@ -16793,6 +18208,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>The Way of the Tiger (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="104264">
 				<rom name="way of the tiger, the (1986)(fil)(fr)[a2].k7" size="104264" crc="67ffb579" sha1="2d42e09d7bdee669477a90efcb7c76597b09ece2"/>
@@ -16804,6 +18220,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>The Way of the Tiger (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="104264">
 				<rom name="the-way-of-the-tiger_mo5.k7" size="104264" crc="3e41520a" sha1="818d46be345f591d94ee40933c036acc5691e46d"/>
@@ -16815,6 +18232,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Westbank</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29030">
 				<rom name="westbank (1987-06-28)(rubio, javier marco - escudero, angelines rubio)(es).k7" size="29030" crc="7a484754" sha1="2862a7d6bf39a360f1f5713fa06f40d2e03f2a23"/>
@@ -16826,6 +18244,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Westbank (alt)</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29030">
 				<rom name="westbank (1987-06-28)(rubio, javier marco - escudero, angelines rubio)(es)[a].k7" size="29030" crc="5c11384a" sha1="1be315d2b64eea0a6aa93c7457984cb761348257"/>
@@ -16837,6 +18256,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Westbank (alt 2)</description>
 		<year>1987</year>
 		<publisher>Javier Marco Rubio - Angelines Rubio Escudero</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="29030">
 				<rom name="westbank_mo5.k7" size="29030" crc="2808b2fa" sha1="bab30feb9b510f3427a9d78f527e6a7822525c92"/>
@@ -16848,6 +18268,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wild Boy</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6262">
 				<rom name="wild boy (19xx)(-)(fr).k7" size="6262" crc="ff160c9f" sha1="3c0d96fb964d0295674b786d04b4661077fb6564"/>
@@ -16859,6 +18280,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wild Boy (alt)</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="6262">
 				<rom name="wildboy_mo5.k7" size="6262" crc="c243e802" sha1="0cd24ab769bb0c04a1f31dddbb01ebcd9f807319"/>
@@ -16870,6 +18292,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wizball</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="57925">
 				<rom name="wizball (1988)(fil)(fr).k7" size="57925" crc="5b6aa9f3" sha1="eb82fbead4806be1049a633394696a9de6bac3c6"/>
@@ -16881,6 +18304,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wizball (alt)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="61286">
 				<rom name="wizball (1988)(fil)(fr)[a].k7" size="61286" crc="7b4993e4" sha1="bbb622b913db2f3693453c7842eaca9f7764d4e8"/>
@@ -16892,6 +18316,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wizball (alt 2)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="61286">
 				<rom name="wizball (1988)(fil)(fr)[a2].k7" size="61286" crc="a9364da0" sha1="07e3a51c29a378d43e694714a2d2a5aed66051a9"/>
@@ -16903,6 +18328,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wizball (alt 3)</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="61286">
 				<rom name="wizball_mo5.k7" size="61286" crc="28d37c3a" sha1="690ed611c767bb63541038a55c8fa44de85e3d3a"/>
@@ -16914,6 +18340,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>X-Ray</description>
 		<year>1986</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="11606858">
 				<rom name="x-ray_mo5.wav" size="11606858" crc="8ccdf8dd" sha1="f9ff59e87300664e33cd3417e8abc3ef9efe1625"/>
@@ -16925,6 +18352,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>X-Ray (alt)</description>
 		<year>1986</year>
 		<publisher>Microids</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="35051">
 				<rom name="x-ray_mo5.k7" size="35051" crc="f8a9199c" sha1="53600b7a0d2058a62bc25f1dd162f417f0b424df"/>
@@ -16936,6 +18364,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Y</description>
 		<year>1988</year>
 		<publisher>G. Fetis</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="18514">
 				<rom name="y (1988)(fetis, g.).k7" size="18514" crc="b211bcc7" sha1="5d4dd7187d71e6601a3b9194f35e980448dd8ea0"/>
@@ -16947,6 +18376,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yahtzee</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10652">
 				<rom name="yahtzee (1985)(hebdogiciel)(fr)(pd).k7" size="10652" crc="cca6d3d0" sha1="23ca2b6b0d08f21c32d446067fa879e07659bc76"/>
@@ -16958,6 +18388,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yahtzee (alt)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10652">
 				<rom name="yahtzee (1985)(hebdogiciel)(fr)(pd)[a].k7" size="10652" crc="e6bff0ae" sha1="53a8903623cdac5787126979f13a3dd6fc7a3b9d"/>
@@ -16969,6 +18400,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yahtzee (alt 2)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10652">
 				<rom name="yahtzee (1985)(hebdogiciel)(fr)(pd)[a2].k7" size="10652" crc="a3942d56" sha1="353cc6f72a67458f749b5a461d99da4bca9f7331"/>
@@ -16980,6 +18412,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yahtzee (alt 3)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="10652">
 				<rom name="yahtzee_mo5.k7" size="10652" crc="301d7fa6" sha1="27086960d8d52df51a38c92574a53e2546f790b0"/>
@@ -16991,6 +18424,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yeti</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="4474808">
 				<rom name="yeti (1984)(loriciels)(fr).wav" size="4474808" crc="dd65a22d" sha1="0fd108081cb70f1aa696f573a255a848ed63040f"/>
@@ -17003,6 +18437,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yeti (alt)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13510">
 				<rom name="yeti (1984)(loriciels)(fr)[b3].k7" size="13510" crc="a6be8075" sha1="7ac9be6a94ed3c5c7e686b54df776f00d0a81d51"/>
@@ -17015,6 +18450,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yeti (alt 2)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13510">
 				<rom name="yeti (1984)(loriciels)(fr)[b4].k7" size="13510" crc="9646972a" sha1="91376ce256eb381fe85b381c003fc7ff25aba339"/>
@@ -17027,6 +18463,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yeti (alt 3)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13510">
 				<rom name="yeti_mo5.k7" size="13510" crc="a8806b5c" sha1="acb283a375878e353031e3cfdae996f0102e0e1a"/>
@@ -17039,6 +18476,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yeti (alt 4)</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="13510">
 				<rom name="yeti_a_mo5.k7" size="13510" crc="abc1f165" sha1="bcec9d2f74577de51246ae39d683a7709e665a88"/>
@@ -17078,6 +18516,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yie Ar Kung Fu II</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="32886">
 				<rom name="yie ar kung fu ii (1986)(fil)(fr)(en-fr).k7" size="32886" crc="574d042c" sha1="64ec01fde551fb3ae9b6a5f47ed1b50c89c46a36"/>
@@ -17089,6 +18528,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yie Ar Kung Fu II (alt)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33041">
 				<rom name="yie ar kung fu ii (1986)(fil)(fr)(en-fr)[a].k7" size="33041" crc="01431c54" sha1="62c77ba28bda6b0847ba429fa243aa5ada0cbb34"/>
@@ -17100,6 +18540,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yie Ar Kung Fu II (alt 2)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33041">
 				<rom name="yie ar kung fu ii (1986)(fil)(fr)(en-fr)[a2].k7" size="33041" crc="04516810" sha1="0fa25862702c024da5454d6cf882c1409f05e3f3"/>
@@ -17111,6 +18552,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Yie Ar Kung Fu II (alt 3)</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="cass1" interface="mo_cass">
 			<dataarea name="cass" size="33041">
 				<rom name="yie-ar-kung-fu_mo5.k7" size="33041" crc="c6c47c35" sha1="73daa439a7dbe950ec1d1ab4b616d1155f81b42e"/>


### PR DESCRIPTION
Lower case on "Alt", "Single Tape", "Cracked", "Format" words in the set description.
Removed empty lines.