### PR TITLE
c64_cass.xml: Added 16 items (15 working, 1 not working)

### DIFF
--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -16213,6 +16213,54 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="willowpa">
+		<description>Willow Pattern</description>
+		<year>1985</year>
+		<publisher>Firebird</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="652340">
+				<rom name="Willow_Pattern.tap" size="652340" crc="138b6222" sha1="e90213a04a938ebdf3ba060995333c707f8499c5"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="652470">
+				<rom name="Willow_Pattern_a1.tap" size="652470" crc="5a53f5a4" sha1="aa39c2f849c5117bd85403cd149fea9029b48ed7"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wimbledo" supported="no"> <!-- game loads fully with a light blue screen but doesn't run -->
+		<description>Wimbledon '64</description>
+		<year>1984</year>
+		<publisher>Merlin Software</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="333715">
+				<rom name="Wimbledon_'64.tap" size="333715" crc="416c49d3" sha1="7e736afc283e0a77c727907f78accdf3a5804517"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="326544">
+				<rom name="Wimbledon_'64_a1.tap" size="326544" crc="7b0cb7fa" sha1="616c3b20e158a8dda711cbcb8ee8d309523e5c5a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wintcamp">
+		<description>Winter Camp</description>
+		<year>1992</year>
+		<publisher>Thalamus</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="2120390">
+				<rom name="Winter_Camp.tap" size="2120390" crc="7af77350" sha1="410fdabcf946f8736634b170e0be9c052f9a55ec"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="wingames">
 		<description>Winter Games</description>
 		<year>1987</year>
@@ -16237,6 +16285,55 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="wingamesu" cloneof="wingames">
+		<description>Winter Games (U.S. Gold)</description>
+		<year>1985</year>
+		<publisher>U.S. Gold</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="2851745">
+				<rom name="Winter_Games.tap" size="2851745" crc="eae1686c" sha1="1a824bd603ac9589b2acf8bfee7414761fedd712"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wintolym">
+		<description>Winter Olympiad 88</description>
+		<year>1988</year>
+		<publisher>Tynesoft</publisher>
+		<info name="alt_title" value="Winter Challenge: World Class Competition"/>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="2934641">
+				<rom name="Winter_Olympiad_88.tap" size="2934641" crc="c1d59af2" sha1="374dd5f072ac76fb0e880c64bc55c86ae0dc0add"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="2934641">
+				<rom name="Winter_Olympiad_88_a1.tap" size="2934641" crc="b06d733b" sha1="f4712de485550a29d2a071861f931e5f99096c83"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wiz">
+		<description>Wiz</description>
+		<year>1987</year>
+		<publisher>Melbourne House</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="671678">
+				<rom name="Wiz.tap" size="671678" crc="36e69c58" sha1="0afeba6637a3207f3fa11147790509ade8986518"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="671647">
+				<rom name="Wiz_a1.tap" size="671647" crc="8887c464" sha1="f679d1a7993cccd67651bc0a858cdd6a5e448760"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="wizbiz">
 		<description>Wiz Biz</description>
 		<year>1987</year>
@@ -16245,6 +16342,25 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="453987">
 				<rom name="Wiz_Biz.tap" size="453987" crc="13e552ac" sha1="461e4e403615c4cbd0d83c6f7bbd170be7192db3"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wizardry">
+		<description>Wizardry</description>
+		<year>1985</year>
+		<publisher>The Edge</publisher>
+		<info name="alt_title" value="Spell of Destruction"/>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="1510746">
+				<rom name="Wizardry.tap" size="1510746" crc="6129d510" sha1="8cdda74b85077724f1034a1c655a936dfc9de90a"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="1510746">
+				<rom name="Wizardry_a1.tap" size="1510746" crc="2681bebf" sha1="5772535868d2e329ebc904f72226cb60b63516d8"/>
 			</dataarea>
 		</part>
 	</software>
@@ -16261,6 +16377,30 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="wizballo" cloneof="wizball">
+		<description>Wizball (Ocean)</description>
+		<year>1987</year>
+		<publisher>Ocean</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="725538">
+				<rom name="Wizball.tap" size="725538" crc="9920abdf" sha1="77d556b9ee83a2b53e41890212c7d89cf3c4c6ed"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wboy">
+		<description>Wonder Boy</description>
+		<year>1987</year>
+		<publisher>Activision</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="613447">
+				<rom name="Wonder_Boy.tap" size="613447" crc="10f0a74e" sha1="5740fdbfd25dc182ed500ca7f1526a2dce832c72"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="wordfeud">
 		<description>Word Feud</description>
 		<year>1983</year>
@@ -16269,6 +16409,64 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="448764">
 				<rom name="Word_Feud.tap" size="448764" crc="aefdafc4" sha1="19ce40b06a6db465542c0bf452ed45f1b9357811"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wcsoccer">
+		<description>World Championship Soccer</description>
+		<year>1991</year>
+		<publisher>Elite Systems</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="541513">
+				<rom name="World_Championship_Soccer.tap" size="541513" crc="6fffaa5c" sha1="c558416d81d3289ad61e2553d4955d8fec664bd9"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wclb">
+		<description>World Class Leader Board: The Ultimate Golf Challenge</description>
+		<year>1987</year>
+		<publisher>U.S. Gold</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Tape 1 Side 1: Course A"/>
+			<dataarea name="cass" size="748446">
+				<rom name="World_Class_Leader_Board-_The_Ultimate_Golf_Challenge_Tape_1_Side_1.tap" size="748446" crc="f6a7a8ca" sha1="96d800bd4fcc4e8bf84a461eb03ce135a0a5deb7"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Tape 1 Side 2: Course B"/>
+			<dataarea name="cass" size="744798">
+				<rom name="World_Class_Leader_Board-_The_Ultimate_Golf_Challenge_Tape_1_Side_2.tap" size="744798" crc="6690f80d" sha1="fe1c48d90ecb8919f286aeacacf307a6da4b8470"/>
+			</dataarea>
+		</part>
+
+		<part name="cass3" interface="cbm_cass">
+			<feature name="part_id" value="Tape 2 Side 1: Course C"/>
+			<dataarea name="cass" size="644926">
+				<rom name="World_Class_Leader_Board-_The_Ultimate_Golf_Challenge_Tape_2_Side_1.tap" size="644926" crc="9b67408b" sha1="f15d0cc8221887ecd0e6d35234584b59361c40dd"/>
+			</dataarea>
+		</part>
+
+		<part name="cass4" interface="cbm_cass">
+			<feature name="part_id" value="Tape 2 Side 2: Course D"/>
+			<dataarea name="cass" size="744830">
+				<rom name="World_Class_Leader_Board-_The_Ultimate_Golf_Challenge_Tape_2_Side_2.tap" size="744830" crc="003ee3e0" sha1="6c15f992ecf0f8c7efd89ac6d78ba4720b47d7e1"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wcupcarn">
+		<description>World Cup Carnival</description>
+		<year>1986</year>
+		<publisher>U.S. Gold</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="400325">
+				<rom name="World_Cup_Carnival.tap" size="400325" crc="669b3fdf" sha1="af791664d52e57b797659cd19c76ec15fb487968"/>
 			</dataarea>
 		</part>
 	</software>
@@ -16293,6 +16491,26 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="wrldgamesu" cloneof="wrldgames">
+		<description>World Games (U.S. Gold)</description>
+		<year>1986</year>
+		<publisher>U.S. Gold</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Side 1"/>
+			<dataarea name="cass" size="1764808">
+				<rom name="World_Games_Side_1.tap" size="1764808" crc="107b627b" sha1="b02b95a0e48225f4404dc116037854ede7df04ba"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Side 2"/>
+			<dataarea name="cass" size="1531484">
+				<rom name="World_Games_Side_2.tap" size="1531484" crc="f00604cb" sha1="33e0481a9b09d838ab2138d990469863c303cabb"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="wsb">
 		<description>World Series Baseball</description>
 		<year>1989</year>
@@ -16301,6 +16519,42 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="402702">
 				<rom name="World_Series_Baseball.tap" size="402702" crc="97b6338a" sha1="791a4deaecefad827fe719ab8d3f39a0dd1dde8c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wsbi" cloneof="wsb">
+		<description>World Series Baseball (Imagine)</description>
+		<year>1985</year>
+		<publisher>Imagine</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="454978">
+				<rom name="World_Series_Baseball.tap" size="454978" crc="89ab0eb1" sha1="2c4a8b547f1b8dcfa52f2899df3c0efadb7c8929"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="thewormi">
+		<description>The Worm in Paradise</description>
+		<year>1985</year>
+		<publisher>Level 9 Computing</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="465493">
+				<rom name="Worm_in_Paradise,_The.tap" size="465493" crc="4f3cc7b9" sha1="a8e027a8d8ff350816312eaf8adceec9f2fc2f3f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="x15alpha">
+		<description>X-15 Alpha Mission</description>
+		<year>1987</year>
+		<publisher>Activision</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="486063">
+				<rom name="X-15_Alpha_Mission.tap" size="486063" crc="24f21a0a" sha1="dc59fa94d658639b62e7c602c2ae0fc84f07f5cf"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
New working software list additions
---------------------------------------
Willow Pattern (Firebird) [C64 Ultimate Tape Archive V2.0]
Winter Camp (Thalamus) [C64 Ultimate Tape Archive V2.0]
Winter Games (U.S. Gold) [C64 Ultimate Tape Archive V2.0]
Winter Olympiad 88 (Tynesoft) [C64 Ultimate Tape Archive V2.0]
Wiz (Melbourne House) [C64 Ultimate Tape Archive V2.0]
Wizardry (The Edge) [C64 Ultimate Tape Archive V2.0]
Wizball (Ocean) [C64 Ultimate Tape Archive V2.0]
Wonder Boy (Activision) [C64 Ultimate Tape Archive V2.0]
World Championship Soccer (Elite Systems) [C64 Ultimate Tape Archive V2.0]
World Class Leader Board: The Ultimate Golf Challenge (U.S. Gold) [C64 Ultimate Tape Archive V2.0]
World Cup Carnival (U.S. Gold) [C64 Ultimate Tape Archive V2.0]
World Games (U.S. Gold) [C64 Ultimate Tape Archive V2.0]
World Series Baseball (Imagine) [C64 Ultimate Tape Archive V2.0]
The Worm in Paradise (Level 9 Computing) [C64 Ultimate Tape Archive V2.0]
X-15 Alpha Mission (Activision) [C64 Ultimate Tape Archive V2.0]

New NOT_WORKING software list additions
---------------------------------------
Wimbledon '64 (Merlin Software) [C64 Ultimate Tape Archive V2.0]