### PR TITLE
rescue, minefld: make bullets 2x2 pixels instead of a single pixel

### DIFF
--- a/src/mame/galaxian/galaxold.h
+++ b/src/mame/galaxian/galaxold.h
@@ -227,6 +227,7 @@ public:
 	void scrambold_draw_bullets(bitmap_ind16 &bitmap, const rectangle &cliprect, int offs, int x, int y);
 	void darkplnt_draw_bullets(bitmap_ind16 &bitmap, const rectangle &cliprect, int offs, int x, int y);
 	void dambustr_draw_bullets(bitmap_ind16 &bitmap, const rectangle &cliprect, int offs, int x, int y);
+	void rescue_draw_bullets(bitmap_ind16 &bitmap, const rectangle &cliprect, int offs, int x, int y);
 	void galaxold_draw_background(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void scrambold_draw_background(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void ad2083_draw_background(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);

--- a/src/mame/galaxian/galaxold_v.cpp
+++ b/src/mame/galaxian/galaxold_v.cpp
@@ -441,6 +441,8 @@ VIDEO_START_MEMBER(galaxold_state,rescue)
 {
 	VIDEO_START_CALL_MEMBER(scrambold);
 
+	m_draw_bullets = &galaxold_state::rescue_draw_bullets;
+
 	m_draw_stars = &galaxold_state::rescue_draw_stars;
 
 	m_draw_background = &galaxold_state::rescue_draw_background;
@@ -449,6 +451,8 @@ VIDEO_START_MEMBER(galaxold_state,rescue)
 VIDEO_START_MEMBER(galaxold_state,minefld)
 {
 	VIDEO_START_CALL_MEMBER(scrambold);
+
+	m_draw_bullets = &galaxold_state::rescue_draw_bullets;
 
 	m_draw_stars = &galaxold_state::rescue_draw_stars;
 
@@ -1040,6 +1044,22 @@ void galaxold_state::dambustr_draw_bullets(bitmap_ind16 &bitmap, const rectangle
 	}
 }
 
+void galaxold_state::rescue_draw_bullets(bitmap_ind16 &bitmap, const rectangle &cliprect, int offs, int x, int y)
+{
+	if (flip_screen_x())  x++;
+
+	x = x - 6;
+
+	int color = BULLETS_COLOR_BASE;
+
+	/* bullets are 2 pixels square */
+	for (int i = 0; i < 2; i++)
+		for (int j = 0; j < 2; j++)
+		{
+			if (cliprect.contains(x+i, y+j))
+				bitmap.pix(y+j, x+i) = color;
+		}
+}
 
 
 /* background drawing functions */


### PR DESCRIPTION
Makes the bullets 2x2 instead of a single pixel so you can see your shots as well as incoming shots.  This makes the games much easier to play.

Don't know if it's accurate, but it seems to work (able to get up to level 4).

some additional discussion at:

https://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=121174#Post121174