### PR TITLE
sinclair/specpls3.cpp: external dirve is 35 (MT7553)

### DIFF
--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -15747,7 +15747,7 @@ license:CC0
 		<description>Terminator 2 - Judgment Day (alt)</description>
 		<year>1991</year>
 		<publisher>Ocean Software</publisher>
-		<part name="flop1" interface="floppy_3">
+		<part name="flop1" interface="floppy_35">
 			<dataarea name="flop" size="216320">
 				<rom name="terminator 2 - judgment day (1991)(ocean).dsk" size="216320" crc="d97a5f2a" sha1="512127b1523d9ba51889b3891592007dcbb89ed0"/>
 			</dataarea>

--- a/src/mame/sinclair/specpls3.cpp
+++ b/src/mame/sinclair/specpls3.cpp
@@ -369,6 +369,7 @@ void specpls3_state::plus3_us_w(uint8_t data)
 static void specpls3_floppies(device_slot_interface &device)
 {
 	device.option_add("3ssdd", FLOPPY_3_SSDD);
+	device.option_add("35ssdd", FLOPPY_35_DD);
 }
 
 void specpls3_state::floppy_formats(format_registration &fr)
@@ -425,8 +426,7 @@ void specpls3_state::spectrum_plus3(machine_config &config)
 	UPD765A(config, m_upd765, 16_MHz_XTAL / 4, true, false); // clocked through SED9420
 	m_upd765->us_wr_callback().set(FUNC(specpls3_state::plus3_us_w));
 	FLOPPY_CONNECTOR(config, "upd765:0", specpls3_floppies, "3ssdd", specpls3_state::floppy_formats).enable_sound(true); // internal drive
-	FLOPPY_CONNECTOR(config, "upd765:1", specpls3_floppies, "3ssdd", specpls3_state::floppy_formats).enable_sound(true); // external drive
-
+	FLOPPY_CONNECTOR(config, "upd765:1", specpls3_floppies, "35ssdd", specpls3_state::floppy_formats).enable_sound(true); // external drive
 	SOFTWARE_LIST(config, "flop_list").set_original("specpls3_flop");
 }
 


### PR DESCRIPTION
Configures external (second) drive as 3.5".

There are other things in floppy system which prevents MT7553 from closing:
* https://mametesters.org/view.php?id=8396
* switching floppy_35 interface doesn't show game in software list
* [File Manager] menu for flop2 doesn't provide access to [software list] items