### PR TITLE
devices/cpu/powerpc/ppccom.cpp: (PPC4xx) Add configurable external serial clock and use actual system clock value for serial timer

### DIFF
--- a/src/devices/cpu/powerpc/ppc.h
+++ b/src/devices/cpu/powerpc/ppc.h
@@ -214,6 +214,9 @@ public:
 	void set_bus_frequency(uint32_t bus_frequency) { c_bus_frequency = bus_frequency; }
 	void set_bus_frequency(const XTAL &xtal) { set_bus_frequency(xtal.value()); }
 
+	void set_serial_clock(uint32_t serial_clock) { c_serial_clock = serial_clock; }
+	void set_serial_clock(const XTAL &xtal) { set_serial_clock(xtal.value()); }
+
 	void ppc_set_dcstore_callback(write32sm_delegate callback);
 
 	void ppcdrc_set_options(uint32_t options);
@@ -297,6 +300,7 @@ protected:
 	memory_access<32, 2, 0, ENDIANNESS_BIG>::cache m_cache32;
 	memory_access<32, 3, 0, ENDIANNESS_BIG>::cache m_cache64;
 	uint32_t c_bus_frequency;
+	uint32_t c_serial_clock;
 
 	struct internal_ppc_state
 	{
@@ -499,9 +503,11 @@ protected:
 
 	uint32_t          m_system_clock;
 	uint32_t          m_cpu_clock;
+	uint32_t          m_serial_clock;
 	uint64_t          m_tb_zero_cycles;
 	uint64_t          m_dec_zero_cycles;
 	emu_timer *     m_decrementer_int_timer;
+
 
 	read32sm_delegate  m_dcr_read_func;
 	write32sm_delegate m_dcr_write_func;

--- a/src/devices/cpu/powerpc/ppccom.cpp
+++ b/src/devices/cpu/powerpc/ppccom.cpp
@@ -212,6 +212,7 @@ ppc_device::ppc_device(const machine_config &mconfig, device_type type, const ch
 	, device_vtlb_interface(mconfig, *this, AS_PROGRAM)
 	, m_program_config("program", ENDIANNESS_BIG, data_bits, address_bits, 0, internal_map)
 	, c_bus_frequency(0)
+	, c_serial_clock(0)
 	, m_core(nullptr)
 	, m_bus_freq_multiplier(1)
 	, m_flavor(flavor)
@@ -718,6 +719,8 @@ void ppc_device::device_start()
 
 	m_debugger_temp = 0;
 
+	m_serial_clock = 0;
+
 	m_cache_line_size = 32;
 	m_cpu_clock = clock();
 	m_program = &space(AS_PROGRAM);
@@ -751,6 +754,10 @@ void ppc_device::device_start()
 	m_dcr_write_func.set(nullptr);
 
 	m_tb_divisor = (m_tb_divisor * clock() + m_system_clock / 2 - 1) / m_system_clock;
+
+	m_serial_clock = c_serial_clock != 0 ? c_serial_clock : 3686400;
+	if (m_serial_clock > m_system_clock / 2)
+		fatalerror("PPC: serial clock (%d) must not be more than half of the system clock (%d)\n", m_serial_clock, m_system_clock);
 
 	/* allocate a timer for the compare interrupt */
 	if ((m_cap & PPCCAP_OEA) && (m_tb_divisor))
@@ -2684,7 +2691,7 @@ void ppc_device::ppc4xx_spu_timer_reset()
 	/* if we're enabled, reset at the current baud rate */
 	if (enabled)
 	{
-		attotime clockperiod = attotime::from_hz((m_dcr[DCR4XX_IOCR] & 0x02) ? 3686400 : 33333333);
+		attotime clockperiod = attotime::from_hz((m_dcr[DCR4XX_IOCR] & 0x02) ? m_serial_clock : m_system_clock);
 		int divisor = ((m_spu.regs[SPU4XX_BAUD_DIVISOR_H] * 256 + m_spu.regs[SPU4XX_BAUD_DIVISOR_L]) & 0xfff) + 1;
 		int bpc = 7 + ((m_spu.regs[SPU4XX_CONTROL] & 8) >> 3) + 1 + (m_spu.regs[SPU4XX_CONTROL] & 1);
 		attotime charperiod = clockperiod * (divisor * 16 * bpc);

--- a/src/devices/cpu/powerpc/ppccom.cpp
+++ b/src/devices/cpu/powerpc/ppccom.cpp
@@ -755,9 +755,9 @@ void ppc_device::device_start()
 
 	m_tb_divisor = (m_tb_divisor * clock() + m_system_clock / 2 - 1) / m_system_clock;
 
-	m_serial_clock = c_serial_clock != 0 ? c_serial_clock : 3686400;
+	m_serial_clock = c_serial_clock != 0 ? c_serial_clock : 3'686'400; // TODO: get rid of this hard-coded magic number
 	if (m_serial_clock > m_system_clock / 2)
-		fatalerror("PPC: serial clock (%d) must not be more than half of the system clock (%d)\n", m_serial_clock, m_system_clock);
+		fatalerror("%s: PPC: serial clock (%d) must not be more than half of the system clock (%d)\n", tag(), m_serial_clock, m_system_clock);
 
 	/* allocate a timer for the compare interrupt */
 	if ((m_cap & PPCCAP_OEA) && (m_tb_divisor))

--- a/src/mame/konami/hornet.cpp
+++ b/src/mame/konami/hornet.cpp
@@ -1201,6 +1201,12 @@ void hornet_state::hornet(machine_config &config)
 {
 	// basic machine hardware
 	PPC403GA(config, m_maincpu, XTAL(64'000'000) / 2);   // PowerPC 403GA 32MHz
+	// The default serial clock used by the ppc4xx code results in JVS comm at 57600 baud,
+	// so set serial clock to 7.3728MHz (xtal on PCB) to allow for 115200 baud.
+	// With the slower clock rate the in and out rx ptr slowly desyncs (does not read
+	// last byte sometimes) on frequent large responses and eventually fatal errors with
+	// the message "ppc4xx_spu_rx_data: buffer overrun!".
+	m_maincpu->set_serial_clock(XTAL(7'372'800));
 	m_maincpu->set_addrmap(AS_PROGRAM, &hornet_state::hornet_map);
 
 	M68000(config, m_audiocpu, XTAL(64'000'000) / 4);    // 16MHz


### PR DESCRIPTION
As per the PPC403 CPU manual, SerClk is supposed to be an external clock and can only be up to half of SysClk, and SysClk should be the actual system clock speed.
![image](https://user-images.githubusercontent.com/63495610/203687855-80bc2c45-0d20-4ccd-a28a-ed06a8422fcb.png)

The hardcoded 33333333 (system clock) and 3686400 (serial clock) constants have existed for longer than I can see in the Git history (pre-0.121) so I don't have more context for those specific values.
https://github.com/mamedev/mame/blame/7b77f1218624ea26dbb2efd85a19f795f5d4e02e/src/emu/cpu/powerpc/ppc403.c#L625-L629

I tested with a few random Konami Hornet, Konami Cobra, and Konami Firebeat games and everything seems to be working as well as before, and a fatal error with Hornet games when frequently polling for inputs on the JVS I/O has been fixed (commented in code). The fatal error does not affect any games currently but will occur when a JVS I/O device is hooked up as required for 4 player inputs in NBA Play By Play.