### PR TITLE
taito/tc0100scn.cpp: fix longstanding color regression with wgp

### DIFF
--- a/src/mame/taito/tc0100scn.cpp
+++ b/src/mame/taito/tc0100scn.cpp
@@ -176,7 +176,6 @@ tc0100scn_base_device::tc0100scn_base_device(const machine_config &mconfig, devi
 	, m_flip_text_yoffs(0)
 	, m_multiscrn_xoffs(0)
 	, m_multiscrn_hack(0)
-	, m_col_base(0)
 {
 	std::fill(std::begin(m_bg_colbank), std::end(m_bg_colbank), 0);
 }
@@ -305,9 +304,9 @@ void tc0100scn_base_device::device_start()
 	set_layer_ptrs();
 
 	/* create the char set (gfx will then be updated dynamically from RAM) */
-	gfx(0)->set_colorbase(m_col_base);
-	set_gfx(1, std::make_unique<gfx_element>(&palette(), charlayout, (u8 *)&m_ram[0x6000 / 2], NATIVE_ENDIAN_VALUE_LE_BE(8,0), 64, m_col_base));
-	set_gfx(2, std::make_unique<gfx_element>(&palette(), charlayout, (u8 *)&m_ram[0x11000 / 2], NATIVE_ENDIAN_VALUE_LE_BE(8,0), 64, m_col_base));
+	gfx(0)->set_colorbase(0);
+	set_gfx(1, std::make_unique<gfx_element>(&palette(), charlayout, (u8 *)&m_ram[0x6000 / 2], NATIVE_ENDIAN_VALUE_LE_BE(8,0), 256, 0));
+	set_gfx(2, std::make_unique<gfx_element>(&palette(), charlayout, (u8 *)&m_ram[0x11000 / 2], NATIVE_ENDIAN_VALUE_LE_BE(8,0), 256, 0));
 
 	gfx_element *bg_gfx = gfx(0);
 	gfx_element *txt0 = gfx(1);
@@ -319,8 +318,9 @@ void tc0100scn_base_device::device_start()
 	txt0->set_granularity(bg_gfx->granularity());
 	txt1->set_granularity(bg_gfx->granularity());
 
-	set_colbanks(0, 0, 0);  /* standard values, only Wgp & multiscreen games change them */
-									/* we call this here, so that they can be modified at video_start*/
+	/* standard values, only wgp games change this */
+	/* we call this here, so that they can be modified at video_start */
+	set_colbanks(0, 0, 0);
 
 	save_pointer(NAME(m_ram), TC0100SCN_RAM_SIZE / 2);
 	save_item(NAME(m_ctrl));

--- a/src/mame/taito/tc0100scn.h
+++ b/src/mame/taito/tc0100scn.h
@@ -26,7 +26,6 @@ public:
 
 	// configuration
 	void set_gfxlayout(int layout) { m_gfxlayout = layout; }
-	void set_color_base(u16 base) { m_col_base = base; }
 	template <typename... T> void set_tile_callback(T &&... args) { m_tc0100scn_cb.set(std::forward<T>(args)...); }
 	void set_multiscr_xoffs(int xoffs) { m_multiscrn_xoffs = xoffs; }
 	void set_multiscr_hack(int hack) { m_multiscrn_hack = hack; }
@@ -99,8 +98,6 @@ private:
 	int          m_flip_text_xoffs, m_flip_text_yoffs;
 	int          m_multiscrn_xoffs;
 	int          m_multiscrn_hack;
-
-	u16          m_col_base;
 
 	template<unsigned Offset, unsigned Colbank> TILE_GET_INFO_MEMBER(get_bg_tile_info);
 	template<unsigned Offset, unsigned Gfx> TILE_GET_INFO_MEMBER(get_tx_tile_info);


### PR DESCRIPTION
Caused by https://github.com/mamedev/mame/pull/5207/files#diff-d1157515ada7840f50c950748ba77671119be687fda8d13dfc3c99291f470170L269
- taito/tc0100scn.cpp: removed `set_color_base` setter since it's unused.