### PR TITLE
konmedal.cpp: Corrected the K051649 clock for a few titles.

### DIFF
--- a/src/mame/konami/konmedal.cpp
+++ b/src/mame/konami/konmedal.cpp
@@ -1025,7 +1025,7 @@ void konmedal_state::shuriboy(machine_config &config)
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 
-	K051649(config, "k051649", XTAL(24'000'000) / 6).add_route(ALL_OUTPUTS, "mono", 0.45); // divisor unknown
+	K051649(config, "k051649", XTAL(24'000'000) / 8).add_route(ALL_OUTPUTS, "mono", 0.45); // divisor unknown
 
 	UPD7759(config, m_upd7759, XTAL(640'000)).add_route(ALL_OUTPUTS, "mono", 0.60);
 }


### PR DESCRIPTION
The clock divider that was previously defined caused the music for the games that used shuriboy's machine configuration to be pitched higher than hardware recordings. This should match, if not at least be close, to the actual clock from hardware recordings.

Shuriken Boy: hardware(https://youtu.be/EeRqRCpqzkE?t=23) vs. MAME (https://youtu.be/YkUlJdstDrA?t=33)
Fuusen Pentai: hardware(https://youtu.be/JL45gafk2_Y?t=8) vs. MAME(https://youtu.be/M6qyGSBPD5o?t=6)
Tsururin Kun: hardware(https://youtu.be/loGvV6tgkhY?t=8) vs. MAME(even though it's unplayable, it was affected by this.)
Tsurikko Penta: hardware(https://youtu.be/ggqx9tX3jEw?t=13) vs. MAME(https://youtu.be/J4vxjq8NPwg?t=5)
Mario Roulette: hardware(https://youtu.be/8QMDrwWOvG0?t=4) vs. MAME(https://youtu.be/SmzuAp-lfzA?t=162)

I should preface that Buttobi Striker and Dam Dam Boy have the correct clock settings through comparisons.
You can credit this pull request as BoxCubed.
