### PR TITLE
gameboy.xml: Added a prototype.

### DIFF
--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -688,6 +688,18 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="altspaceup" cloneof="altspace" supported="partial">
+		<description>Altered Space - A 3-D Alien Adventure (USA, prototype, 19910215)</description>
+		<year>1991</year>
+		<publisher>Sony Imagesoft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="u1" size="0x20000" crc="0ba573f4" sha1="ab343a7c94f3f6e1f411ea0b947c109fb20e576d" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="amazpeng">
 		<description>Amazing Penguin (Europe, USA)</description>
 		<year>1990</year>


### PR DESCRIPTION
New working software list additions
-----------------------------------
Altered Space - A 3-D Alien Adventure (USA, prototype, 19910215) [SteelGeneral, Forest of Illusion]

I've marked this as partial because all of its clones are marked partial. I'm not sure if/when there are issues with MAME's emulation for this game. There's this [page](https://mgba.io/2017/05/29/holy-grail-bugs/) which describes issues related to the edge-triggered STAT IRQ. MAME doesn't have the glitches in the screenshot shown there, so maybe things are all good? Or maybe there are yet more subtle issues for this title? I'll leave it to somebody more knowledgeable about the GB drivers to say whether the "partial" flags can be removed here.