### PR TITLE
chdman: Fix TOC session type detection for extractcd

### DIFF
--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -1398,9 +1398,6 @@ void output_track_metadata(int mode, util::core_file &file, int tracknum, const 
 	// non-CUE mode
 	else if (mode == MODE_NORMAL)
 	{
-		// header on the first track
-		if (tracknum == 0)
-			file.printf("CD_ROM\n\n\n");
 		file.printf("// Track %d\n", tracknum + 1);
 
 		// write out the track type
@@ -2484,6 +2481,42 @@ static void do_extract_cd(parameters_map &params)
 		if (mode == MODE_GDI)
 		{
 			output_toc_file->printf("%d\n", toc.numtrks);
+		}
+		else if (mode == MODE_NORMAL)
+		{
+			bool mode1 = false;
+			bool mode2 = false;
+			bool cdda = false;
+
+			for (int tracknum = 0; tracknum < toc.numtrks; tracknum++)
+			{
+				switch (toc.tracks[tracknum].trktype)
+				{
+					case cdrom_file::CD_TRACK_MODE1:
+					case cdrom_file::CD_TRACK_MODE1_RAW:
+						mode1 = true;
+						break;
+
+					case cdrom_file::CD_TRACK_MODE2:
+					case cdrom_file::CD_TRACK_MODE2_FORM1:
+					case cdrom_file::CD_TRACK_MODE2_FORM2:
+					case cdrom_file::CD_TRACK_MODE2_FORM_MIX:
+					case cdrom_file::CD_TRACK_MODE2_RAW:
+						mode2 = true;
+						break;
+
+					case cdrom_file::CD_TRACK_AUDIO:
+						cdda = true;
+						break;
+				}
+			}
+
+			if (mode2)
+				output_toc_file->printf("CD_ROM_XA\n\n\n");
+			else if (cdda && !mode1)
+				output_toc_file->printf("CD_DA\n\n\n");
+			else
+				output_toc_file->printf("CD_ROM\n\n\n");
 		}
 
 		// iterate over tracks and copy all data


### PR DESCRIPTION
Fixes issue mentioned in https://github.com/mamedev/mame/issues/10230 where `CD_ROM_XA` is expected but `CD_ROM` is written. Additionally, I implemented the `CD_DA` session type based on the information found in cdrdao.

The logic used follows cdrdao's cue2toc code (https://github.com/cdrdao/cdrdao/blob/3787686d6f49687ce1b553236482078761e511de/trackdb/Cue2Toc.cc#L605-L642) and matches what's written in the man file (https://github.com/cdrdao/cdrdao/blob/3787686d6f49687ce1b553236482078761e511de/dao/cdrdao.man#L458-L466).

Test TOCs can be found on the cdrdao repo: https://github.com/cdrdao/cdrdao/tree/master/testtocs

I tested the following:
- `CD_ROM` is written when there is mode1 tracks but no mode2
- `CD_ROM_XA` is written when there is a mode2 track (converted a PS1 bin/cue -> chd -> bin/toc to verify this)
- `CD_DA` is written when there is only audio tracks (converted an audio only bin/cue -> chd -> bin/toc to verify this)
