### PR TITLE
ui: Add support for shows localised system name in Favorites.

### DIFF
--- a/src/frontend/mame/ui/selgame.cpp
+++ b/src/frontend/mame/ui/selgame.cpp
@@ -409,6 +409,7 @@ void menu_select_game::populate(float &customtop, float &custombottom)
 				[this, &have_prev_selected, &old_item_selected, curitem = 0] (ui_software_info const &info) mutable
 				{
 					have_prev_selected = have_prev_selected || (&info == m_prev_selected);
+					ui_system_info const &elem = m_persistent_data.systems()[driver_list::find(info.driver->name)];
 					if (info.startempty)
 					{
 						if (old_item_selected == -1 && info.shortname == reselect_last::driver())
@@ -422,13 +423,13 @@ void menu_select_game::populate(float &customtop, float &custombottom)
 								cloneof = false;
 						}
 
-						item_append(info.longname, cloneof ? FLAG_INVERT : 0, (void *)&info);
+						item_append(elem.description, cloneof ? FLAG_INVERT : 0, (void *)&info);
 					}
 					else
 					{
 						if (old_item_selected == -1 && info.shortname == reselect_last::driver())
 							old_item_selected = curitem;
-						item_append(info.longname, info.devicetype, info.parentname.empty() ? 0 : FLAG_INVERT, (void *)&info);
+						item_append(elem.description, info.devicetype, info.parentname.empty() ? 0 : FLAG_INVERT, (void *)&info);
 					}
 					curitem++;
 				});


### PR DESCRIPTION
In #8674,  added UI for selecting localised system names.
But still missing in Favorites.