### PR TITLE
Yamaha DX9 Skeleton Driver

### DIFF
--- a/src/emu/xtal.cpp
+++ b/src/emu/xtal.cpp
@@ -163,6 +163,7 @@ const double XTAL::known_xtals[] = {
 	  9'000'000, /* 9_MHz_XTAL             Homedata PCBs */
 	  9'216'000, /* 9.216_MHz_XTAL         Univac UTS 20 */
 	  9'400'000, /* 9.4_MHz_XTAL           Yamaha MU-5 and TG-100 */
+	  9'426'500, /* 9.4265_MHz_XTAL        Yamaha DX7, and DX9 */
 	  9'600'000, /* 9.6_MHz_XTAL           WD37C65 second clock (for 300 KB/sec rate) */
 	  9'732'000, /* 9.732_MHz_XTAL         CTA Invader */
 	  9'828'000, /* 9.828_MHz_XTAL         Universal PCBs */

--- a/src/mame/layout/dx9.lay
+++ b/src/mame/layout/dx9.lay
@@ -309,36 +309,36 @@ license:CC0
 	<group name="front-panel-buttons-main">
 		<!-- Main buttons -->
 		<element ref="button-text-store"><bounds x="0" y="0" width="72" height="16" /></element>
-		<element ref="button-membrane-red" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x04">
+		<element ref="button-membrane-red" inputtag="KEY_SWITCH_INPUT.0" inputmask="0x04">
 			<bounds x="0" y="16" width="72" height="32" />
 		</element>
 
 		<element ref="button-text-function"><bounds x="80" y="0" width="72" height="16" /></element>
-		<element ref="button-membrane-brown" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x10">
+		<element ref="button-membrane-brown" inputtag="KEY_SWITCH_INPUT.0" inputmask="0x10">
 			<bounds x="80" y="16" width="72" height="32" />
 		</element>
 
 		<element ref="button-text-edit"><bounds x="0" y="64" width="72" height="16" /></element>
-		<element ref="button-membrane-blue" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x20">
+		<element ref="button-membrane-blue" inputtag="KEY_SWITCH_INPUT.0" inputmask="0x20">
 			<bounds x="0" y="80" width="72" height="32" />
 		</element>
 
 		<element ref="button-text-memory"><bounds x="80" y="64" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x40">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.0" inputmask="0x40">
 			<bounds x="80" y="80" width="72" height="32" />
 		</element>
 	</group>
 
 	<group name="front-panel-buttons-up-down">
 		<element ref="button-text-no"><bounds x="0" y="0" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x2">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.0" inputmask="0x2">
 			<bounds x="0" y="16" width="72" height="32" />
 		</element>
 		<element ref="button-text-minus"><bounds x="4" y="22" width="18" height="18" /></element>
 		<element ref="button-text-off"><bounds x="0" y="48" width="72" height="16" /></element>
 
 		<element ref="button-text-yes"><bounds x="80" y="0" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x1">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.0" inputmask="0x1">
 			<bounds x="80" y="16" width="72" height="32" />
 		</element>
 		<element ref="button-text-plus"><bounds x="84" y="22" width="18" height="18" /></element>
@@ -351,7 +351,7 @@ license:CC0
 		<element ref="button-text-operator-copy"><bounds x="0" y="0" width="128" height="16" /></element>
 		<element ref="button-text-separator-blue"><bounds x="0" y="16" width="312" height="1" /></element>
 		<element ref="button-text-operator-1"><bounds x="0" y="16" width="10" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x01">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.1" inputmask="0x01">
 			<bounds x="0" y="32" width="72" height="32" />
 		</element>
 		<element ref="button-number-1"><bounds x="4" y="38" width="10" height="18" /></element>
@@ -360,7 +360,7 @@ license:CC0
 
 		<!-- Button 2 -->
 		<element ref="button-text-operator-2"><bounds x="80" y="16" width="10" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x02">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.1" inputmask="0x02">
 			<bounds x="80" y="32" width="72" height="32" />
 		</element>
 		<element ref="button-number-2"><bounds x="84" y="38" width="10" height="18" /></element>
@@ -368,7 +368,7 @@ license:CC0
 
 		<!-- Button 3 -->
 		<element ref="button-text-operator-3"><bounds x="160" y="16" width="10" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x04">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.1" inputmask="0x04">
 			<bounds x="160" y="32" width="72" height="32" />
 		</element>
 		<element ref="button-number-3"><bounds x="164" y="38" width="10" height="18" /></element>
@@ -377,7 +377,7 @@ license:CC0
 
 		<!-- Button 4 -->
 		<element ref="button-text-operator-4"><bounds x="240" y="16" width="10" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x08">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.1" inputmask="0x08">
 			<bounds x="240" y="32" width="72" height="32" />
 		</element>
 		<element ref="button-number-4"><bounds x="244" y="38" width="10" height="18" /></element>
@@ -388,7 +388,7 @@ license:CC0
 		<!-- Button 5 -->
 		<element ref="button-text-algorithm"><bounds x="320" y="4" width="72" height="16" /></element>
 		<element ref="button-text-feedback"><bounds x="320" y="16" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x10">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.1" inputmask="0x10">
 			<bounds x="320" y="32" width="72" height="32" />
 		</element>
 		<element ref="button-number-5"><bounds x="324" y="38" width="10" height="18" /></element>
@@ -398,14 +398,14 @@ license:CC0
 		<element ref="button-text-lfo"><bounds x="400" y="0" width="72" height="16" /></element>
 		<element ref="button-text-separator-blue"><bounds x="400" y="16" width="312" height="1" /></element>
 		<element ref="button-text-lfo-wave"><bounds x="400" y="16" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x20">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.1" inputmask="0x20">
 			<bounds x="400" y="32" width="72" height="32" />
 		</element>
 		<element ref="button-number-6"><bounds x="404" y="38" width="10" height="18" /></element>
 
 		<!-- Button 7 -->
 		<element ref="button-text-lfo-speed"><bounds x="480" y="16" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x40">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.1" inputmask="0x40">
 			<bounds x="480" y="32" width="72" height="32" />
 		</element>
 		<element ref="button-number-7"><bounds x="484" y="38" width="10" height="18" /></element>
@@ -415,7 +415,7 @@ license:CC0
 
 		<!-- Button 8 -->
 		<element ref="button-text-lfo-delay"><bounds x="560" y="16" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x80">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.1" inputmask="0x80">
 			<bounds x="560" y="32" width="72" height="32" />
 		</element>
 		<element ref="button-number-8"><bounds x="564" y="38" width="10" height="18" /></element>
@@ -423,7 +423,7 @@ license:CC0
 
 		<!-- Button 9 -->
 		<element ref="button-text-lfo-pmd"><bounds x="640" y="16" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x1">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.2" inputmask="0x1">
 			<bounds x="640" y="32" width="72" height="32" />
 		</element>
 		<element ref="button-number-9"><bounds x="644" y="38" width="10" height="18" /></element>
@@ -433,7 +433,7 @@ license:CC0
 		<element ref="button-text-mod-sens"><bounds x="720" y="0" width="72" height="16" /></element>
 		<element ref="button-text-separator-blue"><bounds x="720" y="16" width="72" height="1" /></element>
 		<element ref="button-text-pitch-amp"><bounds x="720" y="16" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x2">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.2" inputmask="0x2">
 			<bounds x="720" y="32" width="72" height="32" />
 		</element>
 		<element ref="button-number-10"><bounds x="724" y="38" width="18" height="18" /></element>
@@ -445,7 +445,7 @@ license:CC0
 		<!-- Button 11 -->
 		<element ref="button-text-operator"><bounds x="0" y="0" width="72" height="16" /></element>
 		<element ref="button-text-select"><bounds x="0" y="12" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x04">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.2" inputmask="0x04">
 			<bounds x="0" y="48" width="72" height="32" />
 		</element>
 		<element ref="button-number-11"><bounds x="4" y="52" width="18" height="18" /></element>
@@ -458,7 +458,7 @@ license:CC0
 		<element ref="button-text-separator-blue"><bounds x="80" y="16" width="230" height="1" /></element>
 		<element ref="button-text-oscillator-frequency"><bounds x="80" y="16" width="72" height="16" /></element>
 		<element ref="button-text-oscillator-coarse"><bounds x="80" y="28" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x08">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.2" inputmask="0x08">
 			<bounds x="80" y="48" width="72" height="32" />
 		</element>
 		<element ref="button-number-12"><bounds x="84" y="52" width="18" height="18" /></element>
@@ -467,7 +467,7 @@ license:CC0
 		<!-- Button 13 -->
 		<element ref="button-text-oscillator-frequency"><bounds x="160" y="16" width="72" height="16" /></element>
 		<element ref="button-text-oscillator-fine"><bounds x="160" y="28" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x10">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.2" inputmask="0x10">
 			<bounds x="160" y="48" width="72" height="32" />
 		</element>
 		<element ref="button-number-13"><bounds x="164" y="52" width="18" height="18" /></element>
@@ -476,7 +476,7 @@ license:CC0
 		<!-- Button 14 -->
 		<element ref="button-text-oscillator-detune"><bounds x="240" y="16" width="72" height="16" /></element>
 		<element ref="button-text-oscillator-sync"><bounds x="240" y="28" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x20">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.2" inputmask="0x20">
 			<bounds x="240" y="48" width="72" height="32" />
 		</element>
 		<element ref="button-number-14"><bounds x="244" y="52" width="18" height="18" /></element>
@@ -486,7 +486,7 @@ license:CC0
 		<element ref="button-text-eg"><bounds x="320" y="0" width="72" height="16" /></element>
 		<element ref="button-text-separator-blue"><bounds x="320" y="16" width="152" height="1" /></element>
 		<element ref="button-text-rate"><bounds x="320" y="28" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x40">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.2" inputmask="0x40">
 			<bounds x="320" y="48" width="72" height="32" />
 		</element>
 		<element ref="button-number-15"><bounds x="324" y="52" width="18" height="18" /></element>
@@ -496,7 +496,7 @@ license:CC0
 
 		<!-- Button 16 -->
 		<element ref="button-text-level"><bounds x="400" y="28" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x80">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.2" inputmask="0x80">
 			<bounds x="400" y="48" width="72" height="32" />
 		</element>
 		<element ref="button-number-16"><bounds x="404" y="52" width="18" height="18" /></element>
@@ -506,7 +506,7 @@ license:CC0
 		<element ref="button-text-scaling"><bounds x="480" y="0" width="150" height="16" /></element>
 		<element ref="button-text-separator-blue"><bounds x="480" y="16" width="152" height="1" /></element>
 		<element ref="button-text-rate"><bounds x="480" y="28" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_3" inputmask="0x02">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.3" inputmask="0x02">
 			<bounds x="480" y="48" width="72" height="32" />
 		</element>
 		<element ref="button-number-17"><bounds x="484" y="52" width="18" height="18" /></element>
@@ -514,7 +514,7 @@ license:CC0
 
 		<!-- Button 18 -->
 		<element ref="button-text-level"><bounds x="560" y="28" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_3" inputmask="0x04">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.3" inputmask="0x04">
 			<bounds x="560" y="48" width="72" height="32" />
 		</element>
 		<element ref="button-number-18"><bounds x="564" y="52" width="18" height="18" /></element>
@@ -525,7 +525,7 @@ license:CC0
 		<element ref="button-text-separator-blue"><bounds x="640" y="16" width="72" height="1" /></element>
 		<element ref="button-text-output"><bounds x="640" y="16" width="72" height="16" /></element>
 		<element ref="button-text-level"><bounds x="640" y="28" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_3" inputmask="0x08">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.3" inputmask="0x08">
 			<bounds x="640" y="48" width="72" height="32" />
 		</element>
 		<element ref="button-number-19"><bounds x="644" y="52" width="18" height="18" /></element>
@@ -535,7 +535,7 @@ license:CC0
 		<!-- Button 20 -->
 		<element ref="button-text-key"><bounds x="720" y="16" width="72" height="16" /></element>
 		<element ref="button-text-transpose"><bounds x="720" y="28" width="72" height="16" /></element>
-		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_3" inputmask="0x10">
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT.3" inputmask="0x10">
 			<bounds x="720" y="48" width="72" height="32" />
 		</element>
 		<element ref="button-number-20"><bounds x="724" y="52" width="18" height="18" /></element>

--- a/src/mame/layout/dx9.lay
+++ b/src/mame/layout/dx9.lay
@@ -345,7 +345,7 @@ license:CC0
 		<element ref="button-text-on"><bounds x="80" y="48" width="72" height="16" /></element>
 	</group>
 
-		<!-- Numeric Buttons Row 1 -->
+	<!-- Numeric Buttons Row 1 -->
 	<group name="front-panel-buttons-numeric-row-1">
 		<!-- Button 1 -->
 		<element ref="button-text-operator-copy"><bounds x="0" y="0" width="128" height="16" /></element>

--- a/src/mame/layout/dx9.lay
+++ b/src/mame/layout/dx9.lay
@@ -1,0 +1,590 @@
+<?xml version="1.0"?>
+<!--
+license:CC0
+-->
+<mamelayout version="2">
+	<element name="background">
+		<rect>
+			<color red="0.12" green="0.10" blue="0.05" />
+		</rect>
+	</element>
+
+	<element name="inset-background">
+		<rect><color red="0.05" green="0.05" blue="0.05" /></rect>
+	</element>
+
+	<element name="led" defstate="0">
+		<led7seg><color red="1.0" green="0.0" blue="0.0" /></led7seg>
+	</element>
+
+	<element name="button-text-separator-blue">
+		<rect><color red="0.13" green="0.65" blue="0.9" /></rect>
+	</element>
+
+	<element name="button-text-separator-brown">
+		<rect><color red="0.72" green="0.48" blue="0.33" /></rect>
+	</element>
+
+	<element name="button-membrane-green" defstate="0">
+		<rect state="0"><color red="0" green="0.8" blue="0.75" /></rect>
+		<rect state="1"><color red="0" green="0.7" blue="0.6" /></rect>
+	</element>
+
+	<element name="button-membrane-red" defstate="0">
+		<rect><color red="1.0" green="0" blue="0" /></rect>
+	</element>
+
+	<element name="button-membrane-blue" defstate="0">
+		<rect><color red="0.13" green="0.65" blue="0.9" /></rect>
+	</element>
+
+	<element name="button-membrane-brown" defstate="0">
+		<rect><color red="0.72" green="0.48" blue="0.33" /></rect>
+	</element>
+
+	<!-- Main Button Labels -->
+	<element name="button-text-store"><text align="1" string="STORE" /></element>
+	<element name="button-text-function"><text align="1" string="FUNCTION" /></element>
+	<element name="button-text-edit"><text align="1" string="EDIT / COMPARE" /></element>
+	<element name="button-text-memory"><text align="1" string="MEMORY SELECT" /></element>
+	
+	<!-- Up/Down Yes/No Button Labels -->
+	<element name="button-text-no"><text align="1" string="NO" /></element>
+	<element name="button-text-off"><text align="1" string="OFF" /></element>
+	<element name="button-text-yes"><text align="1" string="YES" /></element>
+	<element name="button-text-on"><text align="1" string="ON" /></element>
+	<element name="button-text-plus"><text align="1" string="+1" /></element>
+	<element name="button-text-minus"><text align="1" string="-1" /></element>
+
+	<!-- Numeric Button Label Numbers -->
+	<element name="button-number-1"><text align="1" string="1" /></element>
+	<element name="button-number-2"><text align="1" string="2" /></element>
+	<element name="button-number-3"><text align="1" string="3" /></element>
+	<element name="button-number-4"><text align="1" string="4" /></element>
+	<element name="button-number-5"><text align="1" string="5" /></element>
+	<element name="button-number-6"><text align="1" string="6" /></element>
+	<element name="button-number-7"><text align="1" string="7" /></element>
+	<element name="button-number-8"><text align="1" string="8" /></element>
+	<element name="button-number-9"><text align="1" string="9" /></element>
+	<element name="button-number-10"><text align="1" string="10" /></element>
+	<element name="button-number-11"><text align="1" string="11" /></element>
+	<element name="button-number-12"><text align="1" string="12" /></element>
+	<element name="button-number-13"><text align="1" string="13" /></element>
+	<element name="button-number-14"><text align="1" string="14" /></element>
+	<element name="button-number-15"><text align="1" string="15" /></element>
+	<element name="button-number-16"><text align="1" string="16" /></element>
+	<element name="button-number-17"><text align="1" string="17" /></element>
+	<element name="button-number-18"><text align="1" string="18" /></element>
+	<element name="button-number-19"><text align="1" string="19" /></element>
+	<element name="button-number-20"><text align="1" string="20" /></element>
+
+	<!-- Button Labels Row 1 Top -->
+	<element name="button-text-operator-copy">
+		<text align="1" string="OPERATOR ON-OFF/EG COPY">
+			<color red="0.13" green="0.65" blue="0.9" />
+		</text>
+	</element>
+
+	<element name="button-text-operator-1">
+		<text align="1" string="1"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-operator-2">
+		<text align="1" string="2"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-operator-3">
+		<text align="1" string="3"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-operator-4">
+		<text align="1" string="4"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-algorithm">
+		<text align="1" string="ALGORITHM"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-feedback">
+		<text align="1" string="/FEEDBACK"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-lfo">
+		<text align="1" string="LFO"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-lfo-wave">
+		<text align="1" string="WAVE"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-lfo-speed">
+		<text align="1" string="SPEED"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-lfo-delay">
+		<text align="1" string="DELAY"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-lfo-pmd">
+		<text align="1" string="PMD/AMD"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-mod-sens">
+		<text align="1" string="MOD SENS"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-pitch-amp">
+		<text align="1" string="PITCH/AMP"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<!-- Button Labels Row 1 Bottom -->
+	<element name="button-text-master">
+		<text align="1" string="MASTER"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-tune-adj">
+		<text align="1" string="TUNE ADJ"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-poly">
+		<text align="1" string="POLY/MONO"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-pitch-bend">
+		<text align="1" string="PITCH BEND"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-pitch-bend-range">
+		<text align="1" string="RANGE"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-portamento">
+		<text align="1" string="PORTAMENTO"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-portamento-mode">
+		<text align="1" string="MODE"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-portamento-time">
+		<text align="1" string="TIME"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-cassette">
+		<text align="1" string="CASSETTE"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-cassette-save">
+		<text align="1" string="SAVE/VERIFY"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-cassette-load">
+		<text align="1" string="LOAD"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-cassette-load-single">
+		<text align="1" string="LOAD SINGLE"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-cassette-remote">
+		<text align="1" string="REMOTE"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<!-- Labels Row 2 Top -->
+	<element name="button-text-operator">
+		<text align="1" string="OPERATOR"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+	<element name="button-text-select">
+		<text align="1" string="SELECT"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+	
+	<element name="button-text-oscillator">
+		<text align="1" string="OSCILLATOR"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-oscillator-frequency">
+		<text align="1" string="FREQUENCY"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-oscillator-coarse">
+		<text align="1" string="COARSE"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-oscillator-fine">
+		<text align="1" string="FINE"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-oscillator-detune">
+		<text align="1" string="DETUNE"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-oscillator-sync">
+		<text align="1" string="SYNC"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-eg">
+		<text align="1" string="EG"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-rate">
+		<text align="1" string="RATE"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-level">
+		<text align="1" string="LEVEL"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-scaling">
+		<text align="1" string="KEYBOARD SCALING"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-output">
+		<text align="1" string="OUTPUT"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-key">
+		<text align="1" string="KEY"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<element name="button-text-transpose">
+		<text align="1" string="TRANSPOSE"><color red="0.13" green="0.65" blue="0.9" /></text>
+	</element>
+
+	<!-- Button Labels Row 2 Bottom -->
+	<element name="button-text-modulation-wheel">
+		<text align="1" string="MODULATION WHEEL"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-modulation-range">
+		<text align="1" string="RANGE"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-modulation-pitch">
+		<text align="1" string="PITCH"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-modulation-amplitude">
+		<text align="1" string="AMPLITUDE"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-modulation-bias">
+		<text align="1" string="EG BIAS"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-breath-control">
+		<text align="1" string="BREATH CONTROL"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-edit-recall">
+		<text align="1" string="EDIT RECALL"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-voice-init">
+		<text align="1" string="/ VOICE INIT"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-memory-protect">
+		<text align="1" string="MEMORY"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<element name="button-text-protect">
+		<text align="1" string="PROTECT"><color red="0.72" green="0.48" blue="0.33" /></text>
+	</element>
+
+	<group name="group-screen-inset">
+		<element ref="inset-background">
+			<bounds x="0" y="0" width="400" height="80" />
+		</element>
+		<screen index="0">
+			<bounds x="172" y="20" width="160" height="40" />
+		</screen>
+		<element ref="led" name="led_0">
+			<bounds x="48" y="20" width="32" height="40" />
+		</element>
+		<element ref="led" name="led_1">
+			<bounds x="80" y="20" width="32" height="40" />
+		</element>
+	</group>
+
+	<group name="front-panel-buttons-main">
+		<!-- Main buttons -->
+		<element ref="button-text-store"><bounds x="0" y="0" width="72" height="16" /></element>
+		<element ref="button-membrane-red" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x04">
+			<bounds x="0" y="16" width="72" height="32" />
+		</element>
+
+		<element ref="button-text-function"><bounds x="80" y="0" width="72" height="16" /></element>
+		<element ref="button-membrane-brown" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x10">
+			<bounds x="80" y="16" width="72" height="32" />
+		</element>
+
+		<element ref="button-text-edit"><bounds x="0" y="64" width="72" height="16" /></element>
+		<element ref="button-membrane-blue" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x20">
+			<bounds x="0" y="80" width="72" height="32" />
+		</element>
+
+		<element ref="button-text-memory"><bounds x="80" y="64" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x40">
+			<bounds x="80" y="80" width="72" height="32" />
+		</element>
+	</group>
+
+	<group name="front-panel-buttons-up-down">
+		<element ref="button-text-no"><bounds x="0" y="0" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x2">
+			<bounds x="0" y="16" width="72" height="32" />
+		</element>
+		<element ref="button-text-minus"><bounds x="4" y="22" width="18" height="18" /></element>
+		<element ref="button-text-off"><bounds x="0" y="48" width="72" height="16" /></element>
+
+		<element ref="button-text-yes"><bounds x="80" y="0" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_0" inputmask="0x1">
+			<bounds x="80" y="16" width="72" height="32" />
+		</element>
+		<element ref="button-text-plus"><bounds x="84" y="22" width="18" height="18" /></element>
+		<element ref="button-text-on"><bounds x="80" y="48" width="72" height="16" /></element>
+	</group>
+
+		<!-- Numeric Buttons Row 1 -->
+	<group name="front-panel-buttons-numeric-row-1">
+		<!-- Button 1 -->
+		<element ref="button-text-operator-copy"><bounds x="0" y="0" width="128" height="16" /></element>
+		<element ref="button-text-separator-blue"><bounds x="0" y="16" width="312" height="1" /></element>
+		<element ref="button-text-operator-1"><bounds x="0" y="16" width="10" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x01">
+			<bounds x="0" y="32" width="72" height="32" />
+		</element>
+		<element ref="button-number-1"><bounds x="4" y="38" width="10" height="18" /></element>
+		<element ref="button-text-master"><bounds x="0" y="64" width="72" height="16" /></element>
+		<element ref="button-text-tune-adj"><bounds x="0" y="76" width="72" height="16" /></element>
+
+		<!-- Button 2 -->
+		<element ref="button-text-operator-2"><bounds x="80" y="16" width="10" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x02">
+			<bounds x="80" y="32" width="72" height="32" />
+		</element>
+		<element ref="button-number-2"><bounds x="84" y="38" width="10" height="18" /></element>
+		<element ref="button-text-poly"><bounds x="80" y="64" width="72" height="16" /></element>
+
+		<!-- Button 3 -->
+		<element ref="button-text-operator-3"><bounds x="160" y="16" width="10" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x04">
+			<bounds x="160" y="32" width="72" height="32" />
+		</element>
+		<element ref="button-number-3"><bounds x="164" y="38" width="10" height="18" /></element>
+		<element ref="button-text-pitch-bend"><bounds x="160" y="64" width="72" height="16" /></element>
+		<element ref="button-text-pitch-bend-range"><bounds x="160" y="76" width="72" height="16" /></element>
+
+		<!-- Button 4 -->
+		<element ref="button-text-operator-4"><bounds x="240" y="16" width="10" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x08">
+			<bounds x="240" y="32" width="72" height="32" />
+		</element>
+		<element ref="button-number-4"><bounds x="244" y="38" width="10" height="18" /></element>
+		<element ref="button-text-portamento-mode"><bounds x="240" y="64" width="72" height="16" /></element>
+		<element ref="button-text-separator-brown"><bounds x="240" y="80" width="152" height="1" /></element>
+		<element ref="button-text-portamento"><bounds x="240" y="80" width="72" height="16" /></element>
+
+		<!-- Button 5 -->
+		<element ref="button-text-algorithm"><bounds x="320" y="4" width="72" height="16" /></element>
+		<element ref="button-text-feedback"><bounds x="320" y="16" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x10">
+			<bounds x="320" y="32" width="72" height="32" />
+		</element>
+		<element ref="button-number-5"><bounds x="324" y="38" width="10" height="18" /></element>
+		<element ref="button-text-portamento-time"><bounds x="320" y="64" width="72" height="16" /></element>
+
+		<!-- Button 6 -->
+		<element ref="button-text-lfo"><bounds x="400" y="0" width="72" height="16" /></element>
+		<element ref="button-text-separator-blue"><bounds x="400" y="16" width="312" height="1" /></element>
+		<element ref="button-text-lfo-wave"><bounds x="400" y="16" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x20">
+			<bounds x="400" y="32" width="72" height="32" />
+		</element>
+		<element ref="button-number-6"><bounds x="404" y="38" width="10" height="18" /></element>
+
+		<!-- Button 7 -->
+		<element ref="button-text-lfo-speed"><bounds x="480" y="16" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x40">
+			<bounds x="480" y="32" width="72" height="32" />
+		</element>
+		<element ref="button-number-7"><bounds x="484" y="38" width="10" height="18" /></element>
+		<element ref="button-text-cassette-save"><bounds x="480" y="64" width="72" height="16" /></element>
+		<element ref="button-text-separator-brown"><bounds x="480" y="80" width="312" height="1" /></element>
+		<element ref="button-text-cassette"><bounds x="480" y="80" width="72" height="16" /></element>
+
+		<!-- Button 8 -->
+		<element ref="button-text-lfo-delay"><bounds x="560" y="16" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_1" inputmask="0x80">
+			<bounds x="560" y="32" width="72" height="32" />
+		</element>
+		<element ref="button-number-8"><bounds x="564" y="38" width="10" height="18" /></element>
+		<element ref="button-text-cassette-load"><bounds x="560" y="64" width="72" height="16" /></element>
+
+		<!-- Button 9 -->
+		<element ref="button-text-lfo-pmd"><bounds x="640" y="16" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x1">
+			<bounds x="640" y="32" width="72" height="32" />
+		</element>
+		<element ref="button-number-9"><bounds x="644" y="38" width="10" height="18" /></element>
+		<element ref="button-text-cassette-load-single"><bounds x="640" y="64" width="72" height="16" /></element>
+
+		<!-- Button 10 -->
+		<element ref="button-text-mod-sens"><bounds x="720" y="0" width="72" height="16" /></element>
+		<element ref="button-text-separator-blue"><bounds x="720" y="16" width="72" height="1" /></element>
+		<element ref="button-text-pitch-amp"><bounds x="720" y="16" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x2">
+			<bounds x="720" y="32" width="72" height="32" />
+		</element>
+		<element ref="button-number-10"><bounds x="724" y="38" width="18" height="18" /></element>
+		<element ref="button-text-cassette-remote"><bounds x="720" y="64" width="72" height="16" /></element>
+	</group>
+
+	<!-- Numeric Buttons Row 2 -->
+	<group name="front-panel-buttons-numeric-row-2">
+		<!-- Button 11 -->
+		<element ref="button-text-operator"><bounds x="0" y="0" width="72" height="16" /></element>
+		<element ref="button-text-select"><bounds x="0" y="12" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x04">
+			<bounds x="0" y="48" width="72" height="32" />
+		</element>
+		<element ref="button-number-11"><bounds x="4" y="52" width="18" height="18" /></element>
+		<element ref="button-text-modulation-range"><bounds x="0" y="80" width="72" height="16" /></element>
+		<element ref="button-text-separator-brown"><bounds x="0" y="96" width="312" height="1" /></element>
+		<element ref="button-text-modulation-wheel"><bounds x="0" y="96" width="150" height="16" /></element>
+
+		<!-- Button 12 -->
+		<element ref="button-text-oscillator"><bounds x="80" y="0" width="72" height="16" /></element>
+		<element ref="button-text-separator-blue"><bounds x="80" y="16" width="230" height="1" /></element>
+		<element ref="button-text-oscillator-frequency"><bounds x="80" y="16" width="72" height="16" /></element>
+		<element ref="button-text-oscillator-coarse"><bounds x="80" y="28" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x08">
+			<bounds x="80" y="48" width="72" height="32" />
+		</element>
+		<element ref="button-number-12"><bounds x="84" y="52" width="18" height="18" /></element>
+		<element ref="button-text-modulation-pitch"><bounds x="80" y="80" width="72" height="16" /></element>
+
+		<!-- Button 13 -->
+		<element ref="button-text-oscillator-frequency"><bounds x="160" y="16" width="72" height="16" /></element>
+		<element ref="button-text-oscillator-fine"><bounds x="160" y="28" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x10">
+			<bounds x="160" y="48" width="72" height="32" />
+		</element>
+		<element ref="button-number-13"><bounds x="164" y="52" width="18" height="18" /></element>
+		<element ref="button-text-modulation-amplitude"><bounds x="160" y="80" width="72" height="16" /></element>
+
+		<!-- Button 14 -->
+		<element ref="button-text-oscillator-detune"><bounds x="240" y="16" width="72" height="16" /></element>
+		<element ref="button-text-oscillator-sync"><bounds x="240" y="28" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x20">
+			<bounds x="240" y="48" width="72" height="32" />
+		</element>
+		<element ref="button-number-14"><bounds x="244" y="52" width="18" height="18" /></element>
+		<element ref="button-text-modulation-bias"><bounds x="240" y="80" width="72" height="16" /></element>
+
+		<!-- Button 15 -->
+		<element ref="button-text-eg"><bounds x="320" y="0" width="72" height="16" /></element>
+		<element ref="button-text-separator-blue"><bounds x="320" y="16" width="152" height="1" /></element>
+		<element ref="button-text-rate"><bounds x="320" y="28" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x40">
+			<bounds x="320" y="48" width="72" height="32" />
+		</element>
+		<element ref="button-number-15"><bounds x="324" y="52" width="18" height="18" /></element>
+		<element ref="button-text-modulation-range"><bounds x="320" y="80" width="72" height="16" /></element>
+		<element ref="button-text-separator-brown"><bounds x="320" y="96" width="312" height="1" /></element>
+		<element ref="button-text-breath-control"><bounds x="320" y="96" width="150" height="16" /></element>
+
+		<!-- Button 16 -->
+		<element ref="button-text-level"><bounds x="400" y="28" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_2" inputmask="0x80">
+			<bounds x="400" y="48" width="72" height="32" />
+		</element>
+		<element ref="button-number-16"><bounds x="404" y="52" width="18" height="18" /></element>
+		<element ref="button-text-modulation-pitch"><bounds x="400" y="80" width="72" height="16" /></element>
+
+		<!-- Button 17 -->
+		<element ref="button-text-scaling"><bounds x="480" y="0" width="150" height="16" /></element>
+		<element ref="button-text-separator-blue"><bounds x="480" y="16" width="152" height="1" /></element>
+		<element ref="button-text-rate"><bounds x="480" y="28" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_3" inputmask="0x02">
+			<bounds x="480" y="48" width="72" height="32" />
+		</element>
+		<element ref="button-number-17"><bounds x="484" y="52" width="18" height="18" /></element>
+		<element ref="button-text-modulation-amplitude"><bounds x="480" y="80" width="72" height="16" /></element>
+
+		<!-- Button 18 -->
+		<element ref="button-text-level"><bounds x="560" y="28" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_3" inputmask="0x04">
+			<bounds x="560" y="48" width="72" height="32" />
+		</element>
+		<element ref="button-number-18"><bounds x="564" y="52" width="18" height="18" /></element>
+		<element ref="button-text-modulation-bias"><bounds x="560" y="80" width="72" height="16" /></element>
+
+		<!-- Button 19 -->
+		<element ref="button-text-operator"><bounds x="640" y="0" width="72" height="16" /></element>
+		<element ref="button-text-separator-blue"><bounds x="640" y="16" width="72" height="1" /></element>
+		<element ref="button-text-output"><bounds x="640" y="16" width="72" height="16" /></element>
+		<element ref="button-text-level"><bounds x="640" y="28" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_3" inputmask="0x08">
+			<bounds x="640" y="48" width="72" height="32" />
+		</element>
+		<element ref="button-number-19"><bounds x="644" y="52" width="18" height="18" /></element>
+		<element ref="button-text-edit-recall"><bounds x="640" y="80" width="72" height="16" /></element>
+		<element ref="button-text-voice-init"><bounds x="640" y="92" width="72" height="16" /></element>
+
+		<!-- Button 20 -->
+		<element ref="button-text-key"><bounds x="720" y="16" width="72" height="16" /></element>
+		<element ref="button-text-transpose"><bounds x="720" y="28" width="72" height="16" /></element>
+		<element ref="button-membrane-green" inputtag="KEY_SWITCH_INPUT_DRIVER_LINE_3" inputmask="0x10">
+			<bounds x="720" y="48" width="72" height="32" />
+		</element>
+		<element ref="button-number-20"><bounds x="724" y="52" width="18" height="18" /></element>
+		<element ref="button-text-memory-protect"><bounds x="720" y="80" width="72" height="16" /></element>
+		<element ref="button-text-protect"><bounds x="720" y="92" width="72" height="16" /></element>
+	</group>
+
+	<element name="logo-yamaha">
+		<text align="1" string="YAMAHA DX9" />
+	</element>
+	<element name="logo-digital">
+		<text align="1" string="DIGITAL PROGRAMMABLE ALGORITHM SYNTHESIZER" />
+	</element>
+
+	<group name="group-interface">
+		<group ref="group-screen-inset">
+			<bounds x="368" y="24" width="400" height="80" />
+		</group>
+	
+		<group ref="front-panel-buttons-main">
+			<bounds x="168" y="0" width="152" height="112" />
+		</group>
+
+		<group ref="front-panel-buttons-up-down">
+			<bounds x="0" y="64" width="152" height="64" />
+		</group>
+
+		<group ref="front-panel-buttons-numeric-row-1">
+			<bounds x="0" y="192" width="792" height="96" />
+		</group>
+
+		<group ref="front-panel-buttons-numeric-row-2">
+			<bounds x="0" y="320" width="792" height="112" />
+		</group>
+	</group>
+
+	<view name="Standard">
+		<element ref="background">
+			<bounds x="0" y="0" width="824" height="520" />
+		</element>
+		<element ref="logo-yamaha">
+			<bounds x="16" y="16" width="128" height="32" />
+		</element>
+		<element ref="logo-digital">
+			<bounds x="16" y="48" width="256" height="16"/>
+		</element>
+
+		<group ref="group-interface">
+			<bounds x="16" y="72" width="792" height="432"/>
+		</group>
+	</view>
+</mamelayout>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -44589,6 +44589,9 @@ yiear2                          // GX407 (c) 1985
 @source:yamaha/yman1x.cpp
 an1x                            //
 
+@source:yamaha/ymdx9.cpp
+dx9                             //
+
 @source:yamaha/ymdx100.cpp
 dx100                           //
 

--- a/src/mame/mess.flt
+++ b/src/mame/mess.flt
@@ -1262,6 +1262,7 @@ yamaha/fb01.cpp
 yamaha/tg100.cpp
 yamaha/yman1x.cpp
 yamaha/ymdx100.cpp
+yamaha/ymdx9.cpp
 yamaha/ymdx11.cpp
 yamaha/ymmu100.cpp
 yamaha/ymmu5.cpp

--- a/src/mame/yamaha/ymdx9.cpp
+++ b/src/mame/yamaha/ymdx9.cpp
@@ -106,7 +106,7 @@ private:
 	 * Input line 3 covers the numeric front-panel switches 17 though 20, as well as the
 	 * modulation pedal inputs: The Portamento, and Sustain pedals are mapped to 
 	 * bits 6, and 7 respectively.
-	 * Note: Input line 4 covers the keyboard circuit, which is not implemented here.
+	 * Note: Input lines 4-15 are used to map the keyboard, which is not implemented here.
 	 * When the keyboard state is read, the default value of 0 will be returned.
 	 * @param offset The offset into the memory mapped region being read.
 	 * @return uint8_t The value read from the bus.

--- a/src/mame/yamaha/ymdx9.cpp
+++ b/src/mame/yamaha/ymdx9.cpp
@@ -1,0 +1,449 @@
+// license:BSD-3-Clause
+// copyright-holders:ajxs
+/*******************************************************************************
+
+    Skeleton driver for the Yamaha DX9 FM synthesizer.
+    There is currently no MAME emulation of the OPS/EGS chips, so emulating
+    the synth's tone generation functionality is not possible.
+    The cassette interface is currently not emulated.
+    While there are rumours that an updated firmware ROM exists, this driver
+    is set up to work with the only one that is widely available.
+
+*******************************************************************************/
+
+#include "emu.h"
+
+#include "bus/midi/midi.h"
+#include "cpu/m6800/m6801.h"
+#include "machine/adc0808.h"
+#include "machine/clock.h"
+#include "machine/nvram.h"
+#include "video/hd44780.h"
+
+#include "emupal.h"
+#include "screen.h"
+
+#include "dx9.lh"
+
+
+namespace {
+
+class yamaha_dx9_state : public driver_device
+{
+public:
+	yamaha_dx9_state(const machine_config &mconfig, device_type type, const char *tag)
+			: driver_device(mconfig, type, tag),
+			m_maincpu(*this, "maincpu"),
+			m_adc(*this, "adc"),
+			m_leds(*this, "led_%u", 0U),
+			m_key_switch_input_driver_line_0(*this, "KEY_SWITCH_INPUT_DRIVER_LINE_0"),
+			m_key_switch_input_driver_line_1(*this, "KEY_SWITCH_INPUT_DRIVER_LINE_1"),
+			m_key_switch_input_driver_line_2(*this, "KEY_SWITCH_INPUT_DRIVER_LINE_2"),
+			m_key_switch_input_driver_line_3(*this, "KEY_SWITCH_INPUT_DRIVER_LINE_3")
+	{
+	}
+
+	void dx9(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+
+private:
+	/**
+	 * @brief The 63B03RP microcontroller instance.
+	 * Also refer to: https://docs.mamedev.org/techspecs/object_finders.html
+	 */
+	required_device<hd6303r_cpu_device> m_maincpu;
+	required_device<adc0808_device> m_adc;
+	output_finder<2> m_leds;
+	// These ioport instances are used to communicate with the interface in the layout.
+	// They emulate the circuits wired to the 'Key/Switch Scan Driver'.
+	required_ioport m_key_switch_input_driver_line_0;
+	required_ioport m_key_switch_input_driver_line_1;
+	required_ioport m_key_switch_input_driver_line_2;
+	required_ioport m_key_switch_input_driver_line_3;
+
+	/**
+	 * @brief Which input line on the keyboard/switch scan driver is currently selected.
+	 * This driver is used to read the analog switch values from the synth's keyboard, and 
+	 * front-panel switches.
+	 * TODO: I'm currently not sure of the actual implementation of this circuit. This
+	 * implementation is based off the *very* limited description in the service manual, and
+	 * the behaviour that's shown in the firmware.
+	 */
+	uint8_t m_key_switch_scan_driver_select = 0;
+
+	int m_rx_data;
+
+	/** The polarity of the cassette interface's output line. */
+	bool m_cassette_interface_output_polarity = 0;
+
+	/** The polarity of the cassette interface's remote line. */
+	bool m_cassette_interface_remote_polarity = 0;
+
+	/**
+	* @brief LCD pixel update function.
+	* The `HD44780_PIXEL_UPDATE` macro expands the definition to include the correct
+	* parameters for the LCD update function.
+	* Refer to: `src/devices/video/hd44780.h` for the full definition format.
+	*/
+	HD44780_PIXEL_UPDATE(lcd_pixel_update);
+
+	/**
+	* @brief Handles a write to the synth's OPS chip registers.
+	* This chip is currently not emulated, however this function is useful for debugging.
+	* @param offset The offset into the memory mapped region being written.
+	* @param data The data being written.
+	*/
+	void ops_w(offs_t offset, uint8_t data);
+
+	/**
+	* @brief Handles a write to the synth's EGS chip registers.
+	* This chip is currently not emulated, however this function is useful for debugging.
+	* @param offset The offset into the memory mapped region being written.
+	* @param data The data being written.
+	*/
+	void egs_w(offs_t offset, uint8_t data);
+
+	/**
+	 * @brief Handles a read from the keyboard/switch scan driver.
+	 * This multiplexing driver circuit is used to read the states of the synth's front-panel
+	 * switches, and keyboard. The driver's input is wired to the CPU's IO port 1, and the 
+	 * output is wired into the address map.
+	 * Refer to the comments inside the function for the driver's internal mapping.
+	 * @param offset The offset into the memory mapped region being read.
+	 * @return uint8_t The value read from the bus.
+	 */
+	uint8_t key_switch_scan_driver_r(offs_t offset);
+
+	/**
+	* @brief Handles a write to the 7-segment LED memory mapped region.
+	* This function is responsible for setting the two 7-segment LEDs set in the
+	* device's layout file.
+	* @param offset The offset into the memory mapped region being written.
+	* @param data The data being written.
+	*/
+	void led_w(offs_t offset, uint8_t data);
+
+	void palette_init(palette_device &palette);
+
+	void mem_map(address_map &map);
+
+	WRITE_LINE_MEMBER(midi_r) { m_rx_data = state; }
+
+	WRITE_LINE_MEMBER(midiclock_w) { if (state) m_maincpu->m6801_clock_serial(); }
+
+	/**
+	 * @brief Handle a write to the synth's IO Port 1.
+	 * IO Port 1 is mapped as follows:
+	 *  Bit 0: Keyboard/Switch Scan Driver Input.
+	 *  Bit 1: "".
+	 *  Bit 2: "".
+	 *  Bit 3: "".
+	 *  Bit 4: ADC EOC Input Line.
+	 *  Bit 5: Cassette Interface Remote Port.
+	 *  Bit 6: Cassette Interface Tape Output.
+	 *  Bit 7: Cassette Interface Tape Input.
+	 * @param offset The offset into the memory mapped region being written.
+	 * @param data The data being written.
+	 */
+	void p1_w(offs_t offset, uint8_t data);
+
+	/**
+	 * @brief Handle a read from the synth's IO Port 1.
+	 * @param offset The offset into the memory mapped region being read.
+	 * @return uint8_t The value read from the port.
+	 */
+	uint8_t p1_r(offs_t offset);
+
+	void unmapped_w(offs_t address, uint8_t data);
+
+	uint8_t unmapped_r(offs_t offset);
+};
+
+
+/**
+* yamaha_dx9_state::machine_start
+*/
+void yamaha_dx9_state::machine_start()
+{
+	m_leds.resolve();
+	m_rx_data = ASSERT_LINE;
+}
+
+
+/**
+ * yamaha_dx9_state::lcd_pixel_update
+ */
+HD44780_PIXEL_UPDATE(yamaha_dx9_state::lcd_pixel_update)
+{
+	if (x < 5 && y < 8 && line < 2 && pos < 16)
+			bitmap.pix(line * 10 + y + 1 + ((y == 7) ? 1 : 0), pos * 6 + x + 1) = state ? 1 : 2;
+}
+
+
+/**
+ * yamaha_dx9_state::palette_init
+ */
+void yamaha_dx9_state::palette_init(palette_device &palette)
+{
+	palette.set_pen_color(0, rgb_t(0x87, 0xAD, 0x34)); // background
+	palette.set_pen_color(1, rgb_t(0x0, 0x0, 0x0)); // lcd pixel on
+	palette.set_pen_color(2, rgb_t(0x7D, 0x9F, 0x32)); // lcd pixel off
+}
+
+
+/**
+ * yamaha_dx9_state::mem_map
+ */
+void yamaha_dx9_state::mem_map(address_map &map)
+{
+	// Internal CPU registers.
+	map(0x0000, 0x001f).m(m_maincpu, FUNC(hd6303r_cpu_device::m6801_io));
+
+	map(0x20, 0x20).r(FUNC(yamaha_dx9_state::key_switch_scan_driver_r));
+
+	map(0x22, 0x22).r("adc", FUNC(m58990_device::data_r));
+	map(0x24, 0x24).w("adc", FUNC(m58990_device::address_data_start_w));
+
+	// YM21280 OPS.
+	map(0x26, 0x27).w(FUNC(yamaha_dx9_state::ops_w));
+	// HD44780 LCD Controller.
+	map(0x0028, 0x0029).rw("lcdc", FUNC(hd44780_device::read), FUNC(hd44780_device::write));
+	// LED.
+	map(0x2B, 0x2C).w(FUNC(yamaha_dx9_state::led_w));
+
+	// Internal RAM.
+	map(0x0040, 0x00ff).ram();
+
+	// External RAM.
+	// 2 * 2kb RAM1 IC19 M5M118P.
+	map(0x0800, 0x0fff).ram().share("ram1");
+	map(0x1000, 0x1800).ram().share("ram2");
+
+	// YM21290 EGS
+	map(0x1800, 0x18F3).w(FUNC(yamaha_dx9_state::egs_w));
+
+	// ROM.
+	map(0xc000, 0xffff).rom().region("program", 0);
+}
+
+
+/**
+ * yamaha_dx9_state::dx9
+ */
+void yamaha_dx9_state::dx9(machine_config &config)
+{
+	// Initialise the HD63B03RP CPU.
+	// This oscillator frequency comes from the service manual.
+	HD6303R(config, m_maincpu, 9.4265_MHz_XTAL / 2);
+	m_maincpu->set_addrmap(AS_PROGRAM, &yamaha_dx9_state::mem_map);
+
+	// Unlike the DX7 only IO port 1 is used.
+	// The direction flags of other ports are set, however they are never read, or written.
+	m_maincpu->in_p1_cb().set(FUNC(yamaha_dx9_state::p1_r));
+	m_maincpu->in_p2_cb().set(FUNC(yamaha_dx9_state::unmapped_r));
+	m_maincpu->in_p3_cb().set(FUNC(yamaha_dx9_state::unmapped_r));
+	m_maincpu->in_p4_cb().set(FUNC(yamaha_dx9_state::unmapped_r));
+
+	m_maincpu->out_p1_cb().set(FUNC(yamaha_dx9_state::p1_w));
+	m_maincpu->out_p2_cb().set(FUNC(yamaha_dx9_state::unmapped_w));
+	m_maincpu->out_p3_cb().set(FUNC(yamaha_dx9_state::unmapped_w));
+	m_maincpu->out_p4_cb().set(FUNC(yamaha_dx9_state::unmapped_w));
+
+	NVRAM(config, "ram1", nvram_device::DEFAULT_ALL_0);
+	NVRAM(config, "ram2", nvram_device::DEFAULT_ALL_0);
+
+	// Configure the ADC. The clock speed here is a guess.
+	M58990(config, m_adc, 8_MHz_XTAL / 16);
+
+	// ADC source 4 is the battery voltage. Set this input to always read 0x80.
+	// If the read value is below 0x6F, the firmware considers this a low battery voltage.
+	m_adc->in_callback<4>().set_constant(0x80);
+
+	// Configure MIDI.
+	auto &midiclock(CLOCK(config, "midiclock", 500_kHz_XTAL));
+	midiclock.signal_handler().set(FUNC(yamaha_dx9_state::midiclock_w));
+
+	MIDI_PORT(config, "mdin", midiin_slot, "midiin").rxd_handler().set(FUNC(yamaha_dx9_state::midi_r));
+
+	auto &mdout(MIDI_PORT(config, "mdout", midiout_slot, "midiout"));
+	m_maincpu->out_ser_tx_cb().set(mdout, FUNC(midi_port_device::write_txd));
+
+	// Configure the LCD screen.
+	screen_device &lcd_screen(SCREEN(config, "lcd_screen", SCREEN_TYPE_LCD));
+	lcd_screen.set_refresh_hz(60);
+	lcd_screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
+	lcd_screen.set_screen_update("lcdc", FUNC(hd44780_device::screen_update));
+	lcd_screen.set_size(6*16+1, 10*2+1);
+	lcd_screen.set_visarea_full();
+	lcd_screen.set_palette("palette");
+
+	PALETTE(config, "palette", FUNC(yamaha_dx9_state::palette_init), 3);
+
+	hd44780_device &lcdc(HD44780(config, "lcdc", 0));
+	lcdc.set_lcd_size(2, 16);
+	lcdc.set_pixel_update_cb(FUNC(yamaha_dx9_state::lcd_pixel_update));
+
+	config.set_default_layout(layout_dx9);
+}
+
+
+/**
+ * yamaha_dx9_state::unmapped_r
+ */
+uint8_t yamaha_dx9_state::unmapped_r(offs_t offset)
+{
+	return 0xFF;
+}
+
+
+/**
+ * yamaha_dx9_state::key_switch_scan_driver_r
+ */
+uint8_t yamaha_dx9_state::key_switch_scan_driver_r(offs_t offset)
+{
+	/**
+	 * @brief The value to be returned.
+	 * This is implemented as a separate variable to allow for much easier debugging, as
+	 * opposed to just instantly returning the value read from the input lines.
+	 */
+	uint8_t value = 0;
+
+	// Note: Input line 4 covers the keyboard circuit, which is not implemented here.
+	// When the keyboard state is read, the default value of 0 will be returned.
+	if(m_key_switch_scan_driver_select == 0)
+	{
+		// Input line 0 covers the 'main' front-panel switches.
+		value = m_key_switch_input_driver_line_0->read();
+	} else if(m_key_switch_scan_driver_select == 1)
+	{
+		// Input line 1 covers the numeric front-panel switches 1 through 8.
+		value = m_key_switch_input_driver_line_1->read();
+	} else if(m_key_switch_scan_driver_select == 2)
+	{
+		// Input line 2 covers the numeric front-panel switches 9 though 16.
+		value = m_key_switch_input_driver_line_2->read();
+	} else if(m_key_switch_scan_driver_select == 3)
+	{
+		// Input line 3 covers the numeric front-panel switches 17 though 20.
+		// The Portamento, and Sustain pedals are mapped to bits 6, and 7 respectively.
+		value = m_key_switch_input_driver_line_3->read();
+	}
+
+	return value;
+}
+
+
+/**
+ * yamaha_dx9_state::unmapped_w
+ */
+void yamaha_dx9_state::unmapped_w(offs_t address, uint8_t data) {}
+
+
+/**
+ * yamaha_dx9_state::ops_w
+ */
+void yamaha_dx9_state::ops_w(offs_t offset, uint8_t data)
+{
+	// printf("OPS: %02X=%02X\n", offset, data);
+}
+
+
+/**
+ * yamaha_dx9_state::egs_w
+ */
+void yamaha_dx9_state::egs_w(offs_t offset, uint8_t data)
+{
+	// printf("EGS: %02X=%02X\n", offset, data);
+}
+
+
+/**
+ * yamaha_dx9_state::led_w
+ */
+void yamaha_dx9_state::led_w(offs_t offset, uint8_t data)
+{
+	// Since the memory mapped region that calls this function is only two byts in
+	// size, the led number is the least-significant bit of the offset.
+	// The DX9's LEDs are wired so that a high input line disables the segment, so
+	// get the one's complement of the data.
+	m_leds[offset & 1] = (~data) & 0xFF;
+}
+
+
+/**
+ * yamaha_dx9_state::p1_r
+ */
+uint8_t yamaha_dx9_state::p1_r(offs_t offset)
+{
+	// The ADC EOC line is wired to bit 4, as well as the Cassette Interface input, which
+	// is wired to bit 7. This is currently not fully implemented.
+	return m_adc->eoc_r() << 4;
+}
+
+
+/**
+ * yamaha_dx9_state::p1_w
+ */
+void yamaha_dx9_state::p1_w(offs_t offset, uint8_t data)
+{
+	// The low-nibble is written by the firmware to select the key/switch driver input line.
+	m_key_switch_scan_driver_select = data & 0xF;
+
+	// The cassette interface remote port polarity is set by bit 5.
+	m_cassette_interface_remote_polarity = data & 0x20;
+
+	// The cassette interface output polarity is set by bit 6.
+	m_cassette_interface_output_polarity = data & 0x40;
+}
+
+
+static INPUT_PORTS_START(dx9)
+	PORT_START("KEY_SWITCH_INPUT_DRIVER_LINE_0")
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_BUTTON1)    // Front-panel button Yes/Up.
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_BUTTON2)    // Front-panel button No/Down.
+	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_BUTTON3)    // Front-panel button Store.
+	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_BUTTON5)    // Front-panel button Function.
+	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_BUTTON6)    // Front-panel button Edit.
+	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_BUTTON7)    // Front-panel button Memory.
+	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_BUTTON8)
+
+	PORT_START("KEY_SWITCH_INPUT_DRIVER_LINE_1")
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_BUTTON1)    // Front-panel button 1.
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_BUTTON2)    // Front-panel button 2.
+	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_BUTTON3)    // Front-panel button 3.
+	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_BUTTON4)    // Front-panel button 4.
+	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_BUTTON5)    // Front-panel button 5.
+	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_BUTTON6)    // Front-panel button 6.
+	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_BUTTON7)    // Front-panel button 7.
+	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_BUTTON8)    // Front-panel button 8.
+
+	PORT_START("KEY_SWITCH_INPUT_DRIVER_LINE_2")
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_BUTTON1)    // Front-panel button 9.
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_BUTTON2)    // Front-panel button 10.
+	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_BUTTON3)    // Front-panel button 11.
+	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_BUTTON4)    // Front-panel button 12.
+	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_BUTTON5)    // Front-panel button 13.
+	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_BUTTON6)    // Front-panel button 14.
+	PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_BUTTON7)    // Front-panel button 15.
+	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_BUTTON8)    // Front-panel button 16.
+
+	PORT_START("KEY_SWITCH_INPUT_DRIVER_LINE_3")
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_BUTTON1)
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_BUTTON2)    // Front-panel button 17.
+	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_BUTTON3)    // Front-panel button 18.
+	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_BUTTON4)    // Front-panel button 19.
+	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_BUTTON5)    // Front-panel button 20.
+INPUT_PORTS_END
+
+
+ROM_START(dx9)
+	ROM_REGION(0x4000, "program", 0)
+	ROM_LOAD("dx9.bin", 0x0000, 0x4000, CRC(c45e1832) SHA1(a92d7add3b89537ad06c719da0005c450d178d81))
+ROM_END
+
+} // anonymous namespace
+
+
+SYST(1983, dx9, 0, 0, dx9, dx9, yamaha_dx9_state, empty_init, "Yamaha", "DX9 Digital Programmable Algorithm Synthesizer", MACHINE_NO_SOUND | MACHINE_CLICKABLE_ARTWORK)

--- a/src/mame/yamaha/ymdx9.cpp
+++ b/src/mame/yamaha/ymdx9.cpp
@@ -155,10 +155,6 @@ private:
 	 * @return uint8_t The value read from the port.
 	 */
 	uint8_t p1_r(offs_t offset);
-
-	void unmapped_w(offs_t address, uint8_t data);
-
-	uint8_t unmapped_r(offs_t offset);
 };
 
 
@@ -201,17 +197,17 @@ void yamaha_dx9_state::mem_map(address_map &map)
 	// Internal CPU registers.
 	map(0x0000, 0x001f).m(m_maincpu, FUNC(hd6303r_cpu_device::m6801_io));
 
-	map(0x20, 0x20).r(FUNC(yamaha_dx9_state::key_switch_scan_driver_r));
+	map(0x0020, 0x0020).r(FUNC(yamaha_dx9_state::key_switch_scan_driver_r));
 
-	map(0x22, 0x22).r("adc", FUNC(m58990_device::data_r));
-	map(0x24, 0x24).w("adc", FUNC(m58990_device::address_data_start_w));
+	map(0x0022, 0x0022).r("adc", FUNC(m58990_device::data_r));
+	map(0x0024, 0x0024).w("adc", FUNC(m58990_device::address_data_start_w));
 
 	// YM21280 OPS.
-	map(0x26, 0x27).w(FUNC(yamaha_dx9_state::ops_w));
+	map(0x0026, 0x0027).w(FUNC(yamaha_dx9_state::ops_w));
 	// HD44780 LCD Controller.
 	map(0x0028, 0x0029).rw("lcdc", FUNC(hd44780_device::read), FUNC(hd44780_device::write));
 	// LED.
-	map(0x2B, 0x2C).w(FUNC(yamaha_dx9_state::led_w));
+	map(0x002b, 0x002c).w(FUNC(yamaha_dx9_state::led_w));
 
 	// Internal RAM.
 	map(0x0040, 0x00ff).ram();
@@ -222,7 +218,7 @@ void yamaha_dx9_state::mem_map(address_map &map)
 	map(0x1000, 0x1800).ram().share("ram2");
 
 	// YM21290 EGS
-	map(0x1800, 0x18F3).w(FUNC(yamaha_dx9_state::egs_w));
+	map(0x1800, 0x18f3).w(FUNC(yamaha_dx9_state::egs_w));
 
 	// ROM.
 	map(0xc000, 0xffff).rom().region("program", 0);
@@ -242,14 +238,7 @@ void yamaha_dx9_state::dx9(machine_config &config)
 	// Unlike the DX7 only IO port 1 is used.
 	// The direction flags of other ports are set, however they are never read, or written.
 	m_maincpu->in_p1_cb().set(FUNC(yamaha_dx9_state::p1_r));
-	m_maincpu->in_p2_cb().set(FUNC(yamaha_dx9_state::unmapped_r));
-	m_maincpu->in_p3_cb().set(FUNC(yamaha_dx9_state::unmapped_r));
-	m_maincpu->in_p4_cb().set(FUNC(yamaha_dx9_state::unmapped_r));
-
 	m_maincpu->out_p1_cb().set(FUNC(yamaha_dx9_state::p1_w));
-	m_maincpu->out_p2_cb().set(FUNC(yamaha_dx9_state::unmapped_w));
-	m_maincpu->out_p3_cb().set(FUNC(yamaha_dx9_state::unmapped_w));
-	m_maincpu->out_p4_cb().set(FUNC(yamaha_dx9_state::unmapped_w));
 
 	NVRAM(config, "ram1", nvram_device::DEFAULT_ALL_0);
 	NVRAM(config, "ram2", nvram_device::DEFAULT_ALL_0);
@@ -290,15 +279,6 @@ void yamaha_dx9_state::dx9(machine_config &config)
 
 
 /**
- * yamaha_dx9_state::unmapped_r
- */
-uint8_t yamaha_dx9_state::unmapped_r(offs_t offset)
-{
-	return 0xFF;
-}
-
-
-/**
  * yamaha_dx9_state::key_switch_scan_driver_r
  */
 uint8_t yamaha_dx9_state::key_switch_scan_driver_r(offs_t offset)
@@ -333,12 +313,6 @@ uint8_t yamaha_dx9_state::key_switch_scan_driver_r(offs_t offset)
 
 	return value;
 }
-
-
-/**
- * yamaha_dx9_state::unmapped_w
- */
-void yamaha_dx9_state::unmapped_w(offs_t address, uint8_t data) {}
 
 
 /**


### PR DESCRIPTION
This is a skeleton driver for the Yamaha DX9 synthesizer. The layout has a functional UI, with the LCD, LEDs, and front-panel buttons. I intend to improve the layout file when time permits.
This is the first driver I've implemented. If there are any issues with how I've structured the code, or any extra documentation required, please let me know, and I'll be happy to correct the issues.
If I understand it correctly, I need to email the required ROM image to the MAME developers. If someone could instruct me where to send that, I'm happy to do so.