### PR TITLE
Don't use the system name for non-system items

### DIFF
--- a/src/frontend/mame/ui/selgame.cpp
+++ b/src/frontend/mame/ui/selgame.cpp
@@ -423,13 +423,19 @@ void menu_select_game::populate(float &customtop, float &custombottom)
 								cloneof = false;
 						}
 
-						item_append(elem.description, cloneof ? FLAG_INVERT : 0, (void *)&info);
+						item_append(info.devicetype.empty() ? elem.description : info.longname,
+								 cloneof ? FLAG_INVERT : 0,
+								 (void *)&info);
 					}
 					else
 					{
 						if (old_item_selected == -1 && info.shortname == reselect_last::driver())
 							old_item_selected = curitem;
-						item_append(elem.description, info.devicetype, info.parentname.empty() ? 0 : FLAG_INVERT, (void *)&info);
+
+						item_append(info.devicetype.empty() ? elem.description : info.longname,
+								info.devicetype,
+								info.parentname.empty() ? 0 : FLAG_INVERT,
+								(void *)&info);
 					}
 					curitem++;
 				});


### PR DESCRIPTION
Behavior in 0.248 list if I have both a system and software list item added to favorites:
Nintendo Entertainment System
Super Mario Bros.

There was a change in behavior where the system name is always used, and looks like this in 0.249:
Nintendo Entertainment System
Nintendo Entertainment System

This commit will use the devicetype to determine what kind of entry it is and toggle between the strings