### PR TITLE
imagedev/midiin.cpp: send All Notes Off CC when unloading a MIDI file

### DIFF
--- a/src/devices/imagedev/midiin.cpp
+++ b/src/devices/imagedev/midiin.cpp
@@ -203,6 +203,16 @@ void midiin_device::call_unload()
 	{
 		m_midi->close();
 	}
+	else
+	{
+		// send "all notes off" CC if unloading a MIDI file
+		for (u8 channel = 0; channel < 0x10; channel++)
+		{
+			xmit_char(0xb0 | channel);
+			xmit_char(123);
+			xmit_char(0);
+		}
+	}
 	m_midi.reset();
 	m_sequence.clear();
 	m_timer->enable(false);


### PR DESCRIPTION
Just so stopping a MIDI file input mid-playback doesn't leave notes hanging on the receiving device. Not sure if this should be tied to another config option or something just so it doesn't risk doing anything weird to non-GM devices, though.