### PR TITLE
Adjusted GitHub CI workflows:

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -24,6 +24,7 @@ permissions:
   contents: read
 
 jobs:
+
   build-linux:
     runs-on: ubuntu-latest
     strategy:
@@ -34,32 +35,40 @@ jobs:
             cc: gcc
             cxx: g++
             archopts: -U_FORTIFY_SOURCE
+            subtarget: tiny
+            executable: mametiny
           - compiler: clang
             cc: clang
             cxx: clang++
+            subtarget: mame
+            executable: mame
     steps:
-      - uses: actions/checkout@master
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libasound2-dev libxinerama-dev libxi-dev qt5-default
-      - name: Install clang
-        if: matrix.compiler == 'clang'
-        run: sudo apt-get install -y clang
-      - name: Build
-        env:
-          OVERRIDE_CC: ${{ matrix.cc }}
-          OVERRIDE_CXX: ${{ matrix.cxx }}
-          ARCHOPTS: ${{ matrix.archopts }}
-          TOOLS: 1
-        run: make -j2
-      - name: Validate
-        run: ./mame -validate
-      - name: Reconcile driver list
-        run: ./mame -listxml | python scripts/build/makedep.py reconcilelist -l src/mame/mame.lst -
-      - name: ORM check
-        run: python scripts/minimaws/minimaws.py load --executable ./mame --softwarepath hash
-      - uses: actions/upload-artifact@master
-        with:
-          name: mame-linux-${{ matrix.compiler }}-${{ github.sha }}
-          path: mame
+    - uses: actions/checkout@master
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libasound2-dev libxinerama-dev libxi-dev qt5-default
+    - name: Install clang
+      if: matrix.compiler == 'clang'
+      run: sudo apt-get install -y clang
+    - name: Build
+      env:
+        OVERRIDE_CC: ${{ matrix.cc }}
+        OVERRIDE_CXX: ${{ matrix.cxx }}
+        ARCHOPTS: ${{ matrix.archopts }}
+        SUBTARGET: ${{ matrix.subtarget }}
+        TOOLS: 1
+      run: make -j2
+    - name: Validate
+      run: ./${{ matrix.executable }} -validate
+    - name: Reconcile driver list
+      run: ./${{ matrix.executable }} -listxml | python scripts/build/makedep.py reconcilelist -l src/mame/${{ matrix.subtarget }}.lst -
+    - name: ORM check
+      run: python scripts/minimaws/minimaws.py load --executable ./${{ matrix.executable }} --softwarepath hash
+    - uses: actions/upload-artifact@master
+      with:
+        name: ${{ matrix.executable }}-linux-${{ matrix.compiler }}-${{ github.sha }}
+        path: |
+          ${{ matrix.executable }}
+          chdman
+          unidasm

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -22,20 +22,24 @@ permissions:
   contents: read
 
 jobs:
+
   build-macos:
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Install dependencies
-        run: brew install python3 sdl2
-      - name: Build
-        env:
-          USE_LIBSDL: 1
-          TOOLS: 1
-        run: make -j2
-      - name: Validate
-        run: ./mame -validate
-      - uses: actions/upload-artifact@master
-        with:
-          name: mame-macos-${{ github.sha }}
-          path: mame
+    - uses: actions/checkout@master
+    - name: Install dependencies
+      run: brew install python3 sdl2
+    - name: Build
+      env:
+        USE_LIBSDL: 1
+        TOOLS: 1
+      run: make -j2
+    - name: Validate
+      run: ./mame -validate
+    - uses: actions/upload-artifact@master
+      with:
+        name: mame-macos-${{ github.sha }}
+        path: |
+          mame
+          chdman
+          unidasm

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -36,10 +36,12 @@ jobs:
             cc: gcc
             cxx: g++
             subtarget: mame
+            executable: mame
           - compiler: clang
             cc: clang
             cxx: clang++
             subtarget: tiny
+            executable: mametiny
     steps:
     - uses: msys2/setup-msys2@v2
       with:
@@ -48,16 +50,19 @@ jobs:
     - name: Build
       env:
         MINGW64: "/mingw64"
-        ARCHOPTS: "-fuse-ld=lld"
         OVERRIDE_AR: "llvm-ar"
         OVERRIDE_CC: ${{ matrix.cc }}
         OVERRIDE_CXX: ${{ matrix.cxx }}
+        ARCHOPTS: "-fuse-ld=lld"
         SUBTARGET: ${{ matrix.subtarget }}
         TOOLS: 1
       run: make -j2
     - name: Validate
-      run: ./mame* -validate
+      run: ./${{ matrix.executable }}.exe -validate
     - uses: actions/upload-artifact@master
       with:
-        name: mame-windows-${{ matrix.compiler }}-${{ github.sha }}
-        path: mame*.exe
+        name: ${{ matrix.executable }}-windows-${{ matrix.compiler }}-${{ github.sha }}
+        path: |
+          ${{ matrix.executable }}.exe
+          chdman.exe
+          unidasm.exe

--- a/src/mame/tiny.lst
+++ b/src/mame/tiny.lst
@@ -34,7 +34,7 @@ starfirea       // (c) 1979 Exidy
 fireone         // (c) 1979 Exidy
 starfir2        // (c) 1979 Exidy
 
-@source:exidy/vicory.cpp
+@source:exidy/victory.cpp
 victory         // (c) 1982
 victorba        // (c) 1982
 topgunnr        // (c) 1986

--- a/src/mame/tiny.lst
+++ b/src/mame/tiny.lst
@@ -9,11 +9,17 @@
 
 ******************************************************************************/
 
-robby           // (c) 1981 Bally Midway
-gridlee         // [1983 Videa] prototype - no copyright notice
-alienar         // (c) 1985 Duncan Brown
-
+@source:exidy/carpolo.cpp
 carpolo         // (c) 1977 Exidy
+
+@source:exidy/circus.cpp
+circus          // (c) 1977 Exidy
+circuso         // (c) 1977 Exidy
+robotbwl        // (c) 197? Exidy
+crash           // (c) 1979 Exidy
+ripcord         // (c) 1979 Exidy
+
+@source:exidy/exidy.cpp
 sidetrac        // (c) 1979 Exidy
 targ            // (c) 1980 Exidy
 spectar         // (c) 1980 Exidy
@@ -21,22 +27,37 @@ teetert         // (c) 1982 Exidy
 hardhat         // (c) 1982
 fax             // (c) 1983
 fax2            // (c) 1983
-circus          // (c) 1977 Exidy
-circuso         // (c) 1977 Exidy
-robotbwl        // (c) 197? Exidy
-crash           // (c) 1979 Exidy
-ripcord         // (c) 1979 Exidy
+
+@source:exidy/starfire.cpp
 starfire        // (c) 1979 Exidy
 starfirea       // (c) 1979 Exidy
 fireone         // (c) 1979 Exidy
 starfir2        // (c) 1979 Exidy
+
+@source:exidy/vicory.cpp
 victory         // (c) 1982
 victorba        // (c) 1982
 topgunnr        // (c) 1986
 
+@source:gaelco/wrally.cpp
+wrally          // (c) 1993 - Ref 930705
+
+@source:midway/astrocde.cpp
+robby           // (c) 1981 Bally Midway
+
+@source:midway/gridlee.cpp
+gridlee         // [1983 Videa] prototype - no copyright notice
+
+@source:midway/williams.cpp
+alienar         // (c) 1985 Duncan Brown
+
+@source:venture/looping.cpp
 looping         // (c) 1982 Video Games GMBH
+
+@source:misc/supertnk.cpp
 supertnk        // (c) 1981 VIDEO GAMES GmbH, W.-GERMANY
 
+@source:misc/goldnpkr.cpp:
 witchgme        // (c) 1991 Video Klein
 witchjol        // (c) 1994 Video Klein
 wldwitch        // (c) 2001 Video Klein
@@ -70,5 +91,3 @@ wstrikea        // (c) 1992 Video Klein
 wtchjack        // (c) 1996 Video Klein
 wtchjacka       // (c) 1996 Video Klein
 wtchjackb       // (c) 1996 Video Klein
-
-wrally          // (c) 1993 - Ref 930705

--- a/src/mame/tiny.lst
+++ b/src/mame/tiny.lst
@@ -34,10 +34,12 @@ starfirea       // (c) 1979 Exidy
 fireone         // (c) 1979 Exidy
 starfir2        // (c) 1979 Exidy
 
+@source:exidy/vertigo.cpp
+topgunnr        // (c) 1986
+
 @source:exidy/victory.cpp
 victory         // (c) 1982
 victorba        // (c) 1982
-topgunnr        // (c) 1986
 
 @source:gaelco/wrally.cpp
 wrally          // (c) 1993 - Ref 930705
@@ -57,7 +59,7 @@ looping         // (c) 1982 Video Games GMBH
 @source:misc/supertnk.cpp
 supertnk        // (c) 1981 VIDEO GAMES GmbH, W.-GERMANY
 
-@source:misc/goldnpkr.cpp:
+@source:misc/goldnpkr.cpp
 witchgme        // (c) 1991 Video Klein
 witchjol        // (c) 1994 Video Klein
 wldwitch        // (c) 2001 Video Klein


### PR DESCRIPTION
* Changed Linux GCC build to use the tiny subtarget.
* Added chdman and unidasm executables to artefacts.

This should still have reasonable coverage, with a bit less resource usage on Linux runners:
* We get a full GCC/libstdc++ build from the Windows GCC build.
* We get a full clang/libstdc++ build from the Linux clang build.
* We get a full clang/libc++ build from the macOS clang build.

We’re already building all the tools in every build, but none of them are currently included in artefacts.  This adds unidasm and chdman to artefacts.  I figure unidasm is the most likely to be changed, given disassemblers are worked on rather frequently, and chdman has a life outside MAME.