### PR TITLE
Update ymfm to latest.

### DIFF
--- a/3rdparty/ymfm/.gitignore
+++ b/3rdparty/ymfm/.gitignore
@@ -37,3 +37,4 @@
 
 # VS Code stuff
 .vs/
+reference/

--- a/3rdparty/ymfm/README.md
+++ b/3rdparty/ymfm/README.md
@@ -1,5 +1,9 @@
 # ymfm
 
+<div style='text-align:center;margin:auto'>
+<img src='https://aarongiles.com/img/icon-ymfm.png' width='128px'>
+</div>
+
 [ymfm](https://github.com/aaronsgiles/ymfm) is a collection of BSD-licensed Yamaha FM sound cores (OPM, OPN, OPL, and others), written by [Aaron Giles](https://aarongiles.com)
 
 ## Supported environments

--- a/3rdparty/ymfm/src/ymfm.h
+++ b/3rdparty/ymfm/src/ymfm.h
@@ -40,6 +40,7 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <algorithm>
 #include <memory>
 #include <string>
@@ -328,7 +329,7 @@ struct ymfm_output
 // ======================> ymfm_wavfile
 
 // this class is a debugging helper that accumulates data and writes it to wav files
-template<int _Channels>
+template<int Channels>
 class ymfm_wavfile
 {
 public:
@@ -360,10 +361,10 @@ public:
 			memcpy(&header[12], "fmt ", 4);
 			*(uint32_t *)&header[16] = 16;
 			*(uint16_t *)&header[20] = 1;
-			*(uint16_t *)&header[22] = _Channels;
+			*(uint16_t *)&header[22] = Channels;
 			*(uint32_t *)&header[24] = m_samplerate;
-			*(uint32_t *)&header[28] = m_samplerate * 2 * _Channels;
-			*(uint16_t *)&header[32] = 2 * _Channels;
+			*(uint32_t *)&header[28] = m_samplerate * 2 * Channels;
+			*(uint16_t *)&header[32] = 2 * Channels;
 			*(uint16_t *)&header[34] = 16;
 			memcpy(&header[36], "data", 4);
 			*(uint32_t *)&header[40] = m_buffer.size() * 2 + 44 - 44;
@@ -376,24 +377,24 @@ public:
 	}
 
 	// add data to the file
-	template<int _Outputs>
-	void add(ymfm_output<_Outputs> output)
+	template<int Outputs>
+	void add(ymfm_output<Outputs> output)
 	{
-		int16_t sum[_Channels] = { 0 };
-		for (int index = 0; index < _Outputs; index++)
-			sum[index % _Channels] += output.data[index];
-		for (int index = 0; index < _Channels; index++)
+		int16_t sum[Channels] = { 0 };
+		for (int index = 0; index < Outputs; index++)
+			sum[index % Channels] += output.data[index];
+		for (int index = 0; index < Channels; index++)
 			m_buffer.push_back(sum[index]);
 	}
 
 	// add data to the file, using a reference
-	template<int _Outputs>
-	void add(ymfm_output<_Outputs> output, ymfm_output<_Outputs> const &ref)
+	template<int Outputs>
+	void add(ymfm_output<Outputs> output, ymfm_output<Outputs> const &ref)
 	{
-		int16_t sum[_Channels] = { 0 };
-		for (int index = 0; index < _Outputs; index++)
-			sum[index % _Channels] += output.data[index] - ref.data[index];
-		for (int index = 0; index < _Channels; index++)
+		int16_t sum[Channels] = { 0 };
+		for (int index = 0; index < Outputs; index++)
+			sum[index % Channels] += output.data[index] - ref.data[index];
+		for (int index = 0; index < Channels; index++)
 			m_buffer.push_back(sum[index]);
 	}
 

--- a/3rdparty/ymfm/src/ymfm_fm.h
+++ b/3rdparty/ymfm/src/ymfm_fm.h
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#define DEBUG_LOG_WAVFILES (0)
+#define YMFM_DEBUG_LOG_WAVFILES (0)
 
 namespace ymfm
 {
@@ -401,7 +401,7 @@ public:
 	// compute sample rate
 	uint32_t sample_rate(uint32_t baseclock) const
 	{
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 		for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 			m_wavfile[chnum].set_samplerate(baseclock / (m_clock_prescale * OPERATORS));
 #endif
@@ -453,7 +453,7 @@ protected:
 	RegisterType m_regs;             // register accessor
 	std::unique_ptr<fm_channel<RegisterType>> m_channel[CHANNELS]; // channel pointers
 	std::unique_ptr<fm_operator<RegisterType>> m_operator[OPERATORS]; // operator pointers
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 	mutable ymfm_wavfile<1> m_wavfile[CHANNELS]; // for debugging
 #endif
 };

--- a/3rdparty/ymfm/src/ymfm_fm.h
+++ b/3rdparty/ymfm/src/ymfm_fm.h
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#define DEBUG_LOG_WAVFILES (0)
+
 namespace ymfm
 {
 
@@ -397,7 +399,14 @@ public:
 	void set_clock_prescale(uint32_t prescale) { m_clock_prescale = prescale; }
 
 	// compute sample rate
-	uint32_t sample_rate(uint32_t baseclock) const { return baseclock / (m_clock_prescale * OPERATORS); }
+	uint32_t sample_rate(uint32_t baseclock) const
+	{
+#if (DEBUG_LOG_WAVFILES)
+		for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
+			m_wavfile[chnum].set_samplerate(baseclock / (m_clock_prescale * OPERATORS));
+#endif
+		return baseclock / (m_clock_prescale * OPERATORS);
+	}
 
 	// return the owning device
 	ymfm_interface &intf() const { return m_intf; }
@@ -444,6 +453,9 @@ protected:
 	RegisterType m_regs;             // register accessor
 	std::unique_ptr<fm_channel<RegisterType>> m_channel[CHANNELS]; // channel pointers
 	std::unique_ptr<fm_operator<RegisterType>> m_operator[OPERATORS]; // operator pointers
+#if (DEBUG_LOG_WAVFILES)
+	mutable ymfm_wavfile<1> m_wavfile[CHANNELS]; // for debugging
+#endif
 };
 
 }

--- a/3rdparty/ymfm/src/ymfm_fm.ipp
+++ b/3rdparty/ymfm/src/ymfm_fm.ipp
@@ -1201,7 +1201,7 @@ fm_engine_base<RegisterType>::fm_engine_base(ymfm_interface &intf) :
 	for (uint32_t opnum = 0; opnum < OPERATORS; opnum++)
 		m_operator[opnum] = std::make_unique<fm_operator<RegisterType>>(*this, RegisterType::operator_offset(opnum));
 
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 	for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 		m_wavfile[chnum].set_index(chnum);
 #endif
@@ -1333,7 +1333,7 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 	chanmask &= debug::GLOBAL_FM_CHANNEL_MASK;
 
 	// mask out inactive channels
-	if (!DEBUG_LOG_WAVFILES)
+	if (!YMFM_DEBUG_LOG_WAVFILES)
 		chanmask &= m_active_channels;
 
 	// handle the rhythm case, where some of the operators are dedicated
@@ -1352,7 +1352,7 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 		for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 			if (bitfield(chanmask, chnum))
 			{
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 				auto reference = output;
 #endif
 				if (chnum == 6)
@@ -1365,7 +1365,7 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 					m_channel[chnum]->output_4op(output, rshift, clipmax);
 				else
 					m_channel[chnum]->output_2op(output, rshift, clipmax);
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 				m_wavfile[chnum].add(output, reference);
 #endif
 			}
@@ -1376,14 +1376,14 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 		for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 			if (bitfield(chanmask, chnum))
 			{
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 				auto reference = output;
 #endif
 				if (m_channel[chnum]->is4op())
 					m_channel[chnum]->output_4op(output, rshift, clipmax);
 				else
 					m_channel[chnum]->output_2op(output, rshift, clipmax);
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 				m_wavfile[chnum].add(output, reference);
 #endif
 			}

--- a/3rdparty/ymfm/src/ymfm_fm.ipp
+++ b/3rdparty/ymfm/src/ymfm_fm.ipp
@@ -1185,6 +1185,7 @@ fm_engine_base<RegisterType>::fm_engine_base(ymfm_interface &intf) :
 	m_irq_mask(STATUS_TIMERA | STATUS_TIMERB),
 	m_irq_state(0),
 	m_timer_running{0,0},
+	m_total_clocks(0),
 	m_active_channels(ALL_CHANNELS),
 	m_modified_channels(ALL_CHANNELS),
 	m_prepare_count(0)
@@ -1199,6 +1200,11 @@ fm_engine_base<RegisterType>::fm_engine_base(ymfm_interface &intf) :
 	// create the operators
 	for (uint32_t opnum = 0; opnum < OPERATORS; opnum++)
 		m_operator[opnum] = std::make_unique<fm_operator<RegisterType>>(*this, RegisterType::operator_offset(opnum));
+
+#if (DEBUG_LOG_WAVFILES)
+	for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
+		m_wavfile[chnum].set_index(chnum);
+#endif
 
 	// do the initial operator assignment
 	assign_operators();
@@ -1327,7 +1333,8 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 	chanmask &= debug::GLOBAL_FM_CHANNEL_MASK;
 
 	// mask out inactive channels
-	chanmask &= m_active_channels;
+	if (!DEBUG_LOG_WAVFILES)
+		chanmask &= m_active_channels;
 
 	// handle the rhythm case, where some of the operators are dedicated
 	// to percussion (this is an OPL-specific feature)
@@ -1345,6 +1352,9 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 		for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 			if (bitfield(chanmask, chnum))
 			{
+#if (DEBUG_LOG_WAVFILES)
+				auto reference = output;
+#endif
 				if (chnum == 6)
 					m_channel[chnum]->output_rhythm_ch6(output, rshift, clipmax);
 				else if (chnum == 7)
@@ -1355,6 +1365,9 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 					m_channel[chnum]->output_4op(output, rshift, clipmax);
 				else
 					m_channel[chnum]->output_2op(output, rshift, clipmax);
+#if (DEBUG_LOG_WAVFILES)
+				m_wavfile[chnum].add(output, reference);
+#endif
 			}
 	}
 	else
@@ -1363,10 +1376,16 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 		for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 			if (bitfield(chanmask, chnum))
 			{
+#if (DEBUG_LOG_WAVFILES)
+				auto reference = output;
+#endif
 				if (m_channel[chnum]->is4op())
 					m_channel[chnum]->output_4op(output, rshift, clipmax);
 				else
 					m_channel[chnum]->output_2op(output, rshift, clipmax);
+#if (DEBUG_LOG_WAVFILES)
+				m_wavfile[chnum].add(output, reference);
+#endif
 			}
 	}
 }

--- a/3rdparty/ymfm/src/ymfm_opl.cpp
+++ b/3rdparty/ymfm/src/ymfm_opl.cpp
@@ -100,6 +100,11 @@ opl_registers_base<Revision>::opl_registers_base() :
 			}
 		}
 	}
+
+	// OPL3/OPL4 have dynamic operators, so initialize the fourop_enable value here
+	// since operator_map() is called right away, prior to reset()
+	if (Revision > 2)
+		m_regdata[0x104 % REGISTERS] = 0;
 }
 
 

--- a/3rdparty/ymfm/src/ymfm_opn.cpp
+++ b/3rdparty/ymfm/src/ymfm_opn.cpp
@@ -205,7 +205,12 @@ int32_t opn_registers_base<IsOpnA>::clock_noise_and_lfo()
 	if (!IsOpnA || !lfo_enable())
 	{
 		m_lfo_counter = 0;
-		m_lfo_am = 0;
+
+		// special case: if LFO is disabled on OPNA, it basically just keeps the counter
+		// at 0; since position 0 gives an AM value of 0x3f, it is important to reflect
+		// that here; for example, MegaDrive Venom plays some notes with LFO globally
+		// disabled but enabling LFO on the operators, and it expects this added attenutation
+		m_lfo_am = IsOpnA ? 0x3f : 0x00;
 		return 0;
 	}
 
@@ -427,10 +432,10 @@ std::string opn_registers_base<IsOpnA>::log_keyon(uint32_t choffs, uint32_t opof
 			ch_output_1(choffs) ? 'R' : '-');
 	if (op_ssg_eg_enable(opoffs))
 		end += sprintf(end, " ssg=%X", op_ssg_eg_mode(opoffs));
-	bool am = (lfo_enable() && op_lfo_am_enable(opoffs) && ch_lfo_am_sens(choffs) != 0);
+	bool am = (op_lfo_am_enable(opoffs) && ch_lfo_am_sens(choffs) != 0);
 	if (am)
 		end += sprintf(end, " am=%u", ch_lfo_am_sens(choffs));
-	bool pm = (lfo_enable() && ch_lfo_pm_sens(choffs) != 0);
+	bool pm = (ch_lfo_pm_sens(choffs) != 0);
 	if (pm)
 		end += sprintf(end, " pm=%u", ch_lfo_pm_sens(choffs));
 	if (am || pm)

--- a/3rdparty/ymfm/src/ymfm_pcm.h
+++ b/3rdparty/ymfm/src/ymfm_pcm.h
@@ -212,8 +212,8 @@ public:
 		uint32_t result = memory_address();
 		uint32_t newval = result + 1;
 		m_regdata[0x05] = newval >> 0;
-		m_regdata[0x06] = newval >> 8;
-		m_regdata[0x07] = (newval >> 16) & 0x3f;
+		m_regdata[0x04] = newval >> 8;
+		m_regdata[0x03] = (newval >> 16) & 0x3f;
 		return result;
 	}
 


### PR DESCRIPTION
Update ymfm library to latest. [Aaron Giles]
* Uninitialized member was causing slight jitter in timing when timer B is used.
* OPNA now has correct attenuation when LFO is disabled.
* PCM address incrementing was incorrect, resulting in some wraparound bugs.
