### PR TITLE
nes.xml: Metadata cleaning

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -98,7 +98,7 @@ license:CC0
 	</software>
 
 	<software name="10yard">
-		<description>10-Yard Fight (Euro, USA)</description><!-- Dump still to be confirmed from a EU cart -->
+		<description>10-Yard Fight (Europe, USA)</description><!-- Dump still to be confirmed from a EU cart -->
 		<year>1985</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-TY-USA"/>
@@ -436,7 +436,7 @@ license:CC0
 	</software>
 
 	<software name="actionny">
-		<description>Action In New York (Euro)</description>
+		<description>Action In New York (Europe)</description>
 		<year>1991</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NES-FV-UKV"/>
@@ -473,7 +473,7 @@ license:CC0
 	</software>
 
 	<software name="addfam">
-		<description>The Addams Family (Euro)</description>
+		<description>The Addams Family (Europe)</description>
 		<year>1992</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-6Z (FRA/SCN/ESP)"/>
@@ -511,7 +511,7 @@ license:CC0
 
 <!-- Glitches on NTSC -->
 	<software name="pugshunt">
-		<description>The Addams Family - Pugsley's Scavenger Hunt (Euro)</description>
+		<description>The Addams Family - Pugsley's Scavenger Hunt (Europe)</description>
 		<year>1993</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-FM-FRA"/>
@@ -529,7 +529,7 @@ license:CC0
 	</software>
 
 	<software name="pugshuntp" cloneof="pugshunt">
-		<description>The Addams Family - Pugsley's Scavenger Hunt (Euro, prototype)</description>
+		<description>The Addams Family - Pugsley's Scavenger Hunt (Europe, prototype)</description>
 		<year>1993</year>
 		<publisher>Ocean</publisher>
 		<part name="cart" interface="nes_cart">
@@ -565,7 +565,7 @@ license:CC0
 	</software>
 
 	<software name="advislnd">
-		<description>Adventure Island in the Pacific - Classic (Euro)</description>
+		<description>Adventure Island in the Pacific - Classic (Europe)</description>
 		<year>1992</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="NES-TB (NOE/ESP)"/>
@@ -602,7 +602,7 @@ license:CC0
 	</software>
 
 	<software name="advisln2">
-		<description>The Adventure Island II (Euro)</description>
+		<description>The Adventure Island II (Europe)</description>
 		<year>1992</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="NES-V7 (AUS/SCN/ESP/NOE)"/>
@@ -658,7 +658,7 @@ license:CC0
 	</software>
 
 	<software name="magickdm">
-		<description>Disney's Adventures in the Magic Kingdom (Euro)</description>
+		<description>Disney's Adventures in the Magic Kingdom (Europe)</description>
 		<year>1992</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-VD (SCN/ESP)"/>
@@ -698,7 +698,7 @@ license:CC0
 
 <!-- glitches on NTSC -->
 	<software name="bayoubil">
-		<description>The Adventures of Bayou Billy (Euro)</description>
+		<description>The Adventures of Bayou Billy (Europe)</description>
 		<year>1991</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-MU-EEC"/>
@@ -817,7 +817,7 @@ license:CC0
 	</software>
 
 	<software name="lolo">
-		<description>Adventures of Lolo (Euro)</description>
+		<description>Adventures of Lolo (Europe)</description>
 		<year>1990</year>
 		<publisher>HAL Laboratory</publisher>
 		<info name="serial" value="NES-AV-EEC"/>
@@ -875,7 +875,7 @@ license:CC0
 	</software>
 
 	<software name="lolo2">
-		<description>Adventures of Lolo 2 (Euro)</description>
+		<description>Adventures of Lolo 2 (Europe)</description>
 		<year>1991</year>
 		<publisher>HAL Laboratory</publisher>
 		<info name="serial" value="NES-A4 (EEC/FRG)"/>
@@ -913,7 +913,7 @@ license:CC0
 	</software>
 
 	<software name="lolo3">
-		<description>Adventures of Lolo 3 (Euro)</description>
+		<description>Adventures of Lolo 3 (Europe)</description>
 		<year>1992</year>
 		<publisher>HAL Laboratory</publisher>
 		<info name="serial" value="NES-QL (SCN/ESP)"/>
@@ -951,7 +951,7 @@ license:CC0
 	</software>
 
 	<software name="radgrav">
-		<description>The Adventures of Rad Gravity (Euro)</description>
+		<description>The Adventures of Rad Gravity (Europe)</description>
 		<year>1991</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="NES-2A (EEC/ESP)"/>
@@ -1086,7 +1086,7 @@ license:CC0
 	</software>
 
 	<software name="airfortr">
-		<description>Air Fortress (Euro)</description>
+		<description>Air Fortress (Europe)</description>
 		<year>1989</year>
 		<publisher>HAL Laboratory</publisher>
 		<info name="serial" value="NES-AI (EEC/AUS)"/>
@@ -1168,7 +1168,7 @@ license:CC0
 	</software>
 
 	<software name="airwolf">
-		<description>Airwolf (Euro)</description>
+		<description>Airwolf (Europe)</description>
 		<year>1990</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-AF (EEC/NOE)"/>
@@ -1361,7 +1361,7 @@ license:CC0
 
 <!-- glitches on NTSC -->
 	<software name="aladdin">
-		<description>Disney's Aladdin (Euro)</description>
+		<description>Disney's Aladdin (Europe)</description>
 		<year>1994</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="NES-AJ (FRA/SCN)"/>
@@ -1434,7 +1434,7 @@ license:CC0
 	</software>
 
 	<software name="alien3" supported="partial">
-		<description>Alien³ (Euro)</description>
+		<description>Alien³ (Europe)</description>
 		<year>1993</year>
 		<publisher>LJN</publisher>
 		<info name="serial" value="NES-X3 (FRA/NOE)"/>
@@ -1491,7 +1491,7 @@ license:CC0
 	</software>
 
 	<software name="alphamis">
-		<description>Alpha Mission (Euro)</description>
+		<description>Alpha Mission (Europe)</description>
 		<year>1989</year>
 		<publisher>SNK</publisher>
 		<info name="serial" value="NES-AM-EEC"/>
@@ -1713,7 +1713,7 @@ license:CC0
 	</software>
 
 	<software name="anticip">
-		<description>Anticipation (Euro)</description>
+		<description>Anticipation (Europe)</description>
 		<year>1989</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-AP-EEC"/>
@@ -1823,7 +1823,7 @@ license:CC0
 	</software>
 
 	<software name="archrivl">
-		<description>Arch Rivals - A Basketbrawl! (Euro)</description>
+		<description>Arch Rivals - A Basketbrawl! (Europe)</description>
 		<year>1991</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-Q4 (ESP/NOE)"/>
@@ -2106,7 +2106,7 @@ license:CC0
 	</software>
 
 	<software name="astyanax">
-		<description>Astyanax (Euro)</description>
+		<description>Astyanax (Europe)</description>
 		<year>1990</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="NES-YX (ESP/NOE)"/>
@@ -2125,7 +2125,7 @@ license:CC0
 
 <!-- glitches on NTSC -->
 	<software name="asterix">
-		<description>Astérix (Euro)</description>
+		<description>Astérix (Europe)</description>
 		<year>1993</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NES-AX (UKV/ESP)"/>
@@ -2202,7 +2202,7 @@ license:CC0
 	</software>
 
 	<software name="athlwrld">
-		<description>Athletic World (Euro)</description>
+		<description>Athletic World (Europe)</description>
 		<year>1988</year>
 		<publisher>Bandai</publisher>
 		<info name="serial" value="NES-AW (EEC/ITA)"/>
@@ -2299,7 +2299,7 @@ license:CC0
 	</software>
 
 	<software name="killtomt">
-		<description>Attack of the Killer Tomatoes (Euro)</description>
+		<description>Attack of the Killer Tomatoes (Europe)</description>
 		<year>1993</year>
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NES-47-NOE"/>
@@ -2318,7 +2318,7 @@ license:CC0
 	</software>
 
 	<software name="aussie">
-		<description>Aussie Rules Footy (Euro)</description>
+		<description>Aussie Rules Footy (Europe)</description>
 		<year>1992</year>
 		<publisher>Laser Beam</publisher>
 		<info name="serial" value="NES-28-AUS"/>
@@ -2455,7 +2455,7 @@ license:CC0
 	</software>
 
 	<software name="baddudes">
-		<description>Bad Dudes vs. Dragon Ninja (Euro)</description>
+		<description>Bad Dudes vs. Dragon Ninja (Europe)</description>
 		<year>1990</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-55 (ESP/FRA)"/>
@@ -2690,7 +2690,7 @@ license:CC0
 	</software>
 
 	<software name="balonfgt">
-		<description>Balloon Fight (Euro)</description>
+		<description>Balloon Fight (Europe)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-BF-EEC"/>
@@ -2854,7 +2854,7 @@ license:CC0
 	</software>
 
 	<software name="barbie">
-		<description>Barbie (Euro)</description>
+		<description>Barbie (Europe)</description>
 		<year>1992</year>
 		<publisher>Hi Tech Expressions</publisher>
 		<info name="serial" value="NES-8V-AUS"/>
@@ -2987,7 +2987,7 @@ license:CC0
 	</software>
 
 	<software name="barkbill">
-		<description>Barker Bill's Trick Shooting (Euro)</description>
+		<description>Barker Bill's Trick Shooting (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-ZT-SCN"/>
@@ -3074,7 +3074,7 @@ license:CC0
 	</software>
 
 	<software name="baseball">
-		<description>Baseball (Euro, USA)</description>
+		<description>Baseball (Europe, USA)</description>
 		<year>1985</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-BA-USA, NES-BA-(ESP/GBR)"/>
@@ -3361,7 +3361,7 @@ license:CC0
 	</software>
 
 	<software name="batman">
-		<description>Batman - The Video Game (Euro)</description>
+		<description>Batman - The Video Game (Europe)</description>
 		<year>1990</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NES-B4 (EEC/FRG/ESP)"/>
@@ -3399,7 +3399,7 @@ license:CC0
 	</software>
 
 	<software name="batmanrn">
-		<description>Batman Returns (Euro)</description>
+		<description>Batman Returns (Europe)</description>
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-BX-FRA"/>
@@ -3467,7 +3467,7 @@ license:CC0
 
 <!-- glitches on NTSC -->
 	<software name="batmanrj" supported="partial">
-		<description>Batman - Return of the Joker (Euro)</description>
+		<description>Batman - Return of the Joker (Europe)</description>
 		<year>1992</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NES-48 (NOE/SCN/ESP)"/>
@@ -3679,7 +3679,7 @@ license:CC0
 	</software>
 
 	<software name="olympus">
-		<description>The Battle of Olympus (Euro)</description>
+		<description>The Battle of Olympus (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-AD (SCN/ESP)"/>
@@ -3717,7 +3717,7 @@ license:CC0
 	</software>
 
 	<software name="bship">
-		<description>Battleship (Euro)</description>
+		<description>Battleship (Europe)</description>
 		<year>1993</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-BH-NOE"/>
@@ -3782,7 +3782,7 @@ license:CC0
 
 <!-- glitches on NTSC -->
 	<software name="btoads" supported="partial">
-		<description>Battletoads (Euro)</description>
+		<description>Battletoads (Europe)</description>
 		<year>1993</year>
 		<publisher>Tradewest</publisher>
 		<info name="serial" value="NES-8T-(SCN/ESP/FRG)"/>
@@ -3801,7 +3801,7 @@ license:CC0
 	</software>
 
 	<software name="btoadsdd">
-		<description>Battletoads &amp; Double Dragon - The Ultimate Team (Euro)</description>
+		<description>Battletoads &amp; Double Dragon - The Ultimate Team (Europe)</description>
 		<year>1993</year>
 		<publisher>Tradewest</publisher>
 		<info name="serial" value="NES-U8-UKV"/>
@@ -4068,7 +4068,7 @@ license:CC0
 
 <!-- glitches on NTSC -->
 	<software name="bestof">
-		<description>Best of the Best - Championship Karate (Euro)</description>
+		<description>Best of the Best - Championship Karate (Europe)</description>
 		<year>1993</year>
 		<publisher>Loriciel</publisher>
 		<info name="serial" value="NES-BB-ESP"/>
@@ -4268,7 +4268,7 @@ license:CC0
 	</software>
 
 	<software name="bigfoot">
-		<description>Bigfoot (Euro)</description>
+		<description>Bigfoot (Europe)</description>
 		<year>1991</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-A8 (EEC/ESP)"/>
@@ -4459,7 +4459,7 @@ license:CC0
 	</software>
 
 	<software name="bionicc">
-		<description>Bionic Commando (Euro)</description>
+		<description>Bionic Commando (Europe)</description>
 		<year>1990</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-CM (EEC/FRG)"/>
@@ -4594,7 +4594,7 @@ license:CC0
 	</software>
 
 	<software name="bladestl">
-		<description>Blades of Steel (Euro)</description>
+		<description>Blades of Steel (Europe)</description>
 		<year>1990</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-VS (FRG/SCN/EEC)"/>
@@ -4649,7 +4649,7 @@ license:CC0
 	</software>
 
 	<software name="bmaster">
-		<description>Blaster Master (Euro)</description>
+		<description>Blaster Master (Europe)</description>
 		<year>1991</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NES-VM (EEC/FRG/SCN)"/>
@@ -4732,7 +4732,7 @@ license:CC0
 	</software>
 
 	<software name="blueshad">
-		<description>Blue Shadow (Euro)</description>
+		<description>Blue Shadow (Europe)</description>
 		<year>1991</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-27 (FRG/SCN)"/>
@@ -4751,7 +4751,7 @@ license:CC0
 	</software>
 
 	<software name="bluesb">
-		<description>The Blues Brothers (Euro)</description>
+		<description>The Blues Brothers (Europe)</description>
 		<year>1992</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="NES-4Z-FRG"/>
@@ -5013,7 +5013,7 @@ license:CC0
 	</software>
 
 	<software name="bdash">
-		<description>Boulder Dash (Euro)</description>
+		<description>Boulder Dash (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-XB (ESP/FRG)"/>
@@ -5051,7 +5051,7 @@ license:CC0
 	</software>
 
 	<software name="boynblob">
-		<description>David Crane's A Boy and His Blob - Trouble on Blobolonia (Euro, rev. A)</description>
+		<description>David Crane's A Boy and His Blob - Trouble on Blobolonia (Europe, rev. A)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-B5 (FRA/NOE/GBR)"/>
@@ -5070,7 +5070,7 @@ license:CC0
 	</software>
 
 	<software name="boynbloba" cloneof="boynblob">
-		<description>David Crane's A Boy and His Blob - Trouble on Blobolonia (Euro)</description>
+		<description>David Crane's A Boy and His Blob - Trouble on Blobolonia (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-B5 (EEC/NOE)"/>
@@ -5111,7 +5111,7 @@ license:CC0
 	</software>
 
 	<software name="dracula">
-		<description>Bram Stoker's Dracula (Euro)</description>
+		<description>Bram Stoker's Dracula (Europe)</description>
 		<year>1993</year>
 		<publisher>Sony Imagesoft</publisher>
 		<info name="serial" value="NES-DR-(NOE/UKV)"/>
@@ -5188,7 +5188,7 @@ license:CC0
 	</software>
 
 	<software name="bublbobl">
-		<description>Bubble Bobble (Euro)</description>
+		<description>Bubble Bobble (Europe)</description>
 		<year>1990</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-B2 (EEC/FRA/FRG/SCN)"/>
@@ -5266,7 +5266,7 @@ license:CC0
 	</software>
 
 	<software name="bucky">
-		<description>Bucky O'Hare (Euro)</description>
+		<description>Bucky O'Hare (Europe)</description>
 		<year>1992</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-56 (NOE/SCN/UKV)"/>
@@ -5327,7 +5327,7 @@ license:CC0
 	</software>
 
 	<software name="bugsbb">
-		<description>The Bugs Bunny Blowout (Euro)</description>
+		<description>The Bugs Bunny Blowout (Europe)</description>
 		<year>1992</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NES-H8 (NOE/ESP/FRG)"/>
@@ -5432,7 +5432,7 @@ license:CC0
 	</software>
 
 	<software name="burai">
-		<description>Burai Fighter (Euro)</description>
+		<description>Burai Fighter (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-UF (FRA/ESP)"/>
@@ -5567,7 +5567,7 @@ license:CC0
 	</software>
 
 	<software name="calgames">
-		<description>California Games (Euro)</description>
+		<description>California Games (Europe)</description>
 		<year>1991</year>
 		<publisher>Milton Bradley</publisher>
 		<info name="serial" value="NES-CG-(NOE/ESP)"/>
@@ -5651,7 +5651,7 @@ license:CC0
 	</software>
 
 	<software name="goldmedl">
-		<description>Capcom's Gold Medal Challenge '92 (Euro)</description>
+		<description>Capcom's Gold Medal Challenge '92 (Europe)</description>
 		<year>1993</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-GM-SCN"/>
@@ -5750,7 +5750,7 @@ license:CC0
 	</software>
 
 	<software name="captplan">
-		<description>Captain Planet and the Planeteers (Euro)</description>
+		<description>Captain Planet and the Planeteers (Europe)</description>
 		<year>1992</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-5C (NOE/SCN/UKV)"/>
@@ -5825,7 +5825,7 @@ license:CC0
 	</software>
 
 	<software name="captskyh">
-		<description>Captain SkyHawk (Euro)</description>
+		<description>Captain SkyHawk (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-YW (FRA/ESP)"/>
@@ -5962,7 +5962,7 @@ license:CC0
 
 <!-- a proto has been found too, containing the same data, with labels "CASTELIAN 2/4/92 CHK$985A" -->
 	<software name="casteln" supported="no"> <!-- freezes when you start game -->
-		<description>Castelian (Euro)</description>
+		<description>Castelian (Europe)</description>
 		<year>1992</year>
 		<publisher>Storm</publisher>
 		<info name="serial" value="NES-4C-ESP"/>
@@ -6097,7 +6097,7 @@ license:CC0
 	</software>
 
 	<software name="cvania">
-		<description>Castlevania (Euro)</description>
+		<description>Castlevania (Europe)</description>
 		<year>1988</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-CV (EEC/NOE)"/>
@@ -6135,7 +6135,7 @@ license:CC0
 	</software>
 
 	<software name="cvania2">
-		<description>Castlevania II - Simon's Quest (Euro)</description>
+		<description>Castlevania II - Simon's Quest (Europe)</description>
 		<year>1990</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-QU-(EEC/FRG)"/>
@@ -6180,7 +6180,7 @@ license:CC0
 	</software>
 
 	<software name="cvania3">
-		<description>Castlevania III - Dracula's Curse (Euro)</description>
+		<description>Castlevania III - Dracula's Curse (Europe)</description>
 		<year>1992</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-VN (FRG/SCN)"/>
@@ -6358,7 +6358,7 @@ license:CC0
 	</software>
 
 	<software name="chrally">
-		<description>Championship Rally (Euro)</description>
+		<description>Championship Rally (Europe)</description>
 		<year>1991</year>
 		<publisher>HAL Laboratory</publisher>
 		<info name="serial" value="NES-29-ESP"/>
@@ -6421,7 +6421,7 @@ license:CC0
 	</software>
 
 	<software name="chessmst">
-		<description>The Chessmaster (Euro)</description>
+		<description>The Chessmaster (Europe)</description>
 		<year>1991</year>
 		<publisher>Hi Tech Expressions</publisher>
 		<info name="serial" value="NES-EM (GPS/FRG/SCN/ESP)"/>
@@ -6571,7 +6571,7 @@ license:CC0
 	</software>
 
 	<software name="chipndl2">
-		<description>Disney's Chip 'n Dale Rescue Rangers 2 (Euro)</description>
+		<description>Disney's Chip 'n Dale Rescue Rangers 2 (Europe)</description>
 		<year>1994</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-DV (SCN/NOE)"/>
@@ -6657,7 +6657,7 @@ license:CC0
 	</software>
 
 	<software name="chipndal">
-		<description>Disney's Chip 'n Dale Rescue Rangers (Euro)</description>
+		<description>Disney's Chip 'n Dale Rescue Rangers (Europe)</description>
 		<year>1991</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-RU (NOE/SCN/ESP)"/>
@@ -6941,7 +6941,7 @@ license:CC0
 	</software>
 
 	<software name="citycon">
-		<description>City Connection (Euro)</description>
+		<description>City Connection (Europe)</description>
 		<year>1988?</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="NES-CI-ESP"/>
@@ -7115,7 +7115,7 @@ license:CC0
 	</software>
 
 	<software name="cobratr">
-		<description>Cobra Triangle (Euro)</description>
+		<description>Cobra Triangle (Europe)</description>
 		<year>1989</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-CU (EEC/ESP)"/>
@@ -7360,7 +7360,7 @@ license:CC0
 	</software>
 
 	<software name="corvetz1">
-		<description>Corvette ZR-1 Challenge (Euro)</description>
+		<description>Corvette ZR-1 Challenge (Europe)</description>
 		<year>1990</year>
 		<publisher>Milton Bradley</publisher>
 		<info name="serial" value="NES-ZJ (ESP/NOE)"/>
@@ -7399,7 +7399,7 @@ license:CC0
 	</software>
 
 	<software name="cosmic">
-		<description>Cosmic Spacehead (Euro)</description>
+		<description>Cosmic Spacehead (Europe)</description>
 		<year>19??</year>
 		<publisher>Codemasters</publisher>
 		<part name="cart" interface="nes_cart">
@@ -7479,7 +7479,7 @@ license:CC0
 	</software>
 
 	<software name="crackout">
-		<description>CrackOut (Euro)</description>
+		<description>CrackOut (Europe)</description>
 		<year>1991</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-37-(NOE/UKV)"/>
@@ -7920,7 +7920,7 @@ license:CC0
 	</software>
 
 	<software name="darkman">
-		<description>Darkman (Euro)</description>
+		<description>Darkman (Europe)</description>
 		<year>1992</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-N8-ESP"/>
@@ -7975,7 +7975,7 @@ license:CC0
 	</software>
 
 	<software name="darkwing">
-		<description>Disney's Darkwing Duck (Euro)</description>
+		<description>Disney's Darkwing Duck (Europe)</description>
 		<year>1993</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-DZ (UKV/SCN)"/>
@@ -8110,7 +8110,7 @@ license:CC0
 	</software>
 
 	<software name="daysthnd">
-		<description>Days of Thunder (Euro)</description>
+		<description>Days of Thunder (Europe)</description>
 		<year>1991</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-YH (EEC/ESP)"/>
@@ -8289,7 +8289,7 @@ license:CC0
 	</software>
 
 	<software name="defcrown">
-		<description>Defender of the Crown (Euro)</description>
+		<description>Defender of the Crown (Europe)</description>
 		<year>1991</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-U3-EEC"/>
@@ -8546,7 +8546,7 @@ license:CC0
 	</software>
 
 	<software name="devlwrld">
-		<description>Devil World (Euro)</description>
+		<description>Devil World (Europe)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-DD-EEC"/>
@@ -8635,7 +8635,7 @@ license:CC0
 	</software>
 
 	<software name="diehard">
-		<description>Die Hard (Euro)</description>
+		<description>Die Hard (Europe)</description>
 		<year>1992</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="NES-57 (AUS/SCN/ESP)"/>
@@ -8732,7 +8732,7 @@ license:CC0
 
 <!-- glitches on NTSC -->
 	<software name="diggertr">
-		<description>Digger T. Rock - The Legend of the Lost City (Euro)</description>
+		<description>Digger T. Rock - The Legend of the Lost City (Europe)</description>
 		<year>1991</year>
 		<publisher>Milton Bradley</publisher>
 		<info name="serial" value="NES-8D (NOE/ESP"/>
@@ -8957,7 +8957,7 @@ license:CC0
 	</software>
 
 	<software name="dkongcl">
-		<description>Donkey Kong Classics (Euro, USA)</description>
+		<description>Donkey Kong Classics (Europe, USA)</description>
 		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-DJ-USA, NES-DJ-(GBR/EEC/NOE/ESP/UKV)"/>
@@ -9018,7 +9018,7 @@ license:CC0
 	</software>
 
 	<software name="dkongjrm">
-		<description>Donkey Kong Jr. Math (Euro, USA)</description>
+		<description>Donkey Kong Jr. Math (Europe, USA)</description>
 		<year>1985</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-CA-USA, NES-CA-EEC"/>
@@ -9234,7 +9234,7 @@ license:CC0
 	</software>
 
 	<software name="ddragon">
-		<description>Double Dragon (Euro)</description>
+		<description>Double Dragon (Europe)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-WD-ESP"/>
@@ -9311,7 +9311,7 @@ license:CC0
 	</software>
 
 	<software name="ddragon2">
-		<description>Double Dragon II - The Revenge (Euro)</description>
+		<description>Double Dragon II - The Revenge (Europe)</description>
 		<year>1990</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-W2 (AUS/EEC/FRG/ESP)"/>
@@ -9368,7 +9368,7 @@ license:CC0
 	</software>
 
 	<software name="ddragon3">
-		<description>Double Dragon III - The Sacred Stones (Euro)</description>
+		<description>Double Dragon III - The Sacred Stones (Europe)</description>
 		<year>1994</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-3W (SCN/ESP/UKV)"/>
@@ -9425,7 +9425,7 @@ license:CC0
 	</software>
 
 	<software name="ddribble">
-		<description>Double Dribble (Euro)</description>
+		<description>Double Dribble (Europe)</description>
 		<year>1989</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-DW (EEC/FRG)"/>
@@ -9667,7 +9667,7 @@ license:CC0
 	</software>
 
 	<software name="drmario">
-		<description>Dr. Mario (Euro)</description>
+		<description>Dr. Mario (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-VU-(NOE/SCN/ESP)"/>
@@ -9754,7 +9754,7 @@ license:CC0
 	</software>
 
 	<software name="dballa" cloneof="dball">
-		<description>Dragon Ball - Le Secret du Dragon (Euro)</description>
+		<description>Dragon Ball - Le Secret du Dragon (Europe)</description>
 		<year>1990</year>
 		<publisher>Bandai</publisher>
 		<info name="serial" value="NES-B8-EEC"/>
@@ -9773,7 +9773,7 @@ license:CC0
 	</software>
 
 	<software name="dball">
-		<description>Dragon Ball - Le Secret du Dragon (Euro, rev. A)</description>
+		<description>Dragon Ball - Le Secret du Dragon (Europe, rev. A)</description>
 		<year>1990</year>
 		<publisher>Bandai</publisher>
 		<info name="serial" value="NES-B8 (EEC/FRA)"/>
@@ -10421,7 +10421,7 @@ license:CC0
 	</software>
 
 	<software name="dlair">
-		<description>Dragon's Lair (Euro)</description>
+		<description>Dragon's Lair (Europe)</description>
 		<year>1992</year>
 		<publisher>Elite</publisher>
 		<info name="serial" value="NES-L9 (SCN/ESP)"/>
@@ -10503,7 +10503,7 @@ license:CC0
 	</software>
 
 	<software name="dropzone">
-		<description>Dropzone (Euro)</description>
+		<description>Dropzone (Europe)</description>
 		<year>1992</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-D5-NOE"/>
@@ -10601,7 +10601,7 @@ license:CC0
 	</software>
 
 	<software name="ducktal2">
-		<description>Disney's DuckTales 2 (Euro)</description>
+		<description>Disney's DuckTales 2 (Europe)</description>
 		<year>1993</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-DL-SCN"/>
@@ -10681,7 +10681,7 @@ license:CC0
 	</software>
 
 	<software name="ducktale">
-		<description>DuckTales (Euro)</description>
+		<description>DuckTales (Europe)</description>
 		<year>1990</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-UK (EEC/FRG/SCN/NOE)"/>
@@ -10827,7 +10827,7 @@ license:CC0
 	</software>
 
 	<software name="dynablas">
-		<description>Dynablaster (Euro)</description>
+		<description>Dynablaster (Europe)</description>
 		<year>1991</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="NES-49 (ESP/FRG)"/>
@@ -11053,7 +11053,7 @@ license:CC0
 	</software>
 
 	<software name="eliminat">
-		<description>Eliminator Boat Duel (Euro)</description>
+		<description>Eliminator Boat Duel (Europe)</description>
 		<year>1993</year>
 		<publisher>Electro Brain</publisher>
 		<info name="serial" value="NES-6R-SCN"/>
@@ -11072,7 +11072,7 @@ license:CC0
 	</software>
 
 	<software name="elite" supported="no">
-		<description>Elite (Euro)</description>
+		<description>Elite (Europe)</description>
 		<year>1992</year>
 		<publisher>Imagineering</publisher>
 		<info name="serial" value="NES-EL (NOE/ESP/UKV)"/>
@@ -11294,7 +11294,7 @@ license:CC0
 	</software>
 
 	<software name="excitbik">
-		<description>Excitebike (Euro)</description>
+		<description>Excitebike (Europe)</description>
 		<year>1986</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-EB (EEC/NOE/ESP)"/>
@@ -11529,7 +11529,7 @@ license:CC0
 	</software>
 
 	<software name="f15se">
-		<description>F-15 Strike Eagle (Euro)</description>
+		<description>F-15 Strike Eagle (Europe)</description>
 		<year>1992</year>
 		<publisher>Microprose</publisher>
 		<info name="serial" value="NES-8F-UKV"/>
@@ -12684,7 +12684,7 @@ license:CC0
 	</software>
 
 	<software name="faxanadu">
-		<description>Faxanadu (Euro)</description>
+		<description>Faxanadu (Europe)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-FX (EEC/NOE/FRA/ESP/UKV)"/>
@@ -12745,7 +12745,7 @@ license:CC0
 	</software>
 
 	<software name="felix">
-		<description>Felix the Cat (Euro)</description>
+		<description>Felix the Cat (Europe)</description>
 		<year>1992</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="NES-FC-FRA"/>
@@ -12785,7 +12785,7 @@ license:CC0
 	</software>
 
 	<software name="ferrari">
-		<description>Ferrari Grand Prix Challenge (Euro)</description>
+		<description>Ferrari Grand Prix Challenge (Europe)</description>
 		<year>1992</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-FG (AUS/NOE/FRA)"/>
@@ -12842,7 +12842,7 @@ license:CC0
 	</software>
 
 	<software name="festrqst">
-		<description>Fester's Quest (Euro)</description>
+		<description>Fester's Quest (Europe)</description>
 		<year>1990</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NES-EQ-EEC"/>
@@ -13364,7 +13364,7 @@ license:CC0
 	</software>
 
 	<software name="flint">
-		<description>The Flintstones - The Rescue of Dino &amp; Hoppy (Euro)</description>
+		<description>The Flintstones - The Rescue of Dino &amp; Hoppy (Europe)</description>
 		<year>1992</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-5Z (SCN/ESP)"/>
@@ -13402,7 +13402,7 @@ license:CC0
 	</software>
 
 	<software name="flintsdp">
-		<description>The Flintstones - The Surprise at Dinosaur Peak! (Euro)</description>
+		<description>The Flintstones - The Surprise at Dinosaur Peak! (Europe)</description>
 		<year>1994</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-FT-SCN"/>
@@ -13558,7 +13558,7 @@ license:CC0
 	</software>
 
 	<software name="f1senstn">
-		<description>Formula 1 Sensation (Euro)</description>
+		<description>Formula 1 Sensation (Europe)</description>
 		<year>1993</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-FL-NOE"/>
@@ -13603,7 +13603,7 @@ license:CC0
 	</software>
 
 	<software name="4ptennis">
-		<description>Four Players' Tennis (Euro)</description>
+		<description>Four Players' Tennis (Europe)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-74 (FRG/ESP)"/>
@@ -13862,7 +13862,7 @@ license:CC0
 	</software>
 
 	<software name="galaga">
-		<description>Galaga - Demons of Death (Euro)</description>
+		<description>Galaga - Demons of Death (Europe)</description>
 		<year>1989</year>
 		<publisher>Bandai</publisher>
 		<info name="serial" value="NES-AG-EEC"/>
@@ -13940,7 +13940,7 @@ license:CC0
 	</software>
 
 	<software name="galaxy5k">
-		<description>Galaxy 5000 - Racing in the 51st Century (Euro)</description>
+		<description>Galaxy 5000 - Racing in the 51st Century (Europe)</description>
 		<year>1992</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="NES-Y5 (ESP/NOE)"/>
@@ -14180,7 +14180,7 @@ license:CC0
 	</software>
 
 	<software name="gargoyl2">
-		<description>Gargoyle's Quest II (Euro)</description>
+		<description>Gargoyle's Quest II (Europe)</description>
 		<year>1993</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-G2-SCN"/>
@@ -14284,7 +14284,7 @@ license:CC0
 	</software>
 
 	<software name="gauntlt2">
-		<description>Gauntlet II (Euro)</description>
+		<description>Gauntlet II (Europe)</description>
 		<year>1991</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-2U (EEC/NOE/SCN)"/>
@@ -14536,7 +14536,7 @@ license:CC0
 	</software>
 
 	<software name="georgeko">
-		<description>George Foreman's KO Boxing (Euro)</description>
+		<description>George Foreman's KO Boxing (Europe)</description>
 		<year>1992</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-KB-ESP"/>
@@ -14641,7 +14641,7 @@ license:CC0
 	</software>
 
 	<software name="ghostbs2">
-		<description>Ghostbusters II (Euro)</description>
+		<description>Ghostbusters II (Europe)</description>
 		<year>1990</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="NES-VV (EEC/ITA/NOE)"/>
@@ -14687,7 +14687,7 @@ license:CC0
 	</software>
 
 	<software name="gng">
-		<description>Ghosts'n Goblins (Euro)</description>
+		<description>Ghosts'n Goblins (Europe)</description>
 		<year>1991</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-GG (FRG/EEC)"/>
@@ -14849,7 +14849,7 @@ license:CC0
 	</software>
 
 	<software name="goal">
-		<description>Goal! (Euro)</description>
+		<description>Goal! (Europe)</description>
 		<year>1991</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="NES-JG (UKV/ESP/FRA)"/>
@@ -14869,7 +14869,7 @@ license:CC0
 
 	<software name="goal2">
 		<!-- Alt. Title: Eric Cantona Football Challenge Goal! 2 (French box and label) -->
-		<description>Goal! 2 (Euro)</description>
+		<description>Goal! 2 (Europe)</description>
 		<year>1992</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="NES-GT (ESP/FRA)"/>
@@ -14946,7 +14946,7 @@ license:CC0
 	</software>
 
 	<software name="godzilla">
-		<description>Godzilla - Monster of Monsters! (Euro)</description>
+		<description>Godzilla - Monster of Monsters! (Europe)</description>
 		<year>1990</year>
 		<publisher>Toho</publisher>
 		<info name="serial" value="NES-GZ-(FRA/UKV)"/>
@@ -15024,7 +15024,7 @@ license:CC0
 	</software>
 
 	<software name="golf">
-		<description>Golf (Euro, rev. M)</description>
+		<description>Golf (Europe, rev. M)</description>
 		<year>1986</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-GF (EEC/ESP/FRA)"/>
@@ -15280,7 +15280,7 @@ license:CC0
 	</software>
 
 	<software name="goonies2">
-		<description>The Goonies II (Euro)</description>
+		<description>The Goonies II (Europe)</description>
 		<year>1988</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-GU-EEC"/>
@@ -15418,7 +15418,7 @@ license:CC0
 	</software>
 
 	<software name="gradius">
-		<description>Gradius (Euro)</description>
+		<description>Gradius (Europe)</description>
 		<year>1988</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-GR (EEC/NOE)"/>
@@ -15623,7 +15623,7 @@ license:CC0
 	</software>
 
 	<software name="gremlin2">
-		<description>Gremlins 2 - The New Batch (Euro)</description>
+		<description>Gremlins 2 - The New Batch (Europe)</description>
 		<year>1991</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NES-2Z (EEC/FRG/ITA))"/>
@@ -15661,7 +15661,7 @@ license:CC0
 	</software>
 
 	<software name="guardlgn" supported="no">
-		<description>The Guardian Legend (Euro)</description>
+		<description>The Guardian Legend (Europe)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-GD (SCN/ESP)"/>
@@ -15700,7 +15700,7 @@ license:CC0
 	</software>
 
 	<software name="gwar">
-		<description>Guerrilla War (Euro)</description>
+		<description>Guerrilla War (Europe)</description>
 		<year>1989</year>
 		<publisher>SNK</publisher>
 		<info name="serial" value="NES-GW-AUS"/>
@@ -15757,7 +15757,7 @@ license:CC0
 	</software>
 
 	<software name="gumshoe">
-		<description>Gumshoe (Euro, USA)</description>
+		<description>Gumshoe (Europe, USA)</description>
 		<year>1986</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-GS-USA, NES-GS-EEC"/>
@@ -15881,7 +15881,7 @@ license:CC0
 	</software>
 
 	<software name="gunsmoke">
-		<description>Gun.Smoke (Euro)</description>
+		<description>Gun.Smoke (Europe)</description>
 		<year>1989</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-GK (EEC/UKV)"/>
@@ -15920,7 +15920,7 @@ license:CC0
 	</software>
 
 	<software name="gyromite" supported="partial">
-		<description>Gyromite (Euro, USA) ~ Gyro (Japan)</description>
+		<description>Gyromite (Europe, USA) ~ Gyro (Japan)</description>
 		<year>1985</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="HVC-GY, NES-GY-USA, NES-GY-(FRA/GBR)"/>
@@ -15981,7 +15981,7 @@ license:CC0
 	</software>
 
 	<software name="hharry">
-		<description>Hammerin' Harry (Euro)</description>
+		<description>Hammerin' Harry (Europe)</description>
 		<year>1992</year>
 		<publisher>Irem</publisher>
 		<info name="serial" value="NES-59 (ESP/FRG)"/>
@@ -16399,7 +16399,7 @@ license:CC0
 	</software>
 
 	<software name="heroqst">
-		<description>Hero Quest (Euro, prototype)</description>
+		<description>Hero Quest (Europe, prototype)</description>
 		<year>1991</year>
 		<publisher>Gremlin Interactive</publisher>
 		<part name="cart" interface="nes_cart">
@@ -16545,7 +16545,7 @@ license:CC0
 	</software>
 
 	<software name="highsped">
-		<description>High Speed (Euro)</description>
+		<description>High Speed (Europe)</description>
 		<year>1994</year>
 		<publisher>Tradewest</publisher>
 		<info name="serial" value="NES-8H (FRA/FRG)"/>
@@ -17074,7 +17074,7 @@ license:CC0
 	</software>
 
 	<software name="homea2">
-		<description>Home Alone 2 - Lost In New York (Euro)</description>
+		<description>Home Alone 2 - Lost In New York (Europe)</description>
 		<year>1992</year>
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NES-HM-NOE"/>
@@ -17222,7 +17222,7 @@ license:CC0
 	</software>
 
 	<software name="hook">
-		<description>Hook (Euro)</description>
+		<description>Hook (Europe)</description>
 		<year>1992</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-7Q-(NOE/UKV/ESP)"/>
@@ -17259,7 +17259,7 @@ license:CC0
 	</software>
 
 	<software name="hoops">
-		<description>Hoops (Euro)</description>
+		<description>Hoops (Europe)</description>
 		<year>1989</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="NES-2B-AUS"/>
@@ -17423,7 +17423,7 @@ license:CC0
 	</software>
 
 	<software name="hudsonh">
-		<description>Hudson Hawk (Euro)</description>
+		<description>Hudson Hawk (Europe)</description>
 		<year>1991</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-Y4 (FRA/ESP)"/>
@@ -17441,7 +17441,7 @@ license:CC0
 	</software>
 
 	<software name="huntred">
-		<description>The Hunt For Red October (Euro)</description>
+		<description>The Hunt For Red October (Europe)</description>
 		<year>1991</year>
 		<publisher>Hi Tech Expressions</publisher>
 		<info name="serial" value="NES-7H (FRA/FRG)"/>
@@ -17712,7 +17712,7 @@ license:CC0
 	</software>
 
 	<software name="iceclimb">
-		<description>Ice Climber (Euro, USA, Kor)</description>
+		<description>Ice Climber (Europe, USA, Korea)</description>
 		<year>1985</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-IC-USA"/>
@@ -17761,7 +17761,7 @@ license:CC0
 	</software>
 
 	<software name="icehocky">
-		<description>Ice Hockey (Euro)</description>
+		<description>Ice Hockey (Europe)</description>
 		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-HY (EEC/ESP)"/>
@@ -17971,7 +17971,7 @@ license:CC0
 	</software>
 
 	<software name="ikari">
-		<description>Ikari Warriors (Euro)</description>
+		<description>Ikari Warriors (Europe)</description>
 		<year>1989</year>
 		<publisher>SNK</publisher>
 		<info name="serial" value="NES-IW-EEC"/>
@@ -18192,7 +18192,7 @@ license:CC0
 	</software>
 
 	<software name="crashdum">
-		<description>The Incredible Crash Dummies (Euro)</description>
+		<description>The Incredible Crash Dummies (Europe)</description>
 		<year>1993</year>
 		<publisher>LJN</publisher>
 		<info name="serial" value="NES-CQ (NOE/SCN)"/>
@@ -18322,7 +18322,7 @@ license:CC0
 	</software>
 
 	<software name="indycrus">
-		<description>Indiana Jones and the Last Crusade (Euro)</description>
+		<description>Indiana Jones and the Last Crusade (Europe)</description>
 		<year>1993</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NES-LR-FRA"/>
@@ -18439,7 +18439,7 @@ license:CC0
 	</software>
 
 	<software name="irontank">
-		<description>Iron Tank - The Invasion of Normandy (Euro)</description>
+		<description>Iron Tank - The Invasion of Normandy (Europe)</description>
 		<year>1988</year>
 		<publisher>SNK</publisher>
 		<info name="serial" value="NES-IT-AUS"/>
@@ -18501,7 +18501,7 @@ license:CC0
 	</software>
 
 	<software name="ironswrd">
-		<description>IronSword - Wizards &amp; Warriors II (Euro)</description>
+		<description>IronSword - Wizards &amp; Warriors II (Europe)</description>
 		<year>1990</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-IR (EEC/FRG/ESP"/>
@@ -18597,7 +18597,7 @@ license:CC0
 	</software>
 
 	<software name="isolatwr">
-		<description>Isolated Warrior (Euro)</description>
+		<description>Isolated Warrior (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-W6 (ESP/UKV)"/>
@@ -18704,7 +18704,7 @@ license:CC0
 	</software>
 
 	<software name="nicklaus">
-		<description>Jack Nicklaus' Greatest 18 Holes of Major Championship Golf (Euro)</description>
+		<description>Jack Nicklaus' Greatest 18 Holes of Major Championship Golf (Europe)</description>
 		<year>1991</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-JC-EEC"/>
@@ -18781,7 +18781,7 @@ license:CC0
 	</software>
 
 	<software name="jchan">
-		<description>Jackie Chan's Action Kung-Fu (Euro)</description>
+		<description>Jackie Chan's Action Kung-Fu (Europe)</description>
 		<year>1991</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="NES-V5 (ESP/UKV)"/>
@@ -18862,7 +18862,7 @@ license:CC0
 	</software>
 
 	<software name="jbjr">
-		<description>James Bond Jr (Euro)</description>
+		<description>James Bond Jr (Europe)</description>
 		<year>1992</year>
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NES-JB-(NOE/UKV)"/>
@@ -19082,7 +19082,7 @@ license:CC0
 	</software>
 
 	<software name="jetsons">
-		<description>The Jetsons - Cogswell's Caper! (Euro)</description>
+		<description>The Jetsons - Cogswell's Caper! (Europe)</description>
 		<year>1993</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-JN (FRG/SCN)"/>
@@ -19160,7 +19160,7 @@ license:CC0
 	</software>
 
 	<software name="connors">
-		<description>Jimmy Connors Tennis (Euro)</description>
+		<description>Jimmy Connors Tennis (Europe)</description>
 		<year>1993</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NES-JT-UKV"/>
@@ -19198,7 +19198,7 @@ license:CC0
 	</software>
 
 	<software name="joemac">
-		<description>Joe &amp; Mac - Caveman Ninja (Euro)</description>
+		<description>Joe &amp; Mac - Caveman Ninja (Europe)</description>
 		<year>1992</year>
 		<publisher>Data East</publisher>
 		<info name="serial" value="NES-CJ (FRG/ESP/SCN/UKV))"/>
@@ -19311,7 +19311,7 @@ license:CC0
 	</software>
 
 	<software name="silius">
-		<description>Journey to Silius (Euro)</description>
+		<description>Journey to Silius (Europe)</description>
 		<year>1991</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NES-4S-EEC"/>
@@ -19457,7 +19457,7 @@ license:CC0
 	</software>
 
 	<software name="jungle">
-		<description>Disney's The Jungle Book (Euro)</description>
+		<description>Disney's The Jungle Book (Europe)</description>
 		<year>1994</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="NES-JJ (SCN/NOE)"/>
@@ -19499,7 +19499,7 @@ license:CC0
 	</software>
 
 	<software name="jpark">
-		<description>Jurassic Park (Euro)</description>
+		<description>Jurassic Park (Europe)</description>
 		<year>1993</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-J9-SCN"/>
@@ -19613,7 +19613,7 @@ license:CC0
 	</software>
 
 	<software name="kabuki">
-		<description>Kabuki - Quantum Fighter (Euro)</description>
+		<description>Kabuki - Quantum Fighter (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-3K (NOE/SCN/ESP)"/>
@@ -20187,7 +20187,7 @@ license:CC0
 
 <!-- glitches on NTSC -->
 	<software name="kickoff">
-		<description>Kick Off (Euro)</description>
+		<description>Kick Off (Europe)</description>
 		<year>1992</year>
 		<publisher>Imagineering</publisher>
 		<info name="serial" value="NES-54 (SCN/ESP/UKV)"/>
@@ -20206,7 +20206,7 @@ license:CC0
 	</software>
 
 	<software name="kickle">
-		<description>Kickle Cubicle (Euro)</description>
+		<description>Kickle Cubicle (Europe)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-QC-(NOE/UKV)"/>
@@ -20243,7 +20243,7 @@ license:CC0
 	</software>
 
 	<software name="kidicars1" cloneof="kidicars">
-		<description>Kid Icarus (Euro, USA)</description>
+		<description>Kid Icarus (Europe, USA)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-KI-(USA/CAN), NES-KI-EEC"/>
@@ -20265,7 +20265,7 @@ license:CC0
 	</software>
 
 	<software name="kidicars">
-		<description>Kid Icarus (Euro, rev. A)</description>
+		<description>Kid Icarus (Europe, rev. A)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-KI(EEC/ESP)"/>
@@ -20767,7 +20767,7 @@ license:CC0
 	</software>
 
 	<software name="kirby">
-		<description>Kirby's Adventure (Euro)</description>
+		<description>Kirby's Adventure (Europe)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-KR-SCN"/>
@@ -20905,7 +20905,7 @@ license:CC0
 	</software>
 
 	<software name="knightr">
-		<description>Knight Rider (Euro)</description>
+		<description>Knight Rider (Europe)</description>
 		<year>1990</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-NR-EEC"/>
@@ -20924,7 +20924,7 @@ license:CC0
 	</software>
 
 	<software name="hyprsocr">
-		<description>Konami Hyper Soccer (Euro)</description>
+		<description>Konami Hyper Soccer (Europe)</description>
 		<year>1992</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-86 (NOE/ESP/FRA)"/>
@@ -21071,7 +21071,7 @@ license:CC0
 	</software>
 
 	<software name="krustyfh">
-		<description>Krusty's Fun House (Euro)</description>
+		<description>Krusty's Fun House (Europe)</description>
 		<year>1992</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-KF-AUS"/>
@@ -21172,7 +21172,7 @@ license:CC0
 	</software>
 
 	<software name="kungfu">
-		<description>Kung Fu (Euro)</description>
+		<description>Kung Fu (Europe)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-SX (EEC/ESP/NOE/GBR/UKV)"/>
@@ -21727,7 +21727,7 @@ license:CC0
 	</software>
 
 	<software name="leetrevn">
-		<description>Lee Trevino's Fighting Golf (Euro)</description>
+		<description>Lee Trevino's Fighting Golf (Europe)</description>
 		<year>1990</year>
 		<publisher>SNK</publisher>
 		<info name="serial" value="NES-FI-EEC"/>
@@ -21784,7 +21784,7 @@ license:CC0
 	</software>
 
 	<software name="valiant">
-		<description>The Legend of Prince Valiant (Euro)</description>
+		<description>The Legend of Prince Valiant (Europe)</description>
 		<year>1992</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-PX (FRA/ESP)"/>
@@ -21849,7 +21849,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaa" cloneof="zelda">
-		<description>The Legend of Zelda (Euro)</description>
+		<description>The Legend of Zelda (Europe)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-ZL-EEC"/>
@@ -21872,7 +21872,7 @@ license:CC0
 	</software>
 
 	<software name="zelda">
-		<description>The Legend of Zelda (Euro, rev. A)</description>
+		<description>The Legend of Zelda (Europe, rev. A)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-ZL (EEC/FRG/ESP/FRA)"/>
@@ -21982,7 +21982,7 @@ license:CC0
 	</software>
 
 	<software name="lemmings">
-		<description>Lemmings (Euro)</description>
+		<description>Lemmings (Europe)</description>
 		<year>1993</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-LG (SCN/ESP)"/>
@@ -22020,7 +22020,7 @@ license:CC0
 	</software>
 
 	<software name="lweapon">
-		<description>Lethal Weapon (Euro)</description>
+		<description>Lethal Weapon (Europe)</description>
 		<year>1993</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-LY-FRA"/>
@@ -22058,7 +22058,7 @@ license:CC0
 	</software>
 
 	<software name="salamand">
-		<description>Life Force Salamander (Euro)</description>
+		<description>Life Force Salamander (Europe)</description>
 		<year>1989</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-LF (EEC/ESP)"/>
@@ -22096,7 +22096,7 @@ license:CC0
 
 <!-- glitches on NTSC -->
 	<software name="lionking">
-		<description>Disney's The Lion King (Euro)</description>
+		<description>Disney's The Lion King (Europe)</description>
 		<year>1994</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="NES-KL (SCN/NOE/ITA/ESP)"/>
@@ -22223,7 +22223,7 @@ license:CC0
 	</software>
 
 	<software name="nemo">
-		<description>Little Nemo - The Dream Master (Euro)</description>
+		<description>Little Nemo - The Dream Master (Europe)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-LN (NOE/SCN/ESP)"/>
@@ -22261,7 +22261,7 @@ license:CC0
 	</software>
 
 	<software name="lilninjb">
-		<description>Little Ninja Brothers (Euro)</description>
+		<description>Little Ninja Brothers (Europe)</description>
 		<year>1992</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="NES-C2-FRG"/>
@@ -22299,7 +22299,7 @@ license:CC0
 	</software>
 
 	<software name="lilsamsn">
-		<description>Little Samson (Euro)</description>
+		<description>Little Samson (Europe)</description>
 		<year>1992</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-LT (SCN/ESP)"/>
@@ -22476,7 +22476,7 @@ license:CC0
 	</software>
 
 	<software name="lowgman">
-		<description>Low G Man - The Low Gravity Man (Euro)</description>
+		<description>Low G Man - The Low Gravity Man (Europe)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-L7-ESP"/>
@@ -22515,7 +22515,7 @@ license:CC0
 	</software>
 
 	<software name="lunarpol">
-		<description>Lunar Pool (Euro)</description>
+		<description>Lunar Pool (Europe)</description>
 		<year>1991</year>
 		<publisher>FCI</publisher>
 		<info name="serial" value="NES-LP-(FRA/UKV)"/>
@@ -22716,7 +22716,7 @@ license:CC0
 
 <!-- glitches on NTSC -->
 	<software name="machridr">
-		<description>Mach Rider (Euro)</description>
+		<description>Mach Rider (Europe)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-MR (GBR/EEC)"/>
@@ -23606,7 +23606,7 @@ license:CC0
 	</software>
 
 	<software name="marble">
-		<description>Marble Madness (Euro)</description>
+		<description>Marble Madness (Europe)</description>
 		<year>1991</year>
 		<publisher>Milton Bradley</publisher>
 		<info name="serial" value="NES-MV-NOE"/>
@@ -23624,7 +23624,7 @@ license:CC0
 	</software>
 
 	<software name="marioyos" supported="partial">
-		<description>Mario &amp; Yoshi (Euro)</description>
+		<description>Mario &amp; Yoshi (Europe)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-YM (NOE/SCN)"/>
@@ -23664,7 +23664,7 @@ license:CC0
 	</software>
 
 	<software name="mario">
-		<description>Mario Bros. (Euro, rev. A)</description>
+		<description>Mario Bros. (Europe, rev. A)</description>
 		<year>1986</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-MA (EEC/FRG)"/>
@@ -23684,7 +23684,7 @@ license:CC0
 	</software>
 
 	<software name="mariocs">
-		<description>Mario Bros. (Classic Series) (Euro)</description>
+		<description>Mario Bros. (Classic Series) (Europe)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-MC-NOE"/>
@@ -23914,7 +23914,7 @@ license:CC0
 	</software>
 
 	<software name="mckids">
-		<description>M.C. Kids (Euro)</description>
+		<description>M.C. Kids (Europe)</description>
 		<year>1992</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-4Q-SCN"/>
@@ -23976,7 +23976,7 @@ license:CC0
 	</software>
 
 	<software name="megaman">
-		<description>Mega Man (Euro)</description>
+		<description>Mega Man (Europe)</description>
 		<year>1989</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-MN (EEC/FRG)"/>
@@ -24020,7 +24020,7 @@ license:CC0
 	</software>
 
 	<software name="megaman2">
-		<description>Mega Man 2 (Euro)</description>
+		<description>Mega Man 2 (Europe)</description>
 		<year>1990</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-XR (EEC/FRG/NOE)"/>
@@ -24082,7 +24082,7 @@ license:CC0
 	</software>
 
 	<software name="megaman3">
-		<description>Mega Man 3 (Euro, rev. A)</description>
+		<description>Mega Man 3 (Europe, rev. A)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-XU-FRA"/>
@@ -24101,7 +24101,7 @@ license:CC0
 	</software>
 
 	<software name="megaman3a" cloneof="megaman3">
-		<description>Mega Man 3 (Euro)</description>
+		<description>Mega Man 3 (Europe)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-XU (FRG/SCN/ESP)"/>
@@ -24164,7 +24164,7 @@ license:CC0
 	</software>
 
 	<software name="megaman4">
-		<description>Mega Man 4 (Euro)</description>
+		<description>Mega Man 4 (Europe)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-4V (FRG/SCN)"/>
@@ -24202,7 +24202,7 @@ license:CC0
 	</software>
 
 	<software name="megaman5">
-		<description>Mega Man 5 (Euro)</description>
+		<description>Mega Man 5 (Europe)</description>
 		<year>1993</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-MZ (FRA/NOE/SCN)"/>
@@ -24501,7 +24501,7 @@ license:CC0
 	</software>
 
 	<software name="mgear">
-		<description>Metal Gear (Euro)</description>
+		<description>Metal Gear (Europe)</description>
 		<year>1989</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-ME-EEC"/>
@@ -24650,7 +24650,7 @@ license:CC0
 	</software>
 
 	<software name="metroid">
-		<description>Metroid (Euro)</description>
+		<description>Metroid (Europe)</description>
 		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-MT (EEC/ESP)"/>
@@ -24833,7 +24833,7 @@ license:CC0
 	</software>
 
 	<software name="micromac">
-		<description>Micro Machines (Euro)</description>
+		<description>Micro Machines (Europe)</description>
 		<year>1992</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="COBIC-7403-MM"/>
@@ -24962,7 +24962,7 @@ license:CC0
 
 <!-- UNF file by Kevin Horton has a 16kb CHR (crc32 613c45a3)!!... check -->
 	<software name="mightybj">
-		<description>Mighty Bomb Jack (Euro)</description>
+		<description>Mighty Bomb Jack (Europe)</description>
 		<year>1992</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="NES-BJ-ESP"/>
@@ -25020,7 +25020,7 @@ license:CC0
 	</software>
 
 	<software name="mffight">
-		<description>Mighty Final Fight (Euro)</description>
+		<description>Mighty Final Fight (Europe)</description>
 		<year>1993</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-MF-NOE"/>
@@ -25075,7 +25075,7 @@ license:CC0
 	</software>
 
 	<software name="tysonpo1" cloneof="tysonpo">
-		<description>Mike Tyson's Punch-Out!! (Euro)</description>
+		<description>Mike Tyson's Punch-Out!! (Europe)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-PT (EEC/ESP/GBR)"/>
@@ -25093,7 +25093,7 @@ license:CC0
 	</software>
 
 	<software name="tysonpo">
-		<description>Mike Tyson's Punch-Out!! (Euro, rev. A)</description>
+		<description>Mike Tyson's Punch-Out!! (Europe, rev. A)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-PT-(EEC/FRA)"/>
@@ -25391,7 +25391,7 @@ license:CC0
 	</software>
 
 	<software name="missimp">
-		<description>Mission: Impossible (Euro)</description>
+		<description>Mission: Impossible (Europe)</description>
 		<year>1991</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-U4 (SCN/NOE)"/>
@@ -25871,7 +25871,7 @@ license:CC0
 	</software>
 
 	<software name="monstpok">
-		<description>Monster In My Pocket (Euro)</description>
+		<description>Monster In My Pocket (Europe)</description>
 		<year>1992</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-1Y-(NOE/UKV)"/>
@@ -26106,7 +26106,7 @@ license:CC0
 
 <!-- a proto has been found too, containing the same data, without labels -->
 	<software name="gimmick">
-		<description>Mr. Gimmick (Euro)</description>
+		<description>Mr. Gimmick (Europe)</description>
 		<year>1993</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NES-G8-SCN"/>
@@ -26352,7 +26352,7 @@ license:CC0
 	</software>
 
 	<software name="nesgolf">
-		<description>NES Open Tournament Golf (Euro)</description>
+		<description>NES Open Tournament Golf (Europe)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-UG (NOE/SCN)"/>
@@ -26736,7 +26736,7 @@ license:CC0
 	</software>
 
 	<software name="nghostb2">
-		<description>New Ghostbusters II (Euro)</description>
+		<description>New Ghostbusters II (Europe)</description>
 		<year>1990</year>
 		<publisher>HAL Laboratory</publisher>
 		<info name="serial" value="NES-QD (AUS/FRA)"/>
@@ -26794,7 +26794,7 @@ license:CC0
 	</software>
 
 	<software name="tnzs">
-		<description>The New Zealand Story (Euro)</description>
+		<description>The New Zealand Story (Europe)</description>
 		<year>1991</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-38-ESP"/>
@@ -26857,7 +26857,7 @@ license:CC0
 	</software>
 
 	<software name="mansell">
-		<description>Nigel Mansell's World Championship Racing (Euro)</description>
+		<description>Nigel Mansell's World Championship Racing (Europe)</description>
 		<year>1993</year>
 		<publisher>Gremlin</publisher>
 		<info name="serial" value="NES-NC-NOE"/>
@@ -27282,7 +27282,7 @@ license:CC0
 	</software>
 
 	<software name="nintenwca" cloneof="nintenwc">
-		<description>Nintendo World Cup (Euro, rev. A)</description>
+		<description>Nintendo World Cup (Europe, rev. A)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-XZ (NOE)"/>
@@ -27301,7 +27301,7 @@ license:CC0
 	</software>
 
 	<software name="nintenwcb" cloneof="nintenwc">
-		<description>Nintendo World Cup (Euro)</description>
+		<description>Nintendo World Cup (Europe)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-XZ (FRA/NOE/SCN)"/>
@@ -27382,7 +27382,7 @@ license:CC0
 
 <!-- a proto has been found too, containing the same data, with labels "RP100 P" and "RP100 C" -->
 	<software name="noah">
-		<description>Noah's Ark (Euro)</description>
+		<description>Noah's Ark (Europe)</description>
 		<year>1992</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-NH-NOE"/>
@@ -27562,7 +27562,7 @@ license:CC0
 	</software>
 
 	<software name="northns">
-		<description>North &amp; South (Euro)</description>
+		<description>North &amp; South (Europe)</description>
 		<year>1992</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NES-N5 (SCN/ESP)"/>
@@ -27828,7 +27828,7 @@ license:CC0
 	</software>
 
 	<software name="opwolf" supported="partial">
-		<description>Operation Wolf - Take no Prisoners (Euro)</description>
+		<description>Operation Wolf - Take no Prisoners (Europe)</description>
 		<year>1992</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-OW (AUS/ESP/UKV)"/>
@@ -27952,7 +27952,7 @@ license:CC0
 	</software>
 
 	<software name="overhorz">
-		<description>Over Horizon (Euro)</description>
+		<description>Over Horizon (Europe)</description>
 		<year>1992</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="NES-Z6-NOE"/>
@@ -28034,7 +28034,7 @@ license:CC0
 	</software>
 
 	<software name="pow">
-		<description>P.O.W. - Prisoners of War (Euro)</description>
+		<description>P.O.W. - Prisoners of War (Europe)</description>
 		<year>1991</year>
 		<publisher>SNK</publisher>
 		<info name="serial" value="NES-EW (ESP/ITA)"/>
@@ -28526,7 +28526,7 @@ license:CC0
 	</software>
 
 	<software name="panicrst">
-		<description>Panic Restaurant (Euro)</description>
+		<description>Panic Restaurant (Europe)</description>
 		<year>1992</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-PR (NOE/ESP)"/>
@@ -28584,7 +28584,7 @@ license:CC0
 	</software>
 
 	<software name="paperboy">
-		<description>Paperboy (Euro)</description>
+		<description>Paperboy (Europe)</description>
 		<year>1990</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-PY (EEC/FRG/SCN)"/>
@@ -28622,7 +28622,7 @@ license:CC0
 	</software>
 
 	<software name="paperbo2">
-		<description>Paperboy 2 (Euro)</description>
+		<description>Paperboy 2 (Europe)</description>
 		<year>1992</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-Y7 (NOE/ESP)"/>
@@ -28661,7 +28661,7 @@ license:CC0
 	</software>
 
 	<software name="parasolp" cloneof="parasol">
-		<description>Parasol Stars - The Story of Bubble Bobble III (Euro, prototype)</description>
+		<description>Parasol Stars - The Story of Bubble Bobble III (Europe, prototype)</description>
 		<year>1992</year>
 		<publisher>Ocean</publisher>
 		<part name="cart" interface="nes_cart">
@@ -28698,7 +28698,7 @@ license:CC0
 	</software>
 
 	<software name="parodius">
-		<description>Parodius (Euro)</description>
+		<description>Parodius (Europe)</description>
 		<year>1992</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-PV-NOE"/>
@@ -28858,7 +28858,7 @@ license:CC0
 	</software>
 
 	<software name="phantom">
-		<description>Phantom Air Mission (Euro)</description>
+		<description>Phantom Air Mission (Europe)</description>
 		<year>1992?</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="NES-PH-ESP"/>
@@ -28918,7 +28918,7 @@ license:CC0
 
 <!-- Glitched in NTSC -->
 	<software name="pinbot">
-		<description>Pin-Bot (Euro)</description>
+		<description>Pin-Bot (Europe)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-IO (EEC/NOE/FRA/ESP)"/>
@@ -28988,7 +28988,7 @@ license:CC0
 	</software>
 
 	<software name="pinball">
-		<description>Pinball (Euro, rev. A)</description>
+		<description>Pinball (Europe, rev. A)</description>
 		<year>1986</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-PN-(EEC/NOE/ESP)"/>
@@ -29376,7 +29376,7 @@ license:CC0
 	</software>
 
 	<software name="powblade">
-		<description>Power Blade (Euro)</description>
+		<description>Power Blade (Europe)</description>
 		<year>1992</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-7T (FRG/SCN)"/>
@@ -29535,7 +29535,7 @@ license:CC0
 	</software>
 
 	<software name="ppersia">
-		<description>Prince of Persia (Euro)</description>
+		<description>Prince of Persia (Europe)</description>
 		<year>1993</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-PA-SCN"/>
@@ -29705,7 +29705,7 @@ license:CC0
 	</software>
 
 	<software name="prowres">
-		<description>Pro Wrestling (Euro)</description>
+		<description>Pro Wrestling (Europe)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-PW (EEC/FRA/ESP)"/>
@@ -29808,7 +29808,7 @@ license:CC0
 	</software>
 
 	<software name="probot">
-		<description>Probotector (Euro)</description>
+		<description>Probotector (Europe)</description>
 		<year>1990</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-77 (EEC/FRG)"/>
@@ -29827,7 +29827,7 @@ license:CC0
 	</software>
 
 	<software name="probot2">
-		<description>Probotector II - Return of the Evil Forces (Euro)</description>
+		<description>Probotector II - Return of the Evil Forces (Europe)</description>
 		<year>1992</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-PD-NOE"/>
@@ -29862,7 +29862,7 @@ license:CC0
 	</software>
 
 	<software name="punchout">
-		<description>Punch-Out!! (Euro)</description>
+		<description>Punch-Out!! (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-QP-(EEC/ESP/UKV)"/>
@@ -29993,7 +29993,7 @@ license:CC0
 	</software>
 
 	<software name="puzznic">
-		<description>Puzznic (Euro)</description>
+		<description>Puzznic (Europe)</description>
 		<year>1991</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-ZP (EEC/NOE)"/>
@@ -30323,7 +30323,7 @@ license:CC0
 	</software>
 
 	<software name="rcproama" cloneof="rcproam">
-		<description>R.C. Pro-Am (Euro)</description>
+		<description>R.C. Pro-Am (Europe)</description>
 		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-PM-EEC"/>
@@ -30342,7 +30342,7 @@ license:CC0
 	</software>
 
 	<software name="rcproam">
-		<description>R.C. Pro-Am (Euro, rev. A)</description>
+		<description>R.C. Pro-Am (Europe, rev. A)</description>
 		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-PM-ESP"/>
@@ -30381,7 +30381,7 @@ license:CC0
 	</software>
 
 	<software name="rcproam2">
-		<description>R.C. Pro-Am II (Euro)</description>
+		<description>R.C. Pro-Am II (Europe)</description>
 		<year>1993</year>
 		<publisher>Tradewest</publisher>
 		<info name="serial" value="NES-R2-SCN"/>
@@ -30561,7 +30561,7 @@ license:CC0
 	</software>
 
 	<software name="racketat">
-		<description>Racket Attack (Euro)</description>
+		<description>Racket Attack (Europe)</description>
 		<year>1994</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="NES-RE-ESP"/>
@@ -30600,7 +30600,7 @@ license:CC0
 	</software>
 
 	<software name="radracer" supported="partial">
-		<description>Rad Racer (Euro)</description>
+		<description>Rad Racer (Europe)</description>
 		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-RC (EEC/NOE/ESP)"/>
@@ -30804,7 +30804,7 @@ license:CC0
 	</software>
 
 	<software name="rbisland">
-		<description>Rainbow Islands - The Story of Bubble Bobble 2 (Euro)</description>
+		<description>Rainbow Islands - The Story of Bubble Bobble 2 (Europe)</description>
 		<year>1991</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-64-(ESP/UKV)"/>
@@ -30918,7 +30918,7 @@ license:CC0
 	</software>
 
 	<software name="rampart">
-		<description>Rampart (Euro)</description>
+		<description>Rampart (Europe)</description>
 		<year>1992</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="NES-73-NOE"/>
@@ -31089,7 +31089,7 @@ license:CC0
 	</software>
 
 	<software name="rescue">
-		<description>Rescue - The Embassy Mission (Euro)</description>
+		<description>Rescue - The Embassy Mission (Europe)</description>
 		<year>1991</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NES-HZ-EEC"/>
@@ -31187,7 +31187,7 @@ license:CC0
 	</software>
 
 	<software name="roadfght">
-		<description>Road Fighter (Euro)</description>
+		<description>Road Fighter (Europe)</description>
 		<year>1992</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-39 (NOE/SCN/AUS/ESP)"/>
@@ -31224,7 +31224,7 @@ license:CC0
 	</software>
 
 	<software name="roadblst">
-		<description>RoadBlasters (Euro)</description>
+		<description>RoadBlasters (Europe)</description>
 		<year>1990</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-VE-NOE"/>
@@ -31319,7 +31319,7 @@ license:CC0
 	</software>
 
 	<software name="robinh">
-		<description>Robin Hood - Prince of Thieves (Euro)</description>
+		<description>Robin Hood - Prince of Thieves (Europe)</description>
 		<year>1992</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-7R-SCN"/>
@@ -31376,7 +31376,7 @@ license:CC0
 	</software>
 
 	<software name="robowarr">
-		<description>Robo Warrior (Euro)</description>
+		<description>Robo Warrior (Europe)</description>
 		<year>1989</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="NES-RR-EEC"/>
@@ -31434,7 +31434,7 @@ license:CC0
 	</software>
 
 	<software name="robocop">
-		<description>RoboCop (Euro)</description>
+		<description>RoboCop (Europe)</description>
 		<year>1991</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-CP-EEC"/>
@@ -31511,7 +31511,7 @@ license:CC0
 	</software>
 
 	<software name="robocop2">
-		<description>RoboCop 2 (Euro)</description>
+		<description>RoboCop 2 (Europe)</description>
 		<year>1992</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-2C (ESP/AUS)"/>
@@ -31550,7 +31550,7 @@ license:CC0
 
 <!-- glitches on NTSC -->
 	<software name="robocop3">
-		<description>RoboCop 3 (Euro)</description>
+		<description>RoboCop 3 (Europe)</description>
 		<year>1994</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NES-R3-ESP"/>
@@ -31644,7 +31644,7 @@ license:CC0
 	</software>
 
 	<software name="rockinkt">
-		<description>Rockin' Kats (Euro)</description>
+		<description>Rockin' Kats (Europe)</description>
 		<year>1992</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="NES-7A (SCN/ESP)"/>
@@ -31802,7 +31802,7 @@ license:CC0
 	</software>
 
 	<software name="rodland">
-		<description>Rod Land (Euro)</description>
+		<description>Rod Land (Europe)</description>
 		<year>1993</year>
 		<publisher>Storm</publisher>
 		<info name="serial" value="NES-R8-ESP"/>
@@ -31821,7 +31821,7 @@ license:CC0
 	</software>
 
 	<software name="rodlandp" cloneof="rodland">
-		<description>Rod Land (Euro, prototype)</description>
+		<description>Rod Land (Europe, prototype)</description>
 		<year>1993</year>
 		<publisher>Storm</publisher>
 		<part name="cart" interface="nes_cart">
@@ -31970,7 +31970,7 @@ license:CC0
 	</software>
 
 	<software name="rollerg">
-		<description>Rollergames (Euro)</description>
+		<description>Rollergames (Europe)</description>
 		<year>1991</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-U5 (NOE/SCN)"/>
@@ -32123,7 +32123,7 @@ license:CC0
 	</software>
 
 	<software name="roundbal">
-		<description>Roundball - 2-on-2 Challenge (Euro)</description>
+		<description>Roundball - 2-on-2 Challenge (Europe)</description>
 		<year>1992</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-RW-NOE"/>
@@ -32210,7 +32210,7 @@ license:CC0
 	</software>
 
 	<software name="rushatck">
-		<description>Rush'n Attack (Euro)</description>
+		<description>Rush'n Attack (Europe)</description>
 		<year>1989</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-RA (EEC/ESP)"/>
@@ -32267,7 +32267,7 @@ license:CC0
 	</software>
 
 	<software name="rygar">
-		<description>Rygar (Euro)</description>
+		<description>Rygar (Europe)</description>
 		<year>1990</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="NES-RY-(EEC/ESP/FRG)"/>
@@ -33145,7 +33145,7 @@ license:CC0
 	</software>
 
 	<software name="smurfs">
-		<description>The Smurfs (Euro)</description>
+		<description>The Smurfs (Europe)</description>
 		<year>1994</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NES-SF (FRA/NOE)"/>
@@ -33218,7 +33218,7 @@ license:CC0
 	</software>
 
 	<software name="sectionz">
-		<description>Section-Z (Euro)</description>
+		<description>Section-Z (Europe)</description>
 		<year>1989</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-SZ-EEC"/>
@@ -33540,7 +33540,7 @@ license:CC0
 	</software>
 
 	<software name="shadwarr">
-		<description>Shadow Warriors (Euro)</description>
+		<description>Shadow Warriors (Europe)</description>
 		<year>1991</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="NES-66 (UKV/SCN/ESP)"/>
@@ -33559,7 +33559,7 @@ license:CC0
 	</software>
 
 	<software name="shadwar2" supported="partial">
-		<description>Shadow Warriors II - The Dark Sword of Chaos (Euro)</description>
+		<description>Shadow Warriors II - The Dark Sword of Chaos (Europe)</description>
 		<year>1991</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="NES-67 (FRG/ESP)"/>
@@ -33643,7 +33643,7 @@ license:CC0
 	</software>
 
 	<software name="shadgate">
-		<description>Shadowgate (Euro)</description>
+		<description>Shadowgate (Europe)</description>
 		<year>1991</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NES-3S-HOL"/>
@@ -33794,7 +33794,7 @@ license:CC0
 	</software>
 
 	<software name="shatterh">
-		<description>Shatterhand (Euro)</description>
+		<description>Shatterhand (Europe)</description>
 		<year>1992</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="NES-9H (NOE/SCN/ESP)"/>
@@ -34223,7 +34223,7 @@ license:CC0
 	</software>
 
 	<software name="sidepock">
-		<description>Side Pocket (Euro)</description>
+		<description>Side Pocket (Europe)</description>
 		<year>1992</year>
 		<publisher>Data East</publisher>
 		<info name="serial" value="NES-PK-SCN"/>
@@ -34298,7 +34298,7 @@ license:CC0
 	</software>
 
 	<software name="silentsr" supported="partial">
-		<description>Silent Service (Euro)</description>
+		<description>Silent Service (Europe)</description>
 		<year>1990</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-IV-EEC"/>
@@ -34462,7 +34462,7 @@ license:CC0
 	</software>
 
 	<software name="bartvssm">
-		<description>The Simpsons - Bart vs. The Space Mutants (Euro)</description>
+		<description>The Simpsons - Bart vs. The Space Mutants (Europe)</description>
 		<year>1991</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-Q5 (FRA/SCN/ESP/UKV)"/>
@@ -34499,7 +34499,7 @@ license:CC0
 	</software>
 
 	<software name="bartvsw">
-		<description>The Simpsons - Bart vs. The World (Euro)</description>
+		<description>The Simpsons - Bart vs. The World (Europe)</description>
 		<year>1992</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-Y9 (AUS/SCN/ESP)"/>
@@ -34535,7 +34535,7 @@ license:CC0
 	</software>
 
 	<software name="bartman">
-		<description>The Simpsons - Bartman Meets Radioactive Man (Euro)</description>
+		<description>The Simpsons - Bartman Meets Radioactive Man (Europe)</description>
 		<year>1992</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-RN-FRA"/>
@@ -34591,7 +34591,7 @@ license:CC0
 	</software>
 
 	<software name="skatedie">
-		<description>Skate or Die! (Euro)</description>
+		<description>Skate or Die! (Europe)</description>
 		<year>1990</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-DI (EEC/ESP/GPS)"/>
@@ -34629,7 +34629,7 @@ license:CC0
 	</software>
 
 	<software name="skiordie">
-		<description>Ski or Die (Euro)</description>
+		<description>Ski or Die (Europe)</description>
 		<year>1991</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-7S-(SCN/ESP)"/>
@@ -34763,7 +34763,7 @@ license:CC0
 	</software>
 
 	<software name="slalom">
-		<description>Slalom (Euro)</description>
+		<description>Slalom (Europe)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-SL-EEC"/>
@@ -34802,7 +34802,7 @@ license:CC0
 	</software>
 
 	<software name="smashtv">
-		<description>Smash T.V. (Euro)</description>
+		<description>Smash T.V. (Europe)</description>
 		<year>1991</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-5V-ESP"/>
@@ -34840,7 +34840,7 @@ license:CC0
 	</software>
 
 	<software name="snakernr">
-		<description>Snake Rattle 'n Roll (Euro)</description>
+		<description>Snake Rattle 'n Roll (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-RJ (EEC/SCN/ESP)"/>
@@ -34878,7 +34878,7 @@ license:CC0
 	</software>
 
 	<software name="mgear2">
-		<description>Snake's Revenge (Euro)</description>
+		<description>Snake's Revenge (Europe)</description>
 		<year>1992</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-E2-SCN"/>
@@ -34935,7 +34935,7 @@ license:CC0
 	</software>
 
 	<software name="snowbros">
-		<description>Snow Brothers (Euro)</description>
+		<description>Snow Brothers (Europe)</description>
 		<year>1991</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-7L (FRG/ESP)"/>
@@ -34973,7 +34973,7 @@ license:CC0
 	</software>
 
 	<software name="soccer">
-		<description>Soccer (Euro, rev. A)</description>
+		<description>Soccer (Europe, rev. A)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-SC (EEC/NOE/ESP)"/>
@@ -35012,7 +35012,7 @@ license:CC0
 	</software>
 
 	<software name="solarjet" supported="partial">
-		<description>Solar Jetman - Hunt for the Golden Warpship (Euro)</description>
+		<description>Solar Jetman - Hunt for the Golden Warpship (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-LJ (EEC/ESP/NOE/SCN)"/>
@@ -35114,7 +35114,7 @@ license:CC0
 	</software>
 
 	<software name="solomon">
-		<description>Solomon's Key (Euro)</description>
+		<description>Solomon's Key (Europe)</description>
 		<year>1990</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="NES-KE (EEC/ESP)"/>
@@ -35157,7 +35157,7 @@ license:CC0
 	</software>
 
 	<software name="solomon2">
-		<description>Solomon's Key 2 (Euro)</description>
+		<description>Solomon's Key 2 (Europe)</description>
 		<year>1993</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="NES-K2 (ESP/FRG/SCN)"/>
@@ -35176,7 +35176,7 @@ license:CC0
 	</software>
 
 	<software name="solstice">
-		<description>Solstice - The Quest for the Staff of Demnos (Euro)</description>
+		<description>Solstice - The Quest for the Staff of Demnos (Europe)</description>
 		<year>1991</year>
 		<publisher>Software Creations</publisher>
 		<info name="serial" value="NES-LX (FRG/ESP/FRA/SCN)"/>
@@ -35470,7 +35470,7 @@ license:CC0
 	</software>
 
 	<software name="spidermn">
-		<description>Spider-Man - Return of the Sinister Six (Euro)</description>
+		<description>Spider-Man - Return of the Sinister Six (Europe)</description>
 		<year>1992</year>
 		<publisher>LJN</publisher>
 		<info name="serial" value="NES-RX-ESP"/>
@@ -35652,7 +35652,7 @@ license:CC0
 	</software>
 
 	<software name="spyvsspy">
-		<description>Spy vs. Spy (Euro)</description>
+		<description>Spy vs. Spy (Europe)</description>
 		<year>1990</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NES-SP-EEC"/>
@@ -35797,7 +35797,7 @@ license:CC0
 	</software>
 
 	<software name="stadevnt" cloneof="wctmeet">
-		<description>Stadium Events (Euro)</description>
+		<description>Stadium Events (Europe)</description>
 		<year>1988?</year>
 		<publisher>Bandai</publisher>
 		<info name="serial" value="NES-SD-EEC"/>
@@ -35893,7 +35893,7 @@ license:CC0
 	</software>
 
 	<software name="starfrce">
-		<description>Star Force (Euro)</description>
+		<description>Star Force (Europe)</description>
 		<year>1990</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="NES-FO-EEC"/>
@@ -36115,7 +36115,7 @@ license:CC0
 	</software>
 
 	<software name="starwars">
-		<description>Star Wars (Euro)</description>
+		<description>Star Wars (Europe)</description>
 		<year>1992</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="NES-7V (NOE/SCN/ESP)"/>
@@ -36156,7 +36156,7 @@ license:CC0
 	</software>
 
 	<software name="esb">
-		<description>Star Wars - The Empire Strikes Back (Euro)</description>
+		<description>Star Wars - The Empire Strikes Back (Europe)</description>
 		<year>1992</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="NES-EK (NOE/ESP)"/>
@@ -36203,7 +36203,7 @@ license:CC0
 	</software>
 
 	<software name="startrpc">
-		<description>StarTropics (Euro)</description>
+		<description>StarTropics (Europe)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-OC (NOE/FRG/SCN)"/>
@@ -36262,7 +36262,7 @@ license:CC0
 	</software>
 
 	<software name="stealth">
-		<description>Stealth ATF (Euro)</description>
+		<description>Stealth ATF (Europe)</description>
 		<year>1991</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="NES-LH (EEC/SCN/ESP)"/>
@@ -36383,7 +36383,7 @@ license:CC0
 	</software>
 
 	<software name="streetgn">
-		<description>Street Gangs (Euro)</description>
+		<description>Street Gangs (Europe)</description>
 		<year>1992</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NES-ST (SCN/UKV)"/>
@@ -36530,7 +36530,7 @@ license:CC0
 	</software>
 
 	<software name="sunman">
-		<description>Sunman (Euro, prototype)</description>
+		<description>Sunman (Europe, prototype)</description>
 		<year>1992</year>
 		<publisher>Sunsoft</publisher>
 		<part name="cart" interface="nes_cart">
@@ -36547,7 +36547,7 @@ license:CC0
 	</software>
 
 	<software name="saq">
-		<description>Super Adventure Quests (Euro)</description>
+		<description>Super Adventure Quests (Europe)</description>
 		<year>19??</year>
 		<publisher>Codemasters</publisher>
 		<part name="cart" interface="nes_cart">
@@ -36795,7 +36795,7 @@ license:CC0
 	</software>
 
 	<software name="smb">
-		<description>Super Mario Bros. (Euro, rev. A)</description>
+		<description>Super Mario Bros. (Europe, rev. A)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-SM (EEC/NOE/SCN/ESP)"/>
@@ -36844,7 +36844,7 @@ license:CC0
 	</software>
 
 	<software name="smbdh">
-		<description>Super Mario Bros. / Duck Hunt (Euro)</description>
+		<description>Super Mario Bros. / Duck Hunt (Europe)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-MH (EEC/ESP)"/>
@@ -36903,7 +36903,7 @@ license:CC0
 	</software>
 
 	<software name="smbtnwca" cloneof="smbtnwc">
-		<description>Super Mario Bros. / Tetris / Nintendo World Cup (Euro)</description>
+		<description>Super Mario Bros. / Tetris / Nintendo World Cup (Europe)</description>
 		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-ZZ (FRG/SCN)"/>
@@ -36922,7 +36922,7 @@ license:CC0
 	</software>
 
 	<software name="smbtnwc">
-		<description>Super Mario Bros. / Tetris / Nintendo World Cup (Euro, rev. A)</description>
+		<description>Super Mario Bros. / Tetris / Nintendo World Cup (Europe, rev. A)</description>
 		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-ZZ-FRG"/>
@@ -36985,7 +36985,7 @@ license:CC0
 	</software>
 
 	<software name="smb2">
-		<description>Super Mario Bros. 2 (Euro)</description>
+		<description>Super Mario Bros. 2 (Europe)</description>
 		<year>1989</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-MW-(EEC/NOE/SCN/ESP)"/>
@@ -37116,7 +37116,7 @@ license:CC0
 	</software>
 
 	<software name="smb3">
-		<description>Super Mario Bros. 3 (Euro)</description>
+		<description>Super Mario Bros. 3 (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-UM (GBR/FRG/NOE/SCN/ESP)"/>
@@ -37225,7 +37225,7 @@ license:CC0
 	</software>
 
 	<software name="offroad">
-		<description>Ivan 'Ironman' Stewart's Super Off Road (Euro)</description>
+		<description>Ivan 'Ironman' Stewart's Super Off Road (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-WU (EEC/ESP)"/>
@@ -37344,7 +37344,7 @@ license:CC0
 	</software>
 
 	<software name="spikvbal">
-		<description>Super Spike V'Ball (Euro)</description>
+		<description>Super Spike V'Ball (Europe)</description>
 		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-VJ (NOE/SCN/ESP/UKV)"/>
@@ -37440,7 +37440,7 @@ license:CC0
 	</software>
 
 	<software name="sspyhunt">
-		<description>Super Spy Hunter (Euro)</description>
+		<description>Super Spy Hunter (Europe)</description>
 		<year>1992</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NES-UY-ESP"/>
@@ -37499,7 +37499,7 @@ license:CC0
 	</software>
 
 	<software name="sturric">
-		<description>Super Turrican (Euro)</description>
+		<description>Super Turrican (Europe)</description>
 		<year>1993</year>
 		<publisher>Imagineering</publisher>
 		<info name="serial" value="NES-TU (SCN/ESP)"/>
@@ -37636,7 +37636,7 @@ license:CC0
 	</software>
 
 	<software name="swamp">
-		<description>Swamp Thing (Euro)</description>
+		<description>Swamp Thing (Europe)</description>
 		<year>1992</year>
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NES-SW-NOE"/>
@@ -37697,7 +37697,7 @@ license:CC0
 	</software>
 
 	<software name="swordmst">
-		<description>Sword Master (Euro)</description>
+		<description>Sword Master (Europe)</description>
 		<year>1993</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="NES-8S (SCN/ESP)"/>
@@ -37736,7 +37736,7 @@ license:CC0
 	</software>
 
 	<software name="swordsrp">
-		<description>Swords and Serpents (Euro)</description>
+		<description>Swords and Serpents (Europe)</description>
 		<year>1993</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-WP (AUS/SCN/UKV/NOE)"/>
@@ -37830,7 +37830,7 @@ license:CC0
 	</software>
 
 	<software name="term2">
-		<description>T2 - Terminator 2 - Judgment Day (Euro)</description>
+		<description>T2 - Terminator 2 - Judgment Day (Europe)</description>
 		<year>1992</year>
 		<publisher>LJN</publisher>
 		<info name="serial" value="NES-62 (NOE/SCN/ESP/UKV)"/>
@@ -38235,7 +38235,7 @@ license:CC0
 	</software>
 
 	<software name="talespin">
-		<description>TaleSpin (Euro)</description>
+		<description>TaleSpin (Europe)</description>
 		<year>1992</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-68 (FRA/SCN/ESP)"/>
@@ -38546,7 +38546,7 @@ license:CC0
 	</software>
 
 	<software name="tecmocup">
-		<description>Tecmo Cup - Football Game (Euro)</description>
+		<description>Tecmo Cup - Football Game (Europe)</description>
 		<year>1992</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="NES-TP-SCN"/>
@@ -38751,7 +38751,7 @@ license:CC0
 	</software>
 
 	<software name="tecmowc">
-		<description>Tecmo World Cup Soccer (Euro)</description>
+		<description>Tecmo World Cup Soccer (Europe)</description>
 		<year>1991</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="NES-WC (FRG/ESP)"/>
@@ -38789,7 +38789,7 @@ license:CC0
 	</software>
 
 	<software name="tecmowrs">
-		<description>Tecmo World Wrestling (Euro)</description>
+		<description>Tecmo World Wrestling (Europe)</description>
 		<year>1990</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="NES-PZ-(EEC/SCN/ESP/FRG)"/>
@@ -38808,7 +38808,7 @@ license:CC0
 	</software>
 
 	<software name="tmnt">
-		<description>Teenage Mutant Hero Turtles (Euro)</description>
+		<description>Teenage Mutant Hero Turtles (Europe)</description>
 		<year>1990</year>
 		<publisher>Palcom</publisher>
 		<info name="serial" value="NES-88 (EEC/SCN/GPS)"/>
@@ -38827,7 +38827,7 @@ license:CC0
 	</software>
 
 	<software name="tmnt2">
-		<description>Teenage Mutant Hero Turtles II - The Arcade Game (Euro)</description>
+		<description>Teenage Mutant Hero Turtles II - The Arcade Game (Europe)</description>
 		<year>1991</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-89 (FRA/SCN/ESP)"/>
@@ -38846,7 +38846,7 @@ license:CC0
 	</software>
 
 	<software name="tmnttf">
-		<description>Teenage Mutant Hero Turtles - Tournament Fighters (Euro)</description>
+		<description>Teenage Mutant Hero Turtles - Tournament Fighters (Europe)</description>
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-HK-NOE"/>
@@ -39135,7 +39135,7 @@ license:CC0
 	</software>
 
 	<software name="tennis">
-		<description>Tennis (Euro)</description>
+		<description>Tennis (Europe)</description>
 		<year>1986</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-TE (EEC/ESP)"/>
@@ -39312,7 +39312,7 @@ license:CC0
 	</software>
 
 	<software name="tetris">
-		<description>Tetris (Euro)</description>
+		<description>Tetris (Europe)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-EI (EEC/ESP/FRA)"/>
@@ -39331,7 +39331,7 @@ license:CC0
 	</software>
 
 	<software name="tetris2">
-		<description>Tetris 2 (Euro)</description>
+		<description>Tetris 2 (Europe)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-TS-UKV"/>
@@ -39640,7 +39640,7 @@ license:CC0
 	</software>
 
 	<software name="tigerhela" cloneof="tigerhel">
-		<description>Tiger-Heli (Euro)</description>
+		<description>Tiger-Heli (Europe)</description>
 		<year>1990</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-TI-EEC"/>
@@ -39695,7 +39695,7 @@ license:CC0
 	</software>
 
 	<software name="timelord">
-		<description>Time Lord (Euro)</description>
+		<description>Time Lord (Europe)</description>
 		<year>1991</year>
 		<publisher>Milton Bradley</publisher>
 		<info name="serial" value="NES-LZ-(NOE/ESP/UKV)"/>
@@ -39811,7 +39811,7 @@ license:CC0
 	</software>
 
 	<software name="ttoonadv">
-		<description>Tiny Toon Adventures (Euro)</description>
+		<description>Tiny Toon Adventures (Europe)</description>
 		<year>1992</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-NI (NOE/SCN)"/>
@@ -39869,7 +39869,7 @@ license:CC0
 	</software>
 
 	<software name="ttoon2">
-		<description>Tiny Toon Adventures 2 - Trouble in Wackyland (Euro)</description>
+		<description>Tiny Toon Adventures 2 - Trouble in Wackyland (Europe)</description>
 		<year>1994</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-T2 (NOE/SCN)"/>
@@ -39910,7 +39910,7 @@ license:CC0
 	</software>
 
 	<software name="ttooncw">
-		<description>Tiny Toon Adventures - Cartoon Workshop (Euro)</description>
+		<description>Tiny Toon Adventures - Cartoon Workshop (Europe)</description>
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-CW-NOE"/>
@@ -39994,7 +39994,7 @@ license:CC0
 	</software>
 
 	<software name="toearth" supported="partial">
-		<description>To The Earth (Euro)</description>
+		<description>To The Earth (Europe)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-ZE (EEC/ESP)"/>
@@ -40150,7 +40150,7 @@ license:CC0
 	</software>
 
 	<software name="tomjerry">
-		<description>Tom &amp; Jerry (Euro)</description>
+		<description>Tom &amp; Jerry (Europe)</description>
 		<year>1992</year>
 		<publisher>Hi Tech Expressions</publisher>
 		<info name="serial" value="NES-5Y (SCN/ESP)"/>
@@ -40284,7 +40284,7 @@ license:CC0
 	</software>
 
 	<software name="topgun">
-		<description>Top Gun (Euro)</description>
+		<description>Top Gun (Europe)</description>
 		<year>1988</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-TG (EEC/NOE)"/>
@@ -40342,7 +40342,7 @@ license:CC0
 	</software>
 
 	<software name="topgun2">
-		<description>Top Gun - The Second Mission (Euro)</description>
+		<description>Top Gun - The Second Mission (Europe)</description>
 		<year>1991</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-OG (SCN/ESP/UKV)"/>
@@ -40443,7 +40443,7 @@ license:CC0
 	</software>
 
 	<software name="totrecal">
-		<description>Total Recall (Euro)</description>
+		<description>Total Recall (Europe)</description>
 		<year>1991</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-L4 (EEC/NOE)"/>
@@ -40481,7 +40481,7 @@ license:CC0
 	</software>
 
 	<software name="totalrad">
-		<description>Totally Rad (Euro)</description>
+		<description>Totally Rad (Europe)</description>
 		<year>1992</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="NES-6T-NOE"/>
@@ -40654,7 +40654,7 @@ license:CC0
 	</software>
 
 	<software name="trackfl2">
-		<description>Track &amp; Field II (Euro)</description>
+		<description>Track &amp; Field II (Europe)</description>
 		<year>1989</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-F2 (EEC/SCN)"/>
@@ -40673,7 +40673,7 @@ license:CC0
 	</software>
 
 	<software name="trackbar">
-		<description>Track &amp; Field in Barcelona (Euro)</description>
+		<description>Track &amp; Field in Barcelona (Europe)</description>
 		<year>1992</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NES-9I (AUS/SCN/ESP)"/>
@@ -40757,7 +40757,7 @@ license:CC0
 	</software>
 
 	<software name="trog">
-		<description>Trog! (Euro)</description>
+		<description>Trog! (Europe)</description>
 		<year>1991</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-4A-AUS"/>
@@ -40802,7 +40802,7 @@ license:CC0
 	</software>
 
 	<software name="trojan">
-		<description>Trojan (Euro)</description>
+		<description>Trojan (Europe)</description>
 		<year>1989</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-TJ-EEC"/>
@@ -40902,7 +40902,7 @@ license:CC0
 	</software>
 
 	<software name="turborac">
-		<description>Turbo Racing (Euro)</description>
+		<description>Turbo Racing (Europe)</description>
 		<year>1992</year>
 		<publisher>Data East</publisher>
 		<info name="serial" value="NES-44-FRG"/>
@@ -41032,7 +41032,7 @@ license:CC0
 	</software>
 
 	<software name="ufouria">
-		<description>U-four-ia - The Saga (Euro)</description>
+		<description>U-four-ia - The Saga (Europe)</description>
 		<year>1992</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NES-6U (NOE/SCN/ESP)"/>
@@ -41265,7 +41265,7 @@ license:CC0
 	</software>
 
 	<software name="uaircomb">
-		<description>Ultimate Air Combat (Euro)</description>
+		<description>Ultimate Air Combat (Europe)</description>
 		<year>1992</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="NES-3Z-AUS"/>
@@ -41859,7 +41859,7 @@ license:CC0
 	</software>
 
 	<software name="volley">
-		<description>Volleyball (Euro, USA)</description>
+		<description>Volleyball (Europe, USA)</description>
 		<year>1987</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-VB-USA, NES-VB-(EEC/FRA)"/>
@@ -41921,7 +41921,7 @@ license:CC0
 	</software>
 
 	<software name="wwfking">
-		<description>WWF King of the Ring (Euro)</description>
+		<description>WWF King of the Ring (Europe)</description>
 		<year>1993</year>
 		<publisher>LJN</publisher>
 		<info name="serial" value="NES-K6-NOE"/>
@@ -41983,7 +41983,7 @@ license:CC0
 	</software>
 
 	<software name="wmania" supported="no">
-		<description>WWF WrestleMania (Euro)</description>
+		<description>WWF WrestleMania (Europe)</description>
 		<year>1992</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-HN-ESP"/>
@@ -42021,7 +42021,7 @@ license:CC0
 	</software>
 
 	<software name="wmaniach">
-		<description>WWF WrestleMania Challenge (Euro)</description>
+		<description>WWF WrestleMania Challenge (Europe)</description>
 		<year>1991</year>
 		<publisher>LJN</publisher>
 		<info name="serial" value="NES-W9-(UKV/NOE)"/>
@@ -42040,7 +42040,7 @@ license:CC0
 	</software>
 
 	<software name="wwfsteel">
-		<description>WWF WrestleMania - Steel Cage Challenge (Euro)</description>
+		<description>WWF WrestleMania - Steel Cage Challenge (Europe)</description>
 		<year>1992</year>
 		<publisher>LJN</publisher>
 		<info name="serial" value="NES-WS-(NOE/UKV)"/>
@@ -42324,7 +42324,7 @@ license:CC0
 	</software>
 
 	<software name="wariowd">
-		<description>Wario's Woods (Euro)</description>
+		<description>Wario's Woods (Europe)</description>
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-WB-NOE"/>
@@ -42425,7 +42425,7 @@ license:CC0
 	</software>
 
 	<software name="werewolf">
-		<description>Werewolf - The Last Warrior (Euro)</description>
+		<description>Werewolf - The Last Warrior (Europe)</description>
 		<year>1991</year>
 		<publisher>Data East</publisher>
 		<info name="serial" value="NES-W8-SCN"/>
@@ -42794,7 +42794,7 @@ license:CC0
 	</software>
 
 	<software name="willow">
-		<description>Willow (Euro)</description>
+		<description>Willow (Europe)</description>
 		<year>1991</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NES-WI (FRG/SCN/ESP)"/>
@@ -43077,7 +43077,7 @@ license:CC0
 	</software>
 
 	<software name="wizardw">
-		<description>Wizards &amp; Warriors (Euro)</description>
+		<description>Wizards &amp; Warriors (Europe)</description>
 		<year>1990</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-WW-EEC"/>
@@ -43115,7 +43115,7 @@ license:CC0
 	</software>
 
 	<software name="wizardw3">
-		<description>Wizards &amp; Warriors III - Kuros... Visions of Power (Euro)</description>
+		<description>Wizards &amp; Warriors III - Kuros... Visions of Power (Europe)</description>
 		<year>1993</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-8W (SCN/ESP)"/>
@@ -43193,7 +43193,7 @@ license:CC0
 	</software>
 
 	<software name="worldchm">
-		<description>World Champ - Super Boxing Great Fight (Euro)</description>
+		<description>World Champ - Super Boxing Great Fight (Europe)</description>
 		<year>1991</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-5E (NOE/ESP)"/>
@@ -43353,7 +43353,7 @@ license:CC0
 	</software>
 
 	<software name="blackmnt">
-		<description>Wrath of the Black Manta (Euro)</description>
+		<description>Wrath of the Black Manta (Europe)</description>
 		<year>1991</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="NES-WK (EEC/ESP)"/>
@@ -43451,7 +43451,7 @@ license:CC0
 	</software>
 
 	<software name="xevious">
-		<description>Xevious (Euro)</description>
+		<description>Xevious (Europe)</description>
 		<year>1989</year>
 		<publisher>Bandai</publisher>
 		<info name="serial" value="NES-XV-EEC"/>
@@ -43721,7 +43721,7 @@ license:CC0
 	</software>
 
 	<software name="yoshicok">
-		<description>Yoshi's Cookie (Euro)</description>
+		<description>Yoshi's Cookie (Europe)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-CH-SCN"/>
@@ -43936,7 +43936,7 @@ license:CC0
 	</software>
 
 	<software name="zelda2b" cloneof="zelda2">
-		<description>Zelda II - The Adventure of Link (Euro)</description>
+		<description>Zelda II - The Adventure of Link (Europe)</description>
 		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-AL-EEC"/>
@@ -43959,7 +43959,7 @@ license:CC0
 	</software>
 
 	<software name="zelda2a" cloneof="zelda2">
-		<description>Zelda II - The Adventure of Link (Euro, rev. A)</description>
+		<description>Zelda II - The Adventure of Link (Europe, rev. A)</description>
 		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-AL-EEC"/>
@@ -43982,7 +43982,7 @@ license:CC0
 	</software>
 
 	<software name="zelda2">
-		<description>Zelda II - The Adventure of Link (Euro, rev. B)</description>
+		<description>Zelda II - The Adventure of Link (Europe, rev. B)</description>
 		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NES-AL (EEC/NOE/ESP)"/>
@@ -44029,7 +44029,7 @@ license:CC0
 	</software>
 
 	<software name="zen">
-		<description>Zen - Intergalactic Ninja (Euro)</description>
+		<description>Zen - Intergalactic Ninja (Europe)</description>
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-ZN-NOE"/>
@@ -44761,7 +44761,7 @@ Also notice that VRAM, WRAM & mirror are probably incorrect for some of these se
 	</software>
 
 	<software name="advisln3p" cloneof="advisln3">
-		<description>Adventure Island 3 (Euro, prototype)</description>
+		<description>Adventure Island 3 (Europe, prototype)</description>
 		<year>1992</year>
 		<publisher>Hudson Soft</publisher>
 		<part name="cart" interface="nes_cart">
@@ -44886,7 +44886,7 @@ Also notice that VRAM, WRAM & mirror are probably incorrect for some of these se
 	</software>
 
 	<software name="alfred">
-		<description>Alfred Chicken (Euro)</description>
+		<description>Alfred Chicken (Europe)</description>
 		<year>1994</year>
 		<publisher>Mindscape</publisher>
 		<part name="cart" interface="nes_cart">
@@ -45216,7 +45216,7 @@ Also notice that VRAM, WRAM & mirror are probably incorrect for some of these se
 	</software>
 
 	<software name="batmanrnp" cloneof="batmanrn">
-		<description>Batman Returns (Euro, prototype)</description>
+		<description>Batman Returns (Europe, prototype)</description>
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<part name="cart" interface="nes_cart">
@@ -45256,7 +45256,7 @@ Also notice that VRAM, WRAM & mirror are probably incorrect for some of these se
 
 <!-- glitches on NTSC -->
 	<software name="beauty">
-		<description>Beauty and the Beast (Euro)</description>
+		<description>Beauty and the Beast (Europe)</description>
 		<year>1994</year>
 		<publisher>Hudson Soft</publisher>
 		<part name="cart" interface="nes_cart">
@@ -45498,7 +45498,7 @@ Also notice that VRAM, WRAM & mirror are probably incorrect for some of these se
 	</software>
 
 	<software name="bugtris">
-		<description>BugTris (Kor)</description>
+		<description>BugTris (Korea)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
@@ -46138,7 +46138,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="indyheat">
-		<description>Danny Sullivan's Indy Heat (Euro)</description>
+		<description>Danny Sullivan's Indy Heat (Europe)</description>
 		<year>1992?</year>
 		<publisher>Tradewest</publisher>
 		<part name="cart" interface="nes_cart">
@@ -46679,7 +46679,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="ducktal2p" cloneof="ducktal2">
-		<description>Disney's DuckTales 2 (Euro, prototype)</description>
+		<description>Disney's DuckTales 2 (Europe, prototype)</description>
 		<year>1993</year>
 		<publisher>Capcom</publisher>
 		<part name="cart" interface="nes_cart">
@@ -47584,7 +47584,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="gremlin2p" cloneof="gremlin2">
-		<description>Gremlins 2 - The New Batch (Euro, prototype)</description>
+		<description>Gremlins 2 - The New Batch (Europe, prototype)</description>
 		<year>1991</year>
 		<publisher>Sunsoft</publisher>
 		<part name="cart" interface="nes_cart">
@@ -48070,7 +48070,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="janggun">
-		<description>Janggun ui Adeul (Kor)</description>
+		<description>Janggun ui Adeul (Korea)</description>
 		<year>1992</year>
 		<publisher>Daou Infosys</publisher>
 		<info name="serial" value="DIF-002"/>
@@ -48443,7 +48443,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="koko" cloneof="buzzwald">
-		<description>Ko Ko Eo Deu Ben Ce (Kor)</description>
+		<description>Ko Ko Eo Deu Ben Ce (Korea)</description>
 		<year>199?</year>
 		<publisher>Daou Infosys</publisher>
 		<info name="serial" value="DS-F301"/>
@@ -48788,7 +48788,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="mmansion">
-		<description>Maniac Mansion (Euro)</description>
+		<description>Maniac Mansion (Europe)</description>
 		<year>1992</year>
 		<publisher>Jaleco</publisher>
 		<part name="cart" interface="nes_cart">
@@ -48848,7 +48848,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="mariomis">
-		<description>Mario is Missing! (Euro)</description>
+		<description>Mario is Missing! (Europe)</description>
 		<year>1993</year>
 		<publisher>The Software Toolworks</publisher>
 		<part name="cart" interface="nes_cart">
@@ -49775,7 +49775,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="nintenwc">
-		<description>Nintendo World Cup (Euro, rev. B)</description>
+		<description>Nintendo World Cup (Europe, rev. B)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="nes_cart">
@@ -49953,7 +49953,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="pacman">
-		<description>Pac-Man (Euro)</description>
+		<description>Pac-Man (Europe)</description>
 		<year>1993</year>
 		<publisher>Namcot</publisher>
 		<part name="cart" interface="nes_cart">
@@ -50014,7 +50014,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="parasol">
-		<description>Parasol Stars - The Story of Bubble Bobble III (Euro)</description>
+		<description>Parasol Stars - The Story of Bubble Bobble III (Europe)</description>
 		<year>1992</year>
 		<publisher>Ocean</publisher>
 		<info name="alt_title" value="Parasol Stars - Rainbow Islands II - The Story of Bubble Bobble III (Box)"/>
@@ -50031,7 +50031,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="parodiusp" cloneof="parodius">
-		<description>Parodius (Euro, prototype)</description>
+		<description>Parodius (Europe, prototype)</description>
 		<year>1992</year>
 		<publisher>Palcom</publisher>
 		<part name="cart" interface="nes_cart">
@@ -50051,7 +50051,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 
 <!-- Glitched in NTSC -->
 	<software name="pirates">
-		<description>Pirates! (Euro)</description>
+		<description>Pirates! (Europe)</description>
 		<year>1991</year>
 		<publisher>Palcom</publisher>
 		<part name="cart" interface="nes_cart">
@@ -50274,7 +50274,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="racktriv">
-		<description>Rackets &amp; Rivals (Euro)</description>
+		<description>Rackets &amp; Rivals (Europe)</description>
 		<year>1993</year>
 		<publisher>Palcom</publisher>
 		<part name="cart" interface="nes_cart">
@@ -50940,7 +50940,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="smurfsp" cloneof="smurfs">
-		<description>The Smurfs (Euro, prototype)</description>
+		<description>The Smurfs (Europe, prototype)</description>
 		<year>1994</year>
 		<publisher>Infogrames</publisher>
 		<info name="alt_title" value="Les Schtroumpfs"/>
@@ -50978,7 +50978,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="snowchal">
-		<description>Snowboard Challenge (Euro)</description>
+		<description>Snowboard Challenge (Europe)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
@@ -51455,7 +51455,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 
 <!-- BMX Simulator doesn't respond to start on its title screen -->
 	<software name="supsporta" cloneof="supsport" supported="partial">
-		<description>Super Sports Challenge (Euro, plug-thru cart)</description>
+		<description>Super Sports Challenge (Europe, plug-thru cart)</description>
 		<year>19??</year>
 		<publisher>Codemasters</publisher>
 		<part name="cart" interface="nes_cart">
@@ -51473,7 +51473,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 
 <!-- BMX Simulator doesn't respond to start on its title screen -->
 	<software name="supsport" supported="partial">
-		<description>Super Sports Challenge (Euro)</description>
+		<description>Super Sports Challenge (Europe)</description>
 		<year>19??</year>
 		<publisher>Codemasters</publisher>
 		<part name="cart" interface="nes_cart">
@@ -51956,7 +51956,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="tigerhel">
-		<description>Tiger-Heli (Euro, rev. A)</description>
+		<description>Tiger-Heli (Europe, rev. A)</description>
 		<year>1990</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-TI-EEC"/>
@@ -52087,7 +52087,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="trollscl">
-		<description>The Trolls In Crazyland (Euro)</description>
+		<description>The Trolls In Crazyland (Europe)</description>
 		<year>199?</year>
 		<publisher>ASC</publisher>
 		<part name="cart" interface="nes_cart">
@@ -52165,7 +52165,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="ufouriap" cloneof="ufouria">
-		<description>U-four-ia - The Saga (Euro, prototype)</description>
+		<description>U-four-ia - The Saga (Europe, prototype)</description>
 		<year>1992</year>
 		<publisher>Sunsoft</publisher>
 		<part name="cart" interface="nes_cart">
@@ -52197,7 +52197,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="uaircombp" cloneof="uaircomb">
-		<description>Ultimate Air Combat (Euro, prototype)</description>
+		<description>Ultimate Air Combat (Europe, prototype)</description>
 		<year>1992</year>
 		<publisher>Activision</publisher>
 		<part name="cart" interface="nes_cart">
@@ -52507,7 +52507,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="wlddizzy" supported="no">
-		<description>Wonderland Dizzy (Euro, prototype)</description>
+		<description>Wonderland Dizzy (Europe, prototype)</description>
 		<year>1991</year>
 		<publisher>Camerica</publisher>
 		<part name="cart" interface="nes_cart">
@@ -52631,7 +52631,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 <!-- Non game cartridges, unconfirmed dumps -->
 
 	<software name="parb" cloneof="par" supported="no">
-		<description>Pro Action Replay (Euro, v1.0)</description>
+		<description>Pro Action Replay (Europe, v1.0)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
@@ -52648,7 +52648,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="para" cloneof="par" supported="no">
-		<description>Pro Action Replay (Euro, v1.2, Cart Present)</description>
+		<description>Pro Action Replay (Europe, v1.2, Cart Present)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
@@ -52665,7 +52665,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="par" supported="no">
-		<description>Pro Action Replay (Euro, v1.2, no Cart Present)</description>
+		<description>Pro Action Replay (Europe, v1.2, no Cart Present)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
@@ -78442,7 +78442,7 @@ We include them here as reference if they should coincide with later revisions o
 	</software>
 
 	<software name="golfgc" cloneof="golf">
-		<description>Golf (Euro, ripped from GC Animal Crossing)</description>
+		<description>Golf (Europe, ripped from GC Animal Crossing)</description>
 		<year>2002</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="nes_cart">
@@ -78496,7 +78496,7 @@ We include them here as reference if they should coincide with later revisions o
 	</software>
 
 	<software name="dkoe" cloneof="dkong">
-		<description>Donkey Kong - Original Edition (Euro, ripped from Wii)</description>
+		<description>Donkey Kong - Original Edition (Europe, ripped from Wii)</description>
 		<year>2010</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="nes_cart">


### PR DESCRIPTION
Replaced the "Euro" and "Kor" abbreviations by the full names.