### PR TITLE
Correct the English translations of Monon Color games

### DIFF
--- a/hash/monon_color.xml
+++ b/hash/monon_color.xml
@@ -40,7 +40,7 @@ license:CC0
   (1) (Note: One known to exist in the wild, was supposedly bought at a thrift store. Based around Jackie Chan fighting)
 -->
 
-	<software name="purcfs"> <!-- 101 - Seer: Ares Fighting Spirit -->
+	<software name="seerfs"> <!-- 101 - Seer: Ares Fighting Spirit -->
 		<description>Sài ěr hào: Zhànshén dòu hún</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -52,7 +52,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="lockmagi"> <!-- 102 - Roco Kingdom: Magic Array -->
+	<software name="rocomagi"> <!-- 102 - Roco Kingdom: Magic Array -->
 		<description>Luòkè wángguó-mófǎ zhèn</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -100,7 +100,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="purceb"> <!-- 105 - Seer: Energy Battle -->
+	<software name="seereb"> <!-- 105 - Seer: Energy Battle -->
 		<description>Sài ěr hào-néngyuán dà zuòzhàn</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -136,7 +136,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="lockba"> <!-- 201 - Roco Kingdom: Big Adventure -->
+	<software name="rocoba"> <!-- 201 - Roco Kingdom: Big Adventure -->
 		<description>Luòkè wángguó-dà màoxiǎn</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -148,7 +148,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="lockice"> <!-- 202 - Roco Kingdom RPG: Ice Blue -->
+	<software name="rocoice"> <!-- 202 - Roco Kingdom RPG: Ice Blue -->
 		<description>Luòkè wángguó-bīng zhī lán</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -160,7 +160,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="lockfire"> <!-- 203 - Roco Kingdom RPG: Black Flame -->
+	<software name="rocofire"> <!-- 203 - Roco Kingdom RPG: Black Flame -->
 		<description>Luòkè wángguó-hēi zhī yán</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -173,7 +173,7 @@ license:CC0
 	</software>
 
 	<!-- there is a second glob in the cartridge, presumably for the card reader -->
-	<software name="lockcard" supported="no"> <!-- 204 - Roco Kingdom: Card Wars -->
+	<software name="rococard" supported="no"> <!-- 204 - Roco Kingdom: Card Wars -->
 		<description>Luòkè wángguó-kǎ pái zhàn jì</description>
 		<year>2015</year>
 		<publisher>M&amp;D</publisher>
@@ -198,7 +198,7 @@ license:CC0
 	</software>
 
 	<!-- there is a second glob in the cartridge, presumably for the badge reader -->
-	<software name="lockbadg" supported="no"> <!-- Roco Kingdom: The King's Badge -->
+	<software name="rocobadg" supported="no"> <!-- Roco Kingdom: The King's Badge -->
 		<description>Luòkè wángguó-wángzhě huīzhāng</description>
 		<year>2015</year>
 		<publisher>M&amp;D</publisher>

--- a/hash/monon_color.xml
+++ b/hash/monon_color.xml
@@ -12,27 +12,27 @@ license:CC0
   <!-- Known games list
 
     English Translation                            Romanization                                Dumped? Released?    Item #      Type?           Full name
-    Purcell: Ares Fighting Spirit                  Sài ěr hào: Zhànshén dòu hún                Y       Y            NO. 101     RPG             赛尔号：战神斗魂
-    Locke Kingdom: Magic Array                     Luòkè wángguó-mófǎ zhèn                     Y       Y            NO. 102     PUZ/EDU         洛克王国-魔法阵
+    Seer: Ares Fighting Spirit                     Sài ěr hào: Zhànshén dòu hún                Y       Y            NO. 101     RPG             赛尔号：战神斗魂
+    Roco Kingdom: Magic Array                      Luòkè wángguó-mófǎ zhèn                     Y       Y            NO. 102     PUZ/EDU         洛克王国-魔法阵
     Mech Cyclone: Fighting Masters                 Jī jiǎ xuànfēng-gédòu dàshī                 Y       Y            NO. 103     FTG             机甲旋风-格斗大师
-    Zinba! : The lost relics                       Shén pò-shīluò de yíjī                      Y       Y            NO. 104     RPG             神魄-失落的遗迹
-    Purcell: Energy Battle                         Sài ěr hào-néngyuán dà zuòzhàn              Y       Y            NO. 105     PUZ             赛尔号-能源大作战
+    Zinba! : The Lost Relics                       Shén pò-shīluò de yíjī                      Y       Y            NO. 104     RPG             神魄-失落的遗迹
+    Seer: Energy Battle                            Sài ěr hào-néngyuán dà zuòzhàn              Y       Y            NO. 105     PUZ             赛尔号-能源大作战
     Iron Man: Hero Strike                          Gāngtiě xiá-yīngxióng fǎnjí zhàn            Y       Y            NO. 106     ACT             钢铁侠-英雄反击战
     Zombie Hunter                                  Jiāngshī lièrén                             Y       Y            NO. 107     ACT             僵尸猎人
     IELTS Adventure                                Yǎsī tǎ dà màoxiǎn                          N       Y            NO. 108     PUZ/EDU         雅思塔大冒险
     Ultimate Brain Power                           Nǎolì liánlián kàn                          N       Y            NO. 109     PUZ/EDU         脑力连连看
-    Locke Kingdom: Big Adventure                   Luòkè wángguó-dà màoxiǎn                    Y       Y            NO. 201     ACT             洛克王国-大冒险
-    Locke Kingdom RPG: Ice Blue                    Luòkè wángguó-bīng zhī lán                  Y       Y            NO. 202     RPG             洛克王国-冰之蓝
-    Locke Kingdom RPG: Black Fire                  Luòkè wángguó-hēi zhī yán                   Y       Y            NO. 203     RPG             洛克王国-黑之炎
-    Locke Kingdom: Card Wars                       Luòkè wángguó-kǎ pái zhàn jì                Y       Y            NO. 204     RPG             洛克王国-卡牌战纪
+    Roco Kingdom: Big Adventure                    Luòkè wángguó-dà màoxiǎn                    Y       Y            NO. 201     ACT             洛克王国-大冒险
+    Roco Kingdom RPG: Ice Blue                     Luòkè wángguó-bīng zhī lán                  Y       Y            NO. 202     RPG             洛克王国-冰之蓝
+    Roco Kingdom RPG: Black Flame                  Luòkè wángguó-hēi zhī yán                   Y       Y            NO. 203     RPG             洛克王国-黑之炎
+    Roco Kingdom: Card Wars                        Luòkè wángguó-kǎ pái zhàn jì                Y       Y            NO. 204     RPG             洛克王国-卡牌战纪
     Armor Warrior                                  Kǎijiǎ yǒngshì dàluàn dòu                   Y       Y            NO. 205     ACT             铠甲勇士大乱斗
-    Locke Kingdom: The King's Badge                Luòkè wángguó-wángzhě huīzhāng              Y       Y            NO. 206     RPG             洛克王国-王者徽章
+    Roco Kingdom: The King's Badge                 Luòkè wángguó-wángzhě huīzhāng              Y       Y            NO. 206     RPG             洛克王国-王者徽章
     Laboratory Mathematica Olympiad                Àoshù shíyàn shì                            N       Y            NO. 207     PUZ/EDU         奥数实验室
     Logic Fight                                    Luójí pīn yī pīn                            Y       Y            NO. 301     PUZ/EDU         逻辑拼一拼
-    Pleasant goat and big big wolf's comet battle  Xǐyángyáng yǔ huītàiláng-juézhàn miē xīng   Y       Y            NO. 302     PUZ/EDU         喜羊羊与灰太狼-决战咩星
+    Pleasant Goat and Big Big Wolf's comet battle  Xǐyángyáng yǔ huītàiláng-juézhàn miē xīng   Y       Y            NO. 302     PUZ/EDU         喜羊羊与灰太狼-决战咩星
     Dragon Ball: The Martial Arts Conference       Lóngzhū-wǔdào dàhuì                         Y       Y            NO. 303     ACT             龙珠-武道大会
     League of Legends: The Ultimate Fight          Yīngxióng liánméng-zhōngjí gédòu            Y       Y            NO. 304     FTG             英雄联盟-终极格斗
-    Ben 10: alien force                            ..                                          N       N?                       ACT             BEN 10: ALIEN FORCE
+    Ben 10: Alien Force                            ..                                          N       N?                       ACT             BEN 10: ALIEN FORCE
     DIGIMON                                        ..                                          N       N?                       RPG             DIGIMON
     Jackie Chan fighting? (1)                      (unknown)                                   N       Y?           NO. 308?    FTG             (unknown)
 
@@ -40,7 +40,7 @@ license:CC0
   (1) (Note: One known to exist in the wild, was supposedly bought at a thrift store. Based around Jackie Chan fighting)
 -->
 
-	<software name="purcfs"> <!-- 101 - Purcell: Ares Fighting Spirit -->
+	<software name="purcfs"> <!-- 101 - Seer: Ares Fighting Spirit -->
 		<description>Sài ěr hào: Zhànshén dòu hún</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -52,7 +52,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="lockmagi"> <!-- 102 - Locke Kingdom: Magic Array -->
+	<software name="lockmagi"> <!-- 102 - Roco Kingdom: Magic Array -->
 		<description>Luòkè wángguó-mófǎ zhèn</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -88,7 +88,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="zinba"> <!-- 104 - Zinba! : The lost relics -->
+	<software name="zinba"> <!-- 104 - Zinba! : The Lost Relics -->
 		<description>Shén pò-shīluò de yíjī</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -100,7 +100,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="purceb"> <!-- 105 - Purcell: Energy Battle -->
+	<software name="purceb"> <!-- 105 - Seer: Energy Battle -->
 		<description>Sài ěr hào-néngyuán dà zuòzhàn</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -136,7 +136,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="lockba"> <!-- 201 - Locke Kingdom: Big Adventure -->
+	<software name="lockba"> <!-- 201 - Roco Kingdom: Big Adventure -->
 		<description>Luòkè wángguó-dà màoxiǎn</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -148,7 +148,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="lockice"> <!-- 202 - Locke Kingdom RPG: Ice Blue -->
+	<software name="lockice"> <!-- 202 - Roco Kingdom RPG: Ice Blue -->
 		<description>Luòkè wángguó-bīng zhī lán</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -160,7 +160,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="lockfire"> <!-- 203 - Locke Kingdom RPG: Black Fire -->
+	<software name="lockfire"> <!-- 203 - Roco Kingdom RPG: Black Flame -->
 		<description>Luòkè wángguó-hēi zhī yán</description>
 		<year>2014</year>
 		<publisher>M&amp;D</publisher>
@@ -173,7 +173,7 @@ license:CC0
 	</software>
 
 	<!-- there is a second glob in the cartridge, presumably for the card reader -->
-	<software name="lockcard" supported="no"> <!-- 204 - Locke Kingdom: Card Wars -->
+	<software name="lockcard" supported="no"> <!-- 204 - Roco Kingdom: Card Wars -->
 		<description>Luòkè wángguó-kǎ pái zhàn jì</description>
 		<year>2015</year>
 		<publisher>M&amp;D</publisher>
@@ -198,7 +198,7 @@ license:CC0
 	</software>
 
 	<!-- there is a second glob in the cartridge, presumably for the badge reader -->
-	<software name="lockbadg" supported="no"> <!-- Locke Kingdom: The King's Badge -->
+	<software name="lockbadg" supported="no"> <!-- Roco Kingdom: The King's Badge -->
 		<description>Luòkè wángguó-wángzhě huīzhāng</description>
 		<year>2015</year>
 		<publisher>M&amp;D</publisher>
@@ -222,7 +222,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="bigwolf"> <!-- 302 - Pleasant goat and big big wolf's comet battle -->
+	<software name="bigwolf"> <!-- 302 - Pleasant Goat and Big Big Wolf's comet battle -->
 		<description>Xǐyángyáng yǔ huītàiláng-juézhàn miē xīng</description>
 		<year>2015</year>
 		<publisher>M&amp;D</publisher>

--- a/hash/monon_color.xml
+++ b/hash/monon_color.xml
@@ -6,7 +6,7 @@ license:CC0
 <softwarelist name="monon_color" description="M&amp;D Monon Color cartridges">
   <!-- Cartridges contain a serial flash ROM, and an epoxy blob.
        The blob contains game specific music, assuming it to be an MCU
-	   
+
        Note, games save data to 0x50000-0x6ffff, in an unused cart this area is always 0xff filled -->
 
   <!-- Known games list
@@ -30,7 +30,7 @@ license:CC0
     Laboratory Mathematica Olympiad                Àoshù shíyàn shì                            N       Y            NO. 207     PUZ/EDU         奥数实验室
     Logic Fight                                    Luójí pīn yī pīn                            Y       Y            NO. 301     PUZ/EDU         逻辑拼一拼
     Pleasant Goat and Big Big Wolf's comet battle  Xǐyángyáng yǔ huītàiláng-juézhàn miē xīng   Y       Y            NO. 302     PUZ/EDU         喜羊羊与灰太狼-决战咩星
-    Dragon Ball: The Martial Arts Conference       Lóngzhū-wǔdào dàhuì                         Y       Y            NO. 303     ACT             龙珠-武道大会
+    Dragon Ball: Budokai                           Lóngzhū-wǔdào dàhuì                         Y       Y            NO. 303     ACT             龙珠-武道大会
     League of Legends: The Ultimate Fight          Yīngxióng liánméng-zhōngjí gédòu            Y       Y            NO. 304     FTG             英雄联盟-终极格斗
     Ben 10: Alien Force                            ..                                          N       N?                       ACT             BEN 10: ALIEN FORCE
     DIGIMON                                        ..                                          N       N?                       RPG             DIGIMON
@@ -234,7 +234,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="drgnbma"> <!-- 303 - Dragon Ball: The Martial Arts Conference -->
+	<software name="drgnbma"> <!-- 303 - Dragon Ball: Budokai -->
 		<description>Lóngzhū-wǔdào dàhuì</description>
 		<year>2015</year>
 		<publisher>M&amp;D</publisher>


### PR DESCRIPTION
A QoL fix rather than anything else

4+ years ago, when I originally translated them, 赛尔号 didn't have an English name. That has changed since then. I overlooked Roco Kingdom as well, so that has been fixed.

The capitalization issues were also bugging me, so I fixed those.

I didn't touch the software names as I was unsure if changes would be needed or not.