### PR TITLE
Avoid null deref in read_stream_view copy ctor

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -1707,9 +1707,10 @@ void floppy_sound_device::sound_stream_update(sound_stream &stream, std::vector<
 		{
 			idx = m_spin_playback_sample;
 			sampleend = m_sample[idx].data.size();
-			out = m_sample[idx].data[m_spin_samplepos++];
-
-			if (m_spin_samplepos >= sampleend)
+			m_spin_samplepos++;
+			if (m_spin_samplepos < sampleend)
+				out = m_sample[idx].data[m_spin_samplepos];
+			else
 			{
 				// Motor sample has completed
 				switch (m_spin_playback_sample)
@@ -1763,7 +1764,8 @@ void floppy_sound_device::sound_stream_update(sound_stream &stream, std::vector<
 			idx = m_step_base + m_seek_playback_sample;
 			sampleend = m_sample[idx].data.size();
 			// Mix it into the stream value
-			out += m_sample[idx].data[(int)m_seek_samplepos];
+			if (m_seek_samplepos < sampleend)
+				out += m_sample[idx].data[(int)m_seek_samplepos];
 			// By adding different values than 1, we can change the playback speed
 			// This will be used to adjust the seek sound
 			m_seek_samplepos += m_seek_pitch;
@@ -1781,8 +1783,10 @@ void floppy_sound_device::sound_stream_update(sound_stream &stream, std::vector<
 				sampleend = m_sample[idx].data.size();
 
 				// Mix it into the stream value
-				out += m_sample[idx].data[m_step_samplepos++];
-				if (m_step_samplepos >= sampleend)
+				m_step_samplepos++;
+				if (m_step_samplepos < sampleend)
+					out += m_sample[idx].data[m_step_samplepos];
+				else
 				{
 					// Step sample done
 					m_step_samplepos = 0;

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -1707,10 +1707,11 @@ void floppy_sound_device::sound_stream_update(sound_stream &stream, std::vector<
 		{
 			idx = m_spin_playback_sample;
 			sampleend = m_sample[idx].data.size();
-			m_spin_samplepos++;
 			if (m_spin_samplepos < sampleend)
 				out = m_sample[idx].data[m_spin_samplepos];
-			else
+			m_spin_samplepos++;
+
+			if (m_spin_samplepos >= sampleend)
 			{
 				// Motor sample has completed
 				switch (m_spin_playback_sample)
@@ -1783,10 +1784,11 @@ void floppy_sound_device::sound_stream_update(sound_stream &stream, std::vector<
 				sampleend = m_sample[idx].data.size();
 
 				// Mix it into the stream value
-				m_step_samplepos++;
 				if (m_step_samplepos < sampleend)
 					out += m_sample[idx].data[m_step_samplepos];
-				else
+				m_step_samplepos++;
+
+				if (m_step_samplepos >= sampleend)
 				{
 					// Step sample done
 					m_step_samplepos = 0;

--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -761,6 +761,9 @@ read_stream_view sound_stream::update_view(attotime start, attotime end, u32 out
 	}
 	g_profiler.stop();
 
+	if (!m_output_view[outputnum].valid())
+		m_output_view[outputnum] = empty_view(start, end);
+
 	// return the requested view
 	return read_stream_view(m_output_view[outputnum], start);
 }

--- a/src/emu/sound.h
+++ b/src/emu/sound.h
@@ -284,6 +284,9 @@ public:
 		return *this;
 	}
 
+	// check basic constraints
+	bool valid() const { return m_buffer != nullptr; }
+
 	// return the local gain
 	sample_t gain() const { return m_gain; }
 


### PR DESCRIPTION
read_stream_view has a copy constructor that uses `src.m_buffer->time_to_buffer_index(start, false)`.  `m_buffer` can be null, causing a segfault.