### PR TITLE
nintendo/nes.cpp: Added an RGB Famicom clone.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -44521,26 +44521,6 @@ We should eventually add it to MAME as a separate driver with a NES CPU and a GB
 		</part>
 	</software>
 
-<!-- This might be the dump of the bios. Investigate... -->
-	<software name="myctv">
-		<description>My Computer TV C1 (Japan)</description>
-		<year>1983</year>
-		<publisher>Sharp</publisher>
-		<info name="alt_title" value="マイコンピュータテレビC1"/>
-		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="nrom" />
-			<feature name="pcb" value="NES-NROM-128" />
-			<feature name="mirroring" value="horizontal" />
-			<dataarea name="chr" size="8192">
-				<rom name="my computer tv c1 (j).chr" size="8192" crc="9cba4524" sha1="2bd833f8049bf7a14ce337c3cde35f2140242a18" offset="00000" status="baddump" />
-			</dataarea>
-			<dataarea name="prg" size="32768">
-				<rom name="my computer tv c1 (j).prg" size="16384" crc="7fd48dad" sha1="08af18a6d42e5ab2a288e347ab1fd4bc52441d71" offset="00000" status="baddump" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-			</dataarea>
-		</part>
-	</software>
-
 <!-- from cah4e3 -->
 	<software name="kbtrans">
 		<description>Keyboard Transformer (Rus)</description>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -33316,6 +33316,7 @@ dendy2                          // Dendy Classic 2 (Russian import of IQ-502 fam
 sb486                           // Subor/Xiao Ba Wang SB-486
 drpcjr                          // Bung Doctor PC Jr
 famicom                         // Nintendo Family Computer (a.k.a. Famicom)
+famitvc1                        // Sharp My Computer Terebi C1
 famitwin                        // Sharp Famicom Twin System
 fds                             // Nintendo Family Computer (a.k.a. Famicom) + Disk System add-on
 gchinatv                        // Golden China TV Game Centre (Chinese famiclone)

--- a/src/mame/nintendo/nes.h
+++ b/src/mame/nintendo/nes.h
@@ -79,11 +79,13 @@ public:
 	DECLARE_MACHINE_START(famitwin);
 	DECLARE_MACHINE_RESET(fds);
 	DECLARE_MACHINE_RESET(famitwin);
+	DECLARE_MACHINE_RESET(famitvc1);
 	void setup_disk(nes_disksys_device *slot);
 
 	void suborkbd(machine_config &config);
 	void famipalc(machine_config &config);
 	void famicom(machine_config &config);
+	void famitvc1(machine_config &config);
 	void famitwin(machine_config &config);
 	void nespal(machine_config &config);
 	void nespalc(machine_config &config);


### PR DESCRIPTION
New working clones
------------------
My Computer Terebi C1 [kmg]

The 2C0x palette is the standard one found in PlayChoice-10 and VS. The builtin ROM was in the software list, but the PRG was an overdump (repeated data). I verified the size at least is correct by looking at the PCB.