### PR TITLE
gamecom.xml: Replaced three underdumped ROMs.

### DIFF
--- a/hash/gamecom.xml
+++ b/hash/gamecom.xml
@@ -37,8 +37,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-709"/>
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="2097152">
-				<rom name="batman &amp; robin (1997).bin" size="2097152" crc="b336e530" sha1="066d5cddce9729044ad598ad3cc3489a834f5197"/>
+			<dataarea name="rom" size="0x200000">
+				<rom name="batman &amp; robin (1997).bin" size="0x200000" crc="b336e530" sha1="066d5cddce9729044ad598ad3cc3489a834f5197"/>
 			</dataarea>
 		</part>
 	</software>
@@ -49,8 +49,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-755" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="262144">
-				<rom name="centipede (1999)(hasbro - tiger electronics).bin" size="262144" crc="1a041ff0" sha1="b3d50e0cca6e2a539fba5883854aaf26424ab382"/>
+			<dataarea name="rom" size="0x40000">
+				<rom name="centipede (1999)(hasbro - tiger electronics).bin" size="0x40000" crc="1a041ff0" sha1="b3d50e0cca6e2a539fba5883854aaf26424ab382"/>
 			</dataarea>
 		</part>
 	</software>
@@ -61,8 +61,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-712" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="2097152">
-				<rom name="duke nukem 3d (1997).bin" size="2097152" crc="884568d1" sha1="9aaa1cf3b12f14201079dfbdd4c17fe868972de6"/>
+			<dataarea name="rom" size="0x200000">
+				<rom name="duke nukem 3d (1997).bin" size="0x200000" crc="884568d1" sha1="9aaa1cf3b12f14201079dfbdd4c17fe868972de6"/>
 			</dataarea>
 		</part>
 	</software>
@@ -73,8 +73,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-739" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="2097152">
-				<rom name="fighters megamix (1998)(sega).bin" size="2097152" crc="061e943f" sha1="c165e5f4b61341ae0e8a4d141b28e18108942326"/>
+			<dataarea name="rom" size="0x200000">
+				<rom name="fighters megamix (1998)(sega).bin" size="0x200000" crc="061e943f" sha1="c165e5f4b61341ae0e8a4d141b28e18108942326"/>
 			</dataarea>
 		</part>
 	</software>
@@ -85,8 +85,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-756" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="1048576">
-				<rom name="frogger (1999)(hasbro - tiger electronics).bin" size="1048576" crc="10e4c5cd" sha1="8224d3e71a3da2f4029bee8b62b4a0c108c054e4"/>
+			<dataarea name="rom" size="0x100000">
+				<rom name="frogger (1999)(hasbro - tiger electronics).bin" size="0x100000" crc="10e4c5cd" sha1="8224d3e71a3da2f4029bee8b62b4a0c108c054e4"/>
 			</dataarea>
 		</part>
 	</software>
@@ -97,8 +97,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-728" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="1048576">
-				<rom name="henry (1997).bin" size="1048576" crc="75d3c8d8" sha1="b72a03af1dec0c621f9eda89ded3845724bb34ac"/>
+			<dataarea name="rom" size="0x100000">
+				<rom name="henry (1997).bin" size="0x100000" crc="75d3c8d8" sha1="b72a03af1dec0c621f9eda89ded3845724bb34ac"/>
 			</dataarea>
 		</part>
 	</software>
@@ -109,8 +109,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-525" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="1048576">
-				<rom name="indy 500 (1997).bin" size="1048576" crc="845ed281" sha1="117bfa1c831fbcf4a1d507cb70b6e0636c29bbd3"/>
+			<dataarea name="rom" size="0x100000">
+				<rom name="indy 500 (1997).bin" size="0x100000" crc="845ed281" sha1="117bfa1c831fbcf4a1d507cb70b6e0636c29bbd3"/>
 			</dataarea>
 		</part>
 	</software>
@@ -121,8 +121,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-726" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="1048576">
-				<rom name="jeopardy (1997).bin" size="1048576" crc="8c512912" sha1="c60ac5e59c3cc092506bc47adb60b40a9415bc97"/>
+			<dataarea name="rom" size="0x100000">
+				<rom name="jeopardy (1997).bin" size="0x100000" crc="8c512912" sha1="c60ac5e59c3cc092506bc47adb60b40a9415bc97"/>
 			</dataarea>
 		</part>
 	</software>
@@ -133,8 +133,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-735" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="lights out (1997).bin" size="32768" crc="496efa62" sha1="1d91b616caa2d35f53ec5680aada8f75e2f0ac43"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="lights out (1997).bin" size="0x8000" crc="496efa62" sha1="1d91b616caa2d35f53ec5680aada8f75e2f0ac43"/>
 			</dataarea>
 		</part>
 	</software>
@@ -145,8 +145,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-704" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="2097152">
-				<rom name="lost world, the - jurassic park (1997).bin" size="2097152" crc="b422c5f8" sha1="648badcac6c386d7ff40f917e34bd309e737c027"/>
+			<dataarea name="rom" size="0x200000">
+				<rom name="lost world, the - jurassic park (1997).bin" size="0x200000" crc="b422c5f8" sha1="648badcac6c386d7ff40f917e34bd309e737c027"/>
 			</dataarea>
 		</part>
 	</software>
@@ -157,8 +157,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-752" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="2097152">
-				<rom name="monopoly (1999).bin" size="2097152" crc="d6a65a07" sha1="8057144f6995eafff6d893383114b48f4c77abc3"/>
+			<dataarea name="rom" size="0x200000">
+				<rom name="monopoly (1999).bin" size="0x200000" crc="d6a65a07" sha1="8057144f6995eafff6d893383114b48f4c77abc3"/>
 			</dataarea>
 		</part>
 	</software>
@@ -181,8 +181,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-524" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="1048576">
-				<rom name="quiz wiz - cyber trivia (1997).bin" size="1048576" crc="0e018f6a" sha1="c9c4435bdcea2b9ddaa2768f28f286abd382608d"/>
+			<dataarea name="rom" size="0x100000">
+				<rom name="quiz wiz - cyber trivia (1997).bin" size="0x100000" crc="0e018f6a" sha1="c9c4435bdcea2b9ddaa2768f28f286abd382608d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -205,8 +205,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-754" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="2097152">
-				<rom name="scrabble (1999)(hasbro - tiger electronics).bin" size="2097152" crc="4d4ad909" sha1="2735d59964fe7c1d43bd260df86b9dfbc1bfd736"/>
+			<dataarea name="rom" size="0x200000">
+				<rom name="scrabble (1999)(hasbro - tiger electronics).bin" size="0x200000" crc="4d4ad909" sha1="2735d59964fe7c1d43bd260df86b9dfbc1bfd736"/>
 			</dataarea>
 		</part>
 	</software>
@@ -217,8 +217,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-734" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="2097152">
-				<rom name="sonic jam (1998)(sega).bin" size="2097152" crc="8b4a63f9" sha1="393a98138c8825ed61990e1b15e1967f87068ac6"/>
+			<dataarea name="rom" size="0x200000">
+				<rom name="sonic jam (1998)(sega).bin" size="0x200000" crc="8b4a63f9" sha1="393a98138c8825ed61990e1b15e1967f87068ac6"/>
 			</dataarea>
 		</part>
 	</software>
@@ -241,8 +241,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-523" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="524288">
-				<rom name="wheel of fortune (1997).bin" size="524288" crc="048347a0" sha1="298c2b87754dd93481feea1d9e01585a1e269770"/>
+			<dataarea name="rom" size="0x80000">
+				<rom name="wheel of fortune (1997).bin" size="0x80000" crc="048347a0" sha1="298c2b87754dd93481feea1d9e01585a1e269770"/>
 			</dataarea>
 		</part>
 	</software>
@@ -253,8 +253,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-527" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="524288">
-				<rom name="wheel of fortune 2 (1998).bin" size="524288" crc="b91e2e32" sha1="30ddd349b8bdc21ef7ada4772ab1f3a9318ab0c8"/>
+			<dataarea name="rom" size="0x80000">
+				<rom name="wheel of fortune 2 (1998).bin" size="0x80000" crc="b91e2e32" sha1="30ddd349b8bdc21ef7ada4772ab1f3a9318ab0c8"/>
 			</dataarea>
 		</part>
 	</software>
@@ -265,8 +265,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-722" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="1048576">
-				<rom name="williams arcade classics (1997).bin" size="1048576" crc="f894065d" sha1="5e2164fa76546b2795af7b04a766e31784b82eca"/>
+			<dataarea name="rom" size="0x100000">
+				<rom name="williams arcade classics (1997).bin" size="0x100000" crc="f894065d" sha1="5e2164fa76546b2795af7b04a766e31784b82eca"/>
 			</dataarea>
 		</part>
 	</software>
@@ -277,8 +277,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-529" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="262144">
-				<rom name="internet (1997)(tiger electronics).bin" size="262144" crc="7e721a84" sha1="4c6b5b91a70397cb5e1add4ab53afe3ec0fe2072"/>
+			<dataarea name="rom" size="0x40000">
+				<rom name="internet (1997)(tiger electronics).bin" size="0x40000" crc="7e721a84" sha1="4c6b5b91a70397cb5e1add4ab53afe3ec0fe2072"/>
 			</dataarea>
 		</part>
 	</software>
@@ -289,8 +289,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-747" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="262144">
-				<rom name="web link (1997)(tiger electronics).bin" size="262144" crc="4c13e65b" sha1="d4e08fc050c006ed6c1a177a1f4c41b4a68c26bb"/>
+			<dataarea name="rom" size="0x40000">
+				<rom name="web link (1997)(tiger electronics).bin" size="0x40000" crc="4c13e65b" sha1="d4e08fc050c006ed6c1a177a1f4c41b4a68c26bb"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/gamecom.xml
+++ b/hash/gamecom.xml
@@ -169,8 +169,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-711" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="1835008">
-				<rom name="mortal kombat trilogy (1997)(midway).bin" size="1835008" crc="72893a77" sha1="d8a403a180f4a397098c8a598dd6cd5b45ef377a"/>
+			<dataarea name="rom" size="0x200000">
+				<rom name="mortal kombat trilogy (1997)(midway).bin" size="0x200000" crc="bd29c844" sha1="a560ad2b916a9e4ace917d7e707cdcafbffe6e66"/>
 			</dataarea>
 		</part>
 	</software>
@@ -193,8 +193,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-745" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="1835008">
-				<rom name="resident evil 2 (1998)(capcom).bin" size="1835008" crc="4f09457d" sha1="1d4d4ff13c8f7c228f30bddab174d4781b370ec9"/>
+			<dataarea name="rom" size="0x200000">
+				<rom name="resident evil 2 (1998)(capcom).bin" size="0x200000" crc="0984c7f5" sha1="e32357d08b07a6a8f6a7e64205cca35e50225269"/>
 			</dataarea>
 		</part>
 	</software>
@@ -229,8 +229,8 @@ List of games which were planned but never finished or released.
 		<publisher>Tiger Electronics</publisher>
 		<info name="serial" value="71-731" />
 		<part name="cart" interface="gamecom_cart">
-			<dataarea name="rom" size="1835008">
-				<rom name="tiger casino (1998).bin" size="1835008" crc="ba698142" sha1="32ce1be96f7f367b8a0adb8cc61a8cca7d6b79dd"/>
+			<dataarea name="rom" size="0x200000">
+				<rom name="tiger casino (1998).bin" size="0x200000" crc="e7fb8fd9" sha1="3620491b531b9fce67545e822eff2f99c1adb4a4"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
These are identical to the existing dumps but with initial 256K padding. Sourced from NoIntro.