### PR TITLE
luaengine_input.cpp: fix input_device_type items upper bound

### DIFF
--- a/src/frontend/mame/luaengine_input.cpp
+++ b/src/frontend/mame/luaengine_input.cpp
@@ -494,7 +494,7 @@ void lua_engine::initialize_input(sol::table &emu)
 			[this] (input_device &dev)
 			{
 				sol::table result = sol().create_table();
-				for (input_item_id id = ITEM_ID_FIRST_VALID; id < dev.maxitem(); id++)
+				for (input_item_id id = ITEM_ID_FIRST_VALID; id <= dev.maxitem(); id++)
 				{
 					input_device_item *item = dev.item(id);
 					if (item)


### PR DESCRIPTION
Noticed that the items table was getting shorted by 1 item:

before: (missing BUTTON8)

[MAME]> lastitem = manager.machine.input.device_classes["joystick"].devices[2].items
[MAME]> for a,b in pairs(lastitem) do print(a,b,b.name,b.current,b.token) end
129	sol.input_device_item*: 0x561402611f08	Button 1	0	BUTTON1
130	sol.input_device_item*: 0x5614026058a8	Button 2	0	BUTTON2
131	sol.input_device_item*: 0x5614026058e8	Button 3	0	BUTTON3
132	sol.input_device_item*: 0x561402649d38	Button 4	0	BUTTON4
133	sol.input_device_item*: 0x561402649d78	Button 5	0	BUTTON5
134	sol.input_device_item*: 0x561402636f28	Button 6	0	BUTTON6
135	sol.input_device_item*: 0x561402636f68	Button 7	0	BUTTON7
121	sol.input_device_item*: 0x561402617438	A1	0	XAXIS
122	sol.input_device_item*: 0x561402617478	A2	0	YAXIS
123	sol.input_device_item*: 0x561402611ec8	A3	0	ZAXIS


after: (includes BUTTON8)
[MAME]> lastitem = manager.machine.input.device_classes["joystick"].devices[2].items
[MAME]> for a,b in pairs(lastitem) do print(a,b,b.name,b.current,b.token) end
129	sol.input_device_item*: 0x557a8d060958	Button 1	0	BUTTON1
130	sol.input_device_item*: 0x557a8d060998	Button 2	0	BUTTON2
131	sol.input_device_item*: 0x557a8d0ad098	Button 3	0	BUTTON3
132	sol.input_device_item*: 0x557a8d0ad0d8	Button 4	0	BUTTON4
133	sol.input_device_item*: 0x557a8d0798a8	Button 5	0	BUTTON5
134	sol.input_device_item*: 0x557a8d0798e8	Button 6	0	BUTTON6
135	sol.input_device_item*: 0x557a8d0b03a8	Button 7	0	BUTTON7
136	sol.input_device_item*: 0x557a8d0b03e8	Button 8	0	BUTTON8
121	sol.input_device_item*: 0x557a8d0a8f78	A1	0	XAXIS
122	sol.input_device_item*: 0x557a8cffb188	A2	0	YAXIS
123	sol.input_device_item*: 0x557a8cffb1c8	A3	0	ZAXIS
