### PR TITLE
konami/hornet.cpp, konami/cobra.cpp, konami/nwk-tr.cpp: Refactor JVS host code

### DIFF
--- a/src/mame/konami/konppc_jvshost.cpp
+++ b/src/mame/konami/konppc_jvshost.cpp
@@ -1,0 +1,93 @@
+// license:BSD-3-Clause
+// copyright-holders:windyfairy
+//
+// JVS Host implementation shared between multiple PowerPC-based Konami platforms
+//
+
+#include "emu.h"
+
+#include "konppc_jvshost.h"
+
+DEFINE_DEVICE_TYPE(KONPPC_JVS_HOST, konppc_jvs_host_device, "konppc_jvs_host", "Konami JVS Host (PowerPC Common)")
+
+konppc_jvs_host_device::konppc_jvs_host_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: jvs_host(mconfig, KONPPC_JVS_HOST, tag, owner, clock),
+	output_cb(*this)
+{
+}
+
+void konppc_jvs_host_device::device_start()
+{
+	jvs_host::device_start();
+
+	output_cb.resolve_safe();
+
+	m_jvs_sdata = make_unique_clear<uint8_t[]>(JVS_BUFFER_SIZE);
+	m_jvs_is_escape_byte = false;
+	m_jvs_sdata_ptr = 0;
+
+	save_pointer(NAME(m_jvs_sdata), JVS_BUFFER_SIZE);
+	save_item(NAME(m_jvs_sdata_ptr));
+	save_item(NAME(m_jvs_is_escape_byte));
+}
+
+void konppc_jvs_host_device::device_reset()
+{
+	jvs_host::device_reset();
+
+	m_jvs_is_escape_byte = false;
+	m_jvs_sdata_ptr = 0;
+}
+
+READ_LINE_MEMBER( konppc_jvs_host_device::sense )
+{
+	return !get_address_set_line();
+}
+
+void konppc_jvs_host_device::read()
+{
+	const uint8_t *data;
+	uint32_t length;
+
+	get_encoded_reply(data, length);
+
+	for (int i = 0; i < length; i++)
+		output_cb(data[i]);
+}
+
+bool konppc_jvs_host_device::write(uint8_t data)
+{
+	bool is_escape_byte = m_jvs_is_escape_byte;
+	m_jvs_is_escape_byte = false;
+
+	// Throw away the buffer and wait for the next sync marker instead of overflowing when
+	// a invalid packet is filling the entire buffer.
+	if (m_jvs_sdata_ptr >= JVS_BUFFER_SIZE)
+		m_jvs_sdata_ptr = 0;
+
+	if (m_jvs_sdata_ptr == 0 && data != 0xe0)
+		return false;
+
+	if (m_jvs_sdata_ptr > 0 && data == 0xd0)
+	{
+		m_jvs_is_escape_byte = true;
+		return false;
+	}
+
+	m_jvs_sdata[m_jvs_sdata_ptr++] = is_escape_byte ? data + 1 : data;
+
+	const bool is_complete_packet = m_jvs_sdata_ptr >= 5
+		&& m_jvs_sdata_ptr == m_jvs_sdata[2] + 3
+		&& m_jvs_sdata[0] == 0xe0
+		&& m_jvs_sdata[1] != 0x00
+		&& m_jvs_sdata[m_jvs_sdata_ptr - 1] == (std::accumulate(&m_jvs_sdata[1], &m_jvs_sdata[m_jvs_sdata_ptr - 1], 0) & 0xff);
+	if (is_complete_packet)
+	{
+		for (int i = 1; i < m_jvs_sdata_ptr - 1; i++)
+			push(m_jvs_sdata[i]);
+		commit_raw();
+		m_jvs_sdata_ptr = 0;
+	}
+
+	return is_complete_packet;
+}

--- a/src/mame/konami/konppc_jvshost.h
+++ b/src/mame/konami/konppc_jvshost.h
@@ -1,0 +1,40 @@
+// license:BSD-3-Clause
+// copyright-holders:windyfairy
+#ifndef MAME_KONAMI_KONPPC_JVSHOST_H
+#define MAME_KONAMI_KONPPC_JVSHOST_H
+
+#pragma once
+
+#include "emu.h"
+
+#include "machine/jvshost.h"
+
+class konppc_jvs_host_device : public jvs_host
+{
+public:
+	// construction/destruction
+	konppc_jvs_host_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	void read();
+	bool write(uint8_t data);
+
+	DECLARE_READ_LINE_MEMBER( sense );
+
+	auto output_callback() { return output_cb.bind(); }
+
+protected:
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+private:
+	static constexpr int JVS_BUFFER_SIZE = 1024;
+
+	devcb_write8 output_cb;
+
+	std::unique_ptr<uint8_t[]> m_jvs_sdata;
+	uint32_t m_jvs_sdata_ptr;
+	bool m_jvs_is_escape_byte;
+};
+
+DECLARE_DEVICE_TYPE(KONPPC_JVS_HOST, konppc_jvs_host_device)
+
+#endif // MAME_KONAMI_KONPPC_JVSHOST_H


### PR DESCRIPTION
I refactored the JVS host code I was using for these PowerPPC 4xx-based Konami machines into konppc_jvshost.cpp and made them use that instead of having 3 identical implementations. konppc.cpp already exists for "Konami PowerPC Common Functions" so I decided to use the same naming scheme since it applies to almost all of the same machines. konami/nwk-tr.cpp's doesn't have anything hooked up to the JVS host but it was tested with the Master Calendar JVS device.

I also ripped out the old generic JVS I/O device code from konami/cobra.cpp and replaced it with a Windy2 I/O device, and fixed the bug stopping coins from working in bujutsu (cc: @angelosa). 