### PR TITLE
Avoid null deref in read_stream_view copy ctor

### DIFF
--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -761,6 +761,9 @@ read_stream_view sound_stream::update_view(attotime start, attotime end, u32 out
 	}
 	g_profiler.stop();
 
+	if (!m_output_view[outputnum].valid())
+		m_output_view[outputnum] = empty_view(start, end);
+
 	// return the requested view
 	return read_stream_view(m_output_view[outputnum], start);
 }

--- a/src/emu/sound.h
+++ b/src/emu/sound.h
@@ -284,6 +284,9 @@ public:
 		return *this;
 	}
 
+	// check basic constraints
+	bool valid() const { return m_buffer != nullptr; }
+
 	// return the local gain
 	sample_t gain() const { return m_gain; }
 


### PR DESCRIPTION
read_stream_view has a copy constructor that uses src.m_buffer->time_to_buffer_index(start, false). m_buffer can be null, causing a segfault.