### PR TITLE
mo5_flop: Metadata cleaning

### DIFF
--- a/hash/mo5_flop.xml
+++ b/hash/mo5_flop.xml
@@ -854,7 +854,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
 		<info name="hacked" value="Prehisto" />
-		
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="mandragore (1984)(infogrames)(fr)[m prehisto][3.5'', bootable].fd" size="327680" crc="acb88fbb" sha1="e2a1cdbea99e22e5b9781bd7fc34bf88748dc6b3"/>

--- a/hash/mo5_flop.xml
+++ b/hash/mo5_flop.xml
@@ -13,7 +13,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3'5 Disk BASIC (v1.0)</description>
 		<year>1985</year>
 		<publisher>Microsoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="3'5 disk basic v1.0 (1985)(microsoft)[3.5''].fd" size="327680" crc="d3bdc693" sha1="927d33041c18cdca720be7d0449519ea4f288d4e"/>
@@ -22,10 +21,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="35basica" cloneof="35basic">
-		<description>3'5 Disk BASIC (v1.0, Alt)</description>
+		<description>3'5 Disk BASIC (v1.0, alt)</description>
 		<year>1985</year>
 		<publisher>Microsoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="basmo5.sap" size="335426" crc="cc578297" sha1="d4f739d27d79c5c2637b150ee6d9e7ac8fc6b0cc"/>
@@ -34,10 +32,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="35basicb" cloneof="35basic">
-		<description>3'5 Disk BASIC (v1.0, Alt 2)</description>
+		<description>3'5 Disk BASIC (v1.0, alt 2)</description>
 		<year>1985</year>
 		<publisher>Microsoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="dos-mo.sap" size="335426" crc="97753fce" sha1="6b9aee850fc64751f247fa83457f6675683858b2"/>
@@ -49,7 +46,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arsene</description>
 		<year>1986</year>
 		<publisher>Triel</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="81920">
 				<rom name="arsene (triel) (jean-michel cohen) (1986) (mo5).fd" size="81920" crc="c917e4db" sha1="a7b9d8dc9e9e5918686bafb1e5403cfcdc292469"/>
@@ -61,7 +57,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Colorcalc</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="colorcalc (fil) (inconnus) (1985) (mo5).fd" size="327680" crc="665494c1" sha1="a6e7821308b71e6482f48ed9392daab6b92053c3"/>
@@ -73,7 +68,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Commande du Robot Youpi (v1.1)</description>
 		<year>1985</year>
 		<publisher>JD Productique</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="commande du robot youpi v1.1 (1985)(jd productique)(fr)[3.5'', bootable].fd" size="327680" crc="0b5c4a0f" sha1="ac217663d31e74c81da5f4113e18df2b0b872ec4"/>
@@ -86,7 +80,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>dcsdboot</description>
 		<year>2012</year>
 		<publisher>DCsoft?</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="dcsdboot.fd" size="327680" crc="856a4963" sha1="7eaa8a78850182f77ebe8f2cc027bcd4841ebfe7"/>
@@ -98,7 +91,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>DOS Reduit BASIC</description>
 		<year>198?</year>
 		<publisher>&lt;hack&gt;</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="dos-reduit-simple-densite_mo5.fd" size="327680" crc="fd1d9352" sha1="e30b0b82aaa21f421177bc5c995a00c981fd88f2"/>
@@ -116,7 +108,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dump rom UC, controleur, cartouche</description>
 		<year>2008</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="dump rom uc, controleur, cartouche (dcsoft) (daniel coulom) (2008) (moto).fd" size="327680" crc="b7892d98" sha1="75569792465e92f0a0f821abdb9709494b7c80dd"/>
@@ -130,7 +121,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dump rom UC, controleur, cartouche (640K Disk)</description>
 		<year>2008</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="655360">
 				<rom name="dump rom uc, controleur, cartouche (dcsoft) (daniel coulom) (2008) (moto)[640k].fd" size="655360" crc="3a1f761c" sha1="99611d9ea0bbc7435535ccaab8d6c63acaf1f0e9"/>
@@ -140,11 +130,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- This version has been modified to boot off a disk instead of a cartridge -->
 	<software name="jane">
-		<description>Jane (Hacked to use boot disk)</description>
+		<description>Jane (hacked to use boot disk)</description>
 		<year>2002</year>
 		<publisher>Thomson - E. Forler</publisher>
 		<info name="usage" value="Insert Chargeur disk first, then load Systeme disk when prompted" />
-
 		<part name="flop1" interface="thom_flop">
 			<feature name="part_id" value="Chargeur"/>
 			<dataarea name="flop" size="163840">
@@ -175,7 +164,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>LOGO DOS</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="dos-logo-mo5.sap" size="335426" crc="656ddf74" sha1="c80c105d6aedd72656603ae090b5a8f2fb24995c"/>
@@ -188,7 +176,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1985</year>
 		<publisher>Microsoft</publisher>
 		<info name="drive_requirement" value="5.25 SD floppy drive"/>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="81920">
 				<rom name="mo5 disk basic v1.0 (1985)(microsoft)[5.25'' sd].fd" size="81920" crc="a51bf32b" sha1="02150026a8ae4c0fbe7edd540d159719f2652b75"/>
@@ -201,7 +188,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1985</year>
 		<publisher>Microsoft</publisher>
 		<info name="drive_requirement" value="5.25 DD floppy drive"/>
-
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="163840">
 				<rom name="mo5 disk basic v1.1 (1985)(microsoft)[5.25'' dd].fd" size="163840" crc="ba22a699" sha1="654ece163199e12219007ba946ffc020c36c4a42"/>
@@ -213,7 +199,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Multidos (v1.0)</description>
 		<year>1986</year>
 		<publisher>Thomson</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="multidos v1.0 (1986)(thomson)(fr).sap" size="335426" crc="1d417334" sha1="e7fe253983b130ca80155a70bb334e874051e367"/>
@@ -226,7 +211,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pico-Reseau CLD75</description>
 		<year>1985</year>
 		<publisher>CNDP</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="pico-reseau_moto.fd" size="327680" crc="d2482574" sha1="40e7745fc9459429f0d0c0332c39c5ecc669f11a"/>
@@ -238,7 +222,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDANIM7</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sdanim7_mo5.fd" size="327680" crc="2076a055" sha1="171647f7a5c62ddd53332f66c78327c6c9d67d06"/>
@@ -250,7 +233,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDPLAY44 (2015.09.24)</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sdplay44_mo5.fd" size="327680" crc="a045af4b" sha1="7b5ac37223c839ccc3416069b15d7da8de7b3fab"/>
@@ -262,7 +244,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDPLAY44 (2015.09.07)</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sdplay44_mo5 [a].fd" size="327680" crc="fd25a97b" sha1="8b5a350ef53f759c0e4e3d20835a0ac98d82c663"/>
@@ -275,7 +256,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDTRANSFERT - Transferts PC-Thomson par carte SD</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sdtransfert - transferts pc _-_ thomson par carte sd (dcsoft) (daniel coulom) (2013) (moto fd).fd" size="327680" crc="abb4c3b6" sha1="4643275c00e44e0f5087662b93f697846d172f02"/>
@@ -288,7 +268,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
 		<info name="alt_title" value="Vox Basic"/>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="1310720">
 				<rom name="vox-basic_mo5.fd" size="1310720" crc="d626e7c0" sha1="a767168d5cdecf009970aba7fb92fea700d1486b"/>
@@ -302,7 +281,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Programmes ludo-educatifs pour MO5 (16-11-2015)</description>
 		<year>2015</year>
 		<publisher>dcmoto.free.fr</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="programmes-ludo-educatifs_a_mo5.fd" size="327680" crc="d1c6584c" sha1="837643e4433bb7076084be9b53e93034415032c6"/>
@@ -314,7 +292,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Programmes ludo-educatifs pour MO5 (07-08-2015)</description>
 		<year>2015</year>
 		<publisher>dcmoto.free.fr</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="programmes-ludo-educatifs_mo5.fd" size="327680" crc="c3177772" sha1="e4bc4edc945809b3bd9e2c693e6d5ee388c0d8f5"/>
@@ -326,7 +303,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Programmes ludo-educatifs pour MO5 (27-07-2015)</description>
 		<year>2015</year>
 		<publisher>dcmoto.free.fr</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="programmes-ludo-educatifs_mo5 [a].fd" size="327680" crc="f392b8bc" sha1="a2963c378af7c93814ab4f83e7448e2110b7d993"/>
@@ -342,7 +318,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
 		<info name="usage" value="Load with Microsoft BASIC 1.0"/>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="classiques vol.2 (1987)(titus)(fr).fd" size="327680" crc="61c44264" sha1="1b616476d5616ccb7bf93a3096eae847ea3249ad"/>
@@ -356,7 +331,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
 		<info name="usage" value="Load with Microsoft BASIC 1.0"/>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="classiques vol.3 (1987)(titus)(fr).fd" size="327680" crc="6c0f6f65" sha1="99147a84ec0d1d655c4b84c7ba59077ccbf94a1e"/>
@@ -370,7 +344,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
 		<info name="usage" value="Load with Microsoft BASIC 1.0"/>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="classiques vol.4 (1987)(titus)(fr).fd" size="327680" crc="085afb85" sha1="a8cb871bc918a5d9d7b20732261a0958b719435f"/>
@@ -382,7 +355,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Hits de Loriciels 1</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="les-hits-de-loriciels-1_mo5.fd" size="327680" crc="e8420f53" sha1="063278385dc58ac1eebc8e936b6a0fcf81d358e8"/>
@@ -391,10 +363,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="hitsloria" cloneof="hitslori">
-		<description>Les Hits de Loriciels 1 (Alt)</description>
+		<description>Les Hits de Loriciels 1 (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="les-hits-de-loriciels-1_a_mo5.fd" size="327680" crc="c82070a8" sha1="0dae5973c91cca0adab43ac4dad534a8f61d68aa"/>
@@ -415,10 +386,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="jeuxsayaa" cloneof="jeuxsaya">
-		<description>Jeux Saya (SAP Format)</description>
+		<description>Jeux Saya (SAP format)</description>
 		<year>198?</year>
 		<publisher>Sayasupacrew</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="jeusaya-mo5.sap" size="335426" crc="7a03b094" sha1="08f1b3011f12f64542dfb3424216b5b8eeb6a682" status="baddump" />
@@ -442,7 +412,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>MEMO5 Chargeur</description>
 		<year>2015</year>
 		<publisher>DSSoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="327680">
@@ -461,7 +430,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>MEMO5 Chargeur (640K)</description>
 		<year>2015</year>
 		<publisher>DSSoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="655360">
 				<rom name="memo5-chargeur_mo5.fd" size="655360" crc="70b94be6" sha1="a0775e9ae42240dbb4d0d82620e3f352f99b82af"/>
@@ -476,7 +444,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>THOM-CAT</description>
 		<year>2015</year>
 		<publisher>Puls</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="thomcat.fd" size="327680" crc="91624ab5" sha1="25bea453e1f28b316ee122d175d228ea5994fae1"/>
@@ -486,10 +453,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 
 	<!-- can also be found in to_flop.xml -->
 	<software name="thomcata" cloneof="thomcat">
-		<description>THOM-CAT (SAP Format)</description>
+		<description>THOM-CAT (SAP format)</description>
 		<year>2015</year>
 		<publisher>Puls</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="thomcat.sap" size="335426" crc="5c883660" sha1="db34390336538e2326c23b20166f03b6fe0f2fb5"/>
@@ -503,7 +469,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Enigme a Oxford</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="enigme a oxford (coktel vision) (beatrice franzi) (1986) (mo5).fd" size="327680" crc="d2b707dc" sha1="148dc4638b582472e25010fc7b8fc0db68da9823"/>
@@ -515,7 +480,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Folle Lecture de Donne Quichotte</description>
 		<year>1988</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="folle lecture de donne quichotte, la (1988)(coktel vision)(fr)[bootable].fd" size="327680" crc="35044566" sha1="f87d465768582ad00397006fc1a39270cf95653a"/>
@@ -539,7 +503,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Parole</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="parole_mo5.fd" size="327680" crc="d8daec11" sha1="957cfc7224531508de4afa718bd381b4b242c466"/>
@@ -551,7 +514,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Visa pour Hyde Park</description>
 		<year>1988</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="visa pour hyde park (1988)(coktel vision)(fr)[bootable].fd" size="327680" crc="394aa11e" sha1="3db9d4c9ebdb6969416753d018005034c3263bbb"/>
@@ -565,7 +527,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le 5eme Axe</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="le-5eme-axe_mo5.fd" size="327680" crc="9f8945a2" sha1="f0764de7147c3e0715916bf4fe31fd14f3ca7184"/>
@@ -577,7 +538,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Aigle d'Or</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="l-aigle-d-or_mo5.fd" size="327680" crc="ebdd24c9" sha1="29ba415e07e1e35ceb108aaad5ff8487f8ce8a71"/>
@@ -589,7 +549,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="androides_mo5.fd" size="327680" crc="99a9f499" sha1="4ac58a32ce73d14ac0896c2af85f6ab4c6c371d6"/>
@@ -601,7 +560,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arkanoid</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="arkanoid_mo5.fd" size="327680" crc="6f3b4312" sha1="3bc946cddc984c0ae4c03e0e077318c80fa039fb"/>
@@ -613,7 +571,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Atlantis</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="atlantis_mo5.fd" size="327680" crc="a6d36e27" sha1="958eaa25777ea9d91e3c49b59f8b3cbaa3186ba3"/>
@@ -625,7 +582,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Atomik</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="atomik_mo5.fd" size="327680" crc="e298ac1b" sha1="174bead99db6e53b7fe72c50d58a43fc566e66c6"/>
@@ -637,7 +593,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balthazar</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="balthazar_mo5.fd" size="327680" crc="420b6c3f" sha1="89fdfa8fd9f0b335dba73c49fe5381f75eca648b"/>
@@ -649,7 +604,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blitz!</description>
 		<year>1985</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="blitz (intelligent software) (richard lang) (1985) (mo5).fd" size="327680" crc="b0b511eb" sha1="8d5719509cb159a38754c85d28f21033a1e455f1"/>
@@ -658,10 +612,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="blitza" cloneof="blitz">
-		<description>Blitz! (Alt)</description>
+		<description>Blitz! (alt)</description>
 		<year>1985</year>
 		<publisher>TO TEK International</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="163840">
 				<rom name="blitz (1985)(to tek)(fr)[3.5'', bootable].fd" size="163840" crc="20e73a19" sha1="2bdc70be628878b46ef0afd6ca753c74ee051777"/>
@@ -673,7 +626,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Brain Power</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="brain-power_mo5.fd" size="327680" crc="44c047fb" sha1="95db8c5caf4083f32d5b3ab6826ef00af3f5c14e"/>
@@ -685,7 +637,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crocky II</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="163840">
 				<rom name="crocky2_mo5.fd" size="163840" crc="1bdd7fd0" sha1="907828023a2f20b8e723ec3a70da7226c4e29aed"/>
@@ -697,7 +648,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crystann</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="crystann_mo5.fd" size="327680" crc="ebd38671" sha1="2b5891a1b5687ef56db4708e434940d1b8d22126"/>
@@ -709,7 +659,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dakar 4x4</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="163840">
 				<rom name="dakar-4x4_mo5.fd" size="163840" crc="f36081c3" sha1="77d433753ae3076ba9704018e3e9c6532f36cd20"/>
@@ -733,7 +682,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>FBI</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="163840">
 				<rom name="fbi_mo5.fd" size="163840" crc="90dd81f6" sha1="51bcbb436441fd4ced04d7c24cd58baf93dd1207"/>
@@ -745,7 +693,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flipper</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="flipper_mo5.fd" size="327680" crc="b351abd1" sha1="7a30a7400d786ba6e47d3eb49d36526cf34fd26d"/>
@@ -757,7 +704,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Formule 1</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="167424">
 				<rom name="formule-1_mo5.fd" size="167424" crc="d5233141" sha1="5774bf9767e79bf2fa1595e444dc9e0bb1fa3dfc"/>
@@ -769,7 +715,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Fox</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="fox_mo5.fd" size="327680" crc="7a3eef3b" sha1="aa2801a4be6a5fd5c55a49bbb90ac4a3d1caf110"/>
@@ -793,7 +738,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Hacker</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="hacker_mo5.fd" size="327680" crc="7679e9cf" sha1="8bb74c0184e7f2150869565db4b7cb488d3451f2"/>
@@ -805,7 +749,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Heritage</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="l-heritage_mo5.fd" size="327680" crc="87182094" sha1="7cbec1df6847c5e3fe17991c9060ac3c5935dff0"/>
@@ -817,7 +760,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>James Debug - Le Grand Saut</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="163840">
 				<rom name="le-grand-saut_mo5.fd" size="163840" crc="0c8021ff" sha1="c7201ab6e710c4260a355ac9c1519f4bb5927a29"/>
@@ -829,7 +771,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe (Blanc)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="1310720">
 				<rom name="labyrinthe-blanc_mo5.fd" size="1310720" crc="e8adbdc1" sha1="5dbeaaaa24c357f7380b6075fae6b989abd78383"/>
@@ -841,7 +782,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe (Noir)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="1310720">
 				<rom name="labyrinthe-noir_mo5.fd" size="1310720" crc="c16fa5d1" sha1="fdc94e7bffe8924c5c160dcd87ea5ee629203672"/>
@@ -850,10 +790,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="mandrago">
-		<description>Mandragore (Hacked by Prehisto)</description>
+		<description>Mandragore (hacked)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
+		<info name="hacked" value="Prehisto" />
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="mandragore (1984)(infogrames)(fr)[m prehisto][3.5'', bootable].fd" size="327680" crc="acb88fbb" sha1="e2a1cdbea99e22e5b9781bd7fc34bf88748dc6b3"/>
@@ -862,10 +802,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="mandragoa" cloneof="mandrago">
-		<description>Mandragore (Hacked by Prehisto, SAP Format)</description>
+		<description>Mandragore (hacked, SAP format)</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
-
+		<info name="hacked" value="Prehisto" />
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="mandragore (1984)(infogrames)(fr)[m prehisto][3.5'', bootable].sap" size="335426" crc="5e31a1e6" sha1="8fc69e896fd22f5fc9b025755f8749c06fa215ca"/>
@@ -877,7 +817,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Mine aux Diamants</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="la-mine-aux-diamants_mo5.fd" size="327680" crc="eee36286" sha1="ae8c3355719f475ccf80069c24a6e3028d80784e"/>
@@ -889,7 +828,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Poseidon</description>
 		<year>1984</year>
 		<publisher>Coktel Vision</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="51200">
 				<rom name="poseidon (1984)(coktel vision)(fr).qd" size="51200" crc="81d0f82d" sha1="cf25c5e691ac4e874ad8fb6f69157ee6e3196f19"/>
@@ -901,7 +839,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sapiens</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sapiens_mo5.fd" size="327680" crc="ba3a803e" sha1="78a279eb50d776acb9241acdae1c471587c1585f"/>
@@ -910,10 +847,9 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	</software>
 
 	<software name="sapiensa" cloneof="sapiens">
-		<description>Sapiens (Alt)</description>
+		<description>Sapiens (alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sapiens_a_mo5.fd" size="327680" crc="d4c362a6" sha1="ac0ef7a6c5c28ee462e0da83ce00b4186d2ca463"/>
@@ -925,7 +861,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sorcery</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sorcery_mo5.fd" size="327680" crc="88802384" sha1="b2e12c15aca2ecff6dc327a3941ec13d4a831aeb"/>
@@ -937,7 +872,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sortileges</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sortileges_mo5.fd" size="327680" crc="6a19d070" sha1="438274cbd81166028b513b6a267e7210990aec62"/>
@@ -949,7 +883,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Tennis (Answare)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="super-tennis_mo5.fd" size="327680" crc="ac941016" sha1="576314b9824c6fb6022c52c0b8bfde09434fa7a5"/>
@@ -961,7 +894,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vampire</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="vampire_mo5.fd" size="327680" crc="2e32aefb" sha1="8d58506898fb60e2130a9b4a04887becd74d7b36"/>
@@ -973,7 +905,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vol Solo</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="vol-solo_mo5.fd" size="327680" crc="b803a305" sha1="c8ce9c572499c0cdb47ac513c9356a0b5e8bd883"/>
@@ -985,7 +916,6 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wizball</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
-
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="wizball_mo5.fd" size="327680" crc="7003e0de" sha1="a15eaa1d4b8039efdd73b39a6be86efe38e6d205"/>

--- a/hash/mo5_flop.xml
+++ b/hash/mo5_flop.xml
@@ -13,6 +13,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3'5 Disk BASIC (v1.0)</description>
 		<year>1985</year>
 		<publisher>Microsoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="3'5 disk basic v1.0 (1985)(microsoft)[3.5''].fd" size="327680" crc="d3bdc693" sha1="927d33041c18cdca720be7d0449519ea4f288d4e"/>
@@ -24,6 +25,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3'5 Disk BASIC (v1.0, alt)</description>
 		<year>1985</year>
 		<publisher>Microsoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="basmo5.sap" size="335426" crc="cc578297" sha1="d4f739d27d79c5c2637b150ee6d9e7ac8fc6b0cc"/>
@@ -35,6 +37,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>3'5 Disk BASIC (v1.0, alt 2)</description>
 		<year>1985</year>
 		<publisher>Microsoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="dos-mo.sap" size="335426" crc="97753fce" sha1="6b9aee850fc64751f247fa83457f6675683858b2"/>
@@ -46,6 +49,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arsene</description>
 		<year>1986</year>
 		<publisher>Triel</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="81920">
 				<rom name="arsene (triel) (jean-michel cohen) (1986) (mo5).fd" size="81920" crc="c917e4db" sha1="a7b9d8dc9e9e5918686bafb1e5403cfcdc292469"/>
@@ -57,6 +61,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Colorcalc</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="colorcalc (fil) (inconnus) (1985) (mo5).fd" size="327680" crc="665494c1" sha1="a6e7821308b71e6482f48ed9392daab6b92053c3"/>
@@ -68,6 +73,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Commande du Robot Youpi (v1.1)</description>
 		<year>1985</year>
 		<publisher>JD Productique</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="commande du robot youpi v1.1 (1985)(jd productique)(fr)[3.5'', bootable].fd" size="327680" crc="0b5c4a0f" sha1="ac217663d31e74c81da5f4113e18df2b0b872ec4"/>
@@ -80,6 +86,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>dcsdboot</description>
 		<year>2012</year>
 		<publisher>DCsoft?</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="dcsdboot.fd" size="327680" crc="856a4963" sha1="7eaa8a78850182f77ebe8f2cc027bcd4841ebfe7"/>
@@ -91,6 +98,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>DOS Reduit BASIC</description>
 		<year>198?</year>
 		<publisher>&lt;hack&gt;</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="dos-reduit-simple-densite_mo5.fd" size="327680" crc="fd1d9352" sha1="e30b0b82aaa21f421177bc5c995a00c981fd88f2"/>
@@ -108,6 +116,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dump rom UC, controleur, cartouche</description>
 		<year>2008</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="dump rom uc, controleur, cartouche (dcsoft) (daniel coulom) (2008) (moto).fd" size="327680" crc="b7892d98" sha1="75569792465e92f0a0f821abdb9709494b7c80dd"/>
@@ -118,9 +127,10 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 	<!-- can also be found in to_flop.xml -->
 	<!-- contains 2 duplicates of parent set -->
 	<software name="dumproma" cloneof="dumprom">
-		<description>Dump rom UC, controleur, cartouche (640K Disk)</description>
+		<description>Dump rom UC, controleur, cartouche (640K disk)</description>
 		<year>2008</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="655360">
 				<rom name="dump rom uc, controleur, cartouche (dcsoft) (daniel coulom) (2008) (moto)[640k].fd" size="655360" crc="3a1f761c" sha1="99611d9ea0bbc7435535ccaab8d6c63acaf1f0e9"/>
@@ -134,6 +144,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>2002</year>
 		<publisher>Thomson - E. Forler</publisher>
 		<info name="usage" value="Insert Chargeur disk first, then load Systeme disk when prompted" />
+
 		<part name="flop1" interface="thom_flop">
 			<feature name="part_id" value="Chargeur"/>
 			<dataarea name="flop" size="163840">
@@ -164,6 +175,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>LOGO DOS</description>
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="dos-logo-mo5.sap" size="335426" crc="656ddf74" sha1="c80c105d6aedd72656603ae090b5a8f2fb24995c"/>
@@ -176,6 +188,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1985</year>
 		<publisher>Microsoft</publisher>
 		<info name="drive_requirement" value="5.25 SD floppy drive"/>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="81920">
 				<rom name="mo5 disk basic v1.0 (1985)(microsoft)[5.25'' sd].fd" size="81920" crc="a51bf32b" sha1="02150026a8ae4c0fbe7edd540d159719f2652b75"/>
@@ -188,6 +201,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1985</year>
 		<publisher>Microsoft</publisher>
 		<info name="drive_requirement" value="5.25 DD floppy drive"/>
+
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="163840">
 				<rom name="mo5 disk basic v1.1 (1985)(microsoft)[5.25'' dd].fd" size="163840" crc="ba22a699" sha1="654ece163199e12219007ba946ffc020c36c4a42"/>
@@ -199,6 +213,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Multidos (v1.0)</description>
 		<year>1986</year>
 		<publisher>Thomson</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="multidos v1.0 (1986)(thomson)(fr).sap" size="335426" crc="1d417334" sha1="e7fe253983b130ca80155a70bb334e874051e367"/>
@@ -211,6 +226,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Pico-Reseau CLD75</description>
 		<year>1985</year>
 		<publisher>CNDP</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="pico-reseau_moto.fd" size="327680" crc="d2482574" sha1="40e7745fc9459429f0d0c0332c39c5ecc669f11a"/>
@@ -222,6 +238,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDANIM7</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sdanim7_mo5.fd" size="327680" crc="2076a055" sha1="171647f7a5c62ddd53332f66c78327c6c9d67d06"/>
@@ -233,6 +250,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDPLAY44 (2015.09.24)</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sdplay44_mo5.fd" size="327680" crc="a045af4b" sha1="7b5ac37223c839ccc3416069b15d7da8de7b3fab"/>
@@ -244,6 +262,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDPLAY44 (2015.09.07)</description>
 		<year>2015</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sdplay44_mo5 [a].fd" size="327680" crc="fd25a97b" sha1="8b5a350ef53f759c0e4e3d20835a0ac98d82c663"/>
@@ -256,6 +275,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>SDTRANSFERT - Transferts PC-Thomson par carte SD</description>
 		<year>2013</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sdtransfert - transferts pc _-_ thomson par carte sd (dcsoft) (daniel coulom) (2013) (moto fd).fd" size="327680" crc="abb4c3b6" sha1="4643275c00e44e0f5087662b93f697846d172f02"/>
@@ -268,6 +288,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1984</year>
 		<publisher>ERE Informatique</publisher>
 		<info name="alt_title" value="Vox Basic"/>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="1310720">
 				<rom name="vox-basic_mo5.fd" size="1310720" crc="d626e7c0" sha1="a767168d5cdecf009970aba7fb92fea700d1486b"/>
@@ -281,6 +302,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Programmes ludo-educatifs pour MO5 (16-11-2015)</description>
 		<year>2015</year>
 		<publisher>dcmoto.free.fr</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="programmes-ludo-educatifs_a_mo5.fd" size="327680" crc="d1c6584c" sha1="837643e4433bb7076084be9b53e93034415032c6"/>
@@ -292,6 +314,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Programmes ludo-educatifs pour MO5 (07-08-2015)</description>
 		<year>2015</year>
 		<publisher>dcmoto.free.fr</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="programmes-ludo-educatifs_mo5.fd" size="327680" crc="c3177772" sha1="e4bc4edc945809b3bd9e2c693e6d5ee388c0d8f5"/>
@@ -303,6 +326,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Programmes ludo-educatifs pour MO5 (27-07-2015)</description>
 		<year>2015</year>
 		<publisher>dcmoto.free.fr</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="programmes-ludo-educatifs_mo5 [a].fd" size="327680" crc="f392b8bc" sha1="a2963c378af7c93814ab4f83e7448e2110b7d993"/>
@@ -318,6 +342,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
 		<info name="usage" value="Load with Microsoft BASIC 1.0"/>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="classiques vol.2 (1987)(titus)(fr).fd" size="327680" crc="61c44264" sha1="1b616476d5616ccb7bf93a3096eae847ea3249ad"/>
@@ -331,6 +356,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
 		<info name="usage" value="Load with Microsoft BASIC 1.0"/>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="classiques vol.3 (1987)(titus)(fr).fd" size="327680" crc="6c0f6f65" sha1="99147a84ec0d1d655c4b84c7ba59077ccbf94a1e"/>
@@ -344,6 +370,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
 		<info name="usage" value="Load with Microsoft BASIC 1.0"/>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="classiques vol.4 (1987)(titus)(fr).fd" size="327680" crc="085afb85" sha1="a8cb871bc918a5d9d7b20732261a0958b719435f"/>
@@ -355,6 +382,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Hits de Loriciels 1</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="les-hits-de-loriciels-1_mo5.fd" size="327680" crc="e8420f53" sha1="063278385dc58ac1eebc8e936b6a0fcf81d358e8"/>
@@ -366,6 +394,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Les Hits de Loriciels 1 (alt)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="les-hits-de-loriciels-1_a_mo5.fd" size="327680" crc="c82070a8" sha1="0dae5973c91cca0adab43ac4dad534a8f61d68aa"/>
@@ -389,6 +418,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Jeux Saya (SAP format)</description>
 		<year>198?</year>
 		<publisher>Sayasupacrew</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="jeusaya-mo5.sap" size="335426" crc="7a03b094" sha1="08f1b3011f12f64542dfb3424216b5b8eeb6a682" status="baddump" />
@@ -412,6 +442,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>MEMO5 Chargeur</description>
 		<year>2015</year>
 		<publisher>DSSoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="327680">
@@ -430,6 +461,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>MEMO5 Chargeur (640K)</description>
 		<year>2015</year>
 		<publisher>DSSoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="655360">
 				<rom name="memo5-chargeur_mo5.fd" size="655360" crc="70b94be6" sha1="a0775e9ae42240dbb4d0d82620e3f352f99b82af"/>
@@ -444,6 +476,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>THOM-CAT</description>
 		<year>2015</year>
 		<publisher>Puls</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="thomcat.fd" size="327680" crc="91624ab5" sha1="25bea453e1f28b316ee122d175d228ea5994fae1"/>
@@ -456,6 +489,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>THOM-CAT (SAP format)</description>
 		<year>2015</year>
 		<publisher>Puls</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="thomcat.sap" size="335426" crc="5c883660" sha1="db34390336538e2326c23b20166f03b6fe0f2fb5"/>
@@ -469,6 +503,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Enigme a Oxford</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="enigme a oxford (coktel vision) (beatrice franzi) (1986) (mo5).fd" size="327680" crc="d2b707dc" sha1="148dc4638b582472e25010fc7b8fc0db68da9823"/>
@@ -480,6 +515,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Folle Lecture de Donne Quichotte</description>
 		<year>1988</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="folle lecture de donne quichotte, la (1988)(coktel vision)(fr)[bootable].fd" size="327680" crc="35044566" sha1="f87d465768582ad00397006fc1a39270cf95653a"/>
@@ -503,6 +539,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Parole</description>
 		<year>1985</year>
 		<publisher>Cedic/Nathan</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="parole_mo5.fd" size="327680" crc="d8daec11" sha1="957cfc7224531508de4afa718bd381b4b242c466"/>
@@ -514,6 +551,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Visa pour Hyde Park</description>
 		<year>1988</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="visa pour hyde park (1988)(coktel vision)(fr)[bootable].fd" size="327680" crc="394aa11e" sha1="3db9d4c9ebdb6969416753d018005034c3263bbb"/>
@@ -527,6 +565,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Le 5eme Axe</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="le-5eme-axe_mo5.fd" size="327680" crc="9f8945a2" sha1="f0764de7147c3e0715916bf4fe31fd14f3ca7184"/>
@@ -538,6 +577,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Aigle d'Or</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="l-aigle-d-or_mo5.fd" size="327680" crc="ebdd24c9" sha1="29ba415e07e1e35ceb108aaad5ff8487f8ce8a71"/>
@@ -549,6 +589,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Androides</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="androides_mo5.fd" size="327680" crc="99a9f499" sha1="4ac58a32ce73d14ac0896c2af85f6ab4c6c371d6"/>
@@ -560,6 +601,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Arkanoid</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="arkanoid_mo5.fd" size="327680" crc="6f3b4312" sha1="3bc946cddc984c0ae4c03e0e077318c80fa039fb"/>
@@ -571,6 +613,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Atlantis</description>
 		<year>1985</year>
 		<publisher>Cobrasoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="atlantis_mo5.fd" size="327680" crc="a6d36e27" sha1="958eaa25777ea9d91e3c49b59f8b3cbaa3186ba3"/>
@@ -582,6 +625,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Atomik</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="atomik_mo5.fd" size="327680" crc="e298ac1b" sha1="174bead99db6e53b7fe72c50d58a43fc566e66c6"/>
@@ -593,6 +637,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Balthazar</description>
 		<year>1987</year>
 		<publisher>Titus Software</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="balthazar_mo5.fd" size="327680" crc="420b6c3f" sha1="89fdfa8fd9f0b335dba73c49fe5381f75eca648b"/>
@@ -604,6 +649,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blitz!</description>
 		<year>1985</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="blitz (intelligent software) (richard lang) (1985) (mo5).fd" size="327680" crc="b0b511eb" sha1="8d5719509cb159a38754c85d28f21033a1e455f1"/>
@@ -615,6 +661,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Blitz! (alt)</description>
 		<year>1985</year>
 		<publisher>TO TEK International</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="163840">
 				<rom name="blitz (1985)(to tek)(fr)[3.5'', bootable].fd" size="163840" crc="20e73a19" sha1="2bdc70be628878b46ef0afd6ca753c74ee051777"/>
@@ -626,6 +673,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Brain Power</description>
 		<year>1987</year>
 		<publisher>SoftBook</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="brain-power_mo5.fd" size="327680" crc="44c047fb" sha1="95db8c5caf4083f32d5b3ab6826ef00af3f5c14e"/>
@@ -637,6 +685,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crocky II</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="163840">
 				<rom name="crocky2_mo5.fd" size="163840" crc="1bdd7fd0" sha1="907828023a2f20b8e723ec3a70da7226c4e29aed"/>
@@ -648,6 +697,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Crystann</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="crystann_mo5.fd" size="327680" crc="ebd38671" sha1="2b5891a1b5687ef56db4708e434940d1b8d22126"/>
@@ -659,6 +709,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Dakar 4x4</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="163840">
 				<rom name="dakar-4x4_mo5.fd" size="163840" crc="f36081c3" sha1="77d433753ae3076ba9704018e3e9c6532f36cd20"/>
@@ -682,6 +733,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>FBI</description>
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="163840">
 				<rom name="fbi_mo5.fd" size="163840" crc="90dd81f6" sha1="51bcbb436441fd4ced04d7c24cd58baf93dd1207"/>
@@ -693,6 +745,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Flipper</description>
 		<year>1984</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="flipper_mo5.fd" size="327680" crc="b351abd1" sha1="7a30a7400d786ba6e47d3eb49d36526cf34fd26d"/>
@@ -704,6 +757,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Formule 1</description>
 		<year>1987</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="167424">
 				<rom name="formule-1_mo5.fd" size="167424" crc="d5233141" sha1="5774bf9767e79bf2fa1595e444dc9e0bb1fa3dfc"/>
@@ -715,6 +769,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Fox</description>
 		<year>1985</year>
 		<publisher>Shift-Edition</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="fox_mo5.fd" size="327680" crc="7a3eef3b" sha1="aa2801a4be6a5fd5c55a49bbb90ac4a3d1caf110"/>
@@ -738,6 +793,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Hacker</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="hacker_mo5.fd" size="327680" crc="7679e9cf" sha1="8bb74c0184e7f2150869565db4b7cb488d3451f2"/>
@@ -749,6 +805,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>L'Heritage</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="l-heritage_mo5.fd" size="327680" crc="87182094" sha1="7cbec1df6847c5e3fe17991c9060ac3c5935dff0"/>
@@ -760,6 +817,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>James Debug - Le Grand Saut</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="163840">
 				<rom name="le-grand-saut_mo5.fd" size="163840" crc="0c8021ff" sha1="c7201ab6e710c4260a355ac9c1519f4bb5927a29"/>
@@ -771,6 +829,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe (Blanc)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="1310720">
 				<rom name="labyrinthe-blanc_mo5.fd" size="1310720" crc="e8adbdc1" sha1="5dbeaaaa24c357f7380b6075fae6b989abd78383"/>
@@ -782,6 +841,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Labyrinthe (Noir)</description>
 		<year>1986</year>
 		<publisher>DCsoft</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="1310720">
 				<rom name="labyrinthe-noir_mo5.fd" size="1310720" crc="c16fa5d1" sha1="fdc94e7bffe8924c5c160dcd87ea5ee629203672"/>
@@ -794,6 +854,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
 		<info name="hacked" value="Prehisto" />
+		
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="mandragore (1984)(infogrames)(fr)[m prehisto][3.5'', bootable].fd" size="327680" crc="acb88fbb" sha1="e2a1cdbea99e22e5b9781bd7fc34bf88748dc6b3"/>
@@ -806,6 +867,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<year>1984</year>
 		<publisher>Infogrames</publisher>
 		<info name="hacked" value="Prehisto" />
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="335426">
 				<rom name="mandragore (1984)(infogrames)(fr)[m prehisto][3.5'', bootable].sap" size="335426" crc="5e31a1e6" sha1="8fc69e896fd22f5fc9b025755f8749c06fa215ca"/>
@@ -817,6 +879,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>La Mine aux Diamants</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="la-mine-aux-diamants_mo5.fd" size="327680" crc="eee36286" sha1="ae8c3355719f475ccf80069c24a6e3028d80784e"/>
@@ -828,6 +891,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Poseidon</description>
 		<year>1984</year>
 		<publisher>Coktel Vision</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="51200">
 				<rom name="poseidon (1984)(coktel vision)(fr).qd" size="51200" crc="81d0f82d" sha1="cf25c5e691ac4e874ad8fb6f69157ee6e3196f19"/>
@@ -839,6 +903,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sapiens</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sapiens_mo5.fd" size="327680" crc="ba3a803e" sha1="78a279eb50d776acb9241acdae1c471587c1585f"/>
@@ -850,6 +915,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sapiens (alt)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sapiens_a_mo5.fd" size="327680" crc="d4c362a6" sha1="ac0ef7a6c5c28ee462e0da83ce00b4186d2ca463"/>
@@ -861,6 +927,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sorcery</description>
 		<year>1986</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sorcery_mo5.fd" size="327680" crc="88802384" sha1="b2e12c15aca2ecff6dc327a3941ec13d4a831aeb"/>
@@ -872,6 +939,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Sortileges</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="sortileges_mo5.fd" size="327680" crc="6a19d070" sha1="438274cbd81166028b513b6a267e7210990aec62"/>
@@ -883,6 +951,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Super Tennis (Answare)</description>
 		<year>1985</year>
 		<publisher>Answare</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="super-tennis_mo5.fd" size="327680" crc="ac941016" sha1="576314b9824c6fb6022c52c0b8bfde09434fa7a5"/>
@@ -894,6 +963,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vampire</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="vampire_mo5.fd" size="327680" crc="2e32aefb" sha1="8d58506898fb60e2130a9b4a04887becd74d7b36"/>
@@ -905,6 +975,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Vol Solo</description>
 		<year>1985</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="vol-solo_mo5.fd" size="327680" crc="b803a305" sha1="c8ce9c572499c0cdb47ac513c9356a0b5e8bd883"/>
@@ -916,6 +987,7 @@ Thanks to DCMOTO (http://dcmoto.free.fr) for info!
 		<description>Wizball</description>
 		<year>1988</year>
 		<publisher>France Image Logiciel (FIL)</publisher>
+
 		<part name="flop1" interface="thom_flop">
 			<dataarea name="flop" size="327680">
 				<rom name="wizball_mo5.fd" size="327680" crc="7003e0de" sha1="a15eaa1d4b8039efdd73b39a6be86efe38e6d205"/>


### PR DESCRIPTION
Lower case on "Alt", "Hacked", "Format" words in the set description.
Removed empty lines.