### PR TITLE
Remove BAD_DUMP marker on sf2049se U27

### DIFF
--- a/src/mame/midway/vegas.cpp
+++ b/src/mame/midway/vegas.cpp
@@ -2533,7 +2533,7 @@ ROM_END
 
 ROM_START( sf2049se )
 	ROM_REGION32_LE( 0x80000, PCI_ID_NILE":rom", 0 )
-	// POST output reports bad checksum for boot ROM, this is correct as verified from several original U27 chips
+	// POST output reports bad checksum for boot ROM, this is correct as verified with several original U27 chips
 	ROM_LOAD( "sf2049se.u27", 0x000000, 0x80000, CRC(da4ecd9c) SHA1(2574ff3d608ebcc59a63cf6dea13ee7650ae8921) )
 
 	ROM_REGION32_LE( 0x100000, PCI_ID_NILE":update", ROMREGION_ERASEFF )

--- a/src/mame/midway/vegas.cpp
+++ b/src/mame/midway/vegas.cpp
@@ -2533,10 +2533,8 @@ ROM_END
 
 ROM_START( sf2049se )
 	ROM_REGION32_LE( 0x80000, PCI_ID_NILE":rom", 0 )
-	// Bad Dump
-	// POST Message: Boot EPROM checksum...FAILED. Computed: F7017455
-	// End of file including checksum area is filled with FF's.
-	ROM_LOAD( "sf2049se.u27", 0x000000, 0x80000, CRC(da4ecd9c) SHA1(2574ff3d608ebcc59a63cf6dea13ee7650ae8921) BAD_DUMP )
+	// POST output reports bad checksum for boot ROM, this is correct as verified from several original U27 chips
+	ROM_LOAD( "sf2049se.u27", 0x000000, 0x80000, CRC(da4ecd9c) SHA1(2574ff3d608ebcc59a63cf6dea13ee7650ae8921) )
 
 	ROM_REGION32_LE( 0x100000, PCI_ID_NILE":update", ROMREGION_ERASEFF )
 


### PR DESCRIPTION
sf2049se boot ROM dump is not bad, POST checksum failing is correct as verified by dumping several original U27 chips