### PR TITLE
-cdi: Added support for Italian version of Quizard 1. [Ryan Holtz, f205v, Team Europe]

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -10315,6 +10315,10 @@ quizard                         // (c) TAB Austria 199?
 quizard_10                      // (c) TAB Austria 1996
 quizard_12                      // (c) TAB Austria 1996
 quizard_17                      // (c) TAB Austria 1996
+quizardi                        // (c) TAB Austria 199?
+quizardi_10                     // (c) TAB Austria 1996
+quizardi_12                     // (c) TAB Austria 1996
+quizardi_17                     // (c) TAB Austria 1996
 quizard2                        // (c) TAB Austria 1995
 quizard2_22                     // (c) TAB Austria 199?
 quizard3                        // (c) TAB Austria 1996

--- a/src/mame/philips/cdi.cpp
+++ b/src/mame/philips/cdi.cpp
@@ -134,6 +134,17 @@ void cdi_state::cdi910_mem(address_map &map)
 *************************/
 
 static INPUT_PORTS_START( cdi )
+	PORT_START("MOUSEX")
+	PORT_BIT(0xffff, 0x000, IPT_MOUSE_X) PORT_SENSITIVITY(100) PORT_KEYDELTA(2)
+
+	PORT_START("MOUSEY")
+	PORT_BIT(0xffff, 0x000, IPT_MOUSE_Y) PORT_SENSITIVITY(100) PORT_KEYDELTA(2)
+
+	PORT_START("MOUSEBTN")
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_BUTTON1) PORT_CODE(MOUSECODE_BUTTON1) PORT_NAME("Button 1")
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_BUTTON2) PORT_CODE(MOUSECODE_BUTTON2) PORT_NAME("Button 2")
+	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_BUTTON3) PORT_CODE(MOUSECODE_BUTTON3) PORT_NAME("Button 3")
+	PORT_BIT(0xf8, IP_ACTIVE_HIGH, IPT_UNUSED)
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( cdimono2 )
@@ -186,6 +197,9 @@ void quizard_state::machine_start()
 {
 	save_item(NAME(m_mcu_rx_from_cpu));
 	save_item(NAME(m_mcu_initial_byte));
+	save_item(NAME(m_boot_press));
+
+	m_boot_timer = timer_alloc(FUNC(quizard_state::boot_press_tick), this);
 }
 
 void quizard_state::machine_reset()
@@ -194,6 +208,8 @@ void quizard_state::machine_reset()
 
 	m_mcu_rx_from_cpu = 0x00;
 	m_mcu_initial_byte = true;
+	m_boot_press = false;
+	m_boot_timer->adjust(attotime::from_seconds(13), 1);
 }
 
 
@@ -251,6 +267,18 @@ void cdi_state::bus_error_w(offs_t offset, uint16_t data)
 /**********************
 *  Quizard Protection *
 **********************/
+
+TIMER_CALLBACK_MEMBER(quizard_state::boot_press_tick)
+{
+	m_boot_press = (bool)param;
+	if (m_boot_press)
+		m_boot_timer->adjust(attotime::from_msec(250), 0);
+}
+
+uint8_t quizard_state::mcu_button_press()
+{
+	return (uint8_t)m_boot_press;
+}
 
 void quizard_state::mcu_rtsn_from_cpu(int state)
 {
@@ -557,6 +585,10 @@ void cdi_state::cdimono1(machine_config &config)
 {
 	cdimono1_base(config);
 
+	m_slave_hle->read_mousex().set_ioport("MOUSEX");
+	m_slave_hle->read_mousey().set_ioport("MOUSEY");
+	m_slave_hle->read_mousebtn().set_ioport("MOUSEBTN");
+
 	CDROM(config, "cdrom").set_interface("cdi_cdrom");
 	SOFTWARE_LIST(config, "cd_list").set_original("cdi").set_filter("!DVC");
 }
@@ -579,6 +611,8 @@ void quizard_state::quizard(machine_config &config)
 	m_mcu->port_out_cb<3>().set(FUNC(quizard_state::mcu_p3_w));
 	m_mcu->serial_tx_cb().set(FUNC(quizard_state::mcu_tx));
 	m_mcu->serial_rx_cb().set(FUNC(quizard_state::mcu_rx));
+
+	m_slave_hle->read_mousebtn().set(FUNC(quizard_state::mcu_button_press));
 }
 
 /*************************
@@ -661,72 +695,102 @@ ROM_END
 
     MCU Notes:
     i8751 MCU dumps confirmed good on original hardware
+    Italian language MCU for Quizard 1 is dumped
     German language MCUs for Quizard 1 through 4 are dumped
     Czech language MCU for Quizard 4 is dumped
-    Italian language MCU for Quizard 1 is known to exist (IT 11 L2, not dumped)
     Alt. German language MCU for Quizard 2 is known to exist (DE 122 D3, not dumped)
 
 */
 
 
+#define QUIZARD_BIOS_ROM \
+	ROM_REGION(0x80000, "maincpu", 0) \
+	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
+
 //********************************************************
 //                     Quizard (1)
 //********************************************************
 
-ROM_START( quizard ) /* CD-ROM printed ??/?? */
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
+#define QUIZARD1_CHD_10 \
+	DISK_REGION( "cdrom" ) \
+	DISK_IMAGE_READONLY( "quizard10", 0, SHA1(5715db50f0d5ffe06f47c0943f4bf0481ab6048e) ) // Dumped via BurnAtOnce 0.99.5, CHDMAN 0.163, TS-L633R drive
 
-	DISK_REGION( "cdrom" )
+// CD-ROM printed 01/95
+#define QUIZARD1_CHD_12 \
+	DISK_REGION( "cdrom" ) \
+	DISK_IMAGE_READONLY( "quizard12", 0, BAD_DUMP SHA1(6e41683b96b74e903040842aeb18437ad7813c82) )
+
+#define QUIZARD1_CHD_17 \
+	DISK_REGION( "cdrom" ) \
+	DISK_IMAGE_READONLY( "quizard17", 0, BAD_DUMP SHA1(4bd698f076505b4e17be978481bce027eb47123b) )
+
+#define QUIZARD1_CHD_18 \
+	DISK_REGION( "cdrom" ) \
 	DISK_IMAGE_READONLY( "quizard18", 0, BAD_DUMP SHA1(ede873b22957f2a707bbd3039e962ef2ca5aedbd) )
 
-	ROM_REGION(0x1000, "mcu", 0)
-	ROM_LOAD( "de_11_d3.bin", 0x0000, 0x1000, CRC(95f45b6b) SHA1(51b34956539b1e2cf0306f243a970750f1e18d01) ) // German language
+// MCU Type: Intel D8751H MCU
+#define QUIZARD1_MCU_DE \
+	ROM_REGION(0x1000, "mcu", 0) \
+	ROM_LOAD( "de_11_d3.bin", 0x0000, 0x1000, CRC(95f45b6b) SHA1(51b34956539b1e2cf0306f243a970750f1e18d01) ) // German
+
+#define QUIZARD1_MCU_IT \
+	ROM_REGION(0x1000, "mcu", 0) \
+	ROM_LOAD( "it_11_i2.bin", 0x0000, 0x1000, CRC(e00dc02c) SHA1(e4ef1ea47c242879a99c9d54cfc008ae99a651cb) ) // Italian
+
+ROM_START( quizard )
+	QUIZARD_BIOS_ROM
+	QUIZARD1_CHD_18
+	QUIZARD1_MCU_DE
 ROM_END
 
 ROM_START( quizard_17 )
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
-
-	DISK_REGION( "cdrom" )
-	DISK_IMAGE_READONLY( "quizard17", 0, BAD_DUMP SHA1(4bd698f076505b4e17be978481bce027eb47123b) )
-
-	ROM_REGION(0x1000, "mcu", 0) // Intel D8751H MCU
-	ROM_LOAD( "de_11_d3.bin", 0x0000, 0x1000, CRC(95f45b6b) SHA1(51b34956539b1e2cf0306f243a970750f1e18d01) ) // German language
+	QUIZARD_BIOS_ROM
+	QUIZARD1_CHD_17
+	QUIZARD1_MCU_DE
 ROM_END
 
-ROM_START( quizard_12 ) /* CD-ROM printed 01/95 */
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
-
-	DISK_REGION( "cdrom" )
-	DISK_IMAGE_READONLY( "quizard12", 0, BAD_DUMP SHA1(6e41683b96b74e903040842aeb18437ad7813c82) )
-
-	ROM_REGION(0x1000, "mcu", 0) // Intel D8751H MCU
-	ROM_LOAD( "de_11_d3.bin", 0x0000, 0x1000, CRC(95f45b6b) SHA1(51b34956539b1e2cf0306f243a970750f1e18d01) ) // German language
+ROM_START( quizard_12 )
+	QUIZARD_BIOS_ROM
+	QUIZARD1_CHD_12
+	QUIZARD1_MCU_DE
 ROM_END
 
 ROM_START( quizard_10 )
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
-
-	// software: BurnAtOnce 0.99.5 / CHDMAN 0.163
-	// Drive: TS-L633R
-	DISK_REGION( "cdrom" )
-	DISK_IMAGE_READONLY( "quizard10", 0, SHA1(5715db50f0d5ffe06f47c0943f4bf0481ab6048e) )
-
-	ROM_REGION(0x1000, "mcu", 0) // Intel D8751H MCU
-	ROM_LOAD( "de_11_d3.bin", 0x0000, 0x1000, CRC(95f45b6b) SHA1(51b34956539b1e2cf0306f243a970750f1e18d01) ) // German language
+	QUIZARD_BIOS_ROM
+	QUIZARD1_CHD_10
+	QUIZARD1_MCU_DE
 ROM_END
 
+ROM_START( quizardi )
+	QUIZARD_BIOS_ROM
+	QUIZARD1_CHD_18
+	QUIZARD1_MCU_IT
+ROM_END
+
+ROM_START( quizardi_17 )
+	QUIZARD_BIOS_ROM
+	QUIZARD1_CHD_17
+	QUIZARD1_MCU_IT
+ROM_END
+
+ROM_START( quizardi_12 )
+	QUIZARD_BIOS_ROM
+	QUIZARD1_CHD_12
+	QUIZARD1_MCU_IT
+ROM_END
+
+ROM_START( quizardi_10 )
+	QUIZARD_BIOS_ROM
+	QUIZARD1_CHD_10
+	QUIZARD1_MCU_IT
+ROM_END
 
 //********************************************************
 //                     Quizard 2
 //********************************************************
 
 ROM_START( quizard2 ) /* CD-ROM printed ??/?? */
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
+	QUIZARD_BIOS_ROM
 
 	DISK_REGION( "cdrom" )
 	DISK_IMAGE_READONLY( "quizard23", 0, BAD_DUMP SHA1(cd909d9a54275d6f2d36e03e83eea996e781b4d3) )
@@ -736,8 +800,7 @@ ROM_START( quizard2 ) /* CD-ROM printed ??/?? */
 ROM_END
 
 ROM_START( quizard2_22 )
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
+	QUIZARD_BIOS_ROM
 
 	DISK_REGION( "cdrom" )
 	DISK_IMAGE_READONLY( "quizard22", 0, BAD_DUMP SHA1(03c8fdcf27ead6e221691111e8c679b551099543) )
@@ -752,8 +815,7 @@ ROM_END
 //********************************************************
 
 ROM_START( quizard3 ) /* CD-ROM printed ??/?? */
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
+	QUIZARD_BIOS_ROM
 
 	DISK_REGION( "cdrom" )
 	DISK_IMAGE_READONLY( "quizard34", 0, BAD_DUMP SHA1(37ad49b72b5175afbb87141d57bc8604347fe032) )
@@ -763,8 +825,7 @@ ROM_START( quizard3 ) /* CD-ROM printed ??/?? */
 ROM_END
 
 ROM_START( quizard3a ) /* CD-ROM printed ??/?? */
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
+	QUIZARD_BIOS_ROM
 
 	DISK_REGION( "cdrom" )
 	DISK_IMAGE_READONLY( "quizard34", 0, BAD_DUMP SHA1(37ad49b72b5175afbb87141d57bc8604347fe032) )
@@ -774,8 +835,7 @@ ROM_START( quizard3a ) /* CD-ROM printed ??/?? */
 ROM_END
 
 ROM_START( quizard3_32 )
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
+	QUIZARD_BIOS_ROM
 
 	DISK_REGION( "cdrom" )
 	DISK_IMAGE_READONLY( "quizard32", 0, BAD_DUMP SHA1(31e9fa2169aa44d799c37170b238134ab738e1a1) )
@@ -790,8 +850,7 @@ ROM_END
 //********************************************************
 
 ROM_START( quizard4 ) /* CD-ROM printed 09/98 */
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
+	QUIZARD_BIOS_ROM
 
 	DISK_REGION( "cdrom" )
 	DISK_IMAGE_READONLY( "quizard4r42", 0, BAD_DUMP SHA1(a5d5c8950b4650b8753f9119dc7f1ccaa2aa5442) )
@@ -801,8 +860,7 @@ ROM_START( quizard4 ) /* CD-ROM printed 09/98 */
 ROM_END
 
 ROM_START( quizard4cz ) /* CD-ROM printed 09/98 */
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
+	QUIZARD_BIOS_ROM
 
 	DISK_REGION( "cdrom" )
 	DISK_IMAGE_READONLY( "quizard4r42", 0, BAD_DUMP SHA1(a5d5c8950b4650b8753f9119dc7f1ccaa2aa5442) )
@@ -812,8 +870,7 @@ ROM_START( quizard4cz ) /* CD-ROM printed 09/98 */
 ROM_END
 
 ROM_START( quizard4_41 )
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
+	QUIZARD_BIOS_ROM
 
 	DISK_REGION( "cdrom" )
 	DISK_IMAGE_READONLY( "quizard4r41", 0, BAD_DUMP SHA1(2c0484c6545aac8e00b318328c6edce6f5dde43d) )
@@ -823,8 +880,7 @@ ROM_START( quizard4_41 )
 ROM_END
 
 ROM_START( quizard4_40 ) /* CD-ROM printed 07/97 */
-	ROM_REGION(0x80000, "maincpu", 0)
-	ROM_LOAD( "cdi220b.rom", 0x000000, 0x80000, CRC(279683ca) SHA1(53360a1f21ddac952e95306ced64186a3fc0b93e) )
+	QUIZARD_BIOS_ROM
 
 	DISK_REGION( "cdrom" )
 	DISK_IMAGE_READONLY( "quizard4r40", 0, BAD_DUMP SHA1(288cc37a994e4f1cbd47aa8c92342879c6fc0b87) )
@@ -853,16 +909,20 @@ GAME( 1995, quizard,     cdibios,  quizard,       quizard,  quizard_state, empty
 GAME( 1995, quizard_17,  quizard,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard (v1.7, German, i8751 DE 11 D3)", MACHINE_IMPERFECT_SOUND )
 GAME( 1995, quizard_12,  quizard,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard (v1.2, German, i8751 DE 11 D3)", MACHINE_IMPERFECT_SOUND )
 GAME( 1995, quizard_10,  quizard,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard (v1.0, German, i8751 DE 11 D3)", MACHINE_IMPERFECT_SOUND )
+GAME( 1995, quizardi,    quizard,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard (v1.8, Italian, i8751 IT 11 I2)", MACHINE_IMPERFECT_SOUND )
+GAME( 1995, quizardi_17, quizard,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard (v1.7, Italian, i8751 IT 11 I2)", MACHINE_IMPERFECT_SOUND )
+GAME( 1995, quizardi_12, quizard,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard (v1.2, Italian, i8751 IT 11 I2)", MACHINE_IMPERFECT_SOUND )
+GAME( 1995, quizardi_10, quizard,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard (v1.0, Italian, i8751 IT 11 I2)", MACHINE_IMPERFECT_SOUND )
 
 GAME( 1995, quizard2,    cdibios,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 2 (v2.3, German, i8751 DN 122 D3)", MACHINE_IMPERFECT_SOUND )
 GAME( 1995, quizard2_22, quizard2, quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 2 (v2.2, German, i8751 DN 122 D3)", MACHINE_IMPERFECT_SOUND )
 
 // Quizard 3 and 4 will hang after starting a game (CDIC issues?)
-GAME( 1995, quizard3,    cdibios,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 3 (v3.4, German, i8751 DE 132 D3)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
-GAME( 1995, quizard3a,   quizard3, quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 3 (v3.4, German, i8751 DE 132 A1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
-GAME( 1996, quizard3_32, quizard3, quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 3 (v3.2, German, i8751 DE 132 D3)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+GAME( 1995, quizard3,    cdibios,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 3 (v3.4, German, i8751 DE 132 D3)", MACHINE_IMPERFECT_SOUND )
+GAME( 1995, quizard3a,   quizard3, quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 3 (v3.4, German, i8751 DE 132 A1)", MACHINE_IMPERFECT_SOUND )
+GAME( 1996, quizard3_32, quizard3, quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 3 (v3.2, German, i8751 DE 132 D3)", MACHINE_IMPERFECT_SOUND )
 
-GAME( 1998, quizard4,    cdibios,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 4 Rainbow (v4.2, German, i8751 DE 142 D3)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
-GAME( 1998, quizard4cz,  quizard4, quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 4 Rainbow (v4.2, Czech, i8751 TS142 CZ1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
-GAME( 1998, quizard4_41, quizard4, quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 4 Rainbow (v4.1, German, i8751 DE 142 D3)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
-GAME( 1997, quizard4_40, quizard4, quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 4 Rainbow (v4.0, German, i8751 DE 142 D3)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+GAME( 1998, quizard4,    cdibios,  quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 4 Rainbow (v4.2, German, i8751 DE 142 D3)", MACHINE_IMPERFECT_SOUND )
+GAME( 1998, quizard4cz,  quizard4, quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 4 Rainbow (v4.2, Czech, i8751 TS142 CZ1)", MACHINE_IMPERFECT_SOUND )
+GAME( 1998, quizard4_41, quizard4, quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 4 Rainbow (v4.1, German, i8751 DE 142 D3)", MACHINE_IMPERFECT_SOUND )
+GAME( 1997, quizard4_40, quizard4, quizard,       quizard,  quizard_state, empty_init,  ROT0, "TAB Austria",  "Quizard 4 Rainbow (v4.0, German, i8751 DE 142 D3)", MACHINE_IMPERFECT_SOUND )

--- a/src/mame/philips/cdi.h
+++ b/src/mame/philips/cdi.h
@@ -23,8 +23,8 @@ public:
 		, m_maincpu(*this, "maincpu")
 		, m_main_rom(*this, "maincpu")
 		, m_lcd(*this, "lcd")
-		, m_plane_ram(*this, "plane%u", 0U)
 		, m_slave_hle(*this, "slave_hle")
+		, m_plane_ram(*this, "plane%u", 0U)
 		, m_servo(*this, "servo")
 		, m_slave(*this, "slave")
 		, m_cdic(*this, "cdic")
@@ -45,6 +45,7 @@ protected:
 	required_device<scc68070_device> m_maincpu;
 	required_region_ptr<uint16_t> m_main_rom;
 	optional_device<screen_device> m_lcd;
+	optional_device<cdislave_hle_device> m_slave_hle;
 
 private:
 	enum servo_portc_bit_t
@@ -72,7 +73,6 @@ private:
 	void bus_error_w(offs_t offset, uint16_t data);
 
 	required_shared_ptr_array<uint16_t, 2> m_plane_ram;
-	optional_device<cdislave_hle_device> m_slave_hle;
 	optional_device<m68hc05c8_device> m_servo;
 	optional_device<m68hc05c8_device> m_slave;
 	optional_device<cdicdic_device> m_cdic;
@@ -96,6 +96,8 @@ private:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
+	TIMER_CALLBACK_MEMBER(boot_press_tick);
+
 	uint8_t mcu_p0_r();
 	uint8_t mcu_p1_r();
 	uint8_t mcu_p2_r();
@@ -110,11 +112,15 @@ private:
 	void mcu_rx_from_cpu(uint8_t data);
 	void mcu_rtsn_from_cpu(int state);
 
+	uint8_t mcu_button_press();
+
 	required_device<i8751_device> m_mcu;
 	required_ioport_array<3> m_inputs;
 
 	uint8_t m_mcu_rx_from_cpu = 0U;
 	bool m_mcu_initial_byte = false;
+	bool m_boot_press = false;
+	emu_timer *m_boot_timer = nullptr;
 };
 
 // Quizard 2 language values:

--- a/src/mame/philips/cdislavehle.cpp
+++ b/src/mame/philips/cdislavehle.cpp
@@ -45,32 +45,22 @@ TIMER_CALLBACK_MEMBER( cdislave_hle_device::trigger_readback_int )
 	m_interrupt_timer->adjust(attotime::never);
 }
 
-void cdislave_hle_device::prepare_readback(const attotime &delay, uint8_t channel, uint8_t count, uint8_t data0, uint8_t data1, uint8_t data2, uint8_t data3, uint8_t cmd)
+TIMER_CALLBACK_MEMBER( cdislave_hle_device::poll_inputs )
 {
-	m_channel[channel].m_out_index = 0;
-	m_channel[channel].m_out_count = count;
-	m_channel[channel].m_out_buf[0] = data0;
-	m_channel[channel].m_out_buf[1] = data1;
-	m_channel[channel].m_out_buf[2] = data2;
-	m_channel[channel].m_out_buf[3] = data3;
-	m_channel[channel].m_out_cmd = cmd;
+	const uint16_t x = m_read_mousex();
+	const uint16_t y = m_read_mousey();
+	const uint8_t btn = m_read_mousebtn();
+	if (x == m_input_mouse_x && y == m_input_mouse_y && btn == m_input_mouse_btn)
+		return;
 
-	m_interrupt_timer->adjust(delay);
-}
-
-INPUT_CHANGED_MEMBER( cdislave_hle_device::mouse_update )
-{
-	const uint8_t button_state = m_mousebtn->read();
+	m_input_mouse_btn = btn;
 	uint8_t button_bits = 0x01;
-	if (BIT(button_state, 0))
+	if (BIT(m_input_mouse_btn, 0))
 		button_bits |= 0x02;
-	if (BIT(button_state, 1))
+	if (BIT(m_input_mouse_btn, 1))
 		button_bits |= 0x04;
-	if (BIT(button_state, 2))
+	if (BIT(m_input_mouse_btn, 2))
 		button_bits |= 0x06;
-
-	const uint16_t x = m_mousex->read();
-	const uint16_t y = m_mousey->read();
 
 	int16_t deltax = 0;
 	int16_t deltay = 0;
@@ -97,23 +87,17 @@ INPUT_CHANGED_MEMBER( cdislave_hle_device::mouse_update )
 	}
 }
 
-static INPUT_PORTS_START(cdislave_mouse)
-	PORT_START("MOUSEX")
-	PORT_BIT(0xffff, 0x000, IPT_MOUSE_X) PORT_SENSITIVITY(100) PORT_KEYDELTA(2) PORT_CHANGED_MEMBER(DEVICE_SELF, cdislave_hle_device, mouse_update, 0)
-
-	PORT_START("MOUSEY")
-	PORT_BIT(0xffff, 0x000, IPT_MOUSE_Y) PORT_SENSITIVITY(100) PORT_KEYDELTA(2) PORT_CHANGED_MEMBER(DEVICE_SELF, cdislave_hle_device, mouse_update, 0)
-
-	PORT_START("MOUSEBTN")
-	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_BUTTON1) PORT_CODE(MOUSECODE_BUTTON1) PORT_NAME("Button 1") PORT_CHANGED_MEMBER(DEVICE_SELF, cdislave_hle_device, mouse_update, 0)
-	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_BUTTON2) PORT_CODE(MOUSECODE_BUTTON2) PORT_NAME("Button 2") PORT_CHANGED_MEMBER(DEVICE_SELF, cdislave_hle_device, mouse_update, 0)
-	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_BUTTON3) PORT_CODE(MOUSECODE_BUTTON3) PORT_NAME("Button 3") PORT_CHANGED_MEMBER(DEVICE_SELF, cdislave_hle_device, mouse_update, 0)
-	PORT_BIT(0xf8, IP_ACTIVE_HIGH, IPT_UNUSED)
-INPUT_PORTS_END
-
-ioport_constructor cdislave_hle_device::device_input_ports() const
+void cdislave_hle_device::prepare_readback(const attotime &delay, uint8_t channel, uint8_t count, uint8_t data0, uint8_t data1, uint8_t data2, uint8_t data3, uint8_t cmd)
 {
-	return INPUT_PORTS_NAME(cdislave_mouse);
+	m_channel[channel].m_out_index = 0;
+	m_channel[channel].m_out_count = count;
+	m_channel[channel].m_out_buf[0] = data0;
+	m_channel[channel].m_out_buf[1] = data1;
+	m_channel[channel].m_out_buf[2] = data2;
+	m_channel[channel].m_out_buf[3] = data3;
+	m_channel[channel].m_out_cmd = cmd;
+
+	m_interrupt_timer->adjust(delay);
 }
 
 uint16_t cdislave_hle_device::slave_r(offs_t offset)
@@ -402,10 +386,10 @@ void cdislave_hle_device::slave_w(offs_t offset, uint16_t data)
 cdislave_hle_device::cdislave_hle_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, CDI_SLAVE_HLE, tag, owner, clock)
 	, m_int_callback(*this)
+	, m_read_mousex(*this)
+	, m_read_mousey(*this)
+	, m_read_mousebtn(*this)
 	, m_dmadac(*this, ":dac%u", 1U)
-	, m_mousex(*this, "MOUSEX")
-	, m_mousey(*this, "MOUSEY")
-	, m_mousebtn(*this, "MOUSEBTN")
 {
 }
 
@@ -418,6 +402,9 @@ cdislave_hle_device::cdislave_hle_device(const machine_config &mconfig, const ch
 void cdislave_hle_device::device_resolve_objects()
 {
 	m_int_callback.resolve_safe();
+	m_read_mousex.resolve_safe(0x0000);
+	m_read_mousey.resolve_safe(0x0000);
+	m_read_mousebtn.resolve_safe(0x00);
 }
 
 //-------------------------------------------------
@@ -473,6 +460,9 @@ void cdislave_hle_device::device_start()
 
 	m_interrupt_timer = timer_alloc(FUNC(cdislave_hle_device::trigger_readback_int), this);
 	m_interrupt_timer->adjust(attotime::never);
+
+	m_input_poll_timer = timer_alloc(FUNC(cdislave_hle_device::poll_inputs), this);
+	m_input_poll_timer->adjust(attotime::never);
 }
 
 //-------------------------------------------------
@@ -509,4 +499,6 @@ void cdislave_hle_device::device_reset()
 	m_device_mouse_y = 0;
 
 	m_int_callback(CLEAR_LINE);
+
+	m_input_poll_timer->adjust(attotime::from_hz(60), 0, attotime::from_hz(60));
 }

--- a/src/mame/philips/cdislavehle.h
+++ b/src/mame/philips/cdislavehle.h
@@ -35,9 +35,9 @@ public:
 	cdislave_hle_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	auto int_callback() { return m_int_callback.bind(); }
-
-	// external callbacks
-	DECLARE_INPUT_CHANGED_MEMBER( mouse_update );
+	auto read_mousex() { return m_read_mousex.bind(); }
+	auto read_mousey() { return m_read_mousey.bind(); }
+	auto read_mousebtn() { return m_read_mousebtn.bind(); }
 
 	uint8_t* get_lcd_state() { return m_lcd_state; }
 
@@ -49,22 +49,21 @@ protected:
 	virtual void device_resolve_objects() override;
 	virtual void device_start() override;
 	virtual void device_reset() override;
-	virtual ioport_constructor device_input_ports() const override;
 
 	// internal callbacks
 	TIMER_CALLBACK_MEMBER( trigger_readback_int );
+	TIMER_CALLBACK_MEMBER( poll_inputs );
 
 private:
 	void prepare_readback(const attotime &delay, uint8_t channel, uint8_t count, uint8_t data0, uint8_t data1, uint8_t data2, uint8_t data3, uint8_t cmd);
 	void set_mouse_position();
 
 	devcb_write_line m_int_callback;
+	devcb_read16 m_read_mousex;
+	devcb_read16 m_read_mousey;
+	devcb_read8 m_read_mousebtn;
 
 	required_device_array<dmadac_sound_device, 2> m_dmadac;
-
-	required_ioport m_mousex;
-	required_ioport m_mousey;
-	required_ioport m_mousebtn;
 
 	struct channel_state
 	{
@@ -76,6 +75,7 @@ private:
 
 	channel_state m_channel[4];
 	emu_timer *m_interrupt_timer;
+	emu_timer *m_input_poll_timer;
 
 	uint8_t m_in_buf[17];
 	uint8_t m_in_index;
@@ -89,6 +89,7 @@ private:
 
 	uint16_t m_input_mouse_x;
 	uint16_t m_input_mouse_y;
+	uint8_t m_input_mouse_btn;
 
 	int16_t m_device_mouse_x;
 	int16_t m_device_mouse_y;


### PR DESCRIPTION
New working machines
--------------------
Quizard (v1.8, Italian, i8751 IT 11 I2) [Ryan Holtz, f205v, Team Europe]
Quizard (v1.7, Italian, i8751 IT 11 I2) [Ryan Holtz, f205v, Team Europe]
Quizard (v1.2, Italian, i8751 IT 11 I2) [Ryan Holtz, f205v, Team Europe]
Quizard (v1.0, Italian, i8751 IT 11 I2) [Ryan Holtz, f205v, Team Europe]

Machines promoted to working
----------------------------
Quizard 3 (v3.4, German, i8751 DE 132 D3) [Ryan Holtz]
Quizard 3 (v3.4, German, i8751 DE 132 A1) [Ryan Holtz]
Quizard 3 (v3.2, German, i8751 DE 132 D3) [Ryan Holtz]
Quizard 4 Rainbow (v4.2, German, i8751 DE 142 D3) [Ryan Holtz]
Quizard 4 Rainbow (v4.2, Czech, i8751 TS142 CZ1) [Ryan Holtz]
Quizard 4 Rainbow (v4.1, German, i8751 DE 142 D3) [Ryan Holtz]
Quizard 4 Rainbow (v4.0, German, i8751 DE 142 D3) [Ryan Holtz]