### PR TITLE
Remove osd_subst_env from osd_file and directory interfaces

### DIFF
--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -310,41 +310,41 @@ public:
 	bool write_config() const { return bool_value(OPTION_WRITECONFIG); }
 
 	// core search path options
-	const char *plugin_data_path() const { return value(OPTION_PLUGINDATAPATH); }
-	const char *media_path() const { return value(OPTION_MEDIAPATH); }
-	const char *hash_path() const { return value(OPTION_HASHPATH); }
-	const char *sample_path() const { return value(OPTION_SAMPLEPATH); }
-	const char *art_path() const { return value(OPTION_ARTPATH); }
-	const char *ctrlr_path() const { return value(OPTION_CTRLRPATH); }
-	const char *ini_path() const { return value(OPTION_INIPATH); }
-	const char *font_path() const { return value(OPTION_FONTPATH); }
-	const char *cheat_path() const { return value(OPTION_CHEATPATH); }
-	const char *crosshair_path() const { return value(OPTION_CROSSHAIRPATH); }
-	const char *plugins_path() const { return value(OPTION_PLUGINSPATH); }
-	const char *language_path() const { return value(OPTION_LANGUAGEPATH); }
-	const char *sw_path() const { return value(OPTION_SWPATH); }
+	std::string plugin_data_path() const { return value_substituted(OPTION_PLUGINDATAPATH); }
+	std::string media_path() const { return value_substituted(OPTION_MEDIAPATH); }
+	std::string hash_path() const { return value_substituted(OPTION_HASHPATH); }
+	std::string sample_path() const { return value_substituted(OPTION_SAMPLEPATH); }
+	std::string art_path() const { return value_substituted(OPTION_ARTPATH); }
+	std::string ctrlr_path() const { return value_substituted(OPTION_CTRLRPATH); }
+	std::string ini_path() const { return value_substituted(OPTION_INIPATH); }
+	std::string font_path() const { return value_substituted(OPTION_FONTPATH); }
+	std::string cheat_path() const { return value_substituted(OPTION_CHEATPATH); }
+	std::string crosshair_path() const { return value_substituted(OPTION_CROSSHAIRPATH); }
+	std::string plugins_path() const { return value_substituted(OPTION_PLUGINSPATH); }
+	std::string language_path() const { return value_substituted(OPTION_LANGUAGEPATH); }
+	std::string sw_path() const { return value_substituted(OPTION_SWPATH); }
 
 	// core directory options
-	const char *cfg_directory() const { return value(OPTION_CFG_DIRECTORY); }
-	const char *nvram_directory() const { return value(OPTION_NVRAM_DIRECTORY); }
-	const char *input_directory() const { return value(OPTION_INPUT_DIRECTORY); }
-	const char *state_directory() const { return value(OPTION_STATE_DIRECTORY); }
-	const char *snapshot_directory() const { return value(OPTION_SNAPSHOT_DIRECTORY); }
-	const char *diff_directory() const { return value(OPTION_DIFF_DIRECTORY); }
-	const char *comment_directory() const { return value(OPTION_COMMENT_DIRECTORY); }
-	const char *share_directory() const { return value(OPTION_SHARE_DIRECTORY); }
+	std::string cfg_directory() const { return value_substituted(OPTION_CFG_DIRECTORY); }
+	std::string nvram_directory() const { return value_substituted(OPTION_NVRAM_DIRECTORY); }
+	std::string input_directory() const { return value_substituted(OPTION_INPUT_DIRECTORY); }
+	const char *state_directory() const { return value(OPTION_STATE_DIRECTORY); } // must be const char * for running_machine::m_saveload_searchpath
+	std::string snapshot_directory() const { return value_substituted(OPTION_SNAPSHOT_DIRECTORY); }
+	std::string diff_directory() const { return value_substituted(OPTION_DIFF_DIRECTORY); }
+	std::string comment_directory() const { return value_substituted(OPTION_COMMENT_DIRECTORY); }
+	std::string share_directory() const { return value_substituted(OPTION_SHARE_DIRECTORY); }
 
 	// core state/playback options
 	const char *state() const { return value(OPTION_STATE); }
 	bool autosave() const { return bool_value(OPTION_AUTOSAVE); }
 	int rewind() const { return bool_value(OPTION_REWIND); }
 	int rewind_capacity() const { return int_value(OPTION_REWIND_CAPACITY); }
-	const char *playback() const { return value(OPTION_PLAYBACK); }
-	const char *record() const { return value(OPTION_RECORD); }
+	std::string playback() const { return value_substituted(OPTION_PLAYBACK); }
+	std::string record() const { return value_substituted(OPTION_RECORD); }
 	bool exit_after_playback() const { return bool_value(OPTION_EXIT_AFTER_PLAYBACK); }
-	const char *mng_write() const { return value(OPTION_MNGWRITE); }
-	const char *avi_write() const { return value(OPTION_AVIWRITE); }
-	const char *wav_write() const { return value(OPTION_WAVWRITE); }
+	std::string mng_write() const { return value_substituted(OPTION_MNGWRITE); }
+	std::string avi_write() const { return value_substituted(OPTION_AVIWRITE); }
+	std::string wav_write() const { return value_substituted(OPTION_WAVWRITE); }
 	const char *snap_name() const { return value(OPTION_SNAPNAME); }
 	const char *snap_size() const { return value(OPTION_SNAPSIZE); }
 	const char *snap_view() const { return value(OPTION_SNAPVIEW); }

--- a/src/emu/hashfile.cpp
+++ b/src/emu/hashfile.cpp
@@ -24,7 +24,7 @@
     hashfile_lookup
 -------------------------------------------------*/
 
-static bool read_hash_config(const char *hash_path, const util::hash_collection &hashes, const char *sysname, std::string &result)
+static bool read_hash_config(std::string_view hash_path, const util::hash_collection &hashes, const char *sysname, std::string &result)
 {
 	/* open a file */
 	emu_file file(hash_path, OPEN_FLAG_READ);
@@ -63,7 +63,7 @@ static bool read_hash_config(const char *hash_path, const util::hash_collection 
 }
 
 
-bool hashfile_extrainfo(const char *hash_path, const game_driver &driver, const util::hash_collection &hashes, std::string &result)
+bool hashfile_extrainfo(std::string_view hash_path, const game_driver &driver, const util::hash_collection &hashes, std::string &result)
 {
 	/* now read the hash file */
 	int drv = driver_list::find(driver);

--- a/src/emu/hashfile.h
+++ b/src/emu/hashfile.h
@@ -15,6 +15,6 @@
 
 
 bool hashfile_extrainfo(device_image_interface &image, std::string &result);
-bool hashfile_extrainfo(const char *hash_path, const game_driver &driver, const util::hash_collection &hashes, std::string &result);
+bool hashfile_extrainfo(std::string_view hash_path, const game_driver &driver, const util::hash_collection &hashes, std::string &result);
 
 #endif // MAME_EMU_HASHFILE_H

--- a/src/emu/ioport.cpp
+++ b/src/emu/ioport.cpp
@@ -2916,8 +2916,8 @@ bool ioport_manager::playback_read<bool>(bool &result)
 time_t ioport_manager::playback_init()
 {
 	// if no file, nothing to do
-	const char *filename = machine().options().playback();
-	if (filename[0] == 0)
+	std::string const filename = machine().options().playback();
+	if (filename.empty())
 		return 0;
 
 	// open the playback file
@@ -3087,8 +3087,8 @@ void ioport_manager::record_write<bool>(bool value)
 void ioport_manager::record_init()
 {
 	// if no file, nothing to do
-	const char *filename = machine().options().record();
-	if (filename[0] == 0)
+	std::string const filename = machine().options().record();
+	if (filename.empty())
 		return;
 
 	// open the record file

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -220,13 +220,13 @@ void running_machine::start()
 	manager().load_cheatfiles(*this);
 
 	// start recording movie if specified
-	const char *filename = options().mng_write();
-	if (filename[0] != 0)
-		m_video->begin_recording(filename, movie_recording::format::MNG);
+	std::string filename = options().mng_write();
+	if (!filename.empty())
+		m_video->begin_recording(filename.c_str(), movie_recording::format::MNG);
 
 	filename = options().avi_write();
-	if (filename[0] != 0 && !m_video->is_recording())
-		m_video->begin_recording(filename, movie_recording::format::AVI);
+	if (!filename.empty() && !m_video->is_recording())
+		m_video->begin_recording(filename.c_str(), movie_recording::format::AVI);
 
 	// if we're coming in with a savegame request, process it now
 	const char *savegame = options().state();
@@ -877,7 +877,7 @@ void running_machine::handle_saveload()
 			u32 const openflags = (m_saveload_schedule == saveload_schedule::LOAD) ? OPEN_FLAG_READ : (OPEN_FLAG_WRITE | OPEN_FLAG_CREATE | OPEN_FLAG_CREATE_PATHS);
 
 			// open the file
-			emu_file file(m_saveload_searchpath ? m_saveload_searchpath : "", openflags);
+			emu_file file(m_saveload_searchpath ? osd_subst_env(m_saveload_searchpath) : std::string(), openflags);
 			auto const filerr = file.open(m_saveload_pending_file);
 			if (!filerr)
 			{

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -2207,12 +2207,12 @@ bool render_target::load_layout_file(const char *dirname, const char *filename)
 	return result;
 }
 
-bool render_target::load_layout_file(device_t &device, util::xml::data_node const &rootnode, const char *searchpath, const char *dirname)
+bool render_target::load_layout_file(device_t &device, util::xml::data_node const &rootnode, std::string &&searchpath, const char *dirname)
 {
 	// parse and catch any errors
 	try
 	{
-		m_filelist.emplace_back(device, rootnode, searchpath, dirname);
+		m_filelist.emplace_back(device, rootnode, std::move(searchpath), dirname);
 	}
 	catch (emu_fatalerror &err)
 	{

--- a/src/emu/render.h
+++ b/src/emu/render.h
@@ -573,7 +573,7 @@ private:
 	void load_additional_layout_files(const char *basename, bool have_artwork);
 	bool load_layout_file(const char *dirname, const char *filename);
 	bool load_layout_file(const char *dirname, const internal_layout &layout_data, device_t *device = nullptr);
-	bool load_layout_file(device_t &device, util::xml::data_node const &rootnode, const char *searchpath, const char *dirname);
+	bool load_layout_file(device_t &device, util::xml::data_node const &rootnode, std::string &&searchpath, const char *dirname);
 	void add_container_primitives(render_primitive_list &list, const object_transform &root_xform, const object_transform &xform, render_container &container, int blendmode);
 	void add_element_primitives(render_primitive_list &list, const object_transform &xform, layout_view_item &item);
 	std::pair<float, float> map_point_internal(s32 target_x, s32 target_y);

--- a/src/emu/rendlay.cpp
+++ b/src/emu/rendlay.cpp
@@ -610,16 +610,16 @@ private:
 	util::ovectorstream m_buffer;
 	std::shared_ptr<NSVGrasterizer> const m_svg_rasterizer;
 	device_t &m_device;
-	char const *const m_search_path;
+	std::string const m_search_path;
 	char const *const m_directory_name;
 	layout_environment *const m_next = nullptr;
 	bool m_cached = false;
 
 public:
-	layout_environment(device_t &device, char const *searchpath, char const *dirname)
+	layout_environment(device_t &device, std::string &&searchpath, char const *dirname)
 		: m_svg_rasterizer(nsvgCreateRasterizer(), util::nsvg_deleter())
 		, m_device(device)
-		, m_search_path(searchpath)
+		, m_search_path(std::move(searchpath))
 		, m_directory_name(dirname)
 	{
 	}
@@ -636,7 +636,7 @@ public:
 	device_t &device() const { return m_device; }
 	running_machine &machine() const { return device().machine(); }
 	bool is_root_device() const { return &device() == &machine().root_device(); }
-	char const *search_path() const { return m_search_path; }
+	std::string const &search_path() const { return m_search_path; }
 	char const *directory_name() const { return m_directory_name; }
 	std::shared_ptr<NSVGrasterizer> const &svg_rasterizer() const { return m_svg_rasterizer; }
 
@@ -1678,7 +1678,7 @@ public:
 	image_component(environment &env, util::xml::data_node const &compnode)
 		: component(env, compnode)
 		, m_rasterizer(env.svg_rasterizer())
-		, m_searchpath(env.search_path() ? env.search_path() : "")
+		, m_searchpath(env.search_path())
 		, m_dirname(env.directory_name() ? env.directory_name() : "")
 		, m_imagefile(env.get_attribute_string(compnode, "file"))
 		, m_alphafile(env.get_attribute_string(compnode, "alphafile"))
@@ -3054,7 +3054,7 @@ public:
 	// construction/destruction
 	reel_component(environment &env, util::xml::data_node const &compnode)
 		: component(env, compnode)
-		, m_searchpath(env.search_path() ? env.search_path() : "")
+		, m_searchpath(env.search_path())
 		, m_dirname(env.directory_name() ? env.directory_name() : "")
 	{
 		osd_printf_warning("Warning: layout file contains deprecated reel component\n");
@@ -5217,7 +5217,7 @@ layout_view::visibility_toggle::visibility_toggle(std::string &&name, u32 mask)
 layout_file::layout_file(
 		device_t &device,
 		util::xml::data_node const &rootnode,
-		char const *searchpath,
+		std::string &&searchpath,
 		char const *dirname)
 	: m_device(device)
 	, m_elemmap()
@@ -5225,7 +5225,7 @@ layout_file::layout_file(
 {
 	try
 	{
-		environment env(device, searchpath, dirname);
+		environment env(device, std::move(searchpath), dirname);
 
 		// find the layout node
 		util::xml::data_node const *const mamelayoutnode = rootnode.get_child("mamelayout");

--- a/src/emu/rendlay.h
+++ b/src/emu/rendlay.h
@@ -593,7 +593,7 @@ public:
 	using resolve_tags_delegate = delegate<void ()>;
 
 	// construction/destruction
-	layout_file(device_t &device, util::xml::data_node const &rootnode, char const *searchpath, char const *dirname);
+	layout_file(device_t &device, util::xml::data_node const &rootnode, std::string &&searchpath, char const *dirname);
 	~layout_file();
 
 	// getters

--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -1094,11 +1094,11 @@ sound_manager::sound_manager(running_machine &machine) :
 	m_first_reset(true)
 {
 	// get filename for WAV file or AVI file if specified
-	const char *wavfile = machine.options().wav_write();
-	const char *avifile = machine.options().avi_write();
+	std::string const wavfile = machine.options().wav_write();
+	std::string const avifile = machine.options().avi_write();
 
 	// handle -nosound and lower sample rate if not recording WAV or AVI
-	if (m_nosound_mode && wavfile[0] == 0 && avifile[0] == 0)
+	if (m_nosound_mode && wavfile.empty() && avifile.empty())
 		machine.m_sample_rate = 11025;
 
 	// count the mixers
@@ -1171,8 +1171,8 @@ bool sound_manager::start_recording(std::string_view filename)
 bool sound_manager::start_recording()
 {
 	// open the output WAV file if specified
-	char const *const filename = machine().options().wav_write();
-	return *filename ? start_recording(filename) : false;
+	std::string const filename = machine().options().wav_write();
+	return filename.empty() ? false : start_recording(filename);
 }
 
 

--- a/src/frontend/mame/clifront.cpp
+++ b/src/frontend/mame/clifront.cpp
@@ -1732,7 +1732,7 @@ void cli_frontend::execute_commands(std::string_view exename)
 		path_iterator iter(m_options.plugins_path());
 		std::string pluginpath;
 		while (iter.next(pluginpath))
-			plugin_opts.scan_directory(osd_subst_env(pluginpath), true);
+			plugin_opts.scan_directory(pluginpath, true);
 
 		emu_file file_plugin(OPEN_FLAG_WRITE | OPEN_FLAG_CREATE | OPEN_FLAG_CREATE_PATHS);
 		if (file_plugin.open("plugin.ini"))

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -142,10 +142,7 @@ void mame_machine_manager::start_luaengine()
 		std::string pluginpath;
 		while (iter.next(pluginpath))
 		{
-			// user may specify environment variables; subsitute them
-			pluginpath = osd_subst_env(pluginpath);
-
-			// and then scan the directory recursively
+			// scan the directory recursively
 			m_plugins->scan_directory(pluginpath, true);
 		}
 
@@ -202,7 +199,7 @@ void mame_machine_manager::start_luaengine()
 		std::error_condition const filerr = file.open("boot.lua");
 		if (!filerr)
 		{
-			const std::string exppath = osd_subst_env(file.fullpath());
+			const std::string exppath = file.fullpath();
 			auto &l(*lua());
 			auto load_result = l.load_script(exppath);
 			if (!load_result.valid())

--- a/src/frontend/mame/ui/custui.cpp
+++ b/src/frontend/mame/ui/custui.cpp
@@ -295,14 +295,14 @@ void menu_custom_ui::find_sysnames()
 			m_sysnames.end(),
 			[] (std::string const &x, std::string const &y) { return 0 > core_stricmp(x, y); });
 
-	char const *const names = ui().options().system_names();
-	if (*names)
+	std::string const names = ui().options().system_names();
+	if (!names.empty())
 	{
 		auto const found = std::lower_bound(
 				std::next(m_sysnames.begin()),
 				m_sysnames.end(),
 				names,
-				[] (std::string const &x, char const *y) { return 0 > core_stricmp(x, y); });
+				[] (std::string const &x, std::string const &y) { return 0 > core_stricmp(x, y); });
 		m_currsysnames = std::distance(m_sysnames.begin(), found);
 		if ((m_sysnames.end() == found) || core_stricmp(*found, names))
 			m_sysnames.emplace(found, names);

--- a/src/frontend/mame/ui/moptions.h
+++ b/src/frontend/mame/ui/moptions.h
@@ -83,29 +83,29 @@ public:
 	ui_options();
 
 	// Search path options
-	const char *history_path() const { return value(OPTION_HISTORY_PATH); }
-	const char *categoryini_path() const { return value(OPTION_CATEGORYINI_PATH); }
-	const char *cabinets_directory() const { return value(OPTION_CABINETS_PATH); }
-	const char *cpanels_directory() const { return value(OPTION_CPANELS_PATH); }
-	const char *pcbs_directory() const { return value(OPTION_PCBS_PATH); }
-	const char *flyers_directory() const { return value(OPTION_FLYERS_PATH); }
-	const char *titles_directory() const { return value(OPTION_TITLES_PATH); }
-	const char *ends_directory() const { return value(OPTION_ENDS_PATH); }
-	const char *marquees_directory() const { return value(OPTION_MARQUEES_PATH); }
-	const char *artprev_directory() const { return value(OPTION_ARTPREV_PATH); }
-	const char *bosses_directory() const { return value(OPTION_BOSSES_PATH); }
-	const char *logos_directory() const { return value(OPTION_LOGOS_PATH); }
-	const char *scores_directory() const { return value(OPTION_SCORES_PATH); }
-	const char *versus_directory() const { return value(OPTION_VERSUS_PATH); }
-	const char *gameover_directory() const { return value(OPTION_GAMEOVER_PATH); }
-	const char *howto_directory() const { return value(OPTION_HOWTO_PATH); }
-	const char *select_directory() const { return value(OPTION_SELECT_PATH); }
-	const char *icons_directory() const { return value(OPTION_ICONS_PATH); }
-	const char *covers_directory() const { return value(OPTION_COVER_PATH); }
-	const char *ui_path() const { return value(OPTION_UI_PATH); }
+	std::string history_path() const { return value_substituted(OPTION_HISTORY_PATH); }
+	std::string categoryini_path() const { return value_substituted(OPTION_CATEGORYINI_PATH); }
+	std::string cabinets_directory() const { return value_substituted(OPTION_CABINETS_PATH); }
+	std::string cpanels_directory() const { return value_substituted(OPTION_CPANELS_PATH); }
+	std::string pcbs_directory() const { return value_substituted(OPTION_PCBS_PATH); }
+	std::string flyers_directory() const { return value_substituted(OPTION_FLYERS_PATH); }
+	std::string titles_directory() const { return value_substituted(OPTION_TITLES_PATH); }
+	std::string ends_directory() const { return value_substituted(OPTION_ENDS_PATH); }
+	std::string marquees_directory() const { return value_substituted(OPTION_MARQUEES_PATH); }
+	std::string artprev_directory() const { return value_substituted(OPTION_ARTPREV_PATH); }
+	std::string bosses_directory() const { return value_substituted(OPTION_BOSSES_PATH); }
+	std::string logos_directory() const { return value_substituted(OPTION_LOGOS_PATH); }
+	std::string scores_directory() const { return value_substituted(OPTION_SCORES_PATH); }
+	std::string versus_directory() const { return value_substituted(OPTION_VERSUS_PATH); }
+	std::string gameover_directory() const { return value_substituted(OPTION_GAMEOVER_PATH); }
+	std::string howto_directory() const { return value_substituted(OPTION_HOWTO_PATH); }
+	std::string select_directory() const { return value_substituted(OPTION_SELECT_PATH); }
+	std::string icons_directory() const { return value_substituted(OPTION_ICONS_PATH); }
+	std::string covers_directory() const { return value_substituted(OPTION_COVER_PATH); }
+	std::string ui_path() const { return value_substituted(OPTION_UI_PATH); }
 
 	// Misc options
-	const char *system_names() const { return value(OPTION_SYSTEM_NAMES); }
+	std::string system_names() const { return value_substituted(OPTION_SYSTEM_NAMES); }
 	bool skip_warnings() const { return bool_value(OPTION_SKIP_WARNINGS); }
 	bool remember_last() const { return bool_value(OPTION_REMEMBER_LAST); }
 	bool enlarge_snaps() const { return bool_value(OPTION_ENLARGE_SNAPS); }

--- a/src/frontend/mame/ui/state.cpp
+++ b/src/frontend/mame/ui/state.cpp
@@ -374,12 +374,10 @@ void menu_load_save_state_base::handle_keys(uint32_t flags, int &iptkey)
 		if (exclusive_input_pressed(iptkey, IPT_UI_SELECT, 0))
 		{
 			// try to remove the file
-			std::string const filename(util::string_format(
-						"%2$s%1$s%3$s%1$s%4$s.sta",
-						PATH_SEPARATOR,
-						machine().options().state_directory(),
+			std::string const filename(util::path_concat(
+						osd_subst_env(machine().options().state_directory()),
 						machine().get_statename(machine().options().state_name()),
-						m_confirm_delete->file_name()));
+						m_confirm_delete->file_name() + ".sta"));
 			std::error_condition const err(osd_file::remove(filename));
 			if (err)
 			{
@@ -486,9 +484,8 @@ const menu_load_save_state_base::file_entry &menu_load_save_state_base::file_ent
 std::string menu_load_save_state_base::state_directory() const
 {
 	const char *stateopt = machine().options().state_name();
-	return util::string_format("%s%s%s",
-			machine().options().state_directory(),
-			PATH_SEPARATOR,
+	return util::path_concat(
+			osd_subst_env(machine().options().state_directory()),
 			machine().get_statename(stateopt));
 }
 

--- a/src/lib/util/options.cpp
+++ b/src/lib/util/options.cpp
@@ -13,6 +13,8 @@
 #include "corefile.h"
 #include "corestr.h"
 
+#include "osdcore.h"
+
 #include <locale>
 #include <string>
 
@@ -997,6 +999,26 @@ float core_options::float_value(std::string_view option) const
 		return fval;
 	else
 		return 0.0f;
+}
+
+
+//-------------------------------------------------
+//  value_substituted - return the value of an
+//  option as a string with OSD environment
+//  variables substituted
+//-------------------------------------------------
+
+std::string core_options::value_substituted(std::string_view option) const
+{
+	auto const entry = get_entry(option);
+	const char *str = nullptr;
+	if (entry != nullptr)
+	{
+		// substitution only makes sense for string values
+		assert(entry->type() == option_type::STRING);
+		str = entry->value();
+	}
+	return str ? osd_subst_env(str) : std::string();
 }
 
 

--- a/src/lib/util/options.h
+++ b/src/lib/util/options.h
@@ -12,6 +12,7 @@
 #define MAME_LIB_UTIL_OPTIONS_H
 
 #include "strformat.h"
+#include "utilfwd.h"
 
 #include <algorithm>
 #include <exception>
@@ -43,7 +44,6 @@ const int OPTION_PRIORITY_MAXIMUM   = 255;          // maximum priority
 //**************************************************************************
 
 struct options_entry;
-namespace util { class core_file; }
 
 // exception thrown by core_options when an illegal request is made
 class options_exception : public std::exception
@@ -203,6 +203,7 @@ public:
 	bool bool_value(std::string_view option) const { return int_value(option) != 0; }
 	int int_value(std::string_view option) const;
 	float float_value(std::string_view option) const;
+	std::string value_substituted(std::string_view option) const;
 
 	// setting
 	void set_value(std::string_view name, std::string_view value, int priority);

--- a/src/osd/modules/file/posixdir.cpp
+++ b/src/osd/modules/file/posixdir.cpp
@@ -193,7 +193,7 @@ bool posix_directory::open_impl(std::string const &dirname)
 {
 	assert(!m_fd);
 
-	m_path = osd_subst_env(dirname);
+	m_path = dirname;
 	m_fd.reset(::opendir(m_path.c_str()));
 	return bool(m_fd);
 }

--- a/src/osd/modules/file/posixfile.cpp
+++ b/src/osd/modules/file/posixfile.cpp
@@ -44,7 +44,6 @@
 
 // MAME headers
 #include "posixfile.h"
-#include "osdcore.h"
 #include "unicode.h"
 
 #include <cassert>
@@ -257,8 +256,6 @@ std::error_condition osd_file::open(std::string const &path, std::uint32_t openf
 	for (auto it = dst.begin(); it != dst.end(); ++it)
 		*it = (INVPATHSEPCH == *it) ? PATHSEPCH : *it;
 #endif
-	try { dst = osd_subst_env(dst); }
-	catch (...) { return std::errc::not_enough_memory; }
 
 	// attempt to open the file
 	int fd = -1;

--- a/src/osd/modules/file/winfile.cpp
+++ b/src/osd/modules/file/winfile.cpp
@@ -12,10 +12,9 @@
 #include "strconv.h"
 #include "winutil.h"
 #include "winutf8.h"
-#include "unicode.h"
 
 // MAME headers
-#include "osdcore.h"
+#include "unicode.h"
 
 #include <cassert>
 #include <cstring>
@@ -161,12 +160,8 @@ DWORD create_path_recursive(TCHAR *path)
 //  osd_open
 //============================================================
 
-std::error_condition osd_file::open(std::string const &orig_path, uint32_t openflags, ptr &file, std::uint64_t &filesize) noexcept
+std::error_condition osd_file::open(std::string const &path, uint32_t openflags, ptr &file, std::uint64_t &filesize) noexcept
 {
-	std::string path;
-	try { path = osd_subst_env(orig_path); }
-	catch (...) { return std::errc::not_enough_memory; }
-
 	if (win_check_socket_path(path))
 		return win_open_socket(path, openflags, file, filesize);
 	else if (win_check_ptty_path(path))

--- a/src/osd/modules/file/winrtfile.cpp
+++ b/src/osd/modules/file/winrtfile.cpp
@@ -13,10 +13,9 @@
 
 // MAMEOS headers
 #include "strconv.h"
-#include "unicode.h"
 
 // MAME headers
-#include "osdcore.h"
+#include "unicode.h"
 
 #include <cassert>
 #include <cstring>
@@ -160,12 +159,8 @@ DWORD create_path_recursive(TCHAR *path)
 //  osd_open
 //============================================================
 
-osd_file::error osd_file::open(std::string const &orig_path, uint32_t openflags, ptr &file, std::uint64_t &filesize)
+osd_file::error osd_file::open(std::string const &path, uint32_t openflags, ptr &file, std::uint64_t &filesize)
 {
-	std::string path;
-	try { path = osd_subst_env(orig_path); }
-	catch (...) { return std::errc::not_enough_memory; }
-
 	if (win_check_socket_path(path))
 		return win_open_socket(path, openflags, file, filesize);
 	else if (win_check_ptty_path(path))

--- a/src/osd/modules/input/input_sdl.cpp
+++ b/src/osd/modules/input/input_sdl.cpp
@@ -854,10 +854,10 @@ private:
 		if (!machine.options().bool_value(SDLOPTION_KEYMAP))
 			return &default_table;
 
-		const char *const keymap_filename = downcast<sdl_options &>(machine.options()).keymap_file();
+		std::string const keymap_filename = downcast<sdl_options &>(machine.options()).keymap_file();
 		osd_printf_verbose("Keymap: Start reading keymap_file %s\n", keymap_filename);
 
-		FILE *const keymap_file = fopen(keymap_filename, "r");
+		FILE *const keymap_file = fopen(keymap_filename.c_str(), "r");
 		if (!keymap_file)
 		{
 			osd_printf_warning("Keymap: Unable to open keymap %s, using default\n", keymap_filename);

--- a/src/osd/modules/lib/osdobj_common.h
+++ b/src/osd/modules/lib/osdobj_common.h
@@ -154,13 +154,13 @@ public:
 	const char *audio_effect(int index) const { return value(util::string_format("%s%d", OSDOPTION_AUDIO_EFFECT, index)); }
 
 	// BGFX specific options
-	const char *bgfx_path() const { return value(OSDOPTION_BGFX_PATH); }
+	std::string bgfx_path() const { return value_substituted(OSDOPTION_BGFX_PATH); }
 	const char *bgfx_backend() const { return value(OSDOPTION_BGFX_BACKEND); }
 	bool bgfx_debug() const { return bool_value(OSDOPTION_BGFX_DEBUG); }
 	const char *bgfx_screen_chains() const { return value(OSDOPTION_BGFX_SCREEN_CHAINS); }
 	const char *bgfx_shadow_mask() const { return value(OSDOPTION_BGFX_SHADOW_MASK); }
 	const char *bgfx_lut() const { return value(OSDOPTION_BGFX_LUT); }
-	const char *bgfx_avi_name() const { return value(OSDOPTION_BGFX_AVI_NAME); }
+	std::string bgfx_avi_name() const { return value_substituted(OSDOPTION_BGFX_AVI_NAME); }
 
 	// PortAudio options
 	const char *pa_api() const { return value(OSDOPTION_PA_API); }

--- a/src/osd/modules/render/bgfx/chainmanager.cpp
+++ b/src/osd/modules/render/bgfx/chainmanager.cpp
@@ -38,6 +38,8 @@
 #include "osdcore.h"
 #include "osdfile.h"
 
+#include "path.h"
+
 using namespace rapidjson;
 
 const uint32_t chain_manager::CHAIN_NONE = 0;
@@ -92,7 +94,7 @@ void chain_manager::refresh_available_chains()
 	m_available_chains.clear();
 	m_available_chains.push_back(chain_desc("none", ""));
 
-	const std::string chains_path  = osd_subst_env(util::string_format("%s" PATH_SEPARATOR "chains", m_options.bgfx_path()));
+	const std::string chains_path = util::path_concat(m_options.bgfx_path(), "chains");
 	find_available_chains(chains_path, "");
 
 	destroy_unloaded_chains();
@@ -169,8 +171,7 @@ bgfx_chain* chain_manager::load_chain(std::string name, uint32_t screen_index)
 	{
 		name = name + ".json";
 	}
-	std::string path = osd_subst_env(util::string_format("%s" PATH_SEPARATOR "chains" PATH_SEPARATOR, m_options.bgfx_path()));
-	path += name;
+	const std::string path = util::path_concat(m_options.bgfx_path(), "chains", name);
 
 	bx::FileReader reader;
 	if (!bx::open(&reader, path.c_str()))

--- a/src/osd/modules/render/bgfx/effectmanager.cpp
+++ b/src/osd/modules/render/bgfx/effectmanager.cpp
@@ -17,6 +17,8 @@
 #include "osdfile.h"
 #include "modules/lib/osdobj_common.h"
 
+#include "path.h"
+
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
 
@@ -33,8 +35,7 @@ static bool prepare_effect_document(std::string &name, osd_options &options, rap
 		full_name = full_name + ".json";
 	}
 
-	std::string path = osd_subst_env(util::string_format("%s" PATH_SEPARATOR "effects" PATH_SEPARATOR, options.bgfx_path()));
-	path += full_name;
+	std::string const path = util::path_concat(options.bgfx_path(), "effects", full_name);
 
 	bx::FileReader reader;
 	if (!bx::open(&reader, path.c_str()))

--- a/src/osd/modules/render/bgfx/shadermanager.cpp
+++ b/src/osd/modules/render/bgfx/shadermanager.cpp
@@ -119,7 +119,7 @@ std::string shader_manager::make_path_string(osd_options &options, std::string n
 			fatalerror("Unknown BGFX renderer type %d", bgfx::getRendererType());
 	}
 	shader_path += PATH_SEPARATOR;
-	return osd_subst_env(shader_path);
+	return shader_path;
 }
 
 const bgfx::Memory* shader_manager::load_mem(std::string name)

--- a/src/osd/modules/render/d3d/d3dhlsl.cpp
+++ b/src/osd/modules/render/d3d/d3dhlsl.cpp
@@ -590,9 +590,9 @@ bool shaders::init(d3d_base *d3dintf, running_machine *machine, renderer_d3d9 *r
 		options->bloom_level6_weight = winoptions.screen_bloom_lvl6_weight();
 		options->bloom_level7_weight = winoptions.screen_bloom_lvl7_weight();
 		options->bloom_level8_weight = winoptions.screen_bloom_lvl8_weight();
-		strncpy(options->lut_texture, winoptions.screen_lut_texture(), sizeof(options->lut_texture));
+		strncpy(options->lut_texture, winoptions.screen_lut_texture().c_str(), sizeof(options->lut_texture));
 		options->lut_enable = winoptions.screen_lut_enable();
-		strncpy(options->ui_lut_texture, winoptions.ui_lut_texture(), sizeof(options->ui_lut_texture));
+		strncpy(options->ui_lut_texture, winoptions.ui_lut_texture().c_str(), sizeof(options->ui_lut_texture));
 		options->ui_lut_enable = winoptions.ui_lut_enable();
 
 		options->params_init = true;

--- a/src/osd/modules/render/drawbgfx.cpp
+++ b/src/osd/modules/render/drawbgfx.cpp
@@ -404,7 +404,7 @@ void renderer_bgfx::record()
 bool renderer_bgfx::init(running_machine &machine)
 {
 	osd_options &options = downcast<osd_options &>(machine.options());
-	const char *bgfx_path = options.bgfx_path();
+	const std::string bgfx_path = options.bgfx_path();
 
 	osd::directory::ptr directory = osd::directory::open(bgfx_path);
 	if (directory == nullptr)
@@ -428,7 +428,7 @@ bool renderer_bgfx::init(running_machine &machine)
 
 	if (!all_gui_valid || !all_screen_valid)
 	{
-		osd_printf_error("BGFX: Unable to load required shaders. Please update the %s folder or adjust your bgfx_path setting.\n", options.bgfx_path());
+		osd_printf_error("BGFX: Unable to load required shaders. Please update the %s folder or adjust your bgfx_path setting.\n", bgfx_path);
 		return true;
 	}
 

--- a/src/osd/sdl/osdsdl.h
+++ b/src/osd/sdl/osdsdl.h
@@ -92,7 +92,7 @@ public:
 
 	// keyboard mapping
 	bool keymap() const { return bool_value(SDLOPTION_KEYMAP); }
-	const char *keymap_file() const { return value(SDLOPTION_KEYMAP_FILE); }
+	std::string keymap_file() const { return value_substituted(SDLOPTION_KEYMAP_FILE); }
 
 	// joystick mapping
 	bool sixaxis() const { return bool_value(SDLOPTION_SIXAXIS); }

--- a/src/osd/windows/winmain.h
+++ b/src/osd/windows/winmain.h
@@ -138,10 +138,10 @@ public:
 	const char *attach_window() const { return value(WINOPTION_ATTACH_WINDOW); }
 
 	// core post-processing options
-	const char *screen_post_fx_dir() const { return value(WINOPTION_HLSLPATH); }
+	std::string screen_post_fx_dir() const { return value_substituted(WINOPTION_HLSLPATH); }
 	bool d3d_hlsl_enable() const { return bool_value(WINOPTION_HLSL_ENABLE); }
 	bool d3d_hlsl_oversampling() const { return bool_value(WINOPTION_HLSL_OVERSAMPLING); }
-	const char *d3d_hlsl_write() const { return value(WINOPTION_HLSL_WRITE); }
+	std::string d3d_hlsl_write() const { return value_substituted(WINOPTION_HLSL_WRITE); }
 	int d3d_snap_width() const { return int_value(WINOPTION_HLSL_SNAP_WIDTH); }
 	int d3d_snap_height() const { return int_value(WINOPTION_HLSL_SNAP_HEIGHT); }
 	int screen_shadow_mask_tile_mode() const { return int_value(WINOPTION_SHADOW_MASK_TILE_MODE); }
@@ -216,9 +216,9 @@ public:
 	const char *screen_chroma_c() const { return value(WINOPTION_CHROMA_C); }
 	const char *screen_chroma_conversion_gain() const { return value(WINOPTION_CHROMA_CONVERSION_GAIN); }
 	const char *screen_chroma_y_gain() const { return value(WINOPTION_CHROMA_Y_GAIN); }
-	const char *screen_lut_texture() const { return value(WINOPTION_LUT_TEXTURE); }
+	std::string screen_lut_texture() const { return value_substituted(WINOPTION_LUT_TEXTURE); }
 	bool screen_lut_enable() const { return bool_value(WINOPTION_LUT_ENABLE); }
-	const char *ui_lut_texture() const { return value(WINOPTION_UI_LUT_TEXTURE); }
+	std::string ui_lut_texture() const { return value_substituted(WINOPTION_UI_LUT_TEXTURE); }
 	bool ui_lut_enable() const { return bool_value(WINOPTION_UI_LUT_ENABLE); }
 
 	// full screen options


### PR DESCRIPTION
This is an alternate means to the same end as PR #9859. The calls to `osd_subst_env` in the various implementations of `osd_file::open` and `osd::directory::open` never properly belonged there, and made it impossible to specify certain kinds of filenames (see issue #9822). The major difference between this and #9859 is that environment variable substitution is not performed statically when the values and default values are set, but dynamically when the values are read out if `value_substituted` is called, and the specific getters now do that where appropriate. One technical issue is that, due to dynamic string allocation, the return type of these getters becomes `std::string` rather than `const char *`, but most use cases needed little to no adjustment, with the major exception of `emu_options::state_directory()` due to some dubiously architected pointer storage in the `running_machine` class which I'm somewhat reluctant to touch (because emu.h rebuilds are a pain).

Somewhat ironically, this approach centralizes the actual calls to `osd_subst_env` more than they were before.