### PR TITLE
konami/hornet.cpp: Fix 4 player cabinet type in NBA Play By Play

### DIFF
--- a/src/mame/konami/hornet.cpp
+++ b/src/mame/konami/hornet.cpp
@@ -1297,7 +1297,7 @@ void hornet_state::nbapbp(machine_config &config)
 	// with the 2L6B panel dipswitch settings on the Windy2 board.
 	// NOTE: Harness JVS + cabinet 4 player will work with a second JVS I/O device hooked up, but then
 	// the official recommended setting of cabinet type 4 player + harness JAMMA breaks.
-	KONAMI_WINDY2_JVS_IO(config, "windy2_jvsio", 0, m_hornet_jvs_host, windy2_device::PANEL_2L6B);
+	KONAMI_WINDY2_JVS_IO_2L6B_PANEL(config, "windy2_jvsio", 0, m_hornet_jvs_host);
 }
 
 void hornet_state::terabrst(machine_config &config) //todo: add K056800 from I/O board

--- a/src/mame/konami/hornet.cpp
+++ b/src/mame/konami/hornet.cpp
@@ -353,6 +353,7 @@ Jumpers set on GFX PCB to scope monitor:
 #include "k037122.h"
 #include "konami_gn676_lan.h"
 #include "konppc.h"
+#include "windy2.h"
 
 #include "cpu/m68000/m68000.h"
 #include "cpu/powerpc/ppc.h"
@@ -472,6 +473,7 @@ public:
 	void hornet(machine_config &config);
 	void hornet_x76(machine_config &config);
 	void hornet_lan(machine_config &config);
+	void nbapbp(machine_config &config);
 	void terabrst(machine_config &config);
 	void sscope(machine_config &config);
 	void sscope2(machine_config &config);
@@ -638,6 +640,9 @@ void hornet_state::sysreg_w(offs_t offset, uint8_t data)
 			    0x04 = LAMP2
 			    0x02 = LAMP1
 			    0x01 = LAMP0
+
+			    The bit used for JVSTXEN changes between 3 and 4 based on the lower 2 bits of IN2.
+			    If m_in[2]->read() & 3 != 0, bit 4 is used. Otherwise, bit 3 is used.
 			*/
 			if (m_x76f041)
 				m_x76f041->write_cs(BIT(data, 6));
@@ -1282,6 +1287,17 @@ void hornet_state::hornet_lan(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &hornet_state::hornet_lan_map);
 
 	KONAMI_GN676_LAN(config, "gn676_lan", 0, m_workram);
+}
+
+void hornet_state::nbapbp(machine_config &config)
+{
+	hornet_x76(config);
+
+	// The official recommended settings in the manual for 4 player mode is cabinet type 4 player + harness JAMMA
+	// with the 2L6B panel dipswitch settings on the Windy2 board.
+	// NOTE: Harness JVS + cabinet 4 player will work with a second JVS I/O device hooked up, but then
+	// the official recommended setting of cabinet type 4 player + harness JAMMA breaks.
+	KONAMI_WINDY2_JVS_IO(config, "windy2_jvsio", 0, m_hornet_jvs_host, windy2_device::PANEL_2L6B);
 }
 
 void hornet_state::terabrst(machine_config &config) //todo: add K056800 from I/O board
@@ -3330,14 +3346,14 @@ GAME(  1998, gradius4ja, gradius4, hornet_x76, gradius4, hornet_state, init_grad
 GAME(  1998, gradius4ua, gradius4, hornet_x76, gradius4, hornet_state, init_gradius4, ROT0, "Konami", "Gradius IV (ver UAA)",           MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 GAME(  1998, gradius4aa, gradius4, hornet_x76, gradius4, hornet_state, init_gradius4, ROT0, "Konami", "Gradius IV (ver AAA)",           MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 
-GAME(  1998, nbapbp,   0,      hornet_x76, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver UAB)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME(  1998, nbapbpa,  nbapbp, hornet_x76, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver AAB)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME(  1998, nbapbpj,  nbapbp, hornet_x76, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver JAB)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME(  1998, nbapbpua, nbapbp, hornet_x76, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver UAA)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME(  1998, nbapbpaa, nbapbp, hornet_x76, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver AAA)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME(  1998, nbapbpja, nbapbp, hornet_x76, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver JAA)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME(  1998, nbaatw,   nbapbp, hornet_x76, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA All The Way (ver EAB)",  MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME(  1998, nbaatwa,  nbapbp, hornet_x76, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA All The Way (ver EAA)",  MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME(  1998, nbapbp,   0,      nbapbp, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver UAB)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME(  1998, nbapbpa,  nbapbp, nbapbp, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver AAB)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME(  1998, nbapbpj,  nbapbp, nbapbp, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver JAB)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME(  1998, nbapbpua, nbapbp, nbapbp, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver UAA)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME(  1998, nbapbpaa, nbapbp, nbapbp, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver AAA)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME(  1998, nbapbpja, nbapbp, nbapbp, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA Play By Play (ver JAA)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME(  1998, nbaatw,   nbapbp, nbapbp, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA All The Way (ver EAB)",  MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME(  1998, nbaatwa,  nbapbp, nbapbp, nbapbp, hornet_state, init_hornet, ROT0, "Konami", "NBA All The Way (ver EAA)",  MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 
 GAME(  1998, terabrst,   0,        terabrst,   terabrst, hornet_state, init_hornet, ROT0, "Konami", "Teraburst (1998/07/17 ver UEL)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 GAME(  1998, terabrstj,  terabrst, terabrst,   terabrst, hornet_state, init_hornet, ROT0, "Konami", "Teraburst (1998/07/17 ver JEL)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/konami/k573mcal.h
+++ b/src/mame/konami/k573mcal.h
@@ -4,8 +4,8 @@
  * Konami 573 Master Calendar
  *
  */
-#ifndef MAME_MACHINE_K573_MCAL_H
-#define MAME_MACHINE_K573_MCAL_H
+#ifndef MAME_KONAMI_K573_MCAL_H
+#define MAME_KONAMI_K573_MCAL_H
 
 #pragma once
 
@@ -27,8 +27,6 @@ public:
 	virtual ioport_constructor device_input_ports() const override;
 
 protected:
-	template <uint8_t First> void set_port_tags() { }
-
 	virtual void device_start() override;
 	virtual void device_reset() override;
 
@@ -49,4 +47,4 @@ private:
 
 DECLARE_DEVICE_TYPE(KONAMI_573_MASTER_CALENDAR, k573mcal_device)
 
-#endif // MAME_MACHINE_K573_MCAL_H
+#endif // MAME_KONAMI_K573_MCAL_H

--- a/src/mame/konami/k573mcr.h
+++ b/src/mame/konami/k573mcr.h
@@ -4,8 +4,8 @@
  * Konami 573 Memory Card Reader
  *
  */
-#ifndef MAME_MACHINE_K573_MCR_H
-#define MAME_MACHINE_K573_MCR_H
+#ifndef MAME_KONAMI_K573_MCR_H
+#define MAME_KONAMI_K573_MCR_H
 
 #pragma once
 
@@ -30,8 +30,6 @@ public:
 	DECLARE_WRITE_LINE_MEMBER(write_rxd);
 
 protected:
-	template <uint8_t First> void set_port_tags() { }
-
 	virtual void device_start() override;
 	virtual void device_reset() override;
 	virtual void device_add_mconfig(machine_config &config) override;
@@ -78,4 +76,4 @@ private:
 
 DECLARE_DEVICE_TYPE(KONAMI_573_MEMORY_CARD_READER, k573mcr_device)
 
-#endif // MAME_MACHINE_K573_MCR_H
+#endif // MAME_KONAMI_K573_MCR_H

--- a/src/mame/konami/windy2.cpp
+++ b/src/mame/konami/windy2.cpp
@@ -2,6 +2,38 @@
 // copyright-holders:windyfairy
 /*
  * Konami Windy2 I/O (JVS)
+ *
+ * Main PCB Layout
+ * ---------------
+ * PWB405270B
+ * (C)1997 KONAMI CO.,LTD.
+ * |------------------------------------------|
+ * |    CN1         CN2                 CN3   |
+ * |                                          |
+ * |                                          |
+ * |                                          |
+ * |  CN6    CN5             JP3 JP4   CN4    |
+ * |                                          |
+ * |               DIPSW8P                    |
+ * |                                          |
+ * |                                          |
+ * |                         SP485        B   |
+ * |                                          |
+ * |                                          |
+ * |7.378MHZ H8                           A   |
+ * |                                          |
+ * |------------------------------------------|
+ *
+ * CN1 - 12-pin connector (for Player 1)
+ * CN2 - 12-pin connector (for Player 2)
+ * CN3 - 8-pin connector
+ * CN4 - 8-pin connector
+ * CN5 - 4-pin connector
+ * CN6 - 6-pin Power Connector
+ * H8 - Hitachi H8/3644 microcontroller labeled '707 V2 31484'
+ * SP485 - 9619 LTC485 CN8 Low Power RS485 Interface Transceiver
+ * A - USB-A connector
+ * B - USB-B connector
  */
 
 #include "emu.h"

--- a/src/mame/konami/windy2.cpp
+++ b/src/mame/konami/windy2.cpp
@@ -262,7 +262,7 @@ ioport_constructor windy2_quiz_device::device_input_ports() const
 // GU707-JC 2L8B panel setup for 2 players with 4 buttons + 4 levers + start + service per player
 // Corresponds to the dipswitch setting of 11000000 on I/O board
 windy2_2l8b_device::windy2_2l8b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	windy2_device(mconfig, KONAMI_WINDY2_JVS_IO_QUIZ_PANEL, tag, owner, clock, 2, 10)
+	windy2_device(mconfig, KONAMI_WINDY2_JVS_IO_2L8B_PANEL, tag, owner, clock, 2, 10)
 {
 }
 
@@ -276,7 +276,7 @@ ioport_constructor windy2_2l8b_device::device_input_ports() const
 // GU707-JD 1L6B panel setup for 1 player with 6 buttons + 4 levers + start + test
 // Corresponds to the dipswitch setting of 10101001 on I/O board
 windy2_1l6b_device::windy2_1l6b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	windy2_device(mconfig, KONAMI_WINDY2_JVS_IO_QUIZ_PANEL, tag, owner, clock, 1, 12)
+	windy2_device(mconfig, KONAMI_WINDY2_JVS_IO_1L6B_PANEL, tag, owner, clock, 1, 12)
 {
 }
 
@@ -290,7 +290,7 @@ ioport_constructor windy2_1l6b_device::device_input_ports() const
 // GU707-JG 2L12B panel setup for 2 players with 6 buttons + 4 levers + start + service per player
 // Corresponds to the dipswitch setting of 10101000 on I/O board
 windy2_2l12b_device::windy2_2l12b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	windy2_device(mconfig, KONAMI_WINDY2_JVS_IO_QUIZ_PANEL, tag, owner, clock, 2, 12)
+	windy2_device(mconfig, KONAMI_WINDY2_JVS_IO_2L12B_PANEL, tag, owner, clock, 2, 12)
 {
 }
 

--- a/src/mame/konami/windy2.cpp
+++ b/src/mame/konami/windy2.cpp
@@ -39,11 +39,11 @@
 #include "emu.h"
 #include "windy2.h"
 
-DEFINE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_2L6B_PANEL,  windy2_2l6b_device,  "windy2", "Konami Windy2 I/O (2L6B Panel, Standard)")
-DEFINE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_QUIZ_PANEL,  windy2_quiz_device,  "windy2", "Konami Windy2 I/O (Quiz Panel, GU707-JB)")
-DEFINE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_2L8B_PANEL,  windy2_2l8b_device,  "windy2", "Konami Windy2 I/O (2L8B Panel, GU707-JC)")
-DEFINE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_1L6B_PANEL,  windy2_1l6b_device,  "windy2", "Konami Windy2 I/O (1L6B Panel, GU707-JD)")
-DEFINE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_2L12B_PANEL, windy2_2l12b_device, "windy2", "Konami Windy2 I/O (2L12B Panel, GU707-JG)")
+DEFINE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_2L6B_PANEL,  windy2_2l6b_device,  "windy2_2l6b", "Konami Windy2 I/O (2L6B Panel, Standard)")
+DEFINE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_QUIZ_PANEL,  windy2_quiz_device,  "windy2_quiz", "Konami Windy2 I/O (Quiz Panel, GU707-JB)")
+DEFINE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_2L8B_PANEL,  windy2_2l8b_device,  "windy2_2l8b", "Konami Windy2 I/O (2L8B Panel, GU707-JC)")
+DEFINE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_1L6B_PANEL,  windy2_1l6b_device,  "windy2_1l6b", "Konami Windy2 I/O (1L6B Panel, GU707-JD)")
+DEFINE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_2L12B_PANEL, windy2_2l12b_device, "windy2_2l12b", "Konami Windy2 I/O (2L12B Panel, GU707-JG)")
 
 windy2_device::windy2_device(const machine_config &mconfig, const device_type type, const char *tag, device_t *owner, uint32_t clock, uint8_t player_count, uint8_t switch_count) :
 	jvs_device(mconfig, type, tag, owner, clock),

--- a/src/mame/konami/windy2.cpp
+++ b/src/mame/konami/windy2.cpp
@@ -1,0 +1,293 @@
+// license:BSD-3-Clause
+// copyright-holders:windyfairy
+/*
+ * Konami Windy2 I/O (JVS)
+ */
+
+#include "emu.h"
+#include "windy2.h"
+
+windy2_device::windy2_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	jvs_device(mconfig, KONAMI_WINDY2_JVS_IO, tag, owner, clock),
+	m_test_port(*this, "TEST"),
+	m_player_ports(*this, "P%u", 1U),
+	m_panel_type(windy2_device::PANEL_2L6B)
+{
+}
+
+void windy2_device::device_start()
+{
+	jvs_device::device_start();
+	save_item(NAME(m_panel_type));
+	save_item(NAME(m_coin_counter));
+}
+
+void windy2_device::device_reset()
+{
+	jvs_device::device_reset();
+	std::fill(std::begin(m_coin_counter), std::end(m_coin_counter), 0);
+}
+
+const char *windy2_device::device_id()
+{
+	// Known device IDs:
+	// KONAMI CO.,LTD.;Windy2;Ver1.0;Windy2 I/O Ver1.0 (referenced by all games I've seen using Windy 2 I/O)
+	// KONAMI CO.,LTD.;Windy2;Ver1.0;Windy2 I/O Ver1.1 (referenced by System 573 games)
+	// The difference between the two is currently unknown.
+	return "KONAMI CO.,LTD.;Windy2;Ver1.0;Windy2 I/O Ver1.0";
+}
+
+uint8_t windy2_device::command_format_version()
+{
+	return 0x11;
+}
+
+uint8_t windy2_device::jvs_standard_version()
+{
+	return 0x20;
+}
+
+uint8_t windy2_device::comm_method_version()
+{
+	return 0x10;
+}
+
+void windy2_device::function_list(uint8_t*& buf)
+{
+	int players, switches;
+
+	switch (m_panel_type) {
+		case windy2_device::PANEL_QUIZ:
+			players = 2;
+			switches = 6; // 4 buttons + start + service
+			break;
+
+		case windy2_device::PANEL_2L8B:
+			players = 2;
+			switches = 10; // 4 lever + 4 buttons + start + service
+			break;
+
+		case windy2_device::PANEL_1L6B:
+			players = 1;
+			switches = 12; // 4 lever + 6 buttons + start + service
+			break;
+
+		case windy2_device::PANEL_2L12B:
+			players = 2;
+			switches = 12; // 4 lever + 6 buttons + start + service
+			break;
+
+		case windy2_device::PANEL_2L6B: // same panel as 2L12B shown in diagram, but only top 3 buttons are used instead of the full 6 buttons
+		default:
+			players = 2;
+			switches = 9; // 4 lever + 3 buttons + start + service
+			break;
+	}
+
+	// Switch input function
+	*buf++ = 0x01;
+	*buf++ = players;
+	*buf++ = switches;
+	*buf++ = 0;
+
+	// Coin input function
+	*buf++ = 0x02;
+	*buf++ = std::size(m_coin_counter);
+	*buf++ = 0;
+	*buf++ = 0;
+}
+
+bool windy2_device::switches(uint8_t*& buf, uint8_t count_players, uint8_t bytes_per_switch)
+{
+	if (count_players > 2 || bytes_per_switch > 2)
+		return false;
+
+	*buf++ = m_test_port->read();
+
+	for (int i = 0; i < count_players; i++) {
+		const uint32_t pval = m_player_ports[i]->read();
+		for (int j = 0; j < bytes_per_switch; j++)
+			*buf++ = BIT(pval, ((bytes_per_switch - 1) - j) * 8, 8);
+	}
+
+	return true;
+}
+
+bool windy2_device::coin_counters(uint8_t*& buf, uint8_t count)
+{
+	if (count > std::size(m_coin_counter))
+		return false;
+
+	for (int i = 0; i < count; i++) {
+		*buf++ = (m_coin_counter[i] >> 8) & 0x3f; // top 2 bits are for coin condition, 0 = normal
+		*buf++ = m_coin_counter[i];
+	}
+
+	return true;
+}
+
+INPUT_CHANGED_MEMBER(windy2_device::coin_inserted)
+{
+	if (newval && param < std::size(m_coin_counter))
+		m_coin_counter[param] = (m_coin_counter[param] + 1) & 0x3fff;
+}
+
+INPUT_PORTS_START( windy2 )
+	PORT_START( "TEST" )
+	PORT_SERVICE_NO_TOGGLE( 0x80, IP_ACTIVE_HIGH )
+	PORT_BIT( 0x7f, IP_ACTIVE_HIGH, IPT_UNUSED )
+
+	PORT_START( "P1" )
+	PORT_BIT( 0xffffffff, IP_ACTIVE_HIGH, IPT_UNUSED )
+
+	PORT_START( "P2" )
+	PORT_BIT( 0xffffffff, IP_ACTIVE_HIGH, IPT_UNUSED )
+
+	PORT_START( "COIN" )
+	PORT_BIT( 0xfc, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_COIN1 ) PORT_CHANGED_MEMBER( DEVICE_SELF, windy2_device, coin_inserted, 0 )
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_COIN2 ) PORT_CHANGED_MEMBER( DEVICE_SELF, windy2_device, coin_inserted, 1 )
+INPUT_PORTS_END
+
+INPUT_PORTS_START( windy2_2l12b )
+	PORT_INCLUDE( windy2 )
+
+	PORT_MODIFY( "P1" )
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_START1 )
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_SERVICE1 )
+	PORT_BIT( 0x2000, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x1000, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0100, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0040, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0020, IP_ACTIVE_HIGH, IPT_BUTTON5 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0010, IP_ACTIVE_HIGH, IPT_BUTTON6 ) PORT_PLAYER( 1 )
+
+	PORT_MODIFY( "P2" )
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_START2 )
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_SERVICE2 )
+	PORT_BIT( 0x2000, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x1000, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0100, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0040, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0020, IP_ACTIVE_HIGH, IPT_BUTTON5 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0010, IP_ACTIVE_HIGH, IPT_BUTTON6 ) PORT_PLAYER( 2 )
+INPUT_PORTS_END
+
+INPUT_PORTS_START( windy2_2l8b )
+	PORT_INCLUDE( windy2 )
+
+	PORT_MODIFY( "P1" )
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_START1 )
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_SERVICE1 )
+	PORT_BIT( 0x2000, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x1000, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0100, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0040, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_PLAYER( 1 )
+
+	PORT_MODIFY( "P2" )
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_START2 )
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_SERVICE2 )
+	PORT_BIT( 0x2000, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x1000, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0100, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0040, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_PLAYER( 2 )
+INPUT_PORTS_END
+
+INPUT_PORTS_START( windy2_2l6b )
+	PORT_INCLUDE( windy2 )
+
+	PORT_MODIFY( "P1" )
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_START1 )
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_SERVICE1 )
+	PORT_BIT( 0x2000, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x1000, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0100, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER( 1 )
+
+	PORT_MODIFY( "P2" )
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_START2 )
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_SERVICE2 )
+	PORT_BIT( 0x2000, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x1000, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_PLAYER( 2 )
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0100, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER( 2 )
+INPUT_PORTS_END
+
+INPUT_PORTS_START( windy2_quiz )
+	PORT_INCLUDE( windy2 )
+
+	PORT_MODIFY( "P1" )
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_START1 )
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_SERVICE1 )
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0100, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0040, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_PLAYER( 1 )
+
+	PORT_MODIFY( "P2" )
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_START2 )
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_SERVICE2 )
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0100, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER( 2 )
+	PORT_BIT( 0x0040, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_PLAYER( 2 )
+INPUT_PORTS_END
+
+INPUT_PORTS_START( windy2_1l6b )
+	PORT_INCLUDE( windy2 )
+
+	PORT_MODIFY( "P1" )
+	PORT_BIT( 0x8000, IP_ACTIVE_HIGH, IPT_START1 )
+	PORT_BIT( 0x4000, IP_ACTIVE_HIGH, IPT_SERVICE1 )
+	PORT_BIT( 0x2000, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x1000, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0800, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0400, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_8WAY PORT_PLAYER( 1 )
+	PORT_BIT( 0x0200, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0100, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0040, IP_ACTIVE_HIGH, IPT_BUTTON4 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0020, IP_ACTIVE_HIGH, IPT_BUTTON5 ) PORT_PLAYER( 1 )
+	PORT_BIT( 0x0010, IP_ACTIVE_HIGH, IPT_BUTTON6 ) PORT_PLAYER( 1 )
+INPUT_PORTS_END
+
+ioport_constructor windy2_device::device_input_ports() const
+{
+	switch (m_panel_type) {
+		case windy2_device::PANEL_2L12B:
+			return INPUT_PORTS_NAME(windy2_2l12b);
+		case windy2_device::PANEL_2L8B:
+			return INPUT_PORTS_NAME(windy2_2l8b);
+		case windy2_device::PANEL_QUIZ:
+			return INPUT_PORTS_NAME(windy2_quiz);
+		case windy2_device::PANEL_1L6B:
+			return INPUT_PORTS_NAME(windy2_1l6b);
+		case windy2_device::PANEL_2L6B:
+		default:
+			return INPUT_PORTS_NAME(windy2_2l6b);
+	}
+}
+
+DEFINE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO, windy2_device, "windy2", "Konami Windy2 I/O")

--- a/src/mame/konami/windy2.h
+++ b/src/mame/konami/windy2.h
@@ -25,21 +25,11 @@ public:
 		PANEL_2L12B = 0b00010101, // 2L12B Panel (2x 1L6B) (GU707-JG)
 	};
 
-	template <typename T>
-	windy2_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&jvs_host_tag, uint8_t panel_type)
-		: windy2_device(mconfig, tag, owner, clock)
-	{
-		host.set_tag(std::forward<T>(jvs_host_tag));
-		m_panel_type = panel_type;
-	}
-
-	windy2_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	virtual ioport_constructor device_input_ports() const override;
-
 	DECLARE_INPUT_CHANGED_MEMBER(coin_inserted);
 
 protected:
+	windy2_device(const machine_config &mconfig, const device_type type, const char *tag, device_t *owner, uint32_t clock, uint8_t player_count, uint8_t switch_count);
+
 	virtual void device_start() override;
 	virtual void device_reset() override;
 
@@ -56,10 +46,101 @@ private:
 	required_ioport m_test_port;
 	required_ioport_array<2> m_player_ports;
 
-	uint8_t m_panel_type;
 	uint16_t m_coin_counter[2];
+	const uint8_t m_player_count, m_switch_count;
 };
 
-DECLARE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO, windy2_device)
+/////////////////////////////////////////////
+
+// Default Windy 2 cabinet panel setup for 2 players with 3 buttons + 4 levers + start + service per player
+// Corresponds to the dipswitch setting of 01000000 on I/O board
+class windy2_2l6b_device : public windy2_device
+{
+public:
+	windy2_2l6b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	template <typename T>
+	windy2_2l6b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&jvs_host_tag)
+		: windy2_2l6b_device(mconfig, tag, owner, clock)
+	{
+		host.set_tag(std::forward<T>(jvs_host_tag));
+	}
+
+	virtual ioport_constructor device_input_ports() const override;
+};
+
+/////////////////////////////////////////////
+
+class windy2_quiz_device : public windy2_device
+{
+public:
+	windy2_quiz_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	template <typename T>
+	windy2_quiz_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&jvs_host_tag)
+		: windy2_quiz_device(mconfig, tag, owner, clock)
+	{
+		host.set_tag(std::forward<T>(jvs_host_tag));
+	}
+
+	virtual ioport_constructor device_input_ports() const override;
+};
+
+/////////////////////////////////////////////
+
+class windy2_2l8b_device : public windy2_device
+{
+public:
+	windy2_2l8b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	template <typename T>
+	windy2_2l8b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&jvs_host_tag)
+		: windy2_2l8b_device(mconfig, tag, owner, clock)
+	{
+		host.set_tag(std::forward<T>(jvs_host_tag));
+	}
+
+	virtual ioport_constructor device_input_ports() const override;
+};
+
+/////////////////////////////////////////////
+
+class windy2_1l6b_device : public windy2_device
+{
+public:
+	windy2_1l6b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	template <typename T>
+	windy2_1l6b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&jvs_host_tag)
+		: windy2_1l6b_device(mconfig, tag, owner, clock)
+	{
+		host.set_tag(std::forward<T>(jvs_host_tag));
+	}
+
+	virtual ioport_constructor device_input_ports() const override;
+};
+
+/////////////////////////////////////////////
+
+class windy2_2l12b_device : public windy2_device
+{
+public:
+	windy2_2l12b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	template <typename T>
+	windy2_2l12b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&jvs_host_tag)
+		: windy2_2l12b_device(mconfig, tag, owner, clock)
+	{
+		host.set_tag(std::forward<T>(jvs_host_tag));
+	}
+
+	virtual ioport_constructor device_input_ports() const override;
+};
+
+DECLARE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_2L6B_PANEL,  windy2_2l6b_device)
+DECLARE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_QUIZ_PANEL,  windy2_quiz_device)
+DECLARE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_2L8B_PANEL,  windy2_2l8b_device)
+DECLARE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_1L6B_PANEL,  windy2_1l6b_device)
+DECLARE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO_2L12B_PANEL, windy2_2l12b_device)
 
 #endif // MAME_KONAMI_WINDY2_H

--- a/src/mame/konami/windy2.h
+++ b/src/mame/konami/windy2.h
@@ -18,6 +18,7 @@ public:
 	enum : uint8_t {
 		// Corresponds to positions on DIPSW8 that controls panel type
 		PANEL_2L6B  = 0b00000010, // "Windy II Standard" 2L6B Panel (2x 1L3B)
+		//PANEL_MAHJONG  = 0b11111111, // Mahjong Panel (23B) (GU707-JA), dipswitch setting unknown
 		PANEL_QUIZ  = 0b00000000, // Quiz Panel (4B) (GU707-JB)
 		PANEL_2L8B  = 0b00000011, // 2L8B Panel (2x 1L4B) (GU707-JC)
 		PANEL_1L6B  = 0b10010101, // 1L6B Panel (GU707-JD)

--- a/src/mame/konami/windy2.h
+++ b/src/mame/konami/windy2.h
@@ -4,8 +4,8 @@
  * Konami Windy2 I/O (JVS)
  *
  */
-#ifndef MAME_MACHINE_WINDY2_H
-#define MAME_MACHINE_WINDY2_H
+#ifndef MAME_KONAMI_WINDY2_H
+#define MAME_KONAMI_WINDY2_H
 
 #pragma once
 
@@ -40,8 +40,6 @@ public:
 	DECLARE_INPUT_CHANGED_MEMBER(coin_inserted);
 
 protected:
-	template <uint8_t First> void set_port_tags() { }
-
 	virtual void device_start() override;
 	virtual void device_reset() override;
 
@@ -64,4 +62,4 @@ private:
 
 DECLARE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO, windy2_device)
 
-#endif // MAME_MACHINE_WINDY2_H
+#endif // MAME_KONAMI_WINDY2_H

--- a/src/mame/konami/windy2.h
+++ b/src/mame/konami/windy2.h
@@ -1,0 +1,66 @@
+// license:BSD-3-Clause
+// copyright-holders:windyfairy
+/*
+ * Konami Windy2 I/O (JVS)
+ *
+ */
+#ifndef MAME_MACHINE_WINDY2_H
+#define MAME_MACHINE_WINDY2_H
+
+#pragma once
+
+#include "machine/jvsdev.h"
+#include "machine/timer.h"
+
+class windy2_device : public jvs_device
+{
+public:
+	enum : uint8_t {
+		// Corresponds to positions on DIPSW8 that controls panel type
+		PANEL_2L6B  = 0b00000010, // "Windy II Standard" 2L6B Panel (2x 1L3B)
+		PANEL_QUIZ  = 0b00000000, // Quiz Panel (4B) (GU707-JB)
+		PANEL_2L8B  = 0b00000011, // 2L8B Panel (2x 1L4B) (GU707-JC)
+		PANEL_1L6B  = 0b10010101, // 1L6B Panel (GU707-JD)
+		PANEL_2L12B = 0b00010101, // 2L12B Panel (2x 1L6B) (GU707-JG)
+	};
+
+	template <typename T>
+	windy2_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&jvs_host_tag, uint8_t panel_type)
+		: windy2_device(mconfig, tag, owner, clock)
+	{
+		host.set_tag(std::forward<T>(jvs_host_tag));
+		m_panel_type = panel_type;
+	}
+
+	windy2_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual ioport_constructor device_input_ports() const override;
+
+	DECLARE_INPUT_CHANGED_MEMBER(coin_inserted);
+
+protected:
+	template <uint8_t First> void set_port_tags() { }
+
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// JVS device overrides
+	virtual const char *device_id() override;
+	virtual uint8_t command_format_version() override;
+	virtual uint8_t jvs_standard_version() override;
+	virtual uint8_t comm_method_version() override;
+	virtual void function_list(uint8_t*& buf) override;
+	virtual bool switches(uint8_t*& buf, uint8_t count_players, uint8_t bytes_per_switch) override;
+	virtual bool coin_counters(uint8_t*& buf, uint8_t count) override;
+
+private:
+	required_ioport m_test_port;
+	required_ioport_array<2> m_player_ports;
+
+	uint8_t m_panel_type;
+	uint16_t m_coin_counter[2];
+};
+
+DECLARE_DEVICE_TYPE(KONAMI_WINDY2_JVS_IO, windy2_device)
+
+#endif // MAME_MACHINE_WINDY2_H

--- a/src/mame/konami/windy2.h
+++ b/src/mame/konami/windy2.h
@@ -15,16 +15,6 @@
 class windy2_device : public jvs_device
 {
 public:
-	enum : uint8_t {
-		// Corresponds to positions on DIPSW8 that controls panel type
-		PANEL_2L6B  = 0b00000010, // "Windy II Standard" 2L6B Panel (2x 1L3B)
-		//PANEL_MAHJONG  = 0b11111111, // Mahjong Panel (23B) (GU707-JA), dipswitch setting unknown
-		PANEL_QUIZ  = 0b00000000, // Quiz Panel (4B) (GU707-JB)
-		PANEL_2L8B  = 0b00000011, // 2L8B Panel (2x 1L4B) (GU707-JC)
-		PANEL_1L6B  = 0b10010101, // 1L6B Panel (GU707-JD)
-		PANEL_2L12B = 0b00010101, // 2L12B Panel (2x 1L6B) (GU707-JG)
-	};
-
 	DECLARE_INPUT_CHANGED_MEMBER(coin_inserted);
 
 protected:


### PR DESCRIPTION
Windy 2 JVS I/O device has been tested in NBA Play By Play on Konami Hornet and Fighting Wu-Shu 2nd! on Konami Cobra hardware.

The panel configuration is normally determined by the DIPSW8 on the I/O PCB but I found the games can be picky about the minimum number of buttons available for it to accept the panel configuration, so I removed the user configurable dipswitch in favor of having the driver programmer decide the best panel type for a game to reduce any false reports from bad panel configuration settings.

This is the panel layout and dipswitch setting reference from the manual:
![image](https://user-images.githubusercontent.com/63495610/203850307-6d51513d-7142-4a39-a279-445b6c9c7a18.png)
