### PR TITLE
Support missing graphical effect for Elevator Action Returns and clones

### DIFF
--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -1822,6 +1822,12 @@ void taito_f3_state::get_line_ram_info(tilemap_t *tmap, int sx, int sy, int pos,
 			line_enable = 2;
 		else if (pri & 0x8000) //alpha2
 			line_enable = 3;
+		/*special case when the blend mode is "normal" but the 6200 area is used, Might be missing a flag*/
+		else if((pri&0x3000) && (m_line_ram[0x6230/4]!= 0)  && (pos == 2) &&
+		  (((m_line_ram[(0x6200/4) + (y>>1)] >> 4) &0xf) != 0xb) && (m_game == EACTION2))
+			{
+			  line_enable=0x22;		
+			}
 		else
 			line_enable = 1;
 
@@ -1903,6 +1909,8 @@ void taito_f3_state::get_line_ram_info(tilemap_t *tmap, int sx, int sy, int pos,
 
 			/* check tile status */
 			visible_tile_check(line_t, y, x_index_fx, y_index, pf_data_n);
+			
+			if ((pos ==1) && ((((m_line_ram[(0x6200/4) + (y>>1)]) >> 4) &0xf) > 0xb)  && (m_game == EACTION2)) line_t->alpha_mode[y] = 0x22;  /*hack*/
 
 			/* If clipping enabled for this line have to disable 'all opaque' optimisation */
 			if (line_t->clip0[y] != 0x7fff0000 || line_t->clip1[y] != 0)


### PR DESCRIPTION
ShmupMAME 19/1/2011 Fixed Elevator Action Returns so that the lighting during the game works properly, shooting lights etc.  will make rooms go dark as it does on pcb, it seems like a minor fix, but this effect is used a lot during the game and was sorely lacking