### PR TITLE
video/gb_lcd.cpp: Always return line counter for offset 4

### DIFF
--- a/src/devices/video/gb_lcd.cpp
+++ b/src/devices/video/gb_lcd.cpp
@@ -2915,6 +2915,11 @@ uint8_t dmg_ppu_device::video_r(offs_t offset)
 		if (offset == 0x29) LOG("BCPD read, palette is %s\n", m_pal_locked == LOCKED ? "LOCKED" : "UNLOCKED");
 	}
 
+	// TODO: Why is m_current_line kept separate?  The way this device keeps state is a mess.
+	// Many 188in1 games hang polling the line counter only seeing 0x00 without this.
+	if (4 == offset)
+		return m_current_line;
+
 	return m_vid_regs[offset];
 }
 


### PR DESCRIPTION
Currently, when running `gbcolor:188in1` on `gameboy`, a large number of games will hang on start polling the frame counter waiting for it to reach 0x91.  With the current code in MAME, it always reads as 0x00, so they never break out of the loop.  An easy example to test is Yakuman (number 15, on the second page).  This code get these games running, but it’s clearly a hack.

Why does the PPU code behave the way it does?
* Why is it keeping `m_current_line` separate from the value kept in `m_vid_regs[4]` in the first place?
* As far as I can tell, this register always returns the current line counter.  Why does MAME get into a state where it reads zero like this?

@wilbertpol can you shed some light on this?