### PR TITLE
cdrom: Pass phys flag to read_partial_sector in read_subcode

### DIFF
--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -360,7 +360,7 @@ cdrom_file::~cdrom_file()
 ***************************************************************************/
 
 /**
- * @fn  std::error_condition read_partial_sector(void *dest, uint32_t lbasector, uint32_t chdsector, uint32_t tracknum, uint32_t startoffs, uint32_t length)
+ * @fn  std::error_condition read_partial_sector(void *dest, uint32_t lbasector, uint32_t chdsector, uint32_t tracknum, uint32_t startoffs, uint32_t length, bool phys)
  *
  * @brief   Reads partial sector.
  *
@@ -370,6 +370,7 @@ cdrom_file::~cdrom_file()
  * @param   tracknum        The tracknum.
  * @param   startoffs       The startoffs.
  * @param   length          The length.
+ * @param   phys            true to physical.
  *
  * @return  The partial sector.
  */
@@ -570,7 +571,7 @@ bool cdrom_file::read_subcode(uint32_t lbasector, void *buffer, bool phys)
 		return false;
 
 	// read the data
-	std::error_condition err = read_partial_sector(buffer, lbasector, chdsector, tracknum, cdtoc.tracks[tracknum].datasize, cdtoc.tracks[tracknum].subsize);
+	std::error_condition err = read_partial_sector(buffer, lbasector, chdsector, tracknum, cdtoc.tracks[tracknum].datasize, cdtoc.tracks[tracknum].subsize, phys);
 	return !err;
 }
 

--- a/src/lib/util/cdrom.h
+++ b/src/lib/util/cdrom.h
@@ -249,7 +249,7 @@ private:
 	static void get_info_from_type_string(const char *typestring, uint32_t *trktype, uint32_t *datasize);
 	static uint8_t ecc_source_byte(const uint8_t *sector, uint32_t offset);
 	static void ecc_compute_bytes(const uint8_t *sector, const uint16_t *row, int rowlen, uint8_t &val1, uint8_t &val2);
-	std::error_condition read_partial_sector(void *dest, uint32_t lbasector, uint32_t chdsector, uint32_t tracknum, uint32_t startoffs, uint32_t length, bool phys=false);
+	std::error_condition read_partial_sector(void *dest, uint32_t lbasector, uint32_t chdsector, uint32_t tracknum, uint32_t startoffs, uint32_t length, bool phys);
 
 	static std::string get_file_path(std::string &path);
 	static uint64_t get_file_size(std::string_view filename);


### PR DESCRIPTION
This fixes the data roundtrip problem mentioned in https://github.com/mamedev/mame/issues/10230. This does not address the TOC returning `CD_ROM` instead of `CD_ROM_XA` that is mentioned in the same issue.

As a test I used a toc/bin I had on hand and went from bin/toc -> chd -> bin/toc and verified the SHA-1 of the two BINs matched. Additionally, I tried some redump PS1 bin/cue files I had on hand and verified that the SHA-1 resulting of the BIN after doing bin/cue -> chd -> bin/cue matches the file I had on hand and also what was listed on the redump website. (see: https://github.com/mamedev/mame/issues/10230#issuecomment-1215996922)

Additionally, the `phys` parameter of `read_partial_sector` has a default value of `false` which made this bug go unnoticed for a long time. All usages of `read_partial_sector` except this one instance already pass a value in for `phys` so I removed the default value from the function so this problem can't happening again. Also updated the inline docs for the function since it was missing the `phys` parameter.