### PR TITLE
wd1000: use resolve_safe for m_intrq_cb

### DIFF
--- a/src/devices/machine/wd1000.cpp
+++ b/src/devices/machine/wd1000.cpp
@@ -58,7 +58,7 @@ void wd1000_device::set_sector_base(uint32_t base)
 void wd1000_device::device_start()
 {
 	// Resolve callbacks
-	m_intrq_cb.resolve();
+	m_intrq_cb.resolve_safe();
 	m_drq_cb.resolve();
 
 	// Allocate timers


### PR DESCRIPTION
Currently the code for the WD1000 controller is using resolve() for its interrupt callback. This changes it to use resolve_safe() to prevent crashes for devices that do not set an interrupt callback.