### PR TITLE
Don't force lower samplerate for `-sound none`

### DIFF
--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -1093,14 +1093,6 @@ sound_manager::sound_manager(running_machine &machine) :
 	m_wavfile(),
 	m_first_reset(true)
 {
-	// get filename for WAV file or AVI file if specified
-	const char *wavfile = machine.options().wav_write();
-	const char *avifile = machine.options().avi_write();
-
-	// handle -nosound and lower sample rate if not recording WAV or AVI
-	if (m_nosound_mode && wavfile[0] == 0 && avifile[0] == 0)
-		machine.m_sample_rate = 11025;
-
 	// count the mixers
 #if VERBOSE
 	mixer_interface_enumerator iter(machine.root_device());


### PR DESCRIPTION
The user can still lower it if needed (probably rare these days?), but in case it was needed to be higher, there was no way to increase it.

When using lua instead of OSD to obtain samples, we don't need sound output, but we need decent samplerate.