### PR TITLE
Major notes update; add extensive TODO list

### DIFF
--- a/src/mame/konami/hornet.cpp
+++ b/src/mame/konami/hornet.cpp
@@ -54,15 +54,14 @@ Specific game hardware configurations:
 
 Game              KONAMI ID  CPU PCB    GFX Board(s)  notes
 ----------------------------------------------------------------------
-Gradius 4         GX837      GN715(A)   GN715(B)
-NBA Play By Play  GX778      GN715(A)   GN715(B)
+Gradius 4         GX837      GN715(A)   GN715(B)      JVS Compatible
+NBA Play By Play  GX778      GN715(A)   GN715(B)      JVS Compatible
 Teraburst         GX715      GN715(A)   GN715(B)      GN680(E) I/O board
 Thrill Drive      GE713UF    GN715(A)   GN715(B)      GN676-PWB(H)A LAN PCB
-Silent Scope      GQ830      GN715(A)   2x GN715(B)
-Silent Scope      GQ830      GN715(A)   2x GQ871(B)
-Silent Scope 2    GQ931      GN715(A)   2x GQ871(B)   GQ931(H) LAN PCB
-Silent Scope 2    GQ931      GN715(A)   2x GN715(B)   GQ931(H) LAN PCB
-
+Silent Scope      GQ830      GN715(A)   2x GN715(B)   GQ830-PWB(J) GUN PCB
+Silent Scope      GQ830      GN715(A)   2x GQ871(B)   GQ830-PWB(J) GUN PCB
+Silent Scope 2    GQ931      GN715(A)   2x GN715(B)   GQ830-PWB(J) GUN PCB & GQ931(H) LAN PCB
+Silent Scope 2    GQ931      GN715(A)   2x GQ871(B)   GQ830-PWB(J) GUN PCB & GQ931(H) LAN PCB
 
 PCB Layouts
 -----------
@@ -104,7 +103,7 @@ Notes:
       DRM1M4SJ8 - Fujitsu 81C4256 256Kx4 DRAM (SOJ24)
        SRAM256K - Cypress CY7C199 32kx8 SRAM (SOJ28)
       DRAM16X16 - Fujitsu 8118160A-60 16megx16 DRAM (SOJ42)
-  0038323 E9825 - SOIC8 (Secured PIC?). I've seen a similar chip in the security cart of System573
+  0038323 E9825 - Xicor X76F041 Secure Serial Flash ROM (not all games had this populated; see below)
   M48T58Y-70PC1 - ST Timekeeper RAM
         RF5C400 - Ricoh RF5C400 PCM 32Ch, 44.1 kHz Stereo, 3D Effect Spatializer, clock input 16.9344MHz
          056800 - Konami Custom (QFP80)
@@ -143,11 +142,10 @@ Notes:
             CN6 - 96-Pin To Lower PCB, Joining Connector
     CN7 to  CN8 - Not used
     CN9 to CN11 - 6-Pin Power Connectors
-           CN19 - USB Connector
-           CN21 - 5-Pin Analog Controls Connector (Tied to USB Connector via the Filter Board)
+           CN19 - USB Connector for JVS I/O board
+           CN21 - 5-Pin Analog Controls Connector
            CN18 - RCA Mono Audio OUT
     CN14 & CN16 - RCA Stereo Audio OUT
-
 
 ROM Usage
 ---------
@@ -236,63 +234,10 @@ S/Scope      830A13  -       830A14  -
 S/Scope 2    -       -       -       -      (no ROMs, not used)
 
 
-Teraburst uses a different variation of the I/O board used in Operation: Thunder Hurricane (see gticlub.cpp). Analog inputs are controlled by
-two CCD cameras, one from each gun. This specific variation uses a K056800 which normally acts as a sound interface controller. Perhaps this
-either sends analog inputs to the main pcb or isn't used at all. No network connection is involved in this setup as this board directly connects
-to the main pcb via joining connector.
-
-GN680 PWB(E)403381B
-|------------------------------------------|
-|CN11  CN12    CN8      CN9    CN10  DSW(4)|
-|                 NRPS11     NRPS11        |
-|                                          |
-|                        LM1881   LM1881   |
-|                                          |
-|LED(x4)                                   |
-|                                          |
-|           68EC000FN16  8464              |
-|    RESET_SW            8464              |
-|32MHz                           715A17.20K|
-|8464                 PAL(002962)          |
-|      056800         PAL(002961)          |
-|   PAL(056787A)      PAL(002960)          |
-|   CN1                                    |
-|------------------------------------------|
-Notes:
-  68EC000 @ 16MHz (32/2)
-  CN11/12 - Power connectors
-  CN8/9   - 6-pin analog control connectors (to CCD cameras)
-  CN1     - Lower joining connector to main pcb
-  NRPS11  - Idec NRPS11 PC Board circuit protector
-  LM1881  - Video sync separator (DIP8)
-  056800  - Konami Custom (QFP80)
-
-
-LAN PCB: GQ931 PWB(H)      (C) 1999 Konami
+Bottom Board
+GQ871 PWB(B)A (C) 1999 Konami
 ------------------------------------------
-
-2 x LAN ports, LANC(1) & LANC(2)
-1 x 32.0000MHz Oscillator
-
-     HYC2485S  SMC ARCNET Media Transceiver, RS485 5Mbps-2.5Mbps
-8E   931A19    Konami 32meg masked ROM, ROM0 (compressed GFX data)
-6E   931A20    Konami 32meg masked ROM, ROM1 (compressed GFX data)
-12F  XC9536    Xilinx  CPLD,  44 pin PLCC, Konami no. Q931H1
-12C  XCS10XL   Xilinx  FPGA, 100 pin PQFP, Konami no. 4C
-12B  CY7C199   Cypress 32kx8 SRAM
-8B   AT93C46   Atmel 1K serial EEPROM, 8 pin SOP
-16G  DS2401    Dallas Silicon Serial Number IC, 6 pin SOP
-
-Note: This PCB does more than just networking. The serial eeprom is used as a means to prevent region change.
-The timekeeper region has to match the serial eeprom. The two mask roms serve as GFX roms as the game "downloads"
-the data from those two roms.
-
-
-GFX PCB: GQ871 PWB(B)A (C) 1999 Konami
---------------------------------------
-
-There are no ROMs on the two GFX PCBs, all sockets are empty. They are located on the LAN PCB.
-Prior to the game starting there is a message saying downloading data.
+Layout is nearly identical to GN715 but with Voodoo 2 chips instead of Voodoo 1
 
 Jumpers set on GFX PCB to main monitor:
 4A   set to TWN (twin GFX PCBs)
@@ -344,6 +289,123 @@ Jumpers set on GFX PCB to scope monitor:
 3R   SM81C256K16CJ-25 Silicon Magic 100MHz EDO RAM, 4Meg
 27G  XC9536           Xilinx, CPLD, Konami no. Q830B1
 21C  MC44200FT        Motorola, 3 Channel video D/A converter
+
+
+JVS I/O Board
+------------------------------------------
+This system was capable of using JVS I/O boards but only two games are known to support this feature; Gradius 4 and NBA Play by Play. The latter
+can make use of this and normal I/O interface for four player simultaneous play. Konami has their own JVS board consisting of an H8-3644FL labeled
+'707 V2 31484' and is not readable.
+
+
+Teraburst Gun Board
+------------------------------------------
+Teraburst uses a different variation of the I/O board used in Operation: Thunder Hurricane (see gticlub.cpp). Analog inputs are controlled by
+two CCD cameras, one from each gun. This specific variation uses a 056800 custom which normally acts as a sound interface controller functioning
+as a 'bridge' between the PPC and 68k. No network connection is involved in this setup as this board directly connects to the main pcb via joining
+connector.
+
+GN680 PWB(E)403381B
+|------------------------------------------|
+|CN11  CN12    CN8      CN9    CN10  DSW(4)|
+|                 NRPS11     NRPS11        |
+|                                          |
+|                        LM1881   LM1881   |
+|                                          |
+|LED(x4)                                   |
+|                                          |
+|           68EC000FN16  8464              |
+|    RESET_SW            8464              |
+|32MHz                           715A17.20K|
+|8464                 PAL(002962)          |
+|      056800         PAL(002961)          |
+|   PAL(056787A)      PAL(002960)          |
+|   CN1                                    |
+|------------------------------------------|
+Notes:
+  68EC000 @ 16MHz (32/2)
+  CN11/12 - Power connectors
+  CN8/9   - 6-pin analog control connectors (to CCD cameras)
+  CN1     - Lower joining connector to main pcb
+  NRPS11  - Idec NRPS11 PC Board circuit protector
+  LM1881  - Video sync separator (DIP8)
+  056800  - Konami Custom (QFP80)
+
+
+Silent Scope Gun Board: GQ830-PWB(J)      (C) 1999 Konami
+------------------------------------------
+This is simply an ADC12138 and is intentionally wired differently as opposed to using the onboard ADC. Only
+Silent Scope 1 and 2 used this but Silent Scope EX, viper.ccp, later used this board wired in a similar manner.
+According to Silent Scope 2's manual, the ADC is wired between the parallel output port and Player 2 buttons 1-3.
+
+Wiring Config:
+SCLK  - Parallel Data Bus 7
+DIN   - Parallel Data Bus 5
+CS    - Parallel Data Bus 4
+CONV  - Parallel Data Bus 3
+EOC   - Player 2 Button 1
+DOR   - Player 2 Button 2
+DOUT  - Player 2 Button 3
+
+
+Silent Scope 2 LAN Board: GQ931 PWB(H)      (C) 1999 Konami
+------------------------------------------
+
+2 x LAN ports, LANC(1) & LANC(2)
+1 x 32.0000MHz Oscillator
+
+     HYC2485S  SMC ARCNET Media Transceiver, RS485 5Mbps-2.5Mbps
+8E   931A19    Konami 32meg masked ROM, ROM0 (compressed GFX data)
+6E   931A20    Konami 32meg masked ROM, ROM1 (compressed GFX data)
+12F  XC9536    Xilinx  CPLD,  44 pin PLCC, Konami no. Q931H1
+12C  XCS10XL   Xilinx  FPGA, 100 pin PQFP, Konami no. 4C
+12B  CY7C199   Cypress 32kx8 SRAM
+8B   AT93C46   Atmel 1K serial EEPROM, 8 pin SOP
+16G  DS2401    Dallas Silicon Serial Number IC, 6 pin SOP
+
+Note: This PCB does more than just networking. The serial eeprom is used as a means to prevent region change
+and allow sscope2 to boot with a sscope timekeeper. If a valid timekeeper and serial eeprom have different
+region strings, the game would boot with a 'security code error'. If the LAN board serial eeprom and/or serial
+number IC aren't present, the game would boot with a 'hardware error -8B'.
+
+The two mask roms serve as compressed GFX roms for the game to "download" data over to both CG boards. 
+
+
+TODO:
+- POST fails to complete the following games:
+  + terabrst: Freezes with colorful jailbars (voodoo buffer offset out of bounds; culprit currently unknown); resets after freezing
+  + thrilldbu: LAN board tests bad (gn676_lan.cpp)
+  + sscope/sscope2: Crashes during second DSP board test (culprit currently unknown)
+- gradius4 hardlocks during mask rom check with SHARC recompiler enabled...
+  + and also crashes during the 6th level boss even (likely) without the recompiler (MT#8423)
+- nbapbp doesn't display a proper region regardless of timekeeper
+- terabrst has priority related issues putting the tilemap above the 3d (title screen, ranking, CG board check)
+- terabrst freezes with sticky 3d during the 'explosion' events (stage 1 gas station and most bosses) with the SHARC
+  recompiler enabled
+- terabrst stage 2 boss doesn't properly spawn with the flying saucer that spawns the boss staying in place (for ~5 mins).
+  On actual h/w, the flying saucer flys over and destroys a nearby building to the left spawning the boss
+- terabrsta doesn't boot at all (culprit currently unknown)
+- thrilldbu randomly freezes with sticky 3d. It's possible to somehow lower the chances of freezing by underclocking
+  the maincpu and/or dsp (culprit currently unknown)
+- implement thrilldbu's wheel feedback logic (controlled through the parallel data port via sysreg_w). Can be bypassed by enabling
+  DIP #2
+- sscope/sscope2's scope monitor has severe lag. The culprit lies within the video core unable to handle two screens
+  with different refresh rates at once (either requiring a timing hack or major video core rewrite).
+- figure out a way to properly hook sscope's additional adc12138
+- sscope/sscope2 has random crashes (was more common in earlier versions but needs a bit more testing)
+- sscope/sscope2 prioity problems:
+  + the main screen's scope in attract mode demo has a tendency to 'wipe/cover' itself in certain areas
+  + the tilemap text and high score graphic are enclosed in a black box
+- sscope2's gfx banking isn't fully understood. Various 3d models show incorrect textures.
+- give proper PCI support for k033906
+  + as a matter of fact, konppc.cpp's current implementation is very werid. How the main/cg interface rewrite is yet to be determined
+  + it would be for the best to put the CG board as a device interface.
+- JVS device fixups (see sysreg_r note)
+- add the onboard X76F041 for the games that support that and their dumps
+- add all remaining timekeeper region files.
+- (eventually) implement sscope2's LAN networking (and also thrilldbu)
+  + sscope2 may not like it if it links to another instance with the same serial ID. If that is the case, then something to set the
+  serial ID should be implemented.
 
 ***************************************************************************
 */
@@ -588,6 +650,11 @@ uint8_t hornet_state::sysreg_r(offs_t offset)
 			    0x04 = ADEOC (ADC EOC)
 			    0x02 = ADDOR (ADC DOR)
 			    0x01 = ADDO (ADC DO)
+			
+			FIXME: Only gradius4 and nbapbp take advantage of JVS; the rest do not.
+			In fact, the rest of the games might NOT like it if a JVS I/O board is
+			plugged in (or the SENSE line is enabled). This needs verifcation on
+			actual hardware.
 			*/
 			r = 0x70;
 			r |= m_hornet_jvs_host->sense() << 7;
@@ -816,7 +883,7 @@ void hornet_state::terabrst_map(address_map &map)
 	map(0x74080000, 0x7408000f).rw(FUNC(hornet_state::gun_r), FUNC(hornet_state::gun_w));
 }
 
-void hornet_state::sscope_map(address_map &map) //placeholder; may remove if mapping the second ADC12138 isn't necessary
+void hornet_state::sscope_map(address_map &map) // placeholder; may remove if mapping the second ADC12138 isn't necessary
 {
 	hornet_map(map);
 
@@ -951,9 +1018,9 @@ static INPUT_PORTS_START( hornet )
 	PORT_DIPNAME( 0x80, 0x00, "Skip Post" ) PORT_DIPLOCATION("SW:1")
 	PORT_DIPSETTING( 0x80, DEF_STR( Off ) )
 	PORT_DIPSETTING( 0x00, DEF_STR( On ) )
-	PORT_DIPNAME( 0x40, 0x00, "Disable Machine Init" ) PORT_DIPLOCATION("SW:2") // Having this on disables the analog controls in terabrst, thrilldbu, sscope and sscope2
+	PORT_DIPNAME( 0x40, 0x00, "Disable Machine Init" ) PORT_DIPLOCATION("SW:2") // Having this on disables the external gun controls in terabrst, sscope, sscope2 and the wheel feedback motor in thrilldbu
 	PORT_DIPSETTING( 0x40, DEF_STR( Off ) )
-	PORT_DIPSETTING( 0x00, DEF_STR( On ) ) //they instead make them usable with JAMMA inputs
+	PORT_DIPSETTING( 0x00, DEF_STR( On ) ) // they instead make terabrst's gun cursor control with 8-way JAMMA stick and sscope/sscope2's cursor with either the 8-way stick or onboard adc12138
 	PORT_DIPNAME( 0x20, 0x20, "DIP3" ) PORT_DIPLOCATION("SW:3")
 	PORT_DIPSETTING( 0x20, DEF_STR( Off ) )
 	PORT_DIPSETTING( 0x00, DEF_STR( On ) )
@@ -1004,7 +1071,7 @@ static INPUT_PORTS_START( gradius4 )
 	PORT_DIPSETTING( 0x00, "15KHz" )
 INPUT_PORTS_END
 
-static INPUT_PORTS_START(nbapbp) //Need to add inputs for player 3 and 4.
+static INPUT_PORTS_START(nbapbp) // Players 3 and 4 are controlled through a JVS I/O board. TODO: Not hooked up
 	PORT_INCLUDE(gradius4)
 
 	PORT_MODIFY("DSW")
@@ -1030,7 +1097,8 @@ static INPUT_PORTS_START(nbapbp) //Need to add inputs for player 3 and 4.
     PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(4)
     PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(4)
     PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(4)
-    PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_PLAYER(4) */
+    PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_PLAYER(4)
+*/
 INPUT_PORTS_END
 
 static INPUT_PORTS_START(terabrst)
@@ -1186,9 +1254,6 @@ void hornet_state::hornet(machine_config &config)
 
 	WATCHDOG_TIMER(config, m_watchdog);
 
-//  PCB description at top doesn't mention any EEPROM on the base board...
-//  EEPROM_93C46_16BIT(config, "eeprom");
-
 	VOODOO_1(config, m_voodoo[0], XTAL(50'000'000));
 	m_voodoo[0]->set_fbmem(2);
 	m_voodoo[0]->set_tmumem(4,0);
@@ -1246,7 +1311,7 @@ void hornet_state::hornet_lan(machine_config &config)
 	KONAMI_GN676_LAN(config, "gn676_lan", 0, m_workram);
 }
 
-void hornet_state::terabrst(machine_config &config) //todo: add K056800 from I/O board
+void hornet_state::terabrst(machine_config &config)
 {
 	hornet(config);
 
@@ -1411,7 +1476,7 @@ void hornet_state::init_sscope()
 	m_maincpu->ppc4xx_spu_set_tx_handler(write8smo_delegate(*this, FUNC(hornet_state::jamma_jvs_w)));
 }
 
-void hornet_state::init_sscope2() //fixme: eventually set sscope2 to load gfx roms from the comm board
+void hornet_state::init_sscope2()
 {
 	m_konppc->set_cgboard_texture_bank(0, "master_cgboard_bank", memregion("master_cgboard")->base());
 	m_konppc->set_cgboard_texture_bank(1, "slave_cgboard_bank", memregion("master_cgboard")->base());
@@ -1440,8 +1505,7 @@ ROM_START(sscope)
 	ROM_LOAD( "830a10.14p", 0x400000, 0x400000, CRC(8b8aaf7e) SHA1(49b694dc171c149056b87c15410a6bf37ff2987f) )
 
 	ROM_REGION(0x2000, "m48t58",0)
-	ROM_LOAD( "m48t58y.35d",   0x000000, 0x002000, CRC(b077e262) SHA1(5cdcc1b742bf23562f4558216063fea903f045ab) ) // this is set to the JXD, I don't think it's valid.
-	ROM_LOAD( "m48t58y-70pc1", 0x000000, 0x002000, CRC(ee815325) SHA1(91b10802791b68a8360c0cd6c376c0c4bbbc6fa0) ) // so just load over it with the US one, we know works.
+	ROM_LOAD( "m48t58y-70pc1", 0x000000, 0x002000, CRC(ee815325) SHA1(91b10802791b68a8360c0cd6c376c0c4bbbc6fa0) )
 ROM_END
 
 ROM_START(sscopec)
@@ -1510,7 +1574,7 @@ ROM_START(sscopea)
 	ROM_LOAD( "m48t58y-70pc1", 0x000000, 0x002000, CRC(ee815325) SHA1(91b10802791b68a8360c0cd6c376c0c4bbbc6fa0) )
 ROM_END
 
-ROM_START(sscoped)
+ROM_START(sscoped) 
 	ROM_REGION32_BE(0x400000, "prgrom", 0)   // PowerPC program
 	ROM_LOAD16_WORD_SWAP("830d01.27p", 0x200000, 0x200000, CRC(de9b3dfa) SHA1(660652a5f745cb04687481c3626d8a43cd169193))
 	ROM_RELOAD(0x000000, 0x200000)
@@ -1590,10 +1654,10 @@ ROM_START(sscope2e)
 	ROM_LOAD( "m48t58y-70pc1", 0x000000, 0x002000, BAD_DUMP CRC(f7c40218) SHA1(5021089803024a6f552e5c9d42b905e804b9d904) ) // needs proper dump for the European version
 
 	ROM_REGION(0x8, "lan_serial_id", 0)     // LAN Board DS2401
-	ROM_LOAD( "ds2401.16g", 0x000000, 0x000008, CRC(2b813979) SHA1(b940f4e1c0e1867788632bca3bdc3df265bdde7a) )
+	ROM_LOAD( "ds2401.16g", 0x000000, 0x000008, BAD_DUMP CRC(2b813979) SHA1(b940f4e1c0e1867788632bca3bdc3df265bdde7a) )
 
 	ROM_REGION16_BE(0x80, "lan_eeprom", 0)       // LAN Board AT93C46
-	ROM_LOAD16_WORD_SWAP( "at93c46.8g", 0x000000, 0x000080, CRC(b6da86a4) SHA1(3a6570ac25748fb5e6b8a0dd6b832ee2d463cc7b) )
+	ROM_LOAD16_WORD_SWAP( "at93c46.8g", 0x000000, 0x000080, BAD_DUMP CRC(b6da86a4) SHA1(3a6570ac25748fb5e6b8a0dd6b832ee2d463cc7b) ) // and a proper LAN EEPROM dump
 ROM_END
 
 ROM_START(sscope2b)
@@ -1618,8 +1682,8 @@ ROM_START(sscope2b)
 	ROM_LOAD("931a10.14p", 0x400000, 0x400000, CRC(78ceb519) SHA1(e61c0d21b6dc37a9293e72814474f5aee59115ad))
 	ROM_LOAD("931a11.12p", 0x800000, 0x400000, CRC(9c8362b2) SHA1(a8158c4db386e2bbd61dc9a600720f07a1eba294))
 
-	ROM_REGION(0x2000, "m48t58", 0)
-	ROM_LOAD("m48t58y-70pc1", 0x000000, 0x002000, CRC(72f41511) SHA1(2097bcf7fe56f798182219ff46908a20aa47546a))
+	ROM_REGION(0x2000, "m48t58",0)
+	ROM_LOAD( "m48t58y-70pc1", 0x000000, 0x002000, CRC(f7c40218) SHA1(5021089803024a6f552e5c9d42b905e804b9d904) )
 
 	ROM_REGION(0x8, "lan_serial_id", 0)     // LAN Board DS2401
 	ROM_LOAD("ds2401.16g", 0x000000, 0x000008, BAD_DUMP CRC(bae36d0b) SHA1(4dd5915888d5718356b40bbe897f2470e410176a)) // hand built
@@ -1650,8 +1714,8 @@ ROM_START(sscope2c)
 	ROM_LOAD("931a10.14p", 0x400000, 0x400000, CRC(78ceb519) SHA1(e61c0d21b6dc37a9293e72814474f5aee59115ad))
 	ROM_LOAD("931a11.12p", 0x800000, 0x400000, CRC(9c8362b2) SHA1(a8158c4db386e2bbd61dc9a600720f07a1eba294))
 
-	ROM_REGION(0x2000, "m48t58", 0)
-	ROM_LOAD("m48t58y-70pc1", 0x000000, 0x002000, CRC(216ec340) SHA1(bbcb42a3fe54d7f5b83d45f063ecbead705c7b66))
+	ROM_REGION(0x2000, "m48t58",0)
+	ROM_LOAD( "m48t58y-70pc1", 0x000000, 0x002000, CRC(f7c40218) SHA1(5021089803024a6f552e5c9d42b905e804b9d904) )
 
 	ROM_REGION(0x8, "lan_serial_id", 0)     // LAN Board DS2401
 	ROM_LOAD("ds2401.16g", 0x000000, 0x000008, BAD_DUMP CRC(bae36d0b) SHA1(4dd5915888d5718356b40bbe897f2470e410176a)) // hand built
@@ -1853,28 +1917,25 @@ ROM_END
 
 GAME(  1998, gradius4,  0,        hornet,     gradius4, hornet_state, init_gradius4, ROT0, "Konami", "Gradius IV: Fukkatsu (ver JAC)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 GAME(  1998, gradius4a, gradius4, hornet,     gradius4, hornet_state, init_gradius4, ROT0, "Konami", "Gradius IV (ver UAA)",           MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME(  1998, nbapbp,    0,        hornet,     nbapbp,   hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver JAA)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME(  1998, nbapbpa,   nbapbp,   hornet,     nbapbp,   hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver AAB)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME(  1998, nbapbp,    0,        hornet,     nbapbp,   hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver JAA)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_CONTROLS | MACHINE_SUPPORTS_SAVE )
+GAME(  1998, nbapbpa,   nbapbp,   hornet,     nbapbp,   hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver AAB)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_CONTROLS | MACHINE_SUPPORTS_SAVE )
 GAME(  1998, terabrst,  0,        terabrst,   terabrst, hornet_state, init_hornet, ROT0, "Konami", "Teraburst (1998/07/17 ver UEL)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 GAME(  1998, terabrsta, terabrst, terabrst,   terabrst, hornet_state, init_hornet, ROT0, "Konami", "Teraburst (1998/02/25 ver AAA)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 // identifies as NWK-LC system
-GAME(  1998, thrilldbu, thrilld,  hornet_lan, thrilld,  hornet_state, init_hornet, ROT0, "Konami", "Thrill Drive (ver UFB)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_NODEVICE_LAN ) // heavy GFX glitches, fails wheel motor test, for now it's possible to get in game by switching "SW:2" to on
+GAME(  1998, thrilldbu, thrilld,  hornet_lan, thrilld,  hornet_state, init_hornet, ROT0, "Konami", "Thrill Drive (ver UFB)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE | MACHINE_NODEVICE_LAN ) // random freezes, fails wheel motor test, for now it's possible to get in game by switching "SW:2" to on
 
-// The region comes from the Timekeeper NVRAM, without a valid default all sets except 'xxD, Ver 1.33' will init their NVRAM to UAx versions, the xxD set seems to incorrectly init it to JXD, which isn't a valid
-// version, and thus can't be booted.  If you copy the NVRAM from another already initialized set, it will boot as UAD.
-// to get the actual game to boot you must calibrate the guns etc.
-GAMEL( 1999, sscope,    0,        sscope,  sscope,    hornet_state, init_sscope,  ROT0, "Konami", "Silent Scope (ver xxD, Ver 1.33)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
-GAMEL( 1999, sscopec,   sscope,   sscope,  sscope,    hornet_state, init_sscope,  ROT0, "Konami", "Silent Scope (ver xxC, Ver 1.30)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
-GAMEL( 1999, sscopeb,   sscope,   sscope,  sscope,    hornet_state, init_sscope,  ROT0, "Konami", "Silent Scope (ver xxB, Ver 1.20)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
-GAMEL( 1999, sscopea,   sscope,   sscope,  sscope,    hornet_state, init_sscope,  ROT0, "Konami", "Silent Scope (ver xxA, Ver 1.00)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
+GAMEL( 1999, sscope,    0,        sscope,  sscope,    hornet_state, init_sscope,  ROT0, "Konami", "Silent Scope (ver UAD, Ver 1.33)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
+GAMEL( 1999, sscopec,   sscope,   sscope,  sscope,    hornet_state, init_sscope,  ROT0, "Konami", "Silent Scope (ver UAC, Ver 1.30)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
+GAMEL( 1999, sscopeb,   sscope,   sscope,  sscope,    hornet_state, init_sscope,  ROT0, "Konami", "Silent Scope (ver UAB, Ver 1.20)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
+GAMEL( 1999, sscopea,   sscope,   sscope,  sscope,    hornet_state, init_sscope,  ROT0, "Konami", "Silent Scope (ver UAA, Ver 1.00)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
 
-// This version of Silent Scope runs on GQ871 video boards (Voodoo 2 instead of Voodoo 1)
+// This version of Silent Scope runs on GQ871 video boards (Voodoo 2 instead of Voodoo 1) TODO: Identical program to sscope meaning it can boot with either with a voodoo 1 or 2. May need to find a way to select which CG board it can use on startup.
 GAMEL( 1999, sscoped,   sscope,   sscope_voodoo2,  sscope,  hornet_state, init_sscope,  ROT0, "Konami", "Silent Scope (ver UAD, Ver 1.33, GQ871 video board)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
 
-GAMEL( 2000, sscope2,   0,        sscope2, sscope2,   hornet_state, init_sscope2, ROT0, "Konami", "Silent Scope 2 : Dark Silhouette (ver UAD)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE | MACHINE_NODEVICE_LAN , layout_dualhsxs )
-GAMEL( 2000, sscope2e,  sscope2,  sscope2, sscope2,   hornet_state, init_sscope2, ROT0, "Konami", "Silent Scope 2 : Fatal Judgement (ver EAD)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE | MACHINE_NODEVICE_LAN , layout_dualhsxs ) // hardware error as the dumped LAN PCB EEPROM region doesn't match the one on the main PCB timekeeper dump
+GAMEL( 2000, sscope2,   0,        sscope2, sscope2,   hornet_state, init_sscope2, ROT0, "Konami", "Silent Scope 2 : Dark Silhouette (ver UAD, Ver 1.03)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE | MACHINE_NODEVICE_LAN , layout_dualhsxs )
+GAMEL( 2000, sscope2e,  sscope2,  sscope2, sscope2,   hornet_state, init_sscope2, ROT0, "Konami", "Silent Scope 2 : Fatal Judgement (ver EAD, Ver 1.03)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE | MACHINE_NODEVICE_LAN , layout_dualhsxs ) // hardware error 8B, has a bad LAN eeprom dump
 //GAMEL( 2000, sscope2j, sscope2  sscope2, sscope2,   hornet_state, init_sscope2, ROT0, "Konami", "Silent Scope 2 : Innocent Sweeper (ver JAD)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE | MACHINE_NODEVICE_LAN , layout_dualhsxs )
 
 // These versions of Silent Scope 2 run on GN715 video boards (Voodoo 1 instead of Voodoo 2)
-GAMEL( 2000, sscope2b, sscope2, sscope2_voodoo1, sscope2, hornet_state, init_sscope2, ROT0, "Konami", "Silent Scope 2 : Fatal Judgement (ver UAB, Ver 1.01, GN715 video board)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
-GAMEL( 2000, sscope2c, sscope2, sscope2_voodoo1, sscope2, hornet_state, init_sscope2, ROT0, "Konami", "Silent Scope 2 : Fatal Judgement (ver UAC, Ver 1.02, GN715 video board)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
+GAMEL( 2000, sscope2b, sscope2, sscope2_voodoo1, sscope2, hornet_state, init_sscope2, ROT0, "Konami", "Silent Scope 2 : Dark Silhouette (ver UAB, Ver 1.01, GN715 video board)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )
+GAMEL( 2000, sscope2c, sscope2, sscope2_voodoo1, sscope2, hornet_state, init_sscope2, ROT0, "Konami", "Silent Scope 2 : Dark Silhouette (ver UAC, Ver 1.02, GN715 video board)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE, layout_dualhsxs )


### PR DESCRIPTION
- sscope2b, sscope2c: replace the timekeeper dump with the parent one to make it happily boot to attract
- nbapbp, nbapbpa: Add an 'IMPERFECT_CONTROLS' flag for the time being (needs JVS I/O for players 3 and 4)
- sscope/clones: Change region to UA. The region determined by the timekeeper effectively means having to add a lot of clones.

Making this a draft right now as some parts of that PR were rushed.