### PR TITLE
machine/8530scc.cpp: Implement SCC baud rate calculation

### DIFF
--- a/src/devices/machine/8530scc.h
+++ b/src/devices/machine/8530scc.h
@@ -86,6 +86,7 @@ private:
 
 	devcb_write_line intrq_cb;
 
+	void updatebaudtimer(int ch);
 	void updateirqs();
 	void initchannel(int ch);
 	void resetchannel(int ch);


### PR DESCRIPTION
- Also fix baud counter registers

Reference: http://www.zilog.com/docs/serial/ps0117.pdf

The X68000 uses the Clock Mode feature of the SCC, which multiplies the baud period by 16. Combined with a bug that read the baud counter from the wrong registers, this meant the emulator had two baud rate expiry callbacks running at some MHz.

The x68k driver doesn't implement RS232 and doesn't yet use the SCC IRQs for mouse updates, so this doesn't yet affect the driver directly, but it does improve performance.