### PR TITLE
docs/source/initialsetup/compilingmame.rst: updated compilation packa…

### DIFF
--- a/docs/source/initialsetup/compilingmame.rst
+++ b/docs/source/initialsetup/compilingmame.rst
@@ -271,7 +271,7 @@ Debian and Ubuntu (including Raspberry Pi and ODROID devices)
 You’ll need a few prerequisites from your Linux distribution.  Make sure you get
 SDL2 2.0.6 or later as earlier versions lack required functionality::
 
-    sudo apt-get install git build-essential python libsdl2-dev libsdl2-ttf-dev libfontconfig-dev libpulse-dev qt5-default qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
+    sudo apt-get install git build-essential python libsdl2-dev libsdl2-ttf-dev libfontconfig-dev libpulse-dev qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
 
 Compilation is exactly as described above in All Platforms.  Note the Ubuntu
 Linux modifies GCC to enable the GNU C Library “fortify source” feature by

--- a/docs/source/initialsetup/compilingmame.rst
+++ b/docs/source/initialsetup/compilingmame.rst
@@ -271,12 +271,8 @@ Debian and Ubuntu (including Raspberry Pi and ODROID devices)
 You’ll need a few prerequisites from your Linux distribution.  Make sure you get
 SDL2 2.0.6 or later as earlier versions lack required functionality::
 
-    sudo apt-get install git build-essential python libsdl2-dev libsdl2-ttf-dev libfontconfig-dev libpulse-dev qt5-default
+    sudo apt-get install git build-essential python libsdl2-dev libsdl2-ttf-dev libfontconfig-dev libpulse-dev qt5-default qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
 
-More recent distributions do not have a qt5-default metapackage.  If you see the error "E: Package 'qt5-default' has no installation candidate" then use the following::
-
-    sudo apt-get install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
- 
 Compilation is exactly as described above in All Platforms.  Note the Ubuntu
 Linux modifies GCC to enable the GNU C Library “fortify source” feature by
 default, which may cause issues compiling MAME (see :ref:`compiling-issues`).

--- a/docs/source/initialsetup/compilingmame.rst
+++ b/docs/source/initialsetup/compilingmame.rst
@@ -273,6 +273,10 @@ SDL2 2.0.6 or later as earlier versions lack required functionality::
 
     sudo apt-get install git build-essential python libsdl2-dev libsdl2-ttf-dev libfontconfig-dev libpulse-dev qt5-default
 
+More recent distributions do not have a qt5-default metapackage.  If you see the error "E: Package 'qt5-default' has no installation candidate" then use the following::
+
+    sudo apt-get install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
+ 
 Compilation is exactly as described above in All Platforms.  Note the Ubuntu
 Linux modifies GCC to enable the GNU C Library “fortify source” feature by
 default, which may cause issues compiling MAME (see :ref:`compiling-issues`).

--- a/docs/source/initialsetup/compilingmame.rst
+++ b/docs/source/initialsetup/compilingmame.rst
@@ -271,7 +271,7 @@ Debian and Ubuntu (including Raspberry Pi and ODROID devices)
 You’ll need a few prerequisites from your Linux distribution.  Make sure you get
 SDL2 2.0.6 or later as earlier versions lack required functionality::
 
-    sudo apt-get install git build-essential python libsdl2-dev libsdl2-ttf-dev libfontconfig-dev libpulse-dev qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
+    sudo apt-get install git build-essential python3 libsdl2-dev libsdl2-ttf-dev libfontconfig-dev libpulse-dev qtbase5-dev qtbase5-dev-tools qtchooser qt5-qmake
 
 Compilation is exactly as described above in All Platforms.  Note the Ubuntu
 Linux modifies GCC to enable the GNU C Library “fortify source” feature by


### PR DESCRIPTION
…ge information for missing qt5-default

The compiling instructions don't mention the missing qt5-default metapackage on more recent editions of debian/ubuntu.

This addition gives a workaround, basically installing the dependencies that were installed as part of the qt5-default metapackage:

https://packages.ubuntu.com/focal/qt5-default