### PR TITLE
gameboy.xml: Converted data sizes to hexadecimal.

### DIFF
--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -57,8 +57,8 @@ license:CC0
 		<info name="alt_title" value="3丁目のタマ タマ&amp;フレンズ 3丁目お化けパニック!!" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="3 choume no tama - tama and friends - 3 choume obake panic (japan).bin" size="131072" crc="b61cd120" sha1="0982bcc82deb9c4db08e602a22a2bb4f31e7e6ae" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="3 choume no tama - tama and friends - 3 choume obake panic (japan).bin" size="0x20000" crc="b61cd120" sha1="0982bcc82deb9c4db08e602a22a2bb4f31e7e6ae" />
 			</dataarea>
 		</part>
 	</software>
@@ -77,10 +77,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-u4j-0.u1" size="65536" crc="cafe0d2b" sha1="76643f3f3481f7e515a24482779870862dd8b373" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-u4j-0.u1" size="0x10000" crc="cafe0d2b" sha1="76643f3f3481f7e515a24482779870862dd8b373" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -97,8 +97,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-f4j-0.u1" size="131072" crc="86f45343" sha1="f1cf115df0246f08d4e886cb046ebd2aa431a6c9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-f4j-0.u1" size="0x20000" crc="86f45343" sha1="f1cf115df0246f08d4e886cb046ebd2aa431a6c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -113,8 +113,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-f4e-0.u1" size="131072" crc="0e0216e6" sha1="b1443c09ee3f2bee5437111a635b6d84155f600e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-f4e-0.u1" size="0x20000" crc="0e0216e6" sha1="b1443c09ee3f2bee5437111a635b6d84155f600e" />
 			</dataarea>
 		</part>
 	</software>
@@ -126,8 +126,8 @@ license:CC0
 		<info name="serial" value="DMG-F9-GPS, DMG-F9-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="4 in 1 funpak vol. ii (usa, europe).bin" size="131072" crc="018b4a02" sha1="5efeddce9e03ad56ee755c58fb658b045dc0fa53" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="4 in 1 funpak vol. ii (usa, europe).bin" size="0x20000" crc="018b4a02" sha1="5efeddce9e03ad56ee755c58fb658b045dc0fa53" />
 			</dataarea>
 		</part>
 	</software>
@@ -142,8 +142,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-afx-0.u1" size="131072" crc="28fa451e" sha1="2246dbdb6c58c77814cf034ae9224be8e73c5084" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-afx-0.u1" size="0x20000" crc="28fa451e" sha1="2246dbdb6c58c77814cf034ae9224be8e73c5084" />
 			</dataarea>
 		</part>
 	</software>
@@ -157,8 +157,8 @@ license:CC0
 		<info name="alt_title" value="アダムス・ファミリー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="addams family, the (japan).bin" size="131072" crc="4c749c14" sha1="10a7d1491001657272755559ed593cc4400014ee" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="addams family, the (japan).bin" size="0x20000" crc="4c749c14" sha1="10a7d1491001657272755559ed593cc4400014ee" />
 			</dataarea>
 		</part>
 	</software>
@@ -173,8 +173,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-afe-0.u1" size="131072" crc="c170a732" sha1="8710ceecbe3e7ade67c0362cc3b455aceb67a90d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-afe-0.u1" size="0x20000" crc="c170a732" sha1="8710ceecbe3e7ade67c0362cc3b455aceb67a90d" />
 			</dataarea>
 		</part>
 	</software>
@@ -186,8 +186,8 @@ license:CC0
 		<info name="serial" value="DMG-A8-NOE, DMG-A8-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="addams family, the - pugsley's scavenger hunt (usa, europe).bin" size="131072" crc="7e054a88" sha1="f9020e3d104cb5c5347e28f45ed9e24e6c0ebddd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="addams family, the - pugsley's scavenger hunt (usa, europe).bin" size="0x20000" crc="7e054a88" sha1="f9020e3d104cb5c5347e28f45ed9e24e6c0ebddd" />
 			</dataarea>
 		</part>
 	</software>
@@ -204,8 +204,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-t3e-0.u1" size="131072" crc="64f4fa44" sha1="4a61945c1e3a37301748314777835c0e122a67e6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-t3e-0.u1" size="0x20000" crc="64f4fa44" sha1="4a61945c1e3a37301748314777835c0e122a67e6" />
 			</dataarea>
 		</part>
 	</software>
@@ -221,8 +221,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-gqe-0.u1" size="262144" crc="783066cf" sha1="1964fd5708150aa9f71c0a79d552466fd5bf5bf8" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-gqe-0.u1" size="0x40000" crc="783066cf" sha1="1964fd5708150aa9f71c0a79d552466fd5bf5bf8" />
 			</dataarea>
 		</part>
 	</software>
@@ -238,8 +238,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-lox-0.u1" size="262144" crc="176d2eeb" sha1="e09277358a7fd4f3a6206464dd9d39f3abe66a53" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-lox-0.u1" size="0x40000" crc="176d2eeb" sha1="e09277358a7fd4f3a6206464dd9d39f3abe66a53" />
 			</dataarea>
 		</part>
 	</software>
@@ -250,8 +250,8 @@ license:CC0
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="adventures of pinocchio, the (usa) (proto).bin" size="65536" crc="0b9de1dc" sha1="6808d5a5fba9b58d67e91f22a2860e4e72f6eec1" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="adventures of pinocchio, the (usa) (proto).bin" size="0x10000" crc="0b9de1dc" sha1="6808d5a5fba9b58d67e91f22a2860e4e72f6eec1" />
 			</dataarea>
 		</part>
 	</software>
@@ -264,8 +264,8 @@ license:CC0
 		<info name="alt_title" value="The Adventures of Rocky and Bullwinkle and Friends (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-rye-0.u1" size="131072" crc="362c841c" sha1="0ce98889e5d9d6167338e91119394537318810da" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-rye-0.u1" size="0x20000" crc="362c841c" sha1="0ce98889e5d9d6167338e91119394537318810da" />
 			</dataarea>
 		</part>
 	</software>
@@ -280,8 +280,8 @@ license:CC0
 		<info name="alt_title" value="The Adventures of Rocky and Bullwinkle and Friends (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="adventures of rocky and bullwinkle and friends, the (usa).bin" size="131072" crc="74c700a4" sha1="924a9bd18328da81b5554e42db873d1981ee9b20" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="adventures of rocky and bullwinkle and friends, the (usa).bin" size="0x20000" crc="74c700a4" sha1="924a9bd18328da81b5554e42db873d1981ee9b20" />
 			</dataarea>
 		</part>
 	</software>
@@ -297,8 +297,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="adventures of star saver, the (usa, europe).bin" size="131072" crc="5d461374" sha1="408b19a92c73daa11b3b1a52aa6a987cc6615e97" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="adventures of star saver, the (usa, europe).bin" size="0x20000" crc="5d461374" sha1="408b19a92c73daa11b3b1a52aa6a987cc6615e97" />
 			</dataarea>
 		</part>
 	</software>
@@ -310,8 +310,8 @@ license:CC0
 		<info name="alt_title" value="Tintin - Prisoners of the Sun (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="adventures of tintin, the - prisoners of the sun (europe) (en,fr,de).bin" size="262144" crc="55fc585f" sha1="a26a769aac6060705f24c3e0dde367b62962e921" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="adventures of tintin, the - prisoners of the sun (europe) (en,fr,de).bin" size="0x40000" crc="55fc585f" sha1="a26a769aac6060705f24c3e0dde367b62962e921" />
 			</dataarea>
 		</part>
 	</software>
@@ -325,8 +325,8 @@ license:CC0
 		<info name="alt_title" value="エアロスター" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="aero star (japan).bin" size="131072" crc="dfa3b28a" sha1="1088817172c10a9080ab6859da85a074569e2cba" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="aero star (japan).bin" size="0x20000" crc="dfa3b28a" sha1="1088817172c10a9080ab6859da85a074569e2cba" />
 			</dataarea>
 		</part>
 	</software>
@@ -341,8 +341,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-aee-0.u1" size="131072" crc="f6fd275e" sha1="2cb231e616008f2c809e0b2caf40f477689e6d07" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-aee-0.u1" size="0x20000" crc="f6fd275e" sha1="2cb231e616008f2c809e0b2caf40f477689e6d07" />
 			</dataarea>
 		</part>
 	</software>
@@ -356,8 +356,8 @@ license:CC0
 		<info name="alt_title" value="アフターバースト" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="after burst (japan).bin" size="65536" crc="c0049d77" sha1="459cb97524669b0de6cd7cfada61ad67339232f1" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="after burst (japan).bin" size="0x10000" crc="c0049d77" sha1="459cb97524669b0de6cd7cfada61ad67339232f1" />
 			</dataarea>
 		</part>
 	</software>
@@ -369,8 +369,8 @@ license:CC0
 		<info name="serial" value="DMG-A6-AUS" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="agro soar (australia).bin" size="131072" crc="9b7945ea" sha1="d635761f247301fe6bae4d71ee67ceef384ca53a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="agro soar (australia).bin" size="0x20000" crc="9b7945ea" sha1="d635761f247301fe6bae4d71ee67ceef384ca53a" />
 			</dataarea>
 		</part>
 	</software>
@@ -384,8 +384,8 @@ license:CC0
 		<info name="alt_title" value="ああ播磨灘" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ah harimanada (japan).bin" size="131072" crc="5bffcc28" sha1="ff3565fcac22b44bf542732d1b0b20ba96a6c961" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ah harimanada (japan).bin" size="0x20000" crc="5bffcc28" sha1="ff3565fcac22b44bf542732d1b0b20ba96a6c961" />
 			</dataarea>
 		</part>
 	</software>
@@ -400,8 +400,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="akazukin chacha (japan).bin" size="262144" crc="898609b4" sha1="d07970a7eae51aef8c4e8b4bcdd57aeed6360bdd" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="akazukin chacha (japan).bin" size="0x40000" crc="898609b4" sha1="d07970a7eae51aef8c4e8b4bcdd57aeed6360bdd" />
 			</dataarea>
 		</part>
 	</software>
@@ -416,10 +416,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="akumajou dracula - shikkokutaru zensoukyoku (japan).bin" size="262144" crc="4825b25f" sha1="baaa12be322adc005e51b43c73a352420d7cd034" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="akumajou dracula - shikkokutaru zensoukyoku (japan).bin" size="0x40000" crc="4825b25f" sha1="baaa12be322adc005e51b43c73a352420d7cd034" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -434,8 +434,8 @@ license:CC0
 		<info name="alt_title" value="悪魔城すぺしゃる ぼくドラキュラくん" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="akumajou special - boku dracula-kun (japan).bin" size="262144" crc="e8335398" sha1="f2f15da8ed94bc8652c23965428f6d767e506e38" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="akumajou special - boku dracula-kun (japan).bin" size="0x40000" crc="e8335398" sha1="f2f15da8ed94bc8652c23965428f6d767e506e38" />
 			</dataarea>
 		</part>
 	</software>
@@ -451,8 +451,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" /> <!-- Also found with [DMG MBC1-B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-alap-0.u1" size="262144" crc="283c58b7" sha1="a40694a808c5a0d3eeb386f81ad5b0c11163238f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-alap-0.u1" size="0x40000" crc="283c58b7" sha1="a40694a808c5a0d3eeb386f81ad5b0c11163238f" />
 			</dataarea>
 		</part>
 	</software>
@@ -464,8 +464,8 @@ license:CC0
 		<publisher>Virgin Interactive</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="aladdin sample (re135).bin" size="262144" crc="28827ea5" sha1="6d925762a46e1996cf3702dfb85be09f546b2137" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="aladdin sample (re135).bin" size="0x40000" crc="28827ea5" sha1="6d925762a46e1996cf3702dfb85be09f546b2137" />
 			</dataarea>
 		</part>
 	</software>
@@ -478,8 +478,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="aladdin (usa).bin" size="262144" crc="af6bdc50" sha1="81b4e56ae235fbb123d7ad4bd7c1d96c3b69eb72" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="aladdin (usa).bin" size="0x40000" crc="af6bdc50" sha1="81b4e56ae235fbb123d7ad4bd7c1d96c3b69eb72" />
 			</dataarea>
 		</part>
 	</software>
@@ -494,8 +494,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-c3x-0.u1" size="131072" crc="3cab28d9" sha1="bc7327008de518ddfad0ad5c69896921dc2378e0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-c3x-0.u1" size="0x20000" crc="3cab28d9" sha1="bc7327008de518ddfad0ad5c69896921dc2378e0" />
 			</dataarea>
 		</part>
 	</software>
@@ -510,8 +510,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="alfred chicken (japan).bin" size="262144" crc="1089098f" sha1="e04ddf4df8b5ef70d85e0523d277abfc68c61496" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="alfred chicken (japan).bin" size="0x40000" crc="1089098f" sha1="e04ddf4df8b5ef70d85e0523d277abfc68c61496" />
 			</dataarea>
 		</part>
 	</software>
@@ -522,8 +522,8 @@ license:CC0
 		<publisher>Mindscape</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="alfred chicken (prototype).bin" size="131072" crc="2e19f638" sha1="a9aa7cf61ffa42a4097f0c900ad4463d6fd89a19" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="alfred chicken (prototype).bin" size="0x20000" crc="2e19f638" sha1="a9aa7cf61ffa42a4097f0c900ad4463d6fd89a19" />
 			</dataarea>
 		</part>
 	</software>
@@ -535,8 +535,8 @@ license:CC0
 		<info name="serial" value="DMG-C3-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="alfred chicken (usa).bin" size="131072" crc="3b9c3bc6" sha1="80c39d93ca58d0d6144fe7f7bdd47c3a4fcf0438" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="alfred chicken (usa).bin" size="0x20000" crc="3b9c3bc6" sha1="80c39d93ca58d0d6144fe7f7bdd47c3a4fcf0438" />
 			</dataarea>
 		</part>
 	</software>
@@ -551,8 +551,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-l3e-0.u1" size="131072" crc="effb960b" sha1="ab4d11eee7faea42c637505469e0671c9d4a83f8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-l3e-0.u1" size="0x20000" crc="effb960b" sha1="ab4d11eee7faea42c637505469e0671c9d4a83f8" />
 			</dataarea>
 		</part>
 	</software>
@@ -566,8 +566,8 @@ license:CC0
 		<info name="alt_title" value="エイリアン3" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="alien 3 (japan).bin" size="131072" crc="e59049b2" sha1="4a3e7eb0edaefec096baa0019b3cba28b4796689" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="alien 3 (japan).bin" size="0x20000" crc="e59049b2" sha1="4a3e7eb0edaefec096baa0019b3cba28b4796689" />
 			</dataarea>
 		</part>
 	</software>
@@ -580,8 +580,8 @@ license:CC0
 		<info name="alt_title" value="Alien Olympics (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="alien olympics 2044 ad (europe).bin" size="131072" crc="583c0e4e" sha1="c6a69416d3f18071942d222d528b1c9d25f980b7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="alien olympics 2044 ad (europe).bin" size="0x20000" crc="583c0e4e" sha1="c6a69416d3f18071942d222d528b1c9d25f980b7" />
 			</dataarea>
 		</part>
 	</software>
@@ -593,8 +593,8 @@ license:CC0
 		<info name="serial" value="DMG-A9-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="alien vs predator - the last of his clan (usa).bin" size="131072" crc="4bbcf652" sha1="c0d39ee87b908cdbd68c59f73e5dc2a7a6ccbedc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="alien vs predator - the last of his clan (usa).bin" size="0x20000" crc="4bbcf652" sha1="c0d39ee87b908cdbd68c59f73e5dc2a7a6ccbedc" />
 			</dataarea>
 		</part>
 	</software>
@@ -608,8 +608,8 @@ license:CC0
 		<info name="alt_title" value="エイリアンVSプレデター ~ Alien vs Predator (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="alien vs predator - the last of his clan (japan).bin" size="131072" crc="e884682b" sha1="5b21dc4a7b48e75da725657d1ccde868759e5699" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="alien vs predator - the last of his clan (japan).bin" size="0x20000" crc="e884682b" sha1="5b21dc4a7b48e75da725657d1ccde868759e5699" />
 			</dataarea>
 		</part>
 	</software>
@@ -622,8 +622,8 @@ license:CC0
 		<info name="release" value="199805xx" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ab9e-0.u1" size="524288" crc="d51ee6d3" sha1="49d13eef514d26cee37b10ff602e21a92b87b69d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ab9e-0.u1" size="0x80000" crc="d51ee6d3" sha1="49d13eef514d26cee37b10ff602e21a92b87b69d" />
 			</dataarea>
 		</part>
 	</software>
@@ -639,8 +639,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-01" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-awa-0.u1" size="32768" crc="5cc01586" sha1="0cf2b8d0428f389f5361f67a0cd1ace05a1c75cc" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-awa-0.u1" size="0x8000" crc="5cc01586" sha1="0cf2b8d0428f389f5361f67a0cd1ace05a1c75cc" />
 			</dataarea>
 		</part>
 	</software>
@@ -651,8 +651,8 @@ license:CC0
 		<publisher>Hi Tech Expressions</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="altered space - a 3-d alien adventure (europe).bin" size="131072" crc="24d5f785" sha1="218da72e38a847bc5152a226c98e843b4941a8a6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="altered space - a 3-d alien adventure (europe).bin" size="0x20000" crc="24d5f785" sha1="218da72e38a847bc5152a226c98e843b4941a8a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -666,8 +666,8 @@ license:CC0
 		<info name="alt_title" value="アルタードスペース" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="altered space - a 3-d alien adventure (japan).bin" size="131072" crc="ce36e36e" sha1="6d19dfedf2c916f13a524acfd7c4e26de040e655" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="altered space - a 3-d alien adventure (japan).bin" size="0x20000" crc="ce36e36e" sha1="6d19dfedf2c916f13a524acfd7c4e26de040e655" />
 			</dataarea>
 		</part>
 	</software>
@@ -682,8 +682,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ale-0.u1" size="131072" crc="141675d3" sha1="ca586c59b2473a8bec2f0f37504cb74e3a1e4d11" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ale-0.u1" size="0x20000" crc="141675d3" sha1="ca586c59b2473a8bec2f0f37504cb74e3a1e4d11" />
 			</dataarea>
 		</part>
 	</software>
@@ -698,8 +698,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-pne-0.u1" size="65536" crc="3011d5ca" sha1="84cc6452823eb05ee38679aec86e3cc6e4a50e6f" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-pne-0.u1" size="0x10000" crc="3011d5ca" sha1="84cc6452823eb05ee38679aec86e3cc6e4a50e6f" />
 			</dataarea>
 		</part>
 	</software>
@@ -714,8 +714,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-sme-0.u1" size="65536" crc="2a4eafe4" sha1="0effb4580efeaa323174a960bfd521fa28a18959" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-sme-0.u1" size="0x10000" crc="2a4eafe4" sha1="0effb4580efeaa323174a960bfd521fa28a18959" />
 			</dataarea>
 		</part>
 	</software>
@@ -730,8 +730,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-zse-0.u1" size="131072" crc="13dd233f" sha1="9d85634232053a52b8d3bbca0f613337fcab32a8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-zse-0.u1" size="0x20000" crc="13dd233f" sha1="9d85634232053a52b8d3bbca0f613337fcab32a8" />
 			</dataarea>
 		</part>
 	</software>
@@ -746,8 +746,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-lqe-0.u1" size="131072" crc="cbb2f22c" sha1="d9687896481316d873046daca43cc0e259c32929" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-lqe-0.u1" size="0x20000" crc="cbb2f22c" sha1="d9687896481316d873046daca43cc0e259c32929" />
 			</dataarea>
 		</part>
 	</software>
@@ -758,8 +758,8 @@ license:CC0
 		<publisher>LJN</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="spider-man 3 - invasion of the spider-slayers (apr 11, 1993 prototype).bin" size="131072" crc="bf2d1f10" sha1="34740dc60663ef33c42573a26e7b207f2cfe4a16" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="spider-man 3 - invasion of the spider-slayers (apr 11, 1993 prototype).bin" size="0x20000" crc="bf2d1f10" sha1="34740dc60663ef33c42573a26e7b207f2cfe4a16" />
 			</dataarea>
 		</part>
 	</software>
@@ -774,8 +774,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-p3e-0.u1" size="65536" crc="d229ac62" sha1="1e475cbd5fb7099df91155a103698e4e66da7a86" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-p3e-0.u1" size="0x10000" crc="d229ac62" sha1="1e475cbd5fb7099df91155a103698e4e66da7a86" />
 			</dataarea>
 		</part>
 	</software>
@@ -789,8 +789,8 @@ license:CC0
 		<info name="alt_title" value="アメリカ横断ウルトラクイズ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="america oudan ultra quiz (japan).bin" size="262144" crc="3be275cd" sha1="9761f22250faf9c241fd7f9e2d00436f3fd454e7" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="america oudan ultra quiz (japan).bin" size="0x40000" crc="3be275cd" sha1="9761f22250faf9c241fd7f9e2d00436f3fd454e7" />
 			</dataarea>
 		</part>
 	</software>
@@ -803,8 +803,8 @@ license:CC0
 		<info name="alt_title" value="アメリカ横断ウルトラクイズ PART2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-auj-1.u1" size="262144" crc="739c26fc" sha1="cb3ed70f4d095405df2c322c528cab2a00d56557" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-auj-1.u1" size="0x40000" crc="739c26fc" sha1="cb3ed70f4d095405df2c322c528cab2a00d56557" />
 			</dataarea>
 		</part>
 	</software>
@@ -818,8 +818,8 @@ license:CC0
 		<info name="alt_title" value="アメリカ横断ウルトラクイズ PART2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="america oudan ultra quiz part 2 (japan).bin" size="262144" crc="1b3231c8" sha1="34c417f6f9db7e8021fb1af6c12f22c9b48bb723" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="america oudan ultra quiz part 2 (japan).bin" size="0x40000" crc="1b3231c8" sha1="34c417f6f9db7e8021fb1af6c12f22c9b48bb723" />
 			</dataarea>
 		</part>
 	</software>
@@ -833,8 +833,8 @@ license:CC0
 		<info name="alt_title" value="アメリカ横断ウルトラクイズ PART3 チャンピオン大会" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="america oudan ultra quiz part 3 - champion taikai (japan).bin" size="262144" crc="80cac37c" sha1="61acfb83a35b2d73fad607ddd7fc1ac49e41492e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="america oudan ultra quiz part 3 - champion taikai (japan).bin" size="0x40000" crc="80cac37c" sha1="61acfb83a35b2d73fad607ddd7fc1ac49e41492e" />
 			</dataarea>
 		</part>
 	</software>
@@ -851,8 +851,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-uaj-0.u1" size="262144" crc="a76043c8" sha1="30184de60214b8d16d044433cd92f0b2a975e9d6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-uaj-0.u1" size="0x40000" crc="a76043c8" sha1="30184de60214b8d16d044433cd92f0b2a975e9d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -873,10 +873,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ajaj-0.u1" size="524288" crc="c2eec22f" sha1="a34b7c4acc4454d96f93a7b04069adbcc3bc75a0" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ajaj-0.u1" size="0x80000" crc="c2eec22f" sha1="a34b7c4acc4454d96f93a7b04069adbcc3bc75a0" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -897,10 +897,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aajj-0.u1" size="524288" crc="8d573f37" sha1="214d75221dbfb1a562740aa53e0239a73bee9a2d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aajj-0.u1" size="0x80000" crc="8d573f37" sha1="214d75221dbfb1a562740aa53e0239a73bee9a2d" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -916,8 +916,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ancp-0.u1" size="262144" crc="7b23e05c" sha1="031421f49f98a15187012dc3f15960b260b9979f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ancp-0.u1" size="0x40000" crc="7b23e05c" sha1="031421f49f98a15187012dc3f15960b260b9979f" />
 			</dataarea>
 		</part>
 	</software>
@@ -930,8 +930,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="animaniacs (usa).bin" size="262144" crc="673c815d" sha1="a0732f81e0c4f1bba592563bdc0eaae9d759ef28" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="animaniacs (usa).bin" size="0x40000" crc="673c815d" sha1="a0732f81e0c4f1bba592563bdc0eaae9d759ef28" />
 			</dataarea>
 		</part>
 	</software>
@@ -946,10 +946,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="another bible (japan).bin" size="524288" crc="4a486435" sha1="6a5d0da889247169135665dc91f153305e1c71b6" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="another bible (japan).bin" size="0x80000" crc="4a486435" sha1="6a5d0da889247169135665dc91f153305e1c71b6" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -967,8 +967,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ashj-0.u1" size="262144" crc="08727760" sha1="95574e1eef5fbebde6f068091bc7298000ea2397" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ashj-0.u1" size="0x40000" crc="08727760" sha1="95574e1eef5fbebde6f068091bc7298000ea2397" />
 			</dataarea>
 		</part>
 	</software>
@@ -984,8 +984,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-amcp-0.u1" size="131072" crc="8259ac54" sha1="a4849175191c44d878aff9ef1a86c3fe5e22e266" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-amcp-0.u1" size="0x20000" crc="8259ac54" sha1="a4849175191c44d878aff9ef1a86c3fe5e22e266" />
 			</dataarea>
 		</part>
 	</software>
@@ -1001,8 +1001,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-acpp-0.u1" size="131072" crc="b14c3b31" sha1="405bc3736cfbea3f2259ad3e53a9d64c6523de4a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-acpp-0.u1" size="0x20000" crc="b14c3b31" sha1="405bc3736cfbea3f2259ad3e53a9d64c6523de4a" />
 			</dataarea>
 		</part>
 	</software>
@@ -1018,8 +1018,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-agcp-0.u1" size="131072" crc="d06b3f8a" sha1="59ea594af8520732f78c337f5c96a5ba2bddf1cb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-agcp-0.u1" size="0x20000" crc="d06b3f8a" sha1="59ea594af8520732f78c337f5c96a5ba2bddf1cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -1035,8 +1035,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-agce-0.u1" size="131072" crc="6a6ecfec" sha1="739671d6cf151fa5527d68f78345197d278cdf19" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-agce-0.u1" size="0x20000" crc="6a6ecfec" sha1="739671d6cf151fa5527d68f78345197d278cdf19" />
 			</dataarea>
 		</part>
 	</software>
@@ -1052,8 +1052,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-adjp-0.u1" size="131072" crc="1c829ce3" sha1="6b046ca1e15e6cecb29e086a5b23eb0019419936" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-adjp-0.u1" size="0x20000" crc="1c829ce3" sha1="6b046ca1e15e6cecb29e086a5b23eb0019419936" />
 			</dataarea>
 		</part>
 	</software>
@@ -1066,8 +1066,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="arcade classics - battlezone &amp; super breakout (usa, europe).bin" size="262144" crc="6c292739" sha1="7d78b06ad896fb949e28858d141f73a37c550fe2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="arcade classics - battlezone &amp; super breakout (usa, europe).bin" size="0x40000" crc="6c292739" sha1="7d78b06ad896fb949e28858d141f73a37c550fe2" />
 			</dataarea>
 		</part>
 	</software>
@@ -1082,10 +1082,10 @@ license:CC0
 		<info name="alt_title" value="アレサ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="aretha (japan).bin" size="131072" crc="1db65649" sha1="eab8f13d110634f4ee750ac93e4f25d91a85000f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="aretha (japan).bin" size="0x20000" crc="1db65649" sha1="eab8f13d110634f4ee750ac93e4f25d91a85000f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -1105,10 +1105,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-a4j-0.u1" size="262144" crc="086e4fc5" sha1="5634a05ea8e93af3dd0e41823576bf6295f8df1f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-a4j-0.u1" size="0x40000" crc="086e4fc5" sha1="5634a05ea8e93af3dd0e41823576bf6295f8df1f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -1129,10 +1129,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="aretha iii (japan).bin" size="262144" crc="430d3d6b" sha1="f57ff26d31283c88cc4c414b18ef6f182d07da9d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="aretha iii (japan).bin" size="0x40000" crc="430d3d6b" sha1="f57ff26d31283c88cc4c414b18ef6f182d07da9d" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -1149,8 +1149,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-atj-0.u1" size="131072" crc="caae6b11" sha1="4c738153a5c9f861117cc23cfedf2c37672e1097" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-atj-0.u1" size="0x20000" crc="caae6b11" sha1="4c738153a5c9f861117cc23cfedf2c37672e1097" />
 			</dataarea>
 		</part>
 	</software>
@@ -1167,8 +1167,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-axs-0.u1" size="262144" crc="b1fd41d0" sha1="b6cd446962357d0f560a5c9fae4c917e039fbb77" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-axs-0.u1" size="0x40000" crc="b1fd41d0" sha1="b6cd446962357d0f560a5c9fae4c917e039fbb77" />
 			</dataarea>
 		</part>
 	</software>
@@ -1185,8 +1185,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-axop-0.u1" size="262144" crc="5143e227" sha1="ebc68b180680c7037b151b9a1b511b681499ba30" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-axop-0.u1" size="0x40000" crc="5143e227" sha1="ebc68b180680c7037b151b9a1b511b681499ba30" />
 			</dataarea>
 		</part>
 	</software>
@@ -1198,8 +1198,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="obelix.bin" size="262144" crc="bfa1d7be" sha1="70472cbe59cfd426b0969150085cc97d31bd6470" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="obelix.bin" size="0x40000" crc="bfa1d7be" sha1="70472cbe59cfd426b0969150085cc97d31bd6470" />
 			</dataarea>
 		</part>
 	</software>
@@ -1214,8 +1214,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" /> <!-- Also with [DMG MBC1B] and [DMG MBC1-B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-xax-0.u1" size="131072" crc="097ffe2c" sha1="7d4ca6925826c0ffca3e3004479b5e9a5b6b311b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-xax-0.u1" size="0x20000" crc="097ffe2c" sha1="7d4ca6925826c0ffca3e3004479b5e9a5b6b311b" />
 			</dataarea>
 		</part>
 	</software>
@@ -1225,8 +1225,8 @@ license:CC0
 		<year>1992</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="asterix (prototype b).bin" size="32768" crc="0050b16f" sha1="5e2423d1d4a1239af2ccafdd6c0a3f2316ae6b51" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="asterix (prototype b).bin" size="0x8000" crc="0050b16f" sha1="5e2423d1d4a1239af2ccafdd6c0a3f2316ae6b51" />
 			</dataarea>
 		</part>
 	</software>
@@ -1236,8 +1236,8 @@ license:CC0
 		<year>1992?</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="asterix (prototype a).bin" size="32768" crc="6ccfee1f" sha1="5077f422e513877e9c4e3497111f853376748826" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="asterix (prototype a).bin" size="0x8000" crc="6ccfee1f" sha1="5077f422e513877e9c4e3497111f853376748826" />
 			</dataarea>
 		</part>
 	</software>
@@ -1250,8 +1250,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-ane-0.u1" size="32768" crc="c1f88833" sha1="435dbdaa9b9d2e0d0bc7c1c010cdc5ec9bd9f359" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-ane-0.u1" size="0x8000" crc="c1f88833" sha1="435dbdaa9b9d2e0d0bc7c1c010cdc5ec9bd9f359" />
 			</dataarea>
 		</part>
 	</software>
@@ -1261,8 +1261,8 @@ license:CC0
 		<year>1991</year>
 		<publisher>Accolade</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="asteroids (prototype).bin" size="32768" crc="eb31e472" sha1="28f4e2a076bfe5f7a77f695332705ea0085fccfb" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="asteroids (prototype).bin" size="0x8000" crc="eb31e472" sha1="28f4e2a076bfe5f7a77f695332705ea0085fccfb" />
 			</dataarea>
 		</part>
 	</software>
@@ -1279,8 +1279,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-ara-0.u1" size="65536" crc="61e48eef" sha1="3e53fd25f350c78a29e0642ee6de80208930d469" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-ara-0.u1" size="0x10000" crc="61e48eef" sha1="3e53fd25f350c78a29e0642ee6de80208930d469" />
 			</dataarea>
 		</part>
 	</software>
@@ -1292,8 +1292,8 @@ license:CC0
 		<info name="serial" value="DMG-HB-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="atomic punk (usa).bin" size="131072" crc="c4720897" sha1="4b364b4c12b83ab7adbec074fac951e2eb63dea8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="atomic punk (usa).bin" size="0x20000" crc="c4720897" sha1="4b364b4c12b83ab7adbec074fac951e2eb63dea8" />
 			</dataarea>
 		</part>
 	</software>
@@ -1307,8 +1307,8 @@ license:CC0
 		<info name="alt_title" value="キラートマト" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="attack of the killer tomatoes (japan).bin" size="131072" crc="23068679" sha1="96cd454513dfb363cda20bf0e72c6d74132a9487" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="attack of the killer tomatoes (japan).bin" size="0x20000" crc="23068679" sha1="96cd454513dfb363cda20bf0e72c6d74132a9487" />
 			</dataarea>
 		</part>
 	</software>
@@ -1323,8 +1323,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ake-0.u1" size="131072" crc="b5b38860" sha1="cbbba5d4f80f2b4ab3e882ceb4f79c293a17904f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ake-0.u1" size="0x20000" crc="b5b38860" sha1="cbbba5d4f80f2b4ab3e882ceb4f79c293a17904f" />
 			</dataarea>
 		</part>
 	</software>
@@ -1339,8 +1339,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-p8x-0.u1" size="262144" crc="cf2ba5f7" sha1="d22cca80a0855d7724539ef71f38e3f8f9656d6b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-p8x-0.u1" size="0x40000" crc="cf2ba5f7" sha1="d22cca80a0855d7724539ef71f38e3f8f9656d6b" />
 			</dataarea>
 		</part>
 	</software>
@@ -1359,10 +1359,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-ayj-0.u1" size="65536" crc="da90f5fc" sha1="dad3ec1a054cbd092eedfdb1d742b811c105181a" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-ayj-0.u1" size="0x10000" crc="da90f5fc" sha1="dad3ec1a054cbd092eedfdb1d742b811c105181a" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -1377,8 +1377,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-gkx-0.u1" size="262144" crc="373343e6" sha1="b91f99408e4a6b69d505f304c176434321f837e7" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-gkx-0.u1" size="0x40000" crc="373343e6" sha1="b91f99408e4a6b69d505f304c176434321f837e7" />
 			</dataarea>
 		</part>
 	</software>
@@ -1394,8 +1394,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-rjx-0.u1" size="262144" crc="c28ef062" sha1="952a14298dcde28975f2cdd61f781000afb53125" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-rjx-0.u1" size="0x40000" crc="c28ef062" sha1="952a14298dcde28975f2cdd61f781000afb53125" />
 			</dataarea>
 		</part>
 	</software>
@@ -1407,8 +1407,8 @@ license:CC0
 		<info name="serial" value="DMG-A6-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="baby t-rex (europe).bin" size="131072" crc="3f73fe7a" sha1="30042c3fc60df0da25fa3db3955a2e4657c1cccf" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="baby t-rex (europe).bin" size="0x20000" crc="3f73fe7a" sha1="30042c3fc60df0da25fa3db3955a2e4657c1cccf" />
 			</dataarea>
 		</part>
 	</software>
@@ -1423,10 +1423,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="bakenou tv '94 (japan).bin" size="131072" crc="d1c3f371" sha1="c567bdd1ca17750c853019f244e208fe812772fd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bakenou tv '94 (japan).bin" size="0x20000" crc="d1c3f371" sha1="c567bdd1ca17750c853019f244e208fe812772fd" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -1446,10 +1446,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-vvj-0.u1" size="131072" crc="4e2fffe5" sha1="b1bf86f4ffb9af9c5f1c592f0cabedb95b405437" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-vvj-0.u1" size="0x20000" crc="4e2fffe5" sha1="b1bf86f4ffb9af9c5f1c592f0cabedb95b405437" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -1465,10 +1465,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="bakuchou retrieve master (japan).bin" size="524288" crc="8a546dec" sha1="bfea17b22b3ac91366156d8db1a7dc619c7b5a28" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="bakuchou retrieve master (japan).bin" size="0x80000" crc="8a546dec" sha1="bfea17b22b3ac91366156d8db1a7dc619c7b5a28" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -1489,10 +1489,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-asyj-0.u1" size="524288" crc="ab3477c4" sha1="53808f56fa68ad8094d0e4ff62e06887b439be9a" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-asyj-0.u1" size="0x80000" crc="ab3477c4" sha1="53808f56fa68ad8094d0e4ff62e06887b439be9a" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -1506,8 +1506,8 @@ license:CC0
 		<info name="alt_title" value="爆裂戦士 ウォーリア" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="bakuretsu senshi warrior (japan).bin" size="65536" crc="ecf1b801" sha1="5f4e63796611a1ed72acd2a5bfe2e2ea3ba5b211" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="bakuretsu senshi warrior (japan).bin" size="0x10000" crc="ecf1b801" sha1="5f4e63796611a1ed72acd2a5bfe2e2ea3ba5b211" />
 			</dataarea>
 		</part>
 	</software>
@@ -1522,8 +1522,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-bte-0.u1" size="131072" crc="d4b655ec" sha1="0cb5adc9bdef5320f3f156efed0d47a618e2299f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-bte-0.u1" size="0x20000" crc="d4b655ec" sha1="0cb5adc9bdef5320f3f156efed0d47a618e2299f" />
 			</dataarea>
 		</part>
 	</software>
@@ -1538,8 +1538,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-a6w-0.u1" size="131072" crc="1b713de0" sha1="92c042a1b3b9704736b6d8b19259efc5110c267d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-a6w-0.u1" size="0x20000" crc="1b713de0" sha1="92c042a1b3b9704736b6d8b19259efc5110c267d" />
 			</dataarea>
 		</part>
 	</software>
@@ -1553,8 +1553,8 @@ license:CC0
 		<info name="alt_title" value="バニシングレーサー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="banishing racer (japan).bin" size="131072" crc="3d13ec6a" sha1="df121645c367d5809ed77bfe48aa537f0d61d276" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="banishing racer (japan).bin" size="0x20000" crc="3d13ec6a" sha1="df121645c367d5809ed77bfe48aa537f0d61d276" />
 			</dataarea>
 		</part>
 	</software>
@@ -1569,8 +1569,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-gue-0.u1" size="131072" crc="94c26cdf" sha1="6660e4457a1de3de1947a90c5ea9ff012d50336e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-gue-0.u1" size="0x20000" crc="94c26cdf" sha1="6660e4457a1de3de1947a90c5ea9ff012d50336e" />
 			</dataarea>
 		</part>
 	</software>
@@ -1581,8 +1581,8 @@ license:CC0
 		<publisher>Hi Tech Expressions</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="barbie - game girl (prototype).bin" size="131072" crc="4660e0ab" sha1="24886a5f26f1969e595f420bf963439ba6a693bd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="barbie - game girl (prototype).bin" size="0x20000" crc="4660e0ab" sha1="24886a5f26f1969e595f420bf963439ba6a693bd" />
 			</dataarea>
 		</part>
 	</software>
@@ -1595,8 +1595,8 @@ license:CC0
 		<info name="release" value="19930226" />
 		<info name="alt_title" value="バートのサバイバルキャンプ ~ Bart no Survival Camp (Box)" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="131072">
-				<rom name="bart no survival camp (japan).bin" size="131072" crc="0fd66b1a" sha1="f0d855bba656b628c7dd9ed9e586853be75b790f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bart no survival camp (japan).bin" size="0x20000" crc="0fd66b1a" sha1="f0d855bba656b628c7dd9ed9e586853be75b790f" />
 			</dataarea>
 		</part>
 	</software>
@@ -1611,8 +1611,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-tse-0.u1" size="131072" crc="5546a382" sha1="89b7b2d4684d703ea5d323e3aaf4910dcdbc47d3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-tse-0.u1" size="0x20000" crc="5546a382" sha1="89b7b2d4684d703ea5d323e3aaf4910dcdbc47d3" />
 			</dataarea>
 		</part>
 	</software>
@@ -1629,8 +1629,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-bsa-0.u1" size="65536" crc="6eea2526" sha1="bb613ed8d492d49db35370bec38d9f2515dc24c9" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-bsa-0.u1" size="0x10000" crc="6eea2526" sha1="bb613ed8d492d49db35370bec38d9f2515dc24c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -1647,8 +1647,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-bkj-0.u1" size="131072" crc="a503cb07" sha1="e4a49a9ecd7a9ce8bb552981e90903f21c741428" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-bkj-0.u1" size="0x20000" crc="a503cb07" sha1="e4a49a9ecd7a9ce8bb552981e90903f21c741428" />
 			</dataarea>
 		</part>
 	</software>
@@ -1661,8 +1661,8 @@ license:CC0
 		<info name="alt_title" value="Bases Loaded for Game Boy (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="bases loaded gb (usa).bin" size="131072" crc="d37a2fdf" sha1="5220db2e87622648caeacdfb8d4f564c9bf479fc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bases loaded gb (usa).bin" size="0x20000" crc="d37a2fdf" sha1="5220db2e87622648caeacdfb8d4f564c9bf479fc" />
 			</dataarea>
 		</part>
 	</software>
@@ -1676,8 +1676,8 @@ license:CC0
 		<info name="alt_title" value="バスフィッシング達人手帳" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="bass fishing tatsujin techou (japan).bin" size="524288" crc="7625e5a5" sha1="503a4cdd6d80ce779ba293022b21f98881af2ab6" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="bass fishing tatsujin techou (japan).bin" size="0x80000" crc="7625e5a5" sha1="503a4cdd6d80ce779ba293022b21f98881af2ab6" />
 			</dataarea>
 		</part>
 	</software>
@@ -1692,8 +1692,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ab8f-0.u1" size="131072" crc="bab8b727" sha1="5c5162743546b258cc9c6316f1437137721f5e99" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ab8f-0.u1" size="0x20000" crc="bab8b727" sha1="5c5162743546b258cc9c6316f1437137721f5e99" />
 			</dataarea>
 		</part>
 	</software>
@@ -1710,8 +1710,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-baa-0.u1" size="131072" crc="6c41d3cd" sha1="ef7d6684a0f737c01a1f2cc2c6609e0f3ac1310e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-baa-0.u1" size="0x20000" crc="6c41d3cd" sha1="ef7d6684a0f737c01a1f2cc2c6609e0f3ac1310e" />
 			</dataarea>
 		</part>
 	</software>
@@ -1723,8 +1723,8 @@ license:CC0
 		<info name="serial" value="DMG-B5-ESP, DMG-B5-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="batman - return of the joker (usa, europe).bin" size="131072" crc="5124bbec" sha1="345a332175f58304f91111a13b770662e5ea92c3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="batman - return of the joker (usa, europe).bin" size="0x20000" crc="5124bbec" sha1="345a332175f58304f91111a13b770662e5ea92c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -1738,8 +1738,8 @@ license:CC0
 		<info name="alt_title" value="バットマン リターン オブ ザ ジョーカー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="batman - return of the joker (japan).bin" size="131072" crc="de459a47" sha1="149586120c3ae9c9614fa6e6a5e298cceae16c4d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="batman - return of the joker (japan).bin" size="0x20000" crc="de459a47" sha1="149586120c3ae9c9614fa6e6a5e298cceae16c4d" />
 			</dataarea>
 		</part>
 	</software>
@@ -1751,8 +1751,8 @@ license:CC0
 		<info name="serial" value="DMG-XM-NOE, DMG-XM-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="batman - the animated series (usa, europe).bin" size="131072" crc="c8e578bf" sha1="4a8c1dd74b1279c0dc85ac2bebb5db2795cb67b0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="batman - the animated series (usa, europe).bin" size="0x20000" crc="c8e578bf" sha1="4a8c1dd74b1279c0dc85ac2bebb5db2795cb67b0" />
 			</dataarea>
 		</part>
 	</software>
@@ -1767,8 +1767,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-a3bp-0.u1" size="262144" crc="ef3592cc" sha1="cb76b6d3ec9903a734f70ff11195f40f13f4d83f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-a3bp-0.u1" size="0x40000" crc="ef3592cc" sha1="cb76b6d3ec9903a734f70ff11195f40f13f4d83f" />
 			</dataarea>
 		</part>
 	</software>
@@ -1782,8 +1782,8 @@ license:CC0
 		<info name="alt_title" value="バットマン フォーエヴァー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="batman forever (japan).bin" size="262144" crc="c2fd6244" sha1="4fab046d18addafbc625fe4cefec37098747d716" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="batman forever (japan).bin" size="0x40000" crc="c2fd6244" sha1="4fab046d18addafbc625fe4cefec37098747d716" />
 			</dataarea>
 		</part>
 	</software>
@@ -1799,8 +1799,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-atdp-0.u1" size="524288" crc="ce34cca4" sha1="f4cc9193ca0b98c69c966cc32e37eae444a8d53b" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-atdp-0.u1" size="0x80000" crc="ce34cca4" sha1="f4cc9193ca0b98c69c966cc32e37eae444a8d53b" />
 			</dataarea>
 		</part>
 	</software>
@@ -1813,8 +1813,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="battle arena toshinden (usa).bin" size="524288" crc="2d0c1073" sha1="9c337d3f56938aa46cfc8b85c0db4631bcbe217c" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="battle arena toshinden (usa).bin" size="0x80000" crc="2d0c1073" sha1="9c337d3f56938aa46cfc8b85c0db4631bcbe217c" />
 			</dataarea>
 		</part>
 	</software>
@@ -1828,8 +1828,8 @@ license:CC0
 		<info name="alt_title" value="バトル・ブル" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="battle bull (japan).bin" size="131072" crc="5c69e449" sha1="74ed574d2179bdf34a6e618a86be9b3e70155370" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="battle bull (japan).bin" size="0x20000" crc="5c69e449" sha1="74ed574d2179bdf34a6e618a86be9b3e70155370" />
 			</dataarea>
 		</part>
 	</software>
@@ -1844,8 +1844,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-bre-0.u1" size="131072" crc="d4d1aea2" sha1="a553b2cf2a5d223b6ac8aca4e9fd65b65087a1f4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-bre-0.u1" size="0x20000" crc="d4d1aea2" sha1="a553b2cf2a5d223b6ac8aca4e9fd65b65087a1f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -1860,8 +1860,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="battle crusher (japan).bin" size="262144" crc="ea4eb1a1" sha1="ae07172c69a7bdece4392016c6a6dd253623f5f8" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="battle crusher (japan).bin" size="0x40000" crc="ea4eb1a1" sha1="ae07172c69a7bdece4392016c6a6dd253623f5f8" />
 			</dataarea>
 		</part>
 	</software>
@@ -1881,10 +1881,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-d6j-0.u1" size="131072" crc="a99242c0" sha1="ed63709af2dd22d2abaa7e99b9dd5373b6cc91c4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-d6j-0.u1" size="0x20000" crc="a99242c0" sha1="ed63709af2dd22d2abaa7e99b9dd5373b6cc91c4" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -1898,8 +1898,8 @@ license:CC0
 		<info name="alt_title" value="バトル オブ キングダム" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="battle of kingdom (japan).bin" size="131072" crc="35914deb" sha1="5761f47a09f91a373bda96840fe2560bff1ffc97" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="battle of kingdom (japan).bin" size="0x20000" crc="35914deb" sha1="5761f47a09f91a373bda96840fe2560bff1ffc97" />
 			</dataarea>
 		</part>
 	</software>
@@ -1911,8 +1911,8 @@ license:CC0
 		<info name="serial" value="DMG-OL-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="battle of olympus, the (europe) (en,fr,de,es,it).bin" size="262144" crc="ca450e93" sha1="c0ca1948c4bfca795a29ce82aa5ab9215b9ed601" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="battle of olympus, the (europe) (en,fr,de,es,it).bin" size="0x40000" crc="ca450e93" sha1="c0ca1948c4bfca795a29ce82aa5ab9215b9ed601" />
 			</dataarea>
 		</part>
 	</software>
@@ -1926,8 +1926,8 @@ license:CC0
 		<info name="alt_title" value="バトルピンポン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="battle pingpong (japan).bin" size="65536" crc="7c787bc4" sha1="5008699f7a31a1a0722114f83e94591e99b22cc0" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="battle pingpong (japan).bin" size="0x10000" crc="7c787bc4" sha1="5008699f7a31a1a0722114f83e94591e99b22cc0" />
 			</dataarea>
 		</part>
 	</software>
@@ -1938,8 +1938,8 @@ license:CC0
 		<publisher>Laguna</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="battle ships (prototype).bin" size="131072" crc="1f8ccb71" sha1="4c04f79c670661fa46b17f7f980e6e7e88e886e7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="battle ships (prototype).bin" size="0x20000" crc="1f8ccb71" sha1="4c04f79c670661fa46b17f7f980e6e7e88e886e7" />
 			</dataarea>
 		</part>
 	</software>
@@ -1982,8 +1982,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-nxj-0.u1" size="65536" crc="a828fd4f" sha1="76e47ad844abdde9eff09ea29a014f9a1eae5093" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-nxj-0.u1" size="0x10000" crc="a828fd4f" sha1="76e47ad844abdde9eff09ea29a014f9a1eae5093" />
 			</dataarea>
 		</part>
 	</software>
@@ -1998,8 +1998,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-bze-0.u1" size="131072" crc="e67a92b3" sha1="eba09c60cd60feba0a7a9e82597dad080ce78d22" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-bze-0.u1" size="0x20000" crc="e67a92b3" sha1="eba09c60cd60feba0a7a9e82597dad080ce78d22" />
 			</dataarea>
 		</part>
 	</software>
@@ -2010,8 +2010,8 @@ license:CC0
 		<publisher>Jaleco</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="jetpack.bin" size="131072" crc="1c223204" sha1="df7abbcaaccd5cff4c55bb331fa5d3049fb92896" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="jetpack.bin" size="0x20000" crc="1c223204" sha1="df7abbcaaccd5cff4c55bb331fa5d3049fb92896" />
 			</dataarea>
 		</part>
 	</software>
@@ -2025,8 +2025,8 @@ license:CC0
 		<info name="alt_title" value="バトルユニットゼオス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="battle unit zeoth (japan).bin" size="131072" crc="a1a1fe77" sha1="35413f3d4b4e68f521a90c3a48d4bd2b5bf90e09" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="battle unit zeoth (japan).bin" size="0x20000" crc="a1a1fe77" sha1="35413f3d4b4e68f521a90c3a48d4bd2b5bf90e09" />
 			</dataarea>
 		</part>
 	</software>
@@ -2039,8 +2039,8 @@ license:CC0
 		<info name="release" value="19910809" />
 		<info name="alt_title" value="バトルシティー" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="battlecity (japan).bin" size="32768" crc="a37a814a" sha1="5c9a6077913b344c8889241ec5f9fdaac7f24c8b" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="battlecity (japan).bin" size="0x8000" crc="a37a814a" sha1="5c9a6077913b344c8889241ec5f9fdaac7f24c8b" />
 			</dataarea>
 		</part>
 	</software>
@@ -2052,8 +2052,8 @@ license:CC0
 		<info name="serial" value="DMG-NB-USA, DMG-NB-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="battleship (usa, europe).bin" size="65536" crc="fef62da5" sha1="d3efb4afebcf94b191a66797a6bae2c90ba92c6a" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="battleship (usa, europe).bin" size="0x10000" crc="fef62da5" sha1="d3efb4afebcf94b191a66797a6bae2c90ba92c6a" />
 			</dataarea>
 		</part>
 	</software>
@@ -2068,8 +2068,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-bve-0.u1" size="131072" crc="b0c3361b" sha1="ba839bea8f76bf955e3edf7083d2cbe780244add" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-bve-0.u1" size="0x20000" crc="b0c3361b" sha1="ba839bea8f76bf955e3edf7083d2cbe780244add" />
 			</dataarea>
 		</part>
 	</software>
@@ -2083,8 +2083,8 @@ license:CC0
 		<info name="alt_title" value="バトルトード" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="battletoads (japan).bin" size="131072" crc="331cf7de" sha1="666ed5d34f508c8805a67f4400fc01a1f2817e03" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="battletoads (japan).bin" size="0x20000" crc="331cf7de" sha1="666ed5d34f508c8805a67f4400fc01a1f2817e03" />
 			</dataarea>
 		</part>
 	</software>
@@ -2095,8 +2095,8 @@ license:CC0
 		<publisher>Sony Imagesoft</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="battletoads double dragon - the ultimate team (europe).bin" size="262144" crc="7b217082" sha1="5a834e0dc81703906eb441555e1aa31de22d39d6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="battletoads double dragon - the ultimate team (europe).bin" size="0x40000" crc="7b217082" sha1="5a834e0dc81703906eb441555e1aa31de22d39d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -2108,8 +2108,8 @@ license:CC0
 		<info name="serial" value="DMG-VN-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="battletoads double dragon - the ultimate team (usa).bin" size="262144" crc="a727f9cd" sha1="ce68df4dc2d604625164430266017b237b72303d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="battletoads double dragon - the ultimate team (usa).bin" size="0x40000" crc="a727f9cd" sha1="ce68df4dc2d604625164430266017b237b72303d" />
 			</dataarea>
 		</part>
 	</software>
@@ -2124,8 +2124,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-r7x-0.u1" size="131072" crc="7ffc34ea" sha1="1852bd23644e28109b66fa937053c689a63f7729" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-r7x-0.u1" size="0x20000" crc="7ffc34ea" sha1="1852bd23644e28109b66fa937053c689a63f7729" />
 			</dataarea>
 		</part>
 	</software>
@@ -2137,8 +2137,8 @@ license:CC0
 		<info name="serial" value="DMG-R7-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="battletoads in ragnarok's world (usa).bin" size="131072" crc="ce316c68" sha1="3df1384e699b91689f015d7aba65ab42410e24f5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="battletoads in ragnarok's world (usa).bin" size="0x20000" crc="ce316c68" sha1="3df1384e699b91689f015d7aba65ab42410e24f5" />
 			</dataarea>
 		</part>
 	</software>
@@ -2153,8 +2153,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-avip-0.u1" size="524288" crc="af1ae123" sha1="918e9cc878a61d8174918c897182604f0c27b1d9" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-avip-0.u1" size="0x80000" crc="af1ae123" sha1="918e9cc878a61d8174918c897182604f0c27b1d9" />
 			</dataarea>
 		</part>
 	</software>
@@ -2166,8 +2166,8 @@ license:CC0
 		<info name="alt_title" value="Beethoven - The Ultimate Canine Caper (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
-			<dataarea name="rom" size="131072">
-				<rom name="beethoven's 2nd (europe).bin" size="131072" crc="637e54e3" sha1="a175778faca00f096f0bfdbaa844a38816bbeb0f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="beethoven's 2nd (europe).bin" size="0x20000" crc="637e54e3" sha1="a175778faca00f096f0bfdbaa844a38816bbeb0f" />
 			</dataarea>
 		</part>
 	</software>
@@ -2179,8 +2179,8 @@ license:CC0
 		<info name="serial" value="DMG-B4-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="beetlejuice (usa).bin" size="131072" crc="33574ecb" sha1="a8bb9681dbf0700d64a88c7d9ad0093f08087046" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="beetlejuice (usa).bin" size="0x20000" crc="33574ecb" sha1="a8bb9681dbf0700d64a88c7d9ad0093f08087046" />
 			</dataarea>
 		</part>
 	</software>
@@ -2195,8 +2195,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-lex-0.u1" size="262144" crc="d5c3da1d" sha1="351446b94176360c0d9ad3cee43166ffbd9a51fa" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-lex-0.u1" size="0x40000" crc="d5c3da1d" sha1="351446b94176360c0d9ad3cee43166ffbd9a51fa" />
 			</dataarea>
 		</part>
 	</software>
@@ -2208,8 +2208,8 @@ license:CC0
 		<info name="serial" value="DMG-LE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="best of the best - championship karate (usa).bin" size="262144" crc="b20280e6" sha1="ba7d64c606cc0f654217e54a0bd5b8dda455a060" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="best of the best - championship karate (usa).bin" size="0x40000" crc="b20280e6" sha1="ba7d64c606cc0f654217e54a0bd5b8dda455a060" />
 			</dataarea>
 		</part>
 	</software>
@@ -2223,8 +2223,8 @@ license:CC0
 		<info name="alt_title" value="びっくり熱血新記録! どこでも金メダル" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="bikkuri nekketsu shinkiroku - dokodemo kin medal (japan).bin" size="262144" crc="86d11d10" sha1="baecee2dfd915a41363fef736f81853822d5dfcd" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="bikkuri nekketsu shinkiroku - dokodemo kin medal (japan).bin" size="0x40000" crc="86d11d10" sha1="baecee2dfd915a41363fef736f81853822d5dfcd" />
 			</dataarea>
 		</part>
 	</software>
@@ -2239,8 +2239,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-lbe-0.u1" size="131072" crc="5e8f656a" sha1="e19a7e5a5bd8fde0f31773c22dbebc9b4cf3824e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-lbe-0.u1" size="0x20000" crc="5e8f656a" sha1="e19a7e5a5bd8fde0f31773c22dbebc9b4cf3824e" />
 			</dataarea>
 		</part>
 	</software>
@@ -2252,8 +2252,8 @@ license:CC0
 		<info name="serial" value="DMG-EL-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="bill elliott's nascar fast tracks (usa).bin" size="131072" crc="71cf43ce" sha1="ebc2ca8b4503f0b05e00749d693462a54f2f95eb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bill elliott's nascar fast tracks (usa).bin" size="0x20000" crc="71cf43ce" sha1="ebc2ca8b4503f0b05e00749d693462a54f2f95eb" />
 			</dataarea>
 		</part>
 	</software>
@@ -2268,8 +2268,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-vse-0.u1" size="65536" crc="a1e55dc2" sha1="9eca6a5fd1e537085598e8b2903ad75fe9c0b785" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-vse-0.u1" size="0x10000" crc="a1e55dc2" sha1="9eca6a5fd1e537085598e8b2903ad75fe9c0b785" />
 			</dataarea>
 		</part>
 	</software>
@@ -2290,8 +2290,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-box-0.u1" size="262144" crc="4c5b4547" sha1="a8ab419b049aef5a04800efd6df58e4b3c3abbe3" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-box-0.u1" size="0x40000" crc="4c5b4547" sha1="a8ab419b049aef5a04800efd6df58e4b3c3abbe3" />
 			</dataarea>
 		</part>
 	</software>
@@ -2306,8 +2306,8 @@ license:CC0
 		<info name="alt_title" value="バイオニックコマンドー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="bionic commando (japan).bin" size="262144" crc="3f4d5c84" sha1="12dc5b05751214be3ce55da0fecaf23a41eb1881" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="bionic commando (japan).bin" size="0x40000" crc="3f4d5c84" sha1="12dc5b05751214be3ce55da0fecaf23a41eb1881" />
 			</dataarea>
 		</part>
 	</software>
@@ -2319,8 +2319,8 @@ license:CC0
 		<info name="serial" value="DMG-BO-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="bionic commando (usa).bin" size="262144" crc="41dbb5fb" sha1="e0ef47568a017ccdd3dbe0db5d7654822b4e5ce1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="bionic commando (usa).bin" size="0x40000" crc="41dbb5fb" sha1="e0ef47568a017ccdd3dbe0db5d7654822b4e5ce1" />
 			</dataarea>
 		</part>
 	</software>
@@ -2334,8 +2334,8 @@ license:CC0
 		<info name="alt_title" value="美少女戦士セーラームーン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="bishoujo senshi sailormoon (japan).bin" size="131072" crc="c2763e73" sha1="c008913a9fbb395a7a504fe65d1d29c530755cb3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bishoujo senshi sailormoon (japan).bin" size="0x20000" crc="c2763e73" sha1="c008913a9fbb395a7a504fe65d1d29c530755cb3" />
 			</dataarea>
 		</part>
 	</software>
@@ -2349,8 +2349,8 @@ license:CC0
 		<info name="alt_title" value="美少女戦士セーラームーンR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="bishoujo senshi sailormoon r (japan).bin" size="262144" crc="ea759875" sha1="959f384998c43072ca154e531917e9aaa80a694d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="bishoujo senshi sailormoon r (japan).bin" size="0x40000" crc="ea759875" sha1="959f384998c43072ca154e531917e9aaa80a694d" />
 			</dataarea>
 		</part>
 	</software>
@@ -2366,8 +2366,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-hpe-0.u1" size="262144" crc="2db3dace" sha1="d9524ac9f7788172a55cc8ceb6e199f8a12e033d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-hpe-0.u1" size="0x40000" crc="2db3dace" sha1="d9524ac9f7788172a55cc8ceb6e199f8a12e033d" />
 			</dataarea>
 		</part>
 	</software>
@@ -2378,8 +2378,8 @@ license:CC0
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="32768">
-				<rom name="blade warrior (prototype).bin" size="32768" crc="cfd54dbc" sha1="53c1e67430f923f74a611e675ca0cad8d0b13d76" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="blade warrior (prototype).bin" size="0x8000" crc="cfd54dbc" sha1="53c1e67430f923f74a611e675ca0cad8d0b13d76" />
 			</dataarea>
 		</part>
 	</software>
@@ -2391,8 +2391,8 @@ license:CC0
 		<info name="serial" value="DMG-UB-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="blades of steel (europe).bin" size="131072" crc="f7be0002" sha1="d030c46bc225fc92aa431276d9ae5812a30d6007" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="blades of steel (europe).bin" size="0x20000" crc="f7be0002" sha1="d030c46bc225fc92aa431276d9ae5812a30d6007" />
 			</dataarea>
 		</part>
 	</software>
@@ -2404,8 +2404,8 @@ license:CC0
 		<info name="serial" value="DMG-UB-USA, DMG-UB-USA-1" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="blades of steel (usa).bin" size="131072" crc="e81c9fb9" sha1="82761dbf5abe276f8e0c82f575356aed87155141" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="blades of steel (usa).bin" size="0x20000" crc="e81c9fb9" sha1="82761dbf5abe276f8e0c82f575356aed87155141" />
 			</dataarea>
 		</part>
 	</software>
@@ -2417,8 +2417,8 @@ license:CC0
 		<info name="serial" value="DMG-BI-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="blaster master boy (usa).bin" size="131072" crc="3b2c7118" sha1="21b1e574a6f4543651e96de65994e7b0b7a6a0f6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="blaster master boy (usa).bin" size="0x20000" crc="3b2c7118" sha1="21b1e574a6f4543651e96de65994e7b0b7a6a0f6" />
 			</dataarea>
 		</part>
 	</software>
@@ -2429,8 +2429,8 @@ license:CC0
 		<publisher>Sunsoft</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="blaster master boy (prototype).bin" size="131072" crc="4ea70173" sha1="f568f9c7fe9ef9726d602727beca13d6978cd770" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="blaster master boy (prototype).bin" size="0x20000" crc="4ea70173" sha1="f568f9c7fe9ef9726d602727beca13d6978cd770" />
 			</dataarea>
 		</part>
 	</software>
@@ -2446,8 +2446,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1 [DMG MBC1B]" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="u2" size="131072" crc="e9f9016f" sha1="6a6deae1942e7cf048ce35d18e9540363c226727" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="u2" size="0x20000" crc="e9f9016f" sha1="6a6deae1942e7cf048ce35d18e9540363c226727" />
 			</dataarea>
 		</part>
 	</software>
@@ -2462,8 +2462,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="block kuzushi gb (japan).bin" size="131072" crc="54b67501" sha1="7540fe9af69d8c7d48f50c2d5fe6d3ce07421f74" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="block kuzushi gb (japan).bin" size="0x20000" crc="54b67501" sha1="7540fe9af69d8c7d48f50c2d5fe6d3ce07421f74" />
 			</dataarea>
 		</part>
 	</software>
@@ -2480,8 +2480,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-bla-0.u1" size="65536" crc="51ff6e53" sha1="a3927543ca471f479ba7aae7295788434672464e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-bla-0.u1" size="0x10000" crc="51ff6e53" sha1="a3927543ca471f479ba7aae7295788434672464e" />
 			</dataarea>
 		</part>
 	</software>
@@ -2493,8 +2493,8 @@ license:CC0
 		<info name="serial" value="DMG-BQ-USA, DMG-BQ-ESP, DMG-BQ-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="blues brothers, the (usa, europe).bin" size="131072" crc="adb66eff" sha1="9dca8b83a5d73270319cf05396fcca8e6027e7b0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="blues brothers, the (usa, europe).bin" size="0x20000" crc="adb66eff" sha1="9dca8b83a5d73270319cf05396fcca8e6027e7b0" />
 			</dataarea>
 		</part>
 	</software>
@@ -2506,8 +2506,8 @@ license:CC0
 		<publisher>Titus</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="bluesbrothers.bin" size="131072" crc="1f90d12a" sha1="f7139bb55c3cc7bae672ade9022fb548b72f6f2f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bluesbrothers.bin" size="0x20000" crc="1f90d12a" sha1="f7139bb55c3cc7bae672ade9022fb548b72f6f2f" />
 			</dataarea>
 		</part>
 	</software>
@@ -2523,8 +2523,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-j6e-0.u1" size="131072" crc="f1c0fb1d" sha1="2005e94222a1f0edd30903411343f9570a91d4f3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-j6e-0.u1" size="0x20000" crc="f1c0fb1d" sha1="2005e94222a1f0edd30903411343f9570a91d4f3" />
 			</dataarea>
 		</part>
 	</software>
@@ -2537,8 +2537,8 @@ license:CC0
 		<info name="alt_title" value="Bo Jackson 2 Games in 1 (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="bo jackson 2 games in 1 - hit and run (usa).bin" size="131072" crc="7edb78ab" sha1="cb360f44a398ff5cd3818b0e244ffdf7019d85c7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bo jackson 2 games in 1 - hit and run (usa).bin" size="0x20000" crc="7edb78ab" sha1="cb360f44a398ff5cd3818b0e244ffdf7019d85c7" />
 			</dataarea>
 		</part>
 	</software>
@@ -2550,8 +2550,8 @@ license:CC0
 		<info name="serial" value="DMG-GL-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="boggle plus (usa).bin" size="131072" crc="70c8c799" sha1="d6cf512f7301ccdc2d802f34fbbde2d0ba2cf3cd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="boggle plus (usa).bin" size="0x20000" crc="70c8c799" sha1="d6cf512f7301ccdc2d802f34fbbde2d0ba2cf3cd" />
 			</dataarea>
 		</part>
 	</software>
@@ -2573,10 +2573,10 @@ license:CC0
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aywj-1.u1" size="524288" crc="da218e44" sha1="a1637d7ba09335631eac1291803ade05adcf5fc7" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aywj-1.u1" size="0x80000" crc="da218e44" sha1="a1637d7ba09335631eac1291803ade05adcf5fc7" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -2599,10 +2599,10 @@ license:CC0
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aywj-0.u1" size="524288" crc="d3e2fd02" sha1="60ecafdb13213b3ac2daa3d71431ef8a89754edb" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aywj-0.u1" size="0x80000" crc="d3e2fd02" sha1="60ecafdb13213b3ac2daa3d71431ef8a89754edb" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -2618,10 +2618,10 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-bywj-0.u1" size="524288" crc="0424df85" sha1="551df2021d0e433e7f07cf881c7b1d534f54f6ad" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-bywj-0.u1" size="0x80000" crc="0424df85" sha1="551df2021d0e433e7f07cf881c7b1d534f54f6ad" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -2632,8 +2632,8 @@ license:CC0
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-B9-SCN" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bomb jack (europe).bin" size="32768" crc="9bd8815e" sha1="a2b2799e867777a5a19155ed1f2245630fc03560" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="bomb jack (europe).bin" size="0x8000" crc="9bd8815e" sha1="a2b2799e867777a5a19155ed1f2245630fc03560" />
 			</dataarea>
 		</part>
 	</software>
@@ -2643,8 +2643,8 @@ license:CC0
 		<year>1992</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bomb jack (prototype a).bin" size="32768" crc="7ca8e543" sha1="6fc3794149f5e75ad82b4a7d47ad5497e1ee4e6a" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="bomb jack (prototype a).bin" size="0x8000" crc="7ca8e543" sha1="6fc3794149f5e75ad82b4a7d47ad5497e1ee4e6a" />
 			</dataarea>
 		</part>
 	</software>
@@ -2654,8 +2654,8 @@ license:CC0
 		<year>1992</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bomb jack (prototype b).bin" size="32768" crc="ffa0e67a" sha1="a4c25218b2c35d6bd4fcf93ebdf81dfe22d4259a" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="bomb jack (prototype b).bin" size="0x8000" crc="ffa0e67a" sha1="a4c25218b2c35d6bd4fcf93ebdf81dfe22d4259a" />
 			</dataarea>
 		</part>
 	</software>
@@ -2677,8 +2677,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-hba-0.u1" size="131072" crc="ef9595ac" sha1="a9baddfb693f20057b17c084422d7bfac590f2ba" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-hba-0.u1" size="0x20000" crc="ef9595ac" sha1="a9baddfb693f20057b17c084422d7bfac590f2ba" />
 			</dataarea>
 		</part>
 	</software>
@@ -2695,8 +2695,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-bia-0.u1" size="131072" crc="b8fe9077" sha1="79f978b9e85c675f7b54229a14d04926348bb70f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-bia-0.u1" size="0x20000" crc="b8fe9077" sha1="79f978b9e85c675f7b54229a14d04926348bb70f" />
 			</dataarea>
 		</part>
 	</software>
@@ -2714,8 +2714,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1col" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-abcj-0.u1" size="1048576" crc="509a6b73" sha1="385f8fafa53a83f8f65e1e619fe124bbf7db4a98" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-abcj-0.u1" size="0x100000" crc="509a6b73" sha1="385f8fafa53a83f8f65e1e619fe124bbf7db4a98" />
 			</dataarea>
 		</part>
 	</software>
@@ -2731,8 +2731,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ab2p-0.u1" size="262144" crc="f372d175" sha1="f7058f31ddaec63f3b9c45ee9caf3c8e2cae1ca8" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ab2p-0.u1" size="0x40000" crc="f372d175" sha1="f7058f31ddaec63f3b9c45ee9caf3c8e2cae1ca8" />
 			</dataarea>
 		</part>
 	</software>
@@ -2750,8 +2750,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-eej-0.u1" size="262144" crc="94337d56" sha1="5b989983c2f80a71dfc7cce29395de3e174fa848" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-eej-0.u1" size="0x40000" crc="94337d56" sha1="5b989983c2f80a71dfc7cce29395de3e174fa848" />
 			</dataarea>
 		</part>
 	</software>
@@ -2769,8 +2769,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="u2" size="262144" crc="6157443b" sha1="004e540e8aed59e5aee1c88ef84975000a6efe6c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="u2" size="0x40000" crc="6157443b" sha1="004e540e8aed59e5aee1c88ef84975000a6efe6c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2786,8 +2786,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="bomberman gb 3 (japan).bin" size="262144" crc="f658b7a7" sha1="98a6327639833e1a6696e4acc5ca162388d5f6e1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="bomberman gb 3 (japan).bin" size="0x40000" crc="f658b7a7" sha1="98a6327639833e1a6696e4acc5ca162388d5f6e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -2799,8 +2799,8 @@ license:CC0
 		<info name="serial" value="DMG-GK-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="bonk's adventure (usa).bin" size="262144" crc="a7cdbb96" sha1="e27d941af0a006c4f5ffd03914265146aa140e2c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="bonk's adventure (usa).bin" size="0x40000" crc="a7cdbb96" sha1="e27d941af0a006c4f5ffd03914265146aa140e2c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2811,8 +2811,8 @@ license:CC0
 		<publisher>Hudson Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="bonk's adventure (prototype).bin" size="262144" crc="8d706dbc" sha1="a26006158d90a61d22abf130f05297fd09a09b7c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="bonk's adventure (prototype).bin" size="0x40000" crc="8d706dbc" sha1="a26006158d90a61d22abf130f05297fd09a09b7c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2825,8 +2825,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="bonk's revenge (usa).bin" size="262144" crc="f1344b78" sha1="8d1b81e456b271ad8f49a2c6efc9ca2504a24591" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="bonk's revenge (usa).bin" size="0x40000" crc="f1344b78" sha1="8d1b81e456b271ad8f49a2c6efc9ca2504a24591" />
 			</dataarea>
 		</part>
 	</software>
@@ -2840,8 +2840,8 @@ license:CC0
 		<info name="alt_title" value="ブービーボーイズ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="booby boys (japan).bin" size="262144" crc="ec83c0b6" sha1="61fe27a4ce83bc6d9dba5d4d0652e83dbec45e6e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="booby boys (japan).bin" size="0x40000" crc="ec83c0b6" sha1="61fe27a4ce83bc6d9dba5d4d0652e83dbec45e6e" />
 			</dataarea>
 		</part>
 	</software>
@@ -2853,8 +2853,8 @@ license:CC0
 		<info name="serial" value="DMG-AS-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="boomer's adventure in asmik world (usa).bin" size="65536" crc="105bc1c0" sha1="3d8a6fcc644290c9d88fe2918bfa6007ee811de8" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="boomer's adventure in asmik world (usa).bin" size="0x10000" crc="105bc1c0" sha1="3d8a6fcc644290c9d88fe2918bfa6007ee811de8" />
 			</dataarea>
 		</part>
 	</software>
@@ -2869,8 +2869,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-01" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-puj-0.u1" size="32768" crc="9f0f3606" sha1="16d54de69814e1c9aae67a59bb0dcd2a1216395b" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-puj-0.u1" size="0x8000" crc="9f0f3606" sha1="16d54de69814e1c9aae67a59bb0dcd2a1216395b" />
 			</dataarea>
 		</part>
 	</software>
@@ -2885,8 +2885,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-bde-0.u1" size="65536" crc="644aec3e" sha1="01cc570a16bad4c2c33b393620ec9e25f131d1f4" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-bde-0.u1" size="0x10000" crc="644aec3e" sha1="01cc570a16bad4c2c33b393620ec9e25f131d1f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -2900,8 +2900,8 @@ license:CC0
 		<info name="alt_title" value="バルダーダッシュ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="boulder dash (japan).bin" size="65536" crc="b5b3f85b" sha1="f5a4a5ccda4f559ce85567c4b68f758216aee2d4" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="boulder dash (japan).bin" size="0x10000" crc="b5b3f85b" sha1="f5a4a5ccda4f559ce85567c4b68f758216aee2d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -2915,8 +2915,8 @@ license:CC0
 		<info name="alt_title" value="ボクシング" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="boxing (japan).bin" size="65536" crc="ef7e9fa0" sha1="5af3a0b6e54ca67c3a4cab8833368725cc68e99f" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="boxing (japan).bin" size="0x10000" crc="ef7e9fa0" sha1="5af3a0b6e54ca67c3a4cab8833368725cc68e99f" />
 			</dataarea>
 		</part>
 	</software>
@@ -2930,8 +2930,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-soe-1.u1" size="32768" crc="c09cee99" sha1="f9d5287bc9d6eda9ec36e9b5a8dbc38cf2cffecf" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-soe-1.u1" size="0x8000" crc="c09cee99" sha1="f9d5287bc9d6eda9ec36e9b5a8dbc38cf2cffecf" />
 			</dataarea>
 		</part>
 	</software>
@@ -2943,8 +2943,8 @@ license:CC0
 		<info name="serial" value="DMG-SO-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-soe-0.u1" size="32768" crc="24843867" sha1="3e169f1db16cc1c3ffbc8645aa7ce28194033d26" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-soe-0.u1" size="0x8000" crc="24843867" sha1="3e169f1db16cc1c3ffbc8645aa7ce28194033d26" />
 			</dataarea>
 		</part>
 	</software>
@@ -2955,8 +2955,8 @@ license:CC0
 		<publisher>FCI</publisher>
 		<info name="serial" value="DMG-SQ-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="boxxle ii (usa).bin" size="32768" crc="c08e9756" sha1="36315dab12915d2d2fad7a37fcb5ce6809118c8a" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="boxxle ii (usa).bin" size="0x8000" crc="c08e9756" sha1="36315dab12915d2d2fad7a37fcb5ce6809118c8a" />
 			</dataarea>
 		</part>
 	</software>
@@ -2969,8 +2969,8 @@ license:CC0
 		<info name="alt_title" value="David Crane's The Rescue of Princess Blobette Starring A Boy and His Blob (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="boy and his blob in the rescue of princess blobette, a (europe).bin" size="65536" crc="25f82bb1" sha1="4800e5d5a4230918ec751ceeae7ac9342e0b8d83" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="boy and his blob in the rescue of princess blobette, a (europe).bin" size="0x10000" crc="25f82bb1" sha1="4800e5d5a4230918ec751ceeae7ac9342e0b8d83" />
 			</dataarea>
 		</part>
 	</software>
@@ -2983,8 +2983,8 @@ license:CC0
 		<info name="alt_title" value="David Crane's The Rescue of Princess Blobette Starring A Boy and His Blob (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="boy and his blob in the rescue of princess blobette, a (usa).bin" size="65536" crc="8210a03f" sha1="0a45d1b98646fd7832b5119b04bc8d6d6d0f657a" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="boy and his blob in the rescue of princess blobette, a (usa).bin" size="0x10000" crc="8210a03f" sha1="0a45d1b98646fd7832b5119b04bc8d6d6d0f657a" />
 			</dataarea>
 		</part>
 	</software>
@@ -2997,8 +2997,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="brain drain (europe).bin" size="131072" crc="8a7fb0e6" sha1="67e1796ed410ecc19efc2f73ef7f5226414cc8bb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="brain drain (europe).bin" size="0x20000" crc="8a7fb0e6" sha1="67e1796ed410ecc19efc2f73ef7f5226414cc8bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -3013,8 +3013,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="brain drain (japan).bin" size="131072" crc="e558aacd" sha1="225c25d94854f509611b8c0b4b415daf48d51310" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="brain drain (japan).bin" size="0x20000" crc="e558aacd" sha1="225c25d94854f509611b8c0b4b415daf48d51310" />
 			</dataarea>
 		</part>
 	</software>
@@ -3027,8 +3027,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="brain drain (usa).bin" size="131072" crc="aff0b159" sha1="da11b3909bef958abc9b3b184771f4f8fe498456" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="brain drain (usa).bin" size="0x20000" crc="aff0b159" sha1="da11b3909bef958abc9b3b184771f4f8fe498456" />
 			</dataarea>
 		</part>
 	</software>
@@ -3041,8 +3041,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-bwx-0.u1" size="32768" crc="b651bf5d" sha1="9502181c62d8343b98cef9b881c29e4573e4fbc9" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-bwx-0.u1" size="0x8000" crc="b651bf5d" sha1="9502181c62d8343b98cef9b881c29e4573e4fbc9" />
 			</dataarea>
 		</part>
 	</software>
@@ -3053,8 +3053,8 @@ license:CC0
 		<publisher>Electro Brain</publisher>
 		<info name="serial" value="DMG-BW-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="brainbender (usa).bin" size="32768" crc="fbb1f2a1" sha1="56ff8684284765a56918d14620ad38477aaaf0ad" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="brainbender (usa).bin" size="0x8000" crc="fbb1f2a1" sha1="56ff8684284765a56918d14620ad38477aaaf0ad" />
 			</dataarea>
 		</part>
 	</software>
@@ -3066,8 +3066,8 @@ license:CC0
 		<info name="serial" value="DMG-D4-USA, DMG-D4-(NOE/UKV)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="bram stoker's dracula (usa, europe).bin" size="131072" crc="00cd1876" sha1="d31cb69613a6f0504b4f3f72c18e96b5827686b9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bram stoker's dracula (usa, europe).bin" size="0x20000" crc="00cd1876" sha1="d31cb69613a6f0504b4f3f72c18e96b5827686b9" />
 			</dataarea>
 		</part>
 	</software>
@@ -3079,8 +3079,8 @@ license:CC0
 		<info name="serial" value="DMG-ABXE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="breakthru (usa).bin" size="131072" crc="5b8f0df2" sha1="d9a49a71e6b554c2fccce08c446274e886225d50" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="breakthru (usa).bin" size="0x20000" crc="5b8f0df2" sha1="d9a49a71e6b554c2fccce08c446274e886225d50" />
 			</dataarea>
 		</part>
 	</software>
@@ -3101,8 +3101,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-b2e-0.u1" size="131072" crc="d516841d" sha1="569881bea21cf5fd542ff3dfc40e1626c6748ceb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-b2e-0.u1" size="0x20000" crc="d516841d" sha1="569881bea21cf5fd542ff3dfc40e1626c6748ceb" />
 			</dataarea>
 		</part>
 	</software>
@@ -3119,8 +3119,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-b2a-0.u1" size="131072" crc="ad9b300c" sha1="3f2e741e0dbdcc65e960f44a322e85748272f3f3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-b2a-0.u1" size="0x20000" crc="ad9b300c" sha1="3f2e741e0dbdcc65e960f44a322e85748272f3f3" />
 			</dataarea>
 		</part>
 	</software>
@@ -3135,8 +3135,8 @@ license:CC0
 		<info name="alt_title" value="バブルボブルジュニア" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="bubble bobble junior (japan).bin" size="131072" crc="39e261b9" sha1="686c526a557065dc0005068eafdbc6736684f925" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bubble bobble junior (japan).bin" size="0x20000" crc="39e261b9" sha1="686c526a557065dc0005068eafdbc6736684f925" />
 			</dataarea>
 		</part>
 	</software>
@@ -3148,8 +3148,8 @@ license:CC0
 		<info name="serial" value="DMG-LX-USA, DMG-LX-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="bubble bobble part 2 (usa, europe).bin" size="131072" crc="4106d781" sha1="e258d852713f392454d4291032ce50ad325aba86" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bubble bobble part 2 (usa, europe).bin" size="0x20000" crc="4106d781" sha1="e258d852713f392454d4291032ce50ad325aba86" />
 			</dataarea>
 		</part>
 	</software>
@@ -3162,8 +3162,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />   <!-- Both USA & UKV cart -->
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-bge-0.u1" size="32768" crc="843068fd" sha1="b08b8a9bf742f7ca4b355a866b4167741252dcf6" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-bge-0.u1" size="0x8000" crc="843068fd" sha1="b08b8a9bf742f7ca4b355a866b4167741252dcf6" />
 			</dataarea>
 		</part>
 	</software>
@@ -3176,8 +3176,8 @@ license:CC0
 		<info name="release" value="19901221" />
 		<info name="alt_title" value="バブルゴースト" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bubble ghost (japan).bin" size="32768" crc="874d0d6f" sha1="f93e37b60025c67d7fbfc035ed727c9a39d8c9f1" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="bubble ghost (japan).bin" size="0x8000" crc="874d0d6f" sha1="f93e37b60025c67d7fbfc035ed727c9a39d8c9f1" />
 			</dataarea>
 		</part>
 	</software>
@@ -3187,8 +3187,8 @@ license:CC0
 		<year>1990</year>
 		<publisher>FCI</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bubble ghost (prototype).bin" size="32768" crc="4a083f6f" sha1="f5d063c70cecadda43d27d0c24f561a8f32b10f2" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="bubble ghost (prototype).bin" size="0x8000" crc="4a083f6f" sha1="f5d063c70cecadda43d27d0c24f561a8f32b10f2" />
 			</dataarea>
 		</part>
 	</software>
@@ -3204,8 +3204,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-abbp-0.u1" size="262144" crc="a3164516" sha1="f59306da42c5d8bbf41c870828c83bbcf1e2f0ac" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-abbp-0.u1" size="0x40000" crc="a3164516" sha1="f59306da42c5d8bbf41c870828c83bbcf1e2f0ac" />
 			</dataarea>
 		</part>
 	</software>
@@ -3218,8 +3218,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="bubsy ii (usa).bin" size="262144" crc="600a6ad5" sha1="1ac9bf5043caf428994bca3e80158ca697e94c58" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="bubsy ii (usa).bin" size="0x40000" crc="600a6ad5" sha1="1ac9bf5043caf428994bca3e80158ca697e94c58" />
 			</dataarea>
 		</part>
 	</software>
@@ -3234,8 +3234,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="bugs bunny collection (japan) (rev 1).bin" size="262144" crc="8244220b" sha1="9d69d72b7de0377cb0439aa301b1fb82d3ce786a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="bugs bunny collection (japan) (rev 1).bin" size="0x40000" crc="8244220b" sha1="9d69d72b7de0377cb0439aa301b1fb82d3ce786a" />
 			</dataarea>
 		</part>
 	</software>
@@ -3250,8 +3250,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="bugs bunny collection (japan).bin" size="262144" crc="d2dbea8f" sha1="4f1f56b06364272033372230cfe0819cb3e25b50" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="bugs bunny collection (japan).bin" size="0x40000" crc="d2dbea8f" sha1="4f1f56b06364272033372230cfe0819cb3e25b50" />
 			</dataarea>
 		</part>
 	</software>
@@ -3266,8 +3266,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-bbe-0.u1" size="65536" crc="403e1b7e" sha1="2a3e982e542a849f95b4497025ca5b04db2abe8c" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-bbe-0.u1" size="0x10000" crc="403e1b7e" sha1="2a3e982e542a849f95b4497025ca5b04db2abe8c" />
 			</dataarea>
 		</part>
 	</software>
@@ -3282,8 +3282,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-bye-0.u1" size="131072" crc="a973e604" sha1="1e4c8c8fe8b6c34f76cd0da876442f14299da725" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-bye-0.u1" size="0x20000" crc="a973e604" sha1="1e4c8c8fe8b6c34f76cd0da876442f14299da725" />
 			</dataarea>
 		</part>
 	</software>
@@ -3298,8 +3298,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-bue-0.u1" size="65536" crc="3c86f5db" sha1="178e18b7e6e65e726b4e06f80d89c55332ea868b" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-bue-0.u1" size="0x10000" crc="3c86f5db" sha1="178e18b7e6e65e726b4e06f80d89c55332ea868b" />
 			</dataarea>
 		</part>
 	</software>
@@ -3316,8 +3316,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-bua-0.u1" size="65536" crc="5a1a20f3" sha1="f8c17e07d25420b7717f4415820c09491bb6a04c" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-bua-0.u1" size="0x10000" crc="5a1a20f3" sha1="f8c17e07d25420b7717f4415820c09491bb6a04c" />
 			</dataarea>
 		</part>
 	</software>
@@ -3339,8 +3339,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-gma-0.u1" size="65536" crc="88219a49" sha1="1aafcef0dd5fbb8e95188631e0b2decdf84e9aed" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-gma-0.u1" size="0x10000" crc="88219a49" sha1="1aafcef0dd5fbb8e95188631e0b2decdf84e9aed" />
 			</dataarea>
 		</part>
 	</software>
@@ -3354,8 +3354,8 @@ license:CC0
 		<info name="alt_title" value="バーニングペーパー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="burning paper (japan).bin" size="131072" crc="88f8c991" sha1="8e2bce98cc840e52d47680f9b1e425bfc9102ac7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="burning paper (japan).bin" size="0x20000" crc="88f8c991" sha1="8e2bce98cc840e52d47680f9b1e425bfc9102ac7" />
 			</dataarea>
 		</part>
 	</software>
@@ -3370,8 +3370,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-abup-0.u1" size="131072" crc="b94724e6" sha1="6b0942c231890d3e2f6c18e7804040eb4c66dcb3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-abup-0.u1" size="0x20000" crc="b94724e6" sha1="6b0942c231890d3e2f6c18e7804040eb4c66dcb3" />
 			</dataarea>
 		</part>
 	</software>
@@ -3383,8 +3383,8 @@ license:CC0
 		<info name="serial" value="DMG-A3VP-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-a3vp-0.u1" size="131072" crc="e555c612" sha1="e89dc67087205c4113a4d152347eba38204e270b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-a3vp-0.u1" size="0x20000" crc="e555c612" sha1="e89dc67087205c4113a4d152347eba38204e270b" />
 			</dataarea>
 		</part>
 	</software>
@@ -3399,8 +3399,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-age-0.u1" size="131072" crc="b4245ca3" sha1="0d1692ff60ef1f6a97bbfd2bf8c1548f1f7439ed" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-age-0.u1" size="0x20000" crc="b4245ca3" sha1="0d1692ff60ef1f6a97bbfd2bf8c1548f1f7439ed" />
 			</dataarea>
 		</part>
 	</software>
@@ -3414,8 +3414,8 @@ license:CC0
 		<info name="alt_title" value="秘伝陰陽気功法図式謎遊戯 華佗" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="ca da (japan).bin" size="65536" crc="9234eeab" sha1="0ba32a4383f1ff89c8838d155cb672ff799f0687" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="ca da (japan).bin" size="0x10000" crc="9234eeab" sha1="0ba32a4383f1ff89c8838d155cb672ff799f0687" />
 			</dataarea>
 		</part>
 	</software>
@@ -3429,8 +3429,8 @@ license:CC0
 		<info name="alt_title" value="キャデラックII" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="cadillac ii (japan).bin" size="65536" crc="a6c98122" sha1="a5d405fe7b4ea23708acb3cb71104f63057df6d4" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="cadillac ii (japan).bin" size="0x10000" crc="a6c98122" sha1="a5d405fe7b4ea23708acb3cb71104f63057df6d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -3445,8 +3445,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-cex-0.u1" size="131072" crc="78bf3633" sha1="6d77ce1b212406ba9737dd99ffd9443a3887ef79" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-cex-0.u1" size="0x20000" crc="78bf3633" sha1="6d77ce1b212406ba9737dd99ffd9443a3887ef79" />
 			</dataarea>
 		</part>
 	</software>
@@ -3460,8 +3460,8 @@ license:CC0
 		<info name="alt_title" value="シーザース パレス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="caesars palace (japan).bin" size="131072" crc="000aaa74" sha1="2cf0e21f7be55e3246d615550c8459a3659094ef" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="caesars palace (japan).bin" size="0x20000" crc="000aaa74" sha1="2cf0e21f7be55e3246d615550c8459a3659094ef" />
 			</dataarea>
 		</part>
 	</software>
@@ -3476,8 +3476,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-cee-1.u1" size="131072" crc="87a9d605" sha1="126e9ef9e975bbbc6303d5d62a379d4dbd404cf0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-cee-1.u1" size="0x20000" crc="87a9d605" sha1="126e9ef9e975bbbc6303d5d62a379d4dbd404cf0" />
 			</dataarea>
 		</part>
 	</software>
@@ -3489,8 +3489,8 @@ license:CC0
 		<info name="serial" value="DMG-CE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="caesars palace (usa).bin" size="131072" crc="d9f901a9" sha1="c1ed80f33fc3603edaba1bdf5c317f1a205da3dc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="caesars palace (usa).bin" size="0x20000" crc="d9f901a9" sha1="c1ed80f33fc3603edaba1bdf5c317f1a205da3dc" />
 			</dataarea>
 		</part>
 	</software>
@@ -3507,8 +3507,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-hhj-0.u1" size="262144" crc="8042afc5" sha1="168583ea18e02647f0b35f9bd0365e37bec076cc" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-hhj-0.u1" size="0x40000" crc="8042afc5" sha1="168583ea18e02647f0b35f9bd0365e37bec076cc" />
 			</dataarea>
 		</part>
 	</software>
@@ -3520,8 +3520,8 @@ license:CC0
 		<info name="serial" value="DMG-VP-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="captain america and the avengers (usa).bin" size="131072" crc="c762b783" sha1="a067c4e20642a6c17f35a855e2d4815470fc6c6b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="captain america and the avengers (usa).bin" size="0x20000" crc="c762b783" sha1="a067c4e20642a6c17f35a855e2d4815470fc6c6b" />
 			</dataarea>
 		</part>
 	</software>
@@ -3536,8 +3536,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="captain tsubasa j - zenkoku seiha e no chousen (japan).bin" size="524288" crc="33a1e1cf" sha1="d3f9c5700389f7a876a4a821db1f99e7da4a6f68" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="captain tsubasa j - zenkoku seiha e no chousen (japan).bin" size="0x80000" crc="33a1e1cf" sha1="d3f9c5700389f7a876a4a821db1f99e7da4a6f68" />
 			</dataarea>
 		</part>
 	</software>
@@ -3554,8 +3554,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-t5j-0.u1" size="262144" crc="a795e851" sha1="1d48763a64c127b7ecff9876f20ae0761347b4c7" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-t5j-0.u1" size="0x40000" crc="a795e851" sha1="1d48763a64c127b7ecff9876f20ae0761347b4c7" />
 			</dataarea>
 		</part>
 	</software>
@@ -3569,8 +3569,8 @@ license:CC0
 		<info name="alt_title" value="カード・ゲーム" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="card game (japan).bin" size="65536" crc="d05f4c90" sha1="9ac64030c1e1ca89828ea54ac1fb0d884d6d92bb" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="card game (japan).bin" size="0x10000" crc="d05f4c90" sha1="9ac64030c1e1ca89828ea54ac1fb0d884d6d92bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -3585,8 +3585,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-acfp-0.u1" size="131072" crc="8641ba55" sha1="4418a8b2029f431efd8888817589af6c8b0e76cc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-acfp-0.u1" size="0x20000" crc="8641ba55" sha1="4418a8b2029f431efd8888817589af6c8b0e76cc" />
 			</dataarea>
 		</part>
 	</software>
@@ -3598,8 +3598,8 @@ license:CC0
 		<info name="serial" value="DMG-ACEP-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="casper (europe).bin" size="131072" crc="e4b30634" sha1="1a3d272d8afe81731862a240a77c0d3b80b1d62f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="casper (europe).bin" size="0x20000" crc="e4b30634" sha1="1a3d272d8afe81731862a240a77c0d3b80b1d62f" />
 			</dataarea>
 		</part>
 	</software>
@@ -3613,8 +3613,8 @@ license:CC0
 			<feature name="u1" value="U1" />
 			<feature name="u2" value="U2 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="casper - gameboy.u1" size="131072" crc="39dcd93a" sha1="f04c2da54ebe91673a651989965ba2aa61d5d7bd" status="baddump" /> <!-- Trimmed from an 8MB overdump. Needs confirmed. -->
+			<dataarea name="rom" size="0x20000">
+				<rom name="casper - gameboy.u1" size="0x20000" crc="39dcd93a" sha1="f04c2da54ebe91673a651989965ba2aa61d5d7bd" status="baddump" /> <!-- Trimmed from an 8MB overdump. Needs confirmed. -->
 			</dataarea>
 		</part>
 	</software>
@@ -3626,8 +3626,8 @@ license:CC0
 		<info name="serial" value="DMG-ACEE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="casper (usa).bin" size="131072" crc="e67a10e1" sha1="18b90172789c87819fe4d606aa7874109bcd8024" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="casper (usa).bin" size="0x20000" crc="e67a10e1" sha1="18b90172789c87819fe4d606aa7874109bcd8024" />
 			</dataarea>
 		</part>
 	</software>
@@ -3638,8 +3638,8 @@ license:CC0
 		<publisher>Sales Curve</publisher>
 		<info name="serial" value="DMG-CJ-NOE, DMG-CJ-ESP, DMG-CJ-FRG" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="castelian (europe).bin" size="32768" crc="2f752404" sha1="6720d86d420831a0a4865d4a59c4ba6fe98fa34d" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="castelian (europe).bin" size="0x8000" crc="2f752404" sha1="6720d86d420831a0a4865d4a59c4ba6fe98fa34d" />
 			</dataarea>
 		</part>
 	</software>
@@ -3650,8 +3650,8 @@ license:CC0
 		<publisher>Triffix</publisher>
 		<info name="serial" value="DMG-CJ-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="castelian (usa).bin" size="32768" crc="f2d739e4" sha1="a03982e2ffa9aa368fe11bc09f024207bada45eb" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="castelian (usa).bin" size="0x8000" crc="f2d739e4" sha1="a03982e2ffa9aa368fe11bc09f024207bada45eb" />
 			</dataarea>
 		</part>
 	</software>
@@ -3663,8 +3663,8 @@ license:CC0
 		<info name="serial" value="DMG-QH-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="castle quest (europe).bin" size="131072" crc="2f8aaf6f" sha1="45b38a334481f620bb7165fee81391036a54a748" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="castle quest (europe).bin" size="0x20000" crc="2f8aaf6f" sha1="45b38a334481f620bb7165fee81391036a54a748" />
 			</dataarea>
 		</part>
 	</software>
@@ -3679,8 +3679,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-cvx-0.u1" size="65536" crc="6977c265" sha1="d54888039344597fa038f2c5eedc0726dd35cc46" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-cvx-0.u1" size="0x10000" crc="6977c265" sha1="d54888039344597fa038f2c5eedc0726dd35cc46" />
 			</dataarea>
 		</part>
 	</software>
@@ -3692,8 +3692,8 @@ license:CC0
 		<info name="serial" value="DMG-CV-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="castlevania adventure, the (usa).bin" size="65536" crc="216e6aa1" sha1="fd9116efcd8eb9698f483cc5745f83b3674d7d13" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="castlevania adventure, the (usa).bin" size="0x10000" crc="216e6aa1" sha1="fd9116efcd8eb9698f483cc5745f83b3674d7d13" />
 			</dataarea>
 		</part>
 	</software>
@@ -3705,8 +3705,8 @@ license:CC0
 		<info name="serial" value="DMG-CW-USA, DMG-CW-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="castlevania ii - belmont's revenge (usa, europe).bin" size="131072" crc="8875c8fe" sha1="696b9ad1e9cfb7112977c9a7c05cf64fe8423d8a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="castlevania ii - belmont's revenge (usa, europe).bin" size="0x20000" crc="8875c8fe" sha1="696b9ad1e9cfb7112977c9a7c05cf64fe8423d8a" />
 			</dataarea>
 		</part>
 	</software>
@@ -3719,8 +3719,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="castlevania legends (usa, europe).bin" size="262144" crc="ad9c17fb" sha1="91a8e49bf6eac5fe62ec2cc5e6decbd08ce9b515" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="castlevania legends (usa, europe).bin" size="0x40000" crc="ad9c17fb" sha1="91a8e49bf6eac5fe62ec2cc5e6decbd08ce9b515" />
 			</dataarea>
 		</part>
 	</software>
@@ -3733,8 +3733,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-pme-0.u1" size="32768" crc="adb96150" sha1="171e4d54f22f8dc137d12828fcc2da9874c56970" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-pme-0.u1" size="0x8000" crc="adb96150" sha1="171e4d54f22f8dc137d12828fcc2da9874c56970" />
 			</dataarea>
 		</part>
 	</software>
@@ -3744,8 +3744,8 @@ license:CC0
 		<year>1990</year>
 		<publisher>Asmik</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="catrap-gb-prototype.bin" size="32768" crc="ca3bc888" sha1="928b9b3cb2ed5e6d6fc754679b3c994f7ed803c3" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="catrap-gb-prototype.bin" size="0x8000" crc="ca3bc888" sha1="928b9b3cb2ed5e6d6fc754679b3c994f7ed803c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -3759,10 +3759,10 @@ license:CC0
 		<info name="alt_title" value="カーブノア" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="cave noire (japan).bin" size="131072" crc="44256a2f" sha1="6acdf05aac8e3792a98a199cb6e90180e95230cd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="cave noire (japan).bin" size="0x20000" crc="44256a2f" sha1="6acdf05aac8e3792a98a199cb6e90180e95230cd" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -3775,8 +3775,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="centipede (usa).bin" size="131072" crc="e957014f" sha1="a3a5755020c9cbe13fc1a815288830d2e143367f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="centipede (usa).bin" size="0x20000" crc="e957014f" sha1="a3a5755020c9cbe13fc1a815288830d2e143367f" />
 			</dataarea>
 		</part>
 	</software>
@@ -3789,8 +3789,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />   <!-- Both FRG & USA cart -->
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-cze-0.u1" size="32768" crc="245afcdc" sha1="0106c3dc8016398e9d24e2472c867487c3bd376f" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-cze-0.u1" size="0x8000" crc="245afcdc" sha1="0106c3dc8016398e9d24e2472c867487c3bd376f" />
 			</dataarea>
 		</part>
 	</software>
@@ -3804,10 +3804,10 @@ license:CC0
 		<info name="alt_title" value="茶々丸冒険記3 アビスの塔" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="chachamaru boukenki 3 - abyss no tou (japan).bin" size="131072" crc="9dfd4bc0" sha1="9a92ccc5758506a7ad07d251bf6c401fe33ad215" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="chachamaru boukenki 3 - abyss no tou (japan).bin" size="0x20000" crc="9dfd4bc0" sha1="9a92ccc5758506a7ad07d251bf6c401fe33ad215" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -3821,8 +3821,8 @@ license:CC0
 		<info name="alt_title" value="茶々丸パニック" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="chachamaru panic (japan).bin" size="65536" crc="aa920298" sha1="c6cbb08d3bb9a4deccf1df880465ce5d23907839" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="chachamaru panic (japan).bin" size="0x10000" crc="aa920298" sha1="c6cbb08d3bb9a4deccf1df880465ce5d23907839" />
 			</dataarea>
 		</part>
 	</software>
@@ -3839,8 +3839,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a2sj-0.u1" size="524288" crc="74d50b47" sha1="55aad975351670c3f632e1ebcc939c48410d29b3" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a2sj-0.u1" size="0x80000" crc="74d50b47" sha1="55aad975351670c3f632e1ebcc939c48410d29b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -3852,8 +3852,8 @@ license:CC0
 		<info name="serial" value="DMG-H4-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="championship pool (usa).bin" size="131072" crc="ef02beb6" sha1="5698fa095f737a4345f02649b4b0b96ad66660d0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="championship pool (usa).bin" size="0x20000" crc="ef02beb6" sha1="5698fa095f737a4345f02649b4b0b96ad66660d0" />
 			</dataarea>
 		</part>
 	</software>
@@ -3874,8 +3874,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-hqe-0.u1" size="131072" crc="67a45d19" sha1="cbcd6254b1b0227ba6aa8d95c979abb7fe8e4d38" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-hqe-0.u1" size="0x20000" crc="67a45d19" sha1="cbcd6254b1b0227ba6aa8d95c979abb7fe8e4d38" />
 			</dataarea>
 		</part>
 	</software>
@@ -3890,8 +3890,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-emx-0.u1" size="65536" crc="02852e24" sha1="26f1d9cbb392ff07eafb8cd59526470849de9f38" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-emx-0.u1" size="0x10000" crc="02852e24" sha1="26f1d9cbb392ff07eafb8cd59526470849de9f38" />
 			</dataarea>
 		</part>
 	</software>
@@ -3908,8 +3908,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-ema-0.u1" size="65536" crc="82150e4a" sha1="092d878bb8431ac1334dfa9cb91c4b12f1a4f365" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-ema-0.u1" size="0x10000" crc="82150e4a" sha1="092d878bb8431ac1334dfa9cb91c4b12f1a4f365" />
 			</dataarea>
 		</part>
 	</software>
@@ -3921,8 +3921,8 @@ license:CC0
 		<publisher>Altron</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="the chessmaster (prototype).bin" size="65536" crc="80ac42ce" sha1="4f750f3f650b197c48188afbce154d0d98c89b52" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="the chessmaster (prototype).bin" size="0x10000" crc="80ac42ce" sha1="4f750f3f650b197c48188afbce154d0d98c89b52" />
 			</dataarea>
 		</part>
 	</software>
@@ -3934,8 +3934,8 @@ license:CC0
 		<info name="serial" value="DMG-EM-USA?" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="chessmaster, the (usa) (rev 1).bin" size="65536" crc="59ed370c" sha1="f0351faab8b912967552684d4160f5cf94540d41" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="chessmaster, the (usa) (rev 1).bin" size="0x10000" crc="59ed370c" sha1="f0351faab8b912967552684d4160f5cf94540d41" />
 			</dataarea>
 		</part>
 	</software>
@@ -3947,8 +3947,8 @@ license:CC0
 		<info name="serial" value="DMG-EM-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="chessmaster, the (usa).bin" size="65536" crc="0c1d2b68" sha1="0e167c8ba379103775ae8e18ec9e0b819bdd5897" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="chessmaster, the (usa).bin" size="0x10000" crc="0c1d2b68" sha1="0e167c8ba379103775ae8e18ec9e0b819bdd5897" />
 			</dataarea>
 		</part>
 	</software>
@@ -3964,8 +3964,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="chibi maruko-chan - maruko deluxe gekijou (japan).bin" size="131072" crc="886049f9" sha1="0e774a12ed2d99b5a62a5ad3f634f2c32da5929a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="chibi maruko-chan - maruko deluxe gekijou (japan).bin" size="0x20000" crc="886049f9" sha1="0e774a12ed2d99b5a62a5ad3f634f2c32da5929a" />
 			</dataarea>
 		</part>
 	</software>
@@ -3982,8 +3982,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-cmj-0.u1" size="65536" crc="eab175ff" sha1="1b6838b9711ecbc6c09606da53d53309593103b2" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-cmj-0.u1" size="0x10000" crc="eab175ff" sha1="1b6838b9711ecbc6c09606da53d53309593103b2" />
 			</dataarea>
 		</part>
 	</software>
@@ -4000,8 +4000,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-c2j-0.u1" size="131072" crc="abff3314" sha1="4fd5eb092086ed62aa978eacc1c3904c921f9615" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-c2j-0.u1" size="0x20000" crc="abff3314" sha1="4fd5eb092086ed62aa978eacc1c3904c921f9615" />
 			</dataarea>
 		</part>
 	</software>
@@ -4018,8 +4018,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-m3j-0.u1" size="131072" crc="44e933c8" sha1="127fa75126fbd45ea0e3f95f862fbd4f8182780e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-m3j-0.u1" size="0x20000" crc="44e933c8" sha1="127fa75126fbd45ea0e3f95f862fbd4f8182780e" />
 			</dataarea>
 		</part>
 	</software>
@@ -4037,8 +4037,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-c4j-0.u1" size="131072" crc="e55138be" sha1="a4b268924e2fb500b8b13461a9cb20aec648a52f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-c4j-0.u1" size="0x20000" crc="e55138be" sha1="a4b268924e2fb500b8b13461a9cb20aec648a52f" />
 			</dataarea>
 		</part>
 	</software>
@@ -4052,10 +4052,10 @@ license:CC0
 		<info name="alt_title" value="チキチキマシン猛レース" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="chiki chiki machine mou race (japan).bin" size="131072" crc="7e40044a" sha1="45963623bc09e0a132867e1a78173b2c747c3b6f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="chiki chiki machine mou race (japan).bin" size="0x20000" crc="7e40044a" sha1="45963623bc09e0a132867e1a78173b2c747c3b6f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -4068,8 +4068,8 @@ license:CC0
 		<info name="release" value="19950428" />
 		<info name="alt_title" value="チキチキ天国" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="chiki chiki tengoku (japan).bin" size="32768" crc="eb33f601" sha1="56012e7f9150ec8f9117b0540dcbd2bf82c948bb" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="chiki chiki tengoku (japan).bin" size="0x8000" crc="eb33f601" sha1="56012e7f9150ec8f9117b0540dcbd2bf82c948bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -4083,8 +4083,8 @@ license:CC0
 		<info name="alt_title" value="チョップリフターII" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="choplifter ii (japan).bin" size="131072" crc="5109f484" sha1="9392ffc6831d5f029f5ad906af40b607b8eb221b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="choplifter ii (japan).bin" size="0x20000" crc="5109f484" sha1="9392ffc6831d5f029f5ad906af40b607b8eb221b" />
 			</dataarea>
 		</part>
 	</software>
@@ -4096,8 +4096,8 @@ license:CC0
 		<info name="serial" value="DMG-V4-ESP, DMG-V4-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="choplifter ii - rescue &amp; survive (europe).bin" size="131072" crc="5e2e4e19" sha1="08f5cdbcb650be51fe3998a28174e40997618349" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="choplifter ii - rescue &amp; survive (europe).bin" size="0x20000" crc="5e2e4e19" sha1="08f5cdbcb650be51fe3998a28174e40997618349" />
 			</dataarea>
 		</part>
 	</software>
@@ -4109,8 +4109,8 @@ license:CC0
 		<info name="serial" value="DMG-V4-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="choplifter ii - rescue &amp; survive (usa).bin" size="131072" crc="9c7d5e79" sha1="76ef770b9c75485cc29869fca6118887aee208da" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="choplifter ii - rescue &amp; survive (usa).bin" size="0x20000" crc="9c7d5e79" sha1="76ef770b9c75485cc29869fca6118887aee208da" />
 			</dataarea>
 		</part>
 	</software>
@@ -4122,8 +4122,8 @@ license:CC0
 		<info name="serial" value="DMG-AC3E-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="choplifter iii (europe).bin" size="131072" crc="1b3b46ef" sha1="fb1c83ee69fa32c26cdc7031733f17b90cdb0570" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="choplifter iii (europe).bin" size="0x20000" crc="1b3b46ef" sha1="fb1c83ee69fa32c26cdc7031733f17b90cdb0570" />
 			</dataarea>
 		</part>
 	</software>
@@ -4136,10 +4136,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="chou mashin eiyuuden wataru - mazekko monster (japan) (beta).bin" size="524288" crc="e6c3a473" sha1="ac2360d790c855fde91fca26ee88a4814a1f2e9f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="chou mashin eiyuuden wataru - mazekko monster (japan) (beta).bin" size="0x80000" crc="e6c3a473" sha1="ac2360d790c855fde91fca26ee88a4814a1f2e9f" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -4160,10 +4160,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-awaj-0.u1" size="524288" crc="b3e8028d" sha1="66e8df39ac137fe2b92581f2d88adfa0b0c3ac14" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-awaj-0.u1" size="0x80000" crc="b3e8028d" sha1="66e8df39ac137fe2b92581f2d88adfa0b0c3ac14" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -4185,10 +4185,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-awmj-0.u1" size="524288" crc="e5520693" sha1="54d2672d9720fa4322a7a45244aa898d321c1dd1" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-awmj-0.u1" size="0x80000" crc="e5520693" sha1="54d2672d9720fa4322a7a45244aa898d321c1dd1" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -4210,10 +4210,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_huc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="chousoku spinner (japan).bin" size="524288" crc="b4fa9cf2" sha1="057a3251bbb7eb4e04b01f786bd2986af5eabc58" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="chousoku spinner (japan).bin" size="0x80000" crc="b4fa9cf2" sha1="057a3251bbb7eb4e04b01f786bd2986af5eabc58" />
 			</dataarea>
-			<dataarea name="ram" size="32768">
+			<dataarea name="ram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -4228,8 +4228,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-qce-0.u1" size="131072" crc="c5951d9e" sha1="601453f98ba7d92ebe71f3e86952a584cbea090c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-qce-0.u1" size="0x20000" crc="c5951d9e" sha1="601453f98ba7d92ebe71f3e86952a584cbea090c" />
 			</dataarea>
 		</part>
 	</software>
@@ -4244,8 +4244,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-15e-0.u1" size="131072" crc="aa133439" sha1="c74f85035842f8a2d9560066d7065ff86d9107e2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-15e-0.u1" size="0x20000" crc="aa133439" sha1="c74f85035842f8a2d9560066d7065ff86d9107e2" />
 			</dataarea>
 		</part>
 	</software>
@@ -4260,8 +4260,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="collection pocket (japan).bin" size="262144" crc="34e62c8b" sha1="daad5ec53da0e375cee3962c0a9031d8a67020fd" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="collection pocket (japan).bin" size="0x40000" crc="34e62c8b" sha1="daad5ec53da0e375cee3962c0a9031d8a67020fd" />
 			</dataarea>
 		</part>
 	</software>
@@ -4273,8 +4273,8 @@ license:CC0
 		<info name="serial" value="DMG-ANYE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="college slam (usa).bin" size="524288" crc="a549a572" sha1="84dc6269fbe4ee4c157f940b0a9630412e099cc6" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="college slam (usa).bin" size="0x80000" crc="a549a572" sha1="84dc6269fbe4ee4c157f940b0a9630412e099cc6" />
 			</dataarea>
 		</part>
 	</software>
@@ -4288,8 +4288,8 @@ license:CC0
 		<info name="alt_title" value="コントラ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="contra (japan).bin" size="131072" crc="cde6de15" sha1="c8b34b5aba3d448e357b59cdf106ee9b134713db" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="contra (japan).bin" size="0x20000" crc="cde6de15" sha1="c8b34b5aba3d448e357b59cdf106ee9b134713db" />
 			</dataarea>
 		</part>
 	</software>
@@ -4302,8 +4302,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="contra - the alien wars (usa).bin" size="131072" crc="f1c81eb0" sha1="2e23477eb8738d7fb45e13b02f054422222c9c4f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="contra - the alien wars (usa).bin" size="0x20000" crc="f1c81eb0" sha1="2e23477eb8738d7fb45e13b02f054422222c9c4f" />
 			</dataarea>
 		</part>
 	</software>
@@ -4318,8 +4318,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="contra spirits (japan).bin" size="131072" crc="7fc22df5" sha1="72213c5d8af05cad5f17a42566f7383066612eee" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="contra spirits (japan).bin" size="0x20000" crc="7fc22df5" sha1="72213c5d8af05cad5f17a42566f7383066612eee" />
 			</dataarea>
 		</part>
 	</software>
@@ -4330,8 +4330,8 @@ license:CC0
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-OP-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="cool ball (usa).bin" size="32768" crc="e045b886" sha1="f1932d4a3f063c5395e8558a63c64e5840789ce6" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="cool ball (usa).bin" size="0x8000" crc="e045b886" sha1="f1932d4a3f063c5395e8558a63c64e5840789ce6" />
 			</dataarea>
 		</part>
 	</software>
@@ -4346,8 +4346,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-acdx-0.u1" size="262144" crc="a2f01695" sha1="b26441e13b9dc806b182999ff8784cef46961010" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-acdx-0.u1" size="0x40000" crc="a2f01695" sha1="b26441e13b9dc806b182999ff8784cef46961010" />
 			</dataarea>
 		</part>
 	</software>
@@ -4362,8 +4362,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-acdp-0.u1" size="262144" crc="0d430d1a" sha1="a6fe59bcc29b6d9ae6712d99822a123d2434f3b3" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-acdp-0.u1" size="0x40000" crc="0d430d1a" sha1="a6fe59bcc29b6d9ae6712d99822a123d2434f3b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -4375,8 +4375,8 @@ license:CC0
 		<info name="serial" value="DMG-QP-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="cool spot (europe).bin" size="131072" crc="1987eacc" sha1="51efa64a6047879b4b9e6e521e65c9d7f191556f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="cool spot (europe).bin" size="0x20000" crc="1987eacc" sha1="51efa64a6047879b4b9e6e521e65c9d7f191556f" />
 			</dataarea>
 		</part>
 	</software>
@@ -4391,8 +4391,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-qpe-0.u1" size="131072" crc="aba1dac9" sha1="b23f3259fdec43ce004e536d30255e1c2a642ffc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-qpe-0.u1" size="0x20000" crc="aba1dac9" sha1="b23f3259fdec43ce004e536d30255e1c2a642ffc" />
 			</dataarea>
 		</part>
 	</software>
@@ -4404,8 +4404,8 @@ license:CC0
 		<info name="serial" value="DMG-WL-USA, DMG-WL-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="cool world (usa, europe).bin" size="131072" crc="a193c0d0" sha1="1919495cc83c4126c90d6cfa2e14427b6364da3a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="cool world (usa, europe).bin" size="0x20000" crc="a193c0d0" sha1="1919495cc83c4126c90d6cfa2e14427b6364da3a" />
 			</dataarea>
 		</part>
 	</software>
@@ -4419,8 +4419,8 @@ license:CC0
 		<info name="alt_title" value="コスモタンク" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="cosmo tank (japan).bin" size="131072" crc="80b21df1" sha1="0d6a0a95f4fc9f2c61e2fccee0321236d3a6f5e5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="cosmo tank (japan).bin" size="0x20000" crc="80b21df1" sha1="0d6a0a95f4fc9f2c61e2fccee0321236d3a6f5e5" />
 			</dataarea>
 		</part>
 	</software>
@@ -4431,8 +4431,8 @@ license:CC0
 		<publisher>Atlus</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="cosmo tank (j) (proto).bin" size="131072" crc="2022bbb9" sha1="8963c2e8e42c452528078f10df699fd266f01749" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="cosmo tank (j) (proto).bin" size="0x20000" crc="2022bbb9" sha1="8963c2e8e42c452528078f10df699fd266f01749" />
 			</dataarea>
 		</part>
 	</software>
@@ -4444,8 +4444,8 @@ license:CC0
 		<info name="serial" value="DMG-CT-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="cosmo tank (usa).bin" size="131072" crc="2e767d25" sha1="48a8f5c50a237f11c8e18efd03a5282f493312bc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="cosmo tank (usa).bin" size="0x20000" crc="2e767d25" sha1="48a8f5c50a237f11c8e18efd03a5282f493312bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -4456,8 +4456,8 @@ license:CC0
 		<publisher>Atlus</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="cosmo tank (us prototype).bin" size="131072" crc="1c6770f0" sha1="863bf21877b5f5993b9e64710f304b8db194d2e7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="cosmo tank (us prototype).bin" size="0x20000" crc="1c6770f0" sha1="863bf21877b5f5993b9e64710f304b8db194d2e7" />
 			</dataarea>
 		</part>
 	</software>
@@ -4472,8 +4472,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="crayon shin-chan - ora no gokigen collection (japan).bin" size="262144" crc="dc723a9e" sha1="1dbd23b639b8a4b20ed28c3637608e03ebf59dad" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="crayon shin-chan - ora no gokigen collection (japan).bin" size="0x40000" crc="dc723a9e" sha1="1dbd23b639b8a4b20ed28c3637608e03ebf59dad" />
 			</dataarea>
 		</part>
 	</software>
@@ -4487,8 +4487,8 @@ license:CC0
 		<info name="alt_title" value="クレヨンしんちゃん 〝オラとシロはお友達だよ〞" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="crayon shin-chan - ora to shiro wa otomodachi dayo (japan).bin" size="131072" crc="2699942c" sha1="e8da27b1b782c154b65ba6cdc2e3915925a67566" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="crayon shin-chan - ora to shiro wa otomodachi dayo (japan).bin" size="0x20000" crc="2699942c" sha1="e8da27b1b782c154b65ba6cdc2e3915925a67566" />
 			</dataarea>
 		</part>
 	</software>
@@ -4505,8 +4505,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-coj-0.u1" size="131072" crc="ca6e0be0" sha1="f034cc9c8b5962c548eba445033c8c912e3a19e2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-coj-0.u1" size="0x20000" crc="ca6e0be0" sha1="f034cc9c8b5962c548eba445033c8c912e3a19e2" />
 			</dataarea>
 		</part>
 	</software>
@@ -4523,8 +4523,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-hjj-0.u1" size="131072" crc="24a12807" sha1="2d0119ec7b44bb89964c98024c46afd39490b5c9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-hjj-0.u1" size="0x20000" crc="24a12807" sha1="2d0119ec7b44bb89964c98024c46afd39490b5c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -4539,8 +4539,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="crayon shin-chan 4 - ora no itazura daihenshin (japan).bin" size="131072" crc="37d4aa8c" sha1="b5bb01ad7e25e9e83c564ccf604a59f8930cd0d5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="crayon shin-chan 4 - ora no itazura daihenshin (japan).bin" size="0x20000" crc="37d4aa8c" sha1="b5bb01ad7e25e9e83c564ccf604a59f8930cd0d5" />
 			</dataarea>
 		</part>
 	</software>
@@ -4553,8 +4553,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-cqe-0.u1" size="32768" crc="51300cfd" sha1="6c3ba1e407ff378dc004ac58d6a16180bd76a1b3" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-cqe-0.u1" size="0x8000" crc="51300cfd" sha1="6c3ba1e407ff378dc004ac58d6a16180bd76a1b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -4568,8 +4568,8 @@ license:CC0
 		<info name="alt_title" value="カルトジャンプ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="cult jump (japan).bin" size="262144" crc="943059ba" sha1="6a67820ef648d2e24c1212079f5cac43e04cf0bf" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="cult jump (japan).bin" size="0x40000" crc="943059ba" sha1="6a67820ef648d2e24c1212079f5cac43e04cf0bf" />
 			</dataarea>
 		</part>
 	</software>
@@ -4583,8 +4583,8 @@ license:CC0
 		<info name="alt_title" value="カルトマスターウルトラマンに魅せられて" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="cult master - ultraman ni miserarete (japan).bin" size="262144" crc="c3eb82ef" sha1="f0e63a0a4e7b576c7460e810eb6f50d4c5b68769" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="cult master - ultraman ni miserarete (japan).bin" size="0x40000" crc="c3eb82ef" sha1="f0e63a0a4e7b576c7460e810eb6f50d4c5b68769" />
 			</dataarea>
 		</part>
 	</software>
@@ -4599,8 +4599,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ac8p-0.u1" size="262144" crc="eebdd360" sha1="5e99ea51b383cdcd53874eb027ebd59d2a3156b9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ac8p-0.u1" size="0x40000" crc="eebdd360" sha1="5e99ea51b383cdcd53874eb027ebd59d2a3156b9" />
 			</dataarea>
 		</part>
 	</software>
@@ -4612,8 +4612,8 @@ license:CC0
 		<info name="serial" value="DMG-WR-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="cyraid (usa).bin" size="65536" crc="9d00da55" sha1="e295fce5531be0df7f5a10628608e0dcf54da71b" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="cyraid (usa).bin" size="0x10000" crc="9d00da55" sha1="e295fce5531be0df7f5a10628608e0dcf54da71b" />
 			</dataarea>
 		</part>
 	</software>
@@ -4624,8 +4624,8 @@ license:CC0
 		<publisher>Vic Tokai</publisher>
 		<info name="serial" value="DMG-PU-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="daedalian opus (usa).bin" size="32768" crc="b6b51fce" sha1="7a9294de582f7d3ffd8d14a786774c56af7ce7bc" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="daedalian opus (usa).bin" size="0x8000" crc="b6b51fce" sha1="7a9294de582f7d3ffd8d14a786774c56af7ce7bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -4641,8 +4641,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-yse-0.u1" size="262144" crc="c47671f3" sha1="75b384222d07947baed2213c288385c4b91e1911" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-yse-0.u1" size="0x40000" crc="c47671f3" sha1="75b384222d07947baed2213c288385c4b91e1911" />
 			</dataarea>
 		</part>
 	</software>
@@ -4657,8 +4657,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="daffy duck - the marvin missions (japan).bin" size="262144" crc="798d9489" sha1="65f063906680e65d8786e698bd51674268d7ae68" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="daffy duck - the marvin missions (japan).bin" size="0x40000" crc="798d9489" sha1="65f063906680e65d8786e698bd51674268d7ae68" />
 			</dataarea>
 		</part>
 	</software>
@@ -4674,8 +4674,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ysx-0.u1" size="131072" crc="13dd647d" sha1="344c3409410fe5f88796aafd125c522319b78012" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ysx-0.u1" size="0x20000" crc="13dd647d" sha1="344c3409410fe5f88796aafd125c522319b78012" />
 			</dataarea>
 		</part>
 	</software>
@@ -4696,10 +4696,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ag2j-0.u1" size="524288" crc="df8b2b20" sha1="0baa751363c05f9830656f98e77902d543822656" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ag2j-0.u1" size="0x80000" crc="df8b2b20" sha1="0baa751363c05f9830656f98e77902d543822656" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -4725,10 +4725,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_huc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-amzj-0.u1" size="524288" crc="26d2d5c2" sha1="44cafcb56f470881b67e57c0649afbc638cda136" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-amzj-0.u1" size="0x80000" crc="26d2d5c2" sha1="44cafcb56f470881b67e57c0649afbc638cda136" />
 			</dataarea>
-			<dataarea name="ram" size="32768">
+			<dataarea name="ram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -4750,8 +4750,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-dij-0.u1" size="262144" crc="9e0d2b45" sha1="90574cc899210515e83dec714eb4d69416dcf3a3" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-dij-0.u1" size="0x40000" crc="9e0d2b45" sha1="90574cc899210515e83dec714eb4d69416dcf3a3" />
 			</dataarea>
 		</part>
 	</software>
@@ -4768,8 +4768,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-d9j-0.u1" size="262144" crc="70819e03" sha1="0c68250aadca89027b05659122c89682ff833298" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-d9j-0.u1" size="0x40000" crc="70819e03" sha1="0c68250aadca89027b05659122c89682ff833298" />
 			</dataarea>
 		</part>
 	</software>
@@ -4788,10 +4788,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-hdj-0.u1" size="131072" crc="c8f80d90" sha1="79e724619d21ebb3cd5de5438535a7ee25009de0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-hdj-0.u1" size="0x20000" crc="c8f80d90" sha1="79e724619d21ebb3cd5de5438535a7ee25009de0" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -4804,8 +4804,8 @@ license:CC0
 		<info name="alt_title" value="弾丸GB" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dangan.bin" size="262144" crc="5359d6db" sha1="10029774046dabec2d8c0533caf94091f6e19071" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dangan.bin" size="0x40000" crc="5359d6db" sha1="10029774046dabec2d8c0533caf94091f6e19071" />
 			</dataarea>
 		</part>
 	</software>
@@ -4817,8 +4817,8 @@ license:CC0
 		<info name="serial" value="DMG-DN-USA, DMG-DN-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="darkman (usa).bin" size="131072" crc="ff858da9" sha1="f168733ddf4f083559e52198a503e4f295fabf0d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="darkman (usa).bin" size="0x20000" crc="ff858da9" sha1="f168733ddf4f083559e52198a503e4f295fabf0d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4833,8 +4833,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" /> <!-- Also found with [DMG MBC1-B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-dcx-0.u1" size="131072" crc="be975b4f" sha1="4e51919597aa72dd32182f9afee34f148036655f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-dcx-0.u1" size="0x20000" crc="be975b4f" sha1="4e51919597aa72dd32182f9afee34f148036655f" />
 			</dataarea>
 		</part>
 	</software>
@@ -4849,8 +4849,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-dcd-0.u1" size="131072" crc="176c1fa2" sha1="5960dc01e06f19e166646504bc3097248f4a22cb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-dcd-0.u1" size="0x20000" crc="176c1fa2" sha1="5960dc01e06f19e166646504bc3097248f4a22cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -4862,8 +4862,8 @@ license:CC0
 		<info name="serial" value="DMG-DC-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="darkwing.bin" size="131072" crc="a1d4c544" sha1="3d4b301aab995bdf19b15ed5040df7426a2e8057" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="darkwing.bin" size="0x20000" crc="a1d4c544" sha1="3d4b301aab995bdf19b15ed5040df7426a2e8057" />
 			</dataarea>
 		</part>
 	</software>
@@ -4874,8 +4874,8 @@ license:CC0
 		<publisher>Capcom</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dwd-24.u1" size="131072" crc="311ade03" sha1="2883b8854529369cce4d473e71fa0193c7df02b6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dwd-24.u1" size="0x20000" crc="311ade03" sha1="2883b8854529369cce4d473e71fa0193c7df02b6" />
 			</dataarea>
 		</part>
 	</software>
@@ -4890,8 +4890,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-dce-0.u1" size="131072" crc="238b9646" sha1="cc1f12f3ec3852657a14d11c13d1ef91fbdda5bb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-dce-0.u1" size="0x20000" crc="238b9646" sha1="cc1f12f3ec3852657a14d11c13d1ef91fbdda5bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -4903,8 +4903,8 @@ license:CC0
 		<info name="serial" value="DMG-TH-USA, DMG-TH-NOE, DMG-TH-ASI" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="days of thunder (usa, europe).bin" size="131072" crc="35d9be0e" sha1="1bf54293a332fd822911218dcc4a94fcda949ccf" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="days of thunder (usa, europe).bin" size="0x20000" crc="35d9be0e" sha1="1bf54293a332fd822911218dcc4a94fcda949ccf" />
 			</dataarea>
 		</part>
 	</software>
@@ -4918,8 +4918,8 @@ license:CC0
 		<info name="alt_title" value="デッドヒート スクランブル" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dead heat scramble (japan).bin" size="65536" crc="a8301bdd" sha1="395c0c80ad5c9a24c00d6d8dfe5894e73e672639" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dead heat scramble (japan).bin" size="0x10000" crc="a8301bdd" sha1="395c0c80ad5c9a24c00d6d8dfe5894e73e672639" />
 			</dataarea>
 		</part>
 	</software>
@@ -4931,8 +4931,8 @@ license:CC0
 		<info name="serial" value="DMG-DH-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dead heat scramble (usa).bin" size="65536" crc="9e3e3656" sha1="71e560dd2b5f5c4f4dcca0837c74bb1b843a15aa" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dead heat scramble (usa).bin" size="0x10000" crc="9e3e3656" sha1="71e560dd2b5f5c4f4dcca0837c74bb1b843a15aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -4943,8 +4943,8 @@ license:CC0
 		<publisher>Catskull Electronics</publisher>
 		<info name="release" value="20191127" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="deathplanet.bin" size="32768" crc="956d9497" sha1="70c711f073c73f237ca5937e7ac5dc86200bcae5" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="deathplanet.bin" size="0x8000" crc="956d9497" sha1="70c711f073c73f237ca5937e7ac5dc86200bcae5" />
 			</dataarea>
 		</part>
 	</software>
@@ -4955,8 +4955,8 @@ license:CC0
 		<publisher>Argonaut Software</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="death track (prototype).bin" size="131072" crc="6ca1c78e" sha1="2b5547522d34bc1c63d853fcf6e833c720bae80a" /> <!-- Trimmed from 512K overdump that repeats 4x -->
+			<dataarea name="rom" size="0x20000">
+				<rom name="death track (prototype).bin" size="0x20000" crc="6ca1c78e" sha1="2b5547522d34bc1c63d853fcf6e833c720bae80a" /> <!-- Trimmed from 512K overdump that repeats 4x -->
 			</dataarea>
 		</part>
 	</software>
@@ -4968,8 +4968,8 @@ license:CC0
 		<info name="serial" value="DMG-YD-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dennis (europe).bin" size="131072" crc="896a30a8" sha1="9b5c289f25829534020951f84732177036837aea" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dennis (europe).bin" size="0x20000" crc="896a30a8" sha1="9b5c289f25829534020951f84732177036837aea" />
 			</dataarea>
 		</part>
 	</software>
@@ -4980,8 +4980,8 @@ license:CC0
 		<publisher>Ocean</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dennis.bin" size="131072" crc="807d34a4" sha1="fab382a28f9d7fefae7dc9a16bf86f309d89e037" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dennis.bin" size="0x20000" crc="807d34a4" sha1="fab382a28f9d7fefae7dc9a16bf86f309d89e037" />
 			</dataarea>
 		</part>
 	</software>
@@ -4995,8 +4995,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-yde-0.u1" size="131072" crc="7eb0cd32" sha1="4695b50738add92926dc5d4b48568b037df7cdb9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-yde-0.u1" size="0x20000" crc="7eb0cd32" sha1="4695b50738add92926dc5d4b48568b037df7cdb9" />
 			</dataarea>
 		</part>
 	</software>
@@ -5012,8 +5012,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-adsp-0.u1" size="262144" crc="b700f7f7" sha1="b49bc8f5d292f0e2b71957c8c4af37b20cfead80" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-adsp-0.u1" size="0x40000" crc="b700f7f7" sha1="b49bc8f5d292f0e2b71957c8c4af37b20cfead80" />
 			</dataarea>
 		</part>
 	</software>
@@ -5026,8 +5026,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="desert strike - return to the gulf (usa).bin" size="262144" crc="6a702c32" sha1="325ee739ecf5aa403741e8dad36abcfa441dd26b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="desert strike - return to the gulf (usa).bin" size="0x40000" crc="6a702c32" sha1="325ee739ecf5aa403741e8dad36abcfa441dd26b" />
 			</dataarea>
 		</part>
 	</software>
@@ -5042,8 +5042,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-fue-0.u1" size="65536" crc="659e2283" sha1="85f0a9ff87ece93097a855d238bc6c7014893c08" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-fue-0.u1" size="0x10000" crc="659e2283" sha1="85f0a9ff87ece93097a855d238bc6c7014893c08" />
 			</dataarea>
 		</part>
 	</software>
@@ -5054,8 +5054,8 @@ license:CC0
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="diablo (usa) (proto).bin" size="131072" crc="aaaad0b6" sha1="8982410ac627618628a8b823c0608cc8b5653f41" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="diablo (usa) (proto).bin" size="0x20000" crc="aaaad0b6" sha1="8982410ac627618628a8b823c0608cc8b5653f41" />
 			</dataarea>
 		</part>
 	</software>
@@ -5067,8 +5067,8 @@ license:CC0
 		<info name="serial" value="DMG-DK-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dick tracy (usa).bin" size="131072" crc="a308b86b" sha1="906361b2066c2b48500b9b709f7b4ed1018309c0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dick tracy (usa).bin" size="0x20000" crc="a308b86b" sha1="906361b2066c2b48500b9b709f7b4ed1018309c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -5080,8 +5080,8 @@ license:CC0
 		<info name="serial" value="DMG-DY-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dig dug (europe).bin" size="131072" crc="0af905c0" sha1="9e008ee24c627309b22bf42ec5a3e08af0af8efe" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dig dug (europe).bin" size="0x20000" crc="0af905c0" sha1="9e008ee24c627309b22bf42ec5a3e08af0af8efe" />
 			</dataarea>
 		</part>
 	</software>
@@ -5093,8 +5093,8 @@ license:CC0
 		<info name="serial" value="DMG-DY-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dig dug (usa).bin" size="131072" crc="6c742478" sha1="951753904389332412d4b0a80b48d7ac61a494fc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dig dug (usa).bin" size="0x20000" crc="6c742478" sha1="951753904389332412d4b0a80b48d7ac61a494fc" />
 			</dataarea>
 		</part>
 	</software>
@@ -5114,10 +5114,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-awdj-1.u1" size="262144" crc="5b289ab4" sha1="a6e24e442de0541c3f5ec4d28650256c5d25f751" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-awdj-1.u1" size="0x40000" crc="5b289ab4" sha1="a6e24e442de0541c3f5ec4d28650256c5d25f751" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5137,10 +5137,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-awdj-0.u1" size="262144" crc="3f0aafec" sha1="80ccbf87dcd4d4e76f1f6a7a94e00ec2857e530a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-awdj-0.u1" size="0x40000" crc="3f0aafec" sha1="80ccbf87dcd4d4e76f1f6a7a94e00ec2857e530a" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5161,10 +5161,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a2dj-0.u1" size="524288" crc="05a3ab7a" sha1="ac4b1fe0e917298d81725d7a9bdf46c285502ac7" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a2dj-0.u1" size="0x80000" crc="05a3ab7a" sha1="ac4b1fe0e917298d81725d7a9bdf46c285502ac7" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5178,8 +5178,8 @@ license:CC0
 		<info name="alt_title" value="ダーティ・レーシング" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dirty racing (japan).bin" size="131072" crc="43af45b1" sha1="5b58b4d02987ce3a16774bc4a6707d12ac404c1c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dirty racing (japan).bin" size="0x20000" crc="43af45b1" sha1="5b58b4d02987ce3a16774bc4a6707d12ac404c1c" />
 			</dataarea>
 		</part>
 	</software>
@@ -5193,8 +5193,8 @@ license:CC0
 		<info name="alt_title" value="ドッジボーイ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dodge boy (japan).bin" size="131072" crc="f58dc358" sha1="b48eb2bdc34588847728936491dadda67394f9b7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dodge boy (japan).bin" size="0x20000" crc="f58dc358" sha1="b48eb2bdc34588847728936491dadda67394f9b7" />
 			</dataarea>
 		</part>
 	</software>
@@ -5216,10 +5216,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-qda-1.u1" size="524288" crc="f777a5d8" sha1="397ad2ff25627b83e02c71b54c72bb4deb39e0c0" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-qda-1.u1" size="0x80000" crc="f777a5d8" sha1="397ad2ff25627b83e02c71b54c72bb4deb39e0c0" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5235,10 +5235,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="donkey kong (world).bin" size="524288" crc="edab3378" sha1="6ed661bd1d6d8cdd48e1c10f8ca4e8dcba49128e" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="donkey kong (world).bin" size="0x80000" crc="edab3378" sha1="6ed661bd1d6d8cdd48e1c10f8ca4e8dcba49128e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5260,10 +5260,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-addj-0.u1" size="524288" crc="9aeca05c" sha1="18fd3fcf90e60122da92079669942b0363049d8f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-addj-0.u1" size="0x80000" crc="9aeca05c" sha1="18fd3fcf90e60122da92079669942b0363049d8f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5282,10 +5282,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" /> <!-- Also found with [6129A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-yte-0.u1" size="524288" crc="49dc0d37" sha1="4e6d8f085ca197479d59912c1d58e4f3b40c28ac" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-yte-0.u1" size="0x80000" crc="49dc0d37" sha1="4e6d8f085ca197479d59912c1d58e4f3b40c28ac" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5304,11 +5304,11 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" /> <!-- Also found with [6129A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
+			<dataarea name="rom" size="0x80000">
 				<!-- DMG-ADDP-0 on European cart -->
-				<rom name="dmg-adde-0.u1" size="524288" crc="2827e5d4" sha1="89cc4f01653a6105ee5c00e10fc65aa1437fd320" />
+				<rom name="dmg-adde-0.u1" size="0x80000" crc="2827e5d4" sha1="89cc4f01653a6105ee5c00e10fc65aa1437fd320" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5327,10 +5327,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [6735]" /> <!-- Also found with [26A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ad3p-1.u1" size="524288" crc="a19acdb6" sha1="a6ce883727212e1afb45b48431a46cfbc6f7f6ef" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ad3p-1.u1" size="0x80000" crc="a19acdb6" sha1="a6ce883727212e1afb45b48431a46cfbc6f7f6ef" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5349,10 +5349,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ad3p-0.u1" size="524288" crc="b40c159c" sha1="a33f10194b5b228863c04abd0e65c7cc5d73fc3e" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ad3p-0.u1" size="0x80000" crc="b40c159c" sha1="a33f10194b5b228863c04abd0e65c7cc5d73fc3e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5364,10 +5364,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="donkeykongland.bin" size="524288" crc="872bbd5e" sha1="9d17bc07bd3c48f8bb8a3315faf817d055417f53" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="donkeykongland.bin" size="0x80000" crc="872bbd5e" sha1="9d17bc07bd3c48f8bb8a3315faf817d055417f53" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5384,8 +5384,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-dej-0.u1" size="131072" crc="a42524a3" sha1="5e89e34a2cec89e0aba4e12d18d96671151730ec" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-dej-0.u1" size="0x20000" crc="a42524a3" sha1="5e89e34a2cec89e0aba4e12d18d96671151730ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -5402,8 +5402,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-dmj-0.u1" size="131072" crc="843bd5bc" sha1="0d72e0310bbf0b23483f37688df61543048c4b31" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-dmj-0.u1" size="0x20000" crc="843bd5bc" sha1="0d72e0310bbf0b23483f37688df61543048c4b31" />
 			</dataarea>
 		</part>
 	</software>
@@ -5424,10 +5424,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-adrj-0.u1" size="262144" crc="dd4e588f" sha1="f19734b2cb19de0be2d9e80297f567806ce4cad5" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-adrj-0.u1" size="0x40000" crc="dd4e588f" sha1="f19734b2cb19de0be2d9e80297f567806ce4cad5" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5443,10 +5443,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="doraemon no game boy de asobouyo deluxe 10 (japan).bin" size="262144" crc="b368e717" sha1="7ad70061c8afbbe0890e3d50accd40b2a8cb9790" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="doraemon no game boy de asobouyo deluxe 10 (japan).bin" size="0x40000" crc="b368e717" sha1="7ad70061c8afbbe0890e3d50accd40b2a8cb9790" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5463,8 +5463,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aikj-0.u1" size="524288" crc="652b3ca4" sha1="7be5e001f60338fd605cb3cd918df66a9ebf2ad2" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aikj-0.u1" size="0x80000" crc="652b3ca4" sha1="7be5e001f60338fd605cb3cd918df66a9ebf2ad2" />
 			</dataarea>
 		</part>
 	</software>
@@ -5481,8 +5481,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aisj-0.u1" size="524288" crc="5333d083" sha1="38b9fafd4604bd69a59f0445508f15bfbba459c6" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aisj-0.u1" size="0x80000" crc="5333d083" sha1="38b9fafd4604bd69a59f0445508f15bfbba459c6" />
 			</dataarea>
 		</part>
 	</software>
@@ -5499,8 +5499,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-akkj-0.u1" size="524288" crc="0356a509" sha1="7fdd0855dce2c5bbd229c2ba8485a3a020b873a1" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-akkj-0.u1" size="0x80000" crc="0356a509" sha1="7fdd0855dce2c5bbd229c2ba8485a3a020b873a1" />
 			</dataarea>
 		</part>
 	</software>
@@ -5513,8 +5513,8 @@ license:CC0
 		<info name="alt_title" value="ドラえもんのスタディボーイ4 小二国語・かん字" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="doraemon no study boy 4 - shou ni kokugo kanji (japan).bin" size="524288" crc="45e3e8f2" sha1="996a57958c9971070cf881f475cfa815361409c4" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="doraemon no study boy 4 - shou ni kokugo kanji (japan).bin" size="0x80000" crc="45e3e8f2" sha1="996a57958c9971070cf881f475cfa815361409c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -5531,8 +5531,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-anbj-0.u1" size="524288" crc="6b39f607" sha1="8bc5692de1850b68767bee01fe4506455aac8cc6" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-anbj-0.u1" size="0x80000" crc="6b39f607" sha1="8bc5692de1850b68767bee01fe4506455aac8cc6" />
 			</dataarea>
 		</part>
 	</software>
@@ -5549,8 +5549,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-aknj-0.u1" size="1048576" crc="5a16c88d" sha1="1bfbd1aa188cfa1a2168b5e245b87bd67090d810" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-aknj-0.u1" size="0x100000" crc="5a16c88d" sha1="1bfbd1aa188cfa1a2168b5e245b87bd67090d810" />
 			</dataarea>
 		</part>
 	</software>
@@ -5564,8 +5564,8 @@ license:CC0
 		<info name="alt_title" value="双截龍" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="double dragon (japan).bin" size="131072" crc="a0645e8a" sha1="7dccd7d3ca7223815e7b00a3b664f5e7d7d433b2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="double dragon (japan).bin" size="0x20000" crc="a0645e8a" sha1="7dccd7d3ca7223815e7b00a3b664f5e7d7d433b2" />
 			</dataarea>
 		</part>
 	</software>
@@ -5580,8 +5580,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-dde-0.u1" size="131072" crc="40a8bf12" sha1="6565a3d89827717d8e5d2e041c743266ba14b412" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-dde-0.u1" size="0x20000" crc="40a8bf12" sha1="6565a3d89827717d8e5d2e041c743266ba14b412" />
 			</dataarea>
 		</part>
 	</software>
@@ -5597,8 +5597,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-dxe-0.u1" size="131072" crc="fc970aef" sha1="c596d069d9fbd6372757e5d669a5144e2eb9d8ff" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-dxe-0.u1" size="0x20000" crc="fc970aef" sha1="c596d069d9fbd6372757e5d669a5144e2eb9d8ff" />
 			</dataarea>
 		</part>
 	</software>
@@ -5613,8 +5613,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-d2e-0.u1" size="131072" crc="5b96e474" sha1="3532462be3ab1a569890261d20a1a37bfe79e1ea" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-d2e-0.u1" size="0x20000" crc="5b96e474" sha1="3532462be3ab1a569890261d20a1a37bfe79e1ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -5626,8 +5626,8 @@ license:CC0
 		<info name="serial" value="DMG-DW-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="double dribble - 5 on 5 (usa).bin" size="131072" crc="ee28749d" sha1="d0f18c97b48dd8b355d195d2ddaeee910c5fc2b1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="double dribble - 5 on 5 (usa).bin" size="0x20000" crc="ee28749d" sha1="d0f18c97b48dd8b355d195d2ddaeee910c5fc2b1" />
 			</dataarea>
 		</part>
 	</software>
@@ -5641,8 +5641,8 @@ license:CC0
 		<info name="alt_title" value="ダブル役満" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="double yakuman (japan).bin" size="131072" crc="252c32b5" sha1="24dd6ba6a82ca3e6aca44aa471cf03d08371dc80" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="double yakuman (japan).bin" size="0x20000" crc="252c32b5" sha1="24dd6ba6a82ca3e6aca44aa471cf03d08371dc80" />
 			</dataarea>
 		</part>
 	</software>
@@ -5656,8 +5656,8 @@ license:CC0
 		<info name="alt_title" value="ダブル役満II" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="double yakuman ii (japan).bin" size="131072" crc="a3d77a55" sha1="7f6ed21bf0cce0d524dcbce56af5cab61c85d729" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="double yakuman ii (japan).bin" size="0x20000" crc="a3d77a55" sha1="7f6ed21bf0cce0d524dcbce56af5cab61c85d729" />
 			</dataarea>
 		</part>
 	</software>
@@ -5671,8 +5671,8 @@ license:CC0
 		<info name="alt_title" value="ダブル役満Jr." />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="double yakuman junior (japan).bin" size="131072" crc="34ac7268" sha1="7d72bc65297f21605521f7320a5b49193e584cd0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="double yakuman junior (japan).bin" size="0x20000" crc="34ac7268" sha1="7d72bc65297f21605521f7320a5b49193e584cd0" />
 			</dataarea>
 		</part>
 	</software>
@@ -5686,8 +5686,8 @@ license:CC0
 		<info name="alt_title" value="ダウンタウン熱血行進曲 どこでも大運動会" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="downtown - nekketsu koushinkyoku - dokodemo daiundoukai (japan).bin" size="262144" crc="82511a8f" sha1="1b8f59467ddce14db359e22567e29f6955c7c92a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="downtown - nekketsu koushinkyoku - dokodemo daiundoukai (japan).bin" size="0x40000" crc="82511a8f" sha1="1b8f59467ddce14db359e22567e29f6955c7c92a" />
 			</dataarea>
 		</part>
 	</software>
@@ -5699,8 +5699,8 @@ license:CC0
 		<info name="serial" value="DMG-FN-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dr. franken (europe) (en,fr,de,es,it,nl,sv).bin" size="262144" crc="f13a60b8" sha1="ba5aaac92c4a2ca2d6a752c521e4d95108444a4e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dr. franken (europe) (en,fr,de,es,it,nl,sv).bin" size="0x40000" crc="f13a60b8" sha1="ba5aaac92c4a2ca2d6a752c521e4d95108444a4e" />
 			</dataarea>
 		</part>
 	</software>
@@ -5711,8 +5711,8 @@ license:CC0
 		<publisher>Elite</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dr. franken.bin" size="262144" crc="a65adc31" sha1="440eb30e54bf257246923149d44bab3dfafed2aa" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dr. franken.bin" size="0x40000" crc="a65adc31" sha1="440eb30e54bf257246923149d44bab3dfafed2aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -5726,8 +5726,8 @@ license:CC0
 		<info name="alt_title" value="ドクターフランケン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dr. franken (japan).bin" size="131072" crc="3d04b8e7" sha1="6350ec30e51f388e0e290f387989cb1c7a24a91c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dr. franken (japan).bin" size="0x20000" crc="3d04b8e7" sha1="6350ec30e51f388e0e290f387989cb1c7a24a91c" />
 			</dataarea>
 		</part>
 	</software>
@@ -5739,8 +5739,8 @@ license:CC0
 		<info name="serial" value="DMG-FN-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dr. franken (usa).bin" size="131072" crc="d409375b" sha1="2b136ef8e3dd082ccb4716035545fb2e03438c66" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dr. franken (usa).bin" size="0x20000" crc="d409375b" sha1="2b136ef8e3dd082ccb4716035545fb2e03438c66" />
 			</dataarea>
 		</part>
 	</software>
@@ -5752,8 +5752,8 @@ license:CC0
 		<info name="serial" value="DMG-DJ-USA, DMG-DJ-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dr. franken ii (usa, europe) (en,fr,de,es,it,nl,sv).bin" size="262144" crc="0d62473d" sha1="8d578ce74907131114279854a0dc376f4426120c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dr. franken ii (usa, europe) (en,fr,de,es,it,nl,sv).bin" size="0x40000" crc="0d62473d" sha1="8d578ce74907131114279854a0dc376f4426120c" />
 			</dataarea>
 		</part>
 	</software>
@@ -5769,8 +5769,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-10" /> <!-- Also found with DMG-AAA-03 -->
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-vua-1.u1" size="32768" crc="f0225dd0" sha1="d31d67d0682515c7c85deaa1752b02231150e5bf" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-vua-1.u1" size="0x8000" crc="f0225dd0" sha1="d31d67d0682515c7c85deaa1752b02231150e5bf" />
 			</dataarea>
 		</part>
 	</software>
@@ -5786,8 +5786,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-vua-0.u1" size="32768" crc="10c98dd1" sha1="f1006d6cf77469092f3b9f266d0a65da9c91ac42" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-vua-0.u1" size="0x8000" crc="10c98dd1" sha1="f1006d6cf77469092f3b9f266d0a65da9c91ac42" />
 			</dataarea>
 		</part>
 	</software>
@@ -5797,8 +5797,8 @@ license:CC0
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="drmario.bin" size="32768" crc="2b2f4f8f" sha1="4b2343f40e7ca3c583108ed70a870c7bd906b108" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="drmario.bin" size="0x8000" crc="2b2f4f8f" sha1="4b2343f40e7ca3c583108ed70a870c7bd906b108" />
 			</dataarea>
 		</part>
 	</software>
@@ -5815,8 +5815,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-cvj-0.u1" size="65536" crc="a35b9ef5" sha1="bedeb390391779400de14196d24f07a451184ece" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-cvj-0.u1" size="0x10000" crc="a35b9ef5" sha1="bedeb390391779400de14196d24f07a451184ece" />
 			</dataarea>
 		</part>
 	</software>
@@ -5830,8 +5830,8 @@ license:CC0
 		<info name="alt_title" value="ドラキュラ伝説II" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dracula densetsu ii (japan).bin" size="131072" crc="7582ae14" sha1="bca90edddbf50d0d05630852c092fc5d3e0df9d4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dracula densetsu ii (japan).bin" size="0x20000" crc="7582ae14" sha1="bca90edddbf50d0d05630852c092fc5d3e0df9d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -5846,10 +5846,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dragon ball z - gokuu gekitouden (japan).bin" size="524288" crc="ff3c027d" sha1="1f7a08d2e51e90d770d9dbf4092166b2bfa5697e" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dragon ball z - gokuu gekitouden (japan).bin" size="0x80000" crc="ff3c027d" sha1="1f7a08d2e51e90d770d9dbf4092166b2bfa5697e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5864,10 +5864,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dragon ball z - gokuu hishouden (japan).bin" size="262144" crc="38da46d7" sha1="6bf8f3400bf323edecc2152c4a86f6b0cae628fe" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dragon ball z - gokuu hishouden (japan).bin" size="0x40000" crc="38da46d7" sha1="6bf8f3400bf323edecc2152c4a86f6b0cae628fe" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5882,10 +5882,10 @@ license:CC0
 		<info name="alt_title" value="ドラゴンスレイヤー外伝 眠りの王冠" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dragon slayer - nemuri no oukan (japan).bin" size="131072" crc="10dcbdc3" sha1="ef58063d896533398288a4f07245f23efa3aee4a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dragon slayer - nemuri no oukan (japan).bin" size="0x20000" crc="10dcbdc3" sha1="ef58063d896533398288a4f07245f23efa3aee4a" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -5899,8 +5899,8 @@ license:CC0
 		<info name="release" value="19900812" />
 		<info name="alt_title" value="ドラゴンスレイヤーI" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="dragon slayer i (japan).bin" size="32768" crc="308a2465" sha1="7d987446f67d8bee42482a4932d0fa60318238e4" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dragon slayer i (japan).bin" size="0x8000" crc="308a2465" sha1="7d987446f67d8bee42482a4932d0fa60318238e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -5914,8 +5914,8 @@ license:CC0
 		<info name="alt_title" value="ドラゴンテール" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dragon tail (japan).bin" size="131072" crc="1d1155af" sha1="390addf6bb52452dc6370eb54c702972e51968a2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dragon tail (japan).bin" size="0x20000" crc="1d1155af" sha1="390addf6bb52452dc6370eb54c702972e51968a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -5929,8 +5929,8 @@ license:CC0
 		<info name="alt_title" value="ドラゴンズ・レア" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dragon's lair (japan).bin" size="131072" crc="73c994a0" sha1="e344b536e3edcf1628d09773f694e14ab2864b7a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dragon's lair (japan).bin" size="0x20000" crc="73c994a0" sha1="e344b536e3edcf1628d09773f694e14ab2864b7a" />
 			</dataarea>
 		</part>
 	</software>
@@ -5942,8 +5942,8 @@ license:CC0
 		<info name="serial" value="DMG-DL-FAH" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dragon's lair - the legend (europe).bin" size="131072" crc="00a14889" sha1="babc3c70d5b73df268cd5c9e5e841fe277b57003" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dragon's lair - the legend (europe).bin" size="0x20000" crc="00a14889" sha1="babc3c70d5b73df268cd5c9e5e841fe277b57003" />
 			</dataarea>
 		</part>
 	</software>
@@ -5955,8 +5955,8 @@ license:CC0
 		<info name="serial" value="DMG-DL-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dragon's lair - the legend (usa).bin" size="131072" crc="7a38b5c3" sha1="4e947908fde7ef9892c59021c6eea0607771f6d2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dragon's lair - the legend (usa).bin" size="0x20000" crc="7a38b5c3" sha1="4e947908fde7ef9892c59021c6eea0607771f6d2" />
 			</dataarea>
 		</part>
 	</software>
@@ -5967,8 +5967,8 @@ license:CC0
 		<publisher>Acclaim Entertainment</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dragonheart (france).bin" size="524288" crc="8d089356" sha1="6b01e78df8a7dc3fb171d488cae38501fce3b660" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dragonheart (france).bin" size="0x80000" crc="8d089356" sha1="6b01e78df8a7dc3fb171d488cae38501fce3b660" />
 			</dataarea>
 		</part>
 	</software>
@@ -5983,8 +5983,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-adhp-0.u1" size="524288" crc="5129a518" sha1="1800ceeba6ed491e5f85997c945ab52b09f6e4ba" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-adhp-0.u1" size="0x80000" crc="5129a518" sha1="1800ceeba6ed491e5f85997c945ab52b09f6e4ba" />
 			</dataarea>
 		</part>
 	</software>
@@ -5995,8 +5995,8 @@ license:CC0
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="DMG-AD4P-EUR" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="dropzone (europe).bin" size="32768" crc="351a7277" sha1="0bf73ffa90fdba5a4ee4e2338bb2f0d01af6fb88" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dropzone (europe).bin" size="0x8000" crc="351a7277" sha1="0bf73ffa90fdba5a4ee4e2338bb2f0d01af6fb88" />
 			</dataarea>
 		</part>
 	</software>
@@ -6007,8 +6007,8 @@ license:CC0
 		<publisher>Mindscape</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="32768">
-				<rom name="dropzone.bin" size="32768" crc="19e7d17d" sha1="dbf866f7ec3f7655c846160240c184c5896b2b3e" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dropzone.bin" size="0x8000" crc="19e7d17d" sha1="dbf866f7ec3f7655c846160240c184c5896b2b3e" />
 			</dataarea>
 		</part>
 	</software>
@@ -6018,8 +6018,8 @@ license:CC0
 		<year>1992</year>
 		<publisher>Mindscape</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="131072">
-				<rom name="dropzone (prototype).bin" size="131072" crc="374f80b0" sha1="ac64c854dfea6387f262a2870f85c369d2cd14f5" /> <!-- Is this an overdump or was this really on a 0xFF-padded 128K ROM? -->
+			<dataarea name="rom" size="0x20000">
+				<rom name="dropzone (prototype).bin" size="0x20000" crc="374f80b0" sha1="ac64c854dfea6387f262a2870f85c369d2cd14f5" /> <!-- Is this an overdump or was this really on a 0xFF-padded 128K ROM? -->
 			</dataarea>
 		</part>
 	</software>
@@ -6036,8 +6036,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ada-0.u1" size="131072" crc="f924bdb1" sha1="7701f8c535f612943d736fef342973e9c77011df" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ada-0.u1" size="0x20000" crc="f924bdb1" sha1="7701f8c535f612943d736fef342973e9c77011df" />
 			</dataarea>
 		</part>
 	</software>
@@ -6052,8 +6052,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" /> <!-- Also found with [DMG MBC1B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-dtx-0.u1" size="65536" crc="ac6483dc" sha1="04aa9c515c2ede8fdf37b29e69c44481f8a8630c" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-dtx-0.u1" size="0x10000" crc="ac6483dc" sha1="04aa9c515c2ede8fdf37b29e69c44481f8a8630c" />
 			</dataarea>
 		</part>
 	</software>
@@ -6067,8 +6067,8 @@ license:CC0
 		<info name="alt_title" value="ダックテールス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="duck tales (japan).bin" size="65536" crc="5b5410f5" sha1="ce734cc3548f1d5a0cb26017b29b714f23d80c0f" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="duck tales (japan).bin" size="0x10000" crc="5b5410f5" sha1="ce734cc3548f1d5a0cb26017b29b714f23d80c0f" />
 			</dataarea>
 		</part>
 	</software>
@@ -6080,8 +6080,8 @@ license:CC0
 		<info name="serial" value="DMG-DT-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="duck tales (usa).bin" size="65536" crc="2bbbb54d" sha1="93460364e33e8fb09a0659738044d0297cd4df69" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="duck tales (usa).bin" size="0x10000" crc="2bbbb54d" sha1="93460364e33e8fb09a0659738044d0297cd4df69" />
 			</dataarea>
 		</part>
 	</software>
@@ -6093,8 +6093,8 @@ license:CC0
 		<info name="serial" value="DMG-D7-(NOE/FAH/UKV)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="duck tales 2 (europe).bin" size="131072" crc="169b00c1" sha1="68113dcd6482a8a54e48c69223fcf2e2dedea844" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="duck tales 2 (europe).bin" size="0x20000" crc="169b00c1" sha1="68113dcd6482a8a54e48c69223fcf2e2dedea844" />
 			</dataarea>
 		</part>
 	</software>
@@ -6108,8 +6108,8 @@ license:CC0
 		<info name="alt_title" value="ダックテイルズ2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="duck tales 2 (japan).bin" size="131072" crc="2b693cde" sha1="d7c33c30e9921d119c4f4c9a77be9406207368eb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="duck tales 2 (japan).bin" size="0x20000" crc="2b693cde" sha1="d7c33c30e9921d119c4f4c9a77be9406207368eb" />
 			</dataarea>
 		</part>
 	</software>
@@ -6121,8 +6121,8 @@ license:CC0
 		<info name="serial" value="DMG-D7-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="duck tales 2 (usa).bin" size="131072" crc="b151509d" sha1="c9d5b7a71badcc7b198897b4888482f663f03504" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="duck tales 2 (usa).bin" size="0x20000" crc="b151509d" sha1="c9d5b7a71badcc7b198897b4888482f663f03504" />
 			</dataarea>
 		</part>
 	</software>
@@ -6142,10 +6142,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-dgj-0.u1" size="131072" crc="11be4b45" sha1="e354b0e78992f66bd598399998790231ff81b86f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-dgj-0.u1" size="0x20000" crc="11be4b45" sha1="e354b0e78992f66bd598399998790231ff81b86f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6156,8 +6156,8 @@ license:CC0
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dungeon warrior (prototype).bin" size="65536" crc="2910429c" sha1="21a6fba83faa7649fbb2e75176649bcd7d846d25" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dungeon warrior (prototype).bin" size="0x10000" crc="2910429c" sha1="21a6fba83faa7649fbb2e75176649bcd7d846d25" />
 			</dataarea>
 		</part>
 	</software>
@@ -6171,10 +6171,10 @@ license:CC0
 		<info name="alt_title" value="DX馬券王Z" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dx bakenou z (japan) (rev 1).bin" size="131072" crc="fadfd0f6" sha1="6e2b9b21ea7d8d482be1f17722a579f720f2029d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dx bakenou z (japan) (rev 1).bin" size="0x20000" crc="fadfd0f6" sha1="6e2b9b21ea7d8d482be1f17722a579f720f2029d" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6188,10 +6188,10 @@ license:CC0
 		<info name="alt_title" value="DX馬券王Z" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dx bakenou z (japan).bin" size="131072" crc="3ef2e823" sha1="346ed92c1f56221d1feda2a008ead2e3940bcbcb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dx bakenou z (japan).bin" size="0x20000" crc="3ef2e823" sha1="346ed92c1f56221d1feda2a008ead2e3940bcbcb" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6206,8 +6206,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-hbx-0.u1" size="131072" crc="9677d157" sha1="3c284831353be165e20b56f3728b0421eaea274a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-hbx-0.u1" size="0x20000" crc="9677d157" sha1="3c284831353be165e20b56f3728b0421eaea274a" />
 			</dataarea>
 		</part>
 	</software>
@@ -6222,8 +6222,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-aejp-0.u1" size="262144" crc="b1a7a008" sha1="4249abe39285b02ccb0e739b5a2cf96ace1281ff" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-aejp-0.u1" size="0x40000" crc="b1a7a008" sha1="4249abe39285b02ccb0e739b5a2cf96ace1281ff" />
 			</dataarea>
 		</part>
 	</software>
@@ -6235,8 +6235,8 @@ license:CC0
 		<info name="serial" value="DMG-AEJE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="earthworm jim (usa).bin" size="262144" crc="259ff267" sha1="f5d3085de17a5181c07739e49be7637faa5ff932" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="earthworm jim (usa).bin" size="0x40000" crc="259ff267" sha1="f5d3085de17a5181c07739e49be7637faa5ff932" />
 			</dataarea>
 		</part>
 	</software>
@@ -6247,8 +6247,8 @@ license:CC0
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="eddies.bin" size="65536" crc="f2600f02" sha1="cd2695295831737d0f8a7eb825bbfe870b9c0bfd" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="eddies.bin" size="0x10000" crc="f2600f02" sha1="cd2695295831737d0f8a7eb825bbfe870b9c0bfd" />
 			</dataarea>
 		</part>
 	</software>
@@ -6261,8 +6261,8 @@ license:CC0
 		<info name="release" value="19910809 " />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="elevator action (japan).bin" size="65536" crc="bead8ae4" sha1="16dbf00df012c1216d9d4abec9abcd5512d053a3" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="elevator action (japan).bin" size="0x10000" crc="bead8ae4" sha1="16dbf00df012c1216d9d4abec9abcd5512d053a3" />
 			</dataarea>
 		</part>
 	</software>
@@ -6283,8 +6283,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-eae-0.u1" size="65536" crc="b749a927" sha1="c0c9de672a31f314e98392160fc343cf46ee98b9" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-eae-0.u1" size="0x10000" crc="b749a927" sha1="c0c9de672a31f314e98392160fc343cf46ee98b9" />
 			</dataarea>
 		</part>
 	</software>
@@ -6297,8 +6297,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="elite soccer (usa).bin" size="131072" crc="f54158a6" sha1="4576881ea25e29ebba91c49c89f8e70e105fbc60" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="elite soccer (usa).bin" size="0x20000" crc="f54158a6" sha1="4576881ea25e29ebba91c49c89f8e70e105fbc60" />
 			</dataarea>
 		</part>
 	</software>
@@ -6314,8 +6314,8 @@ license:CC0
 			<feature name="rom" value="" />
 			<feature name="flipflop" value="[SN74LS377N]" />
 			<feature name="slot" value="rom_wisdom" />
-			<dataarea name="rom" size="131072">
-				<rom name="exodus gameboy ver 1.0.bin" size="131072" crc="2e5497ef" sha1="685d5a47a1fc386d7b451c8b2733e654b7779b71" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="exodus gameboy ver 1.0.bin" size="0x20000" crc="2e5497ef" sha1="685d5a47a1fc386d7b451c8b2733e654b7779b71" />
 			</dataarea>
 		</part>
 	</software>
@@ -6327,8 +6327,8 @@ license:CC0
 		<info name="serial" value="DMG-FS-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="extra bases (usa).bin" size="131072" crc="19608641" sha1="bf44f14a948e8816fb9deea229512d979cb42aec" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="extra bases (usa).bin" size="0x20000" crc="19608641" sha1="bf44f14a948e8816fb9deea229512d979cb42aec" />
 			</dataarea>
 		</part>
 	</software>
@@ -6348,10 +6348,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [6129A]" /> <!-- Also found with [26A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-f1a-1.u1" size="131072" crc="ab83bd70" sha1="0256082f482af57e0472f5713a432a22bfa4d2fc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-f1a-1.u1" size="0x20000" crc="ab83bd70" sha1="0256082f482af57e0472f5713a432a22bfa4d2fc" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6366,10 +6366,10 @@ license:CC0
 		<info name="alt_title" value="F1レース" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="f-1 race (world).bin" size="131072" crc="7e4febdf" sha1="96490be847aeeded0b635f45b05683a6defdf2e8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="f-1 race (world).bin" size="0x20000" crc="7e4febdf" sha1="96490be847aeeded0b635f45b05683a6defdf2e8" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6386,8 +6386,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-fzj-0.u1" size="131072" crc="f9e08783" sha1="4f950151001c2c7e157bc407601d9a8eb9d2523c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-fzj-0.u1" size="0x20000" crc="f9e08783" sha1="4f950151001c2c7e157bc407601d9a8eb9d2523c" />
 			</dataarea>
 		</part>
 	</software>
@@ -6399,8 +6399,8 @@ license:CC0
 		<info name="serial" value="DMG-EG-USA, DMG-EG-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="f-15 strike eagle (usa, europe).bin" size="131072" crc="045dee8c" sha1="237a08abe860bce316f1ce337afb11ee0e566037" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="f-15 strike eagle (usa, europe).bin" size="0x20000" crc="045dee8c" sha1="237a08abe860bce316f1ce337afb11ee0e566037" />
 			</dataarea>
 		</part>
 	</software>
@@ -6414,8 +6414,8 @@ license:CC0
 			<feature name="u1" value="U1" />
 			<feature name="u2" value="U2 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="f-15 strike eagle ii - microprose - july 92.u1" size="131072" crc="d80bdbba" sha1="298c07ef596ab3a3c4a320b2f2d7e2c0dbaf764d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="f-15 strike eagle ii - microprose - july 92.u1" size="0x20000" crc="d80bdbba" sha1="298c07ef596ab3a3c4a320b2f2d7e2c0dbaf764d" />
 			</dataarea>
 		</part>
 	</software>
@@ -6432,8 +6432,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-fbj-0.u1" size="65536" crc="fac1f53b" sha1="632f0ccc2bcb1c33ad46724d7b1bc66b256303a2" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-fbj-0.u1" size="0x10000" crc="fac1f53b" sha1="632f0ccc2bcb1c33ad46724d7b1bc66b256303a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -6446,8 +6446,8 @@ license:CC0
 		<info name="serial" value="DMG-F5-USA, DMG-F5-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="f1 pole position (usa, europe).bin" size="262144" crc="aabe61bb" sha1="a0087bd7421d73e1f8f339a266e62c2d03d081d6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="f1 pole position (usa, europe).bin" size="0x40000" crc="aabe61bb" sha1="a0087bd7421d73e1f8f339a266e62c2d03d081d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -6459,8 +6459,8 @@ license:CC0
 		<info name="serial" value="DMG-FA-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="faceball 2000 (usa).bin" size="131072" crc="7d890cd0" sha1="b0bd15bace04e0a3eb89773f231ac3a532181a0a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="faceball 2000 (usa).bin" size="0x20000" crc="7d890cd0" sha1="b0bd15bace04e0a3eb89773f231ac3a532181a0a" />
 			</dataarea>
 		</part>
 	</software>
@@ -6477,8 +6477,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-fjj-0.u1" size="131072" crc="d6ef1450" sha1="e463999d178489e050504298f4a3ffe30b48494a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-fjj-0.u1" size="0x20000" crc="d6ef1450" sha1="e463999d178489e050504298f4a3ffe30b48494a" />
 			</dataarea>
 		</part>
 	</software>
@@ -6516,10 +6516,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-fvj-0.u1" size="131072" crc="0325e729" sha1="d858fcdfce099435fa632859a9f8e8c82823bbcb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-fvj-0.u1" size="0x20000" crc="0325e729" sha1="d858fcdfce099435fa632859a9f8e8c82823bbcb" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6536,8 +6536,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-fsj-0.u1" size="131072" crc="3d3c059e" sha1="5cb8e63906d32c5408b7f959a75c41578a444c3b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-fsj-0.u1" size="0x20000" crc="3d3c059e" sha1="5cb8e63906d32c5408b7f959a75c41578a444c3b" />
 			</dataarea>
 		</part>
 	</software>
@@ -6554,8 +6554,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-fdj-0.u1" size="131072" crc="241a6e4c" sha1="e6f4ca432c36ec421935e6d4ecfc65c46764bc9c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-fdj-0.u1" size="0x20000" crc="241a6e4c" sha1="e6f4ca432c36ec421935e6d4ecfc65c46764bc9c" />
 			</dataarea>
 		</part>
 	</software>
@@ -6588,10 +6588,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-n3j-0.u1" size="262144" crc="bdc4ccc3" sha1="ac4b03e11e2ba135d0427c8b1da7de57c006b4a6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-n3j-0.u1" size="0x40000" crc="bdc4ccc3" sha1="ac4b03e11e2ba135d0427c8b1da7de57c006b4a6" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6603,10 +6603,10 @@ license:CC0
 		<info name="serial" value="DMG-F2-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-f2e-0.u1" size="131072" crc="a9ba7875" sha1="25bf89b112c9b134b2e4d07354d1a762ab0d4e92" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-f2e-0.u1" size="0x20000" crc="a9ba7875" sha1="25bf89b112c9b134b2e4d07354d1a762ab0d4e92" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6620,10 +6620,10 @@ license:CC0
 		<info name="alt_title" value="ファーステスト・ラップ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="fastest lap (japan, usa).bin" size="131072" crc="59285f0a" sha1="f1abe89a52e4f06e0479277d8681feaa09fcff2f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="fastest lap (japan, usa).bin" size="0x20000" crc="59285f0a" sha1="f1abe89a52e4f06e0479277d8681feaa09fcff2f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6638,8 +6638,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-c6e-0.u1" size="131072" crc="f53f7f00" sha1="c4a0d02d5964335a18839c7c30ac05b6f40c33b3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-c6e-0.u1" size="0x20000" crc="f53f7f00" sha1="c4a0d02d5964335a18839c7c30ac05b6f40c33b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -6650,8 +6650,8 @@ license:CC0
 		<publisher>Hudson Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="felix.bin" size="131072" crc="b1734088" sha1="66fe01233643fb63e758d1f2e9932f63d545e288" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="felix.bin" size="0x20000" crc="b1734088" sha1="66fe01233643fb63e758d1f2e9932f63d545e288" />
 			</dataarea>
 		</part>
 	</software>
@@ -6666,8 +6666,8 @@ license:CC0
 		<info name="alt_title" value="フェラーリ GRAND PRIX CHALLENGE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ferrari (japan).bin" size="131072" crc="a7bdfec8" sha1="f9883af35e5f49736f9dc073ce00f3779e93cf3f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ferrari (japan).bin" size="0x20000" crc="a7bdfec8" sha1="f9883af35e5f49736f9dc073ce00f3779e93cf3f" />
 			</dataarea>
 		</part>
 	</software>
@@ -6679,8 +6679,8 @@ license:CC0
 		<info name="serial" value="DMG-XP-USA, DMG-XP-NOE, DMG-XP-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ferrari grand prix challenge (usa, europe).bin" size="131072" crc="ed6771db" sha1="ecdbe43db8714367bd606127e3276d8a3431841c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ferrari grand prix challenge (usa, europe).bin" size="0x20000" crc="ed6771db" sha1="ecdbe43db8714367bd606127e3276d8a3431841c" />
 			</dataarea>
 		</part>
 	</software>
@@ -6694,8 +6694,8 @@ license:CC0
 		<info name="alt_title" value="フィジェッツ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="fidgetts, the (japan).bin" size="262144" crc="ffd4a9e3" sha1="c701ce4c62c414aada502f8c17aa9261dd635685" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="fidgetts, the (japan).bin" size="0x40000" crc="ffd4a9e3" sha1="c701ce4c62c414aada502f8c17aa9261dd635685" />
 			</dataarea>
 		</part>
 	</software>
@@ -6710,8 +6710,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-f6x-0.u1" size="262144" crc="b3fd3e36" sha1="1100f259fe30857d1103beb116b888497f6fbdaa" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-f6x-0.u1" size="0x40000" crc="b3fd3e36" sha1="1100f259fe30857d1103beb116b888497f6fbdaa" />
 			</dataarea>
 		</part>
 	</software>
@@ -6724,8 +6724,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="fifa international soccer (usa, europe) (en,fr,de,es).bin" size="524288" crc="e5989908" sha1="6f0affdec339d7beb9c565dc51abe59ee0398b7b" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="fifa international soccer (usa, europe) (en,fr,de,es).bin" size="0x80000" crc="e5989908" sha1="6f0affdec339d7beb9c565dc51abe59ee0398b7b" />
 			</dataarea>
 		</part>
 	</software>
@@ -6741,8 +6741,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a8sp-1.u1" size="524288" crc="8dc0d46c" sha1="8dc3ab8f020e4377af1e1f636396cc3881268a1f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a8sp-1.u1" size="0x80000" crc="8dc0d46c" sha1="8dc3ab8f020e4377af1e1f636396cc3881268a1f" />
 			</dataarea>
 		</part>
 	</software>
@@ -6758,8 +6758,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a8sp-0.u1" size="524288" crc="cdf6a5ac" sha1="5ef615a919ea967e749febb046f9d097d91fab0d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a8sp-0.u1" size="0x80000" crc="cdf6a5ac" sha1="5ef615a919ea967e749febb046f9d097d91fab0d" />
 			</dataarea>
 		</part>
 	</software>
@@ -6775,8 +6775,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a6sp-0.u1" size="524288" crc="af4a5de1" sha1="a434f0f96d1aa3ec50d35f82eb5ef876bcd22115" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a6sp-0.u1" size="0x80000" crc="af4a5de1" sha1="a434f0f96d1aa3ec50d35f82eb5ef876bcd22115" />
 			</dataarea>
 		</part>
 	</software>
@@ -6789,8 +6789,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="fifa soccer '97 (usa, europe).bin" size="524288" crc="dcab906c" sha1="dd9b9b99bd663cdf55187ff5867eccd52615f025" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="fifa soccer '97 (usa, europe).bin" size="0x80000" crc="dcab906c" sha1="dd9b9b99bd663cdf55187ff5867eccd52615f025" />
 			</dataarea>
 		</part>
 	</software>
@@ -6805,8 +6805,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-hre-0.u1" size="131072" crc="52678ae8" sha1="9073276d8adf1e59829ae48073b42ae19c9770ce" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-hre-0.u1" size="0x20000" crc="52678ae8" sha1="9073276d8adf1e59829ae48073b42ae19c9770ce" />
 			</dataarea>
 		</part>
 	</software>
@@ -6818,10 +6818,10 @@ license:CC0
 		<info name="serial" value="DMG-FF-USA, DMG-FF-USA-1" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="final fantasy adventure (usa).bin" size="262144" crc="18c78b3a" sha1="8b93c55ee2660c60cf86dd70058f96ace98782c8" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="final fantasy adventure (usa).bin" size="0x40000" crc="18c78b3a" sha1="8b93c55ee2660c60cf86dd70058f96ace98782c8" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6833,10 +6833,10 @@ license:CC0
 		<info name="serial" value="DMG-S2-USA, DMG-S2-USA-1" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="final fantasy legend ii (usa).bin" size="262144" crc="58314182" sha1="6ab6890e8f688bcd87e97886a1748a4d9d341909" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="final fantasy legend ii (usa).bin" size="0x40000" crc="58314182" sha1="6ab6890e8f688bcd87e97886a1748a4d9d341909" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6848,10 +6848,10 @@ license:CC0
 		<info name="serial" value="DMG-OS-USA, DMG-OS-USA-1" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="final fantasy legend iii (usa).bin" size="262144" crc="3e454710" sha1="3864afa48a97db826ffda1d31a7ff9c6c315d5c9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="final fantasy legend iii (usa).bin" size="0x40000" crc="3e454710" sha1="3864afa48a97db826ffda1d31a7ff9c6c315d5c9" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6868,10 +6868,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-sae-0.u1" size="131072" crc="8046148f" sha1="901dfc83c72e172d35a376835807fc788444a9bb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-sae-0.u1" size="0x20000" crc="8046148f" sha1="901dfc83c72e172d35a376835807fc788444a9bb" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6885,8 +6885,8 @@ license:CC0
 		<info name="alt_title" value="ファイナルリバース" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="final reverse (japan).bin" size="65536" crc="e94a6942" sha1="e4b08e702f3b6c575b31dbd62615619126e03af5" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="final reverse (japan).bin" size="0x10000" crc="e94a6942" sha1="e4b08e702f3b6c575b31dbd62615619126e03af5" />
 			</dataarea>
 		</part>
 	</software>
@@ -6898,8 +6898,8 @@ license:CC0
 		<info name="serial" value="DMG-F8-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="fire fighter (europe).bin" size="131072" crc="c46bbd49" sha1="a26a4f0a51fb3aad3f138eedfe326a04af9a1b56" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="fire fighter (europe).bin" size="0x20000" crc="c46bbd49" sha1="a26a4f0a51fb3aad3f138eedfe326a04af9a1b56" />
 			</dataarea>
 		</part>
 	</software>
@@ -6914,8 +6914,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-use-0.u1" size="65536" crc="4b929719" sha1="72d11ae07b6701efe109d20dad6107ff6f603ea5" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-use-0.u1" size="0x10000" crc="4b929719" sha1="72d11ae07b6701efe109d20dad6107ff6f603ea5" />
 			</dataarea>
 		</part>
 	</software>
@@ -6927,8 +6927,8 @@ license:CC0
 		<info name="serial" value="DMG-HK-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="fist of the north star (usa).bin" size="131072" crc="9a84b6cf" sha1="0bf60583da14cd32947f8e8e6b995c2b176d95c5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="fist of the north star (usa).bin" size="0x20000" crc="9a84b6cf" sha1="0bf60583da14cd32947f8e8e6b995c2b176d95c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -6943,8 +6943,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-02" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-v2a-0.u1" size="32768" crc="3b6cdda4" sha1="6517aee7caa2fa60750005ef1dacaeaecee7c2f6" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-v2a-0.u1" size="0x8000" crc="3b6cdda4" sha1="6517aee7caa2fa60750005ef1dacaeaecee7c2f6" />
 			</dataarea>
 		</part>
 	</software>
@@ -6959,8 +6959,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-efe-0.u1" size="131072" crc="6deb1f06" sha1="f7e5701e6fa8fe4440988d1207517668c35088c6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-efe-0.u1" size="0x20000" crc="6deb1f06" sha1="f7e5701e6fa8fe4440988d1207517668c35088c6" />
 			</dataarea>
 		</part>
 	</software>
@@ -6974,10 +6974,10 @@ license:CC0
 		<info name="alt_title" value="フリートコマンダーVS." />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="fleet commander vs. (japan).bin" size="262144" crc="71bf3256" sha1="b858d597e5eea575c5baa953785c96459d9be593" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="fleet commander vs. (japan).bin" size="0x40000" crc="71bf3256" sha1="b858d597e5eea575c5baa953785c96459d9be593" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6989,8 +6989,8 @@ license:CC0
 		<info name="serial" value="DMG-AFNE-USA, DMG-AFNP-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="flintstones, the (usa, europe).bin" size="262144" crc="503d3613" sha1="506a647137bcaad81589f1b3592884b3bbed8aa3" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="flintstones, the (usa, europe).bin" size="0x40000" crc="503d3613" sha1="506a647137bcaad81589f1b3592884b3bbed8aa3" />
 			</dataarea>
 		</part>
 	</software>
@@ -7002,8 +7002,8 @@ license:CC0
 		<info name="serial" value="DMG-FE-USA, DMG-FE-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="flintstones, the - king rock treasure island (usa, europe).bin" size="131072" crc="508282d0" sha1="4ea1609dc273623c677aaa0accd0cd8d4a03efca" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="flintstones, the - king rock treasure island (usa, europe).bin" size="0x20000" crc="508282d0" sha1="4ea1609dc273623c677aaa0accd0cd8d4a03efca" />
 			</dataarea>
 		</part>
 	</software>
@@ -7018,8 +7018,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-02" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-fpa-0.u1" size="32768" crc="198f147d" sha1="090c88ae19892c35608f4fa844a6e9efcbe23893" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-fpa-0.u1" size="0x8000" crc="198f147d" sha1="090c88ae19892c35608f4fa844a6e9efcbe23893" />
 			</dataarea>
 		</part>
 	</software>
@@ -7032,8 +7032,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-02" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-fpe-0.u1" size="32768" crc="a2f30b4b" sha1="54cf45a997d390729dd23b9ed46a967b77cb7664" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-fpe-0.u1" size="0x8000" crc="a2f30b4b" sha1="54cf45a997d390729dd23b9ed46a967b77cb7664" />
 			</dataarea>
 		</part>
 	</software>
@@ -7045,8 +7045,8 @@ license:CC0
 		<info name="serial" value="DMG-GS-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="football international (europe).bin" size="131072" crc="6e659690" sha1="30be5422b15e1960d22dc77d646642d7365b243c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="football international (europe).bin" size="0x20000" crc="6e659690" sha1="30be5422b15e1960d22dc77d646642d7365b243c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7060,8 +7060,8 @@ license:CC0
 		<info name="alt_title" value="フォアマン フォーリアル" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="foreman for real (japan).bin" size="262144" crc="860ea816" sha1="835b3208458e8ca1956e27a693fab036d4b25974" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="foreman for real (japan).bin" size="0x40000" crc="860ea816" sha1="835b3208458e8ca1956e27a693fab036d4b25974" />
 			</dataarea>
 		</part>
 	</software>
@@ -7077,8 +7077,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-afep-0.u1" size="262144" crc="77083ae0" sha1="7b088c7b3a0ad275d340ca27f64a99c1bd6c34e6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-afep-0.u1" size="0x40000" crc="77083ae0" sha1="7b088c7b3a0ad275d340ca27f64a99c1bd6c34e6" />
 			</dataarea>
 		</part>
 	</software>
@@ -7090,8 +7090,8 @@ license:CC0
 		<info name="serial" value="DMG-IY-USA, DMG-IY-(UKV/ESP)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="fortified zone (usa, europe).bin" size="131072" crc="e3b59b7e" sha1="232d2f57ab4bef748eb832dfb4085cc3df1fd532" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="fortified zone (usa, europe).bin" size="0x20000" crc="e3b59b7e" sha1="232d2f57ab4bef748eb832dfb4085cc3df1fd532" />
 			</dataarea>
 		</part>
 	</software>
@@ -7106,8 +7106,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-afkp-0.u1" size="524288" crc="9a494ae6" sha1="ccea5b85ed334a2bf7bd4449f07bbf3a86841dfd" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-afkp-0.u1" size="0x80000" crc="9a494ae6" sha1="ccea5b85ed334a2bf7bd4449f07bbf3a86841dfd" />
 			</dataarea>
 		</part>
 	</software>
@@ -7122,8 +7122,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-e5x-0.u1" size="131072" crc="caf5b372" sha1="b7e292cfd34d64546f158e548afa92efaf8c2acd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-e5x-0.u1" size="0x20000" crc="caf5b372" sha1="b7e292cfd34d64546f158e548afa92efaf8c2acd" />
 			</dataarea>
 		</part>
 	</software>
@@ -7138,8 +7138,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="frisky tom (japan).bin" size="131072" crc="0bef84a1" sha1="4162ca88c94c40e3fa6e09067b956cf4953ccf89" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="frisky tom (japan).bin" size="0x20000" crc="0bef84a1" sha1="4162ca88c94c40e3fa6e09067b956cf4953ccf89" />
 			</dataarea>
 		</part>
 	</software>
@@ -7155,8 +7155,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" /> <!-- Also found with [DMG MBC1-B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-afge-0.u1" size="131072" crc="4d933c08" sha1="1dbb26dd94c9710b029f2f88473aed0267db491c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-afge-0.u1" size="0x20000" crc="4d933c08" sha1="1dbb26dd94c9710b029f2f88473aed0267db491c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7174,8 +7174,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-hxj-0.u1" size="262144" crc="ae478a6f" sha1="0faf2c66a916c979450810ec16029c2258f90f83" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-hxj-0.u1" size="0x40000" crc="ae478a6f" sha1="0faf2c66a916c979450810ec16029c2258f90f83" />
 			</dataarea>
 		</part>
 	</software>
@@ -7190,8 +7190,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="from tv animation slam dunk 2 - zenkoku e no tip off (japan).bin" size="524288" crc="cb35900a" sha1="b8223ce166121ae7224d4431fdf27750c737b3f2" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="from tv animation slam dunk 2 - zenkoku e no tip off (japan).bin" size="0x80000" crc="cb35900a" sha1="b8223ce166121ae7224d4431fdf27750c737b3f2" />
 			</dataarea>
 		</part>
 	</software>
@@ -7205,8 +7205,8 @@ license:CC0
 		<info name="alt_title" value="ファニーフィールド" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="funny field (japan).bin" size="65536" crc="bfd87aa4" sha1="0b74e84ce50454057f78e4178be2599e57c91855" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="funny field (japan).bin" size="0x10000" crc="bfd87aa4" sha1="0b74e84ce50454057f78e4178be2599e57c91855" />
 			</dataarea>
 		</part>
 	</software>
@@ -7220,8 +7220,8 @@ license:CC0
 		<info name="alt_title" value="不思議なブロビー 〜プリンセス・ブロブを救え!〜" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="fushigi na blobby - princess blob o sukue (japan).bin" size="65536" crc="3d0bac10" sha1="fcd6ac8a0ad6eb1f5d9e00c877747521541204de" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="fushigi na blobby - princess blob o sukue (japan).bin" size="0x10000" crc="3d0bac10" sha1="fcd6ac8a0ad6eb1f5d9e00c877747521541204de" />
 			</dataarea>
 		</part>
 	</software>
@@ -7243,10 +7243,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-afdj-0.u1" size="524288" crc="2962afb4" sha1="920ef94c05ac741047a266cb1668c881eab2937c" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-afdj-0.u1" size="0x80000" crc="2962afb4" sha1="920ef94c05ac741047a266cb1668c881eab2937c" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -7261,8 +7261,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="galaga &amp; galaxian (japan).bin" size="131072" crc="532036d5" sha1="2d67a97b4737b24ea0eff7a7c798b7d77e6a0724" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="galaga &amp; galaxian (japan).bin" size="0x20000" crc="532036d5" sha1="2d67a97b4737b24ea0eff7a7c798b7d77e6a0724" />
 			</dataarea>
 		</part>
 	</software>
@@ -7281,10 +7281,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-agap-0.u1" size="262144" crc="96ecc1e0" sha1="31186cff6bb548ecd0c91c07f16dc98de9c19ea2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-agap-0.u1" size="0x40000" crc="96ecc1e0" sha1="31186cff6bb548ecd0c91c07f16dc98de9c19ea2" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7297,10 +7297,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="game &amp; watch gallery (usa) (rev 1).bin" size="262144" crc="9e6cdc96" sha1="4e4da0ed89c2baaed64600f7eaca90aeeadc084e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="game &amp; watch gallery (usa) (rev 1).bin" size="0x40000" crc="9e6cdc96" sha1="4e4da0ed89c2baaed64600f7eaca90aeeadc084e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7313,10 +7313,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="game &amp; watch gallery (usa).bin" size="262144" crc="99b2fe79" sha1="f8c5ad6d6bf1a5a90dffebada1dbd69a93720c83" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="game &amp; watch gallery (usa).bin" size="0x40000" crc="99b2fe79" sha1="f8c5ad6d6bf1a5a90dffebada1dbd69a93720c83" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7326,8 +7326,8 @@ license:CC0
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="game boy controller kensa cartridge (japan).bin" size="32768" crc="f5657fce" sha1="1bed2a9ac25ac2f88b4fc45e729122abcad962f3" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="game boy controller kensa cartridge (japan).bin" size="0x8000" crc="f5657fce" sha1="1bed2a9ac25ac2f88b4fc45e729122abcad962f3" />
 			</dataarea>
 		</part>
 	</software>
@@ -7343,8 +7343,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-agga-0.u1" size="131072" crc="263fd152" sha1="07b6174a413858f84bfc480169945c7fd1a372b9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-agga-0.u1" size="0x20000" crc="263fd152" sha1="07b6174a413858f84bfc480169945c7fd1a372b9" />
 			</dataarea>
 		</part>
 	</software>
@@ -7366,10 +7366,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-agaj-0.u1" size="262144" crc="a93e125b" sha1="9d9465486610ab470203236c614692bc7b86c328" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-agaj-0.u1" size="0x40000" crc="a93e125b" sha1="9d9465486610ab470203236c614692bc7b86c328" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7388,10 +7388,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-agau-0.u1" size="262144" crc="6b09508f" sha1="f002564f9cd9edb704b9c64f889aea3e7836a712" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-agau-0.u1" size="0x40000" crc="6b09508f" sha1="f002564f9cd9edb704b9c64f889aea3e7836a712" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7413,10 +7413,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-agij-0.u1" size="524288" crc="9359a183" sha1="021c47f89fa975e4dc5cc32c61bf87b120a25c09" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-agij-0.u1" size="0x80000" crc="9359a183" sha1="021c47f89fa975e4dc5cc32c61bf87b120a25c09" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7437,10 +7437,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-gwj-0.u1" size="262144" crc="f5d364db" sha1="9f725d3cbbeb5e27b7ee36304f077f78d9ad074e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-gwj-0.u1" size="0x40000" crc="f5d364db" sha1="9f725d3cbbeb5e27b7ee36304f077f78d9ad074e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7462,10 +7462,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-agwj-0.u1" size="524288" crc="94563424" sha1="27121450bee04790e7a0d8a08086ad42302f17e9" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-agwj-0.u1" size="0x80000" crc="94563424" sha1="27121450bee04790e7a0d8a08086ad42302f17e9" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -7477,10 +7477,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="game boy wars turbo - famitsu version (japan).bin" size="262144" crc="86d04bfb" sha1="a0106f20aaf857a7ba033537821e31c6ec074dd6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="game boy wars turbo - famitsu version (japan).bin" size="0x40000" crc="86d04bfb" sha1="a0106f20aaf857a7ba033537821e31c6ec074dd6" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -7501,10 +7501,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ataj-0.u1" size="524288" crc="efc0f266" sha1="5aea023fd373643e55c7276b79a2d042302c3329" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ataj-0.u1" size="0x80000" crc="efc0f266" sha1="5aea023fd373643e55c7276b79a2d042302c3329" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7528,8 +7528,8 @@ license:CC0
 			<feature name="u6" value="U6 TC7S14F [E-A]" />
 			<feature name="u7" value="U7 TC7S04F [E-5]" />
 			<feature name="slot" value="rom_tama5" />
-			<dataarea name="rom" size="524288">
-				<rom name="tama7.u1" size="524288" crc="9694d69d" sha1="e61f7faad888e5a1c56ffe66fa3c0330b5ee459b" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="tama7.u1" size="0x80000" crc="9694d69d" sha1="e61f7faad888e5a1c56ffe66fa3c0330b5ee459b" />
 			</dataarea>
 		</part>
 	</software>
@@ -7550,10 +7550,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-at3j-0.u1" size="524288" crc="19889c43" sha1="ade11f43f6957c75cde8575e7cba11de9e53e0ea" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-at3j-0.u1" size="0x80000" crc="19889c43" sha1="ade11f43f6957c75cde8575e7cba11de9e53e0ea" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7564,8 +7564,8 @@ license:CC0
 		<publisher>Accolade</publisher>
 		<info name="serial" value="DMG-GH-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="game of harmony, the (usa).bin" size="32768" crc="b0074acb" sha1="b0bc752e3ad25fcb83d8ca04a82a0f5e35381db2" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="game of harmony, the (usa).bin" size="0x8000" crc="b0074acb" sha1="b0bc752e3ad25fcb83d8ca04a82a0f5e35381db2" />
 			</dataarea>
 		</part>
 	</software>
@@ -7580,8 +7580,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="gamera - daikaijuu kuuchuu kessen (japan).bin" size="262144" crc="62769ec1" sha1="c6ec7aa3ad2b28ca43551cda3c0cfdbcb4377b45" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="gamera - daikaijuu kuuchuu kessen (japan).bin" size="0x40000" crc="62769ec1" sha1="c6ec7aa3ad2b28ca43551cda3c0cfdbcb4377b45" />
 			</dataarea>
 		</part>
 	</software>
@@ -7596,10 +7596,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="ganbare goemon - kurofunetou no nazo (japan).bin" size="262144" crc="910afe24" sha1="bd336346982e33270128b74a7b356e9e6824e4a6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="ganbare goemon - kurofunetou no nazo (japan).bin" size="0x40000" crc="910afe24" sha1="bd336346982e33270128b74a7b356e9e6824e4a6" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7616,8 +7616,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-gcj-0.u1" size="262144" crc="33261c11" sha1="dd38c2b305160b6bc7e1767a0e7de9850260779c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-gcj-0.u1" size="0x40000" crc="33261c11" sha1="dd38c2b305160b6bc7e1767a0e7de9850260779c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7634,8 +7634,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="u2" size="65536" crc="004443e6" sha1="76be351eac00749553c942b6f8002e65d8a35986" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="u2" size="0x10000" crc="004443e6" sha1="76be351eac00749553c942b6f8002e65d8a35986" />
 			</dataarea>
 		</part>
 	</software>
@@ -7650,8 +7650,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-l4x-0.u1" size="131072" crc="51b8626d" sha1="87913e557dfb98c5f2a0f42ea074c36eca57a4f7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-l4x-0.u1" size="0x20000" crc="51b8626d" sha1="87913e557dfb98c5f2a0f42ea074c36eca57a4f7" />
 			</dataarea>
 		</part>
 	</software>
@@ -7666,8 +7666,8 @@ license:CC0
 		<info name="alt_title" value="Gargoyle's Quest (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-rae-1.u1" size="131072" crc="b86ef7a5" sha1="21fbe39014ffed80d0de2092517522d3cb9b03f9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-rae-1.u1" size="0x20000" crc="b86ef7a5" sha1="21fbe39014ffed80d0de2092517522d3cb9b03f9" />
 			</dataarea>
 		</part>
 	</software>
@@ -7684,8 +7684,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-rae-0.u1" size="131072" crc="0030e61f" sha1="1da5834cd7cea711195cd8581614c5022da768b7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-rae-0.u1" size="0x20000" crc="0030e61f" sha1="1da5834cd7cea711195cd8581614c5022da768b7" />
 			</dataarea>
 		</part>
 	</software>
@@ -7700,8 +7700,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-g2e-0.u1" size="262144" crc="1907dac5" sha1="dc37df322b54a5df5d04bc637e26b011b84598bf" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-g2e-0.u1" size="0x40000" crc="1907dac5" sha1="dc37df322b54a5df5d04bc637e26b011b84598bf" />
 			</dataarea>
 		</part>
 	</software>
@@ -7720,8 +7720,8 @@ license:CC0
 			<feature name="u5" value="U5 MBC1 [DMG MBC1A]" />
 			<feature name="battery" value="Batt CR2035" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="gauntlet2.bin" size="262144" crc="965bbe1f" sha1="53e6162e9276318f357a1e2e5bd706d4e4fd47d2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="gauntlet2.bin" size="0x40000" crc="965bbe1f" sha1="53e6162e9276318f357a1e2e5bd706d4e4fd47d2" />
 			</dataarea>
 		</part>
 	</software>
@@ -7738,8 +7738,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ofj-0.u1" size="131072" crc="d9b24d21" sha1="65f73db2942d400a4c555fbcfd6313f07303d4e4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ofj-0.u1" size="0x20000" crc="d9b24d21" sha1="65f73db2942d400a4c555fbcfd6313f07303d4e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -7756,8 +7756,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="u2" size="262144" crc="690227f6" sha1="c2e98c76e49155e7b9815e0c33ae6cf71daaee2c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="u2" size="0x40000" crc="690227f6" sha1="c2e98c76e49155e7b9815e0c33ae6cf71daaee2c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7776,8 +7776,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="u2" size="262144" crc="6f7ad5d9" sha1="82c1e3dd8b425fb49a1d1c25813002b23963a84a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="u2" size="0x40000" crc="6f7ad5d9" sha1="82c1e3dd8b425fb49a1d1c25813002b23963a84a" />
 			</dataarea>
 		</part>
 	</software>
@@ -7791,8 +7791,8 @@ license:CC0
 		<info name="alt_title" value="GB原人ランド ビバ!ちっくん王国" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="gb genjin land - viva chikkun oukoku (japan).bin" size="262144" crc="b08bb116" sha1="6c7b6268e28281ae06fb621bf3cbbcbadc8e30e8" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="gb genjin land - viva chikkun oukoku (japan).bin" size="0x40000" crc="b08bb116" sha1="6c7b6268e28281ae06fb621bf3cbbcbadc8e30e8" />
 			</dataarea>
 		</part>
 	</software>
@@ -7812,10 +7812,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ipj-0.u1" size="131072" crc="a2e210e9" sha1="7636799f5a57d22cf579bb687be5bb9fedddd0ca" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ipj-0.u1" size="0x20000" crc="a2e210e9" sha1="7636799f5a57d22cf579bb687be5bb9fedddd0ca" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7832,10 +7832,10 @@ license:CC0
 		<info name="serial" value="DMG-AKAJ-JPN" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_huc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="gbkiss mini games (japan).bin" size="262144" crc="92a03fc3" sha1="3c6c78f0a936dbc3f366a82c1eca8be0597d4d5b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="gbkiss mini games (japan).bin" size="0x40000" crc="92a03fc3" sha1="3c6c78f0a936dbc3f366a82c1eca8be0597d4d5b" />
 			</dataarea>
-			<dataarea name="ram" size="32768">
+			<dataarea name="ram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -7850,8 +7850,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-g8e-0.u1" size="131072" crc="b2b72056" sha1="f064c897da11945287ed793fe041d75c1b536709" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-g8e-0.u1" size="0x20000" crc="b2b72056" sha1="f064c897da11945287ed793fe041d75c1b536709" />
 			</dataarea>
 		</part>
 	</software>
@@ -7871,10 +7871,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-aktj-0.u1" size="262144" crc="28e507b0" sha1="fa52c8f0bb31e25be829c7d4f52a7f4db1d5ef5b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-aktj-0.u1" size="0x40000" crc="28e507b0" sha1="fa52c8f0bb31e25be829c7d4f52a7f4db1d5ef5b" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7895,10 +7895,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-apzj-0.u1" size="524288" crc="48c1ee22" sha1="22d6bf37eb3a29aeb1f9969ec51537eca8036a4c" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-apzj-0.u1" size="0x80000" crc="48c1ee22" sha1="22d6bf37eb3a29aeb1f9969ec51537eca8036a4c" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7912,10 +7912,10 @@ license:CC0
 		<info name="alt_title" value="ジェムジェム" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="gem gem (japan).bin" size="65536" crc="a64a8710" sha1="90a29d7a56f64b596cda1c64c8998b63d12c321e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="gem gem (japan).bin" size="0x10000" crc="a64a8710" sha1="90a29d7a56f64b596cda1c64c8998b63d12c321e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -7933,8 +7933,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1col" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-ag3j-0.u1" size="1048576" crc="b2eedd36" sha1="a9f953e2a3680078e51cb42fac44edf81991737b" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-ag3j-0.u1" size="0x100000" crc="b2eedd36" sha1="a9f953e2a3680078e51cb42fac44edf81991737b" />
 			</dataarea>
 		</part>
 	</software>
@@ -7949,8 +7949,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="genjin cottsu (japan).bin" size="262144" crc="95e8fcb1" sha1="70e3cd1df16fbff644c32f588bf80a116b043bb2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="genjin cottsu (japan).bin" size="0x40000" crc="95e8fcb1" sha1="70e3cd1df16fbff644c32f588bf80a116b043bb2" />
 			</dataarea>
 		</part>
 	</software>
@@ -7964,8 +7964,8 @@ license:CC0
 		<info name="alt_title" value="元気爆発ガンバルガー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="genki bakuhatsu gambaruger (japan).bin" size="131072" crc="6226d280" sha1="4ca8a77c95530879b175a2ec9a792485ae18e83c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="genki bakuhatsu gambaruger (japan).bin" size="0x20000" crc="6226d280" sha1="4ca8a77c95530879b175a2ec9a792485ae18e83c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7977,8 +7977,8 @@ license:CC0
 		<info name="serial" value="DMG-JK-USA, DMG-JK-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="george foreman's ko boxing (usa, europe).bin" size="131072" crc="7f62456b" sha1="01e923706486c75b2d0a438d968c5d571b2fdf1c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="george foreman's ko boxing (usa, europe).bin" size="0x20000" crc="7f62456b" sha1="01e923706486c75b2d0a438d968c5d571b2fdf1c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7991,8 +7991,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="getaway, the (usa).bin" size="262144" crc="8f2bf517" sha1="a0ca7187b55135150f348d44544d3a6e6d51394e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="getaway, the (usa).bin" size="0x40000" crc="8f2bf517" sha1="a0ca7187b55135150f348d44544d3a6e6d51394e" />
 			</dataarea>
 		</part>
 	</software>
@@ -8006,8 +8006,8 @@ license:CC0
 		<info name="alt_title" value="ゴーストバスターズ2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ghostbusters ii (japan).bin" size="131072" crc="69b161bc" sha1="0ca645c40ca8dc6102b4f3cf56f0e9ae5d1ffc03" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ghostbusters ii (japan).bin" size="0x20000" crc="69b161bc" sha1="0ca645c40ca8dc6102b4f3cf56f0e9ae5d1ffc03" />
 			</dataarea>
 		</part>
 	</software>
@@ -8022,8 +8022,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-gbe-0.u1" size="131072" crc="5821ecd4" sha1="1e2aa42b7e0f974f45fbca35160cda6d5964f0ad" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-gbe-0.u1" size="0x20000" crc="5821ecd4" sha1="1e2aa42b7e0f974f45fbca35160cda6d5964f0ad" />
 			</dataarea>
 		</part>
 	</software>
@@ -8034,8 +8034,8 @@ license:CC0
 		<publisher>Activision</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ghostbusters ii (prototype).bin" size="131072" crc="41423376" sha1="c96b152f5351eeec19e1b020c9e0d51d582e2e8c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ghostbusters ii (prototype).bin" size="0x20000" crc="41423376" sha1="c96b152f5351eeec19e1b020c9e0d51d582e2e8c" />
 			</dataarea>
 		</part>
 	</software>
@@ -8055,10 +8055,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-gij-0.u1" size="65536" crc="150bc291" sha1="de6109b643a97e7a96e55a6becfd7e61dfdc915e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-gij-0.u1" size="0x10000" crc="150bc291" sha1="de6109b643a97e7a96e55a6becfd7e61dfdc915e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8075,8 +8075,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-gga-0.u1" size="65536" crc="87d0637b" sha1="14f4f14caee081dceadb9d31ae26fd8968c432ea" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-gga-0.u1" size="0x10000" crc="87d0637b" sha1="14f4f14caee081dceadb9d31ae26fd8968c432ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -8091,8 +8091,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-wfd-0.u1" size="131072" crc="e8b26577" sha1="638cd5087b53b7fe7c6ece99fd973f98c0c09ebe" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-wfd-0.u1" size="0x20000" crc="e8b26577" sha1="638cd5087b53b7fe7c6ece99fd973f98c0c09ebe" />
 			</dataarea>
 		</part>
 	</software>
@@ -8110,8 +8110,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ackj-0.u1" size="262144" crc="61d80946" sha1="28ce08f67b4fb26e7a5a46f853b053d20ec9d7cd" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ackj-0.u1" size="0x40000" crc="61d80946" sha1="28ce08f67b4fb26e7a5a46f853b053d20ec9d7cd" />
 			</dataarea>
 		</part>
 	</software>
@@ -8126,10 +8126,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="go go hitchhike (japan).bin" size="524288" crc="845735de" sha1="6a35bc2967f25fda0626b7a00a2cacfec9c53278" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="go go hitchhike (japan).bin" size="0x80000" crc="845735de" sha1="6a35bc2967f25fda0626b7a00a2cacfec9c53278" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8146,8 +8146,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-gta-0.u1" size="65536" crc="30ae39b6" sha1="6a60d5b550355e634ba54d8bd83b51ca55d6874b" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-gta-0.u1" size="0x10000" crc="30ae39b6" sha1="6a60d5b550355e634ba54d8bd83b51ca55d6874b" />
 			</dataarea>
 		</part>
 	</software>
@@ -8158,8 +8158,8 @@ license:CC0
 		<publisher>Copya Systems</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="go go tank (proto).bin" size="65536" crc="6dcf5e7f" sha1="18bbee226858af45a81f7da1186938f53511ef73" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="go go tank (proto).bin" size="0x10000" crc="6dcf5e7f" sha1="18bbee226858af45a81f7da1186938f53511ef73" />
 			</dataarea>
 		</part>
 	</software>
@@ -8174,8 +8174,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="go go tank (usa).bin" size="65536" crc="65dfabcb" sha1="7f3408c951a161f93394812d34f6d2534658b7d3" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="go go tank (usa).bin" size="0x10000" crc="65dfabcb" sha1="7f3408c951a161f93394812d34f6d2534658b7d3" />
 			</dataarea>
 		</part>
 	</software>
@@ -8187,8 +8187,8 @@ license:CC0
 		<info name="serial" value="DMG-JV-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="goal (europe).bin" size="131072" crc="533fa979" sha1="24fffa3db4153895546a346a38971b6946011679" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="goal (europe).bin" size="0x20000" crc="533fa979" sha1="24fffa3db4153895546a346a38971b6946011679" />
 			</dataarea>
 		</part>
 	</software>
@@ -8200,8 +8200,8 @@ license:CC0
 		<info name="serial" value="DMG-JV-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="goal (usa).bin" size="131072" crc="00d4caf2" sha1="9bb15769b2674d41075b45256dbfffc18483fd84" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="goal (usa).bin" size="0x20000" crc="00d4caf2" sha1="9bb15769b2674d41075b45256dbfffc18483fd84" />
 			</dataarea>
 		</part>
 	</software>
@@ -8216,10 +8216,10 @@ license:CC0
 		<info name="alt_title" value="ゴッドメディスン ファンタジー世界の誕生" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="god medicine - fantasy sekai no tanjou (japan).bin" size="262144" crc="a1b29ab8" sha1="b365cd58d133c2b441bbf53c2e5ff9486bbf0bde" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="god medicine - fantasy sekai no tanjou (japan).bin" size="0x40000" crc="a1b29ab8" sha1="b365cd58d133c2b441bbf53c2e5ff9486bbf0bde" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8234,10 +8234,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="god medicine - hukkoku ban (japan).bin" size="524288" crc="847e0772" sha1="61d3579293bf07166402d11d891e14bfd6fef6b4" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="god medicine - hukkoku ban (japan).bin" size="0x80000" crc="847e0772" sha1="61d3579293bf07166402d11d891e14bfd6fef6b4" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8252,8 +8252,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-gze-0.u1" size="131072" crc="fe4f80b7" sha1="c0fa19386aa1e325af42e8dd2caf8e66112b9578" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-gze-0.u1" size="0x20000" crc="fe4f80b7" sha1="c0fa19386aa1e325af42e8dd2caf8e66112b9578" />
 			</dataarea>
 		</part>
 	</software>
@@ -8270,8 +8270,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="godzilla-kun (japan).bin" size="131072" crc="ed204600" sha1="4c03da759e5fb2ec06d286d5f0b52d64621fea41" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="godzilla-kun (japan).bin" size="0x20000" crc="ed204600" sha1="4c03da759e5fb2ec06d286d5f0b52d64621fea41" />
 			</dataarea>
 		</part>
 	</software>
@@ -8291,10 +8291,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-goa-0.u1" size="131072" crc="6ed10383" sha1="2acee1a14ba611e73b0b7d6bce170107213fcc0c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-goa-0.u1" size="0x20000" crc="6ed10383" sha1="2acee1a14ba611e73b0b7d6bce170107213fcc0c" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8307,8 +8307,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="golf classic (europe).bin" size="262144" crc="a6dadb1e" sha1="b7ffb77a5061c33b0bbe5b074c1526e46c5eb7c3" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="golf classic (europe).bin" size="0x40000" crc="a6dadb1e" sha1="b7ffb77a5061c33b0bbe5b074c1526e46c5eb7c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -8328,10 +8328,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-bj3j-0.u1" size="1048576" crc="26772e04" sha1="a6ab7420a2d69d62338bc03dc4e0e46b0dc8429b" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-bj3j-0.u1" size="0x100000" crc="26772e04" sha1="a6ab7420a2d69d62338bc03dc4e0e46b0dc8429b" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8351,10 +8351,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-bs4j-0.u1" size="1048576" crc="5d43a385" sha1="d367f2dab5eacb10e785a13a2550ca7cc3e54177" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-bs4j-0.u1" size="0x100000" crc="5d43a385" sha1="d367f2dab5eacb10e785a13a2550ca7cc3e54177" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8367,10 +8367,10 @@ license:CC0
 		<info name="alt_title" value="ゴールド シカクいアタマをマルくする。 合格ボーイGOLD ■いアタマを●くする。 読み 書き 筆順 熟語 漢字の達人" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-bq2j-0.u1" size="1048576" crc="180d54a7" sha1="7dce0adcbac61f0caae33646847fd06ced8c8b67" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-bq2j-0.u1" size="0x100000" crc="180d54a7" sha1="7dce0adcbac61f0caae33646847fd06ced8c8b67" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8390,10 +8390,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [6735]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-bk4j-0.u1" size="1048576" crc="62b00f69" sha1="1d3e5ad888b8339e35c46455d84017d8a0d69c6d" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-bk4j-0.u1" size="0x100000" crc="62b00f69" sha1="1d3e5ad888b8339e35c46455d84017d8a0d69c6d" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8406,10 +8406,10 @@ license:CC0
 		<info name="alt_title" value="ゴールド シカクいアタマをマルくする。 合格ボーイGOLD ■いアタマを●くする。 整数 小数 分数 単位 計算の達人" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-bc6j-0.u1" size="1048576" crc="04214f92" sha1="6b8726c69a31e674a4c5ab02631de073d42e7d52" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-bc6j-0.u1" size="0x100000" crc="04214f92" sha1="6b8726c69a31e674a4c5ab02631de073d42e7d52" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8429,10 +8429,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-bc4j-0.u1" size="1048576" crc="71acbb67" sha1="e2ac91493248869aba6b7d26a36e5ff6bd6d6f5a" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-bc4j-0.u1" size="0x100000" crc="71acbb67" sha1="e2ac91493248869aba6b7d26a36e5ff6bd6d6f5a" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8452,10 +8452,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-bd4j-0.u1" size="1048576" crc="3c907f2c" sha1="fa7a40acd835676fbcae9507a8aaaf1191f9b1cd" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-bd4j-0.u1" size="0x100000" crc="3c907f2c" sha1="fa7a40acd835676fbcae9507a8aaaf1191f9b1cd" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8469,8 +8469,8 @@ license:CC0
 		<info name="alt_title" value="合格ボーイシリーズ - 99年度版 英単語センター1500" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - 99 nendo ban eitango center 1500 (japan).bin" size="262144" crc="9c0d14c3" sha1="b9e79e032f4d65442daa37767be5238a84c103db" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="goukaku boy series - 99 nendo ban eitango center 1500 (japan).bin" size="0x40000" crc="9c0d14c3" sha1="b9e79e032f4d65442daa37767be5238a84c103db" />
 			</dataarea>
 		</part>
 	</software>
@@ -8487,8 +8487,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-aj5j-0.u1" size="262144" crc="ca20c594" sha1="535fbf6988af70c4283d8101c72acb67d249bb96" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-aj5j-0.u1" size="0x40000" crc="ca20c594" sha1="535fbf6988af70c4283d8101c72acb67d249bb96" />
 			</dataarea>
 		</part>
 	</software>
@@ -8502,8 +8502,8 @@ license:CC0
 		<info name="alt_title" value="合格ボーイシリーズ - よく使われる 英検2級レベルの会話表現333" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - eiken 2kyuu level no kaiwa hyougen 333 (japan).bin" size="262144" crc="46af90da" sha1="e58d4dc3e8b5f0407f156c5d252d34b40e7dfec0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="goukaku boy series - eiken 2kyuu level no kaiwa hyougen 333 (japan).bin" size="0x40000" crc="46af90da" sha1="e58d4dc3e8b5f0407f156c5d252d34b40e7dfec0" />
 			</dataarea>
 		</part>
 	</software>
@@ -8520,8 +8520,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-at2j-0.u1" size="262144" crc="f8406560" sha1="c5f885c9c6b7ab89646b4c17b6ff83b2dfe67a04" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-at2j-0.u1" size="0x40000" crc="f8406560" sha1="c5f885c9c6b7ab89646b4c17b6ff83b2dfe67a04" />
 			</dataarea>
 		</part>
 	</software>
@@ -8535,8 +8535,8 @@ license:CC0
 		<info name="alt_title" value="合格ボーイシリーズ 学研 慣用句・ことわざ210" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - gakken - kanyouku kotowaza 210 (japan).bin" size="262144" crc="44f5a443" sha1="19a6f8c7a98b84b9b0bf53c25dbba02c438c1822" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="goukaku boy series - gakken - kanyouku kotowaza 210 (japan).bin" size="0x40000" crc="44f5a443" sha1="19a6f8c7a98b84b9b0bf53c25dbba02c438c1822" />
 			</dataarea>
 		</part>
 	</software>
@@ -8550,8 +8550,8 @@ license:CC0
 		<info name="alt_title" value="合格ボーイシリーズ 学研 小学校高学年レベル 入試に出た要点 ランク順 歴史512" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - gakken - rekishi 512 (japan).bin" size="262144" crc="10bd83ba" sha1="ab7733c04bc7975312b0cbe75d8d9b2519ac35ae" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="goukaku boy series - gakken - rekishi 512 (japan).bin" size="0x40000" crc="10bd83ba" sha1="ab7733c04bc7975312b0cbe75d8d9b2519ac35ae" />
 			</dataarea>
 		</part>
 	</software>
@@ -8568,8 +8568,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ay3j-1.u1" size="262144" crc="c8e01c7c" sha1="7df1d7b389814c6de2a1b201a00c71316b0ac856" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ay3j-1.u1" size="0x40000" crc="c8e01c7c" sha1="7df1d7b389814c6de2a1b201a00c71316b0ac856" />
 			</dataarea>
 		</part>
 	</software>
@@ -8586,8 +8586,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ay3j-0.u1" size="262144" crc="631a752e" sha1="df253afb9c01615ad8219730573321a40fb5e230" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ay3j-0.u1" size="0x40000" crc="631a752e" sha1="df253afb9c01615ad8219730573321a40fb5e230" />
 			</dataarea>
 		</part>
 	</software>
@@ -8601,8 +8601,8 @@ license:CC0
 		<info name="alt_title" value="合格ボーイシリーズ 桐原書店 頻出英文法・語法問題1000" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - kirihara shoten hinshutsu eibunpou gohou mondai 1000 (japan).bin" size="262144" crc="41c17421" sha1="134a9d7a276b8ef2ed698075e0990d0553ffbf73" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="goukaku boy series - kirihara shoten hinshutsu eibunpou gohou mondai 1000 (japan).bin" size="0x40000" crc="41c17421" sha1="134a9d7a276b8ef2ed698075e0990d0553ffbf73" />
 			</dataarea>
 		</part>
 	</software>
@@ -8619,8 +8619,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ad2j-0.u1" size="262144" crc="e4271f4b" sha1="02baaf987249f2daf9daa6d6000e61adc05b0ef6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ad2j-0.u1" size="0x40000" crc="e4271f4b" sha1="02baaf987249f2daf9daa6d6000e61adc05b0ef6" />
 			</dataarea>
 		</part>
 	</software>
@@ -8637,8 +8637,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ab4j-0.u1" size="262144" crc="d3168eca" sha1="2e30d41e3783da4d3f6bb928c54c0e243f63e4ca" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ab4j-0.u1" size="0x40000" crc="d3168eca" sha1="2e30d41e3783da4d3f6bb928c54c0e243f63e4ca" />
 			</dataarea>
 		</part>
 	</software>
@@ -8652,8 +8652,8 @@ license:CC0
 		<info name="alt_title" value="合格ボーイシリーズ 高校入試“でる順” 漢字問題の征服" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - koukou nyuushi derujun - kanji mondai no seifuku (japan).bin" size="262144" crc="84e30e6c" sha1="2185bbb4868058577fbe696b9a88fa7238ce7098" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="goukaku boy series - koukou nyuushi derujun - kanji mondai no seifuku (japan).bin" size="0x40000" crc="84e30e6c" sha1="2185bbb4868058577fbe696b9a88fa7238ce7098" />
 			</dataarea>
 		</part>
 	</software>
@@ -8667,8 +8667,8 @@ license:CC0
 		<info name="alt_title" value="合格ボーイシリーズ 高校入試 歴史年代あんきポイント240" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - koukou nyuushi derujun - rekishi nendai anki point 240 (japan).bin" size="262144" crc="7e262a4d" sha1="d969dbc0cf3e5d427726bf749d082b89e171354b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="goukaku boy series - koukou nyuushi derujun - rekishi nendai anki point 240 (japan).bin" size="0x40000" crc="7e262a4d" sha1="d969dbc0cf3e5d427726bf749d082b89e171354b" />
 			</dataarea>
 		</part>
 	</software>
@@ -8685,8 +8685,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-as3j-0.u1" size="262144" crc="70468755" sha1="b96acb6454ba916ad5df2256f9a0a8022cdbff3b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-as3j-0.u1" size="0x40000" crc="70468755" sha1="b96acb6454ba916ad5df2256f9a0a8022cdbff3b" />
 			</dataarea>
 		</part>
 	</software>
@@ -8703,8 +8703,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-an3j-0.u1" size="262144" crc="cf133379" sha1="d6178851d778bf794a0fce14a831f6e2cd991f22" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-an3j-0.u1" size="0x40000" crc="cf133379" sha1="d6178851d778bf794a0fce14a831f6e2cd991f22" />
 			</dataarea>
 		</part>
 	</software>
@@ -8721,8 +8721,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-aj6j-0.u1" size="262144" crc="8bd567d1" sha1="75009ac4a2114b4ceac3e4bc7e6c3f3173292bf0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-aj6j-0.u1" size="0x40000" crc="8bd567d1" sha1="75009ac4a2114b4ceac3e4bc7e6c3f3173292bf0" />
 			</dataarea>
 		</part>
 	</software>
@@ -8739,8 +8739,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-bf3j-0.u1" size="262144" crc="7e6e16d5" sha1="3fc9c1bc1d3b8e7ee90c14d4ae4938726f61a2db" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-bf3j-0.u1" size="0x40000" crc="7e6e16d5" sha1="3fc9c1bc1d3b8e7ee90c14d4ae4938726f61a2db" />
 			</dataarea>
 		</part>
 	</software>
@@ -8757,8 +8757,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ae8j-0.u1" size="262144" crc="c34ae38f" sha1="fa92ad7099a6c698088433d7721fd1e87b2b925d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ae8j-0.u1" size="0x40000" crc="c34ae38f" sha1="fa92ad7099a6c698088433d7721fd1e87b2b925d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8775,8 +8775,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-bh4j-0.u1" size="262144" crc="62aa54a4" sha1="4569f5cc0f528fdf46cfd1b3a8ef8a6fd3953d7e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-bh4j-0.u1" size="0x40000" crc="62aa54a4" sha1="4569f5cc0f528fdf46cfd1b3a8ef8a6fd3953d7e" />
 			</dataarea>
 		</part>
 	</software>
@@ -8793,8 +8793,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-af3j-0.u1" size="262144" crc="0dadb829" sha1="a10e78f3fe2c46e167d39ed713106937365a6d55" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-af3j-0.u1" size="0x40000" crc="0dadb829" sha1="a10e78f3fe2c46e167d39ed713106937365a6d55" />
 			</dataarea>
 		</part>
 	</software>
@@ -8811,8 +8811,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-bb4j-0.u1" size="262144" crc="de74fd69" sha1="1e0fe5a54b4eb03a1f108d8650ad5ef8814d7444" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-bb4j-0.u1" size="0x40000" crc="de74fd69" sha1="1e0fe5a54b4eb03a1f108d8650ad5ef8814d7444" />
 			</dataarea>
 		</part>
 	</software>
@@ -8829,8 +8829,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ak8j-0.u1" size="262144" crc="87f0cfad" sha1="edfc194f9f58ef97dfe87092eebd4c73359925e1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ak8j-0.u1" size="0x40000" crc="87f0cfad" sha1="edfc194f9f58ef97dfe87092eebd4c73359925e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -8847,8 +8847,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-be3j-0.u1" size="262144" crc="8ba62b3d" sha1="dfdcabdc06b74f896b9ef47db2a9cc49ddb104c4" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-be3j-0.u1" size="0x40000" crc="8ba62b3d" sha1="dfdcabdc06b74f896b9ef47db2a9cc49ddb104c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -8862,8 +8862,8 @@ license:CC0
 		<info name="alt_title" value="シカクいアタマをマルくする。 合格ボーイシリーズ ■いアタマを●くする。 数字で遊ぼう算数編" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - shikakui atama o marukusuru - suuji de asobou sansuu hen (japan) (rev 1).bin" size="262144" crc="74821248" sha1="b1626c1fe162a7b0292d292e8ba60a1c6823fc8d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="goukaku boy series - shikakui atama o marukusuru - suuji de asobou sansuu hen (japan) (rev 1).bin" size="0x40000" crc="74821248" sha1="b1626c1fe162a7b0292d292e8ba60a1c6823fc8d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8877,8 +8877,8 @@ license:CC0
 		<info name="alt_title" value="シカクいアタマをマルくする。 合格ボーイシリーズ ■いアタマを●くする。 数字で遊ぼう算数編" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - shikakui atama o marukusuru - suuji de asobou sansuu hen (japan).bin" size="262144" crc="f141b2dc" sha1="02ddcaef0008871786797fc76c649d74f010718d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="goukaku boy series - shikakui atama o marukusuru - suuji de asobou sansuu hen (japan).bin" size="0x40000" crc="f141b2dc" sha1="02ddcaef0008871786797fc76c649d74f010718d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8898,10 +8898,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [6735]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-bz4j-0.u1" size="1048576" crc="479e2c18" sha1="630a331a3c89823647fbda13235b6299d91a1b25" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-bz4j-0.u1" size="0x100000" crc="479e2c18" sha1="630a331a3c89823647fbda13235b6299d91a1b25" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -8918,8 +8918,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-an4j-0.u1" size="524288" crc="a09c1790" sha1="6611adc52faa628bbc36cdc759d7c18b00316ba4" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-an4j-0.u1" size="0x80000" crc="a09c1790" sha1="6611adc52faa628bbc36cdc759d7c18b00316ba4" />
 			</dataarea>
 		</part>
 	</software>
@@ -8933,8 +8933,8 @@ license:CC0
 		<info name="alt_title" value="合格ボーイシリーズ 山川 一問一答 世界史B用語問題集" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="goukaku boy series - yamakawa ichimonittou - sekaishi b yougo mondaishuu (japan).bin" size="524288" crc="d185b939" sha1="33e651bbccda46ab395b6609810ee175b5cfacea" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="goukaku boy series - yamakawa ichimonittou - sekaishi b yougo mondaishuu (japan).bin" size="0x80000" crc="d185b939" sha1="33e651bbccda46ab395b6609810ee175b5cfacea" />
 			</dataarea>
 		</part>
 	</software>
@@ -8951,8 +8951,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-aj3j-0.u1" size="262144" crc="dc010f04" sha1="a5f3e531b8becf0fa218d73d21c3775265df607e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-aj3j-0.u1" size="0x40000" crc="dc010f04" sha1="a5f3e531b8becf0fa218d73d21c3775265df607e" />
 			</dataarea>
 		</part>
 	</software>
@@ -8969,8 +8969,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ap7j-0.u1" size="262144" crc="99062c13" sha1="e105f4d680fbf0621997aa2f9ce05cb0651a9ee9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ap7j-0.u1" size="0x40000" crc="99062c13" sha1="e105f4d680fbf0621997aa2f9ce05cb0651a9ee9" />
 			</dataarea>
 		</part>
 	</software>
@@ -8984,8 +8984,8 @@ license:CC0
 		<info name="alt_title" value="合格ボーイシリーズ 「解体英語構文」完全準拠 Z会究極の英語構文285" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - z kai kyuukyoku no eigo koubun 285 (japan).bin" size="262144" crc="d792f747" sha1="4d0d8bf6cbaef902c5855513531203b756deb93f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="goukaku boy series - z kai kyuukyoku no eigo koubun 285 (japan).bin" size="0x40000" crc="d792f747" sha1="4d0d8bf6cbaef902c5855513531203b756deb93f" />
 			</dataarea>
 		</part>
 	</software>
@@ -8999,8 +8999,8 @@ license:CC0
 		<info name="alt_title" value="合格ボーイシリーズ 「解体英熟語」完全準拠 Z会究極の英熟語1017" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - z kai kyuukyoku no eijukugo 1017 (japan).bin" size="262144" crc="12e738ea" sha1="ba02b31919422226d22f89e59df90ab060b046c9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="goukaku boy series - z kai kyuukyoku no eijukugo 1017 (japan).bin" size="0x40000" crc="12e738ea" sha1="ba02b31919422226d22f89e59df90ab060b046c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -9017,8 +9017,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ac2j-0.u1" size="262144" crc="3fac5c42" sha1="f439497b513262d2c98b622af1a00f4efd8650a6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ac2j-0.u1" size="0x40000" crc="3fac5c42" sha1="f439497b513262d2c98b622af1a00f4efd8650a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -9030,8 +9030,8 @@ license:CC0
 		<info name="serial" value="DMG-NE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="gradius - the interstellar assault (usa).bin" size="262144" crc="90f87d57" sha1="7a50fdf0b8ad15556c933df0657fae0a2cd8bc92" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="gradius - the interstellar assault (usa).bin" size="0x40000" crc="90f87d57" sha1="7a50fdf0b8ad15556c933df0657fae0a2cd8bc92" />
 			</dataarea>
 		</part>
 	</software>
@@ -9043,10 +9043,10 @@ license:CC0
 		<info name="serial" value="DMG-B6-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="great greed (usa).bin" size="262144" crc="c4cbf6b1" sha1="9d7de25431f3e31f244925e317e3d0933f5efa2e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="great greed (usa).bin" size="0x40000" crc="c4cbf6b1" sha1="9d7de25431f3e31f244925e317e3d0933f5efa2e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -9060,8 +9060,8 @@ license:CC0
 		<info name="alt_title" value="グレムリン2 新種誕生" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="gremlins 2 - the new batch (world).bin" size="131072" crc="3579e297" sha1="0cb722d9d4e349bea1b1afa85d8d3b93f2dc2aad" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="gremlins 2 - the new batch (world).bin" size="0x20000" crc="3579e297" sha1="0cb722d9d4e349bea1b1afa85d8d3b93f2dc2aad" />
 			</dataarea>
 		</part>
 	</software>
@@ -9082,10 +9082,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-arvj-0.u1" size="524288" crc="e97f2e9a" sha1="d6fc45fd02e3d7c885c0e0244dc3c8073fb64ff4" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-arvj-0.u1" size="0x80000" crc="e97f2e9a" sha1="d6fc45fd02e3d7c885c0e0244dc3c8073fb64ff4" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -9096,8 +9096,8 @@ license:CC0
 		<publisher>HAL</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="hal wrestling (usa) (beta).bin" size="131072" crc="b02faa0b" sha1="6ac35a017fd1f61c19086765107e3940426a2a66" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hal wrestling (usa) (beta).bin" size="0x20000" crc="b02faa0b" sha1="6ac35a017fd1f61c19086765107e3940426a2a66" />
 			</dataarea>
 		</part>
 	</software>
@@ -9112,8 +9112,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-pre-0.u1" size="131072" crc="5e4a61d3" sha1="861f1cd6ea513a003ab8364b37fa73c63b555e38" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-pre-0.u1" size="0x20000" crc="5e4a61d3" sha1="861f1cd6ea513a003ab8364b37fa73c63b555e38" />
 			</dataarea>
 		</part>
 	</software>
@@ -9124,8 +9124,8 @@ license:CC0
 		<publisher>Irem</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="hammerin' harry - ghost building company (europe).bin" size="262144" crc="9f09afe8" sha1="05490ab94ae5e01dd02b4a578bfccc5647816408" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="hammerin' harry - ghost building company (europe).bin" size="0x40000" crc="9f09afe8" sha1="05490ab94ae5e01dd02b4a578bfccc5647816408" />
 			</dataarea>
 		</part>
 	</software>
@@ -9138,10 +9138,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="harvest moon gb (usa).bin" size="524288" crc="1eae0e10" sha1="5b85d2accd3877e80d73a7ad19d9f55c288f43cc" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="harvest moon gb (usa).bin" size="0x80000" crc="1eae0e10" sha1="5b85d2accd3877e80d73a7ad19d9f55c288f43cc" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -9155,8 +9155,8 @@ license:CC0
 		<info name="alt_title" value="ハットリス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="hatris (japan, usa).bin" size="65536" crc="7635f28b" sha1="e8002f226e90ed52e1675c003d3c8ce804b56b0e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="hatris (japan, usa).bin" size="0x10000" crc="7635f28b" sha1="e8002f226e90ed52e1675c003d3c8ce804b56b0e" />
 			</dataarea>
 		</part>
 	</software>
@@ -9174,8 +9174,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aqzj-0.u1" size="524288" crc="60727bf9" sha1="7f0010677e3052c6b9caf41714e87d285ad45a91" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aqzj-0.u1" size="0x80000" crc="60727bf9" sha1="7f0010677e3052c6b9caf41714e87d285ad45a91" />
 			</dataarea>
 		</part>
 	</software>
@@ -9192,8 +9192,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-pqa-0.u1" size="65536" crc="78830daf" sha1="76261091adb7def20a4f76aa6c062c60c6d9761c" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-pqa-0.u1" size="0x10000" crc="78830daf" sha1="76261091adb7def20a4f76aa6c062c60c6d9761c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9208,8 +9208,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-bxe-0.u1" size="65536" crc="1526a96b" sha1="1d6f1afed7ce7a90a07219449d4d3b679afeda6b" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-bxe-0.u1" size="0x10000" crc="1526a96b" sha1="1d6f1afed7ce7a90a07219449d4d3b679afeda6b" />
 			</dataarea>
 		</part>
 	</software>
@@ -9220,8 +9220,8 @@ license:CC0
 		<publisher>Meldac</publisher>
 		<info name="serial" value="DMG-HA-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="heiankyo alien (usa).bin" size="32768" crc="1495bbe5" sha1="7372e49dbe5cbb25b8201f52ca544737d06e0fb6" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="heiankyo alien (usa).bin" size="0x8000" crc="1495bbe5" sha1="7372e49dbe5cbb25b8201f52ca544737d06e0fb6" />
 			</dataarea>
 		</part>
 	</software>
@@ -9234,8 +9234,8 @@ license:CC0
 		<info name="release" value="19900114" />
 		<info name="alt_title" value="平安京エイリアン" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="heiankyou alien (japan).bin" size="32768" crc="08bf29c9" sha1="602561d82cec7484e9509b5739be021f8a3f3449" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="heiankyou alien (japan).bin" size="0x8000" crc="08bf29c9" sha1="602561d82cec7484e9509b5739be021f8a3f3449" />
 			</dataarea>
 		</part>
 	</software>
@@ -9252,8 +9252,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-tfj-0.u1" size="131072" crc="ac044e9a" sha1="aaccd5b75894916ef655082a4ab4e05cb3f6fee8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-tfj-0.u1" size="0x20000" crc="ac044e9a" sha1="aaccd5b75894916ef655082a4ab4e05cb3f6fee8" />
 			</dataarea>
 		</part>
 	</software>
@@ -9266,8 +9266,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="hercules (usa, europe).bin" size="524288" crc="00a9001e" sha1="215cceaccd4a33a2da6205f33a2803ff4004e2b1" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="hercules (usa, europe).bin" size="0x80000" crc="00a9001e" sha1="215cceaccd4a33a2da6205f33a2803ff4004e2b1" />
 			</dataarea>
 		</part>
 	</software>
@@ -9286,10 +9286,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-hej-0.u1" size="262144" crc="4f8a61bf" sha1="c12c60b0c0a2ee1aaded61020fa72b5b467459e1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-hej-0.u1" size="0x40000" crc="4f8a61bf" sha1="c12c60b0c0a2ee1aaded61020fa72b5b467459e1" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -9303,8 +9303,8 @@ license:CC0
 		<info name="alt_title" value="ヒーロー集合!! ピンボールパーティ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="hero shuugou pinball party (japan).bin" size="65536" crc="740552ed" sha1="c4f0428455c6a4772c2db7bab0132dca169e22c7" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="hero shuugou pinball party (japan).bin" size="0x10000" crc="740552ed" sha1="c4f0428455c6a4772c2db7bab0132dca169e22c7" />
 			</dataarea>
 		</part>
 	</software>
@@ -9317,8 +9317,8 @@ license:CC0
 		<info name="alt_title" value="High Stakes Gambling (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="high stakes (usa).bin" size="131072" crc="6b17abe5" sha1="4235ecc5416a3fb0a455bec19bf26ecc9a12197b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="high stakes (usa).bin" size="0x20000" crc="6b17abe5" sha1="4235ecc5416a3fb0a455bec19bf26ecc9a12197b" />
 			</dataarea>
 		</part>
 	</software>
@@ -9332,8 +9332,8 @@ license:CC0
 		<info name="alt_title" value="飛龍の拳 外伝" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="hiryuu no ken gaiden (japan).bin" size="131072" crc="8ee95e0b" sha1="fb4133f25fa0b9eea75f2ec69b786fe2d20d537e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hiryuu no ken gaiden (japan).bin" size="0x20000" crc="8ee95e0b" sha1="fb4133f25fa0b9eea75f2ec69b786fe2d20d537e" />
 			</dataarea>
 		</part>
 	</software>
@@ -9348,8 +9348,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-hce-0.u1" size="131072" crc="2c77f399" sha1="f1631e0a97fd60a285feba1b2fc9082bca3be829" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-hce-0.u1" size="0x20000" crc="2c77f399" sha1="f1631e0a97fd60a285feba1b2fc9082bca3be829" />
 			</dataarea>
 		</part>
 	</software>
@@ -9363,8 +9363,8 @@ license:CC0
 		<info name="alt_title" value="ひとりでできるもん 〜クッキング伝説〜" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="hitori de dekirumon - cooking densetsu (japan).bin" size="131072" crc="59db5e75" sha1="d7b744b84de2097fe77e55c76676256a14b20d74" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hitori de dekirumon - cooking densetsu (japan).bin" size="0x20000" crc="59db5e75" sha1="d7b744b84de2097fe77e55c76676256a14b20d74" />
 			</dataarea>
 		</part>
 	</software>
@@ -9378,8 +9378,8 @@ license:CC0
 		<info name="alt_title" value="ホイホイ ゲームボーイ版" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="hoi hoi - game boy ban (japan).bin" size="131072" crc="c2c2ad19" sha1="d8962cc3a8c4d11af236b2612db7ab3f29615435" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hoi hoi - game boy ban (japan).bin" size="0x20000" crc="c2c2ad19" sha1="d8962cc3a8c4d11af236b2612db7ab3f29615435" />
 			</dataarea>
 		</part>
 	</software>
@@ -9396,8 +9396,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-hkj-0.u1" size="131072" crc="e4b4febc" sha1="4f8e8d2d079a0e3b76a67411d919297808f3849b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-hkj-0.u1" size="0x20000" crc="e4b4febc" sha1="4f8e8d2d079a0e3b76a67411d919297808f3849b" />
 			</dataarea>
 		</part>
 	</software>
@@ -9411,8 +9411,8 @@ license:CC0
 		<info name="alt_title" value="ホーム・アローン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="home alone (japan).bin" size="131072" crc="7c3f3107" sha1="24c58e7b4bcce704ab0976c18919066582e6daf2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="home alone (japan).bin" size="0x20000" crc="7c3f3107" sha1="24c58e7b4bcce704ab0976c18919066582e6daf2" />
 			</dataarea>
 		</part>
 	</software>
@@ -9427,8 +9427,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-hme-0.u1" size="131072" crc="8efc8434" sha1="a3142c83f391eda6f445226f2d49bd8a384be411" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-hme-0.u1" size="0x20000" crc="8efc8434" sha1="a3142c83f391eda6f445226f2d49bd8a384be411" />
 			</dataarea>
 		</part>
 	</software>
@@ -9443,8 +9443,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ahe-0.u1" size="131072" crc="e8e430f1" sha1="853e6f96bcba40bc4cfa72898b02aebc3f9d9498" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ahe-0.u1" size="0x20000" crc="e8e430f1" sha1="853e6f96bcba40bc4cfa72898b02aebc3f9d9498" />
 			</dataarea>
 		</part>
 	</software>
@@ -9459,10 +9459,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="hon shougi (japan).bin" size="65536" crc="6c407eed" sha1="3f49109296b4dc0006b4e8e68133992f5ca2b843" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="hon shougi (japan).bin" size="0x10000" crc="6c407eed" sha1="3f49109296b4dc0006b4e8e68133992f5ca2b843" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -9477,8 +9477,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-hgj-0.u1" size="32768" crc="5ad83d68" sha1="d8dd3e1baa95d8bb0a4e6b4e97ea64b8ec34331a" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-hgj-0.u1" size="0x8000" crc="5ad83d68" sha1="d8dd3e1baa95d8bb0a4e6b4e97ea64b8ec34331a" />
 			</dataarea>
 		</part>
 	</software>
@@ -9492,10 +9492,10 @@ license:CC0
 		<info name="alt_title" value="本命ボーイ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="honmei boy (japan).bin" size="262144" crc="0d255d59" sha1="2d6c460123886502e1590268ec5d8422c5375f7b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="honmei boy (japan).bin" size="0x40000" crc="0d255d59" sha1="2d6c460123886502e1590268ec5d8422c5375f7b" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -9512,8 +9512,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-daj-0.u1" size="262144" crc="ba595897" sha1="417c22bfd8dba5da00c207da7866d8d8e8b292d1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-daj-0.u1" size="0x40000" crc="ba595897" sha1="417c22bfd8dba5da00c207da7866d8d8e8b292d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -9525,8 +9525,8 @@ license:CC0
 		<info name="serial" value="DMG-HS-UKV, DMG-HS-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="hook (europe).bin" size="131072" crc="370a2c2f" sha1="0e0784c238b8a16666157e1ac99cee17feb52c63" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hook (europe).bin" size="0x20000" crc="370a2c2f" sha1="0e0784c238b8a16666157e1ac99cee17feb52c63" />
 			</dataarea>
 		</part>
 	</software>
@@ -9540,8 +9540,8 @@ license:CC0
 		<info name="alt_title" value="フック" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="hook (japan).bin" size="131072" crc="62d8173c" sha1="90eee3e0434bdf63d00b0e9c5cf6f62626974ca4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hook (japan).bin" size="0x20000" crc="62d8173c" sha1="90eee3e0434bdf63d00b0e9c5cf6f62626974ca4" />
 			</dataarea>
 		</part>
 	</software>
@@ -9553,8 +9553,8 @@ license:CC0
 		<info name="serial" value="DMG-HS-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="hook (usa).bin" size="131072" crc="6765b61b" sha1="570d7cc03e80e199e856160912431c21a6ca0f6c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hook (usa).bin" size="0x20000" crc="6765b61b" sha1="570d7cc03e80e199e856160912431c21a6ca0f6c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9566,8 +9566,8 @@ license:CC0
 		<publisher>Sony Imagesoft</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="hook.u1" size="131072" crc="c091abc8" sha1="0299d84e5f722e9298c1ce190b8e4a785849b868" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hook.u1" size="0x20000" crc="c091abc8" sha1="0299d84e5f722e9298c1ce190b8e4a785849b868" />
 			</dataarea>
 		</part>
 	</software>
@@ -9585,8 +9585,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="hoshi no kirby (japan) (rev 1).bin" size="262144" crc="04342c83" sha1="5fe35fab25299b6c53b40decfe2b1827b4a64d2a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="hoshi no kirby (japan) (rev 1).bin" size="0x40000" crc="04342c83" sha1="5fe35fab25299b6c53b40decfe2b1827b4a64d2a" />
 			</dataarea>
 		</part>
 	</software>
@@ -9604,8 +9604,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-kyj-0.u1" size="262144" crc="21035f95" sha1="1e34b7beee30e350087771b3a3e05a40e4a1ea84" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-kyj-0.u1" size="0x40000" crc="21035f95" sha1="1e34b7beee30e350087771b3a3e05a40e4a1ea84" />
 			</dataarea>
 		</part>
 	</software>
@@ -9627,10 +9627,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-akbj-0.u1" size="524288" crc="4bedf22c" sha1="8487fcc3f9005f6c6819c3d5810f54e78b510d47" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-akbj-0.u1" size="0x80000" crc="4bedf22c" sha1="8487fcc3f9005f6c6819c3d5810f54e78b510d47" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -9644,8 +9644,8 @@ license:CC0
 		<info name="alt_title" value="ハドソン・ホーク" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="hudson hawk (japan).bin" size="131072" crc="1cb6158c" sha1="6dfc4f8269dccec1653854b98fa5c8627cd50ce0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hudson hawk (japan).bin" size="0x20000" crc="1cb6158c" sha1="6dfc4f8269dccec1653854b98fa5c8627cd50ce0" />
 			</dataarea>
 		</part>
 	</software>
@@ -9657,8 +9657,8 @@ license:CC0
 		<info name="serial" value="DMG-HW-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="hudson hawk (usa).bin" size="131072" crc="adff7bbd" sha1="efdbb5f86d6ff3b3f248b0360ab548ac1ceb1e0e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hudson hawk (usa).bin" size="0x20000" crc="adff7bbd" sha1="efdbb5f86d6ff3b3f248b0360ab548ac1ceb1e0e" />
 			</dataarea>
 		</part>
 	</software>
@@ -9674,8 +9674,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-agop-0.u1" size="131072" crc="74aa5e0f" sha1="d314dffcf5fb441d5d6d6419e01dc825e90cf0fc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-agop-0.u1" size="0x20000" crc="74aa5e0f" sha1="d314dffcf5fb441d5d6d6419e01dc825e90cf0fc" />
 			</dataarea>
 		</part>
 	</software>
@@ -9687,8 +9687,8 @@ license:CC0
 		<info name="serial" value="DMG-AO2P-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="hugo 2 (germany).bin" size="131072" crc="67998fa4" sha1="66324a9b4d6f8782b706e0d3942d7efdb2b1f141" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hugo 2 (germany).bin" size="0x20000" crc="67998fa4" sha1="66324a9b4d6f8782b706e0d3942d7efdb2b1f141" />
 			</dataarea>
 		</part>
 	</software>
@@ -9703,8 +9703,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B1] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-hux-0.u1" size="262144" crc="999c67d6" sha1="daa810cf09eae39867339b7615c6ffcf4bfd701a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-hux-0.u1" size="0x40000" crc="999c67d6" sha1="daa810cf09eae39867339b7615c6ffcf4bfd701a" />
 			</dataarea>
 		</part>
 	</software>
@@ -9716,8 +9716,8 @@ license:CC0
 		<info name="serial" value="DMG-HU-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="humans, the (usa).bin" size="262144" crc="1df2e81d" sha1="39b7f8f6abb213bb5727379b864106ca2947fe6f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="humans, the (usa).bin" size="0x40000" crc="1df2e81d" sha1="39b7f8f6abb213bb5727379b864106ca2947fe6f" />
 			</dataarea>
 		</part>
 	</software>
@@ -9734,8 +9734,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-andp-0.u1" size="524288" crc="3a4636ff" sha1="de0310602e675924f393140b3fa66284870661dd" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-andp-0.u1" size="0x80000" crc="3a4636ff" sha1="de0310602e675924f393140b3fa66284870661dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -9750,8 +9750,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-hfe-0.u1" size="131072" crc="5a61ee00" sha1="7c9ccfd9e98b30c33ff71b3ab3098c2afeb9037c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-hfe-0.u1" size="0x20000" crc="5a61ee00" sha1="7c9ccfd9e98b30c33ff71b3ab3098c2afeb9037c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9765,8 +9765,8 @@ license:CC0
 		<info name="alt_title" value="ハイパーブラックバス'95" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="hyper black bass '95 (japan).bin" size="262144" crc="32a81a49" sha1="bea9133cdbe8d96ee753a4f55cf5fa7bb80ff490" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="hyper black bass '95 (japan).bin" size="0x40000" crc="32a81a49" sha1="bea9133cdbe8d96ee753a4f55cf5fa7bb80ff490" />
 			</dataarea>
 		</part>
 	</software>
@@ -9783,8 +9783,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-hpj-0.u1" size="262144" crc="c364d55f" sha1="fc8ad749979702c3d52954ed5808065cde77fe38" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-hpj-0.u1" size="0x40000" crc="c364d55f" sha1="fc8ad749979702c3d52954ed5808065cde77fe38" />
 			</dataarea>
 		</part>
 	</software>
@@ -9799,8 +9799,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-dwx-0.u1" size="131072" crc="02d09ce3" sha1="6aca47dd2d9c57999a566903292af2601c832c9c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-dwx-0.u1" size="0x20000" crc="02d09ce3" sha1="6aca47dd2d9c57999a566903292af2601c832c9c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9815,8 +9815,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" /> <!-- Also found with DMG-AAA-01 and DMG-AAA-02 -->
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-hla-1.u1" size="32768" crc="b3a86164" sha1="261da795c7b4155f1b8083acc55da78699c8a0de" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-hla-1.u1" size="0x8000" crc="b3a86164" sha1="261da795c7b4155f1b8083acc55da78699c8a0de" />
 			</dataarea>
 		</part>
 	</software>
@@ -9830,8 +9830,8 @@ license:CC0
 		<info name="alt_title" value="ハイパーロードランナー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-hla-0.u1" size="32768" crc="3fc21b74" sha1="37d0f2cbac0f95af8b22dea0c882612681ec5cc8" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-hla-0.u1" size="0x8000" crc="3fc21b74" sha1="37d0f2cbac0f95af8b22dea0c882612681ec5cc8" />
 			</dataarea>
 		</part>
 	</software>
@@ -9845,8 +9845,8 @@ license:CC0
 		<info name="alt_title" value="怒りの要塞" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ikari no yousai (japan).bin" size="131072" crc="1c2ba2a1" sha1="039da1616e1a179aeda7186d6cc1955149f49581" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ikari no yousai (japan).bin" size="0x20000" crc="1c2ba2a1" sha1="039da1616e1a179aeda7186d6cc1955149f49581" />
 			</dataarea>
 		</part>
 	</software>
@@ -9860,8 +9860,8 @@ license:CC0
 		<info name="alt_title" value="怒りの要塞2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ikari no yousai 2 (japan).bin" size="131072" crc="6d4fd9aa" sha1="ae437d4fb39d7438fc9eb98c91820aa2b5161b4f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ikari no yousai 2 (japan).bin" size="0x20000" crc="6d4fd9aa" sha1="ae437d4fb39d7438fc9eb98c91820aa2b5161b4f" />
 			</dataarea>
 		</part>
 	</software>
@@ -9873,8 +9873,8 @@ license:CC0
 		<info name="serial" value="DMG-YF-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="in your face (usa).bin" size="131072" crc="80ac487e" sha1="0be0f2a952497b321655dbee5c89678f40bf0b5a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="in your face (usa).bin" size="0x20000" crc="80ac487e" sha1="0be0f2a952497b321655dbee5c89678f40bf0b5a" />
 			</dataarea>
 		</part>
 	</software>
@@ -9889,8 +9889,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B1] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-c8e-0.u1" size="131072" crc="d81c08fa" sha1="f62d369b576cfd2882f8e03a5a32238eb1599477" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-c8e-0.u1" size="0x20000" crc="d81c08fa" sha1="f62d369b576cfd2882f8e03a5a32238eb1599477" />
 			</dataarea>
 		</part>
 	</software>
@@ -9904,8 +9904,8 @@ license:CC0
 		<info name="alt_title" value="インディージョーンズ 最後の聖戦" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="indiana jones - saigo no seisen (japan).bin" size="131072" crc="8f234f49" sha1="238499f9fc98183e57222e8f1271b9bbad2af3ec" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="indiana jones - saigo no seisen (japan).bin" size="0x20000" crc="8f234f49" sha1="238499f9fc98183e57222e8f1271b9bbad2af3ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -9921,8 +9921,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-j5e-0.u1" size="131072" crc="9189921a" sha1="b656ba6c03d0cb5c81c2ed8c5c64ea8e36660aaa" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-j5e-0.u1" size="0x20000" crc="9189921a" sha1="b656ba6c03d0cb5c81c2ed8c5c64ea8e36660aaa" />
 			</dataarea>
 		</part>
 	</software>
@@ -9935,8 +9935,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="indien dans la ville, un (france).bin" size="131072" crc="e37e1832" sha1="168337cdd8e4d919ce3b62ea4802ec6b959c6893" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="indien dans la ville, un (france).bin" size="0x20000" crc="e37e1832" sha1="168337cdd8e4d919ce3b62ea4802ec6b959c6893" />
 			</dataarea>
 		</part>
 	</software>
@@ -9952,8 +9952,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-fhe-0.u1" size="131072" crc="80485fda" sha1="ea77a00e9982ffa710ce9e179d4614419f9e1a35" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-fhe-0.u1" size="0x20000" crc="80485fda" sha1="ea77a00e9982ffa710ce9e179d4614419f9e1a35" />
 			</dataarea>
 		</part>
 	</software>
@@ -9969,8 +9969,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-nle-0.u1" size="131072" crc="058eeedb" sha1="ff229bc70ef30154ef4b4d4f9a4f0eb86015682e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-nle-0.u1" size="0x20000" crc="058eeedb" sha1="ff229bc70ef30154ef4b4d4f9a4f0eb86015682e" />
 			</dataarea>
 		</part>
 	</software>
@@ -9983,8 +9983,8 @@ license:CC0
 		<info name="alt_title" value="InfoGenius Productivity Pak - Frommer's Travel Guide (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="infogenius systems - frommer's travel guide (usa).bin" size="262144" crc="40242e35" sha1="e4155270a59b0998b3eeffea779c33713eddf2e6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="infogenius systems - frommer's travel guide (usa).bin" size="0x40000" crc="40242e35" sha1="e4155270a59b0998b3eeffea779c33713eddf2e6" />
 			</dataarea>
 		</part>
 	</software>
@@ -10003,10 +10003,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-zrx-0.u1" size="65536" crc="bfd65534" sha1="434d2acb7c2c23ae58222254f2e2ca2f4ceddc61" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-zrx-0.u1" size="0x10000" crc="bfd65534" sha1="434d2acb7c2c23ae58222254f2e2ca2f4ceddc61" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10025,10 +10025,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-zre-0.u1" size="65536" crc="ca436939" sha1="9f65e16785e82fbddc27d811f051f60f4812fcb4" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-zre-0.u1" size="0x10000" crc="ca436939" sha1="9f65e16785e82fbddc27d811f051f60f4812fcb4" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10040,8 +10040,8 @@ license:CC0
 		<info name="serial" value="DMG-SL-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="infogenius systems - spell checker and calculator (usa).bin" size="131072" crc="754496bb" sha1="654e6f36c1260afba14640cf25c05c31a4075eb6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="infogenius systems - spell checker and calculator (usa).bin" size="0x20000" crc="754496bb" sha1="654e6f36c1260afba14640cf25c05c31a4075eb6" />
 			</dataarea>
 		</part>
 	</software>
@@ -10056,10 +10056,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="initial d gaiden (japan).bin" size="262144" crc="6cc56612" sha1="1b3c4c1c4dfca46a009eb2e5cd45b343d7ee6681" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="initial d gaiden (japan).bin" size="0x40000" crc="6cc56612" sha1="1b3c4c1c4dfca46a009eb2e5cd45b343d7ee6681" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10075,8 +10075,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-aigp-0.u1" size="262144" crc="94757be8" sha1="13f2fc0945fb7a90f4d87d8c4e310dec9af6b792" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-aigp-0.u1" size="0x40000" crc="94757be8" sha1="13f2fc0945fb7a90f4d87d8c4e310dec9af6b792" />
 			</dataarea>
 		</part>
 	</software>
@@ -10088,8 +10088,8 @@ license:CC0
 		<info name="release" value="20190409" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="into the blue.bin" size="131072" crc="7714e96e" sha1="5ac7a349bb37c8767c9db264ed8ae7b7647fa8ea" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="into the blue.bin" size="0x20000" crc="7714e96e" sha1="5ac7a349bb37c8767c9db264ed8ae7b7647fa8ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -10109,10 +10109,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="ippatsu gyakuten dx bakenou (japan).bin" size="65536" crc="8f3e7f95" sha1="991efd117dcb30ddf111bb4f6e46bdda1c811417" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="ippatsu gyakuten dx bakenou (japan).bin" size="0x10000" crc="8f3e7f95" sha1="991efd117dcb30ddf111bb4f6e46bdda1c811417" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10128,8 +10128,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-axip-0.u1" size="524288" crc="173232e5" sha1="4ee9ba152e2339497d6ad49aca6f2c78a8431480" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-axip-0.u1" size="0x80000" crc="173232e5" sha1="4ee9ba152e2339497d6ad49aca6f2c78a8431480" />
 			</dataarea>
 		</part>
 	</software>
@@ -10143,8 +10143,8 @@ license:CC0
 		<info name="alt_title" value="石田芳夫詰碁パラダイス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="ishida yoshio tsume go paradise (japan).bin" size="65536" crc="c97daaca" sha1="dd9fd57dfa72e8818c553db553d9e598edb9d956" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="ishida yoshio tsume go paradise (japan).bin" size="0x10000" crc="c97daaca" sha1="dd9fd57dfa72e8818c553db553d9e598edb9d956" />
 			</dataarea>
 		</part>
 	</software>
@@ -10159,8 +10159,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-stj-0.u1" size="32768" crc="ab367915" sha1="75768fa6c719b96e6642bca5439a78cd3696761f" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-stj-0.u1" size="0x8000" crc="ab367915" sha1="75768fa6c719b96e6642bca5439a78cd3696761f" />
 			</dataarea>
 		</part>
 	</software>
@@ -10175,8 +10175,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-ste-0.u1" size="65536" crc="85b98a77" sha1="41a00b379864cc0be08de75ae0de5bb2c6fbb045" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-ste-0.u1" size="0x10000" crc="85b98a77" sha1="41a00b379864cc0be08de75ae0de5bb2c6fbb045" />
 			</dataarea>
 		</part>
 	</software>
@@ -10192,8 +10192,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-yhe-0.u1" size="131072" crc="ddb147e5" sha1="1dbb3eb39e0a2d695136880e6dd0557eb48ebf21" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-yhe-0.u1" size="0x20000" crc="ddb147e5" sha1="1dbb3eb39e0a2d695136880e6dd0557eb48ebf21" />
 			</dataarea>
 		</part>
 	</software>
@@ -10215,10 +10215,10 @@ license:CC0
 			<feature name="battery" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-anwj-0.u1" size="262144" crc="1c4d3665" sha1="a48d6b68d82b98e775c00366da544402d7c7ac0e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-anwj-0.u1" size="0x40000" crc="1c4d3665" sha1="a48d6b68d82b98e775c00366da544402d7c7ac0e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10233,10 +10233,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="j.league big wave soccer (japan).bin" size="262144" crc="cdd02f22" sha1="00369c42d2c4be0506901b64f7d5424538574ce0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="j.league big wave soccer (japan).bin" size="0x40000" crc="cdd02f22" sha1="00369c42d2c4be0506901b64f7d5424538574ce0" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10256,10 +10256,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-jlj-0.u1" size="131072" crc="17608642" sha1="fbe94c42a9bd7d5ebddb28382caf03ab2f9902d6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-jlj-0.u1" size="0x20000" crc="17608642" sha1="fbe94c42a9bd7d5ebddb28382caf03ab2f9902d6" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10274,10 +10274,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="j.league live '95 (japan).bin" size="262144" crc="f0321342" sha1="3b4922f8034877d1a5aca380f846a7cb6841f6ee" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="j.league live '95 (japan).bin" size="0x40000" crc="f0321342" sha1="3b4922f8034877d1a5aca380f846a7cb6841f6ee" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10297,10 +10297,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-w7j-0.u1" size="131072" crc="adb46f9c" sha1="b8630f06e8b9682e667b7b1f2139162e2f022561" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-w7j-0.u1" size="0x20000" crc="adb46f9c" sha1="b8630f06e8b9682e667b7b1f2139162e2f022561" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10315,8 +10315,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-jne-0.u1" size="131072" crc="654988b2" sha1="bac74527dbd276f395d5c89f14450bb5bc2baab1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-jne-0.u1" size="0x20000" crc="654988b2" sha1="bac74527dbd276f395d5c89f14450bb5bc2baab1" />
 			</dataarea>
 		</part>
 	</software>
@@ -10328,8 +10328,8 @@ license:CC0
 		<info name="serial" value="DMG-JN-FAH" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="jack nicklaus golf (france).bin" size="131072" crc="374893d7" sha1="2bc2c3a95a49498347c49d5dd7182a1387ab531e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="jack nicklaus golf (france).bin" size="0x20000" crc="374893d7" sha1="2bc2c3a95a49498347c49d5dd7182a1387ab531e" />
 			</dataarea>
 		</part>
 	</software>
@@ -10343,8 +10343,8 @@ license:CC0
 		<info name="alt_title" value="ジャレコ J・カップサッカー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="jaleco j.cup soccer (japan).bin" size="131072" crc="98259257" sha1="984f4fd0127325311cad9fbceb5c71f305cb2b23" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="jaleco j.cup soccer (japan).bin" size="0x20000" crc="98259257" sha1="984f4fd0127325311cad9fbceb5c71f305cb2b23" />
 			</dataarea>
 		</part>
 	</software>
@@ -10363,11 +10363,11 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" /> <!-- Also with [6129A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
+			<dataarea name="rom" size="0x80000">
 				<!-- USA cart has label DMG-AW7E-0 -->
-				<rom name="dmg-aw7p-0.u1" size="524288" crc="ca3bc3ce" sha1="e03754173a5d62cb9da7d2306bc41b0e23e3d519" />
+				<rom name="dmg-aw7p-0.u1" size="0x80000" crc="ca3bc3ce" sha1="e03754173a5d62cb9da7d2306bc41b0e23e3d519" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10381,8 +10381,8 @@ license:CC0
 		<info name="alt_title" value="ジャンケンマン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="jankenman (japan).bin" size="65536" crc="37b3d081" sha1="723f34875166b73c95610a6c146eeac34dd90868" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="jankenman (japan).bin" size="0x10000" crc="37b3d081" sha1="723f34875166b73c95610a6c146eeac34dd90868" />
 			</dataarea>
 		</part>
 	</software>
@@ -10399,8 +10399,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-jfj-0.u1" size="65536" crc="0530e1cc" sha1="658120ff41a0fd4c2198f5618dd43a799958aa55" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-jfj-0.u1" size="0x10000" crc="0530e1cc" sha1="658120ff41a0fd4c2198f5618dd43a799958aa55" />
 			</dataarea>
 		</part>
 	</software>
@@ -10414,8 +10414,8 @@ license:CC0
 		<info name="alt_title" value="雀四郎II" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="janshirou ii - sekai saikyou no janshi (japan).bin" size="131072" crc="2812036b" sha1="f85022f21549349f95b58db57ab71998ab24c012" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="janshirou ii - sekai saikyou no janshi (japan).bin" size="0x20000" crc="2812036b" sha1="f85022f21549349f95b58db57ab71998ab24c012" />
 			</dataarea>
 		</part>
 	</software>
@@ -10429,8 +10429,8 @@ license:CC0
 		<info name="alt_title" value="雀卓ボーイ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="jantaku boy (japan).bin" size="131072" crc="04daa03b" sha1="34f0a33f329915800ba681728c43d7451ff1f162" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="jantaku boy (japan).bin" size="0x20000" crc="04daa03b" sha1="34f0a33f329915800ba681728c43d7451ff1f162" />
 			</dataarea>
 		</part>
 	</software>
@@ -10443,8 +10443,8 @@ license:CC0
 		<info name="alt_title" value="Jeep Jamboree - Off Road Adventure (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="jeep jamboree (usa).bin" size="131072" crc="a1e76a33" sha1="988a40823f7db661bc91ffff8fc1bcd80e64f18d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="jeep jamboree (usa).bin" size="0x20000" crc="a1e76a33" sha1="988a40823f7db661bc91ffff8fc1bcd80e64f18d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10456,8 +10456,8 @@ license:CC0
 		<info name="serial" value="DMG-AJBP-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ajbp-0.u1" size="262144" crc="7e6598bb" sha1="579579d660cdc84af2428ccd1b30b40a2fb592fa" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ajbp-0.u1" size="0x40000" crc="7e6598bb" sha1="579579d660cdc84af2428ccd1b30b40a2fb592fa" />
 			</dataarea>
 		</part>
 	</software>
@@ -10469,8 +10469,8 @@ license:CC0
 		<info name="serial" value="DMG-JP-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="jeopardy (usa).bin" size="131072" crc="08725c79" sha1="d0bf6e71ddae1faff179309eaab554c2ae994de0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="jeopardy (usa).bin" size="0x20000" crc="08725c79" sha1="d0bf6e71ddae1faff179309eaab554c2ae994de0" />
 			</dataarea>
 		</part>
 	</software>
@@ -10483,8 +10483,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ajpe-0.u1" size="131072" crc="5206fd09" sha1="35934633a9b301d734a6fced7c56d55eba0385aa" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ajpe-0.u1" size="0x20000" crc="5206fd09" sha1="35934633a9b301d734a6fced7c56d55eba0385aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -10496,8 +10496,8 @@ license:CC0
 		<info name="serial" value="DMG-JE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="jeopardy - sports edition (usa).bin" size="131072" crc="3b523216" sha1="ae534dcdeaa7138e1a0c775e0574c423a8c76dfb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="jeopardy - sports edition (usa).bin" size="0x20000" crc="3b523216" sha1="ae534dcdeaa7138e1a0c775e0574c423a8c76dfb" />
 			</dataarea>
 		</part>
 	</software>
@@ -10510,8 +10510,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ajqe-0.u1" size="131072" crc="cd3df0c1" sha1="20c71f434ef093fac9361fa1db9c2282c938dd71" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ajqe-0.u1" size="0x20000" crc="cd3df0c1" sha1="20c71f434ef093fac9361fa1db9c2282c938dd71" />
 			</dataarea>
 		</part>
 	</software>
@@ -10522,8 +10522,8 @@ license:CC0
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="jet pak jak (prototype).bin" size="131072" crc="2040e99b" sha1="da739097364e31f3be5851461170eaccbcd2aeb3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="jet pak jak (prototype).bin" size="0x20000" crc="2040e99b" sha1="da739097364e31f3be5851461170eaccbcd2aeb3" />
 			</dataarea>
 		</part>
 	</software>
@@ -10534,8 +10534,8 @@ license:CC0
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="32768">
-				<rom name="jet pak man (prototype).bin" size="32768" crc="e40dfc1b" sha1="0080f76961164810d6c0543d951a465cfa1cab54" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="jet pak man (prototype).bin" size="0x8000" crc="e40dfc1b" sha1="0080f76961164810d6c0543d951a465cfa1cab54" />
 			</dataarea>
 		</part>
 	</software>
@@ -10547,8 +10547,8 @@ license:CC0
 		<info name="serial" value="DMG-JS-USA?" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-jse-1.u1" size="131072" crc="cc38cf0d" sha1="38b5ec2c74316696b7731cd88e56be4519084168" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-jse-1.u1" size="0x20000" crc="cc38cf0d" sha1="38b5ec2c74316696b7731cd88e56be4519084168" />
 			</dataarea>
 		</part>
 	</software>
@@ -10564,8 +10564,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-jse-0.u1" size="131072" crc="6386c870" sha1="1790c7462907f803e9641a330df6f06aa5e4e985" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-jse-0.u1" size="0x20000" crc="6386c870" sha1="1790c7462907f803e9641a330df6f06aa5e4e985" />
 			</dataarea>
 		</part>
 	</software>
@@ -10579,10 +10579,10 @@ license:CC0
 		<info name="alt_title" value="時空戦記ムー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="jikuu senki mu (japan).bin" size="262144" crc="435c4697" sha1="799790fdf14c6202a44e5c9a18023fa4245243b8" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="jikuu senki mu (japan).bin" size="0x40000" crc="435c4697" sha1="799790fdf14c6202a44e5c9a18023fa4245243b8" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10599,8 +10599,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-jca-0.u1" size="65536" crc="18671602" sha1="43ae08919dccb5129e17a3fdac553901fb6e3918" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-jca-0.u1" size="0x10000" crc="18671602" sha1="43ae08919dccb5129e17a3fdac553901fb6e3918" />
 			</dataarea>
 		</part>
 	</software>
@@ -10615,8 +10615,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-jce-0.u1" size="65536" crc="9b7ebf91" sha1="d1f93db9a95c9023241e72fe0d7f9848322b53aa" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-jce-0.u1" size="0x10000" crc="9b7ebf91" sha1="d1f93db9a95c9023241e72fe0d7f9848322b53aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -10627,8 +10627,8 @@ license:CC0
 		<publisher>Ubi Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="jimmy connors tennis (prototype).bin" size="131072" crc="eb50caf2" sha1="4ca04a3270e217d54d8c5fa7a254fdbcb48c5b87" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="jimmy connors tennis (prototype).bin" size="0x20000" crc="eb50caf2" sha1="4ca04a3270e217d54d8c5fa7a254fdbcb48c5b87" />
 			</dataarea>
 		</part>
 	</software>
@@ -10644,10 +10644,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="jinsei game (japan).bin" size="262144" crc="09f53d55" sha1="11f883c0f5f4b62d614fd8662ae56e62ab00450b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="jinsei game (japan).bin" size="0x40000" crc="09f53d55" sha1="11f883c0f5f4b62d614fd8662ae56e62ab00450b" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10661,8 +10661,8 @@ license:CC0
 		<info name="alt_title" value="人生ゲーム伝説" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="jinsei game densetsu (japan).bin" size="131072" crc="590f4afc" sha1="106f9671e52d15dd06d614d87b4d690ab95d4131" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="jinsei game densetsu (japan).bin" size="0x20000" crc="590f4afc" sha1="106f9671e52d15dd06d614d87b4d690ab95d4131" />
 			</dataarea>
 		</part>
 	</software>
@@ -10677,8 +10677,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-jmx-0.u1" size="262144" crc="9bd7f196" sha1="88ae07382560825b7cf9307d224938d3a0a89f8d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-jmx-0.u1" size="0x40000" crc="9bd7f196" sha1="88ae07382560825b7cf9307d224938d3a0a89f8d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10689,8 +10689,8 @@ license:CC0
 		<publisher>Elite</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="caveman ninja.bin" size="262144" crc="381c62ee" sha1="979e36765291153b82025b1f036c08fe9c23cfa5" status="baddump" /> <!-- Trimmed from an 8MB overdump. Needs confirmed. -->
+			<dataarea name="rom" size="0x40000">
+				<rom name="caveman ninja.bin" size="0x40000" crc="381c62ee" sha1="979e36765291153b82025b1f036c08fe9c23cfa5" status="baddump" /> <!-- Trimmed from an 8MB overdump. Needs confirmed. -->
 			</dataarea>
 		</part>
 	</software>
@@ -10702,8 +10702,8 @@ license:CC0
 		<info name="serial" value="DMG-JM-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="joe &amp; mac (usa).bin" size="262144" crc="5da86ed4" sha1="dc4dc933c3138a05ab1d11bf77b4c7405cdd524b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="joe &amp; mac (usa).bin" size="0x40000" crc="5da86ed4" sha1="dc4dc933c3138a05ab1d11bf77b4c7405cdd524b" />
 			</dataarea>
 		</part>
 	</software>
@@ -10715,8 +10715,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="john madden football (prototype a).bin" size="131072" crc="4f03ee8c" sha1="c79ecb697723f98448423d311c3d7c76328a46a8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="john madden football (prototype a).bin" size="0x20000" crc="4f03ee8c" sha1="c79ecb697723f98448423d311c3d7c76328a46a8" />
 			</dataarea>
 		</part>
 	</software>
@@ -10731,8 +10731,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-jbe-0.u1" size="65536" crc="c90c5456" sha1="c07fac4e1f29c4216ed94a2cdc7659dc3121b76e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-jbe-0.u1" size="0x10000" crc="c90c5456" sha1="c07fac4e1f29c4216ed94a2cdc7659dc3121b76e" />
 			</dataarea>
 		</part>
 	</software>
@@ -10746,8 +10746,8 @@ license:CC0
 		<info name="alt_title" value="JORDAN VS BIRD ワンオンワン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="jordan vs bird - one on one (japan).bin" size="65536" crc="3fcb174d" sha1="e498c76c6367daed183cc3b185557078832aa5d9" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="jordan vs bird - one on one (japan).bin" size="0x10000" crc="3fcb174d" sha1="e498c76c6367daed183cc3b185557078832aa5d9" />
 			</dataarea>
 		</part>
 	</software>
@@ -10763,8 +10763,8 @@ license:CC0
 			<feature name="rom" value="[JOSHUA GAME BOY VER 1.0]" />
 			<feature name="flipflop" value="[SN74LS377N]" />
 			<feature name="slot" value="rom_wisdom" />
-			<dataarea name="rom" size="131072">
-				<rom name="joshua game boy ver 1.0.rom" size="131072" crc="e0cf879b" sha1="019b4b0e76336e2613ae6e8b415b5c65f6d465a5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="joshua game boy ver 1.0.rom" size="0x20000" crc="e0cf879b" sha1="019b4b0e76336e2613ae6e8b415b5c65f6d465a5" />
 			</dataarea>
 		</part>
 	</software>
@@ -10778,8 +10778,8 @@ license:CC0
 		<info name="alt_title" value="ジャッジ・ドレッド" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="judge dredd (japan).bin" size="262144" crc="951b9907" sha1="cb5d6f34f5289c16782edee0257649bfcb82c096" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="judge dredd (japan).bin" size="0x40000" crc="951b9907" sha1="cb5d6f34f5289c16782edee0257649bfcb82c096" />
 			</dataarea>
 		</part>
 	</software>
@@ -10794,8 +10794,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ajdp-0.u1" size="262144" crc="b9d11656" sha1="36266c67c4fb095566401c25b11981785ac20a7d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ajdp-0.u1" size="0x40000" crc="b9d11656" sha1="36266c67c4fb095566401c25b11981785ac20a7d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10810,8 +10810,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-j7e-0.u1" size="131072" crc="b64d27ee" sha1="ca69dde7b176d4bec9c51f92c37a5d68402af616" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-j7e-0.u1" size="0x20000" crc="b64d27ee" sha1="ca69dde7b176d4bec9c51f92c37a5d68402af616" />
 			</dataarea>
 		</part>
 	</software>
@@ -10826,8 +10826,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="jungle no ouja tarchan (japan).bin" size="262144" crc="96555e9a" sha1="5312e1804848603c41ac804243e5b2b758c75d0d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="jungle no ouja tarchan (japan).bin" size="0x40000" crc="96555e9a" sha1="5312e1804848603c41ac804243e5b2b758c75d0d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10843,8 +10843,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ajgp-0.u1" size="262144" crc="763ababb" sha1="b4c53804f6d7ed230c092232148e69b53f9eb597" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ajgp-0.u1" size="0x40000" crc="763ababb" sha1="b4c53804f6d7ed230c092232148e69b53f9eb597" />
 			</dataarea>
 		</part>
 	</software>
@@ -10856,8 +10856,8 @@ license:CC0
 		<info name="serial" value="DMG-AJGE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ajge-0.u1" size="262144" crc="7a8cdbe8" sha1="ea8b7a5d8d16b4448a3d758fff1f91f27db60292" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ajge-0.u1" size="0x40000" crc="7a8cdbe8" sha1="ea8b7a5d8d16b4448a3d758fff1f91f27db60292" />
 			</dataarea>
 		</part>
 	</software>
@@ -10877,10 +10877,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-jwj-0.u1" size="262144" crc="2ad46ac7" sha1="3835a7821c11197fca87564b8d51a82c81fa7286" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-jwj-0.u1" size="0x40000" crc="2ad46ac7" sha1="3835a7821c11197fca87564b8d51a82c81fa7286" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10895,8 +10895,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" /> <!-- Also found with [DMG MBC1-B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-jqx-0.u1" size="262144" crc="2c8ad255" sha1="efbc825bae50c0498e56b53e9d02f00c400ff6d9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-jqx-0.u1" size="0x40000" crc="2c8ad255" sha1="efbc825bae50c0498e56b53e9d02f00c400ff6d9" />
 			</dataarea>
 		</part>
 	</software>
@@ -10908,8 +10908,8 @@ license:CC0
 		<info name="serial" value="DMG-JQ-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="jurassic park (usa).bin" size="262144" crc="b350bedf" sha1="66273f0b52f9ff2be875b1428add267a5f01adb0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="jurassic park (usa).bin" size="0x40000" crc="b350bedf" sha1="66273f0b52f9ff2be875b1428add267a5f01adb0" />
 			</dataarea>
 		</part>
 	</software>
@@ -10924,8 +10924,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-a2jp-0.u1" size="262144" crc="af3d2e95" sha1="b3df5f3bf73b42696261247c4c9c425a81322bb0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-a2jp-0.u1" size="0x40000" crc="af3d2e95" sha1="b3df5f3bf73b42696261247c4c9c425a81322bb0" />
 			</dataarea>
 		</part>
 	</software>
@@ -10939,10 +10939,10 @@ license:CC0
 		<info name="alt_title" value="勝馬予想 競馬貴族" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="kachiuma yosou keiba kizoku (japan).bin" size="131072" crc="a57e1ac1" sha1="de965fae7d1e744302e6a12656ebb8867ba9cfff" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="kachiuma yosou keiba kizoku (japan).bin" size="0x20000" crc="a57e1ac1" sha1="de965fae7d1e744302e6a12656ebb8867ba9cfff" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10956,10 +10956,10 @@ license:CC0
 		<info name="alt_title" value="勝馬予想 競馬貴族EX'94" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="kachiuma yosou keiba kizoku ex '94 (japan).bin" size="131072" crc="d4319169" sha1="30aab6efed1cc00295d7a35ea8e9f3d809f96334" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="kachiuma yosou keiba kizoku ex '94 (japan).bin" size="0x20000" crc="d4319169" sha1="30aab6efed1cc00295d7a35ea8e9f3d809f96334" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10973,10 +10973,10 @@ license:CC0
 		<info name="alt_title" value="勝馬予想 競馬貴族EX'95" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="kachiuma yosou keiba kizoku ex '95 (japan).bin" size="131072" crc="9c6a4918" sha1="a368d20e2edcb8bc2745ae2c875505f45e40f4fb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="kachiuma yosou keiba kizoku ex '95 (japan).bin" size="0x20000" crc="9c6a4918" sha1="a368d20e2edcb8bc2745ae2c875505f45e40f4fb" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -10991,10 +10991,10 @@ license:CC0
 		<info name="alt_title" value="カエルの為に鐘は鳴る" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="kaeru no tame ni kane wa naru (japan).bin" size="524288" crc="c18cd57a" sha1="ce1e4a788327f3099877c88cc848e48c1fd055ab" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="kaeru no tame ni kane wa naru (japan).bin" size="0x80000" crc="c18cd57a" sha1="ce1e4a788327f3099877c88cc848e48c1fd055ab" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11008,8 +11008,8 @@ license:CC0
 		<info name="alt_title" value="怪獣王ゴジラ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="kaijuu ou godzilla (japan).bin" size="262144" crc="c529a96a" sha1="56271383f34a7709668a982df95ebd083831e30f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="kaijuu ou godzilla (japan).bin" size="0x40000" crc="c529a96a" sha1="56271383f34a7709668a982df95ebd083831e30f" />
 			</dataarea>
 		</part>
 	</software>
@@ -11023,8 +11023,8 @@ license:CC0
 		<info name="alt_title" value="海戦ゲーム ネイビーブルー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="kaisen game - navy blue (japan).bin" size="65536" crc="afd8c47c" sha1="7fbf13dd0b5a4e7798724270a81006be9950f81a" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="kaisen game - navy blue (japan).bin" size="0x10000" crc="afd8c47c" sha1="7fbf13dd0b5a4e7798724270a81006be9950f81a" />
 			</dataarea>
 		</part>
 	</software>
@@ -11039,8 +11039,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-02" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-kmj-0.u1" size="32768" crc="bef1fe2b" sha1="560d174d34b32a35e302297d1667cf67c3d4e8b8" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-kmj-0.u1" size="0x8000" crc="bef1fe2b" sha1="560d174d34b32a35e302297d1667cf67c3d4e8b8" />
 			</dataarea>
 		</part>
 	</software>
@@ -11054,8 +11054,8 @@ license:CC0
 		<info name="alt_title" value="仮面ライダーSD 走れ!マイティライダーズ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="kamen rider sd - hashire mighty riders (japan).bin" size="131072" crc="71c804b3" sha1="03269715c9398659fa685830a6359caa3ffa3bbf" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="kamen rider sd - hashire mighty riders (japan).bin" size="0x20000" crc="71c804b3" sha1="03269715c9398659fa685830a6359caa3ffa3bbf" />
 			</dataarea>
 		</part>
 	</software>
@@ -11077,10 +11077,10 @@ license:CC0
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-akmj-0.u1" size="524288" crc="82e03e10" sha1="9444196c413a13cf326c18c5aa457bcac92114a5" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-akmj-0.u1" size="0x80000" crc="82e03e10" sha1="9444196c413a13cf326c18c5aa457bcac92114a5" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11094,8 +11094,8 @@ license:CC0
 		<info name="alt_title" value="からくり剣豪伝 ムサシロード" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="karakuri kengouden musashi road (japan).bin" size="131072" crc="01aee24b" sha1="abef454ba28d9a89cdeef53dc32549d7bd7d95bb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="karakuri kengouden musashi road (japan).bin" size="0x20000" crc="01aee24b" sha1="abef454ba28d9a89cdeef53dc32549d7bd7d95bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -11110,8 +11110,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="karamuchou no daijiken (japan).bin" size="262144" crc="fa7ea8a0" sha1="d831320bcec612c283afc2b6f194062cf98243dc" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="karamuchou no daijiken (japan).bin" size="0x40000" crc="fa7ea8a0" sha1="d831320bcec612c283afc2b6f194062cf98243dc" />
 			</dataarea>
 		</part>
 	</software>
@@ -11125,10 +11125,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-akrj-1.u1" size="524288" crc="7c94197c" sha1="5759394e2e8bfd68ccf5519362572daaba003573" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-akrj-1.u1" size="0x80000" crc="7c94197c" sha1="5759394e2e8bfd68ccf5519362572daaba003573" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11149,10 +11149,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-akrj-0.u1" size="524288" crc="42e8ba89" sha1="c61050451f8731e35b1b983c610041cb59509ed2" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-akrj-0.u1" size="0x80000" crc="42e8ba89" sha1="c61050451f8731e35b1b983c610041cb59509ed2" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11189,10 +11189,10 @@ license:CC0
 			<feature name="u4" value="U4 [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-k5j-0.u1" size="131072" crc="efbc23fc" sha1="7ac064a877ecc8247dfb7213722dbd0f4be665f0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-k5j-0.u1" size="0x20000" crc="efbc23fc" sha1="7ac064a877ecc8247dfb7213722dbd0f4be665f0" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11214,10 +11214,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a7kj-0.u1" size="524288" crc="147e82ae" sha1="5dc0c9b3fbaf75b44f368b8074c92a294e7382c4" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a7kj-0.u1" size="0x80000" crc="147e82ae" sha1="5dc0c9b3fbaf75b44f368b8074c92a294e7382c4" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11231,10 +11231,10 @@ license:CC0
 		<info name="alt_title" value="携帯競馬エイトスペシャル" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="keitai keiba eight special (japan).bin" size="131072" crc="326273b7" sha1="1bbc35ddf540f2ad9937f57184add528c2811a5d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="keitai keiba eight special (japan).bin" size="0x20000" crc="326273b7" sha1="1bbc35ddf540f2ad9937f57184add528c2811a5d" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11253,10 +11253,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-akgp-0.u1" size="524288" crc="0a9859c1" sha1="7092afa1c1ea592bcd3afd185ae17a7b1cdf6800" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-akgp-0.u1" size="0x80000" crc="0a9859c1" sha1="7092afa1c1ea592bcd3afd185ae17a7b1cdf6800" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11270,8 +11270,8 @@ license:CC0
 		<info name="alt_title" value="剣勇伝説 ヤイバ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="kenyuu densetsu yaiba (japan).bin" size="262144" crc="cc19768e" sha1="c2b71ceee21f66f462df18233f7622d8ec95fcca" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="kenyuu densetsu yaiba (japan).bin" size="0x40000" crc="cc19768e" sha1="c2b71ceee21f66f462df18233f7622d8ec95fcca" />
 			</dataarea>
 		</part>
 	</software>
@@ -11285,8 +11285,8 @@ license:CC0
 		<info name="alt_title" value="ザ・キックボクシング" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="kick boxing, the (japan).bin" size="262144" crc="8056344c" sha1="6fb48835e5401d7b559b7e97c020bc8c356dfa1f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="kick boxing, the (japan).bin" size="0x40000" crc="8056344c" sha1="6fb48835e5401d7b559b7e97c020bc8c356dfa1f" />
 			</dataarea>
 		</part>
 	</software>
@@ -11298,8 +11298,8 @@ license:CC0
 		<info name="serial" value="DMG-DF-USA, DMG-DF-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="kid dracula (usa, europe).bin" size="262144" crc="f27294b7" sha1="f186833a2ccec808210eb4ba669f08401f950e23" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="kid dracula (usa, europe).bin" size="0x40000" crc="f27294b7" sha1="f186833a2ccec808210eb4ba669f08401f950e23" />
 			</dataarea>
 		</part>
 	</software>
@@ -11316,10 +11316,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-kae-0.u1" size="131072" crc="0c042862" sha1="465614bb236c507a5709ecab95827a8be4e2e6b8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-kae-0.u1" size="0x20000" crc="0c042862" sha1="465614bb236c507a5709ecab95827a8be4e2e6b8" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11333,8 +11333,8 @@ license:CC0
 		<info name="alt_title" value="機動警察パトレイバー 狙われた街 1990" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="kidou keisatsu patlabor - nerawareta machi 1990 (japan).bin" size="131072" crc="c7f7f0ac" sha1="63508a4cc76bf1de2125b1055c631d9edfc6e11b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="kidou keisatsu patlabor - nerawareta machi 1990 (japan).bin" size="0x20000" crc="c7f7f0ac" sha1="63508a4cc76bf1de2125b1055c631d9edfc6e11b" />
 			</dataarea>
 		</part>
 	</software>
@@ -11348,8 +11348,8 @@ license:CC0
 		<info name="alt_title" value="機甲警察メタルジャック" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="kikou keisatsu metal jack (japan).bin" size="131072" crc="f3cc5e62" sha1="8245f9f91126faad1f30502e1fc8012cc26c43c1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="kikou keisatsu metal jack (japan).bin" size="0x20000" crc="f3cc5e62" sha1="8245f9f91126faad1f30502e1fc8012cc26c43c1" />
 			</dataarea>
 		</part>
 	</software>
@@ -11365,8 +11365,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aklp-0.u1" size="524288" crc="ac793b54" sha1="65ae38588abc0e699b244b0854f698ddf72c7b46" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aklp-0.u1" size="0x80000" crc="ac793b54" sha1="65ae38588abc0e699b244b0854f698ddf72c7b46" />
 			</dataarea>
 		</part>
 	</software>
@@ -11382,8 +11382,8 @@ license:CC0
 			<feature name="rom" value="[EBGB1.00]" />
 			<feature name="flipflop" value="[T74LS377B1]" />
 			<feature name="slot" value="rom_wisdom" />
-			<dataarea name="rom" size="1048576">
-				<rom name="ebgb1.00.rom" size="1048576" crc="23679231" sha1="6362fde9dcb08242a64f2fbea33de93d1776a6e0" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="ebgb1.00.rom" size="0x100000" crc="23679231" sha1="6362fde9dcb08242a64f2fbea33de93d1776a6e0" />
 			</dataarea>
 		</part>
 	</software>
@@ -11396,8 +11396,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="king of fighters '95, the (europe).bin" size="524288" crc="a3e9b148" sha1="27eeb37f7be07381b6e4e01b5ae0d32f2ec209c0" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="king of fighters '95, the (europe).bin" size="0x80000" crc="a3e9b148" sha1="27eeb37f7be07381b6e4e01b5ae0d32f2ec209c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -11410,8 +11410,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="king of fighters '95, the (usa).bin" size="524288" crc="1ff84e8c" sha1="59c11dd527d47b24323f84fb8a1bb3d06a531f32" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="king of fighters '95, the (usa).bin" size="0x80000" crc="1ff84e8c" sha1="59c11dd527d47b24323f84fb8a1bb3d06a531f32" />
 			</dataarea>
 		</part>
 	</software>
@@ -11427,8 +11427,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ak6p-0.u1" size="524288" crc="4d2d8bc3" sha1="1b5ac034b1333b3340fbdc5c128bc12abd310043" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ak6p-0.u1" size="0x80000" crc="4d2d8bc3" sha1="1b5ac034b1333b3340fbdc5c128bc12abd310043" />
 			</dataarea>
 		</part>
 	</software>
@@ -11443,8 +11443,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-pwx-0.u1" size="65536" crc="d2d648c4" sha1="683fcb45cf98f8d84c221ffb180b06bf81c1cf74" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-pwx-0.u1" size="0x10000" crc="d2d648c4" sha1="683fcb45cf98f8d84c221ffb180b06bf81c1cf74" />
 			</dataarea>
 		</part>
 	</software>
@@ -11456,8 +11456,8 @@ license:CC0
 		<info name="serial" value="DMG-KC-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="kingdom crusade (usa).bin" size="131072" crc="920202dc" sha1="ceca61f9ee1e549ca5b70bf620159cf2c2290423" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="kingdom crusade (usa).bin" size="0x20000" crc="920202dc" sha1="ceca61f9ee1e549ca5b70bf620159cf2c2290423" />
 			</dataarea>
 		</part>
 	</software>
@@ -11474,8 +11474,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ktj-0.u1" size="131072" crc="e69a6f0a" sha1="baf5c1019c9a3752543036dca0925d370aa20d45" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ktj-0.u1" size="0x20000" crc="e69a6f0a" sha1="baf5c1019c9a3752543036dca0925d370aa20d45" />
 			</dataarea>
 		</part>
 	</software>
@@ -11495,10 +11495,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-kjj-0.u1" size="131072" crc="f3ccadc3" sha1="0674abafb9de841d658d249d06a499c14484f72c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-kjj-0.u1" size="0x20000" crc="f3ccadc3" sha1="0674abafb9de841d658d249d06a499c14484f72c" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11512,9 +11512,9 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
 			<dataarea name="rom" size = "131072">
-				<rom name="dmg-onj-1.u1" size="131072" crc="aaf6366c" sha1="298965bc2b99e49339618914114abfd0962560c1" offset="0" />
+				<rom name="dmg-onj-1.u1" size="0x20000" crc="aaf6366c" sha1="298965bc2b99e49339618914114abfd0962560c1" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11534,10 +11534,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-onj-0.u1" size="131072" crc="b7f48649" sha1="7c6c71b52c62b814945ee102054a7a3210b1ecf3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-onj-0.u1" size="0x20000" crc="b7f48649" sha1="7c6c71b52c62b814945ee102054a7a3210b1ecf3" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11551,8 +11551,8 @@ license:CC0
 		<info name="alt_title" value="キン肉マン ザ☆ドリームマッチ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="kinnikuman - the dream match (japan).bin" size="131072" crc="48c2cd38" sha1="cc55e811024f60c0097efdff5962d85830626ab0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="kinnikuman - the dream match (japan).bin" size="0x20000" crc="48c2cd38" sha1="cc55e811024f60c0097efdff5962d85830626ab0" />
 			</dataarea>
 		</part>
 	</software>
@@ -11574,10 +11574,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [6735]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="kirby no block ball (japan).bin" size="524288" crc="df3bbcd7" sha1="3fecc964d2c13ad98abac1df49f05c488833ef5a" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="kirby no block ball (japan).bin" size="0x80000" crc="df3bbcd7" sha1="3fecc964d2c13ad98abac1df49f05c488833ef5a" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11593,10 +11593,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="kirby no kirakira kids (japan).bin" size="262144" crc="47f42f42" sha1="2c46c42be76eca134e188814345afa390e298811" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="kirby no kirakira kids (japan).bin" size="0x40000" crc="47f42f42" sha1="2c46c42be76eca134e188814345afa390e298811" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11616,10 +11616,10 @@ license:CC0
 			<feature name="u2" value="U2 MBC2A [DMG MBC2A]" />
 			<feature name="u3" value="U3 26A [6129]" />
 			<feature name="batt" value="Batt CR1616" />
-			<dataarea name="rom" size="262144">
-				<rom name="kirby no pinball (japan).bin" size="262144" crc="8b44fb7d" sha1="678ca586f5a2e2fc894fb8e9f7b9efa54fabba44" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="kirby no pinball (japan).bin" size="0x40000" crc="8b44fb7d" sha1="678ca586f5a2e2fc894fb8e9f7b9efa54fabba44" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11632,10 +11632,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="kirby's block ball (usa, europe).bin" size="524288" crc="7ad90b4b" sha1="a790d96526972d7ceb026ca27ae41ff475ccb2c5" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="kirby's block ball (usa, europe).bin" size="0x80000" crc="7ad90b4b" sha1="a790d96526972d7ceb026ca27ae41ff475ccb2c5" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11650,8 +11650,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" /> <!-- Also with [DMG MBC1B1] and [DMG MBC1-B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-kye-0.u1" size="262144" crc="40f25740" sha1="90979baa1d0e24b41b5c304c5ddaf77450692d5a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-kye-0.u1" size="0x40000" crc="40f25740" sha1="90979baa1d0e24b41b5c304c5ddaf77450692d5a" />
 			</dataarea>
 		</part>
 	</software>
@@ -11672,10 +11672,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" /> <!-- Also found with [26A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-akbp-0.u1" size="524288" crc="8dc07c35" sha1="8a2898ffa17e25f43793f40c88421d840d372d3c" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-akbp-0.u1" size="0x80000" crc="8dc07c35" sha1="8a2898ffa17e25f43793f40c88421d840d372d3c" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11692,10 +11692,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [6129]" /> <!-- Also found with [26A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-k9e-0.u1" size="262144" crc="31cb6526" sha1="06efdb138ff56cd9522dece44adadd3fae169c76" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-k9e-0.u1" size="0x40000" crc="31cb6526" sha1="06efdb138ff56cd9522dece44adadd3fae169c76" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11714,10 +11714,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-akcp-0.u1" size="262144" crc="91300898" sha1="3999993d31e457bb279efac3e4a65fe4967ba861" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-akcp-0.u1" size="0x40000" crc="91300898" sha1="3999993d31e457bb279efac3e4a65fe4967ba861" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11731,8 +11731,8 @@ license:CC0
 		<info name="alt_title" value="キッチンパニック" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="kitchen panic (japan).bin" size="131072" crc="909937cb" sha1="0e1b2f25c29ebabb1bc67737f3e47b263579423b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="kitchen panic (japan).bin" size="0x20000" crc="909937cb" sha1="0e1b2f25c29ebabb1bc67737f3e47b263579423b" />
 			</dataarea>
 		</part>
 	</software>
@@ -11746,8 +11746,8 @@ license:CC0
 		<info name="alt_title" value="キテレツ大百科 冒険大江戸ジュラ紀" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="kiteretsu daihyakka - bouken ooedo juraki (japan).bin" size="262144" crc="d53548b0" sha1="58d54cdc21c73661ccc0be22e8a40cef84861680" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="kiteretsu daihyakka - bouken ooedo juraki (japan).bin" size="0x40000" crc="d53548b0" sha1="58d54cdc21c73661ccc0be22e8a40cef84861680" />
 			</dataarea>
 		</part>
 	</software>
@@ -11761,8 +11761,8 @@ license:CC0
 		<info name="alt_title" value="木づちだクイズだ源さんだ!" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="kizuchida quiz da gen-san da (japan).bin" size="262144" crc="74a52399" sha1="0729da81a62a1c30e34f5c3157de16fc014c52fe" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="kizuchida quiz da gen-san da (japan).bin" size="0x40000" crc="74a52399" sha1="0729da81a62a1c30e34f5c3157de16fc014c52fe" />
 			</dataarea>
 		</part>
 	</software>
@@ -11777,8 +11777,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-kla-0.u1" size="32768" crc="b4955889" sha1="0bc9af06d21b01bbecbe616c57e9a22f51da3eff" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-kla-0.u1" size="0x8000" crc="b4955889" sha1="0bc9af06d21b01bbecbe616c57e9a22f51da3eff" />
 			</dataarea>
 		</part>
 	</software>
@@ -11790,8 +11790,8 @@ license:CC0
 		<info name="serial" value="DMG-KX-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="klax (usa).bin" size="65536" crc="72660774" sha1="85f6b02815e7131fdd96f3802eb0a17d93277e75" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="klax (usa).bin" size="0x10000" crc="72660774" sha1="85f6b02815e7131fdd96f3802eb0a17d93277e75" />
 			</dataarea>
 		</part>
 	</software>
@@ -11801,8 +11801,8 @@ license:CC0
 		<year>1994</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="klustar (early prototype).bin" size="32768" crc="279dd6cc" sha1="6a5e51bfb4d989fb31f5ed6572d08e5a8b703a8d" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="klustar (early prototype).bin" size="0x8000" crc="279dd6cc" sha1="6a5e51bfb4d989fb31f5ed6572d08e5a8b703a8d" />
 			</dataarea>
 		</part>
 	</software>
@@ -11816,8 +11816,8 @@ license:CC0
 		<info name="alt_title" value="ナイトクエスト" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="knight quest (japan).bin" size="131072" crc="c6f24d2f" sha1="717c65392a5ed9f19fce995be08685df5fa0978b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="knight quest (japan).bin" size="0x20000" crc="c6f24d2f" sha1="717c65392a5ed9f19fce995be08685df5fa0978b" />
 			</dataarea>
 		</part>
 	</software>
@@ -11832,8 +11832,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-fwe-0.u1" size="131072" crc="df50f477" sha1="99eb275df25baa6d1b53f5518e93c5f5913a2b6a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-fwe-0.u1" size="0x20000" crc="df50f477" sha1="99eb275df25baa6d1b53f5518e93c5f5913a2b6a" />
 			</dataarea>
 		</part>
 	</software>
@@ -11846,8 +11846,8 @@ license:CC0
 		<info name="release" value="19910721" />
 		<info name="alt_title" value="恋は駆け引き" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="koi wa kakehiki (japan).bin" size="32768" crc="f3e1e652" sha1="d6a59fc334f93ba0d17faa66542eb74dcc3e536b" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="koi wa kakehiki (japan).bin" size="0x8000" crc="f3e1e652" sha1="d6a59fc334f93ba0d17faa66542eb74dcc3e536b" />
 			</dataarea>
 		</part>
 	</software>
@@ -11863,8 +11863,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="konami gb collection vol.1 (japan).bin" size="524288" crc="992cd78f" sha1="dfb86b1b2db29a7086d60dc143374ef27b130580" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="konami gb collection vol.1 (japan).bin" size="0x80000" crc="992cd78f" sha1="dfb86b1b2db29a7086d60dc143374ef27b130580" />
 			</dataarea>
 		</part>
 	</software>
@@ -11880,8 +11880,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="konami gb collection vol.2 (japan).bin" size="524288" crc="c3b318cd" sha1="5753310cb9fbe44efc2b27ce488cd069ef243199" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="konami gb collection vol.2 (japan).bin" size="0x80000" crc="c3b318cd" sha1="5753310cb9fbe44efc2b27ce488cd069ef243199" />
 			</dataarea>
 		</part>
 	</software>
@@ -11896,8 +11896,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="konami gb collection vol.3 (japan).bin" size="524288" crc="1de9caf9" sha1="db9f1192df7e186ea498c4f576fc016fdc339539" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="konami gb collection vol.3 (japan).bin" size="0x80000" crc="1de9caf9" sha1="db9f1192df7e186ea498c4f576fc016fdc339539" />
 			</dataarea>
 		</part>
 	</software>
@@ -11913,8 +11913,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="konami gb collection vol.4 (japan).bin" size="524288" crc="3a43ea33" sha1="c33ba418386b34b466b5dd28159ea76ca2db12f8" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="konami gb collection vol.4 (japan).bin" size="0x80000" crc="3a43ea33" sha1="c33ba418386b34b466b5dd28159ea76ca2db12f8" />
 			</dataarea>
 		</part>
 	</software>
@@ -11926,10 +11926,10 @@ license:CC0
 		<info name="serial" value="DMG-KG-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="konami golf (europe).bin" size="131072" crc="0fdc9fb1" sha1="59d13714f8477db50cf164254480dd25959ecd23" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="konami golf (europe).bin" size="0x20000" crc="0fdc9fb1" sha1="59d13714f8477db50cf164254480dd25959ecd23" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11943,8 +11943,8 @@ license:CC0
 		<info name="alt_title" value="コナミックバスケット" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="konamic basket (japan).bin" size="131072" crc="8e367457" sha1="10372339db6d65210f7d04591d92c1889cef5133" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="konamic basket (japan).bin" size="0x20000" crc="8e367457" sha1="10372339db6d65210f7d04591d92c1889cef5133" />
 			</dataarea>
 		</part>
 	</software>
@@ -11958,10 +11958,10 @@ license:CC0
 		<info name="alt_title" value="コナミック ゴルフ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="konamic golf (japan).bin" size="131072" crc="c16d4db2" sha1="78d014f8feb88cc8b509172c1a6fa48aa5eed67c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="konamic golf (japan).bin" size="0x20000" crc="c16d4db2" sha1="78d014f8feb88cc8b509172c1a6fa48aa5eed67c" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -11975,8 +11975,8 @@ license:CC0
 		<info name="alt_title" value="コナミックアイスホッケー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="konamic ice hockey (japan).bin" size="131072" crc="d14dee07" sha1="e7feccc615f71ebd7c3d61c3406ed63a894758f0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="konamic ice hockey (japan).bin" size="0x20000" crc="d14dee07" sha1="e7feccc615f71ebd7c3d61c3406ed63a894758f0" />
 			</dataarea>
 		</part>
 	</software>
@@ -11990,8 +11990,8 @@ license:CC0
 		<info name="alt_title" value="コナミックスポーツ イン バルセロナ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="konamic sports in barcelona (japan).bin" size="131072" crc="5721e7d6" sha1="4d3b7d1a615c6783e741812a1b1de4467ed14eef" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="konamic sports in barcelona (japan).bin" size="0x20000" crc="5721e7d6" sha1="4d3b7d1a615c6783e741812a1b1de4467ed14eef" />
 			</dataarea>
 		</part>
 	</software>
@@ -12006,10 +12006,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="konchuu hakase (japan) (rev 1).bin" size="524288" crc="05753790" sha1="3e8e47b36a2171ad93d0e21fe5c22feff17c6d88" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="konchuu hakase (japan) (rev 1).bin" size="0x80000" crc="05753790" sha1="3e8e47b36a2171ad93d0e21fe5c22feff17c6d88" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12024,10 +12024,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="konchuu hakase (japan).bin" size="524288" crc="f6b3e291" sha1="ac792793b43cc8fae098df23e6aeb845f98199cd" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="konchuu hakase (japan).bin" size="0x80000" crc="f6b3e291" sha1="ac792793b43cc8fae098df23e6aeb845f98199cd" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12040,8 +12040,8 @@ license:CC0
 		<info name="release" value="19901207" />
 		<info name="alt_title" value="ころダイス" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="koro dice (japan).bin" size="32768" crc="39608c31" sha1="17d51f459b854d1911c48418ff1592b11981cc84" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="koro dice (japan).bin" size="0x8000" crc="39608c31" sha1="17d51f459b854d1911c48418ff1592b11981cc84" />
 			</dataarea>
 		</part>
 	</software>
@@ -12056,10 +12056,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="koukiatsu boy (japan).bin" size="524288" crc="53ff8041" sha1="f7f5b71a8d3b393b0507eee75fbdaea7006f945f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="koukiatsu boy (japan).bin" size="0x80000" crc="53ff8041" sha1="f7f5b71a8d3b393b0507eee75fbdaea7006f945f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12073,8 +12073,8 @@ license:CC0
 		<info name="alt_title" value="クリスティーワールド" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="krusty world (japan).bin" size="131072" crc="01fbc9f6" sha1="ba64940bce70de459fff84a16222481344749558" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="krusty world (japan).bin" size="0x20000" crc="01fbc9f6" sha1="ba64940bce70de459fff84a16222481344749558" />
 			</dataarea>
 		</part>
 	</software>
@@ -12089,8 +12089,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-fke-0.u1" size="131072" crc="1cedb141" sha1="e61039c52c053a8ae1bdfffa3f694934569bb570" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-fke-0.u1" size="0x20000" crc="1cedb141" sha1="e61039c52c053a8ae1bdfffa3f694934569bb570" />
 			</dataarea>
 		</part>
 	</software>
@@ -12105,8 +12105,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="kuma no puutarou - takara sagashi da ooiri game battle (japan).bin" size="262144" crc="f01d0b87" sha1="b986ce8e1a6a4a1b22e0db5bf03b8b028cce9057" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="kuma no puutarou - takara sagashi da ooiri game battle (japan).bin" size="0x40000" crc="f01d0b87" sha1="b986ce8e1a6a4a1b22e0db5bf03b8b028cce9057" />
 			</dataarea>
 		</part>
 	</software>
@@ -12121,8 +12121,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-sxe-0.u1" size="65536" crc="3340e600" sha1="b0bb485e2b57793da9f153db074c13a060a1e0d4" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-sxe-0.u1" size="0x10000" crc="3340e600" sha1="b0bb485e2b57793da9f153db074c13a060a1e0d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -12133,14 +12133,14 @@ license:CC0
 		<publisher>Irem</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
+			<dataarea name="rom" size="0x10000">
 <!-- Original label:
   "KUNG-FU MASTER"
   IREM AMERICA
   DMG  C9EA
   V.NO. 0.0   9/18
 -->
-				<rom name="kung-fu master.bin" size="65536" crc="e0c33c1a" sha1="1ce6301d56294b71068514c666ad2157551134e7" />
+				<rom name="kung-fu master.bin" size="0x10000" crc="e0c33c1a" sha1="1ce6301d56294b71068514c666ad2157551134e7" />
 			</dataarea>
 		</part>
 	</software>
@@ -12154,10 +12154,10 @@ license:CC0
 		<info name="alt_title" value="ダウンタウンスペシャル くにおくんの時代劇だよ全員集合!" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="kunio-kun no jidaigeki dayo zenin shuugou (japan).bin" size="262144" crc="229e9113" sha1="97ff2392f126b195ac8a1700a9a91aa364549dfd" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="kunio-kun no jidaigeki dayo zenin shuugou (japan).bin" size="0x40000" crc="229e9113" sha1="97ff2392f126b195ac8a1700a9a91aa364549dfd" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12172,8 +12172,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="kuusou kagaku sekai gulliver boy - kuusou kagaku puzzle purittopon (japan).bin" size="262144" crc="fb291e78" sha1="1ba1abc4db088cfc57bc733634c5b02308d132f4" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="kuusou kagaku sekai gulliver boy - kuusou kagaku puzzle purittopon (japan).bin" size="0x40000" crc="fb291e78" sha1="1ba1abc4db088cfc57bc733634c5b02308d132f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -12187,8 +12187,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-ape-0.u1" size="32768" crc="21c98af2" sha1="6ef48e912a47c774048456aa870c7e810fd45685" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-ape-0.u1" size="0x8000" crc="21c98af2" sha1="6ef48e912a47c774048456aa870c7e810fd45685" />
 			</dataarea>
 		</part>
 	</software>
@@ -12201,8 +12201,8 @@ license:CC0
 		<info name="release" value="19921030" />
 		<info name="alt_title" value="キョロちゃんランド" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="kyoro-chan land (japan).bin" size="32768" crc="e158d4db" sha1="67b9b01fbb58c69aad716bcc0409a9dba3bd92b5" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="kyoro-chan land (japan).bin" size="0x8000" crc="e158d4db" sha1="67b9b01fbb58c69aad716bcc0409a9dba3bd92b5" />
 			</dataarea>
 		</part>
 	</software>
@@ -12217,8 +12217,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-l7e-0.u1" size="131072" crc="675e1309" sha1="82a6808f0c4cb1e05a4c2a38a39b0c37874b4211" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-l7e-0.u1" size="0x20000" crc="675e1309" sha1="82a6808f0c4cb1e05a4c2a38a39b0c37874b4211" />
 			</dataarea>
 		</part>
 	</software>
@@ -12230,8 +12230,8 @@ license:CC0
 		<info name="serial" value="DMG-LR-USA, DMG-LR-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="last action hero (usa, europe).bin" size="131072" crc="10499af6" sha1="010eb2cbab987ec242cd0792c789a07c00106f48" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="last action hero (usa, europe).bin" size="0x20000" crc="10499af6" sha1="010eb2cbab987ec242cd0792c789a07c00106f48" />
 			</dataarea>
 		</part>
 	</software>
@@ -12243,8 +12243,8 @@ license:CC0
 		<info name="serial" value="DMG-LR-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="lawnmower man, the (europe).bin" size="131072" crc="134f91d7" sha1="6e63a725fc802966986e6ed6917a7b976794f403" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lawnmower man, the (europe).bin" size="0x20000" crc="134f91d7" sha1="6e63a725fc802966986e6ed6917a7b976794f403" />
 			</dataarea>
 		</part>
 	</software>
@@ -12255,8 +12255,8 @@ license:CC0
 		<publisher>THQ</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="the lawnmower man (prototype).bin" size="131072" crc="1cac0775" sha1="589eedd3919dd29cbdf6fd9c2fa6b4f1c258fc97" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="the lawnmower man (prototype).bin" size="0x20000" crc="1cac0775" sha1="589eedd3919dd29cbdf6fd9c2fa6b4f1c258fc97" />
 			</dataarea>
 		</part>
 	</software>
@@ -12268,10 +12268,10 @@ license:CC0
 		<info name="serial" value="DMG-S5-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="65536">
-				<rom name="lazlos' leap (usa).bin" size="65536" crc="31fb404b" sha1="c111470fcdadf191cf843e50c8f3d3dbb995a5c5" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="lazlos' leap (usa).bin" size="0x10000" crc="31fb404b" sha1="c111470fcdadf191cf843e50c8f3d3dbb995a5c5" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12282,8 +12282,8 @@ license:CC0
 		<publisher>Spidersoft</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="learn and play - blackjack &amp; solitaire (aug 9, 1994 prototype).bin" size="131072" crc="60837c15" sha1="d69062736dfde2af8e0ede2cc3dd5d2b95996e79" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="learn and play - blackjack &amp; solitaire (aug 9, 1994 prototype).bin" size="0x20000" crc="60837c15" sha1="d69062736dfde2af8e0ede2cc3dd5d2b95996e79" />
 			</dataarea>
 		</part>
 	</software>
@@ -12302,10 +12302,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-lgj-0.u1" size="131072" crc="fc20ebf0" sha1="7447b3faa1d15e80815cdace3c6c0691bc28aa90" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-lgj-0.u1" size="0x20000" crc="fc20ebf0" sha1="7447b3faa1d15e80815cdace3c6c0691bc28aa90" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12317,8 +12317,8 @@ license:CC0
 		<info name="serial" value="DMG-KC-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="legend of prince valiant, the (europe) (en,fr,de).bin" size="131072" crc="179c494e" sha1="d56b59ad9e483f6912e8e5869c43e1771cf167c2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="legend of prince valiant, the (europe) (en,fr,de).bin" size="0x20000" crc="179c494e" sha1="d56b59ad9e483f6912e8e5869c43e1771cf167c2" />
 			</dataarea>
 		</part>
 	</software>
@@ -12331,10 +12331,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="legend of the river king gb (australia).bin" size="524288" crc="51627213" sha1="87274e8c0d2daaac2e0dda94651c35d6a0617c0f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="legend of the river king gb (australia).bin" size="0x80000" crc="51627213" sha1="87274e8c0d2daaac2e0dda94651c35d6a0617c0f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12347,10 +12347,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-afhe-0.u1" size="524288" crc="a6e685dc" sha1="d2e8a9aceec8639b528f712532a38fe0c2b0edef" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-afhe-0.u1" size="0x80000" crc="a6e685dc" sha1="d2e8a9aceec8639b528f712532a38fe0c2b0edef" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12363,10 +12363,10 @@ license:CC0
 		<info name="serial" value="DMG-ZL-USA-1, DMG-ZL-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="legend of zelda, the - link's awakening (usa, europe) (rev 2).bin" size="524288" crc="34d08e7b" sha1="5ab63def958728933571c3b4f6af54db14f3f8b2" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="legend of zelda, the - link's awakening (usa, europe) (rev 2).bin" size="0x80000" crc="34d08e7b" sha1="5ab63def958728933571c3b4f6af54db14f3f8b2" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12379,10 +12379,10 @@ license:CC0
 		<info name="serial" value="DMG-ZL-UKV, DMG-ZL-ESP-1, DMG-ZL-CAN" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="legend of zelda, the - link's awakening (usa, europe) (rev 1).bin" size="524288" crc="7d1b6cd6" sha1="5259e68522225a7a830e29ea17dfddc33263ced5" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="legend of zelda, the - link's awakening (usa, europe) (rev 1).bin" size="0x80000" crc="7d1b6cd6" sha1="5259e68522225a7a830e29ea17dfddc33263ced5" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12401,10 +12401,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" /> <!-- Also found with [6129] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-zle-0.u1" size="524288" crc="8cf27c90" sha1="602167f897b4f56fe8cee837933da3bed5882bbd" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-zle-0.u1" size="0x80000" crc="8cf27c90" sha1="602167f897b4f56fe8cee837933da3bed5882bbd" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12422,10 +12422,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129 3809]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-zcf-0.u1" size="524288" crc="4407c759" sha1="4bbd38a4548e0c7922d0a6719ac5d16791e9535b" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-zcf-0.u1" size="0x80000" crc="4407c759" sha1="4bbd38a4548e0c7922d0a6719ac5d16791e9535b" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12443,10 +12443,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129]" /> <!-- Also with [26A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-zlf-0.u1" size="524288" crc="bf2ab18b" sha1="af93e1b3140f61fcd614f1ef9266d6892224767f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-zlf-0.u1" size="0x80000" crc="bf2ab18b" sha1="af93e1b3140f61fcd614f1ef9266d6892224767f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12464,10 +12464,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" /> <!-- Also with [6129] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-zld-0.u1" size="524288" crc="760ab4e7" sha1="cc468442508a8ba6c4661238aa1925a3132f1630" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-zld-0.u1" size="0x80000" crc="760ab4e7" sha1="cc468442508a8ba6c4661238aa1925a3132f1630" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12482,8 +12482,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-l8x-1.u1" size="131072" crc="560d71eb" sha1="c156d7ee57860a23754e87d42f952b17077994ad" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-l8x-1.u1" size="0x20000" crc="560d71eb" sha1="c156d7ee57860a23754e87d42f952b17077994ad" />
 			</dataarea>
 		</part>
 	</software>
@@ -12495,8 +12495,8 @@ license:CC0
 		<info name="serial" value="DMG-L8-(ESP/UKV)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="lemmings (europe).bin" size="131072" crc="23467a35" sha1="8edb7e1a1a7289d4c393fba6d27776ab6af441ff" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lemmings (europe).bin" size="0x20000" crc="23467a35" sha1="8edb7e1a1a7289d4c393fba6d27776ab6af441ff" />
 			</dataarea>
 		</part>
 	</software>
@@ -12510,8 +12510,8 @@ license:CC0
 		<info name="alt_title" value="レミングス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="lemmings (japan).bin" size="131072" crc="7d5cc03a" sha1="0a4fef2a6a09bb66b1b34b5294ff737530cff4e1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lemmings (japan).bin" size="0x20000" crc="7d5cc03a" sha1="0a4fef2a6a09bb66b1b34b5294ff737530cff4e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -12522,8 +12522,8 @@ license:CC0
 		<publisher>Ocean</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="lemmings dmg 19.5.93 1b9b.u1" size="131072" crc="e2a65174" sha1="4f23d9dcc315f5dbd5ef2350f6623b6cd077b393" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lemmings dmg 19.5.93 1b9b.u1" size="0x20000" crc="e2a65174" sha1="4f23d9dcc315f5dbd5ef2350f6623b6cd077b393" />
 			</dataarea>
 		</part>
 	</software>
@@ -12535,8 +12535,8 @@ license:CC0
 		<info name="serial" value="DMG-L8-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="lemmings (usa).bin" size="131072" crc="f2d1c19d" sha1="1754fde0b1c40752a5716a291e842e38401baf08" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lemmings (usa).bin" size="0x20000" crc="f2d1c19d" sha1="1754fde0b1c40752a5716a291e842e38401baf08" />
 			</dataarea>
 		</part>
 	</software>
@@ -12548,8 +12548,8 @@ license:CC0
 		<info name="serial" value="DMG-AL2P-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-al2p-0.u1" size="524288" crc="9800bd49" sha1="76ccf9ac82faebc7f9c4a4c8b5cd47ddea46c486" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-al2p-0.u1" size="0x80000" crc="9800bd49" sha1="76ccf9ac82faebc7f9c4a4c8b5cd47ddea46c486" />
 			</dataarea>
 		</part>
 	</software>
@@ -12565,8 +12565,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-lte-0.u1" size="131072" crc="1f8d207c" sha1="8b4621471b376a6262fbed70c1191416ab3be915" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-lte-0.u1" size="0x20000" crc="1f8d207c" sha1="8b4621471b376a6262fbed70c1191416ab3be915" />
 			</dataarea>
 		</part>
 	</software>
@@ -12577,8 +12577,8 @@ license:CC0
 		<publisher>Ocean</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="lethal weapon (prototype).bin" size="131072" crc="d585ab23" sha1="2221ba322acffc9d7ae5400752e16d0455fda3ef" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lethal weapon (prototype).bin" size="0x20000" crc="d585ab23" sha1="2221ba322acffc9d7ae5400752e16d0455fda3ef" />
 			</dataarea>
 		</part>
 	</software>
@@ -12593,8 +12593,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-lzx-0.u1" size="131072" crc="0ef4637d" sha1="4838c0baae82a9de62e70f2004d674b87caa2043" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-lzx-0.u1" size="0x20000" crc="0ef4637d" sha1="4838c0baae82a9de62e70f2004d674b87caa2043" />
 			</dataarea>
 		</part>
 	</software>
@@ -12610,8 +12610,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-alnp-0.u1" size="524288" crc="8fc3ca73" sha1="043d29ede2af013c000ff650231c10b3f62d7aca" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-alnp-0.u1" size="0x80000" crc="8fc3ca73" sha1="043d29ede2af013c000ff650231c10b3f62d7aca" />
 			</dataarea>
 		</part>
 	</software>
@@ -12625,8 +12625,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="lion king, the (usa).bin" size="524288" crc="3430d261" sha1="fbbdb1d2073bafa45943cb5f4d4aae5648120089" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="lion king, the (usa).bin" size="0x80000" crc="3430d261" sha1="fbbdb1d2073bafa45943cb5f4d4aae5648120089" />
 			</dataarea>
 		</part>
 	</software>
@@ -12641,8 +12641,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-tmd-0.u1" size="131072" crc="e681395b" sha1="d958c99ebe387b1ba489f4ffda943c00345d2f4e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-tmd-0.u1" size="0x20000" crc="e681395b" sha1="d958c99ebe387b1ba489f4ffda943c00345d2f4e" />
 			</dataarea>
 		</part>
 	</software>
@@ -12656,10 +12656,10 @@ license:CC0
 		<info name="alt_title" value="リトルマスター ライクバーンの伝説" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="little master - raikuban no densetsu (japan).bin" size="131072" crc="31cd9670" sha1="7c83b3c6cd9571c422e66e64e522a0416fa477b2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="little master - raikuban no densetsu (japan).bin" size="0x20000" crc="31cd9670" sha1="7c83b3c6cd9571c422e66e64e522a0416fa477b2" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12673,10 +12673,10 @@ license:CC0
 		<info name="alt_title" value="リトルマスター2 雷光の騎士" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="little master 2 - raikou no kishi (japan).bin" size="262144" crc="187de7f8" sha1="9cc2d0f5ec33ca5ebf382e68dd55503c75a889b5" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="little master 2 - raikou no kishi (japan).bin" size="0x40000" crc="187de7f8" sha1="9cc2d0f5ec33ca5ebf382e68dd55503c75a889b5" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12691,8 +12691,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ldx-0.u1" size="131072" crc="00def37a" sha1="62a5beea93d48445a0f16f5582fc4fc61ba9fc1b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ldx-0.u1" size="0x20000" crc="00def37a" sha1="62a5beea93d48445a0f16f5582fc4fc61ba9fc1b" />
 			</dataarea>
 		</part>
 	</software>
@@ -12707,8 +12707,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-lde-0.u1" size="131072" crc="d7c517e5" sha1="9c7d7a82d0eeb4d7b4f4b7ae35e5ebd80c93d780" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-lde-0.u1" size="0x20000" crc="d7c517e5" sha1="9c7d7a82d0eeb4d7b4f4b7ae35e5ebd80c93d780" />
 			</dataarea>
 		</part>
 	</software>
@@ -12730,8 +12730,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-lca-0.u1" size="65536" crc="dab91c7a" sha1="643cbd566d35ce8dbe0f24627e4862c09805a04c" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-lca-0.u1" size="0x10000" crc="dab91c7a" sha1="643cbd566d35ce8dbe0f24627e4862c09805a04c" />
 			</dataarea>
 		</part>
 	</software>
@@ -12745,8 +12745,8 @@ license:CC0
 		<info name="alt_title" value="ロロの大冒険" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="lolo no daibouken (japan).bin" size="131072" crc="d6185941" sha1="2f4a4215e3c95f7f3646ad678c5cd191fce02515" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lolo no daibouken (japan).bin" size="0x20000" crc="d6185941" sha1="2f4a4215e3c95f7f3646ad678c5cd191fce02515" />
 			</dataarea>
 		</part>
 	</software>
@@ -12758,8 +12758,8 @@ license:CC0
 		<info name="serial" value="DMG-LN-USA, DMG-LN-UKV, DMG-LN-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="looney tunes (usa, europe).bin" size="131072" crc="a662a8ef" sha1="97d96f8ec66acba996c7bec0a713c84075f22680" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="looney tunes (usa, europe).bin" size="0x20000" crc="a662a8ef" sha1="97d96f8ec66acba996c7bec0a713c84075f22680" />
 			</dataarea>
 		</part>
 	</software>
@@ -12773,8 +12773,8 @@ license:CC0
 		<info name="alt_title" value="ルーニー・テューンズ バックスバニーとゆかいな仲間たち" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="looney tunes - bugs bunny to yukai na nakama-tachi (japan).bin" size="131072" crc="40e47da3" sha1="ed26fd9d4011c286e2e6109967cad2564c17900b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="looney tunes - bugs bunny to yukai na nakama-tachi (japan).bin" size="0x20000" crc="40e47da3" sha1="ed26fd9d4011c286e2e6109967cad2564c17900b" />
 			</dataarea>
 		</part>
 	</software>
@@ -12789,8 +12789,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-10" />   <!-- NOE cart -->
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-lpa-0.u1" size="32768" crc="531a3e16" sha1="dd2ddac2310409287299c287f1959196e0b4d14e" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-lpa-0.u1" size="0x8000" crc="531a3e16" sha1="dd2ddac2310409287299c287f1959196e0b4d14e" />
 			</dataarea>
 		</part>
 	</software>
@@ -12800,8 +12800,8 @@ license:CC0
 		<year>1990</year>
 		<publisher>Mindscape</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="loopz (prototype).bin" size="32768" crc="15e28642" sha1="01f87439294a2a06604ae0fd41df203713460510" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="loopz (prototype).bin" size="0x8000" crc="15e28642" sha1="01f87439294a2a06604ae0fd41df203713460510" />
 			</dataarea>
 		</part>
 	</software>
@@ -12817,8 +12817,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-alwp-0.u1" size="524288" crc="391f532a" sha1="68bf63ba6a6c9f3a71a933d6f00e5212c66dcd03" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-alwp-0.u1" size="0x80000" crc="391f532a" sha1="68bf63ba6a6c9f3a71a933d6f00e5212c66dcd03" />
 			</dataarea>
 		</part>
 	</software>
@@ -12834,8 +12834,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-alwf-0.u1" size="524288" crc="fb22d72e" sha1="589efa9ef5a6ce38200a137083f856f75d75a8c6" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-alwf-0.u1" size="0x80000" crc="fb22d72e" sha1="589efa9ef5a6ce38200a137083f856f75d75a8c6" />
 			</dataarea>
 		</part>
 	</software>
@@ -12847,8 +12847,8 @@ license:CC0
 		<info name="serial" value="DMG-ALLP-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="lucky luke (europe) (en,fr,de,es).bin" size="262144" crc="538e0591" sha1="7d67aa8b17d7208d8ed234bd70b4def9582b362d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lucky luke (europe) (en,fr,de,es).bin" size="0x40000" crc="538e0591" sha1="7d67aa8b17d7208d8ed234bd70b4def9582b362d" />
 			</dataarea>
 		</part>
 	</software>
@@ -12862,8 +12862,8 @@ license:CC0
 		<info name="alt_title" value="ラッキーモンキー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="lucky monkey (japan).bin" size="65536" crc="a2234eb1" sha1="ab8654013dc574538b815d8b15aa3cae66afc809" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="lucky monkey (japan).bin" size="0x10000" crc="a2234eb1" sha1="ab8654013dc574538b815d8b15aa3cae66afc809" />
 			</dataarea>
 		</part>
 	</software>
@@ -12883,10 +12883,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-lua-0.u1" size="524288" crc="a3d5c8d7" sha1="2fef16fac95ec4ffd252e9974eccfce538e5f797" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-lua-0.u1" size="0x80000" crc="a3d5c8d7" sha1="2fef16fac95ec4ffd252e9974eccfce538e5f797" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12900,8 +12900,8 @@ license:CC0
 		<info name="alt_title" value="ルナ・ランダー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="lunar lander (japan).bin" size="131072" crc="030d2054" sha1="05266f727879963a23dbbcd8c87c68597607f3b8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lunar lander (japan).bin" size="0x20000" crc="030d2054" sha1="05266f727879963a23dbbcd8c87c68597607f3b8" />
 			</dataarea>
 		</part>
 	</software>
@@ -12916,10 +12916,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="mach go go go (japan).bin" size="262144" crc="016d230b" sha1="baea8b49ce2402c5c094ddae0320a382c0d95d86" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="mach go go go (japan).bin" size="0x40000" crc="016d230b" sha1="baea8b49ce2402c5c094ddae0320a382c0d95d86" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12932,8 +12932,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="madden '95 (usa, europe).bin" size="524288" crc="d2585bbb" sha1="b41a14394bbd890e341bf5d27f297cb5e906fd60" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="madden '95 (usa, europe).bin" size="0x80000" crc="d2585bbb" sha1="b41a14394bbd890e341bf5d27f297cb5e906fd60" />
 			</dataarea>
 		</part>
 	</software>
@@ -12946,8 +12946,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="madden '96 (usa, europe).bin" size="524288" crc="fd9dc1ad" sha1="dd67d34b7801f31063df522c45349823713fe99b" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="madden '96 (usa, europe).bin" size="0x80000" crc="fd9dc1ad" sha1="dd67d34b7801f31063df522c45349823713fe99b" />
 			</dataarea>
 		</part>
 	</software>
@@ -12960,8 +12960,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a7me-0.u1" size="524288" crc="88a837a2" sha1="e1d92b6afdd7dc2254c895ad8a9a066262fb214b" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a7me-0.u1" size="0x80000" crc="88a837a2" sha1="e1d92b6afdd7dc2254c895ad8a9a066262fb214b" />
 			</dataarea>
 		</part>
 	</software>
@@ -12975,8 +12975,8 @@ license:CC0
 		<info name="alt_title" value="メルヘン倶楽部" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="maerchen club (japan).bin" size="131072" crc="cdfd660a" sha1="dcb42287ffdbc352cd954b28a797fcd3547730de" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="maerchen club (japan).bin" size="0x20000" crc="cdfd660a" sha1="dcb42287ffdbc352cd954b28a797fcd3547730de" />
 			</dataarea>
 		</part>
 	</software>
@@ -12991,10 +12991,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="magic knight rayearth (japan).bin" size="262144" crc="94838a81" sha1="4f77031946e62772a241a9b5b046d7fcf6a28ea8" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="magic knight rayearth (japan).bin" size="0x40000" crc="94838a81" sha1="4f77031946e62772a241a9b5b046d7fcf6a28ea8" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13009,10 +13009,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="magic knight rayearth 2nd. - the missing colors (japan).bin" size="262144" crc="00202dfa" sha1="afe76c2d6f796813f1803e8c542107bf0827f966" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="magic knight rayearth 2nd. - the missing colors (japan).bin" size="0x40000" crc="00202dfa" sha1="afe76c2d6f796813f1803e8c542107bf0827f966" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13029,8 +13029,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="magical taruruuto-kun (japan).bin" size="131072" crc="9c4f54f1" sha1="0b7723d1761a61dcf42fc93f134b59f2232d4c37" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="magical taruruuto-kun (japan).bin" size="0x20000" crc="9c4f54f1" sha1="0b7723d1761a61dcf42fc93f134b59f2232d4c37" />
 			</dataarea>
 		</part>
 	</software>
@@ -13047,8 +13047,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-mfj-0.u1" size="131072" crc="0aad5217" sha1="3be6c6b8cec80a0fe0f6edbbe40496f4d077c750" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-mfj-0.u1" size="0x20000" crc="0aad5217" sha1="3be6c6b8cec80a0fe0f6edbbe40496f4d077c750" />
 			</dataarea>
 		</part>
 	</software>
@@ -13063,8 +13063,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-kqx-0.u1" size="131072" crc="9c318c64" sha1="da24ba642fc6ea91d0fb395481840cd9060a6de4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-kqx-0.u1" size="0x20000" crc="9c318c64" sha1="da24ba642fc6ea91d0fb395481840cd9060a6de4" />
 			</dataarea>
 		</part>
 	</software>
@@ -13079,8 +13079,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="mahoujin guruguru (japan).bin" size="262144" crc="2d439d0d" sha1="10a55c546c68cb117cc47d49304f807a7bb63687" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="mahoujin guruguru (japan).bin" size="0x40000" crc="2d439d0d" sha1="10a55c546c68cb117cc47d49304f807a7bb63687" />
 			</dataarea>
 		</part>
 	</software>
@@ -13099,10 +13099,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-saj-1.u1" size="131072" crc="1953820f" sha1="cbf480bc92bd98bae4fb79294b604d341fe58cbe" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-saj-1.u1" size="0x20000" crc="1953820f" sha1="cbf480bc92bd98bae4fb79294b604d341fe58cbe" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13121,10 +13121,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-saj-0.u1" size="131072" crc="131b09f2" sha1="7a8f770a34207fee324431c47836f1ab317863f9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-saj-0.u1" size="0x20000" crc="131b09f2" sha1="7a8f770a34207fee324431c47836f1ab317863f9" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13139,8 +13139,8 @@ license:CC0
 		<info name="alt_title" value="魔界村外伝 ザ・デーモン・ダークネス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="makaimura gaiden - the demon darkness (japan).bin" size="262144" crc="cfa358de" sha1="961d05e91288d7ad1f2e6a1c996059d7ab96fe98" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="makaimura gaiden - the demon darkness (japan).bin" size="0x40000" crc="cfa358de" sha1="961d05e91288d7ad1f2e6a1c996059d7ab96fe98" />
 			</dataarea>
 		</part>
 	</software>
@@ -13152,8 +13152,8 @@ license:CC0
 		<info name="serial" value="DMG-SV-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="malibu beach volleyball (usa).bin" size="65536" crc="dfa5da12" sha1="f7fed41b98fc8bcdc8f72c470e20b8bab150ca33" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="malibu beach volleyball (usa).bin" size="0x10000" crc="dfa5da12" sha1="f7fed41b98fc8bcdc8f72c470e20b8bab150ca33" />
 			</dataarea>
 		</part>
 	</software>
@@ -13165,8 +13165,8 @@ license:CC0
 		<info name="serial" value="DMG-601-CHN" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_m161" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-601-chn.bin" size="262144" crc="0c38a775" sha1="dfe46e066c599c17e684ddda3fd74c5357910630" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-601-chn.bin" size="0x40000" crc="0c38a775" sha1="dfe46e066c599c17e684ddda3fd74c5357910630" />
 			</dataarea>
 		</part>
 	</software>
@@ -13178,8 +13178,8 @@ license:CC0
 		<info name="serial" value="DMG-602-CHN" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mmm01" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-602-chn.bin" size="524288" crc="5bfc3ef5" sha1="c0639d6c993690022200f2fa4b3094249b9335c0" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-602-chn.bin" size="0x80000" crc="5bfc3ef5" sha1="c0639d6c993690022200f2fa4b3094249b9335c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13194,8 +13194,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG-ROM" />    <!-- epoxy block -->
 			<feature name="u2" value="U2 [MMM01]" />
 			<feature name="slot" value="rom_mmm01" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-603-chn.u1" size="524288" crc="c373ac09" sha1="0030295574e4c518ff5cdf20febf6b6737426468" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-603-chn.u1" size="0x80000" crc="c373ac09" sha1="0030295574e4c518ff5cdf20febf6b6737426468" />
 			</dataarea>
 		</part>
 	</software>
@@ -13207,8 +13207,8 @@ license:CC0
 		<info name="serial" value="DMG-604-CHN" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mmm01" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-604-chn.bin" size="524288" crc="cb48b6d0" sha1="1c79eb31a6754b4e96d33a182d36833208dc7177" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-604-chn.bin" size="0x80000" crc="cb48b6d0" sha1="1c79eb31a6754b4e96d33a182d36833208dc7177" />
 			</dataarea>
 		</part>
 	</software>
@@ -13220,8 +13220,8 @@ license:CC0
 		<info name="serial" value="DMG-605-CHN" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mmm01" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-605-chn.bin" size="1048576" crc="950773ee" sha1="af4706da224d794668f3b2c68aea7b3c16452d83" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-605-chn.bin" size="0x100000" crc="950773ee" sha1="af4706da224d794668f3b2c68aea7b3c16452d83" />
 			</dataarea>
 		</part>
 	</software>
@@ -13236,8 +13236,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-mbe-0.u1" size="262144" crc="b9725e66" sha1="bf2a73f7adf200410038350c2c754a943d841681" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-mbe-0.u1" size="0x40000" crc="b9725e66" sha1="bf2a73f7adf200410038350c2c754a943d841681" />
 			</dataarea>
 		</part>
 	</software>
@@ -13252,8 +13252,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-yox-0.u1" size="65536" crc="4627d88b" sha1="9bf642eabdb51625d1ef1ac470666ec8f5f10f77" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-yox-0.u1" size="0x10000" crc="4627d88b" sha1="9bf642eabdb51625d1ef1ac470666ec8f5f10f77" />
 			</dataarea>
 		</part>
 	</software>
@@ -13275,10 +13275,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" /> <!-- Also found with [6129A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-apcj-0.u1" size="262144" crc="17533700" sha1="6b72cbff3e224299eff6f79e0110a477b8f840c2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-apcj-0.u1" size="0x40000" crc="17533700" sha1="6b72cbff3e224299eff6f79e0110a477b8f840c2" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13297,10 +13297,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" /> <!-- Also found with [26A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-apcp-0.u1" size="262144" crc="f2d652ad" sha1="9712f37171b8a0cdc99a60170ea7b2aed161195e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-apcp-0.u1" size="0x40000" crc="f2d652ad" sha1="9712f37171b8a0cdc99a60170ea7b2aed161195e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13318,8 +13318,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-amaj-0.u1" size="262144" crc="0f3ff7da" sha1="60125690b7a354ff8e72f497c8a88ecd691e7e4b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-amaj-0.u1" size="0x40000" crc="0f3ff7da" sha1="60125690b7a354ff8e72f497c8a88ecd691e7e4b" />
 			</dataarea>
 		</part>
 	</software>
@@ -13331,8 +13331,8 @@ license:CC0
 		<info name="serial" value="DMG-OJ-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="maru's mission (usa).bin" size="131072" crc="6e4f1eb3" sha1="91446b1cc6dbf3b98b81f13e35ffe7bfaaa027aa" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="maru's mission (usa).bin" size="0x20000" crc="6e4f1eb3" sha1="91446b1cc6dbf3b98b81f13e35ffe7bfaaa027aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -13346,8 +13346,8 @@ license:CC0
 		<info name="alt_title" value="マサカリ伝説−金太郎アクション編−" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="masakari densetsu - kintarou action hen (japan).bin" size="262144" crc="7cb70d3d" sha1="ec23af3d5590b75b2a3b33708a4fe5cffe495a1f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="masakari densetsu - kintarou action hen (japan).bin" size="0x40000" crc="7cb70d3d" sha1="ec23af3d5590b75b2a3b33708a4fe5cffe495a1f" />
 			</dataarea>
 		</part>
 	</software>
@@ -13362,10 +13362,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="masakari densetsu - kintarou rpg hen (japan).bin" size="524288" crc="d8bab8e0" sha1="a9bcb90df5b19a372ceed81c614bb7eb295ec74c" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="masakari densetsu - kintarou rpg hen (japan).bin" size="0x80000" crc="d8bab8e0" sha1="a9bcb90df5b19a372ceed81c614bb7eb295ec74c" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13378,8 +13378,8 @@ license:CC0
 		<info name="release" value="19891228" />
 		<info name="alt_title" value="マスターカラテカ" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="master karateka (japan).bin" size="32768" crc="4c0fb33e" sha1="1ffea01d8d91f026ce6677631bcb10991092ff13" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="master karateka (japan).bin" size="0x8000" crc="4c0fb33e" sha1="1ffea01d8d91f026ce6677631bcb10991092ff13" />
 			</dataarea>
 		</part>
 	</software>
@@ -13397,10 +13397,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ajsd-0.u1" size="262144" crc="631e656f" sha1="eadc06e71ea4f04700e2ed1ef232b6e57cb48725" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ajsd-0.u1" size="0x40000" crc="631e656f" sha1="eadc06e71ea4f04700e2ed1ef232b6e57cb48725" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13414,8 +13414,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-amie-0.u1" size="262144" crc="6f30a43a" sha1="eb401c5ddff1488013ff032918ed365e82104ae0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-amie-0.u1" size="0x40000" crc="6f30a43a" sha1="eb401c5ddff1488013ff032918ed365e82104ae0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13430,8 +13430,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-admp-0.u1" size="262144" crc="478f573c" sha1="bf2b9d7a54ff0b80c2710f747f5457578caa0cd0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-admp-0.u1" size="0x40000" crc="478f573c" sha1="bf2b9d7a54ff0b80c2710f747f5457578caa0cd0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13446,8 +13446,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-kvx-0.u1" size="65536" crc="1b167f00" sha1="1f995332ae8a8832c178b22505d05080bf978aa8" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-kvx-0.u1" size="0x10000" crc="1b167f00" sha1="1f995332ae8a8832c178b22505d05080bf978aa8" />
 			</dataarea>
 		</part>
 	</software>
@@ -13462,8 +13462,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-cux-0.u1" size="131072" crc="81de6c13" sha1="fd11d61f961a7e3c69e272ef19eb243b7df89833" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-cux-0.u1" size="0x20000" crc="81de6c13" sha1="fd11d61f961a7e3c69e272ef19eb243b7df89833" />
 			</dataarea>
 		</part>
 	</software>
@@ -13485,10 +13485,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-amxj-1.u1" size="524288" crc="12a3982d" sha1="1cbc7ab5941dc27bc50699a00ef2b1beb930449d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-amxj-1.u1" size="0x80000" crc="12a3982d" sha1="1cbc7ab5941dc27bc50699a00ef2b1beb930449d" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -13510,10 +13510,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-amxj-0.u1" size="524288" crc="1bab9900" sha1="ae26b9310ab41d94a73b807ef5f30e2d0e34d667" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-amxj-0.u1" size="0x80000" crc="1bab9900" sha1="ae26b9310ab41d94a73b807ef5f30e2d0e34d667" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -13535,10 +13535,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-amyj-1.u1" size="524288" crc="5e77e82e" sha1="2262f69a89abe0f66dc1554c1ee470fd536130a3" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-amyj-1.u1" size="0x80000" crc="5e77e82e" sha1="2262f69a89abe0f66dc1554c1ee470fd536130a3" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -13554,10 +13554,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="medarot - kuwagata version (japan).bin" size="524288" crc="bc0588c4" sha1="f657f822ed15e459c4abcd171c9620cddbdfd022" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="medarot - kuwagata version (japan).bin" size="0x80000" crc="bc0588c4" sha1="f657f822ed15e459c4abcd171c9620cddbdfd022" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -13573,10 +13573,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="medarot - parts collection (japan).bin" size="524288" crc="f4cab596" sha1="eec1245abb1d97cd2df976fdf179c924a4efa720" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="medarot - parts collection (japan).bin" size="0x80000" crc="f4cab596" sha1="eec1245abb1d97cd2df976fdf179c924a4efa720" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -13591,10 +13591,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="medarot - parts collection 2 (japan).bin" size="524288" crc="89f94482" sha1="edd74afbfca5e3d3366fb231c4bedd80fcf8a81e" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="medarot - parts collection 2 (japan).bin" size="0x80000" crc="89f94482" sha1="edd74afbfca5e3d3366fb231c4bedd80fcf8a81e" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -13608,8 +13608,8 @@ license:CC0
 		<info name="alt_title" value="メガリット" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="megalit (japan).bin" size="131072" crc="c764b1f2" sha1="c40e35cf3c7af6cff9e079543650f51cf9777018" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="megalit (japan).bin" size="0x20000" crc="c764b1f2" sha1="c40e35cf3c7af6cff9e079543650f51cf9777018" />
 			</dataarea>
 		</part>
 	</software>
@@ -13624,8 +13624,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-mze-0.u1" size="65536" crc="f315b842" sha1="7f3f6b1cc543228bcdd336dfcd1865a3c8d7d177" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-mze-0.u1" size="0x10000" crc="f315b842" sha1="7f3f6b1cc543228bcdd336dfcd1865a3c8d7d177" />
 			</dataarea>
 		</part>
 	</software>
@@ -13640,8 +13640,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-rwx-0.u1" size="262144" crc="2ea4b976" sha1="11255a24344e9fed53b8f1f6f894d21e161a0d5e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-rwx-0.u1" size="0x40000" crc="2ea4b976" sha1="11255a24344e9fed53b8f1f6f894d21e161a0d5e" />
 			</dataarea>
 		</part>
 	</software>
@@ -13656,8 +13656,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-rwe-0.u1" size="262144" crc="47e70e08" sha1="277edb3c844e812ba4b3eb9a96c9c30414541858" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-rwe-0.u1" size="0x40000" crc="47e70e08" sha1="277edb3c844e812ba4b3eb9a96c9c30414541858" />
 			</dataarea>
 		</part>
 	</software>
@@ -13672,8 +13672,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-w2x-0.u1" size="262144" crc="5e90cb48" sha1="d19993a4630e7f9450ff6469115f4095f6f29667" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-w2x-0.u1" size="0x40000" crc="5e90cb48" sha1="d19993a4630e7f9450ff6469115f4095f6f29667" />
 			</dataarea>
 		</part>
 	</software>
@@ -13688,8 +13688,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-w2e-0.u1" size="262144" crc="e496f686" sha1="334f1a93346d55e1be2967f0af952e37aa52fca7" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-w2e-0.u1" size="0x40000" crc="e496f686" sha1="334f1a93346d55e1be2967f0af952e37aa52fca7" />
 			</dataarea>
 		</part>
 	</software>
@@ -13704,8 +13704,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" /> <!-- Also found with [DMG MBC1B1] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-w3x-0.u1" size="262144" crc="03b0d4ec" sha1="ecadbc9e273e4d99ccd87f98bbbd912aec43c077" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-w3x-0.u1" size="0x40000" crc="03b0d4ec" sha1="ecadbc9e273e4d99ccd87f98bbbd912aec43c077" />
 			</dataarea>
 		</part>
 	</software>
@@ -13717,8 +13717,8 @@ license:CC0
 		<info name="serial" value="DMG-W3-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="megaman iii (usa).bin" size="262144" crc="5175d761" sha1="57347305ab297daa4332564623c4a098e6dbb1a3" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="megaman iii (usa).bin" size="0x40000" crc="5175d761" sha1="57347305ab297daa4332564623c4a098e6dbb1a3" />
 			</dataarea>
 		</part>
 	</software>
@@ -13729,8 +13729,8 @@ license:CC0
 		<publisher>Capcom</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="mm3 35sample.u1" size="262144" crc="82f4c095" sha1="7eea8a96bf64537b041b96ce2cb5dd13cdebb789" /> <!-- original label: MM3 35サンプル -->
+			<dataarea name="rom" size="0x40000">
+				<rom name="mm3 35sample.u1" size="0x40000" crc="82f4c095" sha1="7eea8a96bf64537b041b96ce2cb5dd13cdebb789" /> <!-- original label: MM3 35サンプル -->
 			</dataarea>
 		</part>
 	</software>
@@ -13745,8 +13745,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B1] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-r4x-0.u1" size="524288" crc="060b89e6" sha1="a15a05593bf9bdddb5826b148e25182e7b90f268" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-r4x-0.u1" size="0x80000" crc="060b89e6" sha1="a15a05593bf9bdddb5826b148e25182e7b90f268" />
 			</dataarea>
 		</part>
 	</software>
@@ -13758,8 +13758,8 @@ license:CC0
 		<info name="serial" value="DMG-R4-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="megaman iv (usa).bin" size="524288" crc="abcea00d" sha1="6f0901db2b5dcaace0215c0abdc21a914fa21b65" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="megaman iv (usa).bin" size="0x80000" crc="abcea00d" sha1="6f0901db2b5dcaace0215c0abdc21a914fa21b65" />
 			</dataarea>
 		</part>
 	</software>
@@ -13775,8 +13775,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-wmx-0.u1" size="524288" crc="d12ac4fe" sha1="1a377bb0571bbe48a58b5006ccb02046ec64b076" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-wmx-0.u1" size="0x80000" crc="d12ac4fe" sha1="1a377bb0571bbe48a58b5006ccb02046ec64b076" />
 			</dataarea>
 		</part>
 	</software>
@@ -13789,8 +13789,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="megaman v (usa).bin" size="524288" crc="72e6d21d" sha1="9a7da0e4d3f49e4a0b94e85cd64e28a687d81260" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="megaman v (usa).bin" size="0x80000" crc="72e6d21d" sha1="9a7da0e4d3f49e4a0b94e85cd64e28a687d81260" />
 			</dataarea>
 		</part>
 	</software>
@@ -13804,10 +13804,10 @@ license:CC0
 		<info name="alt_title" value="女神転生外伝 ラストバイブル" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="megami tensei gaiden - last bible (japan).bin" size="262144" crc="fe9dd4c0" sha1="537b38234da5164335e98f6aee3b792048624626" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="megami tensei gaiden - last bible (japan).bin" size="0x40000" crc="fe9dd4c0" sha1="537b38234da5164335e98f6aee3b792048624626" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13821,10 +13821,10 @@ license:CC0
 		<info name="alt_title" value="女神転生外伝 ラストバイブルII" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="megami tensei gaiden - last bible ii (japan).bin" size="262144" crc="f8e519d9" sha1="d7575f7f60c75dd71a7b5be071db57be13237d30" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="megami tensei gaiden - last bible ii (japan).bin" size="0x40000" crc="f8e519d9" sha1="d7575f7f60c75dd71a7b5be071db57be13237d30" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13839,8 +13839,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="meitantei conan - chika yuuenchi satsujin jiken (japan).bin" size="262144" crc="3945bc0d" sha1="2ab6749d2abaf3fc3cb9317f64cec78e0184ff6b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="meitantei conan - chika yuuenchi satsujin jiken (japan).bin" size="0x40000" crc="3945bc0d" sha1="2ab6749d2abaf3fc3cb9317f64cec78e0184ff6b" />
 			</dataarea>
 		</part>
 	</software>
@@ -13855,8 +13855,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="meitantei conan - giwaku no gouka ressha (japan).bin" size="262144" crc="1dc5c31a" sha1="125db863bad5d48033d0bf94ed808b2b8d34ca2f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="meitantei conan - giwaku no gouka ressha (japan).bin" size="0x40000" crc="1dc5c31a" sha1="125db863bad5d48033d0bf94ed808b2b8d34ca2f" />
 			</dataarea>
 		</part>
 	</software>
@@ -13871,8 +13871,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-tke-0.u1" size="131072" crc="9bb5ba03" sha1="35bbde8934792588620d1c242dedef1da9097a2e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-tke-0.u1" size="0x20000" crc="9bb5ba03" sha1="35bbde8934792588620d1c242dedef1da9097a2e" />
 			</dataarea>
 		</part>
 	</software>
@@ -13884,8 +13884,8 @@ license:CC0
 		<info name="serial" value="DMG-E6-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="metal masters (usa).bin" size="131072" crc="bf6866dc" sha1="caae5811b2d2b884b691ea7d940ecb86647cd250" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="metal masters (usa).bin" size="0x20000" crc="bf6866dc" sha1="caae5811b2d2b884b691ea7d940ecb86647cd250" />
 			</dataarea>
 		</part>
 	</software>
@@ -13896,8 +13896,8 @@ license:CC0
 		<publisher>Electro Brain</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="metal masters (prototype).bin" size="131072" crc="3378064b" sha1="572c820f7ec7a3c96df9af441da244befa5223b9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="metal masters (prototype).bin" size="0x20000" crc="3378064b" sha1="572c820f7ec7a3c96df9af441da244befa5223b9" />
 			</dataarea>
 		</part>
 	</software>
@@ -13926,10 +13926,10 @@ license:CC0
 			<feature name="batt" value="Batt CR1616" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-mea-0.u1" size="262144" crc="dee05370" sha1="74a2fad86b9a4c013149b1e214bc4600efb1066d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-mea-0.u1" size="0x40000" crc="dee05370" sha1="74a2fad86b9a4c013149b1e214bc4600efb1066d" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13941,8 +13941,8 @@ license:CC0
 		<info name="serial" value="DMG-M2-(ESP/UKV)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="mickey mouse (europe).bin" size="131072" crc="fc50dee7" sha1="b8e708dfe7496c712bd3ef171429d81cb6619252" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="mickey mouse (europe).bin" size="0x20000" crc="fc50dee7" sha1="b8e708dfe7496c712bd3ef171429d81cb6619252" />
 			</dataarea>
 		</part>
 	</software>
@@ -13956,8 +13956,8 @@ license:CC0
 		<info name="alt_title" value="ミッキーマウス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="mickey mouse (japan).bin" size="65536" crc="4ca75d4d" sha1="a5e526b47e9295c7cbea21a84bef2c1658e6f87e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="mickey mouse (japan).bin" size="0x10000" crc="4ca75d4d" sha1="a5e526b47e9295c7cbea21a84bef2c1658e6f87e" />
 			</dataarea>
 		</part>
 	</software>
@@ -13974,8 +13974,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-i5x-0.u1" size="131072" crc="f0482567" sha1="90a181ee7d42941bce3b425077d6570da0e2fb2c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-i5x-0.u1" size="0x20000" crc="f0482567" sha1="90a181ee7d42941bce3b425077d6570da0e2fb2c" />
 			</dataarea>
 		</part>
 	</software>
@@ -13989,8 +13989,8 @@ license:CC0
 		<info name="alt_title" value="ミッキーマウス2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="mickey mouse ii (japan).bin" size="131072" crc="dfee8bcc" sha1="2d44566d2d74f573d2faf23988a3070abb47555d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="mickey mouse ii (japan).bin" size="0x20000" crc="dfee8bcc" sha1="2d44566d2d74f573d2faf23988a3070abb47555d" />
 			</dataarea>
 		</part>
 	</software>
@@ -14007,8 +14007,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-l4a-0.u1" size="131072" crc="0d30b3a1" sha1="d091d67890103ca97caf2c46d6bf4e2a85c92383" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-l4a-0.u1" size="0x20000" crc="0d30b3a1" sha1="d091d67890103ca97caf2c46d6bf4e2a85c92383" />
 			</dataarea>
 		</part>
 	</software>
@@ -14022,8 +14022,8 @@ license:CC0
 		<info name="alt_title" value="ミッキーマウスV 魔法のステッキ ~ Mickey Mouse V - Mahou no Stick (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="mickey mouse v (japan).bin" size="131072" crc="44cd01dd" sha1="b8537bef22696feadf51343b6e1697370c4a8d5a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="mickey mouse v (japan).bin" size="0x20000" crc="44cd01dd" sha1="b8537bef22696feadf51343b6e1697370c4a8d5a" />
 			</dataarea>
 		</part>
 	</software>
@@ -14036,8 +14036,8 @@ license:CC0
 		<info name="alt_title" value="ミッキーマウスV 魔法のステッキ ~ Mickey Mouse V - Mahou no Stick (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-i5j-1.u1" size="131072" crc="464eaa5d" sha1="095285ec078124e3a4cbbfa3ac0d7680ee491e2b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-i5j-1.u1" size="0x20000" crc="464eaa5d" sha1="095285ec078124e3a4cbbfa3ac0d7680ee491e2b" />
 			</dataarea>
 		</part>
 	</software>
@@ -14050,8 +14050,8 @@ license:CC0
 		<info name="alt_title" value="Mickey's Dangerous Chase (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="mickey's chase (europe).bin" size="131072" crc="e72db762" sha1="1f749b9a805b28ee2f130da9e0e941a0427683d4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="mickey's chase (europe).bin" size="0x20000" crc="e72db762" sha1="1f749b9a805b28ee2f130da9e0e941a0427683d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -14065,8 +14065,8 @@ license:CC0
 		<info name="alt_title" value="ミッキーズチェイス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="mickey's chase (japan).bin" size="131072" crc="0ab490c8" sha1="bd890e13f7518513178f324d6fc5d28bc22e5bfb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="mickey's chase (japan).bin" size="0x20000" crc="0ab490c8" sha1="bd890e13f7518513178f324d6fc5d28bc22e5bfb" />
 			</dataarea>
 		</part>
 	</software>
@@ -14082,8 +14082,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-mce-0.u1" size="131072" crc="7b822d8f" sha1="37d0737be3773ad62664645d34505a136f0be99b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-mce-0.u1" size="0x20000" crc="7b822d8f" sha1="37d0737be3773ad62664645d34505a136f0be99b" />
 			</dataarea>
 		</part>
 	</software>
@@ -14098,8 +14098,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-uve-0.u1" size="262144" crc="23e9d625" sha1="cebdc7b9f5764aebab116ba0a5d06c67cd4bea84" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-uve-0.u1" size="0x40000" crc="23e9d625" sha1="cebdc7b9f5764aebab116ba0a5d06c67cd4bea84" />
 			</dataarea>
 		</part>
 	</software>
@@ -14110,8 +14110,8 @@ license:CC0
 		<publisher>Hi Tech Expressions</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="mickey's ultimate challenge (nov 12, 1993 prototype).bin" size="131072" crc="3fac2661" sha1="e6809004a3af32235e55a300f53b421a00c57b98" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="mickey's ultimate challenge (nov 12, 1993 prototype).bin" size="0x20000" crc="3fac2661" sha1="e6809004a3af32235e55a300f53b421a00c57b98" />
 			</dataarea>
 		</part>
 	</software>
@@ -14123,8 +14123,8 @@ license:CC0
 		<info name="serial" value="DMG-H3-USA, DMG-H3-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="micro machines (usa, europe).bin" size="262144" crc="2088f85f" sha1="62c07baa3ed0ccaf704399f05fe90569d90c6eff" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="micro machines (usa, europe).bin" size="0x40000" crc="2088f85f" sha1="62c07baa3ed0ccaf704399f05fe90569d90c6eff" />
 			</dataarea>
 		</part>
 	</software>
@@ -14139,8 +14139,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a2xp-0.u1" size="524288" crc="24666c4d" sha1="50fea244c7b8c982421fccd67bc8177cf510a306" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a2xp-0.u1" size="0x80000" crc="24666c4d" sha1="50fea244c7b8c982421fccd67bc8177cf510a306" />
 			</dataarea>
 		</part>
 	</software>
@@ -14158,8 +14158,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-anaj-0.u1" size="262144" crc="1dd93d95" sha1="4de380b202e375761f9fe7fb13349f5b02e2dac2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-anaj-0.u1" size="0x40000" crc="1dd93d95" sha1="4de380b202e375761f9fe7fb13349f5b02e2dac2" />
 			</dataarea>
 		</part>
 	</software>
@@ -14175,8 +14175,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-zwe-0.u1" size="262144" crc="c60d032a" sha1="ef88476d9a1a26b67f3535ae7afcf5156578e38c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-zwe-0.u1" size="0x40000" crc="c60d032a" sha1="ef88476d9a1a26b67f3535ae7afcf5156578e38c" />
 			</dataarea>
 		</part>
 	</software>
@@ -14188,8 +14188,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="mighty morphin power rangers (prototype).bin" size="262144" crc="caab9ac9" sha1="be42f45d8038ce28461ed36ba9164854632aebe0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="mighty morphin power rangers (prototype).bin" size="0x40000" crc="caab9ac9" sha1="be42f45d8038ce28461ed36ba9164854632aebe0" />
 			</dataarea>
 		</part>
 	</software>
@@ -14202,8 +14202,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="mighty morphin power rangers - the movie (usa, europe).bin" size="262144" crc="86a1c549" sha1="0646bff26350059224a5dca807218ff02a4704af" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="mighty morphin power rangers - the movie (usa, europe).bin" size="0x40000" crc="86a1c549" sha1="0646bff26350059224a5dca807218ff02a4704af" />
 			</dataarea>
 		</part>
 	</software>
@@ -14216,8 +14216,8 @@ license:CC0
 		<info name="release" value="19920424" />
 		<info name="alt_title" value="ミグレイン" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="migrain (japan).bin" size="32768" crc="ced936f8" sha1="98ea7eab4048cbd0e4aa5f88e9a831e522c493d5" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="migrain (japan).bin" size="0x8000" crc="ced936f8" sha1="98ea7eab4048cbd0e4aa5f88e9a831e522c493d5" />
 			</dataarea>
 		</part>
 	</software>
@@ -14231,8 +14231,8 @@ license:CC0
 		<info name="alt_title" value="三毛猫ホームズの騎士道" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="mikeneko holmes no kishidou (japan).bin" size="131072" crc="73b80b16" sha1="0fa85af4827f141cf3e6788b3bfdbc134d1a80c5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="mikeneko holmes no kishidou (japan).bin" size="0x20000" crc="73b80b16" sha1="0fa85af4827f141cf3e6788b3bfdbc134d1a80c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -14249,8 +14249,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="u2" size="131072" crc="f188c94c" sha1="95e6473824b7671140c738e0d3bfdbe2b1f39480" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="u2" size="0x20000" crc="f188c94c" sha1="95e6473824b7671140c738e0d3bfdbe2b1f39480" />
 			</dataarea>
 		</part>
 	</software>
@@ -14265,8 +14265,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-m8e-0.u1" size="131072" crc="62b4cc8c" sha1="40ff7865b543c9b6a3c2dde542819018e7f06fa8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-m8e-0.u1" size="0x20000" crc="62b4cc8c" sha1="40ff7865b543c9b6a3c2dde542819018e7f06fa8" />
 			</dataarea>
 		</part>
 	</software>
@@ -14276,8 +14276,8 @@ license:CC0
 		<year>1991</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mind bender (mar 4, 1991 prototype).bin" size="32768" crc="984ec5d6" sha1="235f61e7ccc6f9cffe6c30a0abc778f6745d3a5a" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="mind bender (mar 4, 1991 prototype).bin" size="0x8000" crc="984ec5d6" sha1="235f61e7ccc6f9cffe6c30a0abc778f6745d3a5a" />
 			</dataarea>
 		</part>
 	</software>
@@ -14290,8 +14290,8 @@ license:CC0
 		<info name="alt_title" value="Miner 2049er Starring Bounty Bob (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="miner 2049er (usa).bin" size="65536" crc="1a6bd577" sha1="6f62bf7f88263470dfa61d6752b345573f10cd8f" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="miner 2049er (usa).bin" size="0x10000" crc="1a6bd577" sha1="6f62bf7f88263470dfa61d6752b345573f10cd8f" />
 			</dataarea>
 		</part>
 	</software>
@@ -14304,8 +14304,8 @@ license:CC0
 		<info name="release" value="19911213" />
 		<info name="alt_title" value="マインスウィーパー 掃海艇" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="minesweeper - soukaitei (japan).bin" size="32768" crc="5532b3d1" sha1="8538358957b2f6d6c58e2ceb2c83cf82149985fd" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="minesweeper - soukaitei (japan).bin" size="0x8000" crc="5532b3d1" sha1="8538358957b2f6d6c58e2ceb2c83cf82149985fd" />
 			</dataarea>
 		</part>
 	</software>
@@ -14320,10 +14320,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="mini 4 boy (japan).bin" size="524288" crc="0618e4b0" sha1="cb6022ef5729cbf370ccdc9c1958d0b4bcbd5e90" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="mini 4 boy (japan).bin" size="0x80000" crc="0618e4b0" sha1="cb6022ef5729cbf370ccdc9c1958d0b4bcbd5e90" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -14344,10 +14344,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aj2j-0.u1" size="524288" crc="d6962241" sha1="eebcf67ab1455501f1b758ab71a8dc22808b34f1" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aj2j-0.u1" size="0x80000" crc="d6962241" sha1="eebcf67ab1455501f1b758ab71a8dc22808b34f1" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -14361,8 +14361,8 @@ license:CC0
 		<info name="alt_title" value="ミニ・パット" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="mini putt (japan).bin" size="65536" crc="33cd7550" sha1="e2a75fc09d8f9e56325449ca91cda9a68d058c1f" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="mini putt (japan).bin" size="0x10000" crc="33cd7550" sha1="e2a75fc09d8f9e56325449ca91cda9a68d058c1f" />
 			</dataarea>
 		</part>
 	</software>
@@ -14383,10 +14383,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-am4j-0.u1" size="524288" crc="fc0c180b" sha1="a51dc3ea1961297a3056e0326c8a153f496dae8a" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-am4j-0.u1" size="0x80000" crc="fc0c180b" sha1="a51dc3ea1961297a3056e0326c8a153f496dae8a" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -14407,10 +14407,10 @@ license:CC0
 			<feature name="u4" value="U4 [6129A]" />
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-aamj-0.u1" size="1048576" crc="97ebd21d" sha1="ca662cb506b553f1730c29c088e597bace1e0052" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-aamj-0.u1" size="0x100000" crc="97ebd21d" sha1="ca662cb506b553f1730c29c088e597bace1e0052" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -14432,8 +14432,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-esj-0.u1" size="131072" crc="b3ad9b76" sha1="27b272aff632f7e8ca72e87627ce37336666c952" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-esj-0.u1" size="0x20000" crc="b3ad9b76" sha1="27b272aff632f7e8ca72e87627ce37336666c952" />
 			</dataarea>
 		</part>
 	</software>
@@ -14446,8 +14446,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-mwe-0.u1" size="32768" crc="3a6cd4d8" sha1="ed529062ae3d1feb4defbf54c2cc759211e3aeaa" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-mwe-0.u1" size="0x8000" crc="3a6cd4d8" sha1="ed529062ae3d1feb4defbf54c2cc759211e3aeaa" />
 			</dataarea>
 		</part>
 	</software>
@@ -14462,10 +14462,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="mogu mogu gombo (japan).bin" size="262144" crc="85c984f2" sha1="a4524d11f2a86e28bc319335b5c05ea6550b26e1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="mogu mogu gombo (japan).bin" size="0x40000" crc="85c984f2" sha1="a4524d11f2a86e28bc319335b5c05ea6550b26e1" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -14478,8 +14478,8 @@ license:CC0
 		<info name="release" value="19940415" />
 		<info name="alt_title" value="もぐらでポン!" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mogura de pon (japan).bin" size="32768" crc="e1e3629f" sha1="3c6586f3d591cee7415ed76d92355a27ad42e1e3" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="mogura de pon (japan).bin" size="0x8000" crc="e1e3629f" sha1="3c6586f3d591cee7415ed76d92355a27ad42e1e3" />
 			</dataarea>
 		</part>
 	</software>
@@ -14501,10 +14501,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-amoj-0.u1" size="524288" crc="82fca204" sha1="16b6355019e4e0eb8871d6cb16aabb971ab1b62a" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-amoj-0.u1" size="0x80000" crc="82fca204" sha1="16b6355019e4e0eb8871d6cb16aabb971ab1b62a" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -14523,11 +14523,11 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" /> <!-- Also found with [6129A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
+			<dataarea name="rom" size="0x80000">
 				<!-- USA cart has label DMG-AMOE-0 -->
-				<rom name="dmg-amop-0.u1" size="524288" crc="2c36c74c" sha1="37085973519d61e17797693b23016493da56a462" />
+				<rom name="dmg-amop-0.u1" size="0x80000" crc="2c36c74c" sha1="37085973519d61e17797693b23016493da56a462" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -14548,10 +14548,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1col" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-amdj-0.u1" size="1048576" crc="ad376905" sha1="cd7088d13f5b80f32c0fae95a57969f6f33a9a02" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-amdj-0.u1" size="0x100000" crc="ad376905" sha1="cd7088d13f5b80f32c0fae95a57969f6f33a9a02" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -14572,10 +14572,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mmm01" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-am3j-0.u1" size="1048576" crc="562c8f7f" sha1="0d6bd573ae696b337d107eff2aee502bb240a40c" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-am3j-0.u1" size="0x100000" crc="562c8f7f" sha1="0d6bd573ae696b337d107eff2aee502bb240a40c" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -14589,8 +14589,8 @@ license:CC0
 		<info name="alt_title" value="桃太郎電劇" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="momotarou dengeki (japan).bin" size="262144" crc="f09b34ab" sha1="8450758a8338700468f862c73f344c63b921812f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="momotarou dengeki (japan).bin" size="0x40000" crc="f09b34ab" sha1="8450758a8338700468f862c73f344c63b921812f" />
 			</dataarea>
 		</part>
 	</software>
@@ -14606,8 +14606,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="momotarou dengeki 2 (japan).bin" size="524288" crc="3c1c5eb4" sha1="f050cc860e610a07a27c51ff873dd71aca9e23e6" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="momotarou dengeki 2 (japan).bin" size="0x80000" crc="3c1c5eb4" sha1="f050cc860e610a07a27c51ff873dd71aca9e23e6" />
 			</dataarea>
 		</part>
 	</software>
@@ -14621,10 +14621,10 @@ license:CC0
 		<info name="alt_title" value="桃太郎伝説 外伝" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="momotarou densetsu gaiden (japan).bin" size="262144" crc="ba5611ef" sha1="1a819534e7e29a17d5644ef190998cea781a69a6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="momotarou densetsu gaiden (japan).bin" size="0x40000" crc="ba5611ef" sha1="1a819534e7e29a17d5644ef190998cea781a69a6" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -14640,10 +14640,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="momotarou dentetsu jr. - zenkoku ramen meguri no maki (japan).bin" size="524288" crc="218265b3" sha1="30edf17fc9ddd9db7613c8f78b0ebc340cc89eb0" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="momotarou dentetsu jr. - zenkoku ramen meguri no maki (japan).bin" size="0x80000" crc="218265b3" sha1="30edf17fc9ddd9db7613c8f78b0ebc340cc89eb0" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -14661,8 +14661,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-amej-0.u1" size="262144" crc="800226a9" sha1="a52cc4167316683c7ddc0b6fb5370a05ab49dbbe" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-amej-0.u1" size="0x40000" crc="800226a9" sha1="a52cc4167316683c7ddc0b6fb5370a05ab49dbbe" />
 			</dataarea>
 		</part>
 	</software>
@@ -14674,8 +14674,8 @@ license:CC0
 		<info name="serial" value="DMG-ALYP-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="monopoly (europe) (en,fr,de).bin" size="262144" crc="987b621e" sha1="d7bb71f20396b6e65e6396ca75a6d1f992a05b08" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="monopoly (europe) (en,fr,de).bin" size="0x40000" crc="987b621e" sha1="d7bb71f20396b6e65e6396ca75a6d1f992a05b08" />
 			</dataarea>
 		</part>
 	</software>
@@ -14689,8 +14689,8 @@ license:CC0
 		<info name="alt_title" value="モノポリー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="monopoly (japan).bin" size="262144" crc="d8ac08b5" sha1="f6e72820e7d397528a1b225081de96f297e12093" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="monopoly (japan).bin" size="0x40000" crc="d8ac08b5" sha1="f6e72820e7d397528a1b225081de96f297e12093" />
 			</dataarea>
 		</part>
 	</software>
@@ -14705,8 +14705,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-lye-0.u1" size="131072" crc="fd90f0d6" sha1="ff54ef03cb4dda14890ae0394dd7ba5e00130d08" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-lye-0.u1" size="0x20000" crc="fd90f0d6" sha1="ff54ef03cb4dda14890ae0394dd7ba5e00130d08" />
 			</dataarea>
 		</part>
 	</software>
@@ -14742,10 +14742,10 @@ license:CC0
 		<info name="alt_title" value="モンスターメーカー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="monster maker (japan).bin" size="131072" crc="725ee86c" sha1="70d99059ef780033cd0844ab724cb0c1b4b3c839" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="monster maker (japan).bin" size="0x20000" crc="725ee86c" sha1="70d99059ef780033cd0844ab724cb0c1b4b3c839" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -14784,8 +14784,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-qnj-0.u1" size="131072" crc="56ba6a71" sha1="f7a101338c4eebcdcc1e5d9082a30caa2d706969" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-qnj-0.u1" size="0x20000" crc="56ba6a71" sha1="f7a101338c4eebcdcc1e5d9082a30caa2d706969" />
 			</dataarea>
 		</part>
 	</software>
@@ -14805,10 +14805,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-m6j-0.u1" size="262144" crc="66e708fc" sha1="ffac4e116cfe1c2d545c746640cc55e7df59101b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-m6j-0.u1" size="0x40000" crc="66e708fc" sha1="ffac4e116cfe1c2d545c746640cc55e7df59101b" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -14820,8 +14820,8 @@ license:CC0
 		<info name="serial" value="DMG-X8-(EUR/FRG)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="monster max (europe) (en,fr,de,es,it,nl).bin" size="262144" crc="300b1d2d" sha1="4c3647c79c97114bb7daf74b1a30f33fd989cf04" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="monster max (europe) (en,fr,de,es,it,nl).bin" size="0x40000" crc="300b1d2d" sha1="4c3647c79c97114bb7daf74b1a30f33fd989cf04" />
 			</dataarea>
 		</part>
 	</software>
@@ -14832,8 +14832,8 @@ license:CC0
 		<publisher>Titus</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="monster max (apr 1, 1993 prototype).bin" size="131072" crc="e7723a39" sha1="8279a071d6871a38c644381fb1ecfc198e4e263d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="monster max (apr 1, 1993 prototype).bin" size="0x20000" crc="e7723a39" sha1="8279a071d6871a38c644381fb1ecfc198e4e263d" />
 			</dataarea>
 		</part>
 	</software>
@@ -14854,10 +14854,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-amrj-0.u1" size="524288" crc="c191bd66" sha1="bb305ec61ec272a7a2fada1c03ba6784c5168f86" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-amrj-0.u1" size="0x80000" crc="c191bd66" sha1="bb305ec61ec272a7a2fada1c03ba6784c5168f86" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -14878,10 +14878,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-amfj-0.u1" size="524288" crc="bd3039e5" sha1="a566012977dbcede8066c06e445b6a346d158e53" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-amfj-0.u1" size="0x80000" crc="bd3039e5" sha1="a566012977dbcede8066c06e445b6a346d158e53" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -14895,8 +14895,8 @@ license:CC0
 		<info name="alt_title" value="モンスタートラック" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="monster truck (japan).bin" size="65536" crc="abf9b517" sha1="3db1e6333af2da6cd86bffd1afafc7ce96bf4b95" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="monster truck (japan).bin" size="0x10000" crc="abf9b517" sha1="3db1e6333af2da6cd86bffd1afafc7ce96bf4b95" />
 			</dataarea>
 		</part>
 	</software>
@@ -14911,8 +14911,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-atwp-0.u1" size="131072" crc="186c109b" sha1="8efe65d5deb4d0705bf6e11c6c6b97901ac1278a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-atwp-0.u1" size="0x20000" crc="186c109b" sha1="8efe65d5deb4d0705bf6e11c6c6b97901ac1278a" />
 			</dataarea>
 		</part>
 	</software>
@@ -14924,8 +14924,8 @@ license:CC0
 		<info name="serial" value="DMG-AMTP-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="montezuma's return (europe) (en,fr,de,es,it).bin" size="262144" crc="e7ac155b" sha1="a6b90cc58aeb5b44ef674c503a55a58278b1b6fa" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="montezuma's return (europe) (en,fr,de,es,it).bin" size="0x40000" crc="e7ac155b" sha1="a6b90cc58aeb5b44ef674c503a55a58278b1b6fa" />
 			</dataarea>
 		</part>
 	</software>
@@ -14939,8 +14939,8 @@ license:CC0
 		<info name="alt_title" value="モータルコンバット 神拳降臨伝説" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="mortal kombat (japan).bin" size="262144" crc="160fa9ef" sha1="5c24d595401ce3d1bb4027d0bc12312dca275470" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="mortal kombat (japan).bin" size="0x40000" crc="160fa9ef" sha1="5c24d595401ce3d1bb4027d0bc12312dca275470" />
 			</dataarea>
 		</part>
 	</software>
@@ -14955,8 +14955,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" /> <!-- MBC1B1 in NOE-1 cart -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-c9e-0.u1" size="262144" crc="90eb0929" sha1="59752879efaf2f271ce4b8a9d4a455056a2985d0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-c9e-0.u1" size="0x40000" crc="90eb0929" sha1="59752879efaf2f271ce4b8a9d4a455056a2985d0" />
 			</dataarea>
 		</part>
 	</software>
@@ -14967,8 +14967,8 @@ license:CC0
 		<publisher>Acclaim Entertainment</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="arhartle.bin" size="262144" crc="f22346a4" sha1="49f2ffe347758b6a34bfb149a94a867d77b2263e" status="baddump" /> <!-- bin comes from a trimmed overdump -->
+			<dataarea name="rom" size="0x40000">
+				<rom name="arhartle.bin" size="0x40000" crc="f22346a4" sha1="49f2ffe347758b6a34bfb149a94a867d77b2263e" status="baddump" /> <!-- bin comes from a trimmed overdump -->
 			</dataarea>
 		</part>
 	</software>
@@ -14983,8 +14983,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" /> <!-- Also with [DMG MBC1-B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a3mp-0.u1" size="524288" crc="40c9d0f2" sha1="73d10c377eab9bf73b1824ac1fe4a1855dee7303" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a3mp-0.u1" size="0x80000" crc="40c9d0f2" sha1="73d10c377eab9bf73b1824ac1fe4a1855dee7303" />
 			</dataarea>
 		</part>
 	</software>
@@ -14999,8 +14999,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a3me-0.u1" size="524288" crc="bf9c65fb" sha1="b43626e2f20fa865783892ab8a012aa86e1dcee2" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a3me-0.u1" size="0x80000" crc="bf9c65fb" sha1="b43626e2f20fa865783892ab8a012aa86e1dcee2" />
 			</dataarea>
 		</part>
 	</software>
@@ -15014,8 +15014,8 @@ license:CC0
 		<info name="alt_title" value="モータルコンバット&amp;モータルコンバットII" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1col" />
-			<dataarea name="rom" size="1048576">
-				<rom name="mortal kombat i &amp; ii (japan).bin" size="1048576" crc="b1a8dfd0" sha1="cf6ca53e1df526c73bab62743085257119865107" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="mortal kombat i &amp; ii (japan).bin" size="0x100000" crc="b1a8dfd0" sha1="cf6ca53e1df526c73bab62743085257119865107" />
 			</dataarea>
 		</part>
 	</software>
@@ -15030,8 +15030,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1col" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-ak2p-0.u1" size="1048576" crc="55300d0a" sha1="e337489255b33367ce26194fc4038346d3388bd9" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-ak2p-0.u1" size="0x100000" crc="55300d0a" sha1="e337489255b33367ce26194fc4038346d3388bd9" />
 			</dataarea>
 		</part>
 	</software>
@@ -15046,8 +15046,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-amke-0.u1" size="262144" crc="bfaeadd0" sha1="b8d400ee3d78a38f721f97e5222108d3586d2e63" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-amke-0.u1" size="0x40000" crc="bfaeadd0" sha1="b8d400ee3d78a38f721f97e5222108d3586d2e63" />
 			</dataarea>
 		</part>
 	</software>
@@ -15061,8 +15061,8 @@ license:CC0
 		<info name="alt_title" value="モータルコンバットII 究極神拳" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="mortal kombat ii - kyuukyoku shinken (japan).bin" size="262144" crc="57ba5d56" sha1="0661ce04696ad0c1b70345c9e880a8b26cc1218a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="mortal kombat ii - kyuukyoku shinken (japan).bin" size="0x40000" crc="57ba5d56" sha1="0661ce04696ad0c1b70345c9e880a8b26cc1218a" />
 			</dataarea>
 		</part>
 	</software>
@@ -15075,8 +15075,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-mxx-1.u1" size="32768" crc="f867ee3b" sha1="d21f2a4ddb69c408a370b6768f83914c11012c71" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-mxx-1.u1" size="0x8000" crc="f867ee3b" sha1="d21f2a4ddb69c408a370b6768f83914c11012c71" />
 			</dataarea>
 		</part>
 	</software>
@@ -15087,8 +15087,8 @@ license:CC0
 		<publisher>Palcom</publisher>
 		<info name="serial" value="DMG-MX-NOE" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="motocross maniacs (europe).bin" size="32768" crc="e2697678" sha1="956a12a65a1c39948c312303719895bd6f141a61" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="motocross maniacs (europe).bin" size="0x8000" crc="e2697678" sha1="956a12a65a1c39948c312303719895bd6f141a61" />
 			</dataarea>
 		</part>
 	</software>
@@ -15101,8 +15101,8 @@ license:CC0
 		<info name="release" value="19890920" />
 		<info name="alt_title" value="モトクロスマニアックス" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="motocross maniacs (japan).bin" size="32768" crc="da6053c3" sha1="de3fbb541acac5e4fcd828e9cf4eef7541e95645" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="motocross maniacs (japan).bin" size="0x8000" crc="da6053c3" sha1="de3fbb541acac5e4fcd828e9cf4eef7541e95645" />
 			</dataarea>
 		</part>
 	</software>
@@ -15113,8 +15113,8 @@ license:CC0
 		<publisher>Ultra</publisher>
 		<info name="serial" value="DMG-MX-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="motocross maniacs (usa).bin" size="32768" crc="318dbde1" sha1="80575304ccedbd26c0366d8f6f0f0faae09a4f13" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="motocross maniacs (usa).bin" size="0x8000" crc="318dbde1" sha1="80575304ccedbd26c0366d8f6f0f0faae09a4f13" />
 			</dataarea>
 		</part>
 	</software>
@@ -15126,8 +15126,8 @@ license:CC0
 		<info name="serial" value="DMG-MH-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="mouse trap hotel (usa).bin" size="65536" crc="6edf07e5" sha1="301658fd29b1a9277690a3c6e43dc68c8a277c1d" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="mouse trap hotel (usa).bin" size="0x10000" crc="6edf07e5" sha1="301658fd29b1a9277690a3c6e43dc68c8a277c1d" />
 			</dataarea>
 		</part>
 	</software>
@@ -15139,8 +15139,8 @@ license:CC0
 		<info name="serial" value="DMG-AN8P-(NOE/UKV)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-an8p-0.u1" size="262144" crc="03b64a35" sha1="c3dc8fa1aebc92b07eacd6c78aece7c6dd33429d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-an8p-0.u1" size="0x40000" crc="03b64a35" sha1="c3dc8fa1aebc92b07eacd6c78aece7c6dd33429d" />
 			</dataarea>
 		</part>
 	</software>
@@ -15152,8 +15152,8 @@ license:CC0
 		<info name="serial" value="DMG-GP-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="mr. chin's gourmet paradise (usa).bin" size="65536" crc="d03e59aa" sha1="1b510734463a5095fa94786fc233b57587ee402d" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="mr. chin's gourmet paradise (usa).bin" size="0x10000" crc="d03e59aa" sha1="1b510734463a5095fa94786fc233b57587ee402d" />
 			</dataarea>
 		</part>
 	</software>
@@ -15168,8 +15168,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-m4x-0.u1" size="65536" crc="cf84ac77" sha1="83663a2d49cfe41e6d9a6aad6157d7d8f024e969" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-m4x-0.u1" size="0x10000" crc="cf84ac77" sha1="83663a2d49cfe41e6d9a6aad6157d7d8f024e969" />
 			</dataarea>
 		</part>
 	</software>
@@ -15181,8 +15181,8 @@ license:CC0
 		<info name="serial" value="DMG-M4-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="mr. do (usa).bin" size="65536" crc="a1122fc0" sha1="1262a3119e7d7cb724863afa0ac467756f2fe611" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="mr. do (usa).bin" size="0x10000" crc="a1122fc0" sha1="1262a3119e7d7cb724863afa0ac467756f2fe611" />
 			</dataarea>
 		</part>
 	</software>
@@ -15196,10 +15196,10 @@ license:CC0
 		<info name="alt_title" value="Mr.GOの馬券的中術" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="mr. go no baken tekichuu jutsu (japan).bin" size="131072" crc="eadaf1e7" sha1="ddf49bdc73c9b50045396915767c7610eeb296b5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="mr. go no baken tekichuu jutsu (japan).bin" size="0x20000" crc="eadaf1e7" sha1="ddf49bdc73c9b50045396915767c7610eeb296b5" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -15214,8 +15214,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-n4x-0.u1" size="65536" crc="e19f67d7" sha1="c3388250f3fd3e18289edbaf0063ac563e2dfec0" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-n4x-0.u1" size="0x10000" crc="e19f67d7" sha1="c3388250f3fd3e18289edbaf0063ac563e2dfec0" />
 			</dataarea>
 		</part>
 	</software>
@@ -15227,8 +15227,8 @@ license:CC0
 		<info name="serial" value="DMG-N4-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="ms. pac-man (usa).bin" size="65536" crc="0e5bb1c4" sha1="fcc05f0625d52ace28d21fd8270e71246229cbad" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="ms. pac-man (usa).bin" size="0x10000" crc="0e5bb1c4" sha1="fcc05f0625d52ace28d21fd8270e71246229cbad" />
 			</dataarea>
 		</part>
 	</software>
@@ -15241,8 +15241,8 @@ license:CC0
 		<info name="alt_title" value="Muhammad Ali Heavyweight Boxing (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="muhammad ali's boxing (usa, europe).bin" size="131072" crc="97bd3e8f" sha1="9e7002575177a5af87500c53afd6187da3923510" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="muhammad ali's boxing (usa, europe).bin" size="0x20000" crc="97bd3e8f" sha1="9e7002575177a5af87500c53afd6187da3923510" />
 			</dataarea>
 		</part>
 	</software>
@@ -15258,8 +15258,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B1] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-amlp-0.u1" size="524288" crc="e285cf30" sha1="b039f13d7a4eac290ab2d0bf4a4a740cfc517959" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-amlp-0.u1" size="0x80000" crc="e285cf30" sha1="b039f13d7a4eac290ab2d0bf4a4a740cfc517959" />
 			</dataarea>
 		</part>
 	</software>
@@ -15272,8 +15272,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-amle-0.u1" size="524288" crc="bfcf71a1" sha1="7832fcc373ff752e757550079519b39583665c82" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-amle-0.u1" size="0x80000" crc="bfcf71a1" sha1="7832fcc373ff752e757550079519b39583665c82" />
 			</dataarea>
 		</part>
 	</software>
@@ -15287,8 +15287,8 @@ license:CC0
 		<info name="alt_title" value="ミステリアム" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="mysterium (japan).bin" size="131072" crc="3420edea" sha1="775e1ceac81306f0198153920223fcebedfc6616" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="mysterium (japan).bin" size="0x20000" crc="3420edea" sha1="775e1ceac81306f0198153920223fcebedfc6616" />
 			</dataarea>
 		</part>
 	</software>
@@ -15303,8 +15303,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-mye-0.u1" size="131072" crc="eb225e96" sha1="382c346af83e3cb9f95192378843d4e15ef93716" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-mye-0.u1" size="0x20000" crc="eb225e96" sha1="382c346af83e3cb9f95192378843d4e15ef93716" />
 			</dataarea>
 		</part>
 	</software>
@@ -15318,8 +15318,8 @@ license:CC0
 			<feature name="u1" value="U1" />
 			<feature name="u2" value="U2 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="u1" size="131072" crc="004c1af7" sha1="82e058a7608a04a2837d0d8fe810270f804b43f3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="u1" size="0x20000" crc="004c1af7" sha1="82e058a7608a04a2837d0d8fe810270f804b43f3" />
 			</dataarea>
 		</part>
 	</software>
@@ -15331,10 +15331,10 @@ license:CC0
 		<info name="serial" value="DMG-FF-ESP-1, DMG-FF-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="mystic quest (europe).bin" size="262144" crc="57d95c92" sha1="3513310426c6ae88f9beb588f71c666e003273be" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="mystic quest (europe).bin" size="0x40000" crc="57d95c92" sha1="3513310426c6ae88f9beb588f71c666e003273be" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -15345,10 +15345,10 @@ license:CC0
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="mystic quest (france).bin" size="262144" crc="b6e134af" sha1="b52d82248849f1ead9bf22954b3cbf7bf8e02907" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="mystic quest (france).bin" size="0x40000" crc="b6e134af" sha1="b52d82248849f1ead9bf22954b3cbf7bf8e02907" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -15365,10 +15365,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ffd-0.u1" size="262144" crc="0351b9a6" sha1="7cb65cb314e3f26b92549ddc7f4fc275186c6170" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ffd-0.u1" size="0x40000" crc="0351b9a6" sha1="7cb65cb314e3f26b92549ddc7f4fc275186c6170" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -15381,8 +15381,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="mystical ninja starring goemon (europe).bin" size="262144" crc="a1813cd5" sha1="6a47ec0c2a81741d93687b85f966c6bfca039770" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="mystical ninja starring goemon (europe).bin" size="0x40000" crc="a1813cd5" sha1="6a47ec0c2a81741d93687b85f966c6bfca039770" />
 			</dataarea>
 		</part>
 	</software>
@@ -15395,8 +15395,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="mystical ninja starring goemon (usa).bin" size="262144" crc="fafb343c" sha1="6674baaae85a8eb6e950f1ea30527321c942a9bc" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="mystical ninja starring goemon (usa).bin" size="0x40000" crc="fafb343c" sha1="6674baaae85a8eb6e950f1ea30527321c942a9bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -15411,10 +15411,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="nada asatarou &amp; kojima takeo no jissen mahjong kyoushitsu (japan).bin" size="131072" crc="9d335162" sha1="20ba98670eb3bf18756f15e50b5fc65f58a15918" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nada asatarou &amp; kojima takeo no jissen mahjong kyoushitsu (japan).bin" size="0x20000" crc="9d335162" sha1="20ba98670eb3bf18756f15e50b5fc65f58a15918" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -15428,8 +15428,8 @@ license:CC0
 		<info name="alt_title" value="灘麻太郎のパワフル麻雀 次の1手100題" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nada asatarou no powerful mahjong - tsugi no itte 100 dai (japan).bin" size="131072" crc="b4dd8e6a" sha1="cc51ccc05897ec05b31270ef9f30bd8475d1cca0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nada asatarou no powerful mahjong - tsugi no itte 100 dai (japan).bin" size="0x20000" crc="b4dd8e6a" sha1="cc51ccc05897ec05b31270ef9f30bd8475d1cca0" />
 			</dataarea>
 		</part>
 	</software>
@@ -15441,8 +15441,8 @@ license:CC0
 		<info name="serial" value="DMG-DR-USA, DMG-DR-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nail'n scale (usa, europe).bin" size="131072" crc="44badbb7" sha1="96d25741f02ea4744bb9ad81b32f04226847649c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nail'n scale (usa, europe).bin" size="0x20000" crc="44badbb7" sha1="96d25741f02ea4744bb9ad81b32f04226847649c" />
 			</dataarea>
 		</part>
 	</software>
@@ -15459,8 +15459,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-f3j-0.u1" size="131072" crc="e00ebc44" sha1="e07448143b82704fc142e7cce5ddb73866ef1d78" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-f3j-0.u1" size="0x20000" crc="e00ebc44" sha1="e07448143b82704fc142e7cce5ddb73866ef1d78" />
 			</dataarea>
 		</part>
 	</software>
@@ -15474,8 +15474,8 @@ license:CC0
 		<info name="alt_title" value="中嶋 悟 監修 F-1ヒーローGB'92 THE GRADED DRIVER" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="nakajima satoru kanshuu f-1 hero gb '92 - the graded driver (japan).bin" size="262144" crc="b6ef042e" sha1="6fe738c80ecac86db44a032cb636abeb2b00c4cb" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nakajima satoru kanshuu f-1 hero gb '92 - the graded driver (japan).bin" size="0x40000" crc="b6ef042e" sha1="6fe738c80ecac86db44a032cb636abeb2b00c4cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -15492,8 +15492,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-nhj-0.u1" size="131072" crc="ec3257b3" sha1="65b91cc77b1971f8229d4caaf4feb89c64856c8b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-nhj-0.u1" size="0x20000" crc="ec3257b3" sha1="65b91cc77b1971f8229d4caaf4feb89c64856c8b" />
 			</dataarea>
 		</part>
 	</software>
@@ -15509,8 +15509,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="namco gallery vol.1 (japan).bin" size="524288" crc="1902c6bd" sha1="d6b3c5fdb4b710cb104d461faf3b57f6eec066c4" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="namco gallery vol.1 (japan).bin" size="0x80000" crc="1902c6bd" sha1="d6b3c5fdb4b710cb104d461faf3b57f6eec066c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -15525,8 +15525,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="namco gallery vol.2 (japan).bin" size="524288" crc="a69b9260" sha1="02b1d728a8c722bd2299c44b54beb4de6eb70e4f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="namco gallery vol.2 (japan).bin" size="0x80000" crc="a69b9260" sha1="02b1d728a8c722bd2299c44b54beb4de6eb70e4f" />
 			</dataarea>
 		</part>
 	</software>
@@ -15542,8 +15542,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="namco gallery vol.3 (japan).bin" size="524288" crc="7740341e" sha1="a8902e4af858b28c1c934879718e8c971a2000bb" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="namco gallery vol.3 (japan).bin" size="0x80000" crc="7740341e" sha1="a8902e4af858b28c1c934879718e8c971a2000bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -15557,8 +15557,8 @@ license:CC0
 		<info name="alt_title" value="南国少年パワフくん ガンマ団の野望" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nangoku shounen papuwa-kun - ganmadan no yabou (japan).bin" size="131072" crc="798f324a" sha1="bafea45aedf20d2162941fcb3b5e315595e9f481" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nangoku shounen papuwa-kun - ganmadan no yabou (japan).bin" size="0x20000" crc="798f324a" sha1="bafea45aedf20d2162941fcb3b5e315595e9f481" />
 			</dataarea>
 		</part>
 	</software>
@@ -15572,10 +15572,10 @@ license:CC0
 		<info name="alt_title" value="ゲームボーイ電子手帳 ナノノート" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nanonote (japan).bin" size="131072" crc="3e30b63d" sha1="8d280e610a827e56864e6b99a637103a2d14f7bf" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nanonote (japan).bin" size="0x20000" crc="3e30b63d" sha1="8d280e610a827e56864e6b99a637103a2d14f7bf" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -15589,8 +15589,8 @@ license:CC0
 		<info name="alt_title" value="海戦ゲーム ネイビーブルー90" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="navy blue 90 (japan).bin" size="131072" crc="8cfeb2e2" sha1="60fa3fb83910f548047bbac02627c914a9057372" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="navy blue 90 (japan).bin" size="0x20000" crc="8cfeb2e2" sha1="60fa3fb83910f548047bbac02627c914a9057372" />
 			</dataarea>
 		</part>
 	</software>
@@ -15604,8 +15604,8 @@ license:CC0
 		<info name="alt_title" value="ネイビーブルー98" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="navy blue 98 (japan).bin" size="262144" crc="2cbe5381" sha1="fbdf3744335297e64a1578e19d987b9dadb0e2f7" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="navy blue 98 (japan).bin" size="0x40000" crc="2cbe5381" sha1="fbdf3744335297e64a1578e19d987b9dadb0e2f7" />
 			</dataarea>
 		</part>
 	</software>
@@ -15617,8 +15617,8 @@ license:CC0
 		<info name="serial" value="DMG-NV-USA, DMG-NV-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="navy seals (usa, europe).bin" size="131072" crc="296ceacb" sha1="f6930ea45b012ebd16c1d637ae763dfb94198623" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="navy seals (usa, europe).bin" size="0x20000" crc="296ceacb" sha1="f6930ea45b012ebd16c1d637ae763dfb94198623" />
 			</dataarea>
 		</part>
 	</software>
@@ -15630,8 +15630,8 @@ license:CC0
 		<info name="serial" value="DMG-AC-USA, DMG-AC-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="nba all star challenge (usa, europe).bin" size="65536" crc="f25ba8bf" sha1="ff2eddbb7fc60efdcab60bad53d404768afc9f40" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="nba all star challenge (usa, europe).bin" size="0x10000" crc="f25ba8bf" sha1="ff2eddbb7fc60efdcab60bad53d404768afc9f40" />
 			</dataarea>
 		</part>
 	</software>
@@ -15648,8 +15648,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-h2a-0.u1" size="131072" crc="df9db013" sha1="a19b5fcff89e5e58efb19449ace3d8f83a18ea78" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-h2a-0.u1" size="0x20000" crc="df9db013" sha1="a19b5fcff89e5e58efb19449ace3d8f83a18ea78" />
 			</dataarea>
 		</part>
 	</software>
@@ -15664,8 +15664,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-h2e-0.u1" size="131072" crc="c27c0289" sha1="a07672471909cace9e9765bce6a05a8ab74d55d4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-h2e-0.u1" size="0x20000" crc="c27c0289" sha1="a07672471909cace9e9765bce6a05a8ab74d55d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -15680,8 +15680,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-a8np-0.u1" size="262144" crc="0ca07cda" sha1="ceca1552909acaad74241cb3cef360ebb845ac3b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-a8np-0.u1" size="0x40000" crc="0ca07cda" sha1="ceca1552909acaad74241cb3cef360ebb845ac3b" />
 			</dataarea>
 		</part>
 	</software>
@@ -15695,8 +15695,8 @@ license:CC0
 		<info name="alt_title" value="NBA ジャム トーナメントエディション" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="nba jam - tournament edition (japan).bin" size="524288" crc="32909f62" sha1="ed3de869011ccf636a7be0949ca08d029c7873e2" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="nba jam - tournament edition (japan).bin" size="0x80000" crc="32909f62" sha1="ed3de869011ccf636a7be0949ca08d029c7873e2" />
 			</dataarea>
 		</part>
 	</software>
@@ -15711,8 +15711,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ajtp-0.u1" size="524288" crc="27d74c50" sha1="981de2c70a2dfb5ae829d39cc5f302815780e771" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ajtp-0.u1" size="0x80000" crc="27d74c50" sha1="981de2c70a2dfb5ae829d39cc5f302815780e771" />
 			</dataarea>
 		</part>
 	</software>
@@ -15725,8 +15725,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="nba live 96 (usa, europe).bin" size="524288" crc="8885c7cd" sha1="f4d13f947f7f8f074f7979a5889cc2c91c56f4ea" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="nba live 96 (usa, europe).bin" size="0x80000" crc="8885c7cd" sha1="f4d13f947f7f8f074f7979a5889cc2c91c56f4ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -15752,10 +15752,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_huc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="nectaris gb (japan).bin" size="524288" crc="20bfd7ef" sha1="ba251bfef8162ef032da8d5c28fe693ede28f030" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="nectaris gb (japan).bin" size="0x80000" crc="20bfd7ef" sha1="ba251bfef8162ef032da8d5c28fe693ede28f030" />
 			</dataarea>
-			<dataarea name="ram" size="32768">
+			<dataarea name="ram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -15769,8 +15769,8 @@ license:CC0
 		<info name="alt_title" value="熱血硬派くにおくん 番外乱闘編" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nekketsu kouha kunio-kun - bangai rantou hen (japan).bin" size="131072" crc="25b21acc" sha1="28e6edff470613a2abf015c9795581e8e2822029" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nekketsu kouha kunio-kun - bangai rantou hen (japan).bin" size="0x20000" crc="25b21acc" sha1="28e6edff470613a2abf015c9795581e8e2822029" />
 			</dataarea>
 		</part>
 	</software>
@@ -15784,8 +15784,8 @@ license:CC0
 		<info name="alt_title" value="熱血高校ドッジボール部 〜強敵!闘球戦士の巻〜 ~ Nekketsu Koukou Dodgeball Bu - Kyouteki! Toukyuu Senshi no Maki (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nekketsu koukou dodge ball-bu (japan).bin" size="131072" crc="7eaf671a" sha1="4ad83d6edc948cae10221b7aaf8fd8b999d4b489" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nekketsu koukou dodge ball-bu (japan).bin" size="0x20000" crc="7eaf671a" sha1="4ad83d6edc948cae10221b7aaf8fd8b999d4b489" />
 			</dataarea>
 		</part>
 	</software>
@@ -15799,8 +15799,8 @@ license:CC0
 		<info name="alt_title" value="熱血高校サッカー部 ワールドカップ編" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nekketsu koukou soccer-bu - world cup hen (japan).bin" size="131072" crc="50c2ada1" sha1="3763313b9f371e5428a67b7461e4f6f2c1ab8422" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nekketsu koukou soccer-bu - world cup hen (japan).bin" size="0x20000" crc="50c2ada1" sha1="3763313b9f371e5428a67b7461e4f6f2c1ab8422" />
 			</dataarea>
 		</part>
 	</software>
@@ -15815,8 +15815,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="nekketsu beach volley dayo kunio-kun (japan).bin" size="262144" crc="abfb84df" sha1="d3ad43c40c21d9825b4879dbf28ca58835da658a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nekketsu beach volley dayo kunio-kun (japan).bin" size="0x40000" crc="abfb84df" sha1="d3ad43c40c21d9825b4879dbf28ca58835da658a" />
 			</dataarea>
 		</part>
 	</software>
@@ -15830,10 +15830,10 @@ license:CC0
 		<info name="alt_title" value="ネコジャラ物語" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="nekojara monogatari (japan).bin" size="131072" crc="3d6d309b" sha1="f0f320b9170501c762e724e9b22d37cb4d15d0a9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nekojara monogatari (japan).bin" size="0x20000" crc="3d6d309b" sha1="f0f320b9170501c762e724e9b22d37cb4d15d0a9" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -15848,8 +15848,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-nmx-0.u1" size="131072" crc="19930ea5" sha1="e95e7a476a160bc0a685112d80239a5d669fd192" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-nmx-0.u1" size="0x20000" crc="19930ea5" sha1="e95e7a476a160bc0a685112d80239a5d669fd192" />
 			</dataarea>
 		</part>
 	</software>
@@ -15863,8 +15863,8 @@ license:CC0
 		<info name="alt_title" value="ネメシス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nemesis (japan).bin" size="131072" crc="b338dae7" sha1="da54433d91970421a87c6595e0f77eefed750ac1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nemesis (japan).bin" size="0x20000" crc="b338dae7" sha1="da54433d91970421a87c6595e0f77eefed750ac1" />
 			</dataarea>
 		</part>
 	</software>
@@ -15879,8 +15879,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-nme-0.u1" size="131072" crc="5110e971" sha1="0ad4a8f156bc6899e2337417cedf9e279f8abc08" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-nme-0.u1" size="0x20000" crc="5110e971" sha1="0ad4a8f156bc6899e2337417cedf9e279f8abc08" />
 			</dataarea>
 		</part>
 	</software>
@@ -15895,8 +15895,8 @@ license:CC0
 		<info name="alt_title" value="ネメシスII" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="nemesis ii (japan).bin" size="262144" crc="ac5b062d" sha1="f2797d5fa272cecc8ce89f6326a29cad332f72d1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nemesis ii (japan).bin" size="0x40000" crc="ac5b062d" sha1="f2797d5fa272cecc8ce89f6326a29cad332f72d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -15908,8 +15908,8 @@ license:CC0
 		<info name="serial" value="DMG-NE-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="nemesis ii - the return of the hero (europe).bin" size="262144" crc="c3e62a35" sha1="ee59da08c23102ab99a28c5da9ceaf222e7fb461" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nemesis ii - the return of the hero (europe).bin" size="0x40000" crc="c3e62a35" sha1="ee59da08c23102ab99a28c5da9ceaf222e7fb461" />
 			</dataarea>
 		</part>
 	</software>
@@ -15924,8 +15924,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="nettou garou densetsu 2 (japan).bin" size="524288" crc="aa98687f" sha1="74b1e1b53235eb356ae1ef4bce940873a96bd076" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="nettou garou densetsu 2 (japan).bin" size="0x80000" crc="aa98687f" sha1="74b1e1b53235eb356ae1ef4bce940873a96bd076" />
 			</dataarea>
 		</part>
 	</software>
@@ -15948,8 +15948,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-x4j-1.u1" size="524288" crc="c94850cc" sha1="05bfa0c00e29fb8d69ef683eddec52e1de57a9ff" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-x4j-1.u1" size="0x80000" crc="c94850cc" sha1="05bfa0c00e29fb8d69ef683eddec52e1de57a9ff" />
 			</dataarea>
 		</part>
 	</software>
@@ -15964,8 +15964,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="nettou samurai spirits (japan).bin" size="524288" crc="4a306276" sha1="6303a5fb1d99ba8bad36437af5e2592fdecf0f72" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="nettou samurai spirits (japan).bin" size="0x80000" crc="4a306276" sha1="6303a5fb1d99ba8bad36437af5e2592fdecf0f72" />
 			</dataarea>
 		</part>
 	</software>
@@ -15983,8 +15983,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-aszj-0.u1" size="1048576" crc="995d0838" sha1="0ba93965808f7a96c92a85289678e16b41cb09ec" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-aszj-0.u1" size="0x100000" crc="995d0838" sha1="0ba93965808f7a96c92a85289678e16b41cb09ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -15999,8 +15999,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="nettou the king of fighters '95 (japan).bin" size="524288" crc="8712f17b" sha1="af48f83d5dc319aa1e373b8e91ede45606bd867c" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="nettou the king of fighters '95 (japan).bin" size="0x80000" crc="8712f17b" sha1="af48f83d5dc319aa1e373b8e91ede45606bd867c" />
 			</dataarea>
 		</part>
 	</software>
@@ -16018,8 +16018,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ak6j-0.u1" size="524288" crc="fecdae42" sha1="63f25bff422a591907b83ab9f14709e938172839" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ak6j-0.u1" size="0x80000" crc="fecdae42" sha1="63f25bff422a591907b83ab9f14709e938172839" />
 			</dataarea>
 		</part>
 	</software>
@@ -16035,8 +16035,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="nettou toushinden (japan) (rev 1).bin" size="524288" crc="d5a6b132" sha1="5fd55a5d01817c770b251dbb9a0dc73a02d8c566" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="nettou toushinden (japan) (rev 1).bin" size="0x80000" crc="d5a6b132" sha1="5fd55a5d01817c770b251dbb9a0dc73a02d8c566" />
 			</dataarea>
 		</part>
 	</software>
@@ -16052,8 +16052,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="nettou toushinden (japan).bin" size="524288" crc="dde161a5" sha1="61b99fbc4d56dad2e6002c7a8c6b5a1660a23137" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="nettou toushinden (japan).bin" size="0x80000" crc="dde161a5" sha1="61b99fbc4d56dad2e6002c7a8c6b5a1660a23137" />
 			</dataarea>
 		</part>
 	</software>
@@ -16071,8 +16071,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-awjj-0.u1" size="524288" crc="0a12f53c" sha1="0dd04ca0ac61b449d3040587918b63d649fbbcc2" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-awjj-0.u1" size="0x80000" crc="0a12f53c" sha1="0dd04ca0ac61b449d3040587918b63d649fbbcc2" />
 			</dataarea>
 		</part>
 	</software>
@@ -16086,8 +16086,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-awjj-1.u1" size="524288" crc="7c5ffe52" sha1="14bc507f479e814b0131febfab19f2ef30eb23a5" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-awjj-1.u1" size="0x80000" crc="7c5ffe52" sha1="14bc507f479e814b0131febfab19f2ef30eb23a5" />
 			</dataarea>
 		</part>
 	</software>
@@ -16102,8 +16102,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="new chessmaster, the (japan) (en,ja).bin" size="65536" crc="5e1c3e8d" sha1="5d0a22b99ffa528003997c59c54ac9d1c8920d6f" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="new chessmaster, the (japan) (en,ja).bin" size="0x10000" crc="5e1c3e8d" sha1="5d0a22b99ffa528003997c59c54ac9d1c8920d6f" />
 			</dataarea>
 		</part>
 	</software>
@@ -16119,8 +16119,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-n5e-0.u1" size="65536" crc="c7ffc203" sha1="23458fe9e811f2f9ade1acc527024bab0b892bac" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-n5e-0.u1" size="0x10000" crc="c7ffc203" sha1="23458fe9e811f2f9ade1acc527024bab0b892bac" />
 			</dataarea>
 		</part>
 	</software>
@@ -16131,8 +16131,8 @@ license:CC0
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-FT-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="nfl football (usa).bin" size="32768" crc="4c3d1508" sha1="5a74fc3b137986a3569158f3b0e99551a277069c" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="nfl football (usa).bin" size="0x8000" crc="4c3d1508" sha1="5a74fc3b137986a3569158f3b0e99551a277069c" />
 			</dataarea>
 		</part>
 	</software>
@@ -16144,8 +16144,8 @@ license:CC0
 		<info name="serial" value="DMG-AQBE-USA, DMG-AQBP-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="nfl quarterback club '96 (usa, europe).bin" size="262144" crc="d583bc4e" sha1="39abb312f304f9abf88f8e16283b5180c8f2720a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nfl quarterback club '96 (usa, europe).bin" size="0x40000" crc="d583bc4e" sha1="39abb312f304f9abf88f8e16283b5180c8f2720a" />
 			</dataarea>
 		</part>
 	</software>
@@ -16159,8 +16159,8 @@ license:CC0
 		<info name="alt_title" value="NFLクォーターバッククラブ'95" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="nfl quarterback club (japan).bin" size="262144" crc="eecb703c" sha1="454726de3bf724b1cce8d99721bbaa48b5c2b2c6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nfl quarterback club (japan).bin" size="0x40000" crc="eecb703c" sha1="454726de3bf724b1cce8d99721bbaa48b5c2b2c6" />
 			</dataarea>
 		</part>
 	</software>
@@ -16175,8 +16175,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-q6e-0.u1" size="131072" crc="c7838830" sha1="cb5b7b05549e0eeddb820fa92cd46c3e3e28b760" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-q6e-0.u1" size="0x20000" crc="c7838830" sha1="cb5b7b05549e0eeddb820fa92cd46c3e3e28b760" />
 			</dataarea>
 		</part>
 	</software>
@@ -16188,8 +16188,8 @@ license:CC0
 		<info name="serial" value="DMG-AQ9E-USA, DMG-AQ9P-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="nfl quarterback club 2 (usa, europe).bin" size="262144" crc="06f04370" sha1="248313851266fbe5f21b16f0e27c3fb19b796d28" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nfl quarterback club 2 (usa, europe).bin" size="0x40000" crc="06f04370" sha1="248313851266fbe5f21b16f0e27c3fb19b796d28" />
 			</dataarea>
 		</part>
 	</software>
@@ -16205,8 +16205,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a6hp-0.u1" size="524288" crc="15cd2b63" sha1="fb0389a7f4e99a7974dc11b4602af441016fd57c" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a6hp-0.u1" size="0x80000" crc="15cd2b63" sha1="fb0389a7f4e99a7974dc11b4602af441016fd57c" />
 			</dataarea>
 		</part>
 	</software>
@@ -16219,8 +16219,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="nhl hockey '95 (usa, europe).bin" size="524288" crc="bcabd2d2" sha1="baea6987f69b4c8792ff4e453ea88006803a3ef9" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="nhl hockey '95 (usa, europe).bin" size="0x80000" crc="bcabd2d2" sha1="baea6987f69b4c8792ff4e453ea88006803a3ef9" />
 			</dataarea>
 		</part>
 	</software>
@@ -16237,8 +16237,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="nichibutsu mahjong - yoshimoto gekijou (japan).bin" size="262144" crc="d983ff48" sha1="1ccec61dd26b163d921043893b1d2405e05ae3a2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nichibutsu mahjong - yoshimoto gekijou (japan).bin" size="0x40000" crc="d983ff48" sha1="1ccec61dd26b163d921043893b1d2405e05ae3a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -16253,8 +16253,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-wcx-0.u1" size="131072" crc="e1b202db" sha1="db7919cd2e31084ae569821d5acb18140b3cfef4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-wcx-0.u1" size="0x20000" crc="e1b202db" sha1="db7919cd2e31084ae569821d5acb18140b3cfef4" />
 			</dataarea>
 		</part>
 	</software>
@@ -16269,8 +16269,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-wce-0.u1" size="131072" crc="03e84d7d" sha1="beebc29ef505916a525fb9a5ab0d6d11bcbbfb47" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-wce-0.u1" size="0x20000" crc="03e84d7d" sha1="beebc29ef505916a525fb9a5ab0d6d11bcbbfb47" />
 			</dataarea>
 		</part>
 	</software>
@@ -16283,8 +16283,8 @@ license:CC0
 		<info name="alt_title" value="Nigel Mansell's World Championship Racing (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nigel mansell's world championship racing (europe).bin" size="131072" crc="0d0958a3" sha1="7b91447b2162154bc5882c86f2fad5fc414df506" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nigel mansell's world championship racing (europe).bin" size="0x20000" crc="0d0958a3" sha1="7b91447b2162154bc5882c86f2fad5fc414df506" />
 			</dataarea>
 		</part>
 	</software>
@@ -16299,8 +16299,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="nihon daihyou team - eikou no eleven (japan).bin" size="262144" crc="e497842e" sha1="344613295d4b246b8873dde2951b323197d18db7" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nihon daihyou team - eikou no eleven (japan).bin" size="0x40000" crc="e497842e" sha1="344613295d4b246b8873dde2951b323197d18db7" />
 			</dataarea>
 		</part>
 	</software>
@@ -16315,10 +16315,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="nihon daihyou team france de ganbare - j.league supporter soccer (japan).bin" size="524288" crc="91e6bf74" sha1="1f038df0b742a2d76d49eaefe7b753ed0dea3767" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="nihon daihyou team france de ganbare - j.league supporter soccer (japan).bin" size="0x80000" crc="91e6bf74" sha1="1f038df0b742a2d76d49eaefe7b753ed0dea3767" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -16339,10 +16339,10 @@ license:CC0
 			<feature name="battery" value="BATT CR2025" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-antj-0.u1" size="524288" crc="ad3f851d" sha1="4403ddbc2faa6b540893814a7ecaafb218849ee9" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-antj-0.u1" size="0x80000" crc="ad3f851d" sha1="4403ddbc2faa6b540893814a7ecaafb218849ee9" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -16357,8 +16357,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="ninja boy (usa, europe).bin" size="65536" crc="59d3e2ad" sha1="acd93f152574a47e2bef3ba739f722bec90badef" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="ninja boy (usa, europe).bin" size="0x10000" crc="59d3e2ad" sha1="acd93f152574a47e2bef3ba739f722bec90badef" />
 			</dataarea>
 		</part>
 	</software>
@@ -16370,8 +16370,8 @@ license:CC0
 		<info name="serial" value="DMG-CH-USA, DMG-CH-FRG" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="ninja boy 2 (usa, europe).bin" size="262144" crc="64c06d94" sha1="833b20931f29b3bb16736d7d1a1bc98e9a540261" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="ninja boy 2 (usa, europe).bin" size="0x40000" crc="64c06d94" sha1="833b20931f29b3bb16736d7d1a1bc98e9a540261" />
 			</dataarea>
 		</part>
 	</software>
@@ -16383,8 +16383,8 @@ license:CC0
 		<info name="serial" value="DMG-NG-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ninja gaiden shadow (usa).bin" size="131072" crc="d3741a3a" sha1="8aadd7dfb4add75d5ac5351658762e5f56e78c66" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ninja gaiden shadow (usa).bin" size="0x20000" crc="d3741a3a" sha1="8aadd7dfb4add75d5ac5351658762e5f56e78c66" />
 			</dataarea>
 		</part>
 	</software>
@@ -16398,8 +16398,8 @@ license:CC0
 		<info name="alt_title" value="忍者龍剣伝GB 摩天楼決戦" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ninja ryuukenden - matenrou kessen (japan).bin" size="131072" crc="d2be3397" sha1="7200ac959877b4e4e423997d699a0e5c144f5b0b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ninja ryuukenden - matenrou kessen (japan).bin" size="0x20000" crc="d2be3397" sha1="7200ac959877b4e4e423997d699a0e5c144f5b0b" />
 			</dataarea>
 		</part>
 	</software>
@@ -16411,10 +16411,10 @@ license:CC0
 		<info name="serial" value="DMG-UP-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="ninja taro (usa).bin" size="131072" crc="c53ebfbd" sha1="bd472ed88042e032a57041eb0a889da6aa3d1598" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ninja taro (usa).bin" size="0x20000" crc="c53ebfbd" sha1="bd472ed88042e032a57041eb0a889da6aa3d1598" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -16425,10 +16425,10 @@ license:CC0
 		<publisher>Sammy</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="ninja taro (usa) (beta).bin" size="131072" crc="61598b3d" sha1="d93b6718e9c8a2505f4da73b99f57866111948af" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ninja taro (usa) (beta).bin" size="0x20000" crc="61598b3d" sha1="d93b6718e9c8a2505f4da73b99f57866111948af" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -16439,10 +16439,10 @@ license:CC0
 		<publisher>Sammy</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="ninja taro (prototype b).bin" size="131072" crc="f15b708a" sha1="602ba627007d37f7a2eb456102b3afa79d50ce2f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ninja taro (prototype b).bin" size="0x20000" crc="f15b708a" sha1="602ba627007d37f7a2eb456102b3afa79d50ce2f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -16460,8 +16460,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ankj-0.u1" size="524288" crc="b50119eb" sha1="44b35ae3aa21d42d67b04a8581a0c83dc96521ce" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ankj-0.u1" size="0x80000" crc="b50119eb" sha1="44b35ae3aa21d42d67b04a8581a0c83dc96521ce" />
 			</dataarea>
 		</part>
 	</software>
@@ -16476,8 +16476,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="ninku dai-2-dan - ninku sensou hen (japan).bin" size="524288" crc="7f818772" sha1="52d3ab8b84e3e825280c6b5db80933ace1aa5909" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="ninku dai-2-dan - ninku sensou hen (japan).bin" size="0x80000" crc="7f818772" sha1="52d3ab8b84e3e825280c6b5db80933ace1aa5909" />
 			</dataarea>
 		</part>
 	</software>
@@ -16495,8 +16495,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-agnj-0.u1" size="262144" crc="bd223184" sha1="4110bd38bde1d9a9a20c2a0c73a3e9f799a72847" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-agnj-0.u1" size="0x40000" crc="bd223184" sha1="4110bd38bde1d9a9a20c2a0c73a3e9f799a72847" />
 			</dataarea>
 		</part>
 	</software>
@@ -16511,8 +16511,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="nintama rantarou gb - eawase challenge puzzle (japan).bin" size="524288" crc="0e37e462" sha1="5642c866711bd5057a2c7de2662d23a4a74d8be9" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="nintama rantarou gb - eawase challenge puzzle (japan).bin" size="0x80000" crc="0e37e462" sha1="5642c866711bd5057a2c7de2662d23a4a74d8be9" />
 			</dataarea>
 		</part>
 	</software>
@@ -16527,8 +16527,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" /> <!-- Also found with [DMG MBC1B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-nce-0.u1" size="131072" crc="96c24e13" sha1="9308dadfeb1becb81fe35015397df6e8e8ead06e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-nce-0.u1" size="0x20000" crc="96c24e13" sha1="9308dadfeb1becb81fe35015397df6e8e8ead06e" />
 			</dataarea>
 		</part>
 	</software>
@@ -16544,8 +16544,8 @@ license:CC0
 			<feature name="rom" value="" />
 			<feature name="flipflop" value="[SN74LS377N]" />
 			<feature name="slot" value="rom_wisdom" />
-			<dataarea name="rom" size="2097152">
-				<rom name="NIV100.rom" size="2097152" crc="e7a26b31" sha1="136cf97a8c3560ec9db3d8f354d91b7de27e0743" />
+			<dataarea name="rom" size="0x200000">
+				<rom name="NIV100.rom" size="0x200000" crc="e7a26b31" sha1="136cf97a8c3560ec9db3d8f354d91b7de27e0743" />
 			</dataarea>
 		</part>
 	</software>
@@ -16559,10 +16559,10 @@ license:CC0
 		<info name="alt_title" value="信長の野望 ゲームボーイ版" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nobunaga no yabou - game boy ban (japan).bin" size="131072" crc="8803186a" sha1="b86474be139be4c7bd7aa8ad01c50d2c49f4b78b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nobunaga no yabou - game boy ban (japan).bin" size="0x20000" crc="8803186a" sha1="b86474be139be4c7bd7aa8ad01c50d2c49f4b78b" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -16574,10 +16574,10 @@ license:CC0
 		<info name="serial" value="DMG-NY-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nobunaga's ambition (usa).bin" size="131072" crc="5a843008" sha1="d4dd65535d2a15f177289b53a49f1bc9e9b739f3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nobunaga's ambition (usa).bin" size="0x20000" crc="5a843008" sha1="d4dd65535d2a15f177289b53a49f1bc9e9b739f3" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -16591,8 +16591,8 @@ license:CC0
 		<info name="alt_title" value="ノンタンといっしょ くるくるパズル" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="nontan to issho - kurukuru puzzle (japan).bin" size="131072" crc="6cd63b0b" sha1="d9b2d7a30b68c8bbd4f91203a475b64b410a25ae" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nontan to issho - kurukuru puzzle (japan).bin" size="0x20000" crc="6cd63b0b" sha1="d9b2d7a30b68c8bbd4f91203a475b64b410a25ae" />
 			</dataarea>
 		</part>
 	</software>
@@ -16609,8 +16609,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-nwj-0.u1" size="262144" crc="8bbcc8bb" sha1="b571d9051e3a9f1a55533b4f43941cae907aedff" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-nwj-0.u1" size="0x40000" crc="8bbcc8bb" sha1="b571d9051e3a9f1a55533b4f43941cae907aedff" />
 			</dataarea>
 		</part>
 	</software>
@@ -16626,8 +16626,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aodp-0.u1" size="524288" crc="6510c0e2" sha1="be3f69371b6959dab34014cb1d3672f4f3377c3a" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aodp-0.u1" size="0x80000" crc="6510c0e2" sha1="be3f69371b6959dab34014cb1d3672f4f3377c3a" />
 			</dataarea>
 		</part>
 	</software>
@@ -16644,8 +16644,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="oira jajamaru sekai daibouken (japan).bin" size="131072" crc="2d08d27f" sha1="5e13eeb635b41589689fc1b495ee077125b7e8c1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="oira jajamaru sekai daibouken (japan).bin" size="0x20000" crc="2d08d27f" sha1="5e13eeb635b41589689fc1b495ee077125b7e8c1" />
 			</dataarea>
 		</part>
 	</software>
@@ -16661,8 +16661,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ao9p-0.u1" size="524288" crc="be81bd61" sha1="070d594fcd3637920234bf28206015287b97937e" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ao9p-0.u1" size="0x80000" crc="be81bd61" sha1="070d594fcd3637920234bf28206015287b97937e" />
 			</dataarea>
 		</part>
 	</software>
@@ -16682,10 +16682,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-o2j-0.u1" size="262144" crc="2f895df5" sha1="7b40a873249f8306ff6c0277492ed28250d87fcc" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-o2j-0.u1" size="0x40000" crc="2f895df5" sha1="7b40a873249f8306ff6c0277492ed28250d87fcc" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -16699,10 +16699,10 @@ license:CC0
 		<info name="alt_title" value="ONI III 黒の破壊神" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="oni iii - kuro no hakaishin (japan).bin" size="262144" crc="6cd62fdb" sha1="2813cf81a13d5a07a221320ba80da0d3e271d87c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="oni iii - kuro no hakaishin (japan).bin" size="0x40000" crc="6cd62fdb" sha1="2813cf81a13d5a07a221320ba80da0d3e271d87c" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -16716,10 +16716,10 @@ license:CC0
 		<info name="alt_title" value="ONI IV 鬼神の血族" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="oni iv - kijin no ketsuzoku (japan).bin" size="262144" crc="beff4f57" sha1="5af71863e48afe1fb5f16aee6fbe7f4e97ef54ce" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="oni iv - kijin no ketsuzoku (japan).bin" size="0x40000" crc="beff4f57" sha1="5af71863e48afe1fb5f16aee6fbe7f4e97ef54ce" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -16734,10 +16734,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="oni v - innin o tsugumono (japan).bin" size="262144" crc="af030940" sha1="197e2d2980053104ecf1c0edbff9f4d235518320" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="oni v - innin o tsugumono (japan).bin" size="0x40000" crc="af030940" sha1="197e2d2980053104ecf1c0edbff9f4d235518320" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -16751,8 +16751,8 @@ license:CC0
 		<info name="alt_title" value="鬼ヶ島パチンコ店" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="onigashima pachinkoten (japan).bin" size="131072" crc="f54ec8eb" sha1="ff12ed91aa5cb3216860e7c18ff523b9bcb6a76a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="onigashima pachinkoten (japan).bin" size="0x20000" crc="f54ec8eb" sha1="ff12ed91aa5cb3216860e7c18ff523b9bcb6a76a" />
 			</dataarea>
 		</part>
 	</software>
@@ -16767,8 +16767,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-cne-0.u1" size="131072" crc="2ebbc1ae" sha1="1dc3e1c62e62f77ac633408b544ac1d02b3761eb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-cne-0.u1" size="0x20000" crc="2ebbc1ae" sha1="1dc3e1c62e62f77ac633408b544ac1d02b3761eb" />
 			</dataarea>
 		</part>
 	</software>
@@ -16782,8 +16782,8 @@ license:CC0
 		<info name="alt_title" value="おさわがせ!ペンギンBOY" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="osawagase penguin boy (japan).bin" size="65536" crc="54913227" sha1="1cdcf9810e98ba04378b2d6b555654722cb0acf6" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="osawagase penguin boy (japan).bin" size="0x10000" crc="54913227" sha1="1cdcf9810e98ba04378b2d6b555654722cb0acf6" />
 			</dataarea>
 		</part>
 	</software>
@@ -16796,8 +16796,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-otx-0.u1" size="32768" crc="e6607e29" sha1="03848a74502f4571bec20b42adab86ded357af81" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-otx-0.u1" size="0x8000" crc="e6607e29" sha1="03848a74502f4571bec20b42adab86ded357af81" />
 			</dataarea>
 		</part>
 	</software>
@@ -16810,8 +16810,8 @@ license:CC0
 		<info name="release" value="19900209" />
 		<info name="alt_title" value="オセロ" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-otj-0.bin" size="32768" crc="c17a002e" sha1="60a427c5dc6dad226c80b120aa2e52725d719d16" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-otj-0.bin" size="0x8000" crc="c17a002e" sha1="60a427c5dc6dad226c80b120aa2e52725d719d16" />
 			</dataarea>
 		</part>
 	</software>
@@ -16827,8 +16827,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="othello world (japan).bin" size="65536" crc="64d13a6d" sha1="089013eb2dac79c5525c442bfc9cda74e8660597" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="othello world (japan).bin" size="0x10000" crc="64d13a6d" sha1="089013eb2dac79c5525c442bfc9cda74e8660597" />
 			</dataarea>
 		</part>
 	</software>
@@ -16843,10 +16843,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="otogibanashi taisen (japan).bin" size="262144" crc="98500521" sha1="49176ced7152d6d411db1aa77d7a131f46e7a081" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="otogibanashi taisen (japan).bin" size="0x40000" crc="98500521" sha1="49176ced7152d6d411db1aa77d7a131f46e7a081" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -16861,8 +16861,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-aobp-0.u1" size="262144" crc="0c228a78" sha1="93edd0772a3a65df17ec5877e2bcfafda3020169" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-aobp-0.u1" size="0x40000" crc="0c228a78" sha1="93edd0772a3a65df17ec5877e2bcfafda3020169" />
 			</dataarea>
 		</part>
 	</software>
@@ -16873,8 +16873,8 @@ license:CC0
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="otto's ottifanten (prototype).bin" size="262144" crc="f23e5f91" sha1="22a18f5eb589347fa596432d249b0abca69aa93b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="otto's ottifanten (prototype).bin" size="0x40000" crc="f23e5f91" sha1="22a18f5eb589347fa596432d249b0abca69aa93b" />
 			</dataarea>
 		</part>
 	</software>
@@ -16886,8 +16886,8 @@ license:CC0
 		<info name="serial" value="DMG-FX-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="out of gas (usa).bin" size="131072" crc="1b67e8b1" sha1="770ac35c0780cf432235593bd5674e72edd6cf7d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="out of gas (usa).bin" size="0x20000" crc="1b67e8b1" sha1="770ac35c0780cf432235593bd5674e72edd6cf7d" />
 			</dataarea>
 		</part>
 	</software>
@@ -16898,8 +16898,8 @@ license:CC0
 		<publisher>FCI</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="out of gas.bin" size="131072" crc="c3e365b4" sha1="ff90b89b413437b5e3360e28b6a62573619b4558" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="out of gas.bin" size="0x20000" crc="c3e365b4" sha1="ff90b89b413437b5e3360e28b6a62573619b4558" />
 			</dataarea>
 		</part>
 	</software>
@@ -16916,8 +16916,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-obj-0.u1" size="262144" crc="8afcc4b0" sha1="2d5a27b675a1f3c0be43e6f662f0159a3b3bf92b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-obj-0.u1" size="0x40000" crc="8afcc4b0" sha1="2d5a27b675a1f3c0be43e6f662f0159a3b3bf92b" />
 			</dataarea>
 		</part>
 	</software>
@@ -16932,8 +16932,8 @@ license:CC0
 			<feature name="u1" value="U1" />
 			<feature name="u2" value="U2 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="t.u1" size="262144" crc="9837ffac" sha1="4a45cc555b486f5dafa4e844a7b6afceb709a1b9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="t.u1" size="0x40000" crc="9837ffac" sha1="4a45cc555b486f5dafa4e844a7b6afceb709a1b9" />
 			</dataarea>
 		</part>
 	</software>
@@ -16948,8 +16948,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="oyatsu quiz mogu mogu q (japan).bin" size="262144" crc="79e05789" sha1="9b026834756201ccc58988f1718c2380bd8f6326" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="oyatsu quiz mogu mogu q (japan).bin" size="0x40000" crc="79e05789" sha1="9b026834756201ccc58988f1718c2380bd8f6326" />
 			</dataarea>
 		</part>
 	</software>
@@ -16966,8 +16966,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="p-man gb (japan).bin" size="131072" crc="727d5509" sha1="d8704a68e1f3037c43e8987ca99f557ad6dbc0de" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="p-man gb (japan).bin" size="0x20000" crc="727d5509" sha1="d8704a68e1f3037c43e8987ca99f557ad6dbc0de" />
 			</dataarea>
 		</part>
 	</software>
@@ -16983,8 +16983,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-noe-0.u1" size="131072" crc="94e0af9c" sha1="3fb6907d2352b34e0e60e3ae7b1d32f3e0c84fc9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-noe-0.u1" size="0x20000" crc="94e0af9c" sha1="3fb6907d2352b34e0e60e3ae7b1d32f3e0c84fc9" />
 			</dataarea>
 		</part>
 	</software>
@@ -16997,8 +16997,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-aptp-1.u1" size="262144" crc="7ff79df9" sha1="f30108b8e422c4b9776c90c884710194508545ea" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-aptp-1.u1" size="0x40000" crc="7ff79df9" sha1="f30108b8e422c4b9776c90c884710194508545ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -17014,8 +17014,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-apte-0.u1" size="262144" crc="50a15dc8" sha1="282f9bbabd5a57d5e7755e5d00f4d65094f816d5" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-apte-0.u1" size="0x40000" crc="50a15dc8" sha1="282f9bbabd5a57d5e7755e5d00f4d65094f816d5" />
 			</dataarea>
 		</part>
 	</software>
@@ -17030,8 +17030,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="pac-in-time (japan).bin" size="262144" crc="1a5a38da" sha1="a804e8fc2614c55154b1a904639244bca6553997" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="pac-in-time (japan).bin" size="0x40000" crc="1a5a38da" sha1="a804e8fc2614c55154b1a904639244bca6553997" />
 			</dataarea>
 		</part>
 	</software>
@@ -17047,8 +17047,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-aptp-0.u1" size="262144" crc="8690b691" sha1="63419fd7af5fe2ba2f26a6cdaad5ed9c399fe44a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-aptp-0.u1" size="0x40000" crc="8690b691" sha1="63419fd7af5fe2ba2f26a6cdaad5ed9c399fe44a" />
 			</dataarea>
 		</part>
 	</software>
@@ -17063,8 +17063,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-pcx-0.u1" size="65536" crc="0509069c" sha1="8d9fda32419ca7030ba15f67ff8f857c1a119916" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-pcx-0.u1" size="0x10000" crc="0509069c" sha1="8d9fda32419ca7030ba15f67ff8f857c1a119916" />
 			</dataarea>
 		</part>
 	</software>
@@ -17080,8 +17080,8 @@ license:CC0
 		<info name="alt_title" value="パックマン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="pac-man (japan).bin" size="65536" crc="65998f48" sha1="ae088bba7147780afaf5cff9e5b296f893db823b" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pac-man (japan).bin" size="0x10000" crc="65998f48" sha1="ae088bba7147780afaf5cff9e5b296f893db823b" />
 			</dataarea>
 		</part>
 	</software>
@@ -17096,8 +17096,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-pce-0.u1" size="65536" crc="b681e243" sha1="a05f50d3571c0572eb0433474a99c966a67a2d1b" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-pce-0.u1" size="0x10000" crc="b681e243" sha1="a05f50d3571c0572eb0433474a99c966a67a2d1b" />
 			</dataarea>
 		</part>
 	</software>
@@ -17110,8 +17110,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pac-panic (europe).bin" size="131072" crc="e4af8f75" sha1="963222935becb2139fb0133fbd9b02a1e239bbf2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pac-panic (europe).bin" size="0x20000" crc="e4af8f75" sha1="963222935becb2139fb0133fbd9b02a1e239bbf2" />
 			</dataarea>
 		</part>
 	</software>
@@ -17126,8 +17126,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pac-panic (japan).bin" size="131072" crc="aaebd509" sha1="64573cd6c4a26087485af540818c972cd256a881" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pac-panic (japan).bin" size="0x20000" crc="aaebd509" sha1="64573cd6c4a26087485af540818c972cd256a881" />
 			</dataarea>
 		</part>
 	</software>
@@ -17142,10 +17142,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="pachi-slot hisshou guide gb (japan).bin" size="131072" crc="6ee0f7b9" sha1="48564d29dd997878eb3165d7b40ac3fa8f287143" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pachi-slot hisshou guide gb (japan).bin" size="0x20000" crc="6ee0f7b9" sha1="48564d29dd997878eb3165d7b40ac3fa8f287143" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -17159,8 +17159,8 @@ license:CC0
 		<info name="alt_title" value="パチスロキッズ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pachi-slot kids (japan).bin" size="131072" crc="8c21a77d" sha1="5a510844bcd6adfe73694a4781e446bf87fdf674" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pachi-slot kids (japan).bin" size="0x20000" crc="8c21a77d" sha1="5a510844bcd6adfe73694a4781e446bf87fdf674" />
 			</dataarea>
 		</part>
 	</software>
@@ -17174,8 +17174,8 @@ license:CC0
 		<info name="alt_title" value="パチスロキッズ2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pachi-slot kids 2 (japan).bin" size="131072" crc="deace430" sha1="da6ebc9ad58b427a580f72233cb0364d039342a9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pachi-slot kids 2 (japan).bin" size="0x20000" crc="deace430" sha1="da6ebc9ad58b427a580f72233cb0364d039342a9" />
 			</dataarea>
 		</part>
 	</software>
@@ -17189,8 +17189,8 @@ license:CC0
 		<info name="alt_title" value="パチスロキッズ3" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="pachi-slot kids 3 (japan).bin" size="262144" crc="40fc1186" sha1="73fd8b3caf2c9a50fd5a5fa4be56c50557095a60" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="pachi-slot kids 3 (japan).bin" size="0x40000" crc="40fc1186" sha1="73fd8b3caf2c9a50fd5a5fa4be56c50557095a60" />
 			</dataarea>
 		</part>
 	</software>
@@ -17204,8 +17204,8 @@ license:CC0
 		<info name="alt_title" value="パチスロ ワールドカップ'94" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pachi-slot world cup '94 (japan).bin" size="131072" crc="92c9141f" sha1="fac33654dc37c120674a8f9e20019dfcca72ebcd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pachi-slot world cup '94 (japan).bin" size="0x20000" crc="92c9141f" sha1="fac33654dc37c120674a8f9e20019dfcca72ebcd" />
 			</dataarea>
 		</part>
 	</software>
@@ -17220,10 +17220,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="pachinko cr daiku no gen-san gb (japan).bin" size="262144" crc="69a5e681" sha1="2fc86c0da3601e7b614290b30197aaae50ab510e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="pachinko cr daiku no gen-san gb (japan).bin" size="0x40000" crc="69a5e681" sha1="2fc86c0da3601e7b614290b30197aaae50ab510e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -17238,10 +17238,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="pachinko data card - chou ataru-kun (japan).bin" size="1048576" crc="955b25ba" sha1="b8799e2a7d6df8a41f0e8f8857885f7ccc3397b8" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="pachinko data card - chou ataru-kun (japan).bin" size="0x100000" crc="955b25ba" sha1="b8799e2a7d6df8a41f0e8f8857885f7ccc3397b8" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -17255,8 +17255,8 @@ license:CC0
 		<info name="alt_title" value="パチンコかぐや姫" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pachinko kaguya hime (japan).bin" size="131072" crc="b6d9d6c4" sha1="260e8bdce496ce59eccc48431009839011c1f5bc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pachinko kaguya hime (japan).bin" size="0x20000" crc="b6d9d6c4" sha1="260e8bdce496ce59eccc48431009839011c1f5bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -17271,8 +17271,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="pachinko monogatari gaiden (japan).bin" size="524288" crc="52adb7f9" sha1="b5229f7263ed761fbf30e98d88192787e79bcc56" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="pachinko monogatari gaiden (japan).bin" size="0x80000" crc="52adb7f9" sha1="b5229f7263ed761fbf30e98d88192787e79bcc56" />
 			</dataarea>
 		</part>
 	</software>
@@ -17289,8 +17289,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-pjj-0.u1" size="131072" crc="8f931831" sha1="8bbc798eb5b531f513ffa56f105983f19f9caa1e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-pjj-0.u1" size="0x20000" crc="8f931831" sha1="8bbc798eb5b531f513ffa56f105983f19f9caa1e" />
 			</dataarea>
 		</part>
 	</software>
@@ -17304,8 +17304,8 @@ license:CC0
 		<info name="alt_title" value="パチンコタイム" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="pachinko time (japan).bin" size="65536" crc="47658ade" sha1="ef0e7c6b39744342397523e31e861ec09246613d" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pachinko time (japan).bin" size="0x10000" crc="47658ade" sha1="ef0e7c6b39744342397523e31e861ec09246613d" />
 			</dataarea>
 		</part>
 	</software>
@@ -17319,8 +17319,8 @@ license:CC0
 		<info name="alt_title" value="GB パチ夫くん" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pachio-kun (japan).bin" size="131072" crc="9a3e2dc2" sha1="a7d82002b2a263b2ce4c09417fc639713601aec1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pachio-kun (japan).bin" size="0x20000" crc="9a3e2dc2" sha1="a7d82002b2a263b2ce4c09417fc639713601aec1" />
 			</dataarea>
 		</part>
 	</software>
@@ -17334,8 +17334,8 @@ license:CC0
 		<info name="alt_title" value="パチ夫くんゲームギャラリー GB PACHIOKUN 1・2・3 &amp; CASTLE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="pachio-kun - game gallery (japan).bin" size="524288" crc="be4718e8" sha1="010f512c53a84edbc38c817e7f556eb308834e29" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="pachio-kun - game gallery (japan).bin" size="0x80000" crc="be4718e8" sha1="010f512c53a84edbc38c817e7f556eb308834e29" />
 			</dataarea>
 		</part>
 	</software>
@@ -17349,8 +17349,8 @@ license:CC0
 		<info name="alt_title" value="パチ夫くんキャッスル" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pachio-kun - puzzle castle (japan).bin" size="131072" crc="3690c99c" sha1="946d25b62c6f4bea3214551260eb52ba68e23c8e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pachio-kun - puzzle castle (japan).bin" size="0x20000" crc="3690c99c" sha1="946d25b62c6f4bea3214551260eb52ba68e23c8e" />
 			</dataarea>
 		</part>
 	</software>
@@ -17364,8 +17364,8 @@ license:CC0
 		<info name="alt_title" value="GB パチ夫くん2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pachio-kun 2 (japan).bin" size="131072" crc="3e8d0ae9" sha1="aa7f33113cabb0395848a237f819300b0f2e13db" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pachio-kun 2 (japan).bin" size="0x20000" crc="3e8d0ae9" sha1="aa7f33113cabb0395848a237f819300b0f2e13db" />
 			</dataarea>
 		</part>
 	</software>
@@ -17379,8 +17379,8 @@ license:CC0
 		<info name="alt_title" value="GB パチ夫くん3" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pachio-kun 3 (japan).bin" size="131072" crc="c6dd7d92" sha1="a57e7919d962df82d77d39bf81dfcab124506aca" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pachio-kun 3 (japan).bin" size="0x20000" crc="c6dd7d92" sha1="a57e7919d962df82d77d39bf81dfcab124506aca" />
 			</dataarea>
 		</part>
 	</software>
@@ -17393,8 +17393,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="pagemaster, the (europe).bin" size="262144" crc="c9be96d3" sha1="9b3063350581cec9cf595a78faa8d415b75be399" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="pagemaster, the (europe).bin" size="0x40000" crc="c9be96d3" sha1="9b3063350581cec9cf595a78faa8d415b75be399" />
 			</dataarea>
 		</part>
 	</software>
@@ -17410,8 +17410,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-apme-0.u1" size="262144" crc="cdfa71e5" sha1="1d1dfdab693fdb1a3a1388cae34af017f79c41ab" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-apme-0.u1" size="0x40000" crc="cdfa71e5" sha1="1d1dfdab693fdb1a3a1388cae34af017f79c41ab" />
 			</dataarea>
 		</part>
 	</software>
@@ -17425,8 +17425,8 @@ license:CC0
 		<info name="alt_title" value="ペインターモモピー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="painter momopie (japan).bin" size="65536" crc="fb79ef58" sha1="193901223ffc89cf4f42a19e57447249affcc843" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="painter momopie (japan).bin" size="0x10000" crc="fb79ef58" sha1="193901223ffc89cf4f42a19e57447249affcc843" />
 			</dataarea>
 		</part>
 	</software>
@@ -17439,8 +17439,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-pxx-0.u1" size="32768" crc="526942e1" sha1="f93f5b939985935b9cce1364119344b9dc236f57" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-pxx-0.u1" size="0x8000" crc="526942e1" sha1="f93f5b939985935b9cce1364119344b9dc236f57" />
 			</dataarea>
 		</part>
 	</software>
@@ -17453,8 +17453,8 @@ license:CC0
 		<info name="release" value="19901012" />
 		<info name="alt_title" value="パラメデス" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="palamedes (japan).bin" size="32768" crc="4b993d0d" sha1="789694fce114bf076f77dda4858c1ab53b35e6a4" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="palamedes (japan).bin" size="0x8000" crc="4b993d0d" sha1="789694fce114bf076f77dda4858c1ab53b35e6a4" />
 			</dataarea>
 		</part>
 	</software>
@@ -17466,8 +17466,8 @@ license:CC0
 		<info name="serial" value="DMG-YB-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="panel action bingo (usa).bin" size="65536" crc="d000a116" sha1="527aeaaa52722605c98314cb7e522bb3a95a3b29" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="panel action bingo (usa).bin" size="0x10000" crc="d000a116" sha1="527aeaaa52722605c98314cb7e522bb3a95a3b29" />
 			</dataarea>
 		</part>
 	</software>
@@ -17481,8 +17481,8 @@ license:CC0
 		<info name="alt_title" value="パネルの忍者ケサマル -サラ姫お助け申す!の巻-" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="panel no ninja kesamaru (japan).bin" size="65536" crc="12caa1ca" sha1="67f8dea045bc2d01c00936a66cd4b56b10fa0f39" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="panel no ninja kesamaru (japan).bin" size="0x10000" crc="12caa1ca" sha1="67f8dea045bc2d01c00936a66cd4b56b10fa0f39" />
 			</dataarea>
 		</part>
 	</software>
@@ -17497,8 +17497,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-agx-0.u1" size="131072" crc="ea9615b4" sha1="7ca64a45ea6a68770658ae39ef21c41f806988c5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-agx-0.u1" size="0x20000" crc="ea9615b4" sha1="7ca64a45ea6a68770658ae39ef21c41f806988c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -17509,8 +17509,8 @@ license:CC0
 		<publisher>Hudson Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pang.bin" size="131072" crc="54d2754a" sha1="b57d436d8a83f2fb1e42bad3150893ef8ffab0d4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pang.bin" size="0x20000" crc="54d2754a" sha1="b57d436d8a83f2fb1e42bad3150893ef8ffab0d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -17527,8 +17527,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pang (uk).bin" size="131072" crc="9ae199df" sha1="ae97143e51b6f031efb83b245b1b2558e6cb9026" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pang (uk).bin" size="0x20000" crc="9ae199df" sha1="ae97143e51b6f031efb83b245b1b2558e6cb9026" />
 			</dataarea>
 		</part>
 	</software>
@@ -17540,8 +17540,8 @@ license:CC0
 		<info name="serial" value="DMG-MP-USA, DMG-MP-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="paperboy (usa, europe).bin" size="65536" crc="46de32ba" sha1="4103b51bbd75572181d407821890f167462a996b" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="paperboy (usa, europe).bin" size="0x10000" crc="46de32ba" sha1="4103b51bbd75572181d407821890f167462a996b" />
 			</dataarea>
 		</part>
 	</software>
@@ -17553,8 +17553,8 @@ license:CC0
 		<info name="serial" value="DMG-Y2-USA, DMG-Y2-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="paperboy 2 (usa, europe).bin" size="262144" crc="8ee404ca" sha1="473d84e2bfdb2dc2615b2ea416188c62fedb4ecf" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="paperboy 2 (usa, europe).bin" size="0x40000" crc="8ee404ca" sha1="473d84e2bfdb2dc2615b2ea416188c62fedb4ecf" />
 			</dataarea>
 		</part>
 	</software>
@@ -17571,8 +17571,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="u2" size="65536" crc="ae97ec53" sha1="8f319d3d1929d953934e32ce900249ecf6b55fbd" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="u2" size="0x10000" crc="ae97ec53" sha1="8f319d3d1929d953934e32ce900249ecf6b55fbd" />
 			</dataarea>
 		</part>
 	</software>
@@ -17588,8 +17588,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-p6x-0.u1" size="131072" crc="c35ad128" sha1="4970bbf5456305f2bfdb27e3a0dc14be4a0e10b7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-p6x-0.u1" size="0x20000" crc="c35ad128" sha1="4970bbf5456305f2bfdb27e3a0dc14be4a0e10b7" />
 			</dataarea>
 		</part>
 	</software>
@@ -17604,8 +17604,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" /> <!-- Also found with [DMG MBC1B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-pvx-0.u1" size="262144" crc="85748525" sha1="a00a1adc326d368e9198c006d43c0fd1ab290219" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-pvx-0.u1" size="0x40000" crc="85748525" sha1="a00a1adc326d368e9198c006d43c0fd1ab290219" />
 			</dataarea>
 		</part>
 	</software>
@@ -17619,8 +17619,8 @@ license:CC0
 		<info name="alt_title" value="パロディウスだ!" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="parodius da (japan).bin" size="262144" crc="1791e952" sha1="cfe0c6619a28ddd535214c8f8c446081c0ed8194" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="parodius da (japan).bin" size="0x40000" crc="1791e952" sha1="cfe0c6619a28ddd535214c8f8c446081c0ed8194" />
 			</dataarea>
 		</part>
 	</software>
@@ -17634,8 +17634,8 @@ license:CC0
 		<info name="alt_title" value="ピータン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="peetan (japan).bin" size="131072" crc="d0040f49" sha1="d3059a96dcbce249de69a969003e3164a6896c5e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="peetan (japan).bin" size="0x20000" crc="d0040f49" sha1="d3059a96dcbce249de69a969003e3164a6896c5e" />
 			</dataarea>
 		</part>
 	</software>
@@ -17652,8 +17652,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="u2" size="65536" crc="a66f5c02" sha1="a782f490ae8f7eb7140d9d23fd8bd181b1a916f4" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="u2" size="0x10000" crc="a66f5c02" sha1="a782f490ae8f7eb7140d9d23fd8bd181b1a916f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -17666,8 +17666,8 @@ license:CC0
 		<info name="release" value="19900321" />
 		<info name="alt_title" value="ペンギンランド" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="penguin land (japan).bin" size="32768" crc="a9e62e88" sha1="c9cb05557006b0f99790d19e3972258ab92da6cf" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="penguin land (japan).bin" size="0x8000" crc="a9e62e88" sha1="c9cb05557006b0f99790d19e3972258ab92da6cf" />
 			</dataarea>
 		</part>
 	</software>
@@ -17679,8 +17679,8 @@ license:CC0
 		<info name="serial" value="DMG-PW-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="penguin wars (usa).bin" size="65536" crc="eecff7f3" sha1="2c00f5678d55dcb865b596fcb1dbecd2c9213988" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="penguin wars (usa).bin" size="0x10000" crc="eecff7f3" sha1="2c00f5678d55dcb865b596fcb1dbecd2c9213988" />
 			</dataarea>
 		</part>
 	</software>
@@ -17694,8 +17694,8 @@ license:CC0
 		<info name="alt_title" value="ぺんぎんくん wars vs." />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="penguin-kun wars vs. (japan).bin" size="65536" crc="c169606d" sha1="f19e870e95c03288b019ef6bac3966bf74dd48fb" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="penguin-kun wars vs. (japan).bin" size="0x10000" crc="c169606d" sha1="f19e870e95c03288b019ef6bac3966bf74dd48fb" />
 			</dataarea>
 		</part>
 	</software>
@@ -17709,10 +17709,10 @@ license:CC0
 		<info name="alt_title" value="ペンタドラゴン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="penta dragon (japan).bin" size="262144" crc="1e2efaee" sha1="fd75d43258e79f14d104fb4756e219141882c837" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="penta dragon (japan).bin" size="0x40000" crc="1e2efaee" sha1="fd75d43258e79f14d104fb4756e219141882c837" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -17728,8 +17728,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aprp-0.u1" size="524288" crc="7d7def64" sha1="ff0fdf447e91af93fda6c1b6a1675986d798798a" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aprp-0.u1" size="0x80000" crc="7d7def64" sha1="ff0fdf447e91af93fda6c1b6a1675986d798798a" />
 			</dataarea>
 		</part>
 	</software>
@@ -17745,8 +17745,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a3gp-0.u1" size="524288" crc="6ff72043" sha1="8566f5c09ccb682bbc74cadcbc9ffcc8fc349968" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a3gp-0.u1" size="0x80000" crc="6ff72043" sha1="8566f5c09ccb682bbc74cadcbc9ffcc8fc349968" />
 			</dataarea>
 		</part>
 	</software>
@@ -17760,8 +17760,8 @@ license:CC0
 		<info name="alt_title" value="ファンタズム" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="phantasm (japan).bin" size="262144" crc="e742561e" sha1="64b55f6fce16e80bdb9825b5246e7c05d76af7ae" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="phantasm (japan).bin" size="0x40000" crc="e742561e" sha1="64b55f6fce16e80bdb9825b5246e7c05d76af7ae" />
 			</dataarea>
 		</part>
 	</software>
@@ -17773,8 +17773,8 @@ license:CC0
 		<info name="serial" value="DMG-UR-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="phantom air mission (europe).bin" size="131072" crc="8aced4a6" sha1="2a270597d7b814a1c8819a5698ab922200569206" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="phantom air mission (europe).bin" size="0x20000" crc="8aced4a6" sha1="2a270597d7b814a1c8819a5698ab922200569206" />
 			</dataarea>
 		</part>
 	</software>
@@ -17795,10 +17795,10 @@ license:CC0
 			<feature name="u3" value="U3 RAM [LH5268ANF-10PLL]" /> <!-- Also found with [HY6264ALLJ-10] -->
 			<feature name="u4" value="U4 26A [26A]" /> <!-- Also found with [6129A] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ap2j-0.u1" size="524288" crc="f5aa5902" sha1="57788519111cbe9e20b43d1935e9f52ae165e858" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ap2j-0.u1" size="0x80000" crc="f5aa5902" sha1="57788519111cbe9e20b43d1935e9f52ae165e858" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -17813,8 +17813,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-y5x-0.u1" size="131072" crc="0145bb6c" sha1="5a2e27c74df619adf2c80964f9edcebd0d82c581" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-y5x-0.u1" size="0x20000" crc="0145bb6c" sha1="5a2e27c74df619adf2c80964f9edcebd0d82c581" />
 			</dataarea>
 		</part>
 	</software>
@@ -17831,8 +17831,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1A]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-pbj-0.u1" size="65536" crc="1b3a89c6" sha1="3671335514b388ee08322416abd873f11a5e0b66" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-pbj-0.u1" size="0x10000" crc="1b3a89c6" sha1="3671335514b388ee08322416abd873f11a5e0b66" />
 			</dataarea>
 		</part>
 	</software>
@@ -17847,8 +17847,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-pbe-0.u1" size="65536" crc="79804305" sha1="493834db1c3c7859086a1c570a4bf5e5f6dd332b" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-pbe-0.u1" size="0x10000" crc="79804305" sha1="493834db1c3c7859086a1c570a4bf5e5f6dd332b" />
 			</dataarea>
 		</part>
 	</software>
@@ -17859,8 +17859,8 @@ license:CC0
 		<publisher>HAL</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="pinball - revenge of the 'gator (prototype).bin" size="65536" crc="048d3ab0" sha1="7f25663b3c1c15a3ee4f1bb719741823eea71ebb" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pinball - revenge of the 'gator (prototype).bin" size="0x10000" crc="048d3ab0" sha1="7f25663b3c1c15a3ee4f1bb719741823eea71ebb" />
 			</dataarea>
 		</part>
 	</software>
@@ -17876,8 +17876,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" /> <!-- Also found with [DMG MBC1-B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-apdp-0.u1" size="262144" crc="02864c32" sha1="a99d8a9880ed79b40766b3a532f8a165171ca450" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-apdp-0.u1" size="0x40000" crc="02864c32" sha1="a99d8a9880ed79b40766b3a532f8a165171ca450" />
 			</dataarea>
 		</part>
 	</software>
@@ -17892,8 +17892,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-d8e-0.u1" size="131072" crc="6da713e3" sha1="a84e46e6a102b9dd65c3156582c0b22b3d9d6832" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-d8e-0.u1" size="0x20000" crc="6da713e3" sha1="a84e46e6a102b9dd65c3156582c0b22b3d9d6832" />
 			</dataarea>
 		</part>
 	</software>
@@ -17908,8 +17908,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-apfp-0.u1" size="262144" crc="f056a911" sha1="58243f69598f2119f42dc4b35e89f04f92bb6d72" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-apfp-0.u1" size="0x40000" crc="f056a911" sha1="58243f69598f2119f42dc4b35e89f04f92bb6d72" />
 			</dataarea>
 		</part>
 	</software>
@@ -17921,8 +17921,8 @@ license:CC0
 		<info name="serial" value="DMG-APIP-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="pinball mania (europe).bin" size="262144" crc="edc8d122" sha1="0541161b4b93fffc3c75708aca86ea0873747ced" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="pinball mania (europe).bin" size="0x40000" crc="edc8d122" sha1="0541161b4b93fffc3c75708aca86ea0873747ced" />
 			</dataarea>
 		</part>
 	</software>
@@ -17936,8 +17936,8 @@ license:CC0
 		<info name="alt_title" value="ピングー〜世界で一番元気なペンギン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="pingu - sekai de 1ban genki na penguin (japan).bin" size="262144" crc="a8dd80c6" sha1="3ee536ad6cee67db12de648b60e4e71e50a072ac" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="pingu - sekai de 1ban genki na penguin (japan).bin" size="0x40000" crc="a8dd80c6" sha1="3ee536ad6cee67db12de648b60e4e71e50a072ac" />
 			</dataarea>
 		</part>
 	</software>
@@ -17952,8 +17952,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-acgp-0.u1" size="262144" crc="085c4a02" sha1="7716809645e00be2fdbbbfd05823a14856f01183" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-acgp-0.u1" size="0x40000" crc="085c4a02" sha1="7716809645e00be2fdbbbfd05823a14856f01183" />
 			</dataarea>
 		</part>
 	</software>
@@ -17965,8 +17965,8 @@ license:CC0
 		<info name="serial" value="DMG-ACGE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="pinocchio (usa).bin" size="262144" crc="2d924e46" sha1="e17c15325a1eaf5bb365ae4923c660e8c98a1d6b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="pinocchio (usa).bin" size="0x40000" crc="2d924e46" sha1="e17c15325a1eaf5bb365ae4923c660e8c98a1d6b" />
 			</dataarea>
 		</part>
 	</software>
@@ -17979,8 +17979,8 @@ license:CC0
 		<info name="release" value="19900703" />
 		<info name="alt_title" value="パイプドリーム" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pipe dream (japan).bin" size="32768" crc="d8b4aea4" sha1="64a58aafecb0aceed2dde843a19a28b2bb000b2f" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="pipe dream (japan).bin" size="0x8000" crc="d8b4aea4" sha1="64a58aafecb0aceed2dde843a19a28b2bb000b2f" />
 			</dataarea>
 		</part>
 	</software>
@@ -17991,8 +17991,8 @@ license:CC0
 		<publisher>Bullet-Proof Software</publisher>
 		<info name="serial" value="DMG-PD-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pipe dream (usa).bin" size="32768" crc="f59cedea" sha1="12a2c76ec96cc94a4c7eead6536eddd5f3f9998f" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="pipe dream (usa).bin" size="0x8000" crc="f59cedea" sha1="12a2c76ec96cc94a4c7eead6536eddd5f3f9998f" />
 			</dataarea>
 		</part>
 	</software>
@@ -18007,8 +18007,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-qfe-0.u1" size="262144" crc="0680bfc3" sha1="2a399b0524e9983fd361a98ec4b99d562361223b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-qfe-0.u1" size="0x40000" crc="0680bfc3" sha1="2a399b0524e9983fd361a98ec4b99d562361223b" />
 			</dataarea>
 		</part>
 	</software>
@@ -18021,8 +18021,8 @@ license:CC0
 		<info name="release" value="19900601" />
 		<info name="alt_title" value="ピットマン" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pitman (japan).bin" size="32768" crc="a0b68136" sha1="a698d4bccd69d2ca51cb48877bde5d1f83d4317f" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="pitman (japan).bin" size="0x8000" crc="a0b68136" sha1="a698d4bccd69d2ca51cb48877bde5d1f83d4317f" />
 			</dataarea>
 		</part>
 	</software>
@@ -18034,8 +18034,8 @@ license:CC0
 		<info name="serial" value="DMG-FL-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="play action football (usa).bin" size="131072" crc="983caf46" sha1="dc2981baf1bb4d0a65ec45fb22d44a5ca4c06254" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="play action football (usa).bin" size="0x20000" crc="983caf46" sha1="dc2981baf1bb4d0a65ec45fb22d44a5ca4c06254" />
 			</dataarea>
 		</part>
 	</software>
@@ -18051,8 +18051,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ahqp-0.u1" size="524288" crc="ce58c63d" sha1="2a974981cfaae8096f09b76d060ec06c696963ac" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ahqp-0.u1" size="0x80000" crc="ce58c63d" sha1="2a974981cfaae8096f09b76d060ec06c696963ac" />
 			</dataarea>
 		</part>
 	</software>
@@ -18067,8 +18067,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pocket bass fishing (japan).bin" size="131072" crc="2c88f996" sha1="c59402eaf86fb8d52ddf81e3054ab78a06a07eb3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pocket bass fishing (japan).bin" size="0x20000" crc="2c88f996" sha1="c59402eaf86fb8d52ddf81e3054ab78a06a07eb3" />
 			</dataarea>
 		</part>
 	</software>
@@ -18082,8 +18082,8 @@ license:CC0
 		<info name="alt_title" value="ポケットバトル" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pocket battle (japan).bin" size="131072" crc="17114316" sha1="9993242a8c9412a88b207a941531c0a5d0e4b8ec" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pocket battle (japan).bin" size="0x20000" crc="17114316" sha1="9993242a8c9412a88b207a941531c0a5d0e4b8ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -18096,8 +18096,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-akop-0.u1" size="524288" crc="0fd1ae54" sha1="34f377a6de2961fe16bfb854e0cebc7fdba7cf4b" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-akop-0.u1" size="0x80000" crc="0fd1ae54" sha1="34f377a6de2961fe16bfb854e0cebc7fdba7cf4b" />
 			</dataarea>
 		</part>
 	</software>
@@ -18123,10 +18123,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_huc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-apoj-0.u1" size="524288" crc="212b47a5" sha1="83d1c2420ae69d2a7ca9880c9b84f0ba948e39eb" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-apoj-0.u1" size="0x80000" crc="212b47a5" sha1="83d1c2420ae69d2a7ca9880c9b84f0ba948e39eb" />
 			</dataarea>
-			<dataarea name="ram" size="32768">
+			<dataarea name="ram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18141,8 +18141,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="pocket densha (japan).bin" size="524288" crc="845bb677" sha1="702981654640fe59c2f6b47c7191a58be0804a4d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="pocket densha (japan).bin" size="0x80000" crc="845bb677" sha1="702981654640fe59c2f6b47c7191a58be0804a4d" />
 			</dataarea>
 		</part>
 	</software>
@@ -18169,10 +18169,10 @@ license:CC0
 			<feature name="u5" value="U5 [LVX04]" />
 			<feature name="batt" value="BATT CR2025" />
 			<feature name="slot" value="rom_huc3" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-hfaj-0.u1" size="524288" crc="48993d4f" sha1="162b0ab1fcfcf9b7ac888f137fedc41264219cf9" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-hfaj-0.u1" size="0x80000" crc="48993d4f" sha1="162b0ab1fcfcf9b7ac888f137fedc41264219cf9" />
 			</dataarea>
-			<dataarea name="ram" size="32768">
+			<dataarea name="ram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18186,8 +18186,8 @@ license:CC0
 		<info name="alt_title" value="ポケットゴルフ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pocket golf (japan).bin" size="131072" crc="755152bb" sha1="7747dc7e6beaf824c79dd4308735e259445d5e19" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pocket golf (japan).bin" size="0x20000" crc="755152bb" sha1="7747dc7e6beaf824c79dd4308735e259445d5e19" />
 			</dataarea>
 		</part>
 	</software>
@@ -18202,10 +18202,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="pocket kanjirou (japan).bin" size="524288" crc="e18aedaf" sha1="ef150c97cb4e9a46f90d826b1aad208cbaa4410f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="pocket kanjirou (japan).bin" size="0x80000" crc="e18aedaf" sha1="ef150c97cb4e9a46f90d826b1aad208cbaa4410f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -18225,10 +18225,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-akyj-0.u1" size="262144" crc="c034ece1" sha1="0506deffdf9fee21dda394e272c84fe8df2fbec0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-akyj-0.u1" size="0x40000" crc="c034ece1" sha1="0506deffdf9fee21dda394e272c84fe8df2fbec0" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -18249,10 +18249,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aplj-0.u1" size="524288" crc="d570a9df" sha1="69f08aa97b5b72e99c826c810fdaebd766c2b416" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aplj-0.u1" size="0x80000" crc="d570a9df" sha1="69f08aa97b5b72e99c826c810fdaebd766c2b416" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -18273,10 +18273,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apvj-0.u1" size="1048576" crc="9f8440b5" sha1="b35c25ae2a621748abb68a7c2fc7a3c7927467e8" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apvj-0.u1" size="0x100000" crc="9f8440b5" sha1="b35c25ae2a621748abb68a7c2fc7a3c7927467e8" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -18293,8 +18293,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-abgj-0.u1" size="131072" crc="90f026d4" sha1="f559e999a9957d5804eab7a250cdcfef1708e7f7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-abgj-0.u1" size="0x20000" crc="90f026d4" sha1="f559e999a9957d5804eab7a250cdcfef1708e7f7" />
 			</dataarea>
 		</part>
 	</software>
@@ -18315,10 +18315,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" /> <!-- Also found with [6735] -->
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apsj-3.u1" size="1048576" crc="e9e6483a" sha1="a40298a8123613ee60cd7aab204d788b8425976e" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apsj-3.u1" size="0x100000" crc="e9e6483a" sha1="a40298a8123613ee60cd7aab204d788b8425976e" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18339,10 +18339,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" /> <!-- Also found with [6129A] and [26A] -->
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apsj-2.u1" size="1048576" crc="fd3da7ff" sha1="91864ecdf26d1c593bde4d9ed615520eb57d5e41" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apsj-2.u1" size="0x100000" crc="fd3da7ff" sha1="91864ecdf26d1c593bde4d9ed615520eb57d5e41" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18363,10 +18363,10 @@ license:CC0
 			<feature name="u4" value="U4 [6129A]" />
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apsj-1.u1" size="1048576" crc="a2545d33" sha1="28e4b8531ea4ea1de5a396fccb0cfba51b06b149" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apsj-1.u1" size="0x100000" crc="a2545d33" sha1="28e4b8531ea4ea1de5a396fccb0cfba51b06b149" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18387,10 +18387,10 @@ license:CC0
 			<feature name="u4" value="U4 [6129A]" /> <!-- Also found with [26A] -->
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apsj-0.u1" size="1048576" crc="4ec85504" sha1="1fb6c264e950d97ce3fd99b347e485b2150df4ff" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apsj-0.u1" size="0x100000" crc="4ec85504" sha1="1fb6c264e950d97ce3fd99b347e485b2150df4ff" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18411,10 +18411,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" /> <!-- Also found with [134A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-apaj-1.u1" size="524288" crc="b77be1e0" sha1="ef74c79cded14204ac79e77f4964d9cb25003120" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-apaj-1.u1" size="0x80000" crc="b77be1e0" sha1="ef74c79cded14204ac79e77f4964d9cb25003120" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18435,10 +18435,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-apaj-0.u1" size="524288" crc="13652705" sha1="0623ad12f48c259447980d68bd85ddbf8204b2cd" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-apaj-0.u1" size="0x80000" crc="13652705" sha1="0623ad12f48c259447980d68bd85ddbf8204b2cd" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18453,10 +18453,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="pocket monsters ao (japan).bin" size="524288" crc="e4468d14" sha1="0da501e3e5c51ab8fef55b092dcdd7e6b050e424" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="pocket monsters ao (japan).bin" size="0x80000" crc="e4468d14" sha1="0da501e3e5c51ab8fef55b092dcdd7e6b050e424" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18477,10 +18477,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" /> <!-- Also found with [6129A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-apbj-1.u1" size="524288" crc="37ae8dc4" sha1="4b97cd44aa3f0dd290bfe7b3ac17b7bd8270897b" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-apbj-1.u1" size="0x80000" crc="37ae8dc4" sha1="4b97cd44aa3f0dd290bfe7b3ac17b7bd8270897b" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18495,10 +18495,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="pocket monsters midori (japan).bin" size="524288" crc="baeacd2b" sha1="82c0eef40a5e2423699d9fd8ba15dfaa8b51d196" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="pocket monsters midori (japan).bin" size="0x80000" crc="baeacd2b" sha1="82c0eef40a5e2423699d9fd8ba15dfaa8b51d196" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18515,8 +18515,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-apyj-1.u1" size="262144" crc="cae8a317" sha1="36b677b76af12287cdbdec9ae06ca3f9dbfc1e67" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-apyj-1.u1" size="0x40000" crc="cae8a317" sha1="36b677b76af12287cdbdec9ae06ca3f9dbfc1e67" />
 			</dataarea>
 		</part>
 	</software>
@@ -18531,8 +18531,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="pocket puyo puyo tsuu (japan).bin" size="262144" crc="43e47a81" sha1="2ffbff6706047988468a7952de09c2720c3019ed" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="pocket puyo puyo tsuu (japan).bin" size="0x40000" crc="43e47a81" sha1="2ffbff6706047988468a7952de09c2720c3019ed" />
 			</dataarea>
 		</part>
 	</software>
@@ -18547,8 +18547,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="pocket shougi (japan).bin" size="262144" crc="2fa1bde6" sha1="5bc0aea0beb7c80f3d2bc650499a6c0e30006544" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="pocket shougi (japan).bin" size="0x40000" crc="2fa1bde6" sha1="5bc0aea0beb7c80f3d2bc650499a6c0e30006544" />
 			</dataarea>
 		</part>
 	</software>
@@ -18565,8 +18565,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-pkj-0.u1" size="65536" crc="c7bd9228" sha1="7ba422f2b48ff09673f7f1a258be6ecc1ff6a8d7" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-pkj-0.u1" size="0x10000" crc="c7bd9228" sha1="7ba422f2b48ff09673f7f1a258be6ecc1ff6a8d7" />
 			</dataarea>
 		</part>
 	</software>
@@ -18585,11 +18585,11 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" /> <!-- Also found with [26A] -->
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
-			<dataarea name="rom" size="1048576">
+			<dataarea name="rom" size="0x100000">
 				<!-- USA cart has label DMG-APEE-0 -->
-				<rom name="dmg-apeu-0.u1" size="1048576" crc="d6da8a1a" sha1="d7037c83e1ae5b39bde3c30787637ba1d4c48ce2" />
+				<rom name="dmg-apeu-0.u1" size="0x100000" crc="d6da8a1a" sha1="d7037c83e1ae5b39bde3c30787637ba1d4c48ce2" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18602,10 +18602,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="pokemon - version bleue (france).bin" size="1048576" crc="50e2fc1d" sha1="47faa910d0e073c600665bf9c83b6bd17babdf8a" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="pokemon - version bleue (france).bin" size="0x100000" crc="50e2fc1d" sha1="47faa910d0e073c600665bf9c83b6bd17babdf8a" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18624,10 +18624,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-aped-0.u1" size="1048576" crc="9c336307" sha1="20e72dc6f41493eee1fdd0cef54214e6c3389688" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-aped-0.u1" size="0x100000" crc="9c336307" sha1="20e72dc6f41493eee1fdd0cef54214e6c3389688" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18646,10 +18646,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apei-0.u1" size="1048576" crc="4d0984a9" sha1="f69ed1a1332f04c24c7db899a09019bb045fa8b3" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apei-0.u1" size="0x100000" crc="4d0984a9" sha1="f69ed1a1332f04c24c7db899a09019bb045fa8b3" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18662,10 +18662,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="pokemon - edicion azul (spain).bin" size="1048576" crc="d95416f9" sha1="7715e7b133e8634df48918b9138374110212a108" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="pokemon - edicion azul (spain).bin" size="0x100000" crc="d95416f9" sha1="7715e7b133e8634df48918b9138374110212a108" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18684,10 +18684,10 @@ license:CC0
 			<feature name="u3" value="U3 RAM [W24257S-70LL]" /> <!-- Also found with [LH52256CN-10LL] -->
 			<feature name="u4" value="U4 MM1134 [134A]" /> <!-- Also found with [6129A] -->
 			<feature name="batt" value="Batt CR2025" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apau-0.u1" size="1048576" crc="9f7fdd53" sha1="ea9bcae617fdf159b045185467ae58b2e4a48b9a" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apau-0.u1" size="0x100000" crc="9f7fdd53" sha1="ea9bcae617fdf159b045185467ae58b2e4a48b9a" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18706,10 +18706,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apaf-0.u1" size="1048576" crc="337fce11" sha1="47a7622fa30e6402a3891fe65b3a930bf9bd7aec" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apaf-0.u1" size="0x100000" crc="337fce11" sha1="47a7622fa30e6402a3891fe65b3a930bf9bd7aec" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18728,10 +18728,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apad-0.u1" size="1048576" crc="89197825" sha1="87d523fe1a0c548db7c5477b451ddec1eb083c06" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apad-0.u1" size="0x100000" crc="89197825" sha1="87d523fe1a0c548db7c5477b451ddec1eb083c06" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18750,10 +18750,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apai-0.u1" size="1048576" crc="2945aceb" sha1="65b97cf8f2f1cff711a6d08c6c894c8ce65ce522" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apai-0.u1" size="0x100000" crc="2945aceb" sha1="65b97cf8f2f1cff711a6d08c6c894c8ce65ce522" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18766,10 +18766,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="pokemon - edicion roja (spain).bin" size="1048576" crc="d8507d8a" sha1="fc17c5b904d551b1b908054ccd1c493f755f832a" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="pokemon - edicion roja (spain).bin" size="0x100000" crc="d8507d8a" sha1="fc17c5b904d551b1b908054ccd1c493f755f832a" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18782,9 +18782,9 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<dataarea name="rom" size = "1048576">
-				<rom name="Pokemon - Cock Version (Bootleg).gb" size="1048576" crc="5716d623" sha1="cfe7ba33ae527d057c631ea27ad1b77b551ec480" offset="0" />
+				<rom name="Pokemon - Cock Version (Bootleg).gb" size="0x100000" crc="5716d623" sha1="cfe7ba33ae527d057c631ea27ad1b77b551ec480" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18803,11 +18803,11 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" /> <!-- Also found with [6735] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
+			<dataarea name="rom" size="0x100000">
 				<!-- USA cart has label DMG-APSE-0 -->
-				<rom name="dmg-apsu-0.u1" size="1048576" crc="7d527d62" sha1="cc7d03262ebfaf2f06772c1a480c7d9d5f4a38e1" />
+				<rom name="dmg-apsu-0.u1" size="0x100000" crc="7d527d62" sha1="cc7d03262ebfaf2f06772c1a480c7d9d5f4a38e1" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18826,10 +18826,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [6735]" /> <!-- Also found with [134A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apsf-0.u1" size="1048576" crc="d03426e9" sha1="0aceec0ef7aa2ca5aa831554598d91f61a925591" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apsf-0.u1" size="0x100000" crc="d03426e9" sha1="0aceec0ef7aa2ca5aa831554598d91f61a925591" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18848,10 +18848,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [6735]" /> <!-- Also found with [134A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apsd-0.u1" size="1048576" crc="7a01e45a" sha1="42f3714eec6eca25200d42461ff08d57c98f6d1d" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apsd-0.u1" size="0x100000" crc="7a01e45a" sha1="42f3714eec6eca25200d42461ff08d57c98f6d1d" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18870,10 +18870,10 @@ license:CC0
 			<feature name="u4" value="U4 MM1134A [134A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-apsi-0.u1" size="1048576" crc="8b56fe33" sha1="05bb8e99f24d498613930949730afa8024e77d08" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-apsi-0.u1" size="0x100000" crc="8b56fe33" sha1="05bb8e99f24d498613930949730afa8024e77d08" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18886,10 +18886,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="pokemon - edicion amarilla (spain).bin" size="1048576" crc="964b7a10" sha1="1dc242039218fba50928d1afb66b70565b6b9daf" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="pokemon - edicion amarilla (spain).bin" size="0x100000" crc="964b7a10" sha1="1dc242039218fba50928d1afb66b70565b6b9daf" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -18904,8 +18904,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="pokonyan - yume no daibouken (japan).bin" size="262144" crc="61c34232" sha1="c5706e26f1cc591cd1fe762ace097df868703480" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="pokonyan - yume no daibouken (japan).bin" size="0x40000" crc="61c34232" sha1="c5706e26f1cc591cd1fe762ace097df868703480" />
 			</dataarea>
 		</part>
 	</software>
@@ -18919,8 +18919,8 @@ license:CC0
 		<info name="alt_title" value="ポン太とヒナ子の珍道中 友情編" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="ponta to hinako no chindouchuu - yuujou hen (japan).bin" size="65536" crc="058b3dab" sha1="83110ce7b82117069c9f147219fc2efbd1cdd103" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="ponta to hinako no chindouchuu - yuujou hen (japan).bin" size="0x10000" crc="058b3dab" sha1="83110ce7b82117069c9f147219fc2efbd1cdd103" />
 			</dataarea>
 		</part>
 	</software>
@@ -18933,8 +18933,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" /> <!-- Also found with DMG-AAA-10 -->
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-opx-0.u1" size="32768" crc="7f545b40" sha1="80094c524c8c9dd01d1402692837b4bc9701350f" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-opx-0.u1" size="0x8000" crc="7f545b40" sha1="80094c524c8c9dd01d1402692837b4bc9701350f" />
 			</dataarea>
 		</part>
 	</software>
@@ -18949,8 +18949,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-tdx-0.u1" size="131072" crc="d07db274" sha1="0206230b55c15a8c18fbb85f852967e44b33a0a4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-tdx-0.u1" size="0x20000" crc="d07db274" sha1="0206230b55c15a8c18fbb85f852967e44b33a0a4" />
 			</dataarea>
 		</part>
 	</software>
@@ -18967,8 +18967,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="popeye (japan).bin" size="131072" crc="2fb4da21" sha1="d7c4cfa460e65368477f9394164b67e03310fc69" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="popeye (japan).bin" size="0x20000" crc="2fb4da21" sha1="d7c4cfa460e65368477f9394164b67e03310fc69" />
 			</dataarea>
 		</part>
 	</software>
@@ -18980,8 +18980,8 @@ license:CC0
 		<info name="serial" value="DMG-PG-FRG" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="popeye 2 (europe).bin" size="131072" crc="c07ed722" sha1="d3078fceadf469ab976422707a24b396530aae05" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="popeye 2 (europe).bin" size="0x20000" crc="c07ed722" sha1="d3078fceadf469ab976422707a24b396530aae05" />
 			</dataarea>
 		</part>
 	</software>
@@ -18995,8 +18995,8 @@ license:CC0
 		<info name="alt_title" value="ポパイ2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="popeye 2 (japan).bin" size="131072" crc="4372ed68" sha1="d59986195bd74dde865245fae9c4081a8a24efb0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="popeye 2 (japan).bin" size="0x20000" crc="4372ed68" sha1="d59986195bd74dde865245fae9c4081a8a24efb0" />
 			</dataarea>
 		</part>
 	</software>
@@ -19010,8 +19010,8 @@ license:CC0
 		<info name="alt_title" value="ポパイ2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-pgj-1.u1" size="131072" crc="8cd93719" sha1="7c4ac88e7a9f034da08ee84f299d9093e40213fd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-pgj-1.u1" size="0x20000" crc="8cd93719" sha1="7c4ac88e7a9f034da08ee84f299d9093e40213fd" />
 			</dataarea>
 		</part>
 	</software>
@@ -19023,8 +19023,8 @@ license:CC0
 		<info name="serial" value="DMG-PG-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="popeye 2 (usa).bin" size="131072" crc="729c2e40" sha1="dd673ee4dd847a3a217f5f5b6e76ff4d418f2d41" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="popeye 2 (usa).bin" size="0x20000" crc="729c2e40" sha1="dd673ee4dd847a3a217f5f5b6e76ff4d418f2d41" />
 			</dataarea>
 		</part>
 	</software>
@@ -19039,8 +19039,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-p9x-0.u1" size="131072" crc="453057ac" sha1="4e3976fe32f4db8f2e56eae539d7cae04d1b64cb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-p9x-0.u1" size="0x20000" crc="453057ac" sha1="4e3976fe32f4db8f2e56eae539d7cae04d1b64cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -19054,8 +19054,8 @@ license:CC0
 		<info name="alt_title" value="ポピュラス外伝" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="populous (japan).bin" size="131072" crc="f327167e" sha1="fde1789eb253309cae80faf4fe7241c6f9d72f29" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="populous (japan).bin" size="0x20000" crc="f327167e" sha1="fde1789eb253309cae80faf4fe7241c6f9d72f29" />
 			</dataarea>
 		</part>
 	</software>
@@ -19066,8 +19066,8 @@ license:CC0
 		<publisher>Imagineer</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="populous.bin" size="131072" crc="ecf2dd6f" sha1="76a08b4a0448641a263ce4dc65a2181192a0a621" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="populous.bin" size="0x20000" crc="ecf2dd6f" sha1="76a08b4a0448641a263ce4dc65a2181192a0a621" />
 			</dataarea>
 		</part>
 	</software>
@@ -19081,8 +19081,8 @@ license:CC0
 		<info name="alt_title" value="パワーミッション" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="power mission (japan) (rev 1).bin" size="131072" crc="e30ef8ab" sha1="89b2306ad9c9e296884354ec3be039b944d52d13" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="power mission (japan) (rev 1).bin" size="0x20000" crc="e30ef8ab" sha1="89b2306ad9c9e296884354ec3be039b944d52d13" />
 			</dataarea>
 		</part>
 	</software>
@@ -19099,8 +19099,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1A]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-xca-0.u1" size="131072" crc="0e2a1414" sha1="ef28356e7a3b82f64e62cb9a7b4c121aa626ff7c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-xca-0.u1" size="0x20000" crc="0e2a1414" sha1="ef28356e7a3b82f64e62cb9a7b4c121aa626ff7c" />
 			</dataarea>
 		</part>
 	</software>
@@ -19112,8 +19112,8 @@ license:CC0
 		<info name="serial" value="DMG-XC-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="power mission (usa).bin" size="131072" crc="46cb2f33" sha1="7eb044e49c370c8e85619cfe42a5b4fb41cbcf17" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="power mission (usa).bin" size="0x20000" crc="46cb2f33" sha1="7eb044e49c370c8e85619cfe42a5b4fb41cbcf17" />
 			</dataarea>
 		</part>
 	</software>
@@ -19128,10 +19128,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="power pro gb (japan) (rev 1).bin" size="262144" crc="71bea855" sha1="ebca3bce624d19a0fa3a92d30a5c543c12541ea4" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="power pro gb (japan) (rev 1).bin" size="0x40000" crc="71bea855" sha1="ebca3bce624d19a0fa3a92d30a5c543c12541ea4" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -19146,10 +19146,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="power pro gb (japan).bin" size="262144" crc="2e123f5b" sha1="135d04cbaab6afd03997bceb6b1a2a8aa1dbc7e8" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="power pro gb (japan).bin" size="0x40000" crc="2e123f5b" sha1="135d04cbaab6afd03997bceb6b1a2a8aa1dbc7e8" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -19161,8 +19161,8 @@ license:CC0
 		<info name="serial" value="DMG-PQ-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="power racer (europe).bin" size="65536" crc="cf8aeee8" sha1="6e10f59bb4090c0d0e79b57a2e39d9577ce0282e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="power racer (europe).bin" size="0x10000" crc="cf8aeee8" sha1="6e10f59bb4090c0d0e79b57a2e39d9577ce0282e" />
 			</dataarea>
 		</part>
 	</software>
@@ -19174,8 +19174,8 @@ license:CC0
 		<info name="serial" value="DMG-PQ-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="power racer (usa).bin" size="65536" crc="afc6a949" sha1="c0c8f28a9b66b6c08a0ed4d31a186c3382160c3d" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="power racer (usa).bin" size="0x10000" crc="afc6a949" sha1="c0c8f28a9b66b6c08a0ed4d31a186c3382160c3d" />
 			</dataarea>
 		</part>
 	</software>
@@ -19190,8 +19190,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-uhe-0.u1" size="131072" crc="c5204156" sha1="1139d6b799b8585bbb7868bd3bca5ba9dea4eef5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-uhe-0.u1" size="0x20000" crc="c5204156" sha1="1139d6b799b8585bbb7868bd3bca5ba9dea4eef5" />
 			</dataarea>
 		</part>
 	</software>
@@ -19205,8 +19205,8 @@ license:CC0
 		<info name="alt_title" value="プリプリ PRIMITIVE PRINCESS!" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="pri pri - primitive princess (japan).bin" size="65536" crc="55da3515" sha1="fea367a2fc321daeae59746ee2cb7ffafd51479a" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pri pri - primitive princess (japan).bin" size="0x10000" crc="55da3515" sha1="fea367a2fc321daeae59746ee2cb7ffafd51479a" />
 			</dataarea>
 		</part>
 	</software>
@@ -19222,8 +19222,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ar9p-0.u1" size="262144" crc="c95d927b" sha1="8561d62cd7df59082d6b3c048ca3b85a30d769b7" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ar9p-0.u1" size="0x40000" crc="c95d927b" sha1="8561d62cd7df59082d6b3c048ca3b85a30d769b7" />
 			</dataarea>
 		</part>
 	</software>
@@ -19235,8 +19235,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="primal rage (prototype).bin" size="262144" crc="f738d4d1" sha1="2aa5b610058e8676126c35ad123fcbd5b4ce99a4" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="primal rage (prototype).bin" size="0x40000" crc="f738d4d1" sha1="2aa5b610058e8676126c35ad123fcbd5b4ce99a4" />
 			</dataarea>
 		</part>
 	</software>
@@ -19251,8 +19251,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-npx-0.u1" size="131072" crc="b2cbf20f" sha1="fd4da10c0a7af510b026007fb66a22672634e2d4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-npx-0.u1" size="0x20000" crc="b2cbf20f" sha1="fd4da10c0a7af510b026007fb66a22672634e2d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -19266,8 +19266,8 @@ license:CC0
 		<info name="alt_title" value="プリンスオブペルシャ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="prince of persia (japan).bin" size="131072" crc="1d16d689" sha1="9d6deaafed4328e485d7a9368e0bb4859760edf7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="prince of persia (japan).bin" size="0x20000" crc="1d16d689" sha1="9d6deaafed4328e485d7a9368e0bb4859760edf7" />
 			</dataarea>
 		</part>
 	</software>
@@ -19278,8 +19278,8 @@ license:CC0
 		<publisher>Virgin Games</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pop gb c811" size="131072" crc="c81ca14b" sha1="355709bd9d4b19be5ee57bd62a0b58b73b25e0bf" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pop gb c811" size="0x20000" crc="c81ca14b" sha1="355709bd9d4b19be5ee57bd62a0b58b73b25e0bf" />
 			</dataarea>
 		</part>
 	</software>
@@ -19290,8 +19290,8 @@ license:CC0
 		<publisher>Mindscape</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="prince of persia.bin" size="131072" crc="e0aaad99" sha1="42b6dfbf283946998caa6c383fa70bf1b646217e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="prince of persia.bin" size="0x20000" crc="e0aaad99" sha1="42b6dfbf283946998caa6c383fa70bf1b646217e" />
 			</dataarea>
 		</part>
 	</software>
@@ -19303,8 +19303,8 @@ license:CC0
 		<info name="serial" value="DMG-NP-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="prince of persia (usa).bin" size="131072" crc="2bd995f1" sha1="ef3ef15b791ceff34d7d9bb5b3af2e05842c8323" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="prince of persia (usa).bin" size="0x20000" crc="2bd995f1" sha1="ef3ef15b791ceff34d7d9bb5b3af2e05842c8323" />
 			</dataarea>
 		</part>
 	</software>
@@ -19320,8 +19320,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pro mahjong kiwame gb (japan).bin" size="131072" crc="6f5b6748" sha1="dc6b304ac4e9b679272f843411ba964b438a69b6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pro mahjong kiwame gb (japan).bin" size="0x20000" crc="6f5b6748" sha1="dc6b304ac4e9b679272f843411ba964b438a69b6" />
 			</dataarea>
 		</part>
 	</software>
@@ -19335,8 +19335,8 @@ license:CC0
 		<info name="alt_title" value="プロサッカー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pro soccer (japan).bin" size="131072" crc="a6f3bee2" sha1="ccf50ae867633f608ba38302c8561654223dc14b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pro soccer (japan).bin" size="0x20000" crc="a6f3bee2" sha1="ccf50ae867633f608ba38302c8561654223dc14b" />
 			</dataarea>
 		</part>
 	</software>
@@ -19350,8 +19350,8 @@ license:CC0
 		<info name="alt_title" value="プロレス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="pro wrestling (japan).bin" size="131072" crc="f27c06da" sha1="c368831c5468c3f03f3f38e4c2fa2bab9478fc4e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pro wrestling (japan).bin" size="0x20000" crc="f27c06da" sha1="c368831c5468c3f03f3f38e4c2fa2bab9478fc4e" />
 			</dataarea>
 		</part>
 	</software>
@@ -19370,10 +19370,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-pij-0.u1" size="131072" crc="420881ae" sha1="cc6cbbcaabce4a63106da3c9b5e4a761511cae38" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-pij-0.u1" size="0x20000" crc="420881ae" sha1="cc6cbbcaabce4a63106da3c9b5e4a761511cae38" />
 			</dataarea>
-			<dataarea name="nvram" size="8192"> <!-- unconfirmed size -->
+			<dataarea name="nvram" size="0x2000"> <!-- unconfirmed size -->
 			</dataarea>
 		</part>
 	</software>
@@ -19387,10 +19387,10 @@ license:CC0
 		<info name="alt_title" value="東尾修監修 プロ野球スタジアム'92" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="pro yakyuu stadium '92 (japan).bin" size="262144" crc="71559ba0" sha1="7c89b508b71569776c50256da350652657027cf2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="pro yakyuu stadium '92 (japan).bin" size="0x40000" crc="71559ba0" sha1="7c89b508b71569776c50256da350652657027cf2" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -19405,8 +19405,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-cnx-0.u1" size="131072" crc="c9acc4f4" sha1="45482a44ce0cdfa33fc58a8a8afe2d7284dfa498" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-cnx-0.u1" size="0x20000" crc="c9acc4f4" sha1="45482a44ce0cdfa33fc58a8a8afe2d7284dfa498" />
 			</dataarea>
 		</part>
 	</software>
@@ -19419,8 +19419,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="probotector 2 (europe).bin" size="131072" crc="b5090e43" sha1="d3eafed6727afd14bd30ffc31e2d3e4ee6cfc52e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="probotector 2 (europe).bin" size="0x20000" crc="b5090e43" sha1="d3eafed6727afd14bd30ffc31e2d3e4ee6cfc52e" />
 			</dataarea>
 		</part>
 	</software>
@@ -19432,8 +19432,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="probotector 2 (sample).bin" size="131072" crc="7d60c005" sha1="8f060253ea228c43d2992458dbf904a0b0d7b01e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="probotector 2 (sample).bin" size="0x20000" crc="7d60c005" sha1="8f060253ea228c43d2992458dbf904a0b0d7b01e" />
 			</dataarea>
 		</part>
 	</software>
@@ -19445,8 +19445,8 @@ license:CC0
 		<info name="serial" value="DMG-VC-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="prophecy - the viking child (europe) (en,fr,de,es,it).bin" size="262144" crc="590f5fb1" sha1="dded3db8437ba2342599e9dbde3aa20ce83e15ca" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="prophecy - the viking child (europe) (en,fr,de,es,it).bin" size="0x40000" crc="590f5fb1" sha1="dded3db8437ba2342599e9dbde3aa20ce83e15ca" />
 			</dataarea>
 		</part>
 	</software>
@@ -19458,8 +19458,8 @@ license:CC0
 		<info name="serial" value="DMG-VC-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="prophecy - the viking child (usa).bin" size="262144" crc="80f62f9a" sha1="a6fca2fd143c605dd166e7462729599ad0143457" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="prophecy - the viking child (usa).bin" size="0x40000" crc="80f62f9a" sha1="a6fca2fd143c605dd166e7462729599ad0143457" />
 			</dataarea>
 		</part>
 	</software>
@@ -19474,8 +19474,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-nse-0.u1" size="131072" crc="5916713e" sha1="c7b01ce2f83e00f6f3e0ca65ddedfb2435119ba2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-nse-0.u1" size="0x20000" crc="5916713e" sha1="c7b01ce2f83e00f6f3e0ca65ddedfb2435119ba2" />
 			</dataarea>
 		</part>
 	</software>
@@ -19491,10 +19491,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-appj-1.u1" size="524288" crc="57e9c17d" sha1="90929296b16d89130969041271327bcaa2b6a73e" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-appj-1.u1" size="0x80000" crc="57e9c17d" sha1="90929296b16d89130969041271327bcaa2b6a73e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -19510,10 +19510,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="purikura pocket - fukanzen joshikousei manual (japan).bin" size="524288" crc="acc589fc" sha1="2f2d519e0c9acad3cf96546aebb04b8ff309ab1f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="purikura pocket - fukanzen joshikousei manual (japan).bin" size="0x80000" crc="acc589fc" sha1="2f2d519e0c9acad3cf96546aebb04b8ff309ab1f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -19529,10 +19529,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="purikura pocket 2 - kareshi kaizou daisakusen (japan).bin" size="524288" crc="d145ea23" sha1="6b7ab5728973865f970cd676a4837e7f4c4128bb" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="purikura pocket 2 - kareshi kaizou daisakusen (japan).bin" size="0x80000" crc="d145ea23" sha1="6b7ab5728973865f970cd676a4837e7f4c4128bb" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -19548,10 +19548,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="purikura pocket 3 - talent debut daisakusen (japan).bin" size="1048576" crc="ceb62411" sha1="b8df59d63a2f836ef497f503b67a3401eae497a7" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="purikura pocket 3 - talent debut daisakusen (japan).bin" size="0x100000" crc="ceb62411" sha1="b8df59d63a2f836ef497f503b67a3401eae497a7" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -19569,8 +19569,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B1] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-qqj-1.u1" size="262144" crc="20e48285" sha1="ef05ab17131030554e0d820dd0e602af82e1fe54" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-qqj-1.u1" size="0x40000" crc="20e48285" sha1="ef05ab17131030554e0d820dd0e602af82e1fe54" />
 			</dataarea>
 		</part>
 	</software>
@@ -19588,8 +19588,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-qqj-0.u1" size="262144" crc="9e372d13" sha1="65c80185c8948e1963509e13c40fb670ad6b64c5" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-qqj-0.u1" size="0x40000" crc="9e372d13" sha1="65c80185c8948e1963509e13c40fb670ad6b64c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -19607,8 +19607,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-agpj-0.u1" size="131072" crc="10235e38" sha1="203a39b937e1900fa272f93830d3c6f825e67821" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-agpj-0.u1" size="0x20000" crc="10235e38" sha1="203a39b937e1900fa272f93830d3c6f825e67821" />
 			</dataarea>
 		</part>
 	</software>
@@ -19621,8 +19621,8 @@ license:CC0
 		<info name="release" value="19891124" />
 		<info name="alt_title" value="パズルボーイ" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="puzzle boy (japan).bin" size="32768" crc="2ae2d71c" sha1="67cbf1efb8db55091d87eaee9942bc0d9d5291d4" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="puzzle boy (japan).bin" size="0x8000" crc="2ae2d71c" sha1="67cbf1efb8db55091d87eaee9942bc0d9d5291d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -19636,8 +19636,8 @@ license:CC0
 		<info name="alt_title" value="パズルボーイII" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="puzzle boy ii (japan).bin" size="65536" crc="e5463a1d" sha1="15e325be6272281d74448936fee5179448ae480e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="puzzle boy ii (japan).bin" size="0x10000" crc="e5463a1d" sha1="15e325be6272281d74448936fee5179448ae480e" />
 			</dataarea>
 		</part>
 	</software>
@@ -19655,8 +19655,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-apnj-0.u1" size="262144" crc="952920ba" sha1="5239823f04da93fc6b8fcac48f0d0425f90972bc" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-apnj-0.u1" size="0x40000" crc="952920ba" sha1="5239823f04da93fc6b8fcac48f0d0425f90972bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -19673,8 +19673,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-pza-0.u1" size="65536" crc="916e638d" sha1="74b26b502c5c728bc7b99f387f1aaf817d22b55a" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-pza-0.u1" size="0x10000" crc="916e638d" sha1="74b26b502c5c728bc7b99f387f1aaf817d22b55a" />
 			</dataarea>
 		</part>
 	</software>
@@ -19686,8 +19686,8 @@ license:CC0
 		<info name="serial" value="DMG-YR-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="pyramids of ra (usa).bin" size="65536" crc="abef175b" sha1="8b75bc3127862c8b38b7992d2560966982bbe2e0" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pyramids of ra (usa).bin" size="0x10000" crc="abef175b" sha1="8b75bc3127862c8b38b7992d2560966982bbe2e0" />
 			</dataarea>
 		</part>
 	</software>
@@ -19700,8 +19700,8 @@ license:CC0
 		<info name="release" value="19891222" />
 		<info name="alt_title" value="キュービリオン" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="q billion (japan).bin" size="32768" crc="979ed154" sha1="6344d6f2eefa56655c39c65c0595425799826498" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="q billion (japan).bin" size="0x8000" crc="979ed154" sha1="6344d6f2eefa56655c39c65c0595425799826498" />
 			</dataarea>
 		</part>
 	</software>
@@ -19712,8 +19712,8 @@ license:CC0
 		<publisher>Seta</publisher>
 		<info name="serial" value="DMG-QB-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="q billion (usa).bin" size="32768" crc="7202e973" sha1="cfc54888f1ba368463009983f3cb3f6da66f3aec" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="q billion (usa).bin" size="0x8000" crc="7202e973" sha1="cfc54888f1ba368463009983f3cb3f6da66f3aec" />
 			</dataarea>
 		</part>
 	</software>
@@ -19728,8 +19728,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-qte-0.u1" size="65536" crc="b0109545" sha1="bd56a1e96c3d310b522e25d7b72ceef26af87f2e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-qte-0.u1" size="0x10000" crc="b0109545" sha1="bd56a1e96c3d310b522e25d7b72ceef26af87f2e" />
 			</dataarea>
 		</part>
 	</software>
@@ -19743,8 +19743,8 @@ license:CC0
 		<info name="alt_title" value="キューバート" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="q-bert for game boy (japan).bin" size="65536" crc="e9ba4bad" sha1="44665169fdb96c685646613a82719276e7f07763" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="q-bert for game boy (japan).bin" size="0x10000" crc="e9ba4bad" sha1="44665169fdb96c685646613a82719276e7f07763" />
 			</dataarea>
 		</part>
 	</software>
@@ -19761,8 +19761,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" /> <!-- Also found with [DMG MBC1-B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-qxa-0.u1" size="65536" crc="9185e89e" sha1="fb9935ca821562966eafa8f60ec2f489ad33940a" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-qxa-0.u1" size="0x10000" crc="9185e89e" sha1="fb9935ca821562966eafa8f60ec2f489ad33940a" />
 			</dataarea>
 		</part>
 	</software>
@@ -19776,8 +19776,8 @@ license:CC0
 		<info name="alt_title" value="クォース" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="quarth (japan).bin" size="65536" crc="40e5adc9" sha1="de0f86fdf63461ba0b01df3839416f834133f2c9" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="quarth (japan).bin" size="0x10000" crc="40e5adc9" sha1="de0f86fdf63461ba0b01df3839416f834133f2c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -19789,8 +19789,8 @@ license:CC0
 		<info name="serial" value="DMG-QR-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="quarth (usa, europe).bin" size="65536" crc="bfb112ad" sha1="89448b17700a6016a3f81de09a15e097c060d103" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="quarth (usa, europe).bin" size="0x10000" crc="bfb112ad" sha1="89448b17700a6016a3f81de09a15e097c060d103" />
 			</dataarea>
 		</part>
 	</software>
@@ -19804,8 +19804,8 @@ license:CC0
 		<info name="alt_title" value="クイズ日本昔話 アテナのハテナ?" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="quiz nihon mukashibanashi - athena no hatena (japan).bin" size="262144" crc="471c237b" sha1="c91507aa0e17580e8cf8f1901f328432c12ce2dd" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="quiz nihon mukashibanashi - athena no hatena (japan).bin" size="0x40000" crc="471c237b" sha1="c91507aa0e17580e8cf8f1901f328432c12ce2dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -19819,8 +19819,8 @@ license:CC0
 		<info name="alt_title" value="クイズ世界は SHOW by ショーバイ!!" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="quiz sekai wa show by shoubai (japan).bin" size="262144" crc="d8c33dcd" sha1="5e0004d7c87e49b3ed9e72cb292a967faad6ea6c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="quiz sekai wa show by shoubai (japan).bin" size="0x40000" crc="d8c33dcd" sha1="5e0004d7c87e49b3ed9e72cb292a967faad6ea6c" />
 			</dataarea>
 		</part>
 	</software>
@@ -19835,8 +19835,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ree-0.u1" size="131072" crc="e0f23fc0" sha1="28531a4eb668477df98caf0e87cedc0e5fdfe53b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ree-0.u1" size="0x20000" crc="e0f23fc0" sha1="28531a4eb668477df98caf0e87cedc0e5fdfe53b" />
 			</dataarea>
 		</part>
 	</software>
@@ -19853,8 +19853,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-rea-0.u1" size="131072" crc="e4988910" sha1="440573ce4ea3bab679e25315cd3f05c5530f6bd1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-rea-0.u1" size="0x20000" crc="e4988910" sha1="440573ce4ea3bab679e25315cd3f05c5530f6bd1" />
 			</dataarea>
 		</part>
 	</software>
@@ -19865,8 +19865,8 @@ license:CC0
 		<publisher>Irem</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="r-type ii (europe).bin" size="131072" crc="2fe2a72d" sha1="f19436dfed41b9c2e94e070a76c5bdbcc7f993c3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="r-type ii (europe).bin" size="0x20000" crc="2fe2a72d" sha1="f19436dfed41b9c2e94e070a76c5bdbcc7f993c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -19880,8 +19880,8 @@ license:CC0
 			<feature name="u1" value="U1" />
 			<feature name="u2" value="U2 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="u1" size="131072" crc="e99fec8d" sha1="da727e9541c9885365651fc6eece3f0075a59fe4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="u1" size="0x20000" crc="e99fec8d" sha1="da727e9541c9885365651fc6eece3f0075a59fe4" />
 			</dataarea>
 		</part>
 	</software>
@@ -19898,8 +19898,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="u2" size="131072" crc="6002e291" sha1="28e13db505cbb5c178002acf02e5c0bfcfc6b08f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="u2" size="0x20000" crc="6002e291" sha1="28e13db505cbb5c178002acf02e5c0bfcfc6b08f" />
 			</dataarea>
 		</part>
 	</software>
@@ -19911,8 +19911,8 @@ license:CC0
 		<info name="serial" value="DMG-ARDE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="race days (usa).bin" size="262144" crc="442420b3" sha1="750143b2057b604123972a978a51a14a7e8621bf" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="race days (usa).bin" size="0x40000" crc="442420b3" sha1="750143b2057b604123972a978a51a14a7e8621bf" />
 			</dataarea>
 		</part>
 	</software>
@@ -19927,8 +19927,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ardp-0.u1" size="262144" crc="b9ab5319" sha1="eee5feb39af996804177f4a269d2a41f692120f9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ardp-0.u1" size="0x40000" crc="b9ab5319" sha1="eee5feb39af996804177f4a269d2a41f692120f9" />
 			</dataarea>
 		</part>
 	</software>
@@ -19943,8 +19943,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-rve-0.u1" size="131072" crc="6775ccd6" sha1="67111295fe2095861256b46e7417e4c1d115a6fe" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-rve-0.u1" size="0x20000" crc="6775ccd6" sha1="67111295fe2095861256b46e7417e4c1d115a6fe" />
 			</dataarea>
 		</part>
 	</software>
@@ -19955,8 +19955,8 @@ license:CC0
 		<publisher>T*HQ</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="race drivin' (prototype).bin" size="131072" crc="8c217639" sha1="e1e7dce263d4a99ef04a7803f0e9bdc5d5dce2ed" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="race drivin' (prototype).bin" size="0x20000" crc="8c217639" sha1="e1e7dce263d4a99ef04a7803f0e9bdc5d5dce2ed" />
 			</dataarea>
 		</part>
 	</software>
@@ -19970,8 +19970,8 @@ license:CC0
 		<info name="alt_title" value="レーシング魂" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="racing damashii (japan).bin" size="65536" crc="796fbb66" sha1="4466b36294176b3e1fc1558cd00abdfa4247a75d" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="racing damashii (japan).bin" size="0x10000" crc="796fbb66" sha1="4466b36294176b3e1fc1558cd00abdfa4247a75d" />
 			</dataarea>
 		</part>
 	</software>
@@ -19989,8 +19989,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-rma-0.u1" size="131072" crc="892fc0af" sha1="64a808f582afcbed6a3ce0263f1dae6fde57f30b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-rma-0.u1" size="0x20000" crc="892fc0af" sha1="64a808f582afcbed6a3ce0263f1dae6fde57f30b" />
 			</dataarea>
 		</part>
 	</software>
@@ -20002,8 +20002,8 @@ license:CC0
 		<info name="serial" value="DMG-RM-USA, DMG-RM-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="radar mission (usa, europe).bin" size="131072" crc="581da9c9" sha1="5ab5998a84eebc769f75c482cb0a5586ed97e888" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="radar mission (usa, europe).bin" size="0x20000" crc="581da9c9" sha1="5ab5998a84eebc769f75c482cb0a5586ed97e888" />
 			</dataarea>
 		</part>
 	</software>
@@ -20018,8 +20018,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-obe-0.u1" size="262144" crc="1ef3bedb" sha1="3e9ae5693208b8c377792c0fb67d682c6158b14d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-obe-0.u1" size="0x40000" crc="1ef3bedb" sha1="3e9ae5693208b8c377792c0fb67d682c6158b14d" />
 			</dataarea>
 		</part>
 	</software>
@@ -20033,8 +20033,8 @@ license:CC0
 		<info name="alt_title" value="ランパート" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="rampart (japan).bin" size="131072" crc="96a4c720" sha1="0e196236a21fc4558f3eab92ba38a574a1fde918" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rampart (japan).bin" size="0x20000" crc="96a4c720" sha1="0e196236a21fc4558f3eab92ba38a574a1fde918" />
 			</dataarea>
 		</part>
 	</software>
@@ -20046,8 +20046,8 @@ license:CC0
 		<info name="serial" value="DMG-R8-USA, DMG-R8-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="rampart (usa, europe).bin" size="131072" crc="6d347812" sha1="51e5408e5e8243c762f4218fd4138c849ee7d625" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rampart (usa, europe).bin" size="0x20000" crc="6d347812" sha1="51e5408e5e8243c762f4218fd4138c849ee7d625" />
 			</dataarea>
 		</part>
 	</software>
@@ -20061,8 +20061,8 @@ license:CC0
 		<info name="alt_title" value="らんま1/2 かくれんぼデスマッチ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="ranma 1-2 (japan).bin" size="65536" crc="4e05537e" sha1="c869d7fc1fce8ea7ca534e29e8da826017f4ca4f" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="ranma 1-2 (japan).bin" size="0x10000" crc="4e05537e" sha1="c869d7fc1fce8ea7ca534e29e8da826017f4ca4f" />
 			</dataarea>
 		</part>
 	</software>
@@ -20076,8 +20076,8 @@ license:CC0
 		<info name="alt_title" value="らんま1/2 格劇問答!!" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="ranma 1-2 - kakugeki mondou (japan).bin" size="262144" crc="613e657a" sha1="57fd028fd44d6096967a3c80afd9e17c38c2513e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="ranma 1-2 - kakugeki mondou (japan).bin" size="0x40000" crc="613e657a" sha1="57fd028fd44d6096967a3c80afd9e17c38c2513e" />
 			</dataarea>
 		</part>
 	</software>
@@ -20091,8 +20091,8 @@ license:CC0
 		<info name="alt_title" value="らんま1/2 2 熱烈格闘編" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="ranma 1-2 - netsuretsu kakutou hen (japan).bin" size="262144" crc="d9d57151" sha1="62bfbb19b825c3305c819da06332f731437c51f0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="ranma 1-2 - netsuretsu kakutou hen (japan).bin" size="0x40000" crc="d9d57151" sha1="62bfbb19b825c3305c819da06332f731437c51f0" />
 			</dataarea>
 		</part>
 	</software>
@@ -20106,8 +20106,8 @@ license:CC0
 		<info name="alt_title" value="ライサンダー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ray-thunder (japan).bin" size="131072" crc="a00a9468" sha1="e250e681b26835ff60b5ef0d9ce4513d8caf59e5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ray-thunder (japan).bin" size="0x20000" crc="a00a9468" sha1="e250e681b26835ff60b5ef0d9ce4513d8caf59e5" />
 			</dataarea>
 		</part>
 	</software>
@@ -20125,8 +20125,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-arbj-0.u1" size="524288" crc="f4031d4c" sha1="d67a26af79becdf957cca82bc472b188f5754cd2" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-arbj-0.u1" size="0x80000" crc="f4031d4c" sha1="d67a26af79becdf957cca82bc472b188f5754cd2" />
 			</dataarea>
 		</part>
 	</software>
@@ -20138,8 +20138,8 @@ license:CC0
 		<info name="serial" value="DMG-L4-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="real ghostbusters, the (usa).bin" size="131072" crc="e1592b83" sha1="f470bf48b02e95b7f2c0d82b5c676bd298ab6d52" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="real ghostbusters, the (usa).bin" size="0x20000" crc="e1592b83" sha1="f470bf48b02e95b7f2c0d82b5c676bd298ab6d52" />
 			</dataarea>
 		</part>
 	</software>
@@ -20157,8 +20157,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" /> <!-- Also found with [DMG MBC1A] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-raj-0.u1" size="131072" crc="ae0122aa" sha1="dd49a66372411da76023e993b3476190f76eeca8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-raj-0.u1" size="0x20000" crc="ae0122aa" sha1="dd49a66372411da76023e993b3476190f76eeca8" />
 			</dataarea>
 		</part>
 	</software>
@@ -20172,8 +20172,8 @@ license:CC0
 		<info name="alt_title" value="レッド・オクトーバーを追え!" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="red october o oe (japan).bin" size="131072" crc="c2e7be35" sha1="48d5f02a126c32423569065f31d2c5695e39fd2f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="red october o oe (japan).bin" size="0x20000" crc="c2e7be35" sha1="48d5f02a126c32423569065f31d2c5695e39fd2f" />
 			</dataarea>
 		</part>
 	</software>
@@ -20188,8 +20188,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-rxe-0.u1" size="262144" crc="2085aad9" sha1="da7634aa8e34be43d7dc89a572be2126795989af" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-rxe-0.u1" size="0x40000" crc="2085aad9" sha1="da7634aa8e34be43d7dc89a572be2126795989af" />
 			</dataarea>
 		</part>
 	</software>
@@ -20201,8 +20201,8 @@ license:CC0
 		<info name="serial" value="DMG-VD-USA, DMG-VD-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="ren &amp; stimpy show, the - veediots (usa, europe).bin" size="262144" crc="504cbd1d" sha1="40e278161a0268f00dcae5b7f16ae390d0400937" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="ren &amp; stimpy show, the - veediots (usa, europe).bin" size="0x40000" crc="504cbd1d" sha1="40e278161a0268f00dcae5b7f16ae390d0400937" />
 			</dataarea>
 		</part>
 	</software>
@@ -20216,8 +20216,8 @@ license:CC0
 		<info name="alt_title" value="連珠倶楽部 五目ならべ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
-			<dataarea name="rom" size="32768">
-				<rom name="renju club (japan).bin" size="32768" crc="52f5e960" sha1="d5d2a3f194af308a2e7fbbf0f893537bd9e44a68" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="renju club (japan).bin" size="0x8000" crc="52f5e960" sha1="d5d2a3f194af308a2e7fbbf0f893537bd9e44a68" />
 			</dataarea>
 		</part>
 	</software>
@@ -20231,10 +20231,10 @@ license:CC0
 		<info name="alt_title" value="連対王" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="rentaiou (japan).bin" size="65536" crc="2350922b" sha1="5b2fa3da4dcd8afcd88c00134a2bbc8942135897" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="rentaiou (japan).bin" size="0x10000" crc="2350922b" sha1="5b2fa3da4dcd8afcd88c00134a2bbc8942135897" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -20249,8 +20249,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-arsp-0.u1" size="262144" crc="2d33e175" sha1="08dad9ac1f045d1c9e403c4ea1368aee991e0094" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-arsp-0.u1" size="0x40000" crc="2d33e175" sha1="08dad9ac1f045d1c9e403c4ea1368aee991e0094" />
 			</dataarea>
 		</part>
 	</software>
@@ -20261,8 +20261,8 @@ license:CC0
 		<publisher>Mega Cat Studios</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="retroid.bin" size="262144" crc="9f759f25" sha1="4c7323d6a10852fe416c7bd581d6ffdd2d473bb5" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="retroid.bin" size="0x40000" crc="9f759f25" sha1="4c7323d6a10852fe416c7bd581d6ffdd2d473bb5" />
 			</dataarea>
 		</part>
 	</software>
@@ -20277,8 +20277,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-xwx-0.u1" size="131072" crc="8de1ae9c" sha1="261a6272560e04bef0819fd38e70607d7e23eea5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-xwx-0.u1" size="0x20000" crc="8de1ae9c" sha1="261a6272560e04bef0819fd38e70607d7e23eea5" />
 			</dataarea>
 		</part>
 	</software>
@@ -20290,8 +20290,8 @@ license:CC0
 		<info name="serial" value="DMG-XW-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="riddick bowe boxing (usa).bin" size="131072" crc="fb5d24e0" sha1="93a8a28244461b564e828cca876821fb7a60fc89" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="riddick bowe boxing (usa).bin" size="0x20000" crc="fb5d24e0" sha1="93a8a28244461b564e828cca876821fb7a60fc89" />
 			</dataarea>
 		</part>
 	</software>
@@ -20305,8 +20305,8 @@ license:CC0
 			<feature name="u1" value="U1" />
 			<feature name="u2" value="U2 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="bowe dmg.u1" size="131072" crc="a07512a6" sha1="69685eaffa523bf199be0c540d9eb561bb27d584" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bowe dmg.u1" size="0x20000" crc="a07512a6" sha1="69685eaffa523bf199be0c540d9eb561bb27d584" />
 			</dataarea>
 		</part>
 	</software>
@@ -20320,8 +20320,8 @@ license:CC0
 		<info name="alt_title" value="リングレイジ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ring rage (japan).bin" size="131072" crc="fd3d5ba7" sha1="c6689e9df7312ddff14f3e7b483fb02107c7b84b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ring rage (japan).bin" size="0x20000" crc="fd3d5ba7" sha1="c6689e9df7312ddff14f3e7b483fb02107c7b84b" />
 			</dataarea>
 		</part>
 	</software>
@@ -20333,8 +20333,8 @@ license:CC0
 		<info name="serial" value="DMG-RU-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ring rage (usa).bin" size="131072" crc="bce5dfb7" sha1="eb9509415d08792a29712814a7887824f11624c0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ring rage (usa).bin" size="0x20000" crc="bce5dfb7" sha1="eb9509415d08792a29712814a7887824f11624c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -20345,8 +20345,8 @@ license:CC0
 		<publisher>Ocean</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="road rash (usa, europe) (beta).bin" size="131072" crc="4f09238a" sha1="5cc1416eedeabc32d8d0a7a42d170b70c6117b19" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="road rash (usa, europe) (beta).bin" size="0x20000" crc="4f09238a" sha1="5cc1416eedeabc32d8d0a7a42d170b70c6117b19" />
 			</dataarea>
 		</part>
 	</software>
@@ -20358,8 +20358,8 @@ license:CC0
 		<info name="serial" value="DMG-H5-USA, DMG-H5-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="road rash (usa, europe).bin" size="131072" crc="88edc83d" sha1="488e699490598234e762ecf864c75edcb1bc6066" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="road rash (usa, europe).bin" size="0x20000" crc="88edc83d" sha1="488e699490598234e762ecf864c75edcb1bc6066" />
 			</dataarea>
 		</part>
 	</software>
@@ -20373,8 +20373,8 @@ license:CC0
 		<info name="alt_title" value="ロードスター" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="roadster (japan).bin" size="131072" crc="04453e78" sha1="685c31496de738c27160d1f75408da6b95daaae8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="roadster (japan).bin" size="0x20000" crc="04453e78" sha1="685c31496de738c27160d1f75408da6b95daaae8" />
 			</dataarea>
 		</part>
 	</software>
@@ -20389,8 +20389,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-rhx-0.u1" size="262144" crc="55bba483" sha1="7e7b7508f810d0cab2d0873b7cb8dcb61f4b493a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-rhx-0.u1" size="0x40000" crc="55bba483" sha1="7e7b7508f810d0cab2d0873b7cb8dcb61f4b493a" />
 			</dataarea>
 		</part>
 	</software>
@@ -20405,8 +20405,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-rhf-0.u1" size="262144" crc="ef1a493a" sha1="0c74624f8d2f6f7f1a969c4fa9b621734877fbbd" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-rhf-0.u1" size="0x40000" crc="ef1a493a" sha1="0c74624f8d2f6f7f1a969c4fa9b621734877fbbd" />
 			</dataarea>
 		</part>
 	</software>
@@ -20418,8 +20418,8 @@ license:CC0
 		<info name="serial" value="DMG-RH-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="robin hood - prince of thieves (germany).bin" size="262144" crc="0b2071a3" sha1="98fbe26f7c05121dd3a2c8f3cdc4add3e2f81bc1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="robin hood - prince of thieves (germany).bin" size="0x40000" crc="0b2071a3" sha1="98fbe26f7c05121dd3a2c8f3cdc4add3e2f81bc1" />
 			</dataarea>
 		</part>
 	</software>
@@ -20431,8 +20431,8 @@ license:CC0
 		<info name="serial" value="DMG-RH-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="robin hood - prince of thieves (spain).bin" size="262144" crc="7846df7d" sha1="c9afa1afafb05289b5e26b2c3e3d9744067384e7" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="robin hood - prince of thieves (spain).bin" size="0x40000" crc="7846df7d" sha1="c9afa1afafb05289b5e26b2c3e3d9744067384e7" />
 			</dataarea>
 		</part>
 	</software>
@@ -20444,8 +20444,8 @@ license:CC0
 		<info name="serial" value="DMG-RH-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="robin hood - prince of thieves (usa).bin" size="262144" crc="e5c8c2b1" sha1="999bb7878472b657375e04b75ed86efa90933a55" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="robin hood - prince of thieves (usa).bin" size="0x40000" crc="e5c8c2b1" sha1="999bb7878472b657375e04b75ed86efa90933a55" />
 			</dataarea>
 		</part>
 	</software>
@@ -20460,8 +20460,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-cpe-1.u1" size="65536" crc="62d56c31" sha1="b858e5a7b5b87578fb14a60a2d9a330a6c8a10eb" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-cpe-1.u1" size="0x10000" crc="62d56c31" sha1="b858e5a7b5b87578fb14a60a2d9a330a6c8a10eb" />
 			</dataarea>
 		</part>
 	</software>
@@ -20473,8 +20473,8 @@ license:CC0
 		<info name="serial" value="DMG-CP-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="robocop (usa).bin" size="131072" crc="6088b426" sha1="39b92e019134dfd4480b957509c3eb64920cecb3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="robocop (usa).bin" size="0x20000" crc="6088b426" sha1="39b92e019134dfd4480b957509c3eb64920cecb3" />
 			</dataarea>
 		</part>
 	</software>
@@ -20488,8 +20488,8 @@ license:CC0
 		<info name="alt_title" value="ロボコップ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="robocop (japan).bin" size="131072" crc="06d6980b" sha1="11b22799a4fe7a605c54c7d5fb9b9f61eceffd08" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="robocop (japan).bin" size="0x20000" crc="06d6980b" sha1="11b22799a4fe7a605c54c7d5fb9b9f61eceffd08" />
 			</dataarea>
 		</part>
 	</software>
@@ -20503,8 +20503,8 @@ license:CC0
 		<info name="alt_title" value="ロボコップ2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="robocop 2 (japan).bin" size="131072" crc="157ce6e5" sha1="aa5fa94c51ce454d76faa8bf5b3729557d064904" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="robocop 2 (japan).bin" size="0x20000" crc="157ce6e5" sha1="aa5fa94c51ce454d76faa8bf5b3729557d064904" />
 			</dataarea>
 		</part>
 	</software>
@@ -20516,8 +20516,8 @@ license:CC0
 		<info name="serial" value="DMG-R2-USA, DMG-R2-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="robocop 2 (usa).bin" size="131072" crc="4365a789" sha1="b4b78cb9b606d64e8ebb80e047b3b4b4767c019c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="robocop 2 (usa).bin" size="0x20000" crc="4365a789" sha1="b4b78cb9b606d64e8ebb80e047b3b4b4767c019c" />
 			</dataarea>
 		</part>
 	</software>
@@ -20532,8 +20532,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-vrx-0.u1" size="131072" crc="9e3b05c4" sha1="a5abfff1026fc65c8da95b40423c4d136f4bcfba" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-vrx-0.u1" size="0x20000" crc="9e3b05c4" sha1="a5abfff1026fc65c8da95b40423c4d136f4bcfba" />
 			</dataarea>
 		</part>
 	</software>
@@ -20545,8 +20545,8 @@ license:CC0
 		<info name="serial" value="DMG-VR-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="robocop vs. the terminator (usa).bin" size="131072" crc="f82d7223" sha1="ca0484363d1d427474de028f037c7d566e9c1fea" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="robocop vs. the terminator (usa).bin" size="0x20000" crc="f82d7223" sha1="ca0484363d1d427474de028f037c7d566e9c1fea" />
 			</dataarea>
 		</part>
 	</software>
@@ -20561,8 +20561,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="rock'n monster (japan).bin" size="524288" crc="630299c1" sha1="338070ed1ced15eaca02198ab32b9e82a92f77ee" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="rock'n monster (japan).bin" size="0x80000" crc="630299c1" sha1="338070ed1ced15eaca02198ab32b9e82a92f77ee" />
 			</dataarea>
 		</part>
 	</software>
@@ -20577,8 +20577,8 @@ license:CC0
 		<info name="alt_title" value="ロックマンワールド" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="rockman world (japan).bin" size="262144" crc="3be6ac04" sha1="91318509322fbcd1e1e05b98243227377d8f31d5" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="rockman world (japan).bin" size="0x40000" crc="3be6ac04" sha1="91318509322fbcd1e1e05b98243227377d8f31d5" />
 			</dataarea>
 		</part>
 	</software>
@@ -20591,8 +20591,8 @@ license:CC0
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="rockman world (proto).bin" size="262144" crc="d7356a4f" sha1="60c5c997b4b2c47d852520817228d2b8efc2a33f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="rockman world (proto).bin" size="0x40000" crc="d7356a4f" sha1="60c5c997b4b2c47d852520817228d2b8efc2a33f" />
 			</dataarea>
 		</part>
 	</software>
@@ -20607,8 +20607,8 @@ license:CC0
 		<info name="alt_title" value="ロックマンワールド2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="rockman world 2 (japan).bin" size="262144" crc="c34d265e" sha1="5d35baa2fadd07796ed8b441f82ed5b136a999c7" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="rockman world 2 (japan).bin" size="0x40000" crc="c34d265e" sha1="5d35baa2fadd07796ed8b441f82ed5b136a999c7" />
 			</dataarea>
 		</part>
 	</software>
@@ -20623,8 +20623,8 @@ license:CC0
 		<info name="alt_title" value="ロックマンワールド3" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="rockman world 3 (japan).bin" size="262144" crc="e904484f" sha1="201abc73cf669f71a477a431d387518f4b488c1f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="rockman world 3 (japan).bin" size="0x40000" crc="e904484f" sha1="201abc73cf669f71a477a431d387518f4b488c1f" />
 			</dataarea>
 		</part>
 	</software>
@@ -20639,8 +20639,8 @@ license:CC0
 		<info name="alt_title" value="ロックマンワールド4" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="rockman world 4 (japan).bin" size="524288" crc="16aec559" sha1="d0835a9c5dc7fca4da4d62a9bc244525ecd76ee7" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="rockman world 4 (japan).bin" size="0x80000" crc="16aec559" sha1="d0835a9c5dc7fca4da4d62a9bc244525ecd76ee7" />
 			</dataarea>
 		</part>
 	</software>
@@ -20656,8 +20656,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="rockman world 5 (japan).bin" size="524288" crc="eeabd3c6" sha1="f3904d2069a888e45ca44878461324e4c2a8b03d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="rockman world 5 (japan).bin" size="0x80000" crc="eeabd3c6" sha1="f3904d2069a888e45ca44878461324e4c2a8b03d" />
 			</dataarea>
 		</part>
 	</software>
@@ -20672,8 +20672,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-rlx-0.u1" size="65536" crc="6093f4ec" sha1="7865263ed508bff8298444ecabec55efbb64190f" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-rlx-0.u1" size="0x10000" crc="6093f4ec" sha1="7865263ed508bff8298444ecabec55efbb64190f" />
 			</dataarea>
 		</part>
 	</software>
@@ -20687,8 +20687,8 @@ license:CC0
 		<info name="alt_title" value="妖精物語 ロッド・ランド ~ Yousei Monogatari - Rod Land (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="rodland (japan).bin" size="65536" crc="2355be94" sha1="4710264c4837f44bd58673c53725976950de10e9" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="rodland (japan).bin" size="0x10000" crc="2355be94" sha1="4710264c4837f44bd58673c53725976950de10e9" />
 			</dataarea>
 		</part>
 	</software>
@@ -20702,8 +20702,8 @@ license:CC0
 		<info name="alt_title" value="MVPベースボール ~ MVP Baseball (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="roger clemens mvp baseball (japan).bin" size="262144" crc="38c126aa" sha1="f0d921d13689d2afe7838eee127bf670439c8d8d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="roger clemens mvp baseball (japan).bin" size="0x40000" crc="38c126aa" sha1="f0d921d13689d2afe7838eee127bf670439c8d8d" />
 			</dataarea>
 		</part>
 	</software>
@@ -20716,8 +20716,8 @@ license:CC0
 		<info name="alt_title" value="Roger Clemens' MVP Baseball (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-vme-1.u1" size="262144" crc="fa955b39" sha1="678ea6ec765c467862be861d2c61fbb3a582c1f2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-vme-1.u1" size="0x40000" crc="fa955b39" sha1="678ea6ec765c467862be861d2c61fbb3a582c1f2" />
 			</dataarea>
 		</part>
 	</software>
@@ -20730,8 +20730,8 @@ license:CC0
 		<info name="alt_title" value="Roger Clemens' MVP Baseball (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="roger clemens mvp baseball (usa).bin" size="262144" crc="9da8595b" sha1="2b37b40ab05bee2b23b30b898af6197a35278c10" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="roger clemens mvp baseball (usa).bin" size="0x40000" crc="9da8595b" sha1="2b37b40ab05bee2b23b30b898af6197a35278c10" />
 			</dataarea>
 		</part>
 	</software>
@@ -20743,8 +20743,8 @@ license:CC0
 		<info name="serial" value="DMG-VE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="rolan's curse (usa).bin" size="65536" crc="1a602590" sha1="d5eeb34b24691eb6895d3349a05e2a75d910cf16" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="rolan's curse (usa).bin" size="0x10000" crc="1a602590" sha1="d5eeb34b24691eb6895d3349a05e2a75d910cf16" />
 			</dataarea>
 		</part>
 	</software>
@@ -20756,10 +20756,10 @@ license:CC0
 		<info name="serial" value="DMG-VT-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="rolan's curse ii (usa).bin" size="131072" crc="2754f360" sha1="7632e23853dd2579012489f75bd370473f0f2c46" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rolan's curse ii (usa).bin" size="0x20000" crc="2754f360" sha1="7632e23853dd2579012489f75bd370473f0f2c46" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -20773,8 +20773,8 @@ license:CC0
 		<info name="alt_title" value="ラブルセイバー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="rubble saver (japan).bin" size="131072" crc="e8aea452" sha1="b535b2b78611ba1eb59e530456545fced0fddb76" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rubble saver (japan).bin" size="0x20000" crc="e8aea452" sha1="b535b2b78611ba1eb59e530456545fced0fddb76" />
 			</dataarea>
 		</part>
 	</software>
@@ -20788,8 +20788,8 @@ license:CC0
 		<info name="alt_title" value="ラブルセイバーII" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="rubble saver ii (japan).bin" size="65536" crc="92c95f2d" sha1="49a07665695018b29def2cf3f843e10b88889775" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="rubble saver ii (japan).bin" size="0x10000" crc="92c95f2d" sha1="49a07665695018b29def2cf3f843e10b88889775" />
 			</dataarea>
 		</part>
 	</software>
@@ -20802,8 +20802,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="rugrats movie, the (usa).bin" size="524288" crc="124a0d06" sha1="70384eb3474637b81bec3018ebf0c2d6fa1d8a9d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="rugrats movie, the (usa).bin" size="0x80000" crc="124a0d06" sha1="70384eb3474637b81bec3018ebf0c2d6fa1d8a9d" />
 			</dataarea>
 		</part>
 	</software>
@@ -20823,10 +20823,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-s2j-1.u1" size="262144" crc="f6cfcfb1" sha1="96ef7d31ad098a620ba7ac57afef416972707ea3" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-s2j-1.u1" size="0x40000" crc="f6cfcfb1" sha1="96ef7d31ad098a620ba7ac57afef416972707ea3" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -20840,10 +20840,10 @@ license:CC0
 		<info name="alt_title" value="サ・ガ2 秘宝伝説" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="sa-ga 2 - hihou densetsu (japan).bin" size="262144" crc="18055bb9" sha1="f1db92d8076237489aa1528141fe240843111a54" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="sa-ga 2 - hihou densetsu (japan).bin" size="0x40000" crc="18055bb9" sha1="f1db92d8076237489aa1528141fe240843111a54" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -20863,10 +20863,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="sa-ga 3 - jikuu no hasha (japan).bin" size="262144" crc="575d6d9d" sha1="c8dcbefc0352b0590fd85a683d983b5510a63519" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="sa-ga 3 - jikuu no hasha (japan).bin" size="0x40000" crc="575d6d9d" sha1="c8dcbefc0352b0590fd85a683d983b5510a63519" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -20884,8 +20884,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1 [MBC1B]" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="u2" size="131072" crc="e43da090" sha1="79600f8602ca33f2b39a9b8d9824dff55dfc1ef0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="u2" size="0x20000" crc="e43da090" sha1="79600f8602ca33f2b39a9b8d9824dff55dfc1ef0" />
 			</dataarea>
 		</part>
 	</software>
@@ -20902,8 +20902,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="u2" size="131072" crc="b864a3b6" sha1="f983bd9b58ee07204e50c9fdd8a76ba57f2fb40c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="u2" size="0x20000" crc="b864a3b6" sha1="f983bd9b58ee07204e50c9fdd8a76ba57f2fb40c" />
 			</dataarea>
 		</part>
 	</software>
@@ -20917,10 +20917,10 @@ license:CC0
 		<info name="alt_title" value="セイントパラダイス 最強の戦士たち" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="saint paradise - saikyou no senshi-tachi (japan).bin" size="262144" crc="d6fe3c56" sha1="e7cf9eabead0e5c0d3228871bb8219643e5bd7e0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="saint paradise - saikyou no senshi-tachi (japan).bin" size="0x40000" crc="d6fe3c56" sha1="e7cf9eabead0e5c0d3228871bb8219643e5bd7e0" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -20934,8 +20934,8 @@ license:CC0
 		<info name="alt_title" value="魁!!男塾 冥凰島決戦" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="sakigake otoko juku - meioutou kessen (japan).bin" size="131072" crc="2f0f7f63" sha1="c731f8be269d74748ae54fe5ce5faea89a825e0f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sakigake otoko juku - meioutou kessen (japan).bin" size="0x20000" crc="2f0f7f63" sha1="c731f8be269d74748ae54fe5ce5faea89a825e0f" />
 			</dataarea>
 		</part>
 	</software>
@@ -20951,10 +20951,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="same game (japan).bin" size="262144" crc="70393c0f" sha1="9dcb5a95e808423e6bd1149319ca8eda069363c8" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="same game (japan).bin" size="0x40000" crc="70393c0f" sha1="9dcb5a95e808423e6bd1149319ca8eda069363c8" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -20966,8 +20966,8 @@ license:CC0
 		<info name="serial" value="DMG-X4-USA, DMG-X4-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="samurai shodown (usa, europe).bin" size="524288" crc="69292ee6" sha1="d696ba3562bed549a144ffe0b97fbf4c528f325f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="samurai shodown (usa, europe).bin" size="0x80000" crc="69292ee6" sha1="d696ba3562bed549a144ffe0b97fbf4c528f325f" />
 			</dataarea>
 		</part>
 	</software>
@@ -20978,8 +20978,8 @@ license:CC0
 		<publisher>Takara</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="samurai shodown (usa, europe, proto).bin" size="524288" crc="90d51289" sha1="1ddb05f7237e792dda9924ac0c525d8d1950cb44" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="samurai shodown (usa, europe, proto).bin" size="0x80000" crc="90d51289" sha1="1ddb05f7237e792dda9924ac0c525d8d1950cb44" />
 			</dataarea>
 		</part>
 	</software>
@@ -20993,10 +20993,10 @@ license:CC0
 		<info name="alt_title" value="三國志 ゲームボーイ版" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="sangokushi - game boy ban (japan).bin" size="262144" crc="83706e92" sha1="e94128d58341caaee595ed75292908a9ac5a466d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="sangokushi - game boy ban (japan).bin" size="0x40000" crc="83706e92" sha1="e94128d58341caaee595ed75292908a9ac5a466d" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -21010,8 +21010,8 @@ license:CC0
 		<info name="alt_title" value="サンリオカーニバル" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="sanrio carnival (japan).bin" size="65536" crc="48d8ab7a" sha1="e17fa516e0f85c6dd80f29573363e42528d88266" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="sanrio carnival (japan).bin" size="0x10000" crc="48d8ab7a" sha1="e17fa516e0f85c6dd80f29573363e42528d88266" />
 			</dataarea>
 		</part>
 	</software>
@@ -21025,8 +21025,8 @@ license:CC0
 		<info name="alt_title" value="サンリオカーニバル2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="sanrio carnival 2 (japan).bin" size="65536" crc="758c7b2a" sha1="7ff76205c59cd090fdc91b2d8c57cb44fd4b009b" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="sanrio carnival 2 (japan).bin" size="0x10000" crc="758c7b2a" sha1="7ff76205c59cd090fdc91b2d8c57cb44fd4b009b" />
 			</dataarea>
 		</part>
 	</software>
@@ -21043,8 +21043,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ag7j-1.u1" size="262144" crc="d0687d9f" sha1="72dfcc83dbd78ad2b5b43014fc9adf05431e230c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ag7j-1.u1" size="0x40000" crc="d0687d9f" sha1="72dfcc83dbd78ad2b5b43014fc9adf05431e230c" />
 			</dataarea>
 		</part>
 	</software>
@@ -21061,8 +21061,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ag7j-0.u1" size="262144" crc="0d4c02a7" sha1="0d12280e689eb320df06ceb469c629d93860dc2e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ag7j-0.u1" size="0x40000" crc="0d4c02a7" sha1="0d12280e689eb320df06ceb469c629d93860dc2e" />
 			</dataarea>
 		</part>
 	</software>
@@ -21073,8 +21073,8 @@ license:CC0
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="sarakon (prototype).bin" size="131072" crc="c8c5f76f" sha1="09c0795e45b84e9d8d017d7d38f4806422d6ea23" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sarakon (prototype).bin" size="0x20000" crc="c8c5f76f" sha1="09c0795e45b84e9d8d017d7d38f4806422d6ea23" />
 			</dataarea>
 		</part>
 	</software>
@@ -21089,8 +21089,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ab8d-0.u1" size="131072" crc="1cb8bfc2" sha1="00745f75877423494679bbc3912e58238ac399c3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ab8d-0.u1" size="0x20000" crc="1cb8bfc2" sha1="00745f75877423494679bbc3912e58238ac399c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -21104,8 +21104,8 @@ license:CC0
 		<info name="alt_title" value="スコットランドヤード" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="scotland yard (japan).bin" size="131072" crc="4a0f5972" sha1="8b6d7db97da4664353241d67ea225e74dba6a170" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="scotland yard (japan).bin" size="0x20000" crc="4a0f5972" sha1="8b6d7db97da4664353241d67ea225e74dba6a170" />
 			</dataarea>
 		</part>
 	</software>
@@ -21122,8 +21122,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="sd command gundam - g-arms (japan).bin" size="131072" crc="39058153" sha1="7d8011636fe36266b5f716e78e3e29006f024992" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sd command gundam - g-arms (japan).bin" size="0x20000" crc="39058153" sha1="7d8011636fe36266b5f716e78e3e29006f024992" />
 			</dataarea>
 		</part>
 	</software>
@@ -21142,10 +21142,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-lhj-0.u1" size="131072" crc="c9dbba10" sha1="bc598168a70bbbc1b89b3de13086ec89e8ce9ded" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-lhj-0.u1" size="0x20000" crc="c9dbba10" sha1="bc598168a70bbbc1b89b3de13086ec89e8ce9ded" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -21163,8 +21163,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="u2" size="524288" crc="c4d09768" sha1="e62b70188b146b82196f09720e99c7dd6f03036f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="u2" size="0x80000" crc="c4d09768" sha1="e62b70188b146b82196f09720e99c7dd6f03036f" />
 			</dataarea>
 		</part>
 	</software>
@@ -21182,8 +21182,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-ahvj-0.u1" size="1048576" crc="10034d19" sha1="d3e747b341d76dc3582257fe53111ece385eb399" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-ahvj-0.u1" size="0x100000" crc="10034d19" sha1="d3e747b341d76dc3582257fe53111ece385eb399" />
 			</dataarea>
 		</part>
 	</software>
@@ -21197,8 +21197,8 @@ license:CC0
 		<info name="alt_title" value="SDルパン三世 金庫破り大作戦" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="sd lupin iii - kinko yaburi daisakusen (japan).bin" size="65536" crc="f0b73db4" sha1="758ff1bf4fe54feba8750238cd062a1ad37843e7" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="sd lupin iii - kinko yaburi daisakusen (japan).bin" size="0x10000" crc="f0b73db4" sha1="758ff1bf4fe54feba8750238cd062a1ad37843e7" />
 			</dataarea>
 		</part>
 	</software>
@@ -21215,8 +21215,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1A]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-sdj-0.u1" size="131072" crc="016a0552" sha1="86a57796557698def6ee760bfa03c8e3befcc4ef" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-sdj-0.u1" size="0x20000" crc="016a0552" sha1="86a57796557698def6ee760bfa03c8e3befcc4ef" />
 			</dataarea>
 		</part>
 	</software>
@@ -21230,10 +21230,10 @@ license:CC0
 		<info name="alt_title" value="SDガンダム SD戦国伝2 天下統一編 ~ SD Gundam - SD Sengokuden 2 - Tenka Touitsu Hen (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="sd sengokuden 2 - tenka touitsu hen (japan).bin" size="262144" crc="5b7c6faa" sha1="4494a8a9f960c55b056b12d2d2760cc976e36e17" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="sd sengokuden 2 - tenka touitsu hen (japan).bin" size="0x40000" crc="5b7c6faa" sha1="4494a8a9f960c55b056b12d2d2760cc976e36e17" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -21252,10 +21252,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-d3j-0.u1" size="262144" crc="7c61426c" sha1="2cb0368452033029ef8b8d92698d95ed41114a73" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-d3j-0.u1" size="0x40000" crc="7c61426c" sha1="2cb0368452033029ef8b8d92698d95ed41114a73" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -21267,8 +21267,8 @@ license:CC0
 		<info name="serial" value="DMG-AB8P-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="sea battle (europe) (en,fr,de,es).bin" size="131072" crc="ba091b91" sha1="560d62b96a1b9820e3fd953f76e33b4f5fdc9e2f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sea battle (europe) (en,fr,de,es).bin" size="0x20000" crc="ba091b91" sha1="560d62b96a1b9820e3fd953f76e33b4f5fdc9e2f" />
 			</dataarea>
 		</part>
 	</software>
@@ -21284,8 +21284,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-asqe-0.u1" size="262144" crc="31a3bd99" sha1="e9572941b35f119746b995f7fe578c31ef778026" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-asqe-0.u1" size="0x40000" crc="31a3bd99" sha1="e9572941b35f119746b995f7fe578c31ef778026" />
 			</dataarea>
 		</part>
 	</software>
@@ -21302,8 +21302,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1A]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-svj-0.u1" size="65536" crc="79afe59e" sha1="42ec788b74b03000164533c87cab0292b0d37995" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-svj-0.u1" size="0x10000" crc="79afe59e" sha1="42ec788b74b03000164533c87cab0292b0d37995" />
 			</dataarea>
 		</part>
 	</software>
@@ -21322,10 +21322,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ffj-0.u1" size="262144" crc="d771c1b6" sha1="998a5e6df52dff24ae686e287eed06f125940194" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ffj-0.u1" size="0x40000" crc="d771c1b6" sha1="998a5e6df52dff24ae686e287eed06f125940194" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -21342,8 +21342,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1A]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="selection - erabareshi mono (japan).bin" size="131072" crc="799c5cdb" sha1="a52a8dcd93c4fa4f020719c83780092b514d2b03" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="selection - erabareshi mono (japan).bin" size="0x20000" crc="799c5cdb" sha1="a52a8dcd93c4fa4f020719c83780092b514d2b03" />
 			</dataarea>
 		</part>
 	</software>
@@ -21358,10 +21358,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="selection i &amp; ii (japan).bin" size="524288" crc="a6027919" sha1="58c0c524b07018beb2d9178de53fe2f6cbb6670f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="selection i &amp; ii (japan).bin" size="0x80000" crc="a6027919" sha1="58c0c524b07018beb2d9178de53fe2f6cbb6670f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -21375,10 +21375,10 @@ license:CC0
 		<info name="alt_title" value="セレクションII 暗黒の封印" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="selection ii - ankoku no fuuin (japan).bin" size="262144" crc="d09073f6" sha1="6e524d0894de0db1b3eb4ca0c1075f6ea1a2ffc1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="selection ii - ankoku no fuuin (japan).bin" size="0x40000" crc="d09073f6" sha1="6e524d0894de0db1b3eb4ca0c1075f6ea1a2ffc1" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -21392,10 +21392,10 @@ license:CC0
 		<info name="alt_title" value="戦国忍者くん" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="sengoku ninja-kun (japan).bin" size="131072" crc="6bae3a41" sha1="a60f4f815467298bd3928fe4aee0edd763ebe85d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sengoku ninja-kun (japan).bin" size="0x20000" crc="6bae3a41" sha1="a60f4f815467298bd3928fe4aee0edd763ebe85d" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -21407,8 +21407,8 @@ license:CC0
 		<info name="serial" value="DMG-VZ-(NOE/UKV)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="sensible soccer - european champions (europe).bin" size="131072" crc="bd022658" sha1="eb9f0c6d3c137be7991e9d28fe48d5026beb2f35" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sensible soccer - european champions (europe).bin" size="0x20000" crc="bd022658" sha1="eb9f0c6d3c137be7991e9d28fe48d5026beb2f35" />
 			</dataarea>
 		</part>
 	</software>
@@ -21421,8 +21421,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-kme-0.u1" size="32768" crc="74d466d7" sha1="3122b3c12c2580c3a81d70c5648f767bf3590aaf" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-kme-0.u1" size="0x8000" crc="74d466d7" sha1="3122b3c12c2580c3a81d70c5648f767bf3590aaf" />
 			</dataarea>
 		</part>
 	</software>
@@ -21434,8 +21434,8 @@ license:CC0
 		<info name="serial" value="DMG-NG-FAH" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="shadow warriors (europe).bin" size="131072" crc="bcc18e24" sha1="f19075aa787cce771077152f0d6c83527b9d7104" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="shadow warriors (europe).bin" size="0x20000" crc="bcc18e24" sha1="f19075aa787cce771077152f0d6c83527b9d7104" />
 			</dataarea>
 		</part>
 	</software>
@@ -21448,8 +21448,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-10" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-zzj-0.u1" size="32768" crc="6aa684eb" sha1="2569352ea796864fcd769cc9b25c6497516134c6" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-zzj-0.u1" size="0x8000" crc="6aa684eb" sha1="2569352ea796864fcd769cc9b25c6497516134c6" />
 			</dataarea>
 		</part>
 	</software>
@@ -21464,8 +21464,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-01" /> <!-- Also found with DMG-AAA-02 -->
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-shj-0.u1" size="32768" crc="7c29672b" sha1="7756e8c955e3bd4fe9b007c9ea4c83f914a100ae" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-shj-0.u1" size="0x8000" crc="7c29672b" sha1="7756e8c955e3bd4fe9b007c9ea4c83f914a100ae" />
 			</dataarea>
 		</part>
 	</software>
@@ -21476,8 +21476,8 @@ license:CC0
 		<publisher>HAL</publisher>
 		<info name="serial" value="DMG-SH-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="shanghai (usa).bin" size="32768" crc="580fcb18" sha1="d5cc81d0379982fe69e8fe30868fdcc621dd1bae" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="shanghai (usa).bin" size="0x8000" crc="580fcb18" sha1="d5cc81d0379982fe69e8fe30868fdcc621dd1bae" />
 			</dataarea>
 		</part>
 	</software>
@@ -21492,8 +21492,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="shanghai pocket (japan).bin" size="262144" crc="6b8eff2c" sha1="82fe97442aa625fd36cf865d82f78b07108ede7f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="shanghai pocket (japan).bin" size="0x40000" crc="6b8eff2c" sha1="82fe97442aa625fd36cf865d82f78b07108ede7f" />
 			</dataarea>
 		</part>
 	</software>
@@ -21506,8 +21506,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="shaq fu (usa).bin" size="524288" crc="7ed43fe6" sha1="5e9e68d9235cf8149232b85fd6080ba8796cb85e" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="shaq fu (usa).bin" size="0x80000" crc="7ed43fe6" sha1="5e9e68d9235cf8149232b85fd6080ba8796cb85e" />
 			</dataarea>
 		</part>
 	</software>
@@ -21521,8 +21521,8 @@ license:CC0
 		<info name="alt_title" value="紫禁城" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="shikinjou (japan).bin" size="65536" crc="f8ec3a41" sha1="84cb709a3e66b8b5f8b9415bc3cd34bf8f7e7b12" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="shikinjou (japan).bin" size="0x10000" crc="f8ec3a41" sha1="84cb709a3e66b8b5f8b9415bc3cd34bf8f7e7b12" />
 			</dataarea>
 		</part>
 	</software>
@@ -21543,10 +21543,10 @@ license:CC0
 			<feature name="u4" value="U4" />
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aqgj-0.u1" size="524288" crc="490f8c46" sha1="8d65a4f9f7b903d145fa863d09c8894db4fd742a" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aqgj-0.u1" size="0x80000" crc="490f8c46" sha1="8d65a4f9f7b903d145fa863d09c8894db4fd742a" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -21560,8 +21560,8 @@ license:CC0
 		<info name="alt_title" value="新日本プロレスリング 闘魂三銃士" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="shin nihon pro wrestling - toukon sanjuushi (japan).bin" size="131072" crc="a8a43013" sha1="b8b7f4177d87124a5cd6c931fbc2ee3c6d97b3d4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="shin nihon pro wrestling - toukon sanjuushi (japan).bin" size="0x20000" crc="a8a43013" sha1="b8b7f4177d87124a5cd6c931fbc2ee3c6d97b3d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -21576,8 +21576,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="shin sd gundam gaiden - knight gundam monogatari (japan).bin" size="262144" crc="e5a78b9b" sha1="62e1d4dc9f6fae94e981bdcf2fa4b65bb3949644" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="shin sd gundam gaiden - knight gundam monogatari (japan).bin" size="0x40000" crc="e5a78b9b" sha1="62e1d4dc9f6fae94e981bdcf2fa4b65bb3949644" />
 			</dataarea>
 		</part>
 	</software>
@@ -21591,8 +21591,8 @@ license:CC0
 		<info name="alt_title" value="ザ・心理ゲーム" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="shinri game, the (japan).bin" size="262144" crc="fb2fe362" sha1="f47114a20db53b8b789790ddcff1cd3105b35482" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="shinri game, the (japan).bin" size="0x40000" crc="fb2fe362" sha1="f47114a20db53b8b789790ddcff1cd3105b35482" />
 			</dataarea>
 		</part>
 	</software>
@@ -21606,8 +21606,8 @@ license:CC0
 		<info name="alt_title" value="ザ・心理ゲーム2 大阪編" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="shinri game 2, the - oosaka hen (japan).bin" size="262144" crc="47095204" sha1="1899a1ee1a6d7b69e2697395ce23fc3ce1e88624" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="shinri game 2, the - oosaka hen (japan).bin" size="0x40000" crc="47095204" sha1="1899a1ee1a6d7b69e2697395ce23fc3ce1e88624" />
 			</dataarea>
 		</part>
 	</software>
@@ -21621,8 +21621,8 @@ license:CC0
 		<info name="alt_title" value="新世紀GPX サイバーフォーミュラ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="shinseiki gpx cyber formula (japan).bin" size="131072" crc="72b42ea7" sha1="5716f20e0726450a4ff7c9c6fd3fdc8004d38a77" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="shinseiki gpx cyber formula (japan).bin" size="0x20000" crc="72b42ea7" sha1="5716f20e0726450a4ff7c9c6fd3fdc8004d38a77" />
 			</dataarea>
 		</part>
 	</software>
@@ -21639,8 +21639,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-tgj-0.u1" size="65536" crc="56410442" sha1="71e605d62c80bd2905a5ed3ce6cc1590638f2f2f" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-tgj-0.u1" size="0x10000" crc="56410442" sha1="71e605d62c80bd2905a5ed3ce6cc1590638f2f2f" />
 			</dataarea>
 		</part>
 	</software>
@@ -21654,8 +21654,8 @@ license:CC0
 		<info name="alt_title" value="疾風!アイアンリーガー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="shippuu iron leaguer (japan).bin" size="131072" crc="8e3c7e15" sha1="2555e4b9426ff90efd431d46be5371d3e0a6dabf" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="shippuu iron leaguer (japan).bin" size="0x20000" crc="8e3c7e15" sha1="2555e4b9426ff90efd431d46be5371d3e0a6dabf" />
 			</dataarea>
 		</part>
 	</software>
@@ -21675,8 +21675,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-maa-0.u1" size="32768" crc="0cdd8b04" sha1="6e84a906f9e1ce43272db84c63f1b037096ac34f" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-maa-0.u1" size="0x8000" crc="0cdd8b04" sha1="6e84a906f9e1ce43272db84c63f1b037096ac34f" />
 			</dataarea>
 		</part>
 	</software>
@@ -21690,8 +21690,8 @@ license:CC0
 		<info name="alt_title" value="将棋" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="shougi (japan).bin" size="131072" crc="4fb44cb4" sha1="76d5d8c622f62563e0ab1e242b924b24c8dc42f0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="shougi (japan).bin" size="0x20000" crc="4fb44cb4" sha1="76d5d8c622f62563e0ab1e242b924b24c8dc42f0" />
 			</dataarea>
 		</part>
 	</software>
@@ -21706,8 +21706,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="shougi saikyou (japan) (rev 1).bin" size="262144" crc="a074bf7e" sha1="1c5a97aa3a09362c94fdd630456e5e59ae3af5fa" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="shougi saikyou (japan) (rev 1).bin" size="0x40000" crc="a074bf7e" sha1="1c5a97aa3a09362c94fdd630456e5e59ae3af5fa" />
 			</dataarea>
 		</part>
 	</software>
@@ -21725,8 +21725,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-amsj-0.u1" size="262144" crc="2f0f7c6e" sha1="0638c6c66b94e70ba658240be457da5ce913bc8b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-amsj-0.u1" size="0x40000" crc="2f0f7c6e" sha1="0638c6c66b94e70ba658240be457da5ce913bc8b" />
 			</dataarea>
 		</part>
 	</software>
@@ -21740,8 +21740,8 @@ license:CC0
 		<info name="alt_title" value="少年アシベ ゆうえんちパニック" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="shounen ashibe - yuuenchi panic (japan).bin" size="131072" crc="b3063db5" sha1="0ba051e85f793db4466f10ab7452c778c55337df" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="shounen ashibe - yuuenchi panic (japan).bin" size="0x20000" crc="b3063db5" sha1="0ba051e85f793db4466f10ab7452c778c55337df" />
 			</dataarea>
 		</part>
 	</software>
@@ -21755,8 +21755,8 @@ license:CC0
 		<info name="alt_title" value="主役戦隊アイレムファイター" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="shuyaku sentai irem fighter (japan).bin" size="262144" crc="ecd61f03" sha1="714134877092ddb688ded5d3516d7db4b22e329e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="shuyaku sentai irem fighter (japan).bin" size="0x40000" crc="ecd61f03" sha1="714134877092ddb688ded5d3516d7db4b22e329e" />
 			</dataarea>
 		</part>
 	</software>
@@ -21778,8 +21778,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-swa-0.u1" size="65536" crc="9a1e30b4" sha1="0e9d907e9ebf8d69fb94133362590c8ac6aa6392" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-swa-0.u1" size="0x10000" crc="9a1e30b4" sha1="0e9d907e9ebf8d69fb94133362590c8ac6aa6392" />
 			</dataarea>
 		</part>
 	</software>
@@ -21794,8 +21794,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-eke-0.u1" size="131072" crc="517a614c" sha1="98a2d90717d8c9f7feb2d7653aaab6faa0f3ee64" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-eke-0.u1" size="0x20000" crc="517a614c" sha1="98a2d90717d8c9f7feb2d7653aaab6faa0f3ee64" />
 			</dataarea>
 		</part>
 	</software>
@@ -21808,8 +21808,8 @@ license:CC0
 		<info name="release" value="19940930" />
 		<info name="alt_title" value="バートのジャックと豆の木 ~ Bart no Jack to Mame no Ki (Box)" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="131072">
-				<rom name="bart no jack to mame no ki (japan).bin" size="131072" crc="7aa4e0bb" sha1="f73e5fda698e102d8cad610bd601c73f6ec6e51a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bart no jack to mame no ki (japan).bin" size="0x20000" crc="7aa4e0bb" sha1="f73e5fda698e102d8cad610bd601c73f6ec6e51a" />
 			</dataarea>
 		</part>
 	</software>
@@ -21824,8 +21824,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-jue-0.u1" size="131072" crc="6819cf0d" sha1="95d60b87862fccd914446e0581146142d19c76bd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-jue-0.u1" size="0x20000" crc="6819cf0d" sha1="95d60b87862fccd914446e0581146142d19c76bd" />
 			</dataarea>
 		</part>
 	</software>
@@ -21837,8 +21837,8 @@ license:CC0
 		<info name="serial" value="DMG-SK-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="skate or die - bad 'n rad (europe).bin" size="131072" crc="ac1fb27a" sha1="11508d5834eea7352493d193a097c95e38ec4a55" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="skate or die - bad 'n rad (europe).bin" size="0x20000" crc="ac1fb27a" sha1="11508d5834eea7352493d193a097c95e38ec4a55" />
 			</dataarea>
 		</part>
 	</software>
@@ -21850,8 +21850,8 @@ license:CC0
 		<info name="serial" value="DMG-SK-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="skate or die - bad 'n rad (usa).bin" size="131072" crc="4db7c817" sha1="6a128648584ae17ac6dee5a2bdba10b0bb220434" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="skate or die - bad 'n rad (usa).bin" size="0x20000" crc="4db7c817" sha1="6a128648584ae17ac6dee5a2bdba10b0bb220434" />
 			</dataarea>
 		</part>
 	</software>
@@ -21863,8 +21863,8 @@ license:CC0
 		<info name="serial" value="DMG-KD-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="skate or die - tour de thrash (usa).bin" size="131072" crc="02b77c09" sha1="6e1610450da0c836983a1c310524639fefcc304f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="skate or die - tour de thrash (usa).bin" size="0x20000" crc="02b77c09" sha1="6e1610450da0c836983a1c310524639fefcc304f" />
 			</dataarea>
 		</part>
 	</software>
@@ -21880,8 +21880,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-asip-0.u1" size="524288" crc="dbf106d1" sha1="fce53aed026e3171ac5c26d21d5dbcbbb2c14968" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-asip-0.u1" size="0x80000" crc="dbf106d1" sha1="fce53aed026e3171ac5c26d21d5dbcbbb2c14968" />
 			</dataarea>
 		</part>
 	</software>
@@ -21892,10 +21892,10 @@ license:CC0
 		<publisher>&lt;unlicensed&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="smartcom (europe) (unl).bin" size="262144" crc="1ef0abf1" sha1="a04bbf813bcd9b7e3af97d388ad77d25c1403831" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="smartcom (europe) (unl).bin" size="0x40000" crc="1ef0abf1" sha1="a04bbf813bcd9b7e3af97d388ad77d25c1403831" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -21911,8 +21911,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-au3p-0.u1" size="262144" crc="8ef938c4" sha1="efbc4bc9714393d5f493ad653fc1fa2180b40892" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-au3p-0.u1" size="0x40000" crc="8ef938c4" sha1="efbc4bc9714393d5f493ad653fc1fa2180b40892" />
 			</dataarea>
 		</part>
 	</software>
@@ -21928,8 +21928,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-aufp-0.u1" size="131072" crc="cb2c7198" sha1="e138c3ac1bc2e23091e71cc1aa90788770622458" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-aufp-0.u1" size="0x20000" crc="cb2c7198" sha1="e138c3ac1bc2e23091e71cc1aa90788770622458" />
 			</dataarea>
 		</part>
 	</software>
@@ -21945,8 +21945,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ufx-1.u1" size="131072" crc="8b5bcde7" sha1="a0d6a85331fb034f68f05629a5ff85e13adab205" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ufx-1.u1" size="0x20000" crc="8b5bcde7" sha1="a0d6a85331fb034f68f05629a5ff85e13adab205" />
 			</dataarea>
 		</part>
 	</software>
@@ -21962,8 +21962,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ufx-0.u1" size="131072" crc="cdff161f" sha1="9fc50648c18f7f8f0e567ba8791b1d9a43c9f044" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ufx-0.u1" size="0x20000" crc="cdff161f" sha1="9fc50648c18f7f8f0e567ba8791b1d9a43c9f044" />
 			</dataarea>
 		</part>
 	</software>
@@ -21975,8 +21975,8 @@ license:CC0
 		<info name="serial" value="DMG-NK-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="sneaky snakes (usa, europe).bin" size="131072" crc="7bf40d7d" sha1="9087b44139ea56d85c8ecadb2603a2d599c2a00b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sneaky snakes (usa, europe).bin" size="0x20000" crc="7bf40d7d" sha1="9087b44139ea56d85c8ecadb2603a2d599c2a00b" />
 			</dataarea>
 		</part>
 	</software>
@@ -21990,8 +21990,8 @@ license:CC0
 		<info name="alt_title" value="スヌーピー マジック・ショー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="snoopy - magic show (japan).bin" size="65536" crc="4892984d" sha1="07bf2dd8c1bebd40a63fb571c587f0e77286c6a0" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="snoopy - magic show (japan).bin" size="0x10000" crc="4892984d" sha1="07bf2dd8c1bebd40a63fb571c587f0e77286c6a0" />
 			</dataarea>
 		</part>
 	</software>
@@ -22007,8 +22007,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-sne-0.u1" size="65536" crc="2b7a5034" sha1="bc21fb3aa1a58e2aef30fabe103b2e5bec02b535" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-sne-0.u1" size="0x10000" crc="2b7a5034" sha1="bc21fb3aa1a58e2aef30fabe103b2e5bec02b535" />
 			</dataarea>
 		</part>
 	</software>
@@ -22023,8 +22023,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="snoopy no hajimete no otsukai (japan).bin" size="131072" crc="8900a7c0" sha1="535a85e3955ec58754395a8bf7c4f5b7d319e57f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="snoopy no hajimete no otsukai (japan).bin" size="0x20000" crc="8900a7c0" sha1="535a85e3955ec58754395a8bf7c4f5b7d319e57f" />
 			</dataarea>
 		</part>
 	</software>
@@ -22036,8 +22036,8 @@ license:CC0
 		<info name="serial" value="DMG-SJ-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="snow bros. jr. (europe).bin" size="131072" crc="9014b3d8" sha1="fe6754976f6758a91d2594d7cb9781ca0a340a90" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="snow bros. jr. (europe).bin" size="0x20000" crc="9014b3d8" sha1="fe6754976f6758a91d2594d7cb9781ca0a340a90" />
 			</dataarea>
 		</part>
 	</software>
@@ -22051,8 +22051,8 @@ license:CC0
 		<info name="alt_title" value="スノーブラザースJr." />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="snow bros. jr. (japan).bin" size="131072" crc="e5a22f5a" sha1="d46e6bb01129f0725e73b6b9aca35a1aceb7e415" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="snow bros. jr. (japan).bin" size="0x20000" crc="e5a22f5a" sha1="d46e6bb01129f0725e73b6b9aca35a1aceb7e415" />
 			</dataarea>
 		</part>
 	</software>
@@ -22064,8 +22064,8 @@ license:CC0
 		<info name="serial" value="DMG-SJ-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="snow bros. jr. (usa).bin" size="131072" crc="d45a1daa" sha1="3798924873d76952810b28925662f9cf805a17cc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="snow bros. jr. (usa).bin" size="0x20000" crc="d45a1daa" sha1="3798924873d76952810b28925662f9cf805a17cc" />
 			</dataarea>
 		</part>
 	</software>
@@ -22081,8 +22081,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B1] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-yky-0.u1" size="131072" crc="c36b199b" sha1="355fb7f220a0ba470011220282a59e707f168e1a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-yky-0.u1" size="0x20000" crc="c36b199b" sha1="355fb7f220a0ba470011220282a59e707f168e1a" />
 			</dataarea>
 		</part>
 	</software>
@@ -22096,8 +22096,8 @@ license:CC0
 		<info name="alt_title" value="サッカー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="soccer (japan).bin" size="131072" crc="be51a876" sha1="f9fd41616185ead719774acb2b826c5c7359cdb2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="soccer (japan).bin" size="0x20000" crc="be51a876" sha1="f9fd41616185ead719774acb2b826c5c7359cdb2" />
 			</dataarea>
 		</part>
 	</software>
@@ -22111,8 +22111,8 @@ license:CC0
 		<info name="alt_title" value="サッカー・ボーイ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="soccer boy (japan).bin" size="65536" crc="23f64e82" sha1="7554b42d1c38508fd615828c96ab58ea8f41de4d" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="soccer boy (japan).bin" size="0x10000" crc="23f64e82" sha1="7554b42d1c38508fd615828c96ab58ea8f41de4d" />
 			</dataarea>
 		</part>
 	</software>
@@ -22124,8 +22124,8 @@ license:CC0
 		<info name="serial" value="DMG-SB-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="soccer mania (japan, usa).bin" size="65536" crc="6f87b543" sha1="6e641fee2628e98890e579e3ab6574b1757b8d08" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="soccer mania (japan, usa).bin" size="0x10000" crc="6f87b543" sha1="6e641fee2628e98890e579e3ab6574b1757b8d08" />
 			</dataarea>
 		</part>
 	</software>
@@ -22143,8 +22143,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-ssa-0.u1" size="65536" crc="11817103" sha1="a8d6acb026b0d0a8a2bcaea094951e915a3deb80" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-ssa-0.u1" size="0x10000" crc="11817103" sha1="a8d6acb026b0d0a8a2bcaea094951e915a3deb80" />
 			</dataarea>
 		</part>
 	</software>
@@ -22158,8 +22158,8 @@ license:CC0
 		<info name="alt_title" value="ソルダム" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="soldam (japan).bin" size="131072" crc="7c5aec86" sha1="b50a35a605baefba743819c2f0f3a494eaec4e11" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="soldam (japan).bin" size="0x20000" crc="7c5aec86" sha1="b50a35a605baefba743819c2f0f3a494eaec4e11" />
 			</dataarea>
 		</part>
 	</software>
@@ -22173,10 +22173,10 @@ license:CC0
 		<info name="alt_title" value="ソリテア" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="65536">
-				<rom name="solitaire (japan).bin" size="65536" crc="1119484a" sha1="220f5b230559ae0c5742a31c59a90615c7fb8613" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="solitaire (japan).bin" size="0x10000" crc="1119484a" sha1="220f5b230559ae0c5742a31c59a90615c7fb8613" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -22191,8 +22191,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-uxe-0.u1" size="131072" crc="35a5234a" sha1="185b95313d437b9e4bed2d10a346d16c4640325c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-uxe-0.u1" size="0x20000" crc="35a5234a" sha1="185b95313d437b9e4bed2d10a346d16c4640325c" />
 			</dataarea>
 		</part>
 	</software>
@@ -22207,8 +22207,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-scx-0.u1" size="65536" crc="701ccdb3" sha1="9e4a1c2608da3e245fe3c35c8a9f626c1bd6152e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-scx-0.u1" size="0x10000" crc="701ccdb3" sha1="9e4a1c2608da3e245fe3c35c8a9f626c1bd6152e" />
 			</dataarea>
 		</part>
 	</software>
@@ -22225,8 +22225,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="u2" size="65536" crc="901bff2e" sha1="dc60824a69856a162aee6f7fa86bd2d283fadd32" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="u2" size="0x10000" crc="901bff2e" sha1="dc60824a69856a162aee6f7fa86bd2d283fadd32" />
 			</dataarea>
 		</part>
 	</software>
@@ -22238,8 +22238,8 @@ license:CC0
 		<info name="serial" value="DMG-SC-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="solomon's club (usa).bin" size="65536" crc="cea9622a" sha1="36abf2be4a16df8e9fe30307cbd8cb949a9b9bdb" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="solomon's club (usa).bin" size="0x10000" crc="cea9622a" sha1="36abf2be4a16df8e9fe30307cbd8cb949a9b9bdb" />
 			</dataarea>
 		</part>
 	</software>
@@ -22252,8 +22252,8 @@ license:CC0
 		<info name="release" value="19901023" />
 		<info name="alt_title" value="アミーダくん 阿弥陀 ~ Soreike! Amida-kun (Box?)" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="soreike amida-kun (japan).bin" size="32768" crc="60128aa8" sha1="2b502583aa73cb72557589791dec7e28a2d29969" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="soreike amida-kun (japan).bin" size="0x8000" crc="60128aa8" sha1="2b502583aa73cb72557589791dec7e28a2d29969" />
 			</dataarea>
 		</part>
 	</software>
@@ -22267,8 +22267,8 @@ license:CC0
 		<info name="alt_title" value="それゆけ!スピーディーゴンザレス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="soreyuke speedy gonzales (japan).bin" size="262144" crc="b2e6a1c5" sha1="306b85bec28fa6e4a47f9ccaa5384afd8547c7ea" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="soreyuke speedy gonzales (japan).bin" size="0x40000" crc="b2e6a1c5" sha1="306b85bec28fa6e4a47f9ccaa5384afd8547c7ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -22282,8 +22282,8 @@ license:CC0
 		<info name="alt_title" value="それゆけ!!キッド" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="soreyuke kid (japan).bin" size="131072" crc="2a4a2d2b" sha1="b3b46d61c49a22145ce57b881d355b86d5c5ecc1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="soreyuke kid (japan).bin" size="0x20000" crc="2a4a2d2b" sha1="b3b46d61c49a22145ce57b881d355b86d5c5ecc1" />
 			</dataarea>
 		</part>
 	</software>
@@ -22296,8 +22296,8 @@ license:CC0
 		<info name="release" value="19890901" />
 		<info name="alt_title" value="倉庫番" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="soukoban (japan).bin" size="32768" crc="d50d6d0a" sha1="aa0cfcb8e049533bc4ae9afe4e97f5336425d5a7" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="soukoban (japan).bin" size="0x8000" crc="d50d6d0a" sha1="aa0cfcb8e049533bc4ae9afe4e97f5336425d5a7" />
 			</dataarea>
 		</part>
 	</software>
@@ -22310,8 +22310,8 @@ license:CC0
 		<info name="release" value="19900622" />
 		<info name="alt_title" value="倉庫番2" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="soukoban 2 (japan).bin" size="32768" crc="d9da6741" sha1="211221bd34b3ae86ce5d647a81caab8bb91bfa71" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="soukoban 2 (japan).bin" size="0x8000" crc="d9da6741" sha1="211221bd34b3ae86ce5d647a81caab8bb91bfa71" />
 			</dataarea>
 		</part>
 	</software>
@@ -22327,8 +22327,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-spx-0.u1" size="524288" crc="891b8f04" sha1="6395ca055de6b6538b915d0cb69bd829d7aa2e2a" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-spx-0.u1" size="0x80000" crc="891b8f04" sha1="6395ca055de6b6538b915d0cb69bd829d7aa2e2a" />
 			</dataarea>
 		</part>
 	</software>
@@ -22343,8 +22343,8 @@ license:CC0
 		<info name="release" value="19900330" />
 		<info name="alt_title" value="スペースインベーダー" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="space invaders (japan).bin" size="32768" crc="868b57b2" sha1="9e94553ecb76e95eb85a5f8fbbb201b96271710a" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="space invaders (japan).bin" size="0x8000" crc="868b57b2" sha1="9e94553ecb76e95eb85a5f8fbbb201b96271710a" />
 			</dataarea>
 		</part>
 	</software>
@@ -22357,8 +22357,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="space invaders (usa).bin" size="524288" crc="7f0f5762" sha1="da48687f3a5ee547510a0ea9eb05859b4ea9531d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="space invaders (usa).bin" size="0x80000" crc="7f0f5762" sha1="da48687f3a5ee547510a0ea9eb05859b4ea9531d" />
 			</dataarea>
 		</part>
 	</software>
@@ -22373,8 +22373,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-lmx-0.u1" size="65536" crc="e9ef8136" sha1="7708270675979f25453e680bc8a6d45b5929afa8" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-lmx-0.u1" size="0x10000" crc="e9ef8136" sha1="7708270675979f25453e680bc8a6d45b5929afa8" />
 			</dataarea>
 		</part>
 	</software>
@@ -22386,8 +22386,8 @@ license:CC0
 		<info name="serial" value="DMG-LM-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="spanky's quest (usa).bin" size="65536" crc="6ee7ca79" sha1="8f448eab7e6a05266d62f3564a00813f79314736" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="spanky's quest (usa).bin" size="0x10000" crc="6ee7ca79" sha1="8f448eab7e6a05266d62f3564a00813f79314736" />
 			</dataarea>
 		</part>
 	</software>
@@ -22401,8 +22401,8 @@ license:CC0
 		<info name="alt_title" value="スパルタンX" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="spartan x (japan).bin" size="65536" crc="ca7b4229" sha1="e2319966ea5ebb99db6f6178bb927dc1c7f734b2" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="spartan x (japan).bin" size="0x10000" crc="ca7b4229" sha1="e2319966ea5ebb99db6f6178bb927dc1c7f734b2" />
 			</dataarea>
 		</part>
 	</software>
@@ -22414,8 +22414,8 @@ license:CC0
 		<info name="serial" value="DMG-E2-USA, DMG-E2-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="speedball 2 - brutal deluxe (usa, europe).bin" size="131072" crc="fd06e22d" sha1="9ec7ef7f362cda3c28a727d2d8a8458ffd80cda0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="speedball 2 - brutal deluxe (usa, europe).bin" size="0x20000" crc="fd06e22d" sha1="9ec7ef7f362cda3c28a727d2d8a8458ffd80cda0" />
 			</dataarea>
 		</part>
 	</software>
@@ -22430,8 +22430,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-g6e-0.u1" size="262144" crc="27cde8d6" sha1="805be36b4701dda53b967c0153b9bfcc2c059f75" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-g6e-0.u1" size="0x40000" crc="27cde8d6" sha1="805be36b4701dda53b967c0153b9bfcc2c059f75" />
 			</dataarea>
 		</part>
 	</software>
@@ -22447,8 +22447,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-xge-0.u1" size="131072" crc="1009c6c0" sha1="fb3770e2da5c668d23e5f96a4806a6d3db24eaeb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-xge-0.u1" size="0x20000" crc="1009c6c0" sha1="fb3770e2da5c668d23e5f96a4806a6d3db24eaeb" />
 			</dataarea>
 		</part>
 	</software>
@@ -22460,8 +22460,8 @@ license:CC0
 		<info name="serial" value="DMG-FZ-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="spirit of f-1, the (europe).bin" size="131072" crc="2b795480" sha1="a777c399bb4b8d3e55ee0e8b29890e20b859d5e4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="spirit of f-1, the (europe).bin" size="0x20000" crc="2b795480" sha1="a777c399bb4b8d3e55ee0e8b29890e20b859d5e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -22476,8 +22476,8 @@ license:CC0
 			<feature name="rom" value="" />
 			<feature name="flipflop" value="[SN74LS377N]" />
 			<feature name="slot" value="rom_wisdom" />
-			<dataarea name="rom" size="262144">
-				<rom name="spiritual warfare gb.bin" size="262144" crc="f7a961ba" sha1="6e6ae5dbd8ff8b8f41b8411ef119e96e4ecf763f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="spiritual warfare gb.bin" size="0x40000" crc="f7a961ba" sha1="6e6ae5dbd8ff8b8f41b8411ef119e96e4ecf763f" />
 			</dataarea>
 		</part>
 	</software>
@@ -22489,8 +22489,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="spirou (europe) (en,fr,de,es) (beta).bin" size="262144" crc="35415a00" sha1="556641fc79700c5ccb4f8feaec1d7fafe99c31c4" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="spirou (europe) (en,fr,de,es) (beta).bin" size="0x40000" crc="35415a00" sha1="556641fc79700c5ccb4f8feaec1d7fafe99c31c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -22506,8 +22506,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-auop-0.u1" size="262144" crc="735b29e2" sha1="5eef57753b7faae2b9710e38be30662b0b77383a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-auop-0.u1" size="0x40000" crc="735b29e2" sha1="5eef57753b7faae2b9710e38be30662b0b77383a" />
 			</dataarea>
 		</part>
 	</software>
@@ -22519,8 +22519,8 @@ license:CC0
 		<info name="serial" value="DMG-R5-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="splitz (europe).bin" size="65536" crc="112487c9" sha1="27a8c04bf7126d2b9f564b5f8f709c08817d9692" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="splitz (europe).bin" size="0x10000" crc="112487c9" sha1="27a8c04bf7126d2b9f564b5f8f709c08817d9692" />
 			</dataarea>
 		</part>
 	</software>
@@ -22531,8 +22531,8 @@ license:CC0
 		<publisher>Imagineer</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="splitz (prototype).bin" size="131072" crc="5e8f955e" sha1="5f36290557f23c48ca7f2f17a1af9b691ede5bff" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="splitz (prototype).bin" size="0x20000" crc="5e8f955e" sha1="5f36290557f23c48ca7f2f17a1af9b691ede5bff" />
 			</dataarea>
 		</part>
 	</software>
@@ -22549,8 +22549,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-r5a-0.u1" size="65536" crc="b07a2745" sha1="c71d031da8206798a56beae6a90f143174a76947" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-r5a-0.u1" size="0x10000" crc="b07a2745" sha1="c71d031da8206798a56beae6a90f143174a76947" />
 			</dataarea>
 		</part>
 	</software>
@@ -22564,8 +22564,8 @@ license:CC0
 		<info name="alt_title" value="内祝　兄弟神技のパズルゲーム" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="uchiiwai - kyoudai kamiwaza no puzzle game (japan).bin" size="65536" crc="8059bc15" sha1="8992f55380b6ae7da14dcc3b3158c5c160953a1c" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="uchiiwai - kyoudai kamiwaza no puzzle game (japan).bin" size="0x10000" crc="8059bc15" sha1="8992f55380b6ae7da14dcc3b3158c5c160953a1c" />
 			</dataarea>
 		</part>
 	</software>
@@ -22579,8 +22579,8 @@ license:CC0
 		<info name="alt_title" value="スポーツ コレクション シーサイドバレー, ボクシング, ロードスター, サッカー, ドッジボーイ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="sports collection (japan).bin" size="524288" crc="24dd09e0" sha1="23c51363b64bd7ce2f2581e1fe9c5368fd8d8afb" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="sports collection (japan).bin" size="0x80000" crc="24dd09e0" sha1="23c51363b64bd7ce2f2581e1fe9c5368fd8d8afb" />
 			</dataarea>
 		</part>
 	</software>
@@ -22592,8 +22592,8 @@ license:CC0
 		<info name="serial" value="DMG-QM-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="sports illustrated - football &amp; baseball (usa).bin" size="524288" crc="235171c4" sha1="ab8272544d97b97d48420649070a927e6a0d2ac7" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="sports illustrated - football &amp; baseball (usa).bin" size="0x80000" crc="235171c4" sha1="ab8272544d97b97d48420649070a927e6a0d2ac7" />
 			</dataarea>
 		</part>
 	</software>
@@ -22609,8 +22609,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-agfe-0.u1" size="262144" crc="87b306b4" sha1="39761cfedcfe4e5cf161f58a91f5fd364fc3ddb9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-agfe-0.u1" size="0x40000" crc="87b306b4" sha1="39761cfedcfe4e5cf161f58a91f5fd364fc3ddb9" />
 			</dataarea>
 		</part>
 	</software>
@@ -22622,8 +22622,8 @@ license:CC0
 		<info name="serial" value="DMG-U8-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="sports illustrated for kids - the ultimate triple dare (usa).bin" size="262144" crc="f0d76d49" sha1="170a9b400e7db3270883dbb58704fc141053faa9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="sports illustrated for kids - the ultimate triple dare (usa).bin" size="0x40000" crc="f0d76d49" sha1="170a9b400e7db3270883dbb58704fc141053faa9" />
 			</dataarea>
 		</part>
 	</software>
@@ -22634,8 +22634,8 @@ license:CC0
 		<publisher>Virgin Games</publisher>
 		<info name="serial" value="DMG-S3-NOE" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="spot (europe).bin" size="32768" crc="04e241e4" sha1="10577304fae59b9c5d8b72bbf710ba97ef85ac90" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="spot (europe).bin" size="0x8000" crc="04e241e4" sha1="10577304fae59b9c5d8b72bbf710ba97ef85ac90" />
 			</dataarea>
 		</part>
 	</software>
@@ -22648,8 +22648,8 @@ license:CC0
 		<info name="release" value="19921016" />
 		<info name="alt_title" value="スポット" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="spot (japan).bin" size="32768" crc="2ca58280" sha1="a14cf8c28e8bcc573b7ed6543cb40d6b1467fa6b" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="spot (japan).bin" size="0x8000" crc="2ca58280" sha1="a14cf8c28e8bcc573b7ed6543cb40d6b1467fa6b" />
 			</dataarea>
 		</part>
 	</software>
@@ -22660,8 +22660,8 @@ license:CC0
 		<publisher>Virgin Games</publisher>
 		<info name="serial" value="DMG-S3-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="spot (usa).bin" size="32768" crc="fcd61b98" sha1="1a1ae34a3ec668d9a69c9c851c0291752dc63238" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="spot (usa).bin" size="0x8000" crc="fcd61b98" sha1="1a1ae34a3ec668d9a69c9c851c0291752dc63238" />
 			</dataarea>
 		</part>
 	</software>
@@ -22675,8 +22675,8 @@ license:CC0
 		<info name="alt_title" value="スポットクールアドベンチャー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="spot - the cool adventure (japan).bin" size="131072" crc="552a53b9" sha1="075512a3af4bc7c2da2d51d84df2d04c81b2a8ad" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="spot - the cool adventure (japan).bin" size="0x20000" crc="552a53b9" sha1="075512a3af4bc7c2da2d51d84df2d04c81b2a8ad" />
 			</dataarea>
 		</part>
 	</software>
@@ -22688,8 +22688,8 @@ license:CC0
 		<info name="serial" value="DMG-CU-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="spot - the cool adventure (usa).bin" size="131072" crc="76f67428" sha1="bcc923e6e73efe7e865625bb6ecf2ef08e380826" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="spot - the cool adventure (usa).bin" size="0x20000" crc="76f67428" sha1="bcc923e6e73efe7e865625bb6ecf2ef08e380826" />
 			</dataarea>
 		</part>
 	</software>
@@ -22701,8 +22701,8 @@ license:CC0
 		<info name="serial" value="DMG-TV-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="spud's adventure (usa).bin" size="65536" crc="70e5ed99" sha1="556f6bf41d671a80b0b71d5897c4d8a6ffc7b5b1" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="spud's adventure (usa).bin" size="0x10000" crc="70e5ed99" sha1="556f6bf41d671a80b0b71d5897c4d8a6ffc7b5b1" />
 			</dataarea>
 		</part>
 	</software>
@@ -22716,8 +22716,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-tox-0.u1" size="131072" crc="36645203" sha1="f3405ab4e07570db790850c928a2d338478b93ff" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-tox-0.u1" size="0x20000" crc="36645203" sha1="f3405ab4e07570db790850c928a2d338478b93ff" />
 			</dataarea>
 		</part>
 	</software>
@@ -22728,8 +22728,8 @@ license:CC0
 		<publisher>Kemco</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="spy vs spy - operation boobytrap (usa).bin" size="131072" crc="6d40e5a2" sha1="1a84bb71a8e655f9741f825d515cb9ce02cfab9a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="spy vs spy - operation boobytrap (usa).bin" size="0x20000" crc="6d40e5a2" sha1="1a84bb71a8e655f9741f825d515cb9ce02cfab9a" />
 			</dataarea>
 		</part>
 	</software>
@@ -22741,8 +22741,8 @@ license:CC0
 		<info name="serial" value="DMG-CA-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="square deal (usa).bin" size="65536" crc="8b882745" sha1="ace72e1d6607b162bdaa88499db9828444ecd2c0" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="square deal (usa).bin" size="0x10000" crc="8b882745" sha1="ace72e1d6607b162bdaa88499db9828444ecd2c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -22754,8 +22754,8 @@ license:CC0
 		<info name="serial" value="DMG-WK-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="star hawk (europe).bin" size="131072" crc="e032e502" sha1="4c22e06cb98119923126f6500568ce9f136a33c5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="star hawk (europe).bin" size="0x20000" crc="e032e502" sha1="4c22e06cb98119923126f6500568ce9f136a33c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -22770,10 +22770,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="star sweep (japan).bin" size="262144" crc="d6fd967c" sha1="caabaa2e9cbab27859db80ef6b0e90e7b94b3bd0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="star sweep (japan).bin" size="0x40000" crc="d6fd967c" sha1="caabaa2e9cbab27859db80ef6b0e90e7b94b3bd0" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -22785,8 +22785,8 @@ license:CC0
 		<info name="serial" value="DMG-RK-ESP, DMG-RK-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="star trek - 25th anniversary (usa, europe).bin" size="131072" crc="605de43a" sha1="bca2e328fe76d877f09251f2efd5438116f0648c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="star trek - 25th anniversary (usa, europe).bin" size="0x20000" crc="605de43a" sha1="bca2e328fe76d877f09251f2efd5438116f0648c" />
 			</dataarea>
 		</part>
 	</software>
@@ -22799,8 +22799,8 @@ license:CC0
 		<info name="serial" value="DMG-NU-USA, DMG-NU-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="star trek - the next generation (usa, europe).bin" size="131072" crc="3a5a56cb" sha1="8a50eb7863bf6abf329f218aea8bbd354a1bd970" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="star trek - the next generation (usa, europe).bin" size="0x20000" crc="3a5a56cb" sha1="8a50eb7863bf6abf329f218aea8bbd354a1bd970" />
 			</dataarea>
 		</part>
 	</software>
@@ -22815,8 +22815,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-nud-0.u1" size="131072" crc="129616b3" sha1="1b89db710c22c563c764b667c3897d817b05f18a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-nud-0.u1" size="0x20000" crc="129616b3" sha1="1b89db710c22c563c764b667c3897d817b05f18a" />
 			</dataarea>
 		</part>
 	</software>
@@ -22827,8 +22827,8 @@ license:CC0
 		<publisher>Absolute Entertainment</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="star trek - the next generation (prototype).bin" size="131072" crc="89e73128" sha1="8366108fcf9e5cb0f95d221b5e9800e801cd9634" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="star trek - the next generation (prototype).bin" size="0x20000" crc="89e73128" sha1="8366108fcf9e5cb0f95d221b5e9800e801cd9634" />
 			</dataarea>
 		</part>
 	</software>
@@ -22843,8 +22843,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-nus-0.u1" size="131072" crc="4fded9c4" sha1="890ed0aa9453fd1a38eefe77f761155382471a56" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-nus-0.u1" size="0x20000" crc="4fded9c4" sha1="890ed0aa9453fd1a38eefe77f761155382471a56" />
 			</dataarea>
 		</part>
 	</software>
@@ -22860,8 +22860,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-astp-0.u1" size="131072" crc="d925d15d" sha1="47af2970d4feada0b59db59af6130b1999bb5f3f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-astp-0.u1" size="0x20000" crc="d925d15d" sha1="47af2970d4feada0b59db59af6130b1999bb5f3f" />
 			</dataarea>
 		</part>
 	</software>
@@ -22874,8 +22874,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="star trek generations - beyond the nexus (usa).bin" size="131072" crc="9f2d11c6" sha1="86a97ad95738bbcbbe94fc9911d6fd6a92a7a636" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="star trek generations - beyond the nexus (usa).bin" size="0x20000" crc="9f2d11c6" sha1="86a97ad95738bbcbbe94fc9911d6fd6a92a7a636" />
 			</dataarea>
 		</part>
 	</software>
@@ -22890,9 +22890,9 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
+			<dataarea name="rom" size="0x20000">
 				<!-- USA cart has label DMG-WSE-1 -->
-				<rom name="dmg-wsx-1.u1" size="131072" crc="5d8deb5b" sha1="f6563f526fc786c8666d75dfba9e6d42d787ea89" />
+				<rom name="dmg-wsx-1.u1" size="0x20000" crc="5d8deb5b" sha1="f6563f526fc786c8666d75dfba9e6d42d787ea89" />
 			</dataarea>
 		</part>
 	</software>
@@ -22907,8 +22907,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-wsx-0.u1" size="131072" crc="7e3f6bbe" sha1="3a6028708d9fb23a27104201fa8725a5dfb3b161" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-wsx-0.u1" size="0x20000" crc="7e3f6bbe" sha1="3a6028708d9fb23a27104201fa8725a5dfb3b161" />
 			</dataarea>
 		</part>
 	</software>
@@ -22920,8 +22920,8 @@ license:CC0
 		<info name="serial" value="DMG-WS-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="star wars (usa).bin" size="131072" crc="b01da1ae" sha1="82c4114312efdc86c578e8683941a950fc2bb4c3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="star wars (usa).bin" size="0x20000" crc="b01da1ae" sha1="82c4114312efdc86c578e8683941a950fc2bb4c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -22936,8 +22936,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ebx-0.u1" size="131072" crc="240c589d" sha1="c8458c870e6ac535aaff6bf97ec47fb3cb0daa8a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ebx-0.u1" size="0x20000" crc="240c589d" sha1="c8458c870e6ac535aaff6bf97ec47fb3cb0daa8a" />
 			</dataarea>
 		</part>
 	</software>
@@ -22952,8 +22952,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ebe-0.u1" size="131072" crc="a0fff8e7" sha1="9ca1d6d479f5a3beb32f2461637b489f245323ff" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ebe-0.u1" size="0x20000" crc="a0fff8e7" sha1="9ca1d6d479f5a3beb32f2461637b489f245323ff" />
 			</dataarea>
 		</part>
 	</software>
@@ -22968,8 +22968,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-agtp-0.u1" size="131072" crc="4789295c" sha1="3d2d65252fd57dc1d96c234a436fa377a769c708" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-agtp-0.u1" size="0x20000" crc="4789295c" sha1="3d2d65252fd57dc1d96c234a436fa377a769c708" />
 			</dataarea>
 		</part>
 	</software>
@@ -22981,8 +22981,8 @@ license:CC0
 		<info name="serial" value="DMG-HZ-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="stop that roach (usa).bin" size="131072" crc="86107477" sha1="b7265343bd77f966b31f871fd471559266e5fc82" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="stop that roach (usa).bin" size="0x20000" crc="86107477" sha1="b7265343bd77f966b31f871fd471559266e5fc82" />
 			</dataarea>
 		</part>
 	</software>
@@ -22998,8 +22998,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="street fighter ii (japan).bin" size="524288" crc="c775f488" sha1="52fdac69097e9323ab867e0139e860b9ad55d500" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="street fighter ii (japan).bin" size="0x80000" crc="c775f488" sha1="52fdac69097e9323ab867e0139e860b9ad55d500" />
 			</dataarea>
 		</part>
 	</software>
@@ -23015,9 +23015,9 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
+			<dataarea name="rom" size="0x80000">
 				<!-- USA cart has label DMG-ASFE-1 -->
-				<rom name="dmg-asfp-1.u1" size="524288" crc="54a0aaa3" sha1="3b6ecf34043c0bcf2ac279eaf30b9d1b0d941e91" />
+				<rom name="dmg-asfp-1.u1" size="0x80000" crc="54a0aaa3" sha1="3b6ecf34043c0bcf2ac279eaf30b9d1b0d941e91" />
 			</dataarea>
 		</part>
 	</software>
@@ -23033,8 +23033,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-asfe-0.u1" size="524288" crc="0b29830a" sha1="05711638648654e75ca6a563411daec3251c2ef0" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-asfe-0.u1" size="0x80000" crc="0b29830a" sha1="05711638648654e75ca6a563411daec3251c2ef0" />
 			</dataarea>
 		</part>
 	</software>
@@ -23049,8 +23049,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="street racer (japan).bin" size="131072" crc="5bbacaa8" sha1="2e5e0610a7c535980b6a185cab83248f6d6096b3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="street racer (japan).bin" size="0x20000" crc="5bbacaa8" sha1="2e5e0610a7c535980b6a185cab83248f6d6096b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -23065,8 +23065,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-asrp-0.u1" size="131072" crc="fcfb4ce4" sha1="4e1d17772eb939cb0a3bce73e4378384d96836ce" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-asrp-0.u1" size="0x20000" crc="fcfb4ce4" sha1="4e1d17772eb939cb0a3bce73e4378384d96836ce" />
 			</dataarea>
 		</part>
 	</software>
@@ -23078,8 +23078,8 @@ license:CC0
 		<info name="serial" value="DMG-SF-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="sumo fighter (usa).bin" size="131072" crc="badc7cee" sha1="48f225f86985d5fb09877e028baad8a6f3ee8d95" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sumo fighter (usa).bin" size="0x20000" crc="badc7cee" sha1="48f225f86985d5fb09877e028baad8a6f3ee8d95" />
 			</dataarea>
 		</part>
 	</software>
@@ -23093,8 +23093,8 @@ license:CC0
 		<info name="alt_title" value="相撲ファイター 東海道場所" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="sumou fighter - toukaidou basho (japan).bin" size="131072" crc="a6905fb2" sha1="de575df6a3752fe3a2013a752054b7b76975e367" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sumou fighter - toukaidou basho (japan).bin" size="0x20000" crc="a6905fb2" sha1="de575df6a3752fe3a2013a752054b7b76975e367" />
 			</dataarea>
 		</part>
 	</software>
@@ -23109,8 +23109,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-fbx-0.u1" size="65536" crc="8c5dee4d" sha1="ea2445e062c535f8d8a3129d7016f5e8a7ac82cf" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-fbx-0.u1" size="0x10000" crc="8c5dee4d" sha1="ea2445e062c535f8d8a3129d7016f5e8a7ac82cf" />
 			</dataarea>
 		</part>
 	</software>
@@ -23136,10 +23136,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_huc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-abdj-0.u1" size="524288" crc="239711ec" sha1="36eac648d0406c84d6708695f30bc8739d1bc648" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-abdj-0.u1" size="0x80000" crc="239711ec" sha1="36eac648d0406c84d6708695f30bc8739d1bc648" />
 			</dataarea>
-			<dataarea name="ram" size="32768">
+			<dataarea name="ram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -23154,8 +23154,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-n6x-0.u1" size="131072" crc="31a227ed" sha1="4931b578626abf8fd2e7b6e344234e7e688a1406" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-n6x-0.u1" size="0x20000" crc="31a227ed" sha1="4931b578626abf8fd2e7b6e344234e7e688a1406" />
 			</dataarea>
 		</part>
 	</software>
@@ -23170,8 +23170,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-n6e-0.u1" size="131072" crc="da27e798" sha1="7ad8cb997676b30befdebb7fae2a341d3712cef1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-n6e-0.u1" size="0x20000" crc="da27e798" sha1="7ad8cb997676b30befdebb7fae2a341d3712cef1" />
 			</dataarea>
 		</part>
 	</software>
@@ -23185,8 +23185,8 @@ license:CC0
 		<info name="alt_title" value="スーパービックリマン 伝説の石版" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="super bikkuriman - densetsu no sekiban (japan).bin" size="262144" crc="c1e1a041" sha1="b7dac857947fce1069145a1f5d560c26aa3c8f42" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="super bikkuriman - densetsu no sekiban (japan).bin" size="0x40000" crc="c1e1a041" sha1="b7dac857947fce1069145a1f5d560c26aa3c8f42" />
 			</dataarea>
 		</part>
 	</software>
@@ -23198,8 +23198,8 @@ license:CC0
 		<info name="serial" value="DMG-A2BE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="super black bass (usa).bin" size="524288" crc="6b497842" sha1="4d3cb96da714d785dfbcc3ba242f9a7a221c9cbb" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="super black bass (usa).bin" size="0x80000" crc="6b497842" sha1="4d3cb96da714d785dfbcc3ba242f9a7a221c9cbb" />
 			</dataarea>
 		</part>
 	</software>
@@ -23214,10 +23214,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="1048576">
-				<rom name="super black bass pocket (japan).bin" size="1048576" crc="8a7c1678" sha1="1fb714757e9a0ad02c96feb57a0d04163e44dc74" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="super black bass pocket (japan).bin" size="0x100000" crc="8a7c1678" sha1="1fb714757e9a0ad02c96feb57a0d04163e44dc74" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23238,10 +23238,10 @@ license:CC0
 			<feature name="u4" value="U4 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-abtj-0.u1" size="1048576" crc="68a553b6" sha1="86ec8d2e1a3151878b3d6a6c22d14a1ac7d26e39" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-abtj-0.u1" size="0x100000" crc="68a553b6" sha1="86ec8d2e1a3151878b3d6a6c22d14a1ac7d26e39" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23256,8 +23256,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super bombliss (japan).bin" size="131072" crc="b503ffad" sha1="8f44cd2d819a3cd0ab697e60939d5921e29609ac" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super bombliss (japan).bin" size="0x20000" crc="b503ffad" sha1="8f44cd2d819a3cd0ab697e60939d5921e29609ac" />
 			</dataarea>
 		</part>
 	</software>
@@ -23273,8 +23273,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-aboe-0.u1" size="131072" crc="1dc0f813" sha1="f98ff68b3004212d09904c5db5ccfcf1d20405c3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-aboe-0.u1" size="0x20000" crc="1dc0f813" sha1="f98ff68b3004212d09904c5db5ccfcf1d20405c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -23286,8 +23286,8 @@ license:CC0
 		<info name="serial" value="DMG-Q2-USA, DMG-Q2-USA-1, DMG-Q2-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super chase h.q. (usa, europe).bin" size="131072" crc="630e0e00" sha1="d5184c1849d8e0addd4e1d31812068931bf98adc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super chase h.q. (usa, europe).bin" size="0x20000" crc="630e0e00" sha1="d5184c1849d8e0addd4e1d31812068931bf98adc" />
 			</dataarea>
 		</part>
 	</software>
@@ -23305,8 +23305,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-affj-0.u1" size="1048576" crc="b526a116" sha1="081a6f607c4a07fc0bab2f86cf0d1adff1173239" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-affj-0.u1" size="0x100000" crc="b526a116" sha1="081a6f607c4a07fc0bab2f86cf0d1adff1173239" />
 			</dataarea>
 		</part>
 	</software>
@@ -23323,8 +23323,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="u2" size="65536" crc="037d966a" sha1="1810b088f5cb395512a04ba6a3c47d9ab74aa8cc" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="u2" size="0x10000" crc="037d966a" sha1="1810b088f5cb395512a04ba6a3c47d9ab74aa8cc" />
 			</dataarea>
 		</part>
 	</software>
@@ -23342,8 +23342,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1" />
 			<feature name="slot" value="rom_mbc1col" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-aldj-0.u1" size="1048576" crc="7d1d8fdc" sha1="2c2a1c2de0c2a88bc0a73b44f04f2ca434573d68" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-aldj-0.u1" size="0x100000" crc="7d1d8fdc" sha1="2c2a1c2de0c2a88bc0a73b44f04f2ca434573d68" />
 			</dataarea>
 		</part>
 	</software>
@@ -23357,8 +23357,8 @@ license:CC0
 		<info name="alt_title" value="スーパーチャイニーズランド2 -宇宙大冒険-" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="super chinese land 2 (japan).bin" size="262144" crc="88508483" sha1="7f355e4a02fbefa3f539fa95f089c8a48508a937" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="super chinese land 2 (japan).bin" size="0x40000" crc="88508483" sha1="7f355e4a02fbefa3f539fa95f089c8a48508a937" />
 			</dataarea>
 		</part>
 	</software>
@@ -23376,8 +23376,8 @@ license:CC0
 			<feature name="u1" value="U1 MBC1 [MBC1-B]" />
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="u2" size="262144" crc="e01caf0b" sha1="6d8ef3fdd1702d629c679636698e1d483fc3723b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="u2" size="0x40000" crc="e01caf0b" sha1="6d8ef3fdd1702d629c679636698e1d483fc3723b" />
 			</dataarea>
 		</part>
 	</software>
@@ -23399,10 +23399,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-ytj-0.u1" size="524288" crc="695f4600" sha1="fca5ebc5eebc20b0088423631719fb2dc862b276" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-ytj-0.u1" size="0x80000" crc="695f4600" sha1="fca5ebc5eebc20b0088423631719fb2dc862b276" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23414,8 +23414,8 @@ license:CC0
 		<info name="serial" value="DMG-HN-UKV, DMG-HN-UKV-1" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super hunchback (europe).bin" size="131072" crc="2359d61e" sha1="9ea125f907fa610205e9c09a08802b1a128e4ff7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super hunchback (europe).bin" size="0x20000" crc="2359d61e" sha1="9ea125f907fa610205e9c09a08802b1a128e4ff7" />
 			</dataarea>
 		</part>
 	</software>
@@ -23429,8 +23429,8 @@ license:CC0
 		<info name="alt_title" value="スーパーハンチバック" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super hunchback (japan).bin" size="131072" crc="f20078c2" sha1="608092d4be5d32d5b8b4d50c2d9284a00ea885cb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super hunchback (japan).bin" size="0x20000" crc="f20078c2" sha1="608092d4be5d32d5b8b4d50c2d9284a00ea885cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -23442,8 +23442,8 @@ license:CC0
 		<info name="serial" value="DMG-HN-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super hunchback (usa).bin" size="131072" crc="1a45706e" sha1="9d53fbfeeec5a1a8352177c157ce615621c4b30c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super hunchback (usa).bin" size="0x20000" crc="1a45706e" sha1="9d53fbfeeec5a1a8352177c157ce615621c4b30c" />
 			</dataarea>
 		</part>
 	</software>
@@ -23455,8 +23455,8 @@ license:CC0
 		<info name="serial" value="DMG-JD-ESP, DMG-JD-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super james pond (europe).bin" size="131072" crc="6dc1bb2c" sha1="cacb8a79cf66dcb8c3d4f71c94d535cf9e5ad63b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super james pond (europe).bin" size="0x20000" crc="6dc1bb2c" sha1="cacb8a79cf66dcb8c3d4f71c94d535cf9e5ad63b" />
 			</dataarea>
 		</part>
 	</software>
@@ -23468,8 +23468,8 @@ license:CC0
 		<info name="serial" value="DMG-KF-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super kick off (europe) (en,fr,de,it,nl).bin" size="131072" crc="4b1dfe3d" sha1="c178dafc472de4c8dcdbc8361ee078641ae61b84" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super kick off (europe) (en,fr,de,it,nl).bin" size="0x20000" crc="4b1dfe3d" sha1="c178dafc472de4c8dcdbc8361ee078641ae61b84" />
 			</dataarea>
 		</part>
 	</software>
@@ -23492,8 +23492,8 @@ license:CC0
 			<feature name="u2" value="U2 PRG-ROM [epoxy]" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-mla-1.u1" size="65536" crc="2c27ec70" sha1="418203621b887caa090215d97e3f509b79affd3e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-mla-1.u1" size="0x10000" crc="2c27ec70" sha1="418203621b887caa090215d97e3f509b79affd3e" />
 			</dataarea>
 		</part>
 	</software>
@@ -23508,8 +23508,8 @@ license:CC0
 		<info name="alt_title" value="スーパーマリオランド" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="super mario land (world).bin" size="65536" crc="90776841" sha1="3a4ddb39b234a67ffb361ee7abc3d23e0a8b1c89" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="super mario land (world).bin" size="0x10000" crc="90776841" sha1="3a4ddb39b234a67ffb361ee7abc3d23e0a8b1c89" />
 			</dataarea>
 		</part>
 	</software>
@@ -23531,10 +23531,10 @@ license:CC0
 			<feature name="pcb" value="DMG-DECN-M11" />
 			-->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-mqe-2.u1" size="524288" crc="635a9112" sha1="d11d94fa3c36b9f72e925070b66bb4f16d31001e" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-mqe-2.u1" size="0x80000" crc="635a9112" sha1="d11d94fa3c36b9f72e925070b66bb4f16d31001e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23552,10 +23552,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="super mario land 2 - 6 golden coins (usa, europe) (rev 1).bin" size="524288" crc="e6f886e5" sha1="96e3a314561fb394cdf51101f9178a32713c2313" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="super mario land 2 - 6 golden coins (usa, europe) (rev 1).bin" size="0x80000" crc="e6f886e5" sha1="96e3a314561fb394cdf51101f9178a32713c2313" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23573,10 +23573,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-mqe-0.u1" size="524288" crc="d5ec24e4" sha1="bba408539ecbf8d322324956d859bc86e2a9977b" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-mqe-0.u1" size="0x80000" crc="d5ec24e4" sha1="bba408539ecbf8d322324956d859bc86e2a9977b" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23597,10 +23597,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-l6j-2.u1" size="524288" crc="29e0911a" sha1="aaadb040ee6d85418e12f9993beb4f2cb8dc9953" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-l6j-2.u1" size="0x80000" crc="29e0911a" sha1="aaadb040ee6d85418e12f9993beb4f2cb8dc9953" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23621,10 +23621,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-l6j-1.u1" size="524288" crc="bf733e10" sha1="f536d4d76a22668b8672bb291e4c738abc55d759" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-l6j-1.u1" size="0x80000" crc="bf733e10" sha1="f536d4d76a22668b8672bb291e4c738abc55d759" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23645,10 +23645,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-l6j-0.u1" size="524288" crc="a715daf5" sha1="dc410e83f06ebd63ae5bd97e1b9562f0c887be37" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-l6j-0.u1" size="0x80000" crc="a715daf5" sha1="dc410e83f06ebd63ae5bd97e1b9562f0c887be37" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23667,10 +23667,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-mdj-0.u1" size="262144" crc="4ca6d91a" sha1="c142845225145f1ece8aa4cdfd207402146edfc0" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-mdj-0.u1" size="0x40000" crc="4ca6d91a" sha1="c142845225145f1ece8aa4cdfd207402146edfc0" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23690,10 +23690,10 @@ license:CC0
 			<feature name="u3" value="U3 RAM [HY6264ALLJ-10]" />
 			<feature name="u4" value="U4 26A" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="super momotarou dentetsu ii (japan).bin" size="262144" crc="e8b4891f" sha1="4974d8e868cc359dca73312749b71b0f163df92e" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="super momotarou dentetsu ii (japan).bin" size="0x40000" crc="e8b4891f" sha1="4974d8e868cc359dca73312749b71b0f163df92e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23708,8 +23708,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ore-0.u1" size="131072" crc="3e2810be" sha1="acde7750bcf99d7bb76b895534fda43ece222dfa" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ore-0.u1" size="0x20000" crc="3e2810be" sha1="acde7750bcf99d7bb76b895534fda43ece222dfa" />
 			</dataarea>
 		</part>
 	</software>
@@ -23720,8 +23720,8 @@ license:CC0
 		<publisher>Tradewest</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super off road.bin" size="131072" crc="419a2ae3" sha1="742c33e45d3b79101d34fdc6537371ae96084235" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super off road.bin" size="0x20000" crc="419a2ae3" sha1="742c33e45d3b79101d34fdc6537371ae96084235" />
 			</dataarea>
 		</part>
 	</software>
@@ -23736,8 +23736,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="super pachinko taisen (japan).bin" size="262144" crc="cde0ff00" sha1="642f4f6b043d8886d02552430bf3b3c87142ad2d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="super pachinko taisen (japan).bin" size="0x40000" crc="cde0ff00" sha1="642f4f6b043d8886d02552430bf3b3c87142ad2d" />
 			</dataarea>
 		</part>
 	</software>
@@ -23749,8 +23749,8 @@ license:CC0
 		<info name="serial" value="DMG-RC-ESP-1, DMG-RC-NOE, DMG-RC-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super r.c. pro-am (usa, europe).bin" size="131072" crc="7960f33f" sha1="37c0a74532ed283f56e940bb5c38e757a0eee6e0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super r.c. pro-am (usa, europe).bin" size="0x20000" crc="7960f33f" sha1="37c0a74532ed283f56e940bb5c38e757a0eee6e0" />
 			</dataarea>
 		</part>
 	</software>
@@ -23764,10 +23764,10 @@ license:CC0
 		<info name="alt_title" value="スーパーロボット大戦" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="super robot taisen (japan).bin" size="131072" crc="7dd9d7d6" sha1="267d77866c798d33c973fff25d246fff584bf9a3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super robot taisen (japan).bin" size="0x20000" crc="7dd9d7d6" sha1="267d77866c798d33c973fff25d246fff584bf9a3" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -23779,8 +23779,8 @@ license:CC0
 		<info name="serial" value="DMG-SR-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super scrabble (usa).bin" size="131072" crc="3874b7a2" sha1="59755c83dc26015c4084296ab06600ffc235f026" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super scrabble (usa).bin" size="0x20000" crc="3874b7a2" sha1="59755c83dc26015c4084296ab06600ffc235f026" />
 			</dataarea>
 		</part>
 	</software>
@@ -23795,8 +23795,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="super snakey (japan).bin" size="65536" crc="984d0f7f" sha1="f4746aace9190196ca82003b8e479a130926035e" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="super snakey (japan).bin" size="0x10000" crc="984d0f7f" sha1="f4746aace9190196ca82003b8e479a130926035e" />
 			</dataarea>
 		</part>
 	</software>
@@ -23812,8 +23812,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-arjp-0.u1" size="524288" crc="6cb73dc7" sha1="4947f04548ddcf22a6f064601de48925099d1e1d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-arjp-0.u1" size="0x80000" crc="6cb73dc7" sha1="4947f04548ddcf22a6f064601de48925099d1e1d" />
 			</dataarea>
 		</part>
 	</software>
@@ -23830,8 +23830,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-f7a-0.u1" size="131072" crc="a269559f" sha1="4180a7a7f7e1f8de07875246a3079a6d1507fa06" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-f7a-0.u1" size="0x20000" crc="a269559f" sha1="4180a7a7f7e1f8de07875246a3079a6d1507fa06" />
 			</dataarea>
 		</part>
 	</software>
@@ -23849,8 +23849,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-vba-0.u1" size="131072" crc="8090c9cc" sha1="3b52fa182c42e3d058d341aee46fcfc63ae978eb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-vba-0.u1" size="0x20000" crc="8090c9cc" sha1="3b52fa182c42e3d058d341aee46fcfc63ae978eb" />
 			</dataarea>
 		</part>
 	</software>
@@ -23866,8 +23866,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-asmp-0.u1" size="131072" crc="358e0091" sha1="3a987cb4ba6f33717ea70d7388ec1dfe6ab934e8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-asmp-0.u1" size="0x20000" crc="358e0091" sha1="3a987cb4ba6f33717ea70d7388ec1dfe6ab934e8" />
 			</dataarea>
 		</part>
 	</software>
@@ -23881,8 +23881,8 @@ license:CC0
 		<info name="alt_title" value="鈴木亜久里のF-1スーパードライビング" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-fqj-0.u1" size="262144" crc="7fe42a7f" sha1="40f1280c87918307ebc2a3f2ec1ce9b66ff9a67b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-fqj-0.u1" size="0x40000" crc="7fe42a7f" sha1="40f1280c87918307ebc2a3f2ec1ce9b66ff9a67b" />
 			</dataarea>
 		</part>
 	</software>
@@ -23896,8 +23896,8 @@ license:CC0
 		<info name="alt_title" value="鈴木亜久里のF-1スーパードライビング" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="suzuki aguri no f-1 super driving (japan).bin" size="262144" crc="e82692d9" sha1="98d0e39251413f2f3bf2f001c48ccf88f27190ba" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="suzuki aguri no f-1 super driving (japan).bin" size="0x40000" crc="e82692d9" sha1="98d0e39251413f2f3bf2f001c48ccf88f27190ba" />
 			</dataarea>
 		</part>
 	</software>
@@ -23912,8 +23912,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-wge-0.u1" size="131072" crc="76ae62c8" sha1="1ff322b5f44d21c951dcdf8d062d99ffa65827e3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-wge-0.u1" size="0x20000" crc="76ae62c8" sha1="1ff322b5f44d21c951dcdf8d062d99ffa65827e3" />
 			</dataarea>
 		</part>
 	</software>
@@ -23928,8 +23928,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-see-0.u1" size="131072" crc="7e923846" sha1="5f30147162e2a38dbb90a233f22df0a6aa3d99fb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-see-0.u1" size="0x20000" crc="7e923846" sha1="5f30147162e2a38dbb90a233f22df0a6aa3d99fb" />
 			</dataarea>
 		</part>
 	</software>
@@ -23941,8 +23941,8 @@ license:CC0
 		<info name="serial" value="DMG-SE-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="sword of hope, the (germany).bin" size="131072" crc="498e0e9f" sha1="4d442bda629f64a277d0f6bcc7e7fa640294bd7e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sword of hope, the (germany).bin" size="0x20000" crc="498e0e9f" sha1="4d442bda629f64a277d0f6bcc7e7fa640294bd7e" />
 			</dataarea>
 		</part>
 	</software>
@@ -23957,8 +23957,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ses-0.u1" size="131072" crc="28c311d7" sha1="dbd0fd8f870b883d19455f2d276edc1028c9d916" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ses-0.u1" size="0x20000" crc="28c311d7" sha1="dbd0fd8f870b883d19455f2d276edc1028c9d916" />
 			</dataarea>
 		</part>
 	</software>
@@ -23970,8 +23970,8 @@ license:CC0
 		<info name="serial" value="DMG-SE-SCN" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="sword of hope, the (sweden).bin" size="131072" crc="c7e48c7c" sha1="fda0cc9b3c02f6dbc1fb44636c98dcc4dfbce5ec" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sword of hope, the (sweden).bin" size="0x20000" crc="c7e48c7c" sha1="fda0cc9b3c02f6dbc1fb44636c98dcc4dfbce5ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -23983,10 +23983,10 @@ license:CC0
 		<info name="serial" value="DMG-SI-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-sie-0.u1" size="262144" crc="5b7ff38c" sha1="3ccb37fd8e6e39a9e8421ee6f1ae199b4586afc1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-sie-0.u1" size="0x40000" crc="5b7ff38c" sha1="3ccb37fd8e6e39a9e8421ee6f1ae199b4586afc1" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -24000,8 +24000,8 @@ license:CC0
 		<info name="alt_title" value="T2 ザ・アーケード・ゲーム" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="t2 - the arcade game (japan).bin" size="131072" crc="7ec795fa" sha1="363edd30041b562ce522f68e451feee5e94ef03f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="t2 - the arcade game (japan).bin" size="0x20000" crc="7ec795fa" sha1="363edd30041b562ce522f68e451feee5e94ef03f" />
 			</dataarea>
 		</part>
 	</software>
@@ -24013,8 +24013,8 @@ license:CC0
 		<info name="serial" value="DMG-AV-USA, DMG-AV-(ESP/NOE)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="t2 - the arcade game (usa, europe).bin" size="131072" crc="00f09c7f" sha1="a362a05b2616bca1375d3f4f979d12bdb9bca53a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="t2 - the arcade game (usa, europe).bin" size="0x20000" crc="00f09c7f" sha1="a362a05b2616bca1375d3f4f979d12bdb9bca53a" />
 			</dataarea>
 		</part>
 	</software>
@@ -24031,8 +24031,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="taikyoku renju (japan) (en,ja).bin" size="65536" crc="62a31de6" sha1="4bd7e9944be0f71258b9955c77c0696484e9773a" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="taikyoku renju (japan) (en,ja).bin" size="0x10000" crc="62a31de6" sha1="4bd7e9944be0f71258b9955c77c0696484e9773a" />
 			</dataarea>
 		</part>
 	</software>
@@ -24047,8 +24047,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-tge-0.u1" size="65536" crc="c5acce7c" sha1="ed5f1110a9db4c48d26d53af0973e8b46fe7e4e1" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-tge-0.u1" size="0x10000" crc="c5acce7c" sha1="ed5f1110a9db4c48d26d53af0973e8b46fe7e4e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -24065,8 +24065,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-hqj-0.u1" size="131072" crc="c58bb4f5" sha1="d448c5c63a0cca4f7c4ee806ff928c564d40d386" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-hqj-0.u1" size="0x20000" crc="c58bb4f5" sha1="d448c5c63a0cca4f7c4ee806ff928c564d40d386" />
 			</dataarea>
 		</part>
 	</software>
@@ -24083,8 +24083,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MMM01 [MMM01 649 103]" />
 			<feature name="slot" value="rom_mmm01" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-avpj-0.u1" size="524288" crc="6dbaa5e8" sha1="53995f1b9c8a0bf8545414bd5e5defef617b7a55" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-avpj-0.u1" size="0x80000" crc="6dbaa5e8" sha1="53995f1b9c8a0bf8545414bd5e5defef617b7a55" />
 			</dataarea>
 		</part>
 	</software>
@@ -24098,8 +24098,8 @@ license:CC0
 		<info name="alt_title" value="太陽の天使マーロー お花畑は大パニック!" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="taiyou no tenshi marlowe - ohanabatake wa dai-panic (japan).bin" size="262144" crc="1132c6bb" sha1="3b9f13100a797623d1700ccfeff0b31da52f5dc3" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="taiyou no tenshi marlowe - ohanabatake wa dai-panic (japan).bin" size="0x40000" crc="1132c6bb" sha1="3b9f13100a797623d1700ccfeff0b31da52f5dc3" />
 			</dataarea>
 		</part>
 	</software>
@@ -24116,8 +24116,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-tyj-0.u1" size="131072" crc="723eb882" sha1="7a2b9864bf2a93d271694d9bc7eedb55f0f15fad" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-tyj-0.u1" size="0x20000" crc="723eb882" sha1="7a2b9864bf2a93d271694d9bc7eedb55f0f15fad" />
 			</dataarea>
 		</part>
 	</software>
@@ -24131,8 +24131,8 @@ license:CC0
 		<info name="alt_title" value="高橋名人の冒険島II" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="takahashi meijin no boukenjima ii (japan).bin" size="131072" crc="f1071e08" sha1="504d9096c9eace691ad23b2119749bc24f6e7d45" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="takahashi meijin no boukenjima ii (japan).bin" size="0x20000" crc="f1071e08" sha1="504d9096c9eace691ad23b2119749bc24f6e7d45" />
 			</dataarea>
 		</part>
 	</software>
@@ -24147,8 +24147,8 @@ license:CC0
 		<info name="alt_title" value="高橋名人の冒険島III" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="takahashi meijin no boukenjima iii (japan).bin" size="262144" crc="f8fc0b41" sha1="e3fe857a1b7f00a6f7862d7dd401063f98fd0cb6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="takahashi meijin no boukenjima iii (japan).bin" size="0x40000" crc="f8fc0b41" sha1="e3fe857a1b7f00a6f7862d7dd401063f98fd0cb6" />
 			</dataarea>
 		</part>
 	</software>
@@ -24163,8 +24163,8 @@ license:CC0
 		<info name="alt_title" value="武田修宏のエースストライカー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="takeda nobuhiro no ace striker (japan).bin" size="262144" crc="7ff546df" sha1="e354310c9946f48eb325c070e9c2c5ccb2e9f429" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="takeda nobuhiro no ace striker (japan).bin" size="0x40000" crc="7ff546df" sha1="e354310c9946f48eb325c070e9c2c5ccb2e9f429" />
 			</dataarea>
 		</part>
 	</software>
@@ -24177,8 +24177,8 @@ license:CC0
 		<info name="alt_title" value="Disney's TaleSpin (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tale spin (europe).bin" size="131072" crc="d29ddc91" sha1="4ca2962c76f9015246663564b9c7006b5fa37a03" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tale spin (europe).bin" size="0x20000" crc="d29ddc91" sha1="4ca2962c76f9015246663564b9c7006b5fa37a03" />
 			</dataarea>
 		</part>
 	</software>
@@ -24191,8 +24191,8 @@ license:CC0
 		<info name="alt_title" value="Disney's TaleSpin (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tale spin (usa).bin" size="131072" crc="de383e73" sha1="155eb5458c971a9a84e3be19711994ca2a4c24d8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tale spin (usa).bin" size="0x20000" crc="de383e73" sha1="155eb5458c971a9a84e3be19711994ca2a4c24d8" />
 			</dataarea>
 		</part>
 	</software>
@@ -24211,10 +24211,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-atap-0.u1" size="524288" crc="dbf1bd20" sha1="7368ec190bed39429812a26e18b2d3e153cf4e81" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-atap-0.u1" size="0x80000" crc="dbf1bd20" sha1="7368ec190bed39429812a26e18b2d3e153cf4e81" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -24227,10 +24227,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="tamagotchi (france).bin" size="524288" crc="084c2401" sha1="0f4e508f90e52a869efb245894a362e5f677c2ed" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="tamagotchi (france).bin" size="0x80000" crc="084c2401" sha1="0f4e508f90e52a869efb245894a362e5f677c2ed" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -24246,8 +24246,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-zke-0.u1" size="131072" crc="c2f50fb3" sha1="eaff826c9256358d7920de3956a8ab563d004d51" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-zke-0.u1" size="0x20000" crc="c2f50fb3" sha1="eaff826c9256358d7920de3956a8ab563d004d51" />
 			</dataarea>
 		</part>
 	</software>
@@ -24260,8 +24260,8 @@ license:CC0
 		<info name="release" value="19900727" />
 		<info name="alt_title" value="タスマニア物語" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tasmania story (japan).bin" size="32768" crc="9ea867a7" sha1="6d036755c55c84b05fe1c015cc567f1889d27576" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="tasmania story (japan).bin" size="0x8000" crc="9ea867a7" sha1="6d036755c55c84b05fe1c015cc567f1889d27576" />
 			</dataarea>
 		</part>
 	</software>
@@ -24272,8 +24272,8 @@ license:CC0
 		<publisher>FCI</publisher>
 		<info name="serial" value="DMG-TA-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tasmania story (usa).bin" size="32768" crc="a33c4fff" sha1="70e206bcd2c5c55ec1270bcb63cbfe8f5d049363" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="tasmania story (usa).bin" size="0x8000" crc="a33c4fff" sha1="70e206bcd2c5c55ec1270bcb63cbfe8f5d049363" />
 			</dataarea>
 		</part>
 	</software>
@@ -24289,8 +24289,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-zte-0.u1" size="262144" crc="22d07cf6" sha1="d36d731bd2644ee84c7cf77a2c1d319851e4d6bb" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-zte-0.u1" size="0x40000" crc="22d07cf6" sha1="d36d731bd2644ee84c7cf77a2c1d319851e4d6bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -24302,8 +24302,8 @@ license:CC0
 		<info name="serial" value="DMG-ZM-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="taz-mania (europe).bin" size="131072" crc="0860b667" sha1="c184e8e11ef2388c60b69d445a46fc22a11d175e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="taz-mania (europe).bin" size="0x20000" crc="0860b667" sha1="c184e8e11ef2388c60b69d445a46fc22a11d175e" />
 			</dataarea>
 		</part>
 	</software>
@@ -24314,8 +24314,8 @@ license:CC0
 		<publisher>THQ</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tazmania.bin" size="131072" crc="c3d85ef6" sha1="b31f8ec2a330d57ec7736e405833508ca8a98700" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tazmania.bin" size="0x20000" crc="c3d85ef6" sha1="b31f8ec2a330d57ec7736e405833508ca8a98700" />
 			</dataarea>
 		</part>
 	</software>
@@ -24327,8 +24327,8 @@ license:CC0
 		<info name="serial" value="DMG-ATZE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-atze-0.u1" size="131072" crc="4ccb65e0" sha1="60116a304e85f04209dc7eb64d9649dc41c963f6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-atze-0.u1" size="0x20000" crc="4ccb65e0" sha1="60116a304e85f04209dc7eb64d9649dc41c963f6" />
 			</dataarea>
 		</part>
 	</software>
@@ -24342,8 +24342,8 @@ license:CC0
 		<info name="alt_title" value="テクモボウル ジービー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="tecmo bowl (japan).bin" size="262144" crc="cfd74e34" sha1="2447006c578e1df0256e9155c8b65fa2a6b0004b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="tecmo bowl (japan).bin" size="0x40000" crc="cfd74e34" sha1="2447006c578e1df0256e9155c8b65fa2a6b0004b" />
 			</dataarea>
 		</part>
 	</software>
@@ -24355,8 +24355,8 @@ license:CC0
 		<info name="serial" value="DMG-TL-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="tecmo bowl (usa).bin" size="262144" crc="e4f29760" sha1="a3d7559db6aebf77ec6a682b7d39c1976f80c7a1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="tecmo bowl (usa).bin" size="0x40000" crc="e4f29760" sha1="a3d7559db6aebf77ec6a682b7d39c1976f80c7a1" />
 			</dataarea>
 		</part>
 	</software>
@@ -24371,8 +24371,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ntx-0.u1" size="131072" crc="ed8a73fb" sha1="cf1d432b93e6a606d95bf7397a088b79cd69e108" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ntx-0.u1" size="0x20000" crc="ed8a73fb" sha1="cf1d432b93e6a606d95bf7397a088b79cd69e108" />
 			</dataarea>
 		</part>
 	</software>
@@ -24387,8 +24387,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ttx-0.u1" size="262144" crc="cf24506c" sha1="350fff58e59114ef37b232c8588a44910bd02d27" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ttx-0.u1" size="0x40000" crc="cf24506c" sha1="350fff58e59114ef37b232c8588a44910bd02d27" />
 			</dataarea>
 		</part>
 	</software>
@@ -24400,8 +24400,8 @@ license:CC0
 		<info name="serial" value="DMG-K8-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="teenage mutant hero turtles iii - radical rescue (europe).bin" size="131072" crc="9f3245f3" sha1="bd0aecb9b752eef5a9628ac9c649cad1efb8cb62" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="teenage mutant hero turtles iii - radical rescue (europe).bin" size="0x20000" crc="9f3245f3" sha1="bd0aecb9b752eef5a9628ac9c649cad1efb8cb62" />
 			</dataarea>
 		</part>
 	</software>
@@ -24413,8 +24413,8 @@ license:CC0
 		<info name="serial" value="DMG-K8-UKV?" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-k8x-1.u1" size="131072" crc="5b7c9a54" sha1="5f01016c06c7d52bb434540b9ca327abe5039936" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-k8x-1.u1" size="0x20000" crc="5b7c9a54" sha1="5f01016c06c7d52bb434540b9ca327abe5039936" />
 			</dataarea>
 		</part>
 	</software>
@@ -24428,8 +24428,8 @@ license:CC0
 		<info name="alt_title" value="ティーンエイジ・ミュータント・ニンジャ・タートルズ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="teenage mutant ninja turtles (japan).bin" size="131072" crc="74078236" sha1="1f17169d70365831537376beb2477374649f830b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="teenage mutant ninja turtles (japan).bin" size="0x20000" crc="74078236" sha1="1f17169d70365831537376beb2477374649f830b" />
 			</dataarea>
 		</part>
 	</software>
@@ -24441,8 +24441,8 @@ license:CC0
 		<info name="serial" value="DMG-NT-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="teenage mutant ninja turtles - fall of the foot clan (usa).bin" size="131072" crc="5a6984c3" sha1="6e8a43bc0c18129d74ff3322658a2ce8c24d201e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="teenage mutant ninja turtles - fall of the foot clan (usa).bin" size="0x20000" crc="5a6984c3" sha1="6e8a43bc0c18129d74ff3322658a2ce8c24d201e" />
 			</dataarea>
 		</part>
 	</software>
@@ -24456,8 +24456,8 @@ license:CC0
 		<info name="alt_title" value="ティーンエイジ ミュータント ニンジャ タートルズ2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="teenage mutant ninja turtles 2 (japan).bin" size="262144" crc="84e6fb25" sha1="27e254854d72195de4bc5146d69d30cb3c10912a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="teenage mutant ninja turtles 2 (japan).bin" size="0x40000" crc="84e6fb25" sha1="27e254854d72195de4bc5146d69d30cb3c10912a" />
 			</dataarea>
 		</part>
 	</software>
@@ -24468,8 +24468,8 @@ license:CC0
 		<publisher>Konami</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="teenage mutant ninja turtles ii - back from the sewers (may 20, 1991 prototype).bin" size="262144" crc="64a667a3" sha1="864a686f74a22ff8d27da511b08bbfbef1bd563d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="teenage mutant ninja turtles ii - back from the sewers (may 20, 1991 prototype).bin" size="0x40000" crc="64a667a3" sha1="864a686f74a22ff8d27da511b08bbfbef1bd563d" />
 			</dataarea>
 		</part>
 	</software>
@@ -24483,8 +24483,8 @@ license:CC0
 		<info name="alt_title" value="ティーンエイジ ミュータント ニンジャ タートルズ3 〜タートルズ危機一髪" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="teenage mutant ninja turtles 3 - turtles kiki ippatsu (japan).bin" size="131072" crc="55153bb5" sha1="15fd427b7ed6abe0b8d5685c17d01a96fa41de49" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="teenage mutant ninja turtles 3 - turtles kiki ippatsu (japan).bin" size="0x20000" crc="55153bb5" sha1="15fd427b7ed6abe0b8d5685c17d01a96fa41de49" />
 			</dataarea>
 		</part>
 	</software>
@@ -24496,8 +24496,8 @@ license:CC0
 		<info name="serial" value="DMG-TT-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="teenage mutant ninja turtles ii - back from the sewers (usa).bin" size="262144" crc="44f51c73" sha1="08aabd7be3d4b78a8b124a58afae4fec758b225f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="teenage mutant ninja turtles ii - back from the sewers (usa).bin" size="0x40000" crc="44f51c73" sha1="08aabd7be3d4b78a8b124a58afae4fec758b225f" />
 			</dataarea>
 		</part>
 	</software>
@@ -24508,8 +24508,8 @@ license:CC0
 		<publisher>Konami</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="teenage mutant ninja turtles ii - back from the sewers (prototype b).bin" size="262144" crc="ee25b752" sha1="7fd1df99ed3bc088c737f0ef8b7f0caa95d73b65" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="teenage mutant ninja turtles ii - back from the sewers (prototype b).bin" size="0x40000" crc="ee25b752" sha1="7fd1df99ed3bc088c737f0ef8b7f0caa95d73b65" />
 			</dataarea>
 		</part>
 	</software>
@@ -24521,8 +24521,8 @@ license:CC0
 		<info name="serial" value="DMG-K8-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="teenage mutant ninja turtles iii - radical rescue (usa).bin" size="131072" crc="58832bbc" sha1="29f5de9e4c0f21bf8bffc721dacf1790446a5923" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="teenage mutant ninja turtles iii - radical rescue (usa).bin" size="0x20000" crc="58832bbc" sha1="29f5de9e4c0f21bf8bffc721dacf1790446a5923" />
 			</dataarea>
 		</part>
 	</software>
@@ -24536,8 +24536,8 @@ license:CC0
 		<info name="alt_title" value="てけてけ!アスミッくんワールド ~ Teke Teke! Asmik-kun World" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="teke teke asmik-kun world (japan).bin" size="65536" crc="a817450d" sha1="389cc31472b87ec70e3ea6487f8ad9198887bb89" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="teke teke asmik-kun world (japan).bin" size="0x10000" crc="a817450d" sha1="389cc31472b87ec70e3ea6487f8ad9198887bb89" />
 			</dataarea>
 		</part>
 	</software>
@@ -24551,10 +24551,10 @@ license:CC0
 		<info name="alt_title" value="的中ラッシュ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="65536">
-				<rom name="tekichuu rush (japan).bin" size="65536" crc="7b903a6f" sha1="037b677a369fc892e08c268a8334d7f48b1fa05c" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="tekichuu rush (japan).bin" size="0x10000" crc="7b903a6f" sha1="037b677a369fc892e08c268a8334d7f48b1fa05c" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -24571,8 +24571,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tekkyu fight - the great battle gaiden (japan).bin" size="131072" crc="b8da8eb5" sha1="06a6ab3ba59286772f915053cfcd6e1e873358b1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tekkyu fight - the great battle gaiden (japan).bin" size="0x20000" crc="b8da8eb5" sha1="06a6ab3ba59286772f915053cfcd6e1e873358b1" />
 			</dataarea>
 		</part>
 	</software>
@@ -24586,10 +24586,10 @@ license:CC0
 		<info name="alt_title" value="天地を喰らう" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="tenchi o kurau (japan).bin" size="262144" crc="a9018354" sha1="312bc91b1b857cc7ec0cb8bc7cfa80bfe10d7b4b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="tenchi o kurau (japan).bin" size="0x40000" crc="a9018354" sha1="312bc91b1b857cc7ec0cb8bc7cfa80bfe10d7b4b" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -24606,8 +24606,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-tkj-0.u1" size="131072" crc="b71396a6" sha1="7d3cdce222e27cb9ac958c590936d7b8270ba34d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-tkj-0.u1" size="0x20000" crc="b71396a6" sha1="7d3cdce222e27cb9ac958c590936d7b8270ba34d" />
 			</dataarea>
 		</part>
 	</software>
@@ -24623,8 +24623,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" /> <!-- DMG-TN-NOE and DMG-TNA carts -->
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-tna-0.u1" size="32768" crc="5009215f" sha1="ec45a932fb3fc21394fef5e27e7fe9eccd0c7f70" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-tna-0.u1" size="0x8000" crc="5009215f" sha1="ec45a932fb3fc21394fef5e27e7fe9eccd0c7f70" />
 			</dataarea>
 		</part>
 	</software>
@@ -24636,8 +24636,8 @@ license:CC0
 		<info name="serial" value="DMG-TZ-USA, DMG-TZ-(NOE/ESP/UKV)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="terminator 2 - judgment day (usa, europe).bin" size="131072" crc="21848101" sha1="d2b94304971900dc2ff4945ad5cb445bfe434a5c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="terminator 2 - judgment day (usa, europe).bin" size="0x20000" crc="21848101" sha1="d2b94304971900dc2ff4945ad5cb445bfe434a5c" />
 			</dataarea>
 		</part>
 	</software>
@@ -24650,8 +24650,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-erx-0.u1" size="32768" crc="679b6530" sha1="69c2d689c52a3430a84aa8c9f020a2ce3d9a3c55" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-erx-0.u1" size="0x8000" crc="679b6530" sha1="69c2d689c52a3430a84aa8c9f020a2ce3d9a3c55" />
 			</dataarea>
 		</part>
 	</software>
@@ -24661,8 +24661,8 @@ license:CC0
 		<year>1993</year>
 		<publisher>GameTek</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tesserae (prototype).bin" size="32768" crc="ca2a5bfa" sha1="46af203ac1b5b6690d85931845e3f0d9e8d47774" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="tesserae (prototype).bin" size="0x8000" crc="ca2a5bfa" sha1="46af203ac1b5b6690d85931845e3f0d9e8d47774" />
 			</dataarea>
 		</part>
 	</software>
@@ -24673,8 +24673,8 @@ license:CC0
 		<publisher>GameTek</publisher>
 		<info name="serial" value="DMG-ER-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tesserae (usa).bin" size="32768" crc="c77e316f" sha1="9506a7ea6664bb6c65dfcf0476f209b65d9306fb" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="tesserae (usa).bin" size="0x8000" crc="c77e316f" sha1="9506a7ea6664bb6c65dfcf0476f209b65d9306fb" />
 			</dataarea>
 		</part>
 	</software>
@@ -24690,8 +24690,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" /> <!-- Also found with AAAC S -->
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-tra-1.u1" size="32768" crc="46df91ad" sha1="74591cc9501af93873f9a5d3eb12da12c0723bbc" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-tra-1.u1" size="0x8000" crc="46df91ad" sha1="74591cc9501af93873f9a5d3eb12da12c0723bbc" />
 			</dataarea>
 		</part>
 	</software>
@@ -24707,8 +24707,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-tra-0.u1" size="32768" crc="63f9407d" sha1="3f2a6407c9900ad5817ee1cfb3609c5ee17400fc" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-tra-0.u1" size="0x8000" crc="63f9407d" sha1="3f2a6407c9900ad5817ee1cfb3609c5ee17400fc" />
 			</dataarea>
 		</part>
 	</software>
@@ -24720,8 +24720,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ehx-1.u1" size="131072" crc="25c3100a" sha1="51bdceed8fc384b593444a5306b6a46a4672c96b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ehx-1.u1" size="0x20000" crc="25c3100a" sha1="51bdceed8fc384b593444a5306b6a46a4672c96b" />
 			</dataarea>
 		</part>
 	</software>
@@ -24738,8 +24738,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ehx-0.u1" size="131072" crc="ea19a9d9" sha1="1f88be9dea864eaa74c3b5ce3488e61139818e8d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ehx-0.u1" size="0x20000" crc="ea19a9d9" sha1="1f88be9dea864eaa74c3b5ce3488e61139818e8d" />
 			</dataarea>
 		</part>
 	</software>
@@ -24752,8 +24752,8 @@ license:CC0
 		<info name="serial" value="DMG-EH-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tetris 2 (usa).bin" size="131072" crc="aa4a1edb" sha1="ec7b3419c08f1a5713afff2b26c1534d91602338" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tetris 2 (usa).bin" size="0x20000" crc="aa4a1edb" sha1="ec7b3419c08f1a5713afff2b26c1534d91602338" />
 			</dataarea>
 		</part>
 	</software>
@@ -24766,8 +24766,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="tetris attack (usa).bin" size="524288" crc="b76c769b" sha1="3de8d7f30322bc50008ab0d917acd0a934b5b195" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="tetris attack (usa).bin" size="0x80000" crc="b76c769b" sha1="3de8d7f30322bc50008ab0d917acd0a934b5b195" />
 			</dataarea>
 		</part>
 	</software>
@@ -24783,8 +24783,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aylp-1.u1" size="524288" crc="5ee45a4d" sha1="85b4b0d5a5a0417e10fed853419fe65975a6071f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aylp-1.u1" size="0x80000" crc="5ee45a4d" sha1="85b4b0d5a5a0417e10fed853419fe65975a6071f" />
 			</dataarea>
 		</part>
 	</software>
@@ -24797,8 +24797,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tetris blast (usa, europe).bin" size="131072" crc="7be5a73f" sha1="14de1e47820b8aef8475d1ba94ea3d49cc45d06c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tetris blast (usa, europe).bin" size="0x20000" crc="7be5a73f" sha1="14de1e47820b8aef8475d1ba94ea3d49cc45d06c" />
 			</dataarea>
 		</part>
 	</software>
@@ -24813,8 +24813,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tetris flash (japan).bin" size="131072" crc="9dfcb385" sha1="ee30c75e068aefe131b880d611d987c41a421470" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tetris flash (japan).bin" size="0x20000" crc="9dfcb385" sha1="ee30c75e068aefe131b880d611d987c41a421470" />
 			</dataarea>
 		</part>
 	</software>
@@ -24829,10 +24829,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="tetris plus (japan).bin" size="262144" crc="2ec9120a" sha1="dbb20951409739f1e11ffbcd8b0af1e802bf693a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="tetris plus (japan).bin" size="0x40000" crc="2ec9120a" sha1="dbb20951409739f1e11ffbcd8b0af1e802bf693a" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -24851,10 +24851,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-atrp-0.u1" size="262144" crc="dafc3bff" sha1="dfab75ab6bdc0765ba9a5d33a93ffdb114a49cbf" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-atrp-0.u1" size="0x40000" crc="dafc3bff" sha1="dfab75ab6bdc0765ba9a5d33a93ffdb114a49cbf" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -24868,8 +24868,8 @@ license:CC0
 		<info name="alt_title" value="サンダーバード" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="thunderbirds (japan).bin" size="131072" crc="149e9393" sha1="440169376982aa89cedde08edbc9efdfafc6c7f1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="thunderbirds (japan).bin" size="0x20000" crc="149e9393" sha1="440169376982aa89cedde08edbc9efdfafc6c7f1" />
 			</dataarea>
 		</part>
 	</software>
@@ -24882,8 +24882,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-at6x-0.u1" size="262144" crc="7a7d820f" sha1="a69bee8c26a520b648a780c67e4a73d54e1bf812" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-at6x-0.u1" size="0x40000" crc="7a7d820f" sha1="a69bee8c26a520b648a780c67e4a73d54e1bf812" />
 			</dataarea>
 		</part>
 	</software>
@@ -24895,8 +24895,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="tintin au tibet.bin" size="262144" crc="68b7fcf2" sha1="63070514f0a692cef70e9344ca0a973f6af510c9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="tintin au tibet.bin" size="0x40000" crc="68b7fcf2" sha1="63070514f0a692cef70e9344ca0a973f6af510c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -24909,8 +24909,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="tintin in tibet (europe) (en,fr,de,nl).bin" size="262144" crc="5d2bd778" sha1="8d8978fbd5a5634e2cce940122039d575e7b3646" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="tintin in tibet (europe) (en,fr,de,nl).bin" size="0x40000" crc="5d2bd778" sha1="8d8978fbd5a5634e2cce940122039d575e7b3646" />
 			</dataarea>
 		</part>
 	</software>
@@ -24924,8 +24924,8 @@ license:CC0
 		<info name="alt_title" value="タイニー・トゥーン アドベンチャーズ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tiny toon adventures (japan).bin" size="131072" crc="fb13462b" sha1="08948315649160c62546f541f173808595f75149" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tiny toon adventures (japan).bin" size="0x20000" crc="fb13462b" sha1="08948315649160c62546f541f173808595f75149" />
 			</dataarea>
 		</part>
 	</software>
@@ -24937,8 +24937,8 @@ license:CC0
 		<info name="serial" value="DMG-TX-USA, DMG-TX-(NOE/ESP)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tiny toon adventures - babs' big break (usa, europe).bin" size="131072" crc="9b5e6219" sha1="7baa81c93ea86a5ddb9b26545a446fe9b8979590" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tiny toon adventures - babs' big break (usa, europe).bin" size="0x20000" crc="9b5e6219" sha1="7baa81c93ea86a5ddb9b26545a446fe9b8979590" />
 			</dataarea>
 		</part>
 	</software>
@@ -24949,8 +24949,8 @@ license:CC0
 		<publisher>Konami</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tiny toon adventures - babs' big break (sep 6, 1991 prototype).bin" size="131072" crc="7bf96ca9" sha1="2d15917713d9f7ba62b6b54b4bd845617515e847" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tiny toon adventures - babs' big break (sep 6, 1991 prototype).bin" size="0x20000" crc="7bf96ca9" sha1="2d15917713d9f7ba62b6b54b4bd845617515e847" />
 			</dataarea>
 		</part>
 	</software>
@@ -24961,8 +24961,8 @@ license:CC0
 		<publisher>Konami</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tiny toon adventures - babs' big break (jul 16, 1991 prototype).bin" size="131072" crc="4e4a17b5" sha1="cb9753abd9f5ba69f310d7309a2a824caafa7f54" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tiny toon adventures - babs' big break (jul 16, 1991 prototype).bin" size="0x20000" crc="4e4a17b5" sha1="cb9753abd9f5ba69f310d7309a2a824caafa7f54" />
 			</dataarea>
 		</part>
 	</software>
@@ -24976,8 +24976,8 @@ license:CC0
 		<info name="alt_title" value="タイニー・トゥーン アドベンチャーズ 3 ドキドキスポーツフェスティバル" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tiny toon adventures - dokidoki sport festival (japan).bin" size="131072" crc="3fa10931" sha1="e4b8d9bed45083472141f6856a13b04825164166" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tiny toon adventures - dokidoki sport festival (japan).bin" size="0x20000" crc="3fa10931" sha1="e4b8d9bed45083472141f6856a13b04825164166" />
 			</dataarea>
 		</part>
 	</software>
@@ -24992,8 +24992,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-t8e-0.u1" size="131072" crc="c5c7868d" sha1="b76aa64cc4123b7900569ff9db680935198db73f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-t8e-0.u1" size="0x20000" crc="c5c7868d" sha1="b76aa64cc4123b7900569ff9db680935198db73f" />
 			</dataarea>
 		</part>
 	</software>
@@ -25008,8 +25008,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-edx-0.u1" size="131072" crc="d731bda2" sha1="5b3e522f92c87e67a6d6c1922ce8df4314f7f504" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-edx-0.u1" size="0x20000" crc="d731bda2" sha1="5b3e522f92c87e67a6d6c1922ce8df4314f7f504" />
 			</dataarea>
 		</part>
 	</software>
@@ -25021,8 +25021,8 @@ license:CC0
 		<info name="serial" value="DMG-ED-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tiny toon adventures - wacky sports (usa).bin" size="131072" crc="d3904be9" sha1="f44adc4a41331e31627d23305579bd4e493610de" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tiny toon adventures - wacky sports (usa).bin" size="0x20000" crc="d3904be9" sha1="f44adc4a41331e31627d23305579bd4e493610de" />
 			</dataarea>
 		</part>
 	</software>
@@ -25036,8 +25036,8 @@ license:CC0
 		<info name="alt_title" value="タイニー・トゥーン アドベンチャーズ2 バスターバニーのかっとびだいぼうけん" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tiny toon adventures 2 (japan).bin" size="131072" crc="0fd47f8a" sha1="2a32b1761f512616613e42daf700b9d718883eb6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tiny toon adventures 2 (japan).bin" size="0x20000" crc="0fd47f8a" sha1="2a32b1761f512616613e42daf700b9d718883eb6" />
 			</dataarea>
 		</part>
 	</software>
@@ -25049,8 +25049,8 @@ license:CC0
 		<info name="serial" value="DMG-OF-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tip off (europe).bin" size="131072" crc="eaf523ec" sha1="a43ee2c068053e49dfc6e22a0cd781df357905ec" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tip off (europe).bin" size="0x20000" crc="eaf523ec" sha1="a43ee2c068053e49dfc6e22a0cd781df357905ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -25065,8 +25065,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-foe-0.u1" size="262144" crc="814fa146" sha1="ba0037aeb21de0bbba3f9294a7861d90aefa5008" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-foe-0.u1" size="0x40000" crc="814fa146" sha1="ba0037aeb21de0bbba3f9294a7861d90aefa5008" />
 			</dataarea>
 		</part>
 	</software>
@@ -25080,10 +25080,10 @@ license:CC0
 		<info name="alt_title" value="トキオ戦鬼 英雄列伝" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tokio senki - eiyuu retsuden (japan).bin" size="131072" crc="9db7dcc3" sha1="1aa4f93a4ad0e0a273a723c70e01494f04b1f214" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tokio senki - eiyuu retsuden (japan).bin" size="0x20000" crc="9db7dcc3" sha1="1aa4f93a4ad0e0a273a723c70e01494f04b1f214" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25098,10 +25098,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="tokoro's mahjong jr. (japan).bin" size="262144" crc="56afca4c" sha1="bc6ae2ade135ef59aa1a213df004252149937aa8" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="tokoro's mahjong jr. (japan).bin" size="0x40000" crc="56afca4c" sha1="bc6ae2ade135ef59aa1a213df004252149937aa8" />
 			</dataarea>
-			<dataarea name="ram" size="8192">
+			<dataarea name="ram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25116,8 +25116,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="tokyo disneyland - fantasy tour (japan).bin" size="524288" crc="28b85584" sha1="e413b0ab506cb12b68439ccc0a72e4664c112378" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="tokyo disneyland - fantasy tour (japan).bin" size="0x80000" crc="28b85584" sha1="e413b0ab506cb12b68439ccc0a72e4664c112378" />
 			</dataarea>
 		</part>
 	</software>
@@ -25132,8 +25132,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="tokyo disneyland - mickey no cinderella-jou mystery tour (japan).bin" size="524288" crc="77d69349" sha1="8e7ab2d9477f58254db3dfea749e12f535dc104c" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="tokyo disneyland - mickey no cinderella-jou mystery tour (japan).bin" size="0x80000" crc="77d69349" sha1="8e7ab2d9477f58254db3dfea749e12f535dc104c" />
 			</dataarea>
 		</part>
 	</software>
@@ -25145,8 +25145,8 @@ license:CC0
 		<info name="serial" value="DMG-JY-USA, DMG-JY-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tom &amp; jerry (usa, europe).bin" size="131072" crc="0636d89e" sha1="732c02f610d5614fce0a092d920cf3484d0cfd38" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tom &amp; jerry (usa, europe).bin" size="0x20000" crc="0636d89e" sha1="732c02f610d5614fce0a092d920cf3484d0cfd38" />
 			</dataarea>
 		</part>
 	</software>
@@ -25161,8 +25161,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-j8e-0.u1" size="131072" crc="c2dbd1aa" sha1="9f8adf286e5ce5868c758b1c2f195ef596a3df2b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-j8e-0.u1" size="0x20000" crc="c2dbd1aa" sha1="9f8adf286e5ce5868c758b1c2f195ef596a3df2b" />
 			</dataarea>
 		</part>
 	</software>
@@ -25173,8 +25173,8 @@ license:CC0
 		<publisher>Hi Tech Expressions</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tom and jerry - frantic antics (prototype).bin" size="131072" crc="4415cc6b" sha1="56dd5f7346ea60e6d5e081462c4fa73389777494" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tom and jerry - frantic antics (prototype).bin" size="0x20000" crc="4415cc6b" sha1="56dd5f7346ea60e6d5e081462c4fa73389777494" />
 			</dataarea>
 		</part>
 	</software>
@@ -25188,8 +25188,8 @@ license:CC0
 		<info name="alt_title" value="トムとジェリー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tom to jerry (japan).bin" size="131072" crc="ca836e6d" sha1="accba2abd506321934e5e7b49a14bbbfaa261171" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tom to jerry (japan).bin" size="0x20000" crc="ca836e6d" sha1="accba2abd506321934e5e7b49a14bbbfaa261171" />
 			</dataarea>
 		</part>
 	</software>
@@ -25203,8 +25203,8 @@ license:CC0
 		<info name="alt_title" value="トムとジェリー パート2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tom to jerry part 2 (japan).bin" size="131072" crc="dd19a9ec" sha1="adcf89690d0daf0d8e007b6b404305ef4dec689b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tom to jerry part 2 (japan).bin" size="0x20000" crc="dd19a9ec" sha1="adcf89690d0daf0d8e007b6b404305ef4dec689b" />
 			</dataarea>
 		</part>
 	</software>
@@ -25219,8 +25219,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-gne-0.u1" size="131072" crc="0506c12b" sha1="f23604c43798c6066b1d34fa8168a26108c64731" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-gne-0.u1" size="0x20000" crc="0506c12b" sha1="f23604c43798c6066b1d34fa8168a26108c64731" />
 			</dataarea>
 		</part>
 	</software>
@@ -25232,10 +25232,10 @@ license:CC0
 		<info name="serial" value="DMG-XT-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="top rank tennis (usa).bin" size="262144" crc="3c4e29b4" sha1="2fa95dfe097b31fc1a94a5e864308b417bf832d4" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="top rank tennis (usa).bin" size="0x40000" crc="3c4e29b4" sha1="2fa95dfe097b31fc1a94a5e864308b417bf832d4" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25252,10 +25252,10 @@ license:CC0
 			<feature name="u3" value="U3 26A [6129]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-xtx-0.u1" size="262144" crc="d577d8e0" sha1="e628b00e7f88742c99cbb51fae4be0d0cfa77405" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-xtx-0.u1" size="0x40000" crc="d577d8e0" sha1="e628b00e7f88742c99cbb51fae4be0d0cfa77405" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25269,10 +25269,10 @@ license:CC0
 		<info name="alt_title" value="トーピドーレンジ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="torpedo range (japan).bin" size="131072" crc="1fb35885" sha1="4cd1702228d3d82abda1672f21b79446385a2c68" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="torpedo range (japan).bin" size="0x20000" crc="1fb35885" sha1="4cd1702228d3d82abda1672f21b79446385a2c68" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25284,10 +25284,10 @@ license:CC0
 		<info name="serial" value="DMG-TE-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="torpedo range (usa).bin" size="131072" crc="ed9882a9" sha1="0aac562f0f62916839cffe472aa21e0cee6269f0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="torpedo range (usa).bin" size="0x20000" crc="ed9882a9" sha1="0aac562f0f62916839cffe472aa21e0cee6269f0" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25299,8 +25299,8 @@ license:CC0
 		<info name="serial" value="DMG-N8-USA, DMG-N8-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="total carnage (usa, europe).bin" size="131072" crc="3700927f" sha1="a735c8d212c5fcb47a1d25599edb1fb815593dd1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="total carnage (usa, europe).bin" size="0x20000" crc="3700927f" sha1="a735c8d212c5fcb47a1d25599edb1fb815593dd1" />
 			</dataarea>
 		</part>
 	</software>
@@ -25314,8 +25314,8 @@ license:CC0
 		<info name="alt_title" value="突撃ばれいしょんず" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="totsugeki valations (japan).bin" size="65536" crc="f2119a2d" sha1="cd4317bbf8774370d7c84b216c950d4867342793" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="totsugeki valations (japan).bin" size="0x10000" crc="f2119a2d" sha1="cd4317bbf8774370d7c84b216c950d4867342793" />
 			</dataarea>
 		</part>
 	</software>
@@ -25329,8 +25329,8 @@ license:CC0
 		<info name="alt_title" value="突撃!ポンコツタンク" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="totsugeki ponkotsu tank (japan).bin" size="131072" crc="9b5b7bff" sha1="2baabb0b3e846e31188388e43ef822a03c777ead" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="totsugeki ponkotsu tank (japan).bin" size="0x20000" crc="9b5b7bff" sha1="2baabb0b3e846e31188388e43ef822a03c777ead" />
 			</dataarea>
 		</part>
 	</software>
@@ -25345,8 +25345,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="tottemo luckyman (japan).bin" size="262144" crc="8f9e28ad" sha1="25e5e07b4945145f2681f0c991583335826c4f82" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="tottemo luckyman (japan).bin" size="0x40000" crc="8f9e28ad" sha1="25e5e07b4945145f2681f0c991583335826c4f82" />
 			</dataarea>
 		</part>
 	</software>
@@ -25358,8 +25358,8 @@ license:CC0
 		<info name="serial" value="DMG-XL-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="toxic crusaders (usa).bin" size="131072" crc="ea59c6e3" sha1="236420607be545e0156f2df0a5982c46bc6e10e3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="toxic crusaders (usa).bin" size="0x20000" crc="ea59c6e3" sha1="236420607be545e0156f2df0a5982c46bc6e10e3" />
 			</dataarea>
 		</part>
 	</software>
@@ -25375,8 +25375,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-aqhp-0.u1" size="524288" crc="d8e5060f" sha1="0120d5097f06ea6e222e5ceb31484f3375af6f5b" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-aqhp-0.u1" size="0x80000" crc="d8e5060f" sha1="0120d5097f06ea6e222e5ceb31484f3375af6f5b" />
 			</dataarea>
 		</part>
 	</software>
@@ -25389,8 +25389,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="toy story (usa) (rev 1).bin" size="524288" crc="6f36b6ed" sha1="04227fcd3e049465f4499fefe6519322ee492a82" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="toy story (usa) (rev 1).bin" size="0x80000" crc="6f36b6ed" sha1="04227fcd3e049465f4499fefe6519322ee492a82" />
 			</dataarea>
 		</part>
 	</software>
@@ -25403,8 +25403,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="toy story (usa).bin" size="524288" crc="d34287cc" sha1="ac2cdbd6ae42edcf407f02150add2c0442ec116c" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="toy story (usa).bin" size="0x80000" crc="d34287cc" sha1="ac2cdbd6ae42edcf407f02150add2c0442ec116c" />
 			</dataarea>
 		</part>
 	</software>
@@ -25416,8 +25416,8 @@ license:CC0
 		<info name="serial" value="DMG-KH-USA, DMG-KH-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="track &amp; field (usa, europe).bin" size="131072" crc="c0ef39f0" sha1="577a9f03adda485855c9164b4b8a2a351c214e3b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="track &amp; field (usa, europe).bin" size="0x20000" crc="c0ef39f0" sha1="577a9f03adda485855c9164b4b8a2a351c214e3b" />
 			</dataarea>
 		</part>
 	</software>
@@ -25429,8 +25429,8 @@ license:CC0
 		<info name="serial" value="DMG-TM-USA, DMG-TM-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="track meet (usa, europe).bin" size="131072" crc="7b5dc3e4" sha1="5ecb205b1b85f6c88d36386be071a6473de87221" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="track meet (usa, europe).bin" size="0x20000" crc="7b5dc3e4" sha1="5ecb205b1b85f6c88d36386be071a6473de87221" />
 			</dataarea>
 		</part>
 	</software>
@@ -25444,8 +25444,8 @@ license:CC0
 		<info name="alt_title" value="トラックミート 目指せバルセロナ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="track meet - mezase barcelona (japan).bin" size="131072" crc="48d37cd2" sha1="0f60ced77232215d86b9c4555caf9880cce008b7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="track meet - mezase barcelona (japan).bin" size="0x20000" crc="48d37cd2" sha1="0f60ced77232215d86b9c4555caf9880cce008b7" />
 			</dataarea>
 		</part>
 	</software>
@@ -25459,8 +25459,8 @@ license:CC0
 		<info name="alt_title" value="スパイvsスパイ とらっぱーず天国" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="trappers tengoku - spy vs spy (japan).bin" size="131072" crc="afefd085" sha1="c9eb687f6de7b821255fdd0cbf14f68ad789f97f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="trappers tengoku - spy vs spy (japan).bin" size="0x20000" crc="afefd085" sha1="c9eb687f6de7b821255fdd0cbf14f68ad789f97f" />
 			</dataarea>
 		</part>
 	</software>
@@ -25472,8 +25472,8 @@ license:CC0
 		<info name="serial" value="DMG-TP-USA, DMG-TP-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="trax (usa, europe).bin" size="131072" crc="4a38be7d" sha1="3f3a31ed7e47319c5815dd6e31ca27a52377423c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="trax (usa, europe).bin" size="0x20000" crc="4a38be7d" sha1="3f3a31ed7e47319c5815dd6e31ca27a52377423c" />
 			</dataarea>
 		</part>
 	</software>
@@ -25485,8 +25485,8 @@ license:CC0
 		<info name="serial" value="DMG-T4-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="trip world (europe).bin" size="262144" crc="85d910b9" sha1="adc10a23dd33d40740f5c8c086dfcb97b8389286" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="trip world (europe).bin" size="0x40000" crc="85d910b9" sha1="adc10a23dd33d40740f5c8c086dfcb97b8389286" />
 			</dataarea>
 		</part>
 	</software>
@@ -25500,8 +25500,8 @@ license:CC0
 		<info name="alt_title" value="トリップワールド" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="trip world (japan).bin" size="262144" crc="11568e64" sha1="ac19d49906e72aaebeffa9ab7106eb346a5efa07" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="trip world (japan).bin" size="0x40000" crc="11568e64" sha1="ac19d49906e72aaebeffa9ab7106eb346a5efa07" />
 			</dataarea>
 		</part>
 	</software>
@@ -25512,8 +25512,8 @@ license:CC0
 		<publisher>Hudson Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="triumph.bin" size="131072" crc="746159b2" sha1="90a40fc94709a3ec6945281bde2644d91bef28b5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="triumph.bin" size="0x20000" crc="746159b2" sha1="90a40fc94709a3ec6945281bde2644d91bef28b5" />
 			</dataarea>
 		</part>
 	</software>
@@ -25528,8 +25528,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-atlp-0.u1" size="262144" crc="edec63e6" sha1="95dda9821e6755c12fec9d4c0c9db8bb515843a6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-atlp-0.u1" size="0x40000" crc="edec63e6" sha1="95dda9821e6755c12fec9d4c0c9db8bb515843a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -25544,8 +25544,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-02" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-tbj-0.u1" size="32768" crc="fd16ac45" sha1="192ccf904e028a44d0d959bfae8fe4a9dcd4394e" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-tbj-0.u1" size="0x8000" crc="fd16ac45" sha1="192ccf904e028a44d0d959bfae8fe4a9dcd4394e" />
 			</dataarea>
 		</part>
 	</software>
@@ -25559,8 +25559,8 @@ license:CC0
 		<info name="alt_title" value="トランプボーイII" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="trump boy ii (japan).bin" size="65536" crc="39157849" sha1="ac526cf1b1463b2af83e2b3eef3680caa5dae94f" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="trump boy ii (japan).bin" size="0x10000" crc="39157849" sha1="ac526cf1b1463b2af83e2b3eef3680caa5dae94f" />
 			</dataarea>
 		</part>
 	</software>
@@ -25574,8 +25574,8 @@ license:CC0
 		<info name="alt_title" value="トランプコレクションGB" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="trump collection gb (japan).bin" size="131072" crc="8341be0f" sha1="fd8af42fecef8d1c826df7fed7859e2b03d861ba" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="trump collection gb (japan).bin" size="0x20000" crc="8341be0f" sha1="fd8af42fecef8d1c826df7fed7859e2b03d861ba" />
 			</dataarea>
 		</part>
 	</software>
@@ -25590,8 +25590,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tsume go series 1 - fujisawa hideyuki meiyo kisei (japan).bin" size="131072" crc="ceee6a61" sha1="4c16e7298713de7741ceb6513fa50a8b12432578" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tsume go series 1 - fujisawa hideyuki meiyo kisei (japan).bin" size="0x20000" crc="ceee6a61" sha1="4c16e7298713de7741ceb6513fa50a8b12432578" />
 			</dataarea>
 		</part>
 	</software>
@@ -25605,8 +25605,8 @@ license:CC0
 		<info name="alt_title" value="詰め将棋 百番勝負" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="tsume shougi - hyakuban shoubu (japan).bin" size="65536" crc="43e2a5c0" sha1="257a73694a6535aafa58d346b06d2ee386989578" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="tsume shougi - hyakuban shoubu (japan).bin" size="0x10000" crc="43e2a5c0" sha1="257a73694a6535aafa58d346b06d2ee386989578" />
 			</dataarea>
 		</part>
 	</software>
@@ -25618,8 +25618,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tsume shougi - kamiki godan (japan) (beta).bin" size="131072" crc="9995ee1a" sha1="eae6cdb4425ddae51bee0e7d0aa956b72e897743" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tsume shougi - kamiki godan (japan) (beta).bin" size="0x20000" crc="9995ee1a" sha1="eae6cdb4425ddae51bee0e7d0aa956b72e897743" />
 			</dataarea>
 		</part>
 	</software>
@@ -25634,8 +25634,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tsume shougi - kamiki godan (japan).bin" size="131072" crc="d5434c94" sha1="2e54faf9f97b6e590caacb26294bdafe40ca7214" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tsume shougi - kamiki godan (japan).bin" size="0x20000" crc="d5434c94" sha1="2e54faf9f97b6e590caacb26294bdafe40ca7214" />
 			</dataarea>
 		</part>
 	</software>
@@ -25649,8 +25649,8 @@ license:CC0
 		<info name="alt_title" value="詰将棋 問題提供『将棋世界』" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="tsume shougi - mondai teikyou shougi sekai (japan).bin" size="65536" crc="6403af06" sha1="d4d200c152b9fa1af758333210bef2649f0271ec" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="tsume shougi - mondai teikyou shougi sekai (japan).bin" size="0x10000" crc="6403af06" sha1="d4d200c152b9fa1af758333210bef2649f0271ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -25665,10 +25665,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="tsuri sensei (japan).bin" size="524288" crc="dc324100" sha1="be079a98f072c4b694a10154c351379529897ff6" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="tsuri sensei (japan).bin" size="0x80000" crc="dc324100" sha1="be079a98f072c4b694a10154c351379529897ff6" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25682,8 +25682,8 @@ license:CC0
 		<info name="alt_title" value="タンブルポップ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="tumble pop (japan).bin" size="131072" crc="881afd62" sha1="84a97f2db289951cba2eb6f7369bd6629c2687b2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="tumble pop (japan).bin" size="0x20000" crc="881afd62" sha1="84a97f2db289951cba2eb6f7369bd6629c2687b2" />
 			</dataarea>
 		</part>
 	</software>
@@ -25698,8 +25698,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-t6e-0.u1" size="131072" crc="8a3aab31" sha1="1b5a9b71bc14f9725b37fa0a166253f1047943b1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-t6e-0.u1" size="0x20000" crc="8a3aab31" sha1="1b5a9b71bc14f9725b37fa0a166253f1047943b1" />
 			</dataarea>
 		</part>
 	</software>
@@ -25711,8 +25711,8 @@ license:CC0
 		<info name="serial" value="DMG-UR-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="turn and burn (usa).bin" size="131072" crc="91394bd8" sha1="28bf175c8b3990f97039062c22d80bc7a524f060" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="turn and burn (usa).bin" size="0x20000" crc="91394bd8" sha1="28bf175c8b3990f97039062c22d80bc7a524f060" />
 			</dataarea>
 		</part>
 	</software>
@@ -25727,8 +25727,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-atup-0.u1" size="262144" crc="518c2d2f" sha1="8dcecc535909ef9d1b6dac658fa41ddcbb75c208" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-atup-0.u1" size="0x40000" crc="518c2d2f" sha1="8dcecc535909ef9d1b6dac658fa41ddcbb75c208" />
 			</dataarea>
 		</part>
 	</software>
@@ -25742,8 +25742,8 @@ license:CC0
 		<info name="alt_title" value="テュロック 〜バイオノザウルスの戦い〜" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="turok - battle of the bionosaurs (japan).bin" size="262144" crc="c88e751d" sha1="332517218856313559c483c57256977e0ce07ad7" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="turok - battle of the bionosaurs (japan).bin" size="0x40000" crc="c88e751d" sha1="332517218856313559c483c57256977e0ce07ad7" />
 			</dataarea>
 		</part>
 	</software>
@@ -25758,8 +25758,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-tqe-0.u1" size="131072" crc="2359bf0c" sha1="3023b2b831be9fe7db62857f1b353700a1c31c75" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-tqe-0.u1" size="0x20000" crc="2359bf0c" sha1="3023b2b831be9fe7db62857f1b353700a1c31c75" />
 			</dataarea>
 		</part>
 	</software>
@@ -25774,8 +25774,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="tv champion (japan).bin" size="262144" crc="18f64779" sha1="eddc884ff0fea50dc059b650728d2d3507461dfe" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="tv champion (japan).bin" size="0x40000" crc="18f64779" sha1="eddc884ff0fea50dc059b650728d2d3507461dfe" />
 			</dataarea>
 		</part>
 	</software>
@@ -25789,8 +25789,8 @@ license:CC0
 		<info name="alt_title" value="ツイン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="twin (japan).bin" size="131072" crc="2413acaa" sha1="2075027f6a45d1d970908254680077f3d18a3b1f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="twin (japan).bin" size="0x20000" crc="2413acaa" sha1="2075027f6a45d1d970908254680077f3d18a3b1f" />
 			</dataarea>
 		</part>
 	</software>
@@ -25804,8 +25804,8 @@ license:CC0
 		<info name="alt_title" value="ツインビーだ!!" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="twinbee da (japan).bin" size="131072" crc="017fd6f5" sha1="8f1c54d2116118ba085b384a01ea0c410ad2deac" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="twinbee da (japan).bin" size="0x20000" crc="017fd6f5" sha1="8f1c54d2116118ba085b384a01ea0c410ad2deac" />
 			</dataarea>
 		</part>
 	</software>
@@ -25819,8 +25819,8 @@ license:CC0
 		<info name="alt_title" value="宇宙の騎士 テッカマンブレード" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="uchuu no kishi tekkaman blade (japan).bin" size="131072" crc="22d8889e" sha1="ed7370f4d59cce1edb76e28bdcbe5e79fa3c07c4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="uchuu no kishi tekkaman blade (japan).bin" size="0x20000" crc="22d8889e" sha1="ed7370f4d59cce1edb76e28bdcbe5e79fa3c07c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -25834,8 +25834,8 @@ license:CC0
 		<info name="alt_title" value="宇宙戦艦ヤマト" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="uchuu senkan yamato (japan).bin" size="262144" crc="5bf747f8" sha1="574cfb77817d3466672a9b39e6e8d467295ffd66" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="uchuu senkan yamato (japan).bin" size="0x40000" crc="5bf747f8" sha1="574cfb77817d3466672a9b39e6e8d467295ffd66" />
 			</dataarea>
 		</part>
 	</software>
@@ -25847,10 +25847,10 @@ license:CC0
 		<info name="serial" value="DMG-UT-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="ultima - runes of virtue (usa).bin" size="131072" crc="c44a0f1e" sha1="8d911cbbc6bd1518a85282def7f01d3add16e596" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ultima - runes of virtue (usa).bin" size="0x20000" crc="c44a0f1e" sha1="8d911cbbc6bd1518a85282def7f01d3add16e596" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25862,10 +25862,10 @@ license:CC0
 		<info name="serial" value="DMG-U2-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="ultima - runes of virtue ii (usa).bin" size="262144" crc="c449fbbf" sha1="99c4fbf832edb9b58960ec744ae784b55c7d63d2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="ultima - runes of virtue ii (usa).bin" size="0x40000" crc="c449fbbf" sha1="99c4fbf832edb9b58960ec744ae784b55c7d63d2" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25879,10 +25879,10 @@ license:CC0
 		<info name="alt_title" value="ウルティマ 〜失われたルーン〜" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="ultima - ushinawareta runes (japan).bin" size="131072" crc="d2f94181" sha1="3a1d88736e13436cde15029dadd951b0b1c637e5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ultima - ushinawareta runes (japan).bin" size="0x20000" crc="d2f94181" sha1="3a1d88736e13436cde15029dadd951b0b1c637e5" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25896,10 +25896,10 @@ license:CC0
 		<info name="alt_title" value="ウルティマ 失われたルーン2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="ultima - ushinawareta runes ii (japan).bin" size="262144" crc="796fd6a5" sha1="f83a209c29e324578e74fb1cc7b3c990dd5a67a9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="ultima - ushinawareta runes ii (japan).bin" size="0x40000" crc="796fd6a5" sha1="f83a209c29e324578e74fb1cc7b3c990dd5a67a9" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25911,10 +25911,10 @@ license:CC0
 		<info name="serial" value="DMG-KG-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="ultra golf (usa).bin" size="131072" crc="12de9bac" sha1="a20c0a995a91b20646564965705fad129474e9bf" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ultra golf (usa).bin" size="0x20000" crc="12de9bac" sha1="a20c0a995a91b20646564965705fad129474e9bf" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25925,10 +25925,10 @@ license:CC0
 		<publisher>Ultra</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="ultra golf (nov 20, 1991 prototype).bin" size="131072" crc="d9ddb091" sha1="b29e5da6f794a010d858f4398da85145f20d8c55" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ultra golf (nov 20, 1991 prototype).bin" size="0x20000" crc="d9ddb091" sha1="b29e5da6f794a010d858f4398da85145f20d8c55" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -25942,8 +25942,8 @@ license:CC0
 		<info name="alt_title" value="ウルトラマン" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ultraman (japan).bin" size="131072" crc="5944c3ed" sha1="a4fbe124b257109ba9566fae59ac008f52317f2d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ultraman (japan).bin" size="0x20000" crc="5944c3ed" sha1="a4fbe124b257109ba9566fae59ac008f52317f2d" />
 			</dataarea>
 		</part>
 	</software>
@@ -25958,8 +25958,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="ultraman ball (japan).bin" size="131072" crc="468d1a2e" sha1="3cdfcfb1a88d0cbfeb1c7b12751409faf69bba02" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="ultraman ball (japan).bin" size="0x20000" crc="468d1a2e" sha1="3cdfcfb1a88d0cbfeb1c7b12751409faf69bba02" />
 			</dataarea>
 		</part>
 	</software>
@@ -25974,8 +25974,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="ultraman chou toushi gekiden (japan).bin" size="262144" crc="b904230d" sha1="1a55b76a4039fb6ff1ef0b1914dd9a7ccddde2b2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="ultraman chou toushi gekiden (japan).bin" size="0x40000" crc="b904230d" sha1="1a55b76a4039fb6ff1ef0b1914dd9a7ccddde2b2" />
 			</dataarea>
 		</part>
 	</software>
@@ -25992,8 +25992,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-ulj-0.u1" size="65536" crc="91eda860" sha1="298b912dd8cddc078b60b75718eca25870142a18" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-ulj-0.u1" size="0x10000" crc="91eda860" sha1="298b912dd8cddc078b60b75718eca25870142a18" />
 			</dataarea>
 		</part>
 	</software>
@@ -26009,10 +26009,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="umi no nushi tsuri 2 (japan).bin" size="524288" crc="19ff5b3e" sha1="8e533bea9ce1ce1f5a984e7cc4414f02bc98f1c1" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="umi no nushi tsuri 2 (japan).bin" size="0x80000" crc="19ff5b3e" sha1="8e533bea9ce1ce1f5a984e7cc4414f02bc98f1c1" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26026,8 +26026,8 @@ license:CC0
 		<info name="alt_title" value="アンダーカバーコップス 破壊神ガルマァ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="undercover cops gaiden - hakaishin garumaa (japan).bin" size="262144" crc="b7af37f5" sha1="e391ea099ce371eef858d57e6c2da63a25944472" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="undercover cops gaiden - hakaishin garumaa (japan).bin" size="0x40000" crc="b7af37f5" sha1="e391ea099ce371eef858d57e6c2da63a25944472" />
 			</dataarea>
 		</part>
 	</software>
@@ -26039,8 +26039,8 @@ license:CC0
 		<info name="serial" value="DMG-UD-USA, DMG-UD-(ESP/FRG)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="universal soldier (usa, europe).bin" size="262144" crc="99ae9d06" sha1="dbaf863d66a1e4c0a4f022bb2b228f0547674cde" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="universal soldier (usa, europe).bin" size="0x40000" crc="99ae9d06" sha1="dbaf863d66a1e4c0a4f022bb2b228f0547674cde" />
 			</dataarea>
 		</part>
 	</software>
@@ -26054,8 +26054,8 @@ license:CC0
 		<info name="alt_title" value="UNO スモールワールド" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="uno - small world (japan).bin" size="262144" crc="a37c022d" sha1="4a0eb686cbee455197e0890210fade5c21b4954b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="uno - small world (japan).bin" size="0x40000" crc="a37c022d" sha1="4a0eb686cbee455197e0890210fade5c21b4954b" />
 			</dataarea>
 		</part>
 	</software>
@@ -26070,8 +26070,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="uno 2 - small world (japan).bin" size="131072" crc="a7ad65ef" sha1="d2d281da240779a3605356513132687a485c0b39" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="uno 2 - small world (japan).bin" size="0x20000" crc="a7ad65ef" sha1="d2d281da240779a3605356513132687a485c0b39" />
 			</dataarea>
 		</part>
 	</software>
@@ -26085,8 +26085,8 @@ license:CC0
 		<info name="alt_title" value="うおーズ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="uoozu (japan).bin" size="65536" crc="f7e1c9c5" sha1="d1b466b5a46de120d18309efade02d1745760d70" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="uoozu (japan).bin" size="0x10000" crc="f7e1c9c5" sha1="d1b466b5a46de120d18309efade02d1745760d70" />
 			</dataarea>
 		</part>
 	</software>
@@ -26099,8 +26099,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="urban strike (usa, europe).bin" size="524288" crc="89625945" sha1="6bc1010aad73d2cde677f897adb77684d9b508ed" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="urban strike (usa, europe).bin" size="0x80000" crc="89625945" sha1="6bc1010aad73d2cde677f897adb77684d9b508ed" />
 			</dataarea>
 		</part>
 	</software>
@@ -26114,10 +26114,10 @@ license:CC0
 		<info name="alt_title" value="うる星やつら −ミス友引を捜せ!−" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="urusei yatsura - miss tomobiki o saguse (japan).bin" size="262144" crc="56800c6b" sha1="f7ac15b9b38027ae473120748e9686c985a40e87" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="urusei yatsura - miss tomobiki o saguse (japan).bin" size="0x40000" crc="56800c6b" sha1="f7ac15b9b38027ae473120748e9686c985a40e87" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26132,8 +26132,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-avlp-0.u1" size="262144" crc="d149652b" sha1="67d2a6e41b6a1d8372808535ac8c8222d7c53480" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-avlp-0.u1" size="0x40000" crc="d149652b" sha1="67d2a6e41b6a1d8372808535ac8c8222d7c53480" />
 			</dataarea>
 		</part>
 	</software>
@@ -26147,8 +26147,8 @@ license:CC0
 		<info name="alt_title" value="ヴァトルギウス" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="vattle giuce (japan).bin" size="131072" crc="956b603c" sha1="ca41cd69249a9ee703acfad044759baa42ef2c9a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="vattle giuce (japan).bin" size="0x20000" crc="956b603c" sha1="ca41cd69249a9ee703acfad044759baa42ef2c9a" />
 			</dataarea>
 		</part>
 	</software>
@@ -26167,10 +26167,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-avsp-0.u1" size="524288" crc="c8be05d8" sha1="93cdf04a473dcfd7f8f4fb06cc0af857d16d00f2" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-avsp-0.u1" size="0x80000" crc="c8be05d8" sha1="93cdf04a473dcfd7f8f4fb06cc0af857d16d00f2" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26187,8 +26187,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-vej-0.u1" size="65536" crc="0817aa32" sha1="dd29da7d83ba9daebf16101e2ca8cc807eeca89d" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-vej-0.u1" size="0x10000" crc="0817aa32" sha1="dd29da7d83ba9daebf16101e2ca8cc807eeca89d" />
 			</dataarea>
 		</part>
 	</software>
@@ -26202,10 +26202,10 @@ license:CC0
 		<info name="alt_title" value="ベリウスII 復讐の邪神" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="velious ii - fukushuu no jashin (japan).bin" size="131072" crc="b55eb427" sha1="d0b009bef968da587148623f9727128ce1aa80e8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="velious ii - fukushuu no jashin (japan).bin" size="0x20000" crc="b55eb427" sha1="d0b009bef968da587148623f9727128ce1aa80e8" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26219,8 +26219,8 @@ license:CC0
 		<info name="alt_title" value="バーサスヒーロー −格闘王への道−" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="versus hero - kakutou ou e no michi (japan).bin" size="131072" crc="449cf2e4" sha1="ac60beecccea7537ad6c6779176d92056c1436fe" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="versus hero - kakutou ou e no michi (japan).bin" size="0x20000" crc="449cf2e4" sha1="ac60beecccea7537ad6c6779176d92056c1436fe" />
 			</dataarea>
 		</part>
 	</software>
@@ -26234,8 +26234,8 @@ license:CC0
 		<info name="alt_title" value="バーチャルウォーズ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="virtual wars (japan).bin" size="131072" crc="220bbcb6" sha1="cb256ee50fb5106c84d96f2f23cf18de3afbd276" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="virtual wars (japan).bin" size="0x20000" crc="220bbcb6" sha1="cb256ee50fb5106c84d96f2f23cf18de3afbd276" />
 			</dataarea>
 		</part>
 	</software>
@@ -26250,10 +26250,10 @@ license:CC0
 		<info name="alt_title" value="ビタミーナ王国物語" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="vitamina oukoku monogatari (japan).bin" size="262144" crc="89a7aeca" sha1="d4195257a2debe78aa4dd433a324aec335ad36d1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="vitamina oukoku monogatari (japan).bin" size="0x40000" crc="89a7aeca" sha1="d4195257a2debe78aa4dd433a324aec335ad36d1" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26266,8 +26266,8 @@ license:CC0
 		<info name="release" value="19900629" />
 		<info name="alt_title" value="バリーファイア" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="volley fire (japan).bin" size="32768" crc="0d06ea32" sha1="4c90e2c4a0b24983b339af8c0405cd5f4bf8881f" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="volley fire (japan).bin" size="0x8000" crc="0d06ea32" sha1="4c90e2c4a0b24983b339af8c0405cd5f4bf8881f" />
 			</dataarea>
 		</part>
 	</software>
@@ -26281,8 +26281,8 @@ license:CC0
 		<info name="alt_title" value="VSバトラー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="vs battler (japan).bin" size="65536" crc="20ae389a" sha1="5f99c7767cbbf5ad9164805214875d7054f49f14" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="vs battler (japan).bin" size="0x10000" crc="20ae389a" sha1="5f99c7767cbbf5ad9164805214875d7054f49f14" />
 			</dataarea>
 		</part>
 	</software>
@@ -26298,8 +26298,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-eee-0.u1" size="262144" crc="927b57a1" sha1="279fb0223e362db553b739b1b8f9c18b81d92413" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-eee-0.u1" size="0x40000" crc="927b57a1" sha1="279fb0223e362db553b739b1b8f9c18b81d92413" />
 			</dataarea>
 		</part>
 	</software>
@@ -26320,10 +26320,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" /> <!-- Also found with [6129A] -->
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-wja-0.u1" size="524288" crc="40be3889" sha1="ae65800302438e37a99e623a71d1c954d73c843e" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-wja-0.u1" size="0x80000" crc="40be3889" sha1="ae65800302438e37a99e623a71d1c954d73c843e" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26342,10 +26342,10 @@ license:CC0
 			<feature name="u4" value="U4 [6129A]" />
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_mbc3" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmg-aw2p-0.u1" size="1048576" crc="9c54358d" sha1="c65820b2e52d00e6ce60e0a432fab002fec4386f" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="dmg-aw2p-0.u1" size="0x100000" crc="9c54358d" sha1="c65820b2e52d00e6ce60e0a432fab002fec4386f" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -26357,8 +26357,8 @@ license:CC0
 		<info name="serial" value="DMG-AWEP-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-awep-0.u1" size="262144" crc="4786fd6e" sha1="e669d47b124a1e12d73f4ac80d8b4c0f917cb058" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-awep-0.u1" size="0x40000" crc="4786fd6e" sha1="e669d47b124a1e12d73f4ac80d8b4c0f917cb058" />
 			</dataarea>
 		</part>
 	</software>
@@ -26370,10 +26370,10 @@ license:CC0
 		<info name="serial" value="DMG-WA-USA, DMG-WA-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="wave race (usa, europe).bin" size="131072" crc="a6595506" sha1="87ecdfe518f1707429fdbdc21d12bbfe1ff52252" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="wave race (usa, europe).bin" size="0x20000" crc="a6595506" sha1="87ecdfe518f1707429fdbdc21d12bbfe1ff52252" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26385,8 +26385,8 @@ license:CC0
 		<info name="serial" value="DMG-WN-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="wayne's world (usa).bin" size="262144" crc="829ea425" sha1="7165b8f31f1c5f783c8cad0399a3d71e87091ba2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="wayne's world (usa).bin" size="0x40000" crc="829ea425" sha1="7165b8f31f1c5f783c8cad0399a3d71e87091ba2" />
 			</dataarea>
 		</part>
 	</software>
@@ -26401,8 +26401,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-w8e-0.u1" size="131072" crc="974e712b" sha1="481750149a0c4812128f0607a6da338cfddf2cea" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-w8e-0.u1" size="0x20000" crc="974e712b" sha1="481750149a0c4812128f0607a6da338cfddf2cea" />
 			</dataarea>
 		</part>
 	</software>
@@ -26417,8 +26417,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-a6e-0.u1" size="131072" crc="c811560b" sha1="ef58224f406cdf66bbe3797e2ef82a453fb1c18c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-a6e-0.u1" size="0x20000" crc="c811560b" sha1="ef58224f406cdf66bbe3797e2ef82a453fb1c18c" />
 			</dataarea>
 		</part>
 	</software>
@@ -26433,8 +26433,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="wedding peach - jamapii panic (japan).bin" size="262144" crc="9812a6c6" sha1="b10bea6e0e57a19cde7f02c7e97227e002cfc6b3" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="wedding peach - jamapii panic (japan).bin" size="0x40000" crc="9812a6c6" sha1="b10bea6e0e57a19cde7f02c7e97227e002cfc6b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -26448,8 +26448,8 @@ license:CC0
 		<info name="alt_title" value="ウェルカム なかよしパーク" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="welcome nakayoshi park (japan).bin" size="262144" crc="f6e2baae" sha1="8779a1557ba0de3c5c8b770413f30bd31717b2ef" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="welcome nakayoshi park (japan).bin" size="0x40000" crc="f6e2baae" sha1="8779a1557ba0de3c5c8b770413f30bd31717b2ef" />
 			</dataarea>
 		</part>
 	</software>
@@ -26461,8 +26461,8 @@ license:CC0
 		<info name="serial" value="DMG-WF-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="wheel of fortune (usa).bin" size="131072" crc="8408fe48" sha1="43de94eda492bfabbdc6e232af9cbd9df080dfd5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="wheel of fortune (usa).bin" size="0x20000" crc="8408fe48" sha1="43de94eda492bfabbdc6e232af9cbd9df080dfd5" />
 			</dataarea>
 		</part>
 	</software>
@@ -26477,8 +26477,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-rrx-0.u1" size="131072" crc="dbeed84e" sha1="4d59882150fc28733902e5e6de8f19a751bd7913" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-rrx-0.u1" size="0x20000" crc="dbeed84e" sha1="4d59882150fc28733902e5e6de8f19a751bd7913" />
 			</dataarea>
 		</part>
 	</software>
@@ -26490,8 +26490,8 @@ license:CC0
 		<info name="serial" value="DMG-RR-ESP" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="who framed roger rabbit.bin" size="131072" crc="cd11c917" sha1="d92515a09d78099238565bb0f1873f57f00b6728" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="who framed roger rabbit.bin" size="0x20000" crc="cd11c917" sha1="d92515a09d78099238565bb0f1873f57f00b6728" />
 			</dataarea>
 		</part>
 	</software>
@@ -26503,8 +26503,8 @@ license:CC0
 		<info name="serial" value="DMG-RR-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="who framed roger rabbit (usa).bin" size="131072" crc="b93138fa" sha1="7e52d507b96fb06c46ef2c885fe58238a3bcf4a8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="who framed roger rabbit (usa).bin" size="0x20000" crc="b93138fa" sha1="7e52d507b96fb06c46ef2c885fe58238a3bcf4a8" />
 			</dataarea>
 		</part>
 	</software>
@@ -26517,8 +26517,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="wild snake (usa).bin" size="65536" crc="72462125" sha1="0ea5c37262ba60ef97dd14f8f673f951534ccd38" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="wild snake (usa).bin" size="0x10000" crc="72462125" sha1="0ea5c37262ba60ef97dd14f8f673f951534ccd38" />
 			</dataarea>
 		</part>
 	</software>
@@ -26532,10 +26532,10 @@ license:CC0
 		<info name="alt_title" value="ウイナーズホース" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="winner's horse (japan).bin" size="131072" crc="14e91757" sha1="4d3a56c78ede434c55994b0452b74358fadf78fe" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="winner's horse (japan).bin" size="0x20000" crc="14e91757" sha1="4d3a56c78ede434c55994b0452b74358fadf78fe" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26547,8 +26547,8 @@ license:CC0
 		<info name="serial" value="DMG-YC-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="winter gold (europe).bin" size="131072" crc="3c4cd245" sha1="6ab5c2ee2157e81b5584562a5e386fb7434b3f80" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="winter gold (europe).bin" size="0x20000" crc="3c4cd245" sha1="6ab5c2ee2157e81b5584562a5e386fb7434b3f80" />
 			</dataarea>
 		</part>
 	</software>
@@ -26562,10 +26562,10 @@ license:CC0
 		<info name="alt_title" value="ウィザードリィ・外伝I 女王の受難" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="wizardry gaiden 1 - joou no junan (japan).bin" size="262144" crc="4d640e73" sha1="e3d03144e4c15522a1469a87eb07130c1884e225" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="wizardry gaiden 1 - joou no junan (japan).bin" size="0x40000" crc="4d640e73" sha1="e3d03144e4c15522a1469a87eb07130c1884e225" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26579,10 +26579,10 @@ license:CC0
 		<info name="alt_title" value="ウィザードリィ・外伝II 古代皇帝の呪い" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="wizardry gaiden 2 - kodai koutei no noroi (japan).bin" size="262144" crc="f6826d12" sha1="8dc0ab82462d4ab287d8155e8eab7e796eb7c766" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="wizardry gaiden 2 - kodai koutei no noroi (japan).bin" size="0x40000" crc="f6826d12" sha1="8dc0ab82462d4ab287d8155e8eab7e796eb7c766" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26602,10 +26602,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [6129]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-w6j-0.u1" size="524288" crc="32c94538" sha1="e169014cf1f12b956f8dff040ddb063ea4f7cab9" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-w6j-0.u1" size="0x80000" crc="32c94538" sha1="e169014cf1f12b956f8dff040ddb063ea4f7cab9" />
 			</dataarea>
-			<dataarea name="nvram" size="32768">
+			<dataarea name="nvram" size="0x8000">
 			</dataarea>
 		</part>
 	</software>
@@ -26621,8 +26621,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-wwe-0.u1" size="65536" crc="104eb503" sha1="22a514056e58263dc08602778bc3bf2c0ca6e681" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-wwe-0.u1" size="0x10000" crc="104eb503" sha1="22a514056e58263dc08602778bc3bf2c0ca6e681" />
 			</dataarea>
 		</part>
 	</software>
@@ -26634,8 +26634,8 @@ license:CC0
 		<info name="serial" value="DMG-WT-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="wordtris (usa).bin" size="131072" crc="075a8231" sha1="ab68498646fb2ca1df9443e6a80062c30b3ea4f9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="wordtris (usa).bin" size="0x20000" crc="075a8231" sha1="ab68498646fb2ca1df9443e6a80062c30b3ea4f9" />
 			</dataarea>
 		</part>
 	</software>
@@ -26649,8 +26649,8 @@ license:CC0
 			<feature name="u1" value="U1" />
 			<feature name="u2" value="U2 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="wordtris v6.bin" size="131072" crc="c2d7d11b" sha1="97544a78925f6bb095c7b2f14878b2e1467dc7d1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="wordtris v6.bin" size="0x20000" crc="c2d7d11b" sha1="97544a78925f6bb095c7b2f14878b2e1467dc7d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -26662,8 +26662,8 @@ license:CC0
 		<info name="serial" value="DMG-WZ-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="wordzap (usa).bin" size="65536" crc="e8e57b50" sha1="3b38771e97eb6cd5e053ac8908482f59dc07248b" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="wordzap (usa).bin" size="0x10000" crc="e8e57b50" sha1="3b38771e97eb6cd5e053ac8908482f59dc07248b" />
 			</dataarea>
 		</part>
 	</software>
@@ -26677,8 +26677,8 @@ license:CC0
 		<info name="alt_title" value="ワールドビーチバレー 1991GBカップ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="world beach volley - 1991 gb cup (japan).bin" size="131072" crc="a2894581" sha1="8ffb79814859a705070a6612313e853dd452a9ff" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="world beach volley - 1991 gb cup (japan).bin" size="0x20000" crc="a2894581" sha1="8ffb79814859a705070a6612313e853dd452a9ff" />
 			</dataarea>
 		</part>
 	</software>
@@ -26693,8 +26693,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-wve-0.u1" size="131072" crc="4023e085" sha1="0d98dd2a489d0c26f153203e14d5997eb2365847" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-wve-0.u1" size="0x20000" crc="4023e085" sha1="0d98dd2a489d0c26f153203e14d5997eb2365847" />
 			</dataarea>
 		</part>
 	</software>
@@ -26705,8 +26705,8 @@ license:CC0
 		<publisher>Taito</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="world beach volley - 1992 gb cup (prototype).bin" size="131072" crc="d654cbcd" sha1="011555cecb84616eb32f25c7db203bb82874292a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="world beach volley - 1992 gb cup (prototype).bin" size="0x20000" crc="d654cbcd" sha1="011555cecb84616eb32f25c7db203bb82874292a" />
 			</dataarea>
 		</part>
 	</software>
@@ -26719,8 +26719,8 @@ license:CC0
 		<info name="release" value="19900113" />
 		<info name="alt_title" value="ワールドボウリング" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="world bowling (japan).bin" size="32768" crc="47feadf2" sha1="c99595de26e63e65d61446dc0338256b9831601a" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="world bowling (japan).bin" size="0x8000" crc="47feadf2" sha1="c99595de26e63e65d61446dc0338256b9831601a" />
 			</dataarea>
 		</part>
 	</software>
@@ -26731,8 +26731,8 @@ license:CC0
 		<publisher>Romstar</publisher>
 		<info name="serial" value="DMG-WB-USA" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="world bowling (usa).bin" size="32768" crc="896e76a2" sha1="f579890b04b33965c009dd3b7300623691ae206a" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="world bowling (usa).bin" size="0x8000" crc="896e76a2" sha1="f579890b04b33965c009dd3b7300623691ae206a" />
 			</dataarea>
 		</part>
 	</software>
@@ -26744,8 +26744,8 @@ license:CC0
 		<info name="serial" value="DMG-FZ-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="world circuit series (usa).bin" size="131072" crc="77c3aa0b" sha1="9aa2b4330a2b8ffd117a871660f2526c4b2b4753" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="world circuit series (usa).bin" size="0x20000" crc="77c3aa0b" sha1="9aa2b4330a2b8ffd117a871660f2526c4b2b4753" />
 			</dataarea>
 		</part>
 	</software>
@@ -26761,8 +26761,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmg-a8wp-0.u1" size="524288" crc="6a3272b1" sha1="f71a802596d2a56ee3e708ecac90735d42757e5b" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="dmg-a8wp-0.u1" size="0x80000" crc="6a3272b1" sha1="f71a802596d2a56ee3e708ecac90735d42757e5b" />
 			</dataarea>
 		</part>
 	</software>
@@ -26776,8 +26776,8 @@ license:CC0
 		<info name="alt_title" value="ワールドカップストライカー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="world cup striker (japan).bin" size="131072" crc="fdefa88d" sha1="9cf86669d784a724eeb3409df732ce84afd38942" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="world cup striker (japan).bin" size="0x20000" crc="fdefa88d" sha1="9cf86669d784a724eeb3409df732ce84afd38942" />
 			</dataarea>
 		</part>
 	</software>
@@ -26789,10 +26789,10 @@ license:CC0
 		<info name="serial" value="DMG-W9-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="world cup usa '94 (europe) (en,fr,de,es,it,nl,pt,sv).bin" size="262144" crc="60231f83" sha1="1bd9910825a1ba3a9a9ad9084c8be0af04f2545f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="world cup usa '94 (europe) (en,fr,de,es,it,nl,pt,sv).bin" size="0x40000" crc="60231f83" sha1="1bd9910825a1ba3a9a9ad9084c8be0af04f2545f" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26807,10 +26807,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="world cup usa '94 (japan) (en,fr,de,es,it,nl,pt,sv).bin" size="262144" crc="9d27f9de" sha1="6f9fb96a4551b4c5b3c6d8928b9a561d1cc28acd" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="world cup usa '94 (japan) (en,fr,de,es,it,nl,pt,sv).bin" size="0x40000" crc="9d27f9de" sha1="6f9fb96a4551b4c5b3c6d8928b9a561d1cc28acd" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26823,8 +26823,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="world heroes 2 jet (usa, europe).bin" size="524288" crc="67303954" sha1="3c5f213104e1bf968a01e0cffbe7b5b5120e0458" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="world heroes 2 jet (usa, europe).bin" size="0x80000" crc="67303954" sha1="3c5f213104e1bf968a01e0cffbe7b5b5120e0458" />
 			</dataarea>
 		</part>
 	</software>
@@ -26838,8 +26838,8 @@ license:CC0
 		<info name="alt_title" value="ワールド・アイスホッケー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="world ice hockey (japan).bin" size="131072" crc="4e345023" sha1="a4ed60dd7354de12c4af04f874ac1fd648f6684b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="world ice hockey (japan).bin" size="0x20000" crc="4e345023" sha1="a4ed60dd7354de12c4af04f874ac1fd648f6684b" />
 			</dataarea>
 		</part>
 	</software>
@@ -26854,10 +26854,10 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="world soccer gb (japan).bin" size="524288" crc="57d21ef4" sha1="aca208dabd8d110cf0334103dcb8dd28b68e450d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="world soccer gb (japan).bin" size="0x80000" crc="57d21ef4" sha1="aca208dabd8d110cf0334103dcb8dd28b68e450d" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -26869,8 +26869,8 @@ license:CC0
 		<info name="serial" value="DMG-AW3P-UKV" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-aw3p-0.u1" size="262144" crc="2ebc40c2" sha1="26137ca97b840c63a462bcf85677a5f3db67fadf" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-aw3p-0.u1" size="0x40000" crc="2ebc40c2" sha1="26137ca97b840c63a462bcf85677a5f3db67fadf" />
 			</dataarea>
 		</part>
 	</software>
@@ -26884,8 +26884,8 @@ license:CC0
 		<info name="alt_title" value="WWF キングオブリング" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="wwf king of the ring (japan).bin" size="131072" crc="3ab55613" sha1="3751261d8113c7b937f9e077803af514f443afbc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="wwf king of the ring (japan).bin" size="0x20000" crc="3ab55613" sha1="3751261d8113c7b937f9e077803af514f443afbc" />
 			</dataarea>
 		</part>
 	</software>
@@ -26900,8 +26900,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-wpe-0.u1" size="131072" crc="7f0cd87c" sha1="fd17015d8f85f407427c8aa3e68fb0a32dc072a8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-wpe-0.u1" size="0x20000" crc="7f0cd87c" sha1="fd17015d8f85f407427c8aa3e68fb0a32dc072a8" />
 			</dataarea>
 		</part>
 	</software>
@@ -26916,8 +26916,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-awfp-0.u1" size="262144" crc="1889552f" sha1="03eb3a9a2af1e24e7de9de21a13dc677f46b06ce" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-awfp-0.u1" size="0x40000" crc="1889552f" sha1="03eb3a9a2af1e24e7de9de21a13dc677f46b06ce" />
 			</dataarea>
 		</part>
 	</software>
@@ -26931,8 +26931,8 @@ license:CC0
 		<info name="alt_title" value="WWFスーパースターズ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="wwf superstars (japan).bin" size="131072" crc="f28e5aa1" sha1="f3101bb0f1fe3f9160e7892dfd70582325e1c44f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="wwf superstars (japan).bin" size="0x20000" crc="f28e5aa1" sha1="f3101bb0f1fe3f9160e7892dfd70582325e1c44f" />
 			</dataarea>
 		</part>
 	</software>
@@ -26947,8 +26947,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-lwe-0.u1" size="131072" crc="adbc4e0a" sha1="957a7d33a1569158f7b1882362262a6ab391ff5b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-lwe-0.u1" size="0x20000" crc="adbc4e0a" sha1="957a7d33a1569158f7b1882362262a6ab391ff5b" />
 			</dataarea>
 		</part>
 	</software>
@@ -26962,8 +26962,8 @@ license:CC0
 		<info name="alt_title" value="WWFスーパースターズ2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="wwf superstars 2 (japan).bin" size="131072" crc="ca12d752" sha1="9b0daa79a455b46f13a7866b575cb229ec9dadf8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="wwf superstars 2 (japan).bin" size="0x20000" crc="ca12d752" sha1="9b0daa79a455b46f13a7866b575cb229ec9dadf8" />
 			</dataarea>
 		</part>
 	</software>
@@ -26978,8 +26978,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-wxe-0.u1" size="131072" crc="8ece1c04" sha1="f5f2a16a9ea5694e3198cb6a9a16bcbca75be12f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-wxe-0.u1" size="0x20000" crc="8ece1c04" sha1="f5f2a16a9ea5694e3198cb6a9a16bcbca75be12f" />
 			</dataarea>
 		</part>
 	</software>
@@ -26992,8 +26992,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="wwf war zone (usa, europe).bin" size="262144" crc="6015b7e1" sha1="6ef34105a8944e5aa8e44f3aebb68b9bb45e9105" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="wwf war zone (usa, europe).bin" size="0x40000" crc="6015b7e1" sha1="6ef34105a8944e5aa8e44f3aebb68b9bb45e9105" />
 			</dataarea>
 		</part>
 	</software>
@@ -27012,10 +27012,10 @@ license:CC0
 			<feature name="u3" value="U3 26A" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ecj-0.u1" size="262144" crc="75e1d268" sha1="c72f0b494ceba72db244266cb29e4d2b4d514263" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ecj-0.u1" size="0x40000" crc="75e1d268" sha1="c72f0b494ceba72db244266cb29e4d2b4d514263" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27027,10 +27027,11 @@ license:CC0
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="245760">
-				<rom name="x (usa) (proto).bin" size="245760" crc="cd555712" sha1="b1c5b60b82aaa0b824f7bf67fc8f111377ccfb6a" />
+			<!-- ROM released by drx but it seems to be missing the last 16K. Underdumped? Or was this trimmed? -->
+			<dataarea name="rom" size="0x3c000">
+				<rom name="x (usa) (proto).bin" size="0x3c000" crc="cd555712" sha1="b1c5b60b82aaa0b824f7bf67fc8f111377ccfb6a" status="baddump" />
 			</dataarea>
-			<dataarea name="nvram" size="8192"> <!-- unconfirmed size -->
+			<dataarea name="nvram" size="0x2000"> <!-- unconfirmed size -->
 			</dataarea>
 		</part>
 	</software>
@@ -27044,8 +27045,8 @@ license:CC0
 		<info name="alt_title" value="ゼノン2 メガブラスト" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="xenon 2 - megablast (japan).bin" size="131072" crc="2feb70d2" sha1="6b2f009b7a443e5ead48a2864bfb1d29096ed6a0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="xenon 2 - megablast (japan).bin" size="0x20000" crc="2feb70d2" sha1="6b2f009b7a443e5ead48a2864bfb1d29096ed6a0" />
 			</dataarea>
 		</part>
 	</software>
@@ -27060,8 +27061,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-x2e-0.u1" size="131072" crc="de398678" sha1="00d76805e1ef3fe0eb5e8fc045cc22decfbe216b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-x2e-0.u1" size="0x20000" crc="de398678" sha1="00d76805e1ef3fe0eb5e8fc045cc22decfbe216b" />
 			</dataarea>
 		</part>
 	</software>
@@ -27073,8 +27074,8 @@ license:CC0
 		<info name="serial" value="DMG-YC-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="xvii olympic winter games, the - lillehammer 1994 (usa).bin" size="131072" crc="1a98f0a4" sha1="95d664a8a0b74d6993501847d4ce065913bd1e08" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="xvii olympic winter games, the - lillehammer 1994 (usa).bin" size="0x20000" crc="1a98f0a4" sha1="95d664a8a0b74d6993501847d4ce065913bd1e08" />
 			</dataarea>
 		</part>
 	</software>
@@ -27090,8 +27091,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
-			<dataarea name="rom" size="32768">
-				<rom name="dmg-mjj-1.u1" size="32768" crc="90cb60c1" sha1="a4db4509382d8a65e8ba4b799add6f98dbd9bc01" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dmg-mjj-1.u1" size="0x8000" crc="90cb60c1" sha1="a4db4509382d8a65e8ba4b799add6f98dbd9bc01" />
 			</dataarea>
 		</part>
 	</software>
@@ -27105,8 +27106,8 @@ license:CC0
 		<info name="release" value="19890421" />
 		<info name="alt_title" value="役満" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="yakuman (japan).bin" size="32768" crc="3134ea60" sha1="3fdb9ea690c0f035dd0dcc98b1dcc83ac5154e17" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="yakuman (japan).bin" size="0x8000" crc="3134ea60" sha1="3fdb9ea690c0f035dd0dcc98b1dcc83ac5154e17" />
 			</dataarea>
 		</part>
 	</software>
@@ -27121,8 +27122,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1-B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-aynp-0.u1" size="65536" crc="402d4d47" sha1="5bc39c44da587a89bef7478617c402855a1b5b24" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-aynp-0.u1" size="0x10000" crc="402d4d47" sha1="5bc39c44da587a89bef7478617c402855a1b5b24" />
 			</dataarea>
 		</part>
 	</software>
@@ -27137,8 +27138,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-ygx-0.u1" size="131072" crc="6e7bb436" sha1="4e9452feaffa508cf40cd89fbc28f215060d28e5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-ygx-0.u1" size="0x20000" crc="6e7bb436" sha1="4e9452feaffa508cf40cd89fbc28f215060d28e5" />
 			</dataarea>
 		</part>
 	</software>
@@ -27150,8 +27151,8 @@ license:CC0
 		<info name="serial" value="DMG-YG-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="yogi bear in yogi bear's goldrush (usa).bin" size="131072" crc="a86bd81b" sha1="d701b98b34c61ea230df1ca9561e1c9474928ebf" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="yogi bear in yogi bear's goldrush (usa).bin" size="0x20000" crc="a86bd81b" sha1="d701b98b34c61ea230df1ca9561e1c9474928ebf" />
 			</dataarea>
 		</part>
 	</software>
@@ -27165,8 +27166,8 @@ license:CC0
 		<info name="alt_title" value="読本 夢五誉身 天神怪戦2" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="yomihon yumegoyomi - tenjin kaisen 2 (japan).bin" size="262144" crc="211c4611" sha1="781bb266b4c9aa59a2db4c278d2d2fe41a60ebb2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="yomihon yumegoyomi - tenjin kaisen 2 (japan).bin" size="0x40000" crc="211c4611" sha1="781bb266b4c9aa59a2db4c278d2d2fe41a60ebb2" />
 			</dataarea>
 		</part>
 	</software>
@@ -27178,8 +27179,8 @@ license:CC0
 		<info name="serial" value="DMG-YO-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="yoshi (usa).bin" size="65536" crc="f2f4bcca" sha1="1b6e41c2270ce67e6fe15cc4977ef2debdd6e6ce" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="yoshi (usa).bin" size="0x10000" crc="f2f4bcca" sha1="1b6e41c2270ce67e6fe15cc4977ef2debdd6e6ce" />
 			</dataarea>
 		</part>
 	</software>
@@ -27194,8 +27195,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1-B]" /> <!-- Also found with [DMG MBC1B1] -->
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-cie-0.u1" size="131072" crc="75336712" sha1="233dcc94d86951ddf167aaa82ec9b94b87b29e2d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dmg-cie-0.u1" size="0x20000" crc="75336712" sha1="233dcc94d86951ddf167aaa82ec9b94b87b29e2d" />
 			</dataarea>
 		</part>
 	</software>
@@ -27210,8 +27211,8 @@ license:CC0
 		<info name="alt_title" value="ヨッシーのクッキー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="yossy no cookie (japan).bin" size="131072" crc="a37255fe" sha1="3b19c51b4e7e7275265b90e991faf6cf64a8085a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="yossy no cookie (japan).bin" size="0x20000" crc="a37255fe" sha1="3b19c51b4e7e7275265b90e991faf6cf64a8085a" />
 			</dataarea>
 		</part>
 	</software>
@@ -27227,8 +27228,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="yossy no panepon (japan).bin" size="524288" crc="3beb7239" sha1="c54d0a33a562c93b9e1243fd9c615b5f92671e58" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="yossy no panepon (japan).bin" size="0x80000" crc="3beb7239" sha1="c54d0a33a562c93b9e1243fd9c615b5f92671e58" />
 			</dataarea>
 		</part>
 	</software>
@@ -27245,8 +27246,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="dmg-yoj-0.u1" size="65536" crc="9b6fcc76" sha1="5cb61dee0eb3f9d35775a607803d06c8cebcb842" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dmg-yoj-0.u1" size="0x10000" crc="9b6fcc76" sha1="5cb61dee0eb3f9d35775a607803d06c8cebcb842" />
 			</dataarea>
 		</part>
 	</software>
@@ -27267,10 +27268,10 @@ license:CC0
 			<feature name="u4" value="U4 26A [26A]" />
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="1048576">
-				<rom name="yu-gi-oh duel monsters (japan).bin" size="1048576" crc="8875ec54" sha1="07ae4a6437f00f6af462bf84fd0ac1cf345c8365" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="yu-gi-oh duel monsters (japan).bin" size="0x100000" crc="8875ec54" sha1="07ae4a6437f00f6af462bf84fd0ac1cf345c8365" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27284,8 +27285,8 @@ license:CC0
 		<info name="alt_title" value="幽☆遊☆白書" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="yuu yuu hakusho (japan).bin" size="262144" crc="7103b4ac" sha1="e4bcd2875aecd45095ce47aae90bd87f7558bc0f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="yuu yuu hakusho (japan).bin" size="0x40000" crc="7103b4ac" sha1="e4bcd2875aecd45095ce47aae90bd87f7558bc0f" />
 			</dataarea>
 		</part>
 	</software>
@@ -27299,8 +27300,8 @@ license:CC0
 		<info name="alt_title" value="幽☆遊☆白書 第2弾 暗黒武術会編" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="yuu yuu hakusho dai-2-dan - ankoku bujutsu kai (japan).bin" size="262144" crc="6a6d7350" sha1="3b28391763e43676389a97620e52908d02510e44" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="yuu yuu hakusho dai-2-dan - ankoku bujutsu kai (japan).bin" size="0x40000" crc="6a6d7350" sha1="3b28391763e43676389a97620e52908d02510e44" />
 			</dataarea>
 		</part>
 	</software>
@@ -27317,8 +27318,8 @@ license:CC0
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1A/1B" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmg-ugj-0.u1" size="262144" crc="25c618f6" sha1="ffaff18cc2028ca7f823ed1c2a025ed5a61d1b9d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dmg-ugj-0.u1" size="0x40000" crc="25c618f6" sha1="ffaff18cc2028ca7f823ed1c2a025ed5a61d1b9d" />
 			</dataarea>
 		</part>
 	</software>
@@ -27333,8 +27334,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="yuu yuu hakusho dai-4-dan - makai touitsu (japan).bin" size="262144" crc="3e7c6b2b" sha1="14a8e39f1adfa6acce11f902eb6763c73ababa47" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="yuu yuu hakusho dai-4-dan - makai touitsu (japan).bin" size="0x40000" crc="3e7c6b2b" sha1="14a8e39f1adfa6acce11f902eb6763c73ababa47" />
 			</dataarea>
 		</part>
 	</software>
@@ -27348,8 +27349,8 @@ license:CC0
 		<info name="alt_title" value="地球解放軍ジアース ~ Chikyuu Kaihou Gun ZAS (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="zas (japan).bin" size="131072" crc="7bfd1cff" sha1="2ff6d0242d845669445e3d97fffae5c5f7943cfd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="zas (japan).bin" size="0x20000" crc="7bfd1cff" sha1="2ff6d0242d845669445e3d97fffae5c5f7943cfd" />
 			</dataarea>
 		</part>
 	</software>
@@ -27362,10 +27363,10 @@ license:CC0
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="zelda no densetsu - yume o miru shima (japan) (rev 1).bin" size="524288" crc="ea20b82a" sha1="80f5d111c7e2d79d39f6c25a37b54c3196d2bd12" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="zelda no densetsu - yume o miru shima (japan) (rev 1).bin" size="0x80000" crc="ea20b82a" sha1="80f5d111c7e2d79d39f6c25a37b54c3196d2bd12" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27379,10 +27380,10 @@ license:CC0
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="zelda no densetsu - yume o miru shima (japan).bin" size="524288" crc="39a6684e" sha1="fa38601c371ca327166bf52be1094697d41a80f3" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="zelda no densetsu - yume o miru shima (japan).bin" size="0x80000" crc="39a6684e" sha1="fa38601c371ca327166bf52be1094697d41a80f3" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27394,8 +27395,8 @@ license:CC0
 		<info name="serial" value="DMG-ZN-NOE" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="zen - intergalactic ninja (europe).bin" size="131072" crc="642c7ebe" sha1="0e753ed48e28a0e6a820ac9b8403c50c004f22e2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="zen - intergalactic ninja (europe).bin" size="0x20000" crc="642c7ebe" sha1="0e753ed48e28a0e6a820ac9b8403c50c004f22e2" />
 			</dataarea>
 		</part>
 	</software>
@@ -27407,8 +27408,8 @@ license:CC0
 		<info name="serial" value="DMG-ZN-USA" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="zen - intergalactic ninja (usa).bin" size="131072" crc="88190730" sha1="47bbc472071770783b3d930141390f48741176af" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="zen - intergalactic ninja (usa).bin" size="0x20000" crc="88190730" sha1="47bbc472071770783b3d930141390f48741176af" />
 			</dataarea>
 		</part>
 	</software>
@@ -27423,8 +27424,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="zen-nihon pro wrestling jet (japan).bin" size="262144" crc="119bcad5" sha1="60d3b8618bb80c61ca29bccc7c1af9244a6c1764" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="zen-nihon pro wrestling jet (japan).bin" size="0x40000" crc="119bcad5" sha1="60d3b8618bb80c61ca29bccc7c1af9244a6c1764" />
 			</dataarea>
 		</part>
 	</software>
@@ -27438,10 +27439,10 @@ license:CC0
 		<info name="alt_title" value="ザードの伝説" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="zerd no densetsu (japan).bin" size="131072" crc="492edb36" sha1="8db8ad90505d9a2b4485e903b9f5d67bb9c0c149" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="zerd no densetsu (japan).bin" size="0x20000" crc="492edb36" sha1="8db8ad90505d9a2b4485e903b9f5d67bb9c0c149" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27455,10 +27456,10 @@ license:CC0
 		<info name="alt_title" value="ザードの伝説II 偽神の領域" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="zerd no densetsu 2 - xerd gishin no ryouiki (japan).bin" size="524288" crc="a197bdb7" sha1="cfa91da4120c6e1ee0f1f121d944d44532506cfa" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="zerd no densetsu 2 - xerd gishin no ryouiki (japan).bin" size="0x80000" crc="a197bdb7" sha1="cfa91da4120c6e1ee0f1f121d944d44532506cfa" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27472,8 +27473,8 @@ license:CC0
 		<info name="alt_title" value="絶対無敵ライジンオー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="zettai muteki raijinou (japan).bin" size="65536" crc="7d03727d" sha1="6269ca535eea41f4bcfef99f512f435daf06c6e3" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="zettai muteki raijinou (japan).bin" size="0x10000" crc="7d03727d" sha1="6269ca535eea41f4bcfef99f512f435daf06c6e3" />
 			</dataarea>
 		</part>
 	</software>
@@ -27487,8 +27488,8 @@ license:CC0
 		<info name="alt_title" value="メカ生体ゾイド ゾイド伝説" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="zoids densetsu (japan).bin" size="65536" crc="c32dca06" sha1="5d6016b605ea22901150bc5735bc13ba64aaf3c6" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="zoids densetsu (japan).bin" size="0x10000" crc="c32dca06" sha1="5d6016b605ea22901150bc5735bc13ba64aaf3c6" />
 			</dataarea>
 		</part>
 	</software>
@@ -27501,8 +27502,8 @@ license:CC0
 		<info name="alt_title" value="Zool - Ninja of the &quot;Nth&quot; Dimension (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="zool (europe).bin" size="131072" crc="ae13e227" sha1="6df1086910ae33d6a699df3ad428b901ab851bb4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="zool (europe).bin" size="0x20000" crc="ae13e227" sha1="6df1086910ae33d6a699df3ad428b901ab851bb4" />
 			</dataarea>
 		</part>
 	</software>
@@ -27515,8 +27516,8 @@ license:CC0
 		<info name="alt_title" value="Zool - Ninja of the &quot;Nth&quot; Dimension (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="zool (usa).bin" size="131072" crc="ef54b46e" sha1="5c1b1af8e70cd23f5f72848d03fcc56869d18be7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="zool (usa).bin" size="0x20000" crc="ef54b46e" sha1="5c1b1af8e70cd23f5f72848d03fcc56869d18be7" />
 			</dataarea>
 		</part>
 	</software>
@@ -27528,8 +27529,8 @@ license:CC0
 		<info name="serial" value="DMG-AZPE-USA, DMG-AZPP-EUR" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="zoop (usa, europe).bin" size="65536" crc="14f8b6bb" sha1="1e0390d456066b9fbe1faff5f7404d4593a2b839" offset="000000" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="zoop (usa, europe).bin" size="0x10000" crc="14f8b6bb" sha1="1e0390d456066b9fbe1faff5f7404d4593a2b839" />
 			</dataarea>
 		</part>
 	</software>
@@ -27544,8 +27545,8 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="zoop (japan).bin" size="65536" crc="10e1a10c" sha1="89a74970761700d591c2affc47c9306f49d22ba8" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="zoop (japan).bin" size="0x10000" crc="10e1a10c" sha1="89a74970761700d591c2affc47c9306f49d22ba8" />
 			</dataarea>
 		</part>
 	</software>
@@ -27559,8 +27560,8 @@ license:CC0
 			<feature name="u1" value="U1" />
 			<feature name="u2" value="U2 [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="zoop.u1" size="65536" crc="7b440074" sha1="97a6ea993bf5b64e38e3bc0adaf5965b442c9cee" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="zoop.u1" size="0x10000" crc="7b440074" sha1="97a6ea993bf5b64e38e3bc0adaf5965b442c9cee" />
 			</dataarea>
 		</part>
 	</software>
@@ -27581,8 +27582,8 @@ license:CC0
 			<!-- SA-111 version only have one epoxy blob combining ROM and Sachen MMC1. -->
 			<!-- SA-1005A version has an epoxy blob Sachen MMC1 and a DIP mask ROM. -->
 			<feature name="slot" value="rom_sachen1" />
-			<dataarea name="rom" size="262144">
-				<rom name="vol.7.u1" size="262144" crc="82f06e93" sha1="7506c75fdfa29935afb1e85f5b6013516b2e9f92" /> <!-- real label: VOL.7 -->
+			<dataarea name="rom" size="0x40000">
+				<rom name="vol.7.u1" size="0x40000" crc="82f06e93" sha1="7506c75fdfa29935afb1e85f5b6013516b2e9f92" /> <!-- real label: VOL.7 -->
 			</dataarea>
 		</part>
 	</software>
@@ -27597,8 +27598,8 @@ license:CC0
 			<!-- 1231 version has an MX27C512PC-70 PROM and an epoxy blob Sachen MMC1. -->
 			<!-- TG-001 version has an epoxy blob ROM and an epoxy blob Sachen MMC1. -->
 			<feature name="slot" value="rom_sachen1" />
-			<dataarea name="rom" size="65536">
-				<rom name="mx27c512pc-70.u1" size="65536" crc="5e438db8" sha1="d9cb1721854709be7667f5dbce0adf2488c0919b" /> <!-- real label: MX27C512PC-70 -->
+			<dataarea name="rom" size="0x10000">
+				<rom name="mx27c512pc-70.u1" size="0x10000" crc="5e438db8" sha1="d9cb1721854709be7667f5dbce0adf2488c0919b" /> <!-- real label: MX27C512PC-70 -->
 			</dataarea>
 		</part>
 	</software>
@@ -27612,8 +27613,8 @@ license:CC0
 			<feature name="pcb" value="No:7203" />
 			<!-- No:7203 version has an epoxy blob Sachen MMC1 and a DIP mask ROM. -->
 			<feature name="slot" value="rom_sachen1" />
-			<dataarea name="rom" size="65536">
-				<rom name="4b-003.bin" size="65536" crc="c294aa21" sha1="b5a3ee09692476d801d873a703d508d17ee24fbd" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="4b-003.bin" size="0x10000" crc="c294aa21" sha1="b5a3ee09692476d801d873a703d508d17ee24fbd" />
 			</dataarea>
 		</part>
 	</software>
@@ -27628,9 +27629,9 @@ license:CC0
 			<!-- SA-1005 version has an epoxy blob Sachen MMC1 and a DIP mask ROM. -->
 			<!-- TG-002 version has an epoxy blob ROM and an epoxy blob Sachen MMC1. -->
 			<feature name="slot" value="rom_sachen1" />
-			<dataarea name="rom" size="262144">
+			<dataarea name="rom" size="0x40000">
 				<!-- alternative label: VOL9 -->
-				<rom name="vol.9.u1" size="262144" crc="c69a19f6" sha1="ca7990dc03a3b3ada1dce37afc4490deaf872402" /> <!-- real label: VOL.9 -->
+				<rom name="vol.9.u1" size="0x40000" crc="c69a19f6" sha1="ca7990dc03a3b3ada1dce37afc4490deaf872402" /> <!-- real label: VOL.9 -->
 			</dataarea>
 		</part>
 	</software>
@@ -27647,8 +27648,8 @@ license:CC0
 			<!-- 1231 version has an epoxy blob Sachen MMC1 and a DIP mask ROM. -->
 			<!-- TG-002 version has an epoxy blob ROM and an epoxy blob Sachen MMC1. -->
 			<feature name="slot" value="rom_sachen1" />
-			<dataarea name="rom" size="262144">
-				<rom name="vol.8.u1" size="262144" crc="f4310eb3" sha1="2107979104cff88bcd635215a936bbc44354ea7c" /> <!-- real label: VOL.8 -->
+			<dataarea name="rom" size="0x40000">
+				<rom name="vol.8.u1" size="0x40000" crc="f4310eb3" sha1="2107979104cff88bcd635215a936bbc44354ea7c" /> <!-- real label: VOL.8 -->
 			</dataarea>
 		</part>
 	</software>
@@ -27662,8 +27663,8 @@ license:CC0
 			<feature name="pcb" value="TG-002" />
 			<!-- TG-002 version has an epoxy blob ROM and an epoxy blob Sachen MMC1. -->
 			<feature name="slot" value="rom_sachen1" />
-			<dataarea name="rom" size="262144">
-				<rom name="4b-006.bin" size="262144" crc="95398da5" sha1="2e856de768c7cb442a206de8c94a23548027bb60" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="4b-006.bin" size="0x40000" crc="95398da5" sha1="2e856de768c7cb442a206de8c94a23548027bb60" />
 			</dataarea>
 		</part>
 	</software>
@@ -27678,8 +27679,8 @@ license:CC0
 			<!-- SA-111 version only have one epoxy blob combining ROM and Sachen MMC1. -->
 			<!-- SA-1005 version has an epoxy blob Sachen MMC1 and a QFN ROM with DIP adapter. -->
 			<feature name="slot" value="rom_sachen1" />
-			<dataarea name="rom" size="262144">
-				<rom name="4b-007.bin" size="262144" crc="62d9350e" sha1="0eef7f3934508ab79e1cad4ddf3bfdb3216b6b4f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="4b-007.bin" size="0x40000" crc="62d9350e" sha1="0eef7f3934508ab79e1cad4ddf3bfdb3216b6b4f" />
 			</dataarea>
 		</part>
 	</software>
@@ -27695,8 +27696,8 @@ license:CC0
 			<!-- TG-002 version has an epoxy blob ROM and an epoxy blob Sachen MMC1. -->
 			<!-- SA-1005 version has an epoxy blob Sachen MMC1 and a QFN ROM with DIP adapter. -->
 			<feature name="slot" value="rom_sachen1" />
-			<dataarea name="rom" size="262144">
-				<rom name="4b-008.bin" size="262144" crc="740e9bc8" sha1="d7c11d56a42ed7c4ef2fe3c752931a63160d7429" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="4b-008.bin" size="0x40000" crc="740e9bc8" sha1="d7c11d56a42ed7c4ef2fe3c752931a63160d7429" />
 			</dataarea>
 		</part>
 	</software>
@@ -27710,8 +27711,8 @@ license:CC0
 			<feature name="pcb" value="TG-002" />
 			<!-- TG-002 version has an epoxy blob ROM and an epoxy blob Sachen MMC1. -->
 			<feature name="slot" value="rom_sachen1" />
-			<dataarea name="rom" size="262144">
-				<rom name="4b-009.bin" size="262144" crc="114e1f1e" sha1="39743e21935a9115fcb4ee86d67d51bdb4b5f6d6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="4b-009.bin" size="0x40000" crc="114e1f1e" sha1="39743e21935a9115fcb4ee86d67d51bdb4b5f6d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -27763,8 +27764,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<info name="serial" value="GS-01" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="gs-01.gb" size="131072" crc="c60456ee" sha1="c03131a77b80ef8bfca511b8c1e6262ffee20846" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="gs-01.gb" size="0x20000" crc="c60456ee" sha1="c03131a77b80ef8bfca511b8c1e6262ffee20846" />
 			</dataarea>
 		</part>
 	</software>
@@ -27776,8 +27777,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<info name="serial" value="GS-06" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="fire dragon (unl).bin" size="65536" crc="275947f5" sha1="a76c8c75fda78516d9b2960717ef6d4eda5efaef" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="fire dragon (unl).bin" size="0x10000" crc="275947f5" sha1="a76c8c75fda78516d9b2960717ef6d4eda5efaef" />
 			</dataarea>
 		</part>
 	</software>
@@ -27789,10 +27790,10 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<info name="serial" value="GS-04" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_lasama" />
-			<dataarea name="rom" size="131072">
-				<rom name="la sa ma chuan qi - story of lasama (unlicensed) [raw dump].bin" size="131072" crc="989a5fe0" sha1="00f139a63c0dd6cdaeac77c6747772ac394c0a79" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="la sa ma chuan qi - story of lasama (unlicensed) [raw dump].bin" size="0x20000" crc="989a5fe0" sha1="00f139a63c0dd6cdaeac77c6747772ac394c0a79" />
 			</dataarea>
-			<dataarea name="ram" size="8192">
+			<dataarea name="ram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27804,8 +27805,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<info name="serial" value="GS-02" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="magic ball (unl).bin" size="131072" crc="0af9089e" sha1="72a58a7af014c8853eba333fc7ce8bf424532d20" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="magic ball (unl).bin" size="0x20000" crc="0af9089e" sha1="72a58a7af014c8853eba333fc7ce8bf424532d20" />
 			</dataarea>
 		</part>
 	</software>
@@ -27816,8 +27817,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>GOWIN</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="65536">
-				<rom name="mi tu de lu (unl).bin" size="65536" crc="9039cbdb" sha1="20dba42f083ae1d7c9f384ac2b3130e0c0abc550" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="mi tu de lu (unl).bin" size="0x10000" crc="9039cbdb" sha1="20dba42f083ae1d7c9f384ac2b3130e0c0abc550" />
 			</dataarea>
 		</part>
 	</software>
@@ -27829,8 +27830,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<info name="serial" value="GS-03" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="prince yehrude (unl).bin" size="131072" crc="db8f4cf7" sha1="9afe8af53cac1d3520ff512d61c5e86ed700dc25" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="prince yehrude (unl).bin" size="0x20000" crc="db8f4cf7" sha1="9afe8af53cac1d3520ff512d61c5e86ed700dc25" />
 			</dataarea>
 		</part>
 	</software>
@@ -27842,8 +27843,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<info name="serial" value="GS-05" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="rainbow prince (unl).bin" size="131072" crc="10f447f0" sha1="2c82530e4c4a256d5c46f1dd34b7bd33d4c5b508" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rainbow prince (unl).bin" size="0x20000" crc="10f447f0" sha1="2c82530e4c4a256d5c46f1dd34b7bd33d4c5b508" />
 			</dataarea>
 		</part>
 	</software>
@@ -27854,10 +27855,10 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>GOWIN</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="tiger a dragon (unl).bin" size="2097152" crc="933513a6" sha1="d327c880e7ffb9db0422e09310031e58a32b8433" />
+			<dataarea name="rom" size="0x200000">
+				<rom name="tiger a dragon (unl).bin" size="0x200000" crc="933513a6" sha1="d327c880e7ffb9db0422e09310031e58a32b8433" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27871,8 +27872,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="super mario world 7 (unlicensed) (multicart rip).bin" size="262144" crc="aad1226e" sha1="0ee89297e9d24c1b4247765c8561a2cc90e383c9" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="super mario world 7 (unlicensed) (multicart rip).bin" size="0x40000" crc="aad1226e" sha1="0ee89297e9d24c1b4247765c8561a2cc90e383c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -27883,10 +27884,10 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_rock8" />
-			<dataarea name="rom" size="262144">
-				<rom name="rockman 8 (hong kong) [p1].bin" size="262144" crc="cc131a94" sha1="496575adfb1296f2f99c00e06e5ca5ee4daf1a12" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="rockman 8 (hong kong) [p1].bin" size="0x40000" crc="cc131a94" sha1="496575adfb1296f2f99c00e06e5ca5ee4daf1a12" />
 			</dataarea>
-			<dataarea name="ram" size="8192">
+			<dataarea name="ram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27897,8 +27898,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super mario land 4 (unl).bin" size="131072" crc="d9f3eb9f" sha1="f0da6eced7492bf51ae5575522cca58726c34feb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super mario land 4 (unl).bin" size="0x20000" crc="d9f3eb9f" sha1="f0da6eced7492bf51ae5575522cca58726c34feb" />
 			</dataarea>
 		</part>
 	</software>
@@ -27909,8 +27910,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_yong" />
-			<dataarea name="rom" size="262144">
-				<rom name="sonic 3d blast 5 (unl).bin" size="262144" crc="5fed0068" sha1="1eb403ee2550106cbb2e3e1d0715b7c9bc07d6be" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="sonic 3d blast 5 (unl).bin" size="0x40000" crc="5fed0068" sha1="1eb403ee2550106cbb2e3e1d0715b7c9bc07d6be" />
 			</dataarea>
 		</part>
 	</software>
@@ -27921,8 +27922,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="sonic 6 (unl).bin" size="524288" crc="aa4e9379" sha1="5f70ee1a1265536c6ed3657bfd5e54516add287d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="sonic 6 (unl).bin" size="0x80000" crc="aa4e9379" sha1="5f70ee1a1265536c6ed3657bfd5e54516add287d" />
 			</dataarea>
 		</part>
 	</software>
@@ -27933,10 +27934,10 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="final fantasy 4 (unl).bin" size="524288" crc="a6b6e233" sha1="0968289212c4ed0a4fb77d1b31e8eaf8663e6ed7" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="final fantasy 4 (unl).bin" size="0x80000" crc="a6b6e233" sha1="0968289212c4ed0a4fb77d1b31e8eaf8663e6ed7" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27947,10 +27948,10 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>SKOB</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="262144">
-				<rom name="meng huan zhi xing (unl).bin" size="262144" crc="76fd8bc5" sha1="40bf296ee9d89a8c4e7bd8ca9f19cd4e449dfd6c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="meng huan zhi xing (unl).bin" size="0x40000" crc="76fd8bc5" sha1="40bf296ee9d89a8c4e7bd8ca9f19cd4e449dfd6c" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27961,10 +27962,10 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>SKOB</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="262144">
-				<rom name="meng huan zhi xing (alt) (unl).bin" size="262144" crc="e498d751" sha1="726158dc176c82cf02b8838a672a5206b72ae9d8" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="meng huan zhi xing (alt) (unl).bin" size="0x40000" crc="e498d751" sha1="726158dc176c82cf02b8838a672a5206b72ae9d8" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -27991,8 +27992,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="32768">
-				<rom name="nintendo game boy aging cartridge.bin" size="32768" crc="4db33858" sha1="3f27a044131548d528783f0d43f918f04418519e" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="nintendo game boy aging cartridge.bin" size="0x8000" crc="4db33858" sha1="3f27a044131548d528783f0d43f918f04418519e" />
 			</dataarea>
 		</part>
 	</software>
@@ -28002,8 +28003,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="game genie bios (usa) (v2.1).bin" size="8192" crc="bc491c4b" sha1="50e2ceb9b83f953d304d5bc6a25065bafad89490" />
+			<dataarea name="rom" size="0x2000">
+				<rom name="game genie bios (usa) (v2.1).bin" size="0x2000" crc="bc491c4b" sha1="50e2ceb9b83f953d304d5bc6a25065bafad89490" />
 			</dataarea>
 		</part>
 	</software>
@@ -28014,8 +28015,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="gameshark bios (usa).bin" size="131072" crc="d6909596" sha1="09a6dae5e5faae1c4b5cf20e1b913b1c5e72297e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="gameshark bios (usa).bin" size="0x20000" crc="d6909596" sha1="09a6dae5e5faae1c4b5cf20e1b913b1c5e72297e" />
 			</dataarea>
 		</part>
 	</software>
@@ -28026,8 +28027,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_huc1" />
-			<dataarea name="rom" size="32768">
-				<rom name="pro action replay bios (europe) (unl).bin" size="32768" crc="a2a6a863" sha1="cc691eeef80423bb55b442cc1d9e5abd8bb80148" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="pro action replay bios (europe) (unl).bin" size="0x8000" crc="a2a6a863" sha1="cc691eeef80423bb55b442cc1d9e5abd8bb80148" />
 			</dataarea>
 		</part>
 	</software>
@@ -28046,10 +28047,10 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 			<feature name="u3" value="U3 [52CV1000SF85LL]" />
 			<feature name="batt" value="Batt CR2025" />
 			<feature name="slot" value="rom_camera" />
-			<dataarea name="rom" size="1048576">
-				<rom name="game boy camera (usa, europe).bin" size="1048576" crc="4640909f" sha1="461c3c37ed270681e3e94053efb21504b600aef5" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="game boy camera (usa, europe).bin" size="0x100000" crc="4640909f" sha1="461c3c37ed270681e3e94053efb21504b600aef5" />
 			</dataarea>
-			<dataarea name="nvram" size="131072">
+			<dataarea name="nvram" size="0x20000">
 			</dataarea>
 		</part>
 	</software>
@@ -28064,10 +28065,10 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_camera" />
-			<dataarea name="rom" size="1048576">
-				<rom name="pocket camera (japan) (rev 1).bin" size="1048576" crc="73e8ef96" sha1="912205ea22e1dd735ed4f41d247039eebf39dddc" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="pocket camera (japan) (rev 1).bin" size="0x100000" crc="73e8ef96" sha1="912205ea22e1dd735ed4f41d247039eebf39dddc" />
 			</dataarea>
-			<dataarea name="nvram" size="131072">
+			<dataarea name="nvram" size="0x20000">
 			</dataarea>
 		</part>
 	</software>
@@ -28079,10 +28080,10 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_camera" />
-			<dataarea name="rom" size="1048576">
-				<rom name="game boy camera gold (usa).bin" size="1048576" crc="a1a3f786" sha1="53a0dd6de3ebd0d3495f8bdc377ab08e5074c0ef" />
+			<dataarea name="rom" size="0x100000">
+				<rom name="game boy camera gold (usa).bin" size="0x100000" crc="a1a3f786" sha1="53a0dd6de3ebd0d3495f8bdc377ab08e5074c0ef" />
 			</dataarea>
-			<dataarea name="nvram" size="131072">
+			<dataarea name="nvram" size="0x20000">
 			</dataarea>
 		</part>
 	</software>
@@ -28107,8 +28108,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 			<feature name="u2" value="U2 MBC1B [MBC1B1]" />
 			<feature name="u3" value="U3 74HC373 [74HC373A]" />
 			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="pocket sonar (japan).bin" size="524288" crc="d68c9f79" sha1="788cdf148431b82b5308c68b3e45b133a7074196" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="pocket sonar (japan).bin" size="0x80000" crc="d68c9f79" sha1="788cdf148431b82b5308c68b3e45b133a7074196" />
 			</dataarea>
 		</part>
 	</software>
@@ -28119,8 +28120,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="serial" value="GBD1" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="game boy datenlogger 1 (germany) (v1.0) (gbd1) (unl).bin" size="32768" crc="9ab28af0" sha1="bfeba84926a72498ea65fcae767df8ba13f28d49" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="game boy datenlogger 1 (germany) (v1.0) (gbd1) (unl).bin" size="0x8000" crc="9ab28af0" sha1="bfeba84926a72498ea65fcae767df8ba13f28d49" />
 			</dataarea>
 		</part>
 	</software>
@@ -28131,8 +28132,8 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="serial" value="GBDSO" />
 		<part name="cart" interface="gameboy_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="game boy digital sampling oscilloscope (europe) (v3.6) (gbdso) (unl).bin" size="32768" crc="572ea59c" sha1="68128bd8b01970054590a88b785d553456b68ec1" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="game boy digital sampling oscilloscope (europe) (v3.6) (gbdso) (unl).bin" size="0x8000" crc="572ea59c" sha1="68128bd8b01970054590a88b785d553456b68ec1" />
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
- Noted probable underdump of Lunar Chase prototype.

There's one comment line added and three extraneous offsets removed, but otherwise this is all mechanical search and replace. Everything but the commented ROM falls into a handful of power-of-two buckets.