### PR TITLE
diagnostics: fix clang Windows build

### DIFF
--- a/src/osd/modules/diagnostics/diagnostics_win32.cpp
+++ b/src/osd/modules/diagnostics/diagnostics_win32.cpp
@@ -507,7 +507,7 @@ bool symbol_manager::parse_sym_line(const char *line, uintptr_t &address, std::s
 	*/
 
 	// first look for a (ty) entry
-	char *type = strstr(line, "(ty  20)");
+	const char *type = strstr(line, "(ty  20)");
 	if (type == nullptr)
 		type = strstr(line, "(ty   20)");
 


### PR DESCRIPTION
Restore necessary const qualifier removed by 0055a33e81b60284c6390e9c73db9fcb19b8ce8b