### PR TITLE
sinclair/pentevo.cpp: Changed default BIOS to non-FE ROM 0.59.04

### DIFF
--- a/src/mame/sinclair/pentevo.cpp
+++ b/src/mame/sinclair/pentevo.cpp
@@ -751,12 +751,10 @@ ROM_START( pentevo )
 	ROM_DEFAULT_BIOS("v0.59.04")
 
 	// http://svn.zxevo.ru/revision.php?repname=pentevo&path=%2From%2Fzxevo_fe.rom&rev=1012&peg=1021
-	ROM_SYSTEM_BIOS(0, "v0.59.04", "Reset Service v0.59.04, NEO-DOS v0.53")
+	ROM_SYSTEM_BIOS(0, "v0.59.04", "ERS v0.59.04, NEO-DOS v0.53")
 	ROMX_LOAD( "zxevo_05904.rom", 0x010000, 0x80000, CRC(8cae52eb) SHA1(992a0dc17fc7283bbfad5c5ebe254cab68bf0d9a), ROM_BIOS(0))
-	ROM_SYSTEM_BIOS(1, "v0.59.02fe_tr503", "Reset Service v0.59.02 (FE), TR-DOS v5.03")
-	ROMX_LOAD( "zxevo_05902fe_trd503.rom", 0x010000, 0x80000, CRC(f7f29dd8) SHA1(dfbcce980cf6244a9491aedf68ebb372677b0593), ROM_BIOS(1))
-	ROM_SYSTEM_BIOS(2, "v0.59.02fe", "Reset Service v0.59.02 (FE), NEO-DOS v0.53")
-	ROMX_LOAD( "zxevo_05902fe.rom", 0x010000, 0x80000, CRC(df144c82) SHA1(e48b8a95576e0123764ff8cc34d9373dc95159bf), ROM_BIOS(2))
+	ROM_SYSTEM_BIOS(1, "v0.59.02fe", "ERS v0.59.02 (FE), NEO-DOS v0.53")
+	ROMX_LOAD( "zxevo_05902fe.rom", 0x010000, 0x80000, CRC(df144c82) SHA1(e48b8a95576e0123764ff8cc34d9373dc95159bf), ROM_BIOS(1))
 
 	// http://svn.zxevo.ru/revision.php?repname=pentevo&path=%2Fcfgs%2Fstandalone_base_trdemu%2Ftrunk%2Fzxevo_fw.bin&rev=994&peg=1021
 	ROM_REGION(0x0C280, "fw", ROMREGION_ERASEFF)

--- a/src/mame/sinclair/pentevo.cpp
+++ b/src/mame/sinclair/pentevo.cpp
@@ -748,13 +748,15 @@ void pentevo_state::pentevo(machine_config &config)
 
 ROM_START( pentevo )
 	ROM_REGION(0x090000, "maincpu", ROMREGION_ERASEFF)
-	ROM_DEFAULT_BIOS("v0.59.02fe_tr503")
+	ROM_DEFAULT_BIOS("v0.59.04")
 
 	// http://svn.zxevo.ru/revision.php?repname=pentevo&path=%2From%2Fzxevo_fe.rom&rev=1012&peg=1021
-	ROM_SYSTEM_BIOS(0, "v0.59.02fe_tr503", "Reset Service v0.59.02 (FE), TR-DOS v5.03")
-	ROMX_LOAD( "zxevo_05902fe_trd503.rom", 0x010000, 0x80000, CRC(f7f29dd8) SHA1(dfbcce980cf6244a9491aedf68ebb372677b0593), ROM_BIOS(0))
-	ROM_SYSTEM_BIOS(1, "v0.59.02fe", "Reset Service v0.59.02 (FE), NEO-DOS v0.53")
-	ROMX_LOAD( "zxevo_05902fe.rom", 0x010000, 0x80000, CRC(df144c82) SHA1(e48b8a95576e0123764ff8cc34d9373dc95159bf), ROM_BIOS(1))
+	ROM_SYSTEM_BIOS(0, "v0.59.04", "Reset Service v0.59.04, NEO-DOS v0.53")
+	ROMX_LOAD( "zxevo_05904.rom", 0x010000, 0x80000, CRC(8cae52eb) SHA1(992a0dc17fc7283bbfad5c5ebe254cab68bf0d9a), ROM_BIOS(0))
+	ROM_SYSTEM_BIOS(1, "v0.59.02fe_tr503", "Reset Service v0.59.02 (FE), TR-DOS v5.03")
+	ROMX_LOAD( "zxevo_05902fe_trd503.rom", 0x010000, 0x80000, CRC(f7f29dd8) SHA1(dfbcce980cf6244a9491aedf68ebb372677b0593), ROM_BIOS(1))
+	ROM_SYSTEM_BIOS(2, "v0.59.02fe", "Reset Service v0.59.02 (FE), NEO-DOS v0.53")
+	ROMX_LOAD( "zxevo_05902fe.rom", 0x010000, 0x80000, CRC(df144c82) SHA1(e48b8a95576e0123764ff8cc34d9373dc95159bf), ROM_BIOS(2))
 
 	// http://svn.zxevo.ru/revision.php?repname=pentevo&path=%2Fcfgs%2Fstandalone_base_trdemu%2Ftrunk%2Fzxevo_fw.bin&rev=994&peg=1021
 	ROM_REGION(0x0C280, "fw", ROMREGION_ERASEFF)


### PR DESCRIPTION
newer non FE ROM better candidate for default