### PR TITLE
machine/upd71071.cpp: initialize variables, prevents random HDD failures in fmtowns

### DIFF
--- a/src/devices/machine/upd71071.cpp
+++ b/src/devices/machine/upd71071.cpp
@@ -122,12 +122,10 @@ void upd71071_device::device_start()
 
 	m_reg.device_control = 0;
 	m_reg.mask = 0x0f;  // mask all channels
-	for (int x = 0; x < 4; x++)
-	{
-		m_reg.address_current[x] = 0;
-		m_reg.count_current[x] = 0;
-		m_reg.mode_control[x] = 0;
-	}
+
+	std::fill(std::begin(m_reg.address_current), std::end(m_reg.address_current), 0);
+	std::fill(std::begin(m_reg.count_current), std::end(m_reg.count_current), 0);
+	std::fill(std::begin(m_reg.mode_control), std::end(m_reg.mode_control), 0);
 
 	save_item(NAME(m_reg.initialise));
 	save_item(NAME(m_reg.channel));

--- a/src/devices/machine/upd71071.cpp
+++ b/src/devices/machine/upd71071.cpp
@@ -123,7 +123,11 @@ void upd71071_device::device_start()
 	m_reg.device_control = 0;
 	m_reg.mask = 0x0f;  // mask all channels
 	for (int x = 0; x < 4; x++)
+	{
+		m_reg.address_current[x] = 0;
+		m_reg.count_current[x] = 0;
 		m_reg.mode_control[x] = 0;
+	}
 
 	save_item(NAME(m_reg.initialise));
 	save_item(NAME(m_reg.channel));


### PR DESCRIPTION
For some time I've noticed that the hard drives were occasionally (randomly) not working on startup in the FM Towns machines, which usually points to something using uninitialized variables. After tracing it with Valgrind it seems the issue is in the uPD71071 DMA controller.

I have tested the driver with these changes and in about 30 tries it hasn't failed at all (it didn't take more than 3 or 4 before), so I'm pretty confident that it's working correctly now.