### PR TITLE
emu/video.cpp: Added a space before %FPS in speed text.

### DIFF
--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -301,7 +301,7 @@ std::string video_manager::speed_text()
 
 	// append the speed for all cases except paused
 	if (!paused)
-		util::stream_format(str, "%4d%%", (int)(100 * m_speed_percent + 0.5));
+		util::stream_format(str, " %3d%%", (int)(100 * m_speed_percent + 0.5));
 
 	// display the number of partial updates as well
 	int partials = 0;


### PR DESCRIPTION
Fixes the contiguous text when unthrottled and %FPS > 999. I can't be the only one annoyed by this?