### PR TITLE
capcom/sonson: Change vsync to 55.40Hz

### DIFF
--- a/src/mame/capcom/sonson.cpp
+++ b/src/mame/capcom/sonson.cpp
@@ -440,7 +440,7 @@ void sonson_state::sonson(machine_config &config)
 
 	// video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(57.37);
+	screen.set_refresh_hz(55.40);
 	screen.set_size(32*8, 32*8);
 	screen.set_visarea(1*8, 31*8-1, 1*8, 31*8-1);
 	screen.set_screen_update(FUNC(sonson_state::screen_update));


### PR DESCRIPTION
Source of measurements --> https://github.com/MikeS11/Arcade-Sonson_MiSTer/issues/1#issuecomment-1312089702

The value originally set must have been a typo, according to @kold669 (aka Corrado Tomaselli who is credited in the original change made back in 0.156). The original PCB alternates between 55.37Hz and 55.43Hz and it is Corrado's suggestion to run it at 55.40Hz. Measurement pictures backed up here as well:

Vsync

![Vsync](https://user-images.githubusercontent.com/16388068/201441044-9711c084-e45c-4c57-bb2a-20bf3955530d.png)

Hsync

![Hsync](https://user-images.githubusercontent.com/16388068/201441051-e92820f0-ba3a-4bd3-8e78-0aff5a1c2796.png)

Csync

![Csync](https://user-images.githubusercontent.com/16388068/201441055-a69c7416-a2ca-4327-89a5-9101086272b2.png)