### PR TITLE
Various software lists: Cleaned up more extraneous spaces.

### DIFF
--- a/hash/a2600.xml
+++ b/hash/a2600.xml
@@ -1508,7 +1508,7 @@ MOS Atari-made game NTSC ROMs had a CO16xxx number and PAL ROMs had CO17xxx numb
 		<description>Bank Heist</description>
 		<year>1983</year>
 		<publisher>20th Century Fox</publisher>
-		<info name="serial" value="11012 " />
+		<info name="serial" value="11012" />
 		<info name="programmer" value="Bill Aspromonte" />
 		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="a2600_cart">

--- a/hash/a800.xml
+++ b/hash/a800.xml
@@ -2794,7 +2794,7 @@ Compiled by K1W1
 
 	<software name="jawbrek2">
 		<description>Jawbreaker II</description>
-		<!-- The title screen says "Jawbreaker (c) 1980", however this actually is Jawbreaker II from 1982, as seen on the box (not in all releases though). -->
+		<!-- The title screen says “Jawbreaker (c) 1980”, however this actually is Jawbreaker II from 1982, as seen on the box (not in all releases though). -->
 		<year>1982</year>
 		<publisher>Sierra On-Line</publisher>
 		<info name="serial" value="JBL-202" />

--- a/hash/a800.xml
+++ b/hash/a800.xml
@@ -2794,7 +2794,7 @@ Compiled by K1W1
 
 	<software name="jawbrek2">
 		<description>Jawbreaker II</description>
-		<!-- The title screen says “Jawbreaker (c) 1980”, however this actually is Jawbreaker II from 1982, as seen on the box (not in all releases though). -->
+		<!-- The title screen says "Jawbreaker (c) 1980", however this actually is Jawbreaker II from 1982, as seen on the box (not in all releases though). -->
 		<year>1982</year>
 		<publisher>Sierra On-Line</publisher>
 		<info name="serial" value="JBL-202" />
@@ -5282,7 +5282,7 @@ Compiled by K1W1
 		<description>Super Cartridge</description>
 		<year>199?</year>
 		<publisher>Unerring Master</publisher>
-		<info name="usage" value="Requires the Atari Super Turbo hardware modification (or compatible ATT, UM) installed in a tape recorder. " />
+		<info name="usage" value="Requires the Atari Super Turbo hardware modification (or compatible ATT, UM) installed in a tape recorder." />
 		<part name="cart" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">

--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -28435,7 +28435,7 @@ ATK test: OK
 ATK test: OK
 ]]></notes>
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Startup Disk " />
+			<feature name="part_id" value="Startup Disk" />
 			<dataarea name="flop" size="1049612">
 				<rom name="king's quest v - absence makes the heart go yonder (europe) (v1.000.000) (startup disk).ipf" size="1049612" crc="2639e123" sha1="38f4317102cd65bf336069f636f2db3ac2a2369c"/>
 			</dataarea>
@@ -29374,7 +29374,7 @@ ATK test: C:0 H:U Bad
 ATK test: OK
 ]]></notes>
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="StartUp Disk " />
+			<feature name="part_id" value="StartUp Disk" />
 			<dataarea name="flop" size="1049612">
 				<rom name="legend of robin hood, the - conquests of the longbow (europe) (v1.000) (startup disk).ipf" size="1049612" crc="f531d078" sha1="0ea0fb16865d6082291de7dd42b0e56883bc725c"/>
 			</dataarea>

--- a/hash/apple2_flop_clcracked.xml
+++ b/hash/apple2_flop_clcracked.xml
@@ -39866,13 +39866,13 @@ license:CC0
 		<info name="release" value="2021-01-01"/>
 
 		<part name="flop1" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 1 - "/>
+			<feature name="part_id" value="Disk 1 - Program"/>
 			<dataarea name="flop" size="143360">
 				<rom name="playwriter - adventures in space (4am crack) disk 1 - program.dsk" size="143360" crc="5cec640f" sha1="bea9881dd3f32c6cd8f2f4525ccfc52ca1d48aff"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk 2 - "/>
+			<feature name="part_id" value="Disk 2 - Story disk"/>
 			<dataarea name="flop" size="143360">
 				<rom name="playwriter - adventures in space (4am crack) disk 2 - story disk.dsk" size="143360" crc="0c9f5920" sha1="f169fcb1b2421663f0aeac1c1b7017b1c2b09ad1"/>
 			</dataarea>
@@ -42903,7 +42903,7 @@ license:CC0
 		<year>1985</year>
 		<publisher>Spectrum Holobyte</publisher>
 		<info name="release" value="2021-04-07"/>
-		<info name="programmer" value="J.A. Yandrofski, Timothy Reese, Paul Artlton, and Ed Dawson "/>
+		<info name="programmer" value="J.A. Yandrofski, Timothy Reese, Paul Artlton, and Ed Dawson"/>
 		<!--"GATO" is a 1985 simulation game developed by J.A. Yandrofski, Timothy Reese, Paul Artlton, and Ed Dawson, and distributed by Spectrum Holobyte. This is version 1.2.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43102,7 +43102,7 @@ license:CC0
 		<year>1981</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-27"/>
-		<info name="programmer" value="Daniel M. Forde, James A. Henke, and David E. Laden "/>
+		<info name="programmer" value="Daniel M. Forde, James A. Henke, and David E. Laden"/>
 		<!--"Elementary Volume 11: Language Arts" is a 1981 educational program developed by Daniel M. Forde, James A. Henke, and David E. Laden, and distributed by MECC. This is version 1.1.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43117,7 +43117,7 @@ license:CC0
 		<year>1980</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-27"/>
-		<info name="programmer" value="Daniel M. Forde, Scott Costello, R. Christiansen, David E. Laden, L. Dixson, S. Costello, J. Cook, L. Borry, and R. Alberti "/>
+		<info name="programmer" value="Daniel M. Forde, Scott Costello, R. Christiansen, David E. Laden, L. Dixson, S. Costello, J. Cook, L. Borry, and R. Alberti"/>
 		<!--"Elementary Volume 12: Language Arts (SIMS)" is a 1980 educational program developed by Daniel M. Forde, Scott Costello, R. Christiansen, David E. Laden, L. Dixson, S. Costello, J. Cook, L. Borry, and R. Alberti, and distributed by MECC. This is version 1.0.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43132,7 +43132,7 @@ license:CC0
 		<year>1980</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-27"/>
-		<info name="programmer" value="Daniel M. Forde, Scott Costello, R. Christiansen, David E. Laden, L. Dixson, S. Costello, J. Cook, L. Borry, and R. Alberti "/>
+		<info name="programmer" value="Daniel M. Forde, Scott Costello, R. Christiansen, David E. Laden, L. Dixson, S. Costello, J. Cook, L. Borry, and R. Alberti"/>
 		<!--"Elementary Volume 12: Language Arts (SIMS)" is a 1980 educational program developed by Daniel M. Forde, Scott Costello, R. Christiansen, David E. Laden, L. Dixson, S. Costello, J. Cook, L. Borry, and R. Alberti, and distributed by MECC. This is version 2.0.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43147,7 +43147,7 @@ license:CC0
 		<year>1981</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-27"/>
-		<info name="programmer" value="Tom Boe and Russ Erickson "/>
+		<info name="programmer" value="Tom Boe and Russ Erickson"/>
 		<!--"Mathematics Volume 2: Measurement" is a 1981 educational program developed by Tom Boe and Russ Erickson, and distributed by MECC. This is version 1.2.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43191,7 +43191,7 @@ license:CC0
 		<year>1981</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-27"/>
-		<info name="programmer" value="Shane Mccarron and Todd Bailey "/>
+		<info name="programmer" value="Shane Mccarron and Todd Bailey"/>
 		<!--"Elementary Volume 13: Nutrition" is a 1981 educational program developed by Shane Mccarron and Todd Bailey, and distributed by MECC. This is version 1.0.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43206,7 +43206,7 @@ license:CC0
 		<year>1981</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-27"/>
-		<info name="programmer" value="A. McCarthy and Darrel Ricke "/>
+		<info name="programmer" value="A. McCarthy and Darrel Ricke"/>
 		<!--"English Volume 1: Parts of Speech" is a 1981 educational program developed by A. McCarthy and Darrel Ricke, and distributed by MECC. This is version 1.3.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43221,7 +43221,7 @@ license:CC0
 		<year>1981</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-27"/>
-		<info name="programmer" value="A. McCarthy and Darrel Ricke "/>
+		<info name="programmer" value="A. McCarthy and Darrel Ricke"/>
 		<!--"English Volume 1: Parts of Speech" is a 1981 educational program developed by A. McCarthy and Darrel Ricke, and distributed by MECC. This is version 1.4.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43287,7 +43287,7 @@ license:CC0
 		<year>1982</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-28"/>
-		<info name="programmer" value="Shane McCarron and Craig W. Copley "/>
+		<info name="programmer" value="Shane McCarron and Craig W. Copley"/>
 		<!--"Health Maintenance Volume 2: Assessment" is a 1982 educational program developed by Shane McCarron and Craig W. Copley, and distributed by MECC. This is version 1.0.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43486,7 +43486,7 @@ license:CC0
 		<year>1983</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-28"/>
-		<info name="programmer" value="H. Bill Way and Mike Boucher "/>
+		<info name="programmer" value="H. Bill Way and Mike Boucher"/>
 		<!--"Adventures with Fractions" is a 1983 educational program developed by H. Bill Way and Mike Boucher, and distributed by MECC. This is version 1.1.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43557,7 +43557,7 @@ license:CC0
 		<year>1983</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-29"/>
-		<info name="programmer" value="H. Bill Way and Craig Solmonson "/>
+		<info name="programmer" value="H. Bill Way and Craig Solmonson"/>
 		<!--"The Friendly Computer" is a 1983 educational program developed by H. Bill Way and Craig Solmonson, and distributed by MECC. This is version 1.5.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43621,7 +43621,7 @@ license:CC0
 		<year>1983</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-29"/>
-		<info name="programmer" value="Cynthia L. Schroeder and R. Philip Bouchard "/>
+		<info name="programmer" value="Cynthia L. Schroeder and R. Philip Bouchard"/>
 		<!--"Oh, Deer!" is a 1983 educational program developed by Cynthia L. Schroeder and R. Philip Bouchard, and distributed by MECC. This is version 1.1.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43636,7 +43636,7 @@ license:CC0
 		<year>1983</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-29"/>
-		<info name="programmer" value="Lois Edwards and Russ Erickson "/>
+		<info name="programmer" value="Lois Edwards and Russ Erickson"/>
 		<!--"Problem-Solving Strategies" is a 1983 educational program developed by Lois Edwards and Russ Erickson, and distributed by MECC. This is version 1.0.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43651,7 +43651,7 @@ license:CC0
 		<year>1983</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-29"/>
-		<info name="programmer" value="Lois Edwards and Russ Erickson "/>
+		<info name="programmer" value="Lois Edwards and Russ Erickson"/>
 		<!--"Problem-Solving Strategies" is a 1983 educational program developed by Lois Edwards and Russ Erickson, and distributed by MECC. This is version 1.3.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43694,7 +43694,7 @@ license:CC0
 		<year>1983</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-29"/>
-		<info name="programmer" value="Frederick Steinmann and Peter Fuglstad "/>
+		<info name="programmer" value="Frederick Steinmann and Peter Fuglstad"/>
 		<!--"Early Addition" is a 1983 educational program developed by Frederick Steinmann and Peter Fuglstad, and distributed by MECC. This is version 1.1.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43709,7 +43709,7 @@ license:CC0
 		<year>1983</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-29"/>
-		<info name="programmer" value="Frederick Steinmann and Peter Fuglstad "/>
+		<info name="programmer" value="Frederick Steinmann and Peter Fuglstad"/>
 		<!--"Early Addition" is a 1983 educational program developed by Frederick Steinmann and Peter Fuglstad, and distributed by MECC. This is version 1.3.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43724,7 +43724,7 @@ license:CC0
 		<year>1983</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-29"/>
-		<info name="programmer" value="Wendell Ruotsi and Andy Hollenbeck "/>
+		<info name="programmer" value="Wendell Ruotsi and Andy Hollenbeck"/>
 		<!--"Experiencing Procedures" is a 1983 educational program developed by Wendell Ruotsi and Andy Hollenbeck, and distributed by MECC. This is version 1.0.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43753,7 +43753,7 @@ license:CC0
 		<year>1983</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-29"/>
-		<info name="programmer" value="Jeff Jorgensen, Dan Pelowski, and Wendell Ruotsi "/>
+		<info name="programmer" value="Jeff Jorgensen, Dan Pelowski, and Wendell Ruotsi"/>
 		<!--"Processing Words" is a 1983 educational program developed by Jeff Jorgensen, Dan Pelowski, and Wendell Ruotsi, and distributed by MECC. This is version 1.0.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43768,7 +43768,7 @@ license:CC0
 		<year>1983</year>
 		<publisher>Sierra On-Line</publisher>
 		<info name="release" value="2021-04-09"/>
-		<info name="programmer" value="Al Lowe, Mike Macchesney, Margaret Lowe, and Rae Lynn Macchesney "/>
+		<info name="programmer" value="Al Lowe, Mike Macchesney, Margaret Lowe, and Rae Lynn Macchesney"/>
 		<!--"Dragon's Keep" is a 1983 adventure game developed by Al Lowe, Mike Macchesney, Margaret Lowe, and Rae Lynn Macchesney, and distributed by Sierra On-Line. This update is dated 1984-06-05 according to program comments. It is preserved here for the first time.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -43783,7 +43783,7 @@ license:CC0
 		<year>1983</year>
 		<publisher>MECC</publisher>
 		<info name="release" value="2021-03-29"/>
-		<info name="programmer" value="Tim Heap and Seth A. Rosenblatt "/>
+		<info name="programmer" value="Tim Heap and Seth A. Rosenblatt"/>
 		<!--"Nutrition" is a 1983 educational program developed by Tim Heap and Seth A. Rosenblatt, and distributed by MECC. This is version 1.0.-->
 
 		<part name="flop1" interface="floppy_5_25">
@@ -44082,7 +44082,7 @@ license:CC0
 		<year>1987</year>
 		<publisher>D.C. Heath</publisher>
 		<info name="release" value="2021-04-18"/>
-		<info name="programmer" value="Rob Shaver and Peter Andrews "/>
+		<info name="programmer" value="Rob Shaver and Peter Andrews"/>
 		<!--"Just Around The Block" is a 1987 educational game developed by Rob Shaver and Peter Andrews, and distributed by D.C. Heath. It is preserved here for the first time.-->
 
 		<part name="flop1" interface="floppy_5_25">

--- a/hash/coleco.xml
+++ b/hash/coleco.xml
@@ -123,7 +123,7 @@ license:CC0
 		<description>Alphabet Zoo</description>
 		<year>1984</year>
 		<publisher>Spinnaker Software</publisher>
-		<info name="author" value="Dale Disharoon &amp; Bill Groetzinger " />
+		<info name="author" value="Dale Disharoon &amp; Bill Groetzinger" />
 		<info name="serial" value="ABC-CV" />
 		<part name="cart" interface="coleco_cart">
 			<dataarea name="rom" size="16384">
@@ -1206,7 +1206,7 @@ license:CC0
 		<description>Pitfall II: Lost Caverns</description>
 		<year>1984</year>
 		<publisher>Activision</publisher>
-		<info name="serial" value="VS-008    " />
+		<info name="serial" value="VS-008" />
 		<part name="cart" interface="coleco_cart">
 			<dataarea name="rom" size="16384">
 				<rom name="pitfall2.1" size="8192" crc="08ad596e" sha1="d4961033a60b00fb9f99de49079a588b4a6518f0" offset="0x0000" />

--- a/hash/ekara_japan_a.xml
+++ b/hash/ekara_japan_a.xml
@@ -31,7 +31,7 @@ license:CC0
 		<description>A-1 Pichi Pichi Pitch vol.1 (Japan)</description>
 		<year>2003</year>
 		<publisher>Takara</publisher>
-		<info name="alt_title" value="ぴちぴちピッチ vol.1 " />
+		<info name="alt_title" value="ぴちぴちピッチ vol.1" />
 		<part name="cart" interface="ekara_cart">
 			<feature name="slot" value="rom_24c08_epitch"/>
 			<dataarea name="rom" size="0x200000">
@@ -44,7 +44,7 @@ license:CC0
 		<description>A-3 Pichi Pichi Pitch vol.3 (Japan)</description>
 		<year>2004</year>
 		<publisher>Takara</publisher>
-		<info name="alt_title" value="ぴちぴちピッチ vol.3 " />
+		<info name="alt_title" value="ぴちぴちピッチ vol.3" />
 		<part name="cart" interface="ekara_cart">
 			<feature name="slot" value="rom_24c08_epitch"/>
 			<dataarea name="rom" size="0x200000">
@@ -57,7 +57,7 @@ license:CC0
 		<description>A-4 Pichi Pichi Pitch Pure Dai 1-shō (Japan)</description>
 		<year>2004</year>
 		<publisher>Takara</publisher>
-		<info name="alt_title" value="ぴちぴちピッチ ピュア第1章 " />
+		<info name="alt_title" value="ぴちぴちピッチ ピュア第1章" />
 		<part name="cart" interface="ekara_cart">
 			<feature name="slot" value="rom_24c08_epitch"/>
 			<dataarea name="rom" size="0x200000">
@@ -82,7 +82,7 @@ license:CC0
 		<description>A-6 Pichi Pichi Pitch Pure Dai 2-shō (Japan)</description>
 		<year>2004</year>
 		<publisher>Takara</publisher>
-		<info name="alt_title" value="ぴちぴちピッチ ピュア第2章 " />
+		<info name="alt_title" value="ぴちぴちピッチ ピュア第2章" />
 		<part name="cart" interface="ekara_cart">
 			<feature name="slot" value="rom_24c08_epitch"/>
 			<dataarea name="rom" size="0x200000">
@@ -95,7 +95,7 @@ license:CC0
 		<description>A-7 Pichi Pichi Pitch Pure Dai 3-shō (Japan)</description>
 		<year>2004</year>
 		<publisher>Takara</publisher>
-		<info name="alt_title" value="ぴちぴちピッチ ピュア第3章 " />
+		<info name="alt_title" value="ぴちぴちピッチ ピュア第3章" />
 		<part name="cart" interface="ekara_cart">
 			<feature name="slot" value="rom_24c08_epitch"/>
 			<dataarea name="rom" size="0x200000">

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -6258,7 +6258,7 @@ license:CC0
 		<year>1991</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-EAA" />
-		<info name="release" value="19910809 " />
+		<info name="release" value="19910809" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="0x10000">

--- a/hash/gba.xml
+++ b/hash/gba.xml
@@ -934,7 +934,7 @@ license:CC0
 		<description>Aleck Bordon Adventure - Tower &amp; Shaft Advance (Jpn)</description>
 		<year>2004</year>
 		<publisher>Aruze</publisher>
-		<info name="serial" value="AGB-BABJ "/>
+		<info name="serial" value="AGB-BABJ"/>
 		<info name="release" value="20041126"/>
 		<info name="alt_title" value="アレックボードンアドベンチャー タワー&amp;シャフト アドバンス"/>
 		<part name="cart" interface="gba_cart">
@@ -3731,7 +3731,7 @@ license:CC0
 		<description>Bouken-ou Beet - Busters Road (Jpn)</description>
 		<year>2004</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="AGB-BOVJ "/>
+		<info name="serial" value="AGB-BOVJ"/>
 		<info name="release" value="20050120"/>
 		<info name="alt_title" value="冒険王ビィト バスターズロード"/>
 		<part name="cart" interface="gba_cart">
@@ -16941,7 +16941,7 @@ license:CC0
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="AGB-BKGJ-JPN"/>
 		<info name="release" value="20030926"/>
-		<info name="alt_title" value="かわいいペット ゲームギャラリー "/>
+		<info name="alt_title" value="かわいいペット ゲームギャラリー"/>
 		<part name="cart" interface="gba_cart">
 			<feature name="slot" value="gba_eeprom" />
 			<dataarea name="rom" size="8388608">
@@ -22435,7 +22435,7 @@ license:CC0
 		<publisher>Success</publisher>
 		<info name="serial" value="AGB-BSGJ-JPN"/>
 		<info name="release" value="20040924"/>
-		<info name="alt_title" value="みんなのソフトシリーズ みんなの将棋 "/>
+		<info name="alt_title" value="みんなのソフトシリーズ みんなの将棋"/>
 		<part name="cart" interface="gba_cart">
 			<feature name="slot" value="gba_eeprom_4k" />
 			<dataarea name="rom" size="4194304">
@@ -22450,7 +22450,7 @@ license:CC0
 		<publisher>Success</publisher>
 		<info name="serial" value="AGB-BSGJ-JPN"/>
 		<info name="release" value="20040924"/>
-		<info name="alt_title" value="みんなのソフトシリーズ みんなの将棋 "/>
+		<info name="alt_title" value="みんなのソフトシリーズ みんなの将棋"/>
 		<part name="cart" interface="gba_cart">
 			<feature name="slot" value="gba_eeprom_4k" />
 			<dataarea name="rom" size="4194304">

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -3799,7 +3799,7 @@ license:CC0
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BDGJ-JPN (RK209-J1)"/>
 		<info name="release" value="20000803"/>
-		<info name="alt_title" value="ダンスダンスレボリューションGB "/>
+		<info name="alt_title" value="ダンスダンスレボリューションGB"/>
 		<sharedfeat name="compatibility" value="GBC"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A09-01" />
@@ -7660,7 +7660,7 @@ license:CC0
 		<description>Gyouten Ningen Batseelor - Doctor Guy no Yabou (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="CGB-BB6J-JPN (RK266-J1) "/>
+		<info name="serial" value="CGB-BB6J-JPN (RK266-J1)"/>
 		<info name="release" value="20011101"/>
 		<info name="alt_title" value="仰天人間バトシーラー ドクトル・ガイの野望"/>
 		<sharedfeat name="compatibility" value="GBC"/>
@@ -7932,7 +7932,7 @@ license:CC0
 		<publisher>TDK Core</publisher>
 		<info name="serial" value="CGB-B87J-JPN"/>
 		<info name="release" value="20010727"/>
-		<info name="alt_title" value="花より男子  アナザーラブストーリー"/>
+		<info name="alt_title" value="花より男子 アナザーラブストーリー"/>
 		<sharedfeat name="compatibility" value="GBC"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
@@ -9609,7 +9609,7 @@ license:CC0
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AKHJ-JPN"/>
 		<info name="release" value="19990409"/>
-		<info name="alt_title" value="加藤一二三 九段の 将棋教室 "/>
+		<info name="alt_title" value="加藤一二三 九段の 将棋教室"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
@@ -25135,7 +25135,7 @@ license:CC0
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_licheng" />
-			<dataarea name="rom"  size="4194304">
+			<dataarea name="rom" size="4194304">
 				<rom name="e mo cheng dx (sintax) (unl).bin" size="4194304" crc="5c388c6d" sha1="7919fe7b54a5bc53ebacc13dd338be9e841dadf7" offset="0" />
 			</dataarea>
 			<dataarea name="nvram" size="32768">
@@ -25703,7 +25703,7 @@ license:CC0
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_sintax" />
-			<dataarea name="rom"  size="2097152">
+			<dataarea name="rom" size="2097152">
 				<rom name="digimon crystal ii (unlicensed, english) [raw dump].bin" size="2097152" crc="685e76df" sha1="4e981044ac3a40d7a9cd63b79d5982b4b4e670a5" offset="0" />
 			</dataarea>
 			<dataarea name="nvram" size="32768">
@@ -25718,7 +25718,7 @@ license:CC0
 		<info name="alt_title" value="老夫子傳奇"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_sintax" />
-			<dataarea name="rom"  size="2097152">
+			<dataarea name="rom" size="2097152">
 				<rom name="lao fuzi chuanqi (unlicensed, chinese) [raw dump].bin" size="2097152" crc="aeca45be" sha1="b7193fcb8b9b8958a2522be0d1a3874cffc1e1db" offset="0" />
 			</dataarea>
 			<dataarea name="nvram" size="32768">
@@ -25733,7 +25733,7 @@ license:CC0
 		<info name="alt_title" value="越南戰役X-深入敵後"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_sintax" />
-			<dataarea name="rom"  size="2097152">
+			<dataarea name="rom" size="2097152">
 				<rom name="yuenan zhanyi x - shenru dihou (unlicensed, chinese) [raw dump].bin" size="2097152" crc="602951a6" sha1="6703e9f68b989c976e93bd2eb63f884ceaff63f1" offset="0" />
 			</dataarea>
 			<dataarea name="nvram" size="32768">
@@ -25748,7 +25748,7 @@ license:CC0
 		<info name="alt_title" value="七龍珠Z3"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_sintax" />
-			<dataarea name="rom"  size="2097152">
+			<dataarea name="rom" size="2097152">
 				<rom name="qi long zhu z 3 (dragon ball - advance adventure) (unlicensed, chinese) [raw dump].bin" size="2097152" crc="ccfdd63a" sha1="4f3b63cd11522b6fb291661f4d918601d95138e0" offset="0" />
 			</dataarea>
 			<dataarea name="nvram" size="32768">

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -10694,7 +10694,7 @@ Only Road Rash portion is present in the dump, the other two entries and menu ar
 		<year>1989</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="G-4004"/>
-		<info name="release" value="19890210 "/>
+		<info name="release" value="19890210"/>
 		<info name="alt_title" value="アレックスキッド 天空魔城 ~ Alex Kidd - Tenkuu Majou (Box)"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">

--- a/hash/msx1_cart.xml
+++ b/hash/msx1_cart.xml
@@ -4529,7 +4529,7 @@ kept for now until finding out what those bytes affect...
 		<info name="alt_title" value="エクセリオン" />
 		<part name="cart" interface="msx_cart">
 			<dataarea name="rom" size="32768">
-				<rom name="exerion (japan) (alt 2).rom" size="16417" crc="369cb84e" sha1="8ecc34ebff9d37c0fe9560cfdc53a052cff3d1ab" status="baddump"  offset="0" />
+				<rom name="exerion (japan) (alt 2).rom" size="16417" crc="369cb84e" sha1="8ecc34ebff9d37c0fe9560cfdc53a052cff3d1ab" status="baddump" offset="0" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/msx2_flop.xml
+++ b/hash/msx2_flop.xml
@@ -13321,7 +13321,7 @@ HOMEBREW
 		<description>ASO Remake (UK?)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
-		<info name="developer" value="sharksym " />
+		<info name="developer" value="sharksym" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="aso_remake_20120205.dsk" size="737280" crc="63505503" sha1="01a2285990d33a927c266812097139a4a443b10d"/>

--- a/hash/n64.xml
+++ b/hash/n64.xml
@@ -13324,7 +13324,7 @@ clips onto the player's ear.
 		<description>Violence Killer - Turok New Generation (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Factory</publisher>
-		<info name="serial" value="NUS-NT2J-JPN "/>
+		<info name="serial" value="NUS-NT2J-JPN"/>
 		<info name="release" value="19990618"/>
 		<info name="alt_title" value="バイオレンスキラーTUROK NEW GENERATION"/>
 		<part name="cart" interface="n64_cart">

--- a/hash/neogeo.xml
+++ b/hash/neogeo.xml
@@ -4785,7 +4785,7 @@ license:CC0
 	</software>
 
 	<software name="stakwindev" cloneof="stakwin" supported="no">
-		<description>Stakes Winner / Stakes Winner - GI Kinzen  Seiha e no Michi (early development board)</description>
+		<description>Stakes Winner / Stakes Winner - GI Kinzen Seiha e no Michi (early development board)</description>
 		<year>1995</year>
 		<publisher>Saurus</publisher>
 		<info name="alt_title" value="ステークスウィナー"/>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -41528,7 +41528,7 @@ license:CC0
 		<description>Urban Champion (World)</description>
 		<year>1984</year>
 		<publisher>Nintendo</publisher>
-		<info name="serial" value="HVC-UC, NES-UC-(USA/CAN), NES-UC-FRA "/>
+		<info name="serial" value="HVC-UC, NES-UC-(USA/CAN), NES-UC-FRA"/>
 		<info name="release" value="19841114 (JPN), 198606xx (USA), 1986? (EUR)"/>
 		<info name="alt_title" value="アーバンチャンピオン"/>
 		<part name="cart" interface="nes_cart">
@@ -49481,7 +49481,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<publisher>Technos</publisher>
 		<info name="serial" value="TJC-BR"/>
 		<info name="release" value="19931217"/>
-		<info name="alt_title" value="熱血!すとりーとバスケット がんばれ  ダンクヒーローズ"/>
+		<info name="alt_title" value="熱血!すとりーとバスケット がんばれ ダンクヒーローズ"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TLROM" />
@@ -57545,7 +57545,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<year>1997</year>
 		<publisher>Waixing</publisher>
 		<info name="serial" value="ES-1064"/>
-		<info name="alt_title" value="七龙珠 (Dragonball) "/>
+		<info name="alt_title" value="七龙珠 (Dragonball)"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="hengg_shjy3" />
 			<feature name="pcb" value="UNL-SHJY3" /> <!-- Chinese dump uses Mapper 253, another image found uses Mapper 251? -->
@@ -58115,7 +58115,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<year>19??</year>
 		<publisher>Waixing</publisher>
 		<info name="serial" value="ES-1098"/>   <!-- some source labeled this as es-1096, but then tszone has dumped Qi Long Zhu Z Wai Zhuan above as es-1096! -->
-		<info name="alt_title" value="塞尔达传说-三神之力 ~ sài ěr dá chuánshuō-sān shén zhī lì "/>
+		<info name="alt_title" value="塞尔达传说-三神之力 ~ sài ěr dá chuánshuō-sān shén zhī lì"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="fs304" />
 			<feature name="pcb" value="UNL-FS304" />
@@ -59258,7 +59258,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<year>19??</year>
 		<publisher>Nanjing</publisher>
 		<info name="serial" value="NJ010"/>
-		<info name="alt_title" value="口袋钻石 ~  Pokémon Diamond"/>
+		<info name="alt_title" value="口袋钻石 ~ Pokémon Diamond"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="nanjing" />
 			<feature name="pcb" value="UNL-NANJING" />
@@ -60008,7 +60008,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<year>19??</year>
 		<publisher>Nanjing</publisher>
 		<info name="serial" value="NJ050 (or NJ033?)"/>
-		<info name="alt_title" value="红楼梦 ~  A Dream of Red Mansions"/>
+		<info name="alt_title" value="红楼梦 ~ A Dream of Red Mansions"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TLROM" />
@@ -62899,7 +62899,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<description>Ying Xiong Chuan Qi (China)</description>
 		<year>19??</year>
 		<publisher>XingXing</publisher>
-		<info name="alt_title" value="英雄传奇 (Hero Legend?) "/>
+		<info name="alt_title" value="英雄传奇 (Hero Legend?)"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TLROM" /> <!-- Maybe Waixing Type J -->
@@ -65406,7 +65406,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="gameinpp" supported="no">
-		<description>Gameinis  - PingPong (Asia)</description>
+		<description>Gameinis - PingPong (Asia)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">

--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -2443,7 +2443,7 @@ ExtractDisk  [02]"SAGA#1          " -> "adventure land_02.d88"
 	</software>
 
 	<!-- hangs at Starcraft logo -->
-	<!-- FDC stalls [Finds a CHRN=(11 01 0a 01) but fails scan ID?]  -->
+	<!-- FDC stalls [Finds a CHRN=(11 01 0a 01) but fails scan ID?] -->
 	<software name="amazongta" cloneof="amazongt" supported="no">
 		<description>Amazon Gakujutsu Tanken (alt)</description>
 		<year>1984</year>
@@ -4563,7 +4563,7 @@ ExtractDisk  [04]"Disk 2          " -> "battle gorilla_04.d88"
 	<!-- Hangs at HARD. DOS loader -->
 	<!-- FDC stalls [tries to scan for missing CHRN=(00 00 01 06)] -->
 	<software name="bshashms1" cloneof="bshashms" supported="no">
-		<description>Bishoujo Shashinkan  - Moving School (alt?)</description>
+		<description>Bishoujo Shashinkan - Moving School (alt?)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="美少女写真館 -ムービング・スクール-"/>
@@ -14080,7 +14080,7 @@ ExtractDisk  [04]"Data Disk    " -> "formula cms_04.d88"
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Data (Map)" />
 			<dataarea name="flop" size="415840">
-				<rom name="gokudo jintori (data  - map).d88" size="415840" crc="b3e5d6b9" sha1="ecc6115143032f8b5cdf6403529e1e7db072d15a"/>
+				<rom name="gokudo jintori (data - map).d88" size="415840" crc="b3e5d6b9" sha1="ecc6115143032f8b5cdf6403529e1e7db072d15a"/>
 			</dataarea>
 		</part>
 	</software>
@@ -33215,7 +33215,7 @@ ExtractDisk  [02]"A DISK          " -> "sorcerian music library_02.d88"
 
 	<!-- [Incorrect layout on track 0 head 0, expected_size=100000, current_size=103616] -->
 	<software name="suiryus2" supported="no">
-		<description>Suiryushi II -  Wadatsumi no Hikari Koto</description>
+		<description>Suiryushi II - Wadatsumi no Hikari Koto</description>
 		<year>1989</year>
 		<publisher>しゃんばら (Shanbara)</publisher>
 		<!-- PC8801mk2SR -->
@@ -33262,7 +33262,7 @@ ExtractDisk  [02]"A DISK          " -> "sorcerian music library_02.d88"
 
 	<!-- [Incorrect layout on track 0 head 0, expected_size=100000, current_size=103616] -->
 	<software name="suiryus2a" cloneof="suiryus2" supported="no">
-		<description>Suiryushi II -  Wadatsumi no Hikari Koto (alt User Disk)</description>
+		<description>Suiryushi II - Wadatsumi no Hikari Koto (alt User Disk)</description>
 		<year>1989</year>
 		<publisher>しゃんばら (Shanbara)</publisher>
 		<!-- PC8801mk2SR -->
@@ -36352,7 +36352,7 @@ ExtractDisk  [02]"PROGRAM        " -> "transylvania_02.d88"
 	</software>
 
 	<software name="ultima3">
-		<description>Ultima III  - Exodus</description>
+		<description>Ultima III - Exodus</description>
 		<year>1989</year>
 		<publisher>ポニカ (Pony Canyon)</publisher>
 		<!-- PC8801mk2SR -->
@@ -36389,7 +36389,7 @@ ExtractDisk  [02]"ｼﾅﾘｵﾃﾞｨｽｸ      " -> "ultima 3(ponyca)_02.d88
 ExtractDisk  [03]"ﾕｰｻﾞｰｼｽﾃﾑﾃﾞｨｽｸ  " -> "ultima 3(ponyca)_03.d88"
 -->
 	<software name="ultima3a" cloneof="ultima3">
-		<description>Ultima III  - Exodus (alt)</description>
+		<description>Ultima III - Exodus (alt)</description>
 		<year>1989</year>
 		<publisher>ポニカ (Pony Canyon)</publisher>
 		<!-- PC8801mk2SR -->
@@ -36419,7 +36419,7 @@ ExtractDisk  [03]"ﾕｰｻﾞｰｼｽﾃﾑﾃﾞｨｽｸ  " -> "ultima 3(pon
 
 <!-- does this contain correct programs?? also flop2 & 3 seem equal except for header... -->
 	<software name="ultima3b" cloneof="ultima3">
-		<description>Ultima III  - Exodus (Bad?)</description>
+		<description>Ultima III - Exodus (Bad?)</description>
 		<year>1989</year>
 		<publisher>ポニカ (Pony Canyon)</publisher>
 		<!-- PC8801mk2SR -->
@@ -48292,7 +48292,7 @@ ExtractDisk  [09]"第4集 B     " -> "jam vol.1 (alt)_09.d88"
 		<description>Chili Tomato</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<!-- TODO: does it really not work on MA 4MHz? Keeps spinning at BASIC otherwise  -->
+		<!-- TODO: does it really not work on MA 4MHz? Keeps spinning at BASIC otherwise -->
 		<info name="usage" value="Set 8MHz mode on a PC8801MA+"/>
 
 		<part name="flop1" interface="floppy_5_25">

--- a/hash/pc98.xml
+++ b/hash/pc98.xml
@@ -1588,7 +1588,7 @@ TODO:
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_5_25">
-			<feature name="part_id" value="Disk A - Dict Std + System 2 "/>
+			<feature name="part_id" value="Disk A - Dict Std + System 2"/>
 			<dataarea name="flop" size="1265664">
 				<rom name="taro4_2_dict_std_+_system2.fdi" size="1265664" crc="8b92a740" sha1="ab6c4167714baa620acbd47625d6c997a3fb036d" offset="0" />
 			</dataarea>
@@ -1797,7 +1797,7 @@ TODO:
 		<description>Chanko Nabe</description>
 		<year>19??</year>
 		<publisher>ウエストサイド (WestSide)</publisher>
-		<info name="alt_title" value="ちゃんこ鍋 " />
+		<info name="alt_title" value="ちゃんこ鍋" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="1334720">
@@ -3578,7 +3578,7 @@ TODO:
 	<software name="aggregat">
 		<description>Aggregate</description>
 		<year>1994</year>
-		<publisher>ジャパンホームビデオ  (Japan Home Video)</publisher>
+		<publisher>ジャパンホームビデオ (Japan Home Video)</publisher>
 		<info name="alt_title" value="アグレガード" />
 		<info name="release" value="19941021" />
 		<part name="flop1" interface="floppy_5_25">
@@ -14374,7 +14374,7 @@ TODO:
 		<!-- Origin: Neo Kobe Collection -->
 		<description>Desert Dragoon - Sabaku no Ryuukihei</description>
 		<year>1993</year>
-		<publisher>ジャパンホームビデオ  (Japan Home Video)</publisher>
+		<publisher>ジャパンホームビデオ (Japan Home Video)</publisher>
 		<info name="alt_title" value="デザートドラグーン ～砂漠の竜騎兵～" />
 		<info name="release" value="19930709" />
 		<info name="usage" value="Has manual copy protection" />
@@ -17452,7 +17452,7 @@ TODO:
 	<software name="duel" supported="partial">
 		<description>Duel</description>
 		<year>1990</year>
-		<publisher>呉ソフトウエア工房  (KSK)</publisher>
+		<publisher>呉ソフトウエア工房 (KSK)</publisher>
 		<info name="alt_title" value="デュエル" />
 		<info name="release" value="19900512" />
 		<part name="flop1" interface="floppy_5_25">
@@ -17479,7 +17479,7 @@ TODO:
 		<!-- Origin: Neo Kobe Collection -->
 		<description>Duel - Kawanakajima Scenario</description>
 		<year>1991</year>
-		<publisher>呉ソフトウエア工房  (KSK)</publisher>
+		<publisher>呉ソフトウエア工房 (KSK)</publisher>
 		<info name="alt_title" value="デュエル 川中島シナリオ" />
 		<info name="release" value="19910720" />
 		<info name="usage" value="Expansion disk for Duel. Boot from the original Duel opening disk, then switch to the character/map disks from this set when prompted" />
@@ -17501,7 +17501,7 @@ TODO:
 		<!-- Origin: Neo Kobe Collection -->
 		<description>Duel Succession</description>
 		<year>1996</year>
-		<publisher>呉ソフトウエア工房  (KSK)</publisher>
+		<publisher>呉ソフトウエア工房 (KSK)</publisher>
 		<info name="alt_title" value="デュエル・サクセション" />
 		<info name="release" value="19960323" />
 		<info name="usage" value="Requires HDD installation. Run DSINST.EXE from DOS." />
@@ -19979,7 +19979,7 @@ TODO:
 	<software name="fqueen">
 		<description>First Queen</description>
 		<year>1988</year>
-		<publisher>呉ソフトウエア工房  (KSK)</publisher>
+		<publisher>呉ソフトウエア工房 (KSK)</publisher>
 		<info name="alt_title" value="ファーストクィーン" />
 		<info name="release" value="198812xx" />
 		<part name="flop1" interface="floppy_5_25">
@@ -19999,7 +19999,7 @@ TODO:
 	<software name="fqueena" cloneof="fqueen">
 		<description>First Queen (Alt)</description>
 		<year>1988</year>
-		<publisher>呉ソフトウエア工房  (KSK)</publisher>
+		<publisher>呉ソフトウエア工房 (KSK)</publisher>
 		<info name="alt_title" value="ファーストクィーン" />
 		<info name="release" value="198812xx" />
 		<part name="flop1" interface="floppy_5_25">
@@ -20019,7 +20019,7 @@ TODO:
 	<software name="fqueen2">
 		<description>First Queen II - Sabaku no Joou</description>
 		<year>1990</year>
-		<publisher>呉ソフトウエア工房  (KSK)</publisher>
+		<publisher>呉ソフトウエア工房 (KSK)</publisher>
 		<info name="alt_title" value="ファーストクィーン２ 砂漠の女王" />
 		<info name="release" value="19901217" />
 		<part name="flop1" interface="floppy_5_25">
@@ -20045,7 +20045,7 @@ TODO:
 	<software name="fqueen3">
 		<description>First Queen III</description>
 		<year>1993</year>
-		<publisher>呉ソフトウエア工房  (KSK)</publisher>
+		<publisher>呉ソフトウエア工房 (KSK)</publisher>
 		<info name="alt_title" value="ファーストクィーン３" />
 		<info name="release" value="19930702" />
 		<part name="flop1" interface="floppy_5_25">
@@ -20071,7 +20071,7 @@ TODO:
 	<software name="fqueen4">
 		<description>First Queen IV - Varcia Senki</description>
 		<year>1994</year>
-		<publisher>呉ソフトウエア工房  (KSK)</publisher>
+		<publisher>呉ソフトウエア工房 (KSK)</publisher>
 		<info name="alt_title" value="ファーストクィーン４ バルシア戦記" />
 		<info name="release" value="19940610" />
 		<part name="flop1" interface="floppy_5_25">
@@ -23576,7 +23576,7 @@ TODO:
 	<software name="headqrt" supported="no">
 		<description>Headquarters - America no Akumu</description>
 		<year>1994</year>
-		<publisher>アルゴラボ  算法研究所 (Algolab)</publisher>
+		<publisher>アルゴラボ 算法研究所 (Algolab)</publisher>
 		<info name="alt_title" value="ヘッドクォーターズ アメリカの悪夢" />
 		<info name="release" value="19940520" />
 		<part name="flop1" interface="floppy_5_25">
@@ -41168,7 +41168,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 	<software name="sotsugyo">
 		<description>Sotsugyou - Graduation</description>
 		<year>1992</year>
-		<publisher>ジャパンホームビデオ  (Japan Home Video)</publisher>
+		<publisher>ジャパンホームビデオ (Japan Home Video)</publisher>
 		<info name="alt_title" value="卒業 －グラデュエーション－" />
 		<info name="release" value="19920625" />
 		<part name="flop1" interface="floppy_5_25">
@@ -49415,7 +49415,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		<description>Zan - Kagerou no Jidai</description>
 		<year>1989</year>
 		<publisher>日本テレネット (Nihon Telenet)</publisher>
-		<info name="alt_title" value="斬 陽炎の時代 " />
+		<info name="alt_title" value="斬 陽炎の時代" />
 		<info name="release" value="19891117" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="System"/>
@@ -49442,7 +49442,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 		<description>Zan - Kagerou no Jidai (Alt?)</description>
 		<year>1989</year>
 		<publisher>日本テレネット (Nihon Telenet)</publisher>
-		<info name="alt_title" value="斬 陽炎の時代 " />
+		<info name="alt_title" value="斬 陽炎の時代" />
 		<info name="release" value="19891117" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="System"/>
@@ -52276,7 +52276,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 	<software name="kawanaka" supported="no">
 		<description>Kawanakajima Ibunroku</description>
 		<year>1992</year>
-		<publisher>呉ソフトウエア工房  (KSK)</publisher>
+		<publisher>呉ソフトウエア工房 (KSK)</publisher>
 		<info name="alt_title" value="川中島異聞録" />
 		<info name="release" value="19920327" />
 		<part name="flop1" interface="floppy_5_25">
@@ -52727,7 +52727,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 	<software name="localba" supported="yes">
 		<description>Locus Alba</description>
 		<year>1995</year>
-		<publisher>アルゴラボ  算法研究所 (Algolab)</publisher>
+		<publisher>アルゴラボ 算法研究所 (Algolab)</publisher>
 		<info name="alt_title" value="ロクス・アルバ" />
 		<info name="release" value="19950421" />
 		<info name="usage" value="Needs a DOS install from HDD, run LAINST.BAT" />
@@ -52754,7 +52754,7 @@ Requires MS-DOS 5.00H plus an unknown procedure (HDD install?)
 	<software name="localbag" supported="no">
 		<description>Locus Alba Gaiden</description>
 		<year>1995</year>
-		<publisher>アルゴラボ  算法研究所 (Algolab)</publisher>
+		<publisher>アルゴラボ 算法研究所 (Algolab)</publisher>
 		<info name="alt_title" value="ロクス・アルバ外伝" />
 		<info name="release" value="19960126" />
 		<part name="flop1" interface="floppy_5_25">
@@ -56811,7 +56811,7 @@ SPACE EMPIRE
 		<publisher>フォア・ナイン (Fournine)</publisher>
 		<info name="alt_title" value="えんじぇる☆ないと ～闇夜を翔ける天使たちの物語～" />
 		<info name="release" value="19960426" />
-		<info name="usage" value="Boot DOS, insert disk B, and run INSTHD.EXE. " />
+		<info name="usage" value="Boot DOS, insert disk B, and run INSTHD.EXE." />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="1069052">
@@ -69256,7 +69256,7 @@ doujin?!?
 		<description>Gassen Sekigahara (Incomplete)</description>
 		<year>1995</year>
 		<publisher>アートディンク (Artdink)</publisher>
-		<info name="alt_title" value="合戦関ヶ原 " />
+		<info name="alt_title" value="合戦関ヶ原" />
 		<info name="release" value="19950602" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1265664">

--- a/hash/pce.xml
+++ b/hash/pce.xml
@@ -3793,7 +3793,7 @@ license:CC0
 		<publisher>Taito</publisher>
 		<info name="serial" value="TP02006"/>
 		<info name="release" value="19900126"/>
-		<info name="alt_title" value="タイトーチェイスH. Q. "/>
+		<info name="alt_title" value="タイトーチェイスH.Q."/>
 		<part name="cart" interface="pce_cart">
 			<dataarea name="rom" size="393216">
 				<rom name="taito chase h.q. (japan).pce" size="393216" crc="6f4fd790" sha1="f4cd413a1f87027194b7cadfbaaa714c137e877f" />

--- a/hash/psx.xml
+++ b/hash/psx.xml
@@ -51860,7 +51860,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Media Entertainment</publisher>
 		<info name="serial" value="SLPS-03108" />
-		<info name="release" value="20001228 " />
+		<info name="release" value="20001228" />
 		<info name="alt_title" value="パチスロ帝王〜バトルナイト・アトランチスドーム〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">

--- a/hash/segacd.xml
+++ b/hash/segacd.xml
@@ -5459,7 +5459,7 @@ Requires [disc swap]
 		<description>ESPN NBA Hangtime '95 (USA)</description>
 		<year>1994</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="serial" value="T-93245 "/>
+		<info name="serial" value="T-93245"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="espn nba hangtime '95 (usa)" sha1="86f1f4ee8da0f04109cf20b6b8ad455900562abe"/>

--- a/hash/snes.xml
+++ b/hash/snes.xml
@@ -6215,7 +6215,7 @@ more investigation needed...
 			<feature name="pcb" value="SHVC-1A3B-01" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
 			<feature name="u2" value="U2 64K SRAM" />
-			<feature name="u3" value="U374LS139 " />
+			<feature name="u3" value="U374LS139" />
 			<feature name="u4" value="U4 CIC" />
 			<feature name="lockout" value="" />
 			<feature name="battery" value="BATT CR2032" />
@@ -8064,7 +8064,7 @@ more investigation needed...
 		<description>Battle Dodge Ball II (Japan)</description>
 		<year>1993</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SHVC-D2 " />
+		<info name="serial" value="SHVC-D2" />
 		<info name="release" value="19930723" />
 		<info name="alt_title" value="バトルドッジボールII" />
 		<part name="cart" interface="snes_cart">
@@ -10250,7 +10250,7 @@ more investigation needed...
 		<description>Chrono Trigger (Japan)</description>
 		<year>1995</year>
 		<publisher>Square</publisher>
-		<info name="serial" value="SHVC-ACTJ-JPN " />
+		<info name="serial" value="SHVC-ACTJ-JPN" />
 		<info name="release" value="19950311" />
 		<info name="alt_title" value="クロノ・トリガー" />
 		<part name="cart" interface="snes_cart">
@@ -10276,7 +10276,7 @@ more investigation needed...
 		<description>Chrono Trigger (Japan, alt)</description>
 		<year>1995</year>
 		<publisher>Square</publisher>
-		<info name="serial" value="SHVC-ACTJ-JPN " />
+		<info name="serial" value="SHVC-ACTJ-JPN" />
 		<info name="release" value="19950311" />
 		<info name="alt_title" value="クロノ・トリガー" />
 		<part name="cart" interface="snes_cart">
@@ -13724,7 +13724,7 @@ more investigation needed...
 			<feature name="cart_model" value="SHVC-006" />
 			<feature name="cart_back_label" value="920214" />
 			<feature name="slot" value="hirom" />
-			<dataarea name="rom" size="3145728 ">
+			<dataarea name="rom" size="3145728">
 				<rom name="shvc-f6-0 p1.u1" size="1048576" crc="bfc35e36" sha1="579cca6fd6c0b4f8d3489ba115d6bd51a745a16a" offset="0x000000" />
 				<rom name="shvc-f6-0 p2.u2" size="1048576" crc="82736bb1" sha1="1931269554c4aebbd4d250c881cd15906347062d" offset="0x100000" />
 				<rom name="shvc-f6-0 p3.u3" size="1048576" crc="38a398a2" sha1="b28c6b17b2b027831b70a3dcc0156e84209da2d0" offset="0x200000" />
@@ -19239,7 +19239,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SHVC-BM4J-JPN" />
 		<info name="release" value="19981204" />
-		<info name="alt_title" value="ミニ四駆 レッツ&amp;ゴー!! POWER WGP2 " />
+		<info name="alt_title" value="ミニ四駆 レッツ&amp;ゴー!! POWER WGP2" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -19839,7 +19839,7 @@ more investigation needed...
 		<description>NBA Jam - Tournament Edition (Euro)</description>
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
-		<info name="serial" value="SNSP-AJTP-EUR " />
+		<info name="serial" value="SNSP-AJTP-EUR" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BA1M-01" />
 			<feature name="u1" value="U1 P0" />
@@ -21582,7 +21582,7 @@ more investigation needed...
 			<feature name="pcb" value="SHVC-1A3B-01" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
 			<feature name="u2" value="U2 64K SRAM" />
-			<feature name="u3" value="U3 74LS139 " />
+			<feature name="u3" value="U3 74LS139" />
 			<feature name="u4" value="U4 CIC" />
 			<feature name="lockout" value="" />
 			<feature name="battery" value="BATT CR2032" />
@@ -23304,7 +23304,7 @@ more investigation needed...
 			<feature name="pcb" value="SHVC-1B3B-01" />
 			<feature name="u1" value="U1 MASKROM(N)" />
 			<feature name="u2" value="U2 64K SRAM" />
-			<feature name="u3" value="U3µPD77C25 " /> <!-- DSP3 -->
+			<feature name="u3" value="U3µPD77C25" /> <!-- DSP3 -->
 			<feature name="u4" value="U4 74LS139" />
 			<feature name="u5" value="U5 74HCU04" />
 			<feature name="u6" value="U6 CIC" />
@@ -23675,7 +23675,7 @@ more investigation needed...
 		<description>Sensible Soccer - European Champions (Euro)</description>
 		<year>1992</year>
 		<publisher>Renegade Software</publisher>
-		<info name="serial" value="SNSP-8S-FAH " />
+		<info name="serial" value="SNSP-8S-FAH" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-10" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -24659,7 +24659,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SHVC-BT" />
 		<info name="release" value="19930621" />
-		<info name="alt_title" value="スペースバズーカ " />
+		<info name="alt_title" value="スペースバズーカ" />
 		<sharedfeat name="compatibility" value="NTSC"/>
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-10" />
@@ -25532,7 +25532,7 @@ more investigation needed...
 			<feature name="u1" value="U1 P0" />
 			<feature name="u2" value="U2 P1" />
 			<feature name="u3" value="U3 64K SRAM" />
-			<feature name="u4" value="U4 µPD77C25 " /> <!-- DSP1 A -->
+			<feature name="u4" value="U4 µPD77C25" /> <!-- DSP1 A -->
 			<feature name="u5" value="U5 74LS139" />
 			<feature name="u6" value="U6 74HCU04" />
 			<feature name="u7" value="U7 CIC" />
@@ -36553,7 +36553,7 @@ List of unclassified roms
 		<publisher>KSS</publisher>
 		<info name="serial" value="SHVC-A3QJ-JPN" />
 		<info name="release" value="19960329" />
-		<info name="alt_title" value="美少女レスラー列伝   ブリザード Yuki 乱入!!" />
+		<info name="alt_title" value="美少女レスラー列伝 ブリザード Yuki 乱入!!" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2621440">
@@ -42916,7 +42916,7 @@ List of unclassified roms
 		<description>Heian Fuuunden (Japan)</description>
 		<year>1995</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SHVC-AKHJ " />
+		<info name="serial" value="SHVC-AKHJ" />
 		<info name="release" value="19950929" />
 		<info name="alt_title" value="平安風雲伝" />
 		<part name="cart" interface="snes_cart">
@@ -49444,7 +49444,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<publisher>Takara</publisher>
 		<info name="serial" value="SHVC-QP" />
 		<info name="release" value="19931022" />
-		<info name="alt_title" value="ミラクルガールズ ともみとみかげの不思議世界の大冒険  " />
+		<info name="alt_title" value="ミラクルガールズ ともみとみかげの不思議世界の大冒険" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -50869,7 +50869,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1996</year>
 		<publisher>Nichibutsu</publisher>
 		<info name="serial" value="SHVC-AECJ-JPN" />
-		<info name="release" value="19961129 " />
+		<info name="release" value="19961129" />
 		<info name="alt_title" value="ニチブツコレクション1 攻略カジノバー, 祗園花" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
@@ -61500,7 +61500,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<publisher>Quest</publisher>
 		<info name="serial" value="SHVC-AO7J-JPN" />
 		<info name="release" value="19951006" />
-		<info name="alt_title" value="タクティクスオウカ " />
+		<info name="alt_title" value="タクティクスオウカ" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -61517,7 +61517,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<publisher>Quest</publisher>
 		<info name="serial" value="SHVC-AO7J-JPN" />
 		<info name="release" value="19951006" />
-		<info name="alt_title" value="タクティクスオウカ " />
+		<info name="alt_title" value="タクティクスオウカ" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -61534,7 +61534,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<publisher>Quest</publisher>
 		<info name="serial" value="SHVC-AO7J-JPN" />
 		<info name="release" value="19951006" />
-		<info name="alt_title" value="タクティクスオウカ " />
+		<info name="alt_title" value="タクティクスオウカ" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">

--- a/hash/snes_bspack.xml
+++ b/hash/snes_bspack.xml
@@ -3747,7 +3747,7 @@ license:CC0
 		<description>Kouryaku Casino Bar Nichiyoubi &amp; 2/24 Game Tora no Ooana Special (0224)</description>
 		<year>199?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="alt_title" value="攻略カジノバー ルーレット +  ゲーム虎の大穴スペシャル 2/24" />
+		<info name="alt_title" value="攻略カジノバー ルーレット + ゲーム虎の大穴スペシャル 2/24" />
 		<part name="cart" interface="bspack">
 
 			<feature name="slot" value="bsmempak" />

--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -4206,7 +4206,7 @@ license:CC0
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3">
-			<feature name="part_id" value="Side B: Dr. Jekyll and Mr. Hyde "/>
+			<feature name="part_id" value="Side B: Dr. Jekyll and Mr. Hyde"/>
 			<dataarea name="flop" size="194816">
 				<rom name="double classic (1988)(zenobi)(side b).dsk" size="194816" crc="a92e7e19" sha1="4e7aeebbe48f81534ac6e8e6d3d64b8e08500c7a"/>
 			</dataarea>

--- a/hash/tutor.xml
+++ b/hash/tutor.xml
@@ -85,7 +85,7 @@ Battlefighter (Original) (Unreleased - Prototype Stage)
 		<description>4-nin Mahjan (Jpn, set 1)</description>
 		<year>1984</year>
 		<publisher>Tomy</publisher>
-		<info name="alt_title" value="四人麻雀 "/>
+		<info name="alt_title" value="四人麻雀"/>
 		<info name="serial" value="021E"/>
 		<part name="cart" interface="tutor_cart">
 			<dataarea name="rom" size="0x4000">
@@ -98,7 +98,7 @@ Battlefighter (Original) (Unreleased - Prototype Stage)
 		<description>4-nin Mahjan (Jpn, set 2)</description>
 		<year>1984</year>
 		<publisher>Tomy</publisher>
-		<info name="alt_title" value="四人麻雀 "/>
+		<info name="alt_title" value="四人麻雀"/>
 		<info name="serial" value="021E"/>
 		<part name="cart" interface="tutor_cart">
 			<dataarea name="rom" size="0x4000">

--- a/hash/x1_cass.xml
+++ b/hash/x1_cass.xml
@@ -126,7 +126,7 @@ Titles, publishers and release dates taken from:
 		<year>1985</year>
 		<publisher>アスキー (ASCII)</publisher>
 		<info name="release" value="198506xx"/>
-		<info name="alt_title" value="ザ・キャッスル "/>
+		<info name="alt_title" value="ザ・キャッスル"/>
 		<part name="cass" interface="x1_cass">
 			<dataarea name="side1" size="300004">
 				<rom name="castle.tap" size="300004" crc="2563d821" sha1="6bae59c7a18a6f07b66b6621016deb3c091a40fd"/>
@@ -139,7 +139,7 @@ Titles, publishers and release dates taken from:
 		<year>1985</year>
 		<publisher>アスキー (ASCII)</publisher>
 		<info name="release" value="198506xx"/>
-		<info name="alt_title" value="ザ・キャッスル "/>
+		<info name="alt_title" value="ザ・キャッスル"/>
 		<part name="cass" interface="x1_cass">
 			<dataarea name="side1" size="300004">
 				<rom name="the castle.tap" size="300004" crc="0ba30a7d" sha1="732e04231f82f749ca2fe529d7ac5db3353d6894"/>
@@ -488,7 +488,7 @@ Titles, publishers and release dates taken from:
 		<year>1985</year>
 		<publisher>ハドソン (Hudson Soft)</publisher>
 		<info name="release" value="198506xx"/>
-		<info name="alt_title" value="任天堂のゴルフ "/>
+		<info name="alt_title" value="任天堂のゴルフ"/>
 		<part name="cass" interface="x1_cass">
 			<dataarea name="side1" size="180004">
 				<rom name="golf.tap" size="180004" crc="d71eebf1" sha1="bd61d8af9ef4beebe6cc21f56edadb1c3bace59b"/>
@@ -501,7 +501,7 @@ Titles, publishers and release dates taken from:
 		<year>1985</year>
 		<publisher>ハドソン (Hudson Soft)</publisher>
 		<info name="release" value="198506xx"/>
-		<info name="alt_title" value="任天堂のゴルフ "/>
+		<info name="alt_title" value="任天堂のゴルフ"/>
 		<part name="cass" interface="x1_cass">
 			<dataarea name="side1" size="180004">
 				<rom name="golfa.tap" size="180004" crc="d731667d" sha1="4e5dc0a29a04d5c1d494f472fbc50c1f72e6b526"/>

--- a/hash/x1_flop.xml
+++ b/hash/x1_flop.xml
@@ -5109,7 +5109,7 @@ Plus, some games crash MAME at exit (e.g. some sorcer disks or some arcus disks)
 		<description>Cream Lemon - Star Trap</description>
 		<year>1987</year>
 		<publisher>ジャスト (Jast)</publisher>
-		<info name="alt_title" value="くりぃむレモン スタートラップ "/>
+		<info name="alt_title" value="くりぃむレモン スタートラップ"/>
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="414128">
 				<rom name="startrap-a.d88" size="414128" crc="a537e078" sha1="0a9f717e4877be0457f33b416605fb5213b0680d"/>


### PR DESCRIPTION
Note there's a weird Unicode code point after the word "Turbo" in the second changed line in a800.xml. It has been removed but doesn't show up on GitHub's diff. Same issue in this file popped up in #8112.