### PR TITLE
Ensure queue->thread will have at least 1 work_thread_info in it

### DIFF
--- a/src/osd/osdsync.cpp
+++ b/src/osd/osdsync.cpp
@@ -286,7 +286,7 @@ osd_work_queue *osd_work_queue_alloc(int flags)
 	if (flags & WORK_QUEUE_FLAG_MULTI)
 		allocthreadnum = queue->threads + 1;
 	else
-		allocthreadnum = queue->threads;
+		allocthreadnum = std::max(queue->threads, 1u);
 
 #if KEEP_STATISTICS
 	printf("osdprocs: %d effecprocs: %d threads: %d allocthreads: %d osdthreads: %d maxthreads: %d queuethreads: %d\n", osd_num_processors, numprocs, threadnum, allocthreadnum, osdthreadnum, WORK_MAX_THREADS, queue->threads);


### PR DESCRIPTION
For platforms which do not support threads (i.e. emuscripten), queue->thread might not have any work_thread_info's added to it. This is bad as osd_work_item_queue_multiple will access queue->thread[0] when queue->threads == 0, and subsequently crash as the queue has no items in it.