### PR TITLE
konami/hornet.cpp: Improvements to Silent Scope and Teraburst

### DIFF
--- a/src/mame/konami/hornet.cpp
+++ b/src/mame/konami/hornet.cpp
@@ -671,15 +671,21 @@ void hornet_state::sysreg_w(offs_t offset, uint8_t data)
 
 		case 7: // CG Control Register
 			/*
-			    0x80 = EXRES1
-			    0x40 = EXRES0
+			    0x80 = EXRES1?
+			    0x40 = EXRES0?
 			    0x20 = EXID1
 			    0x10 = EXID0
 			    0x0C = 0x00 = 24kHz, 0x04 = 31kHz, 0x0c = 15kHz
 			    0x01 = EXRGB
 			*/
-			if (data & 0x80)
-				m_maincpu->set_input_line(INPUT_LINE_IRQ1, CLEAR_LINE);
+
+			// TODO: The IRQ1 clear line is causing Silent Scope's screen to not update
+			// at the correct rate. Bits 6 and 7 always seem to be set even if an IRQ
+			// hasn't been called so they don't appear to be responsible for clearing IRQs,
+			// and ends up clearing IRQs out of turn.
+			// The IRQ0 clear bit is also questionable but games run too fast and crash without it.
+			// if (data & 0x80)
+			// 	m_maincpu->set_input_line(INPUT_LINE_IRQ1, CLEAR_LINE);
 			if (data & 0x40)
 				m_maincpu->set_input_line(INPUT_LINE_IRQ0, CLEAR_LINE);
 


### PR DESCRIPTION
- The Silent Scope's scope I/O board's ADC is hooked up where it should be so the game can boot without the machine init skip dipswitch enabled now.
~~- I added a hack for Silent Scope's scope screen to fix the screen update issue. I documented why the scope screen was broken and why the hack will fix it but I have no idea how to fix it properly so I'm hoping the hack + comment gives someone some leads to fix it properly in the future. The function of interest called by IRQ1 in `sscope` is 0x80008828 if someone wants to take a look at it.~~
- I hooked up controls to `gun_r` which allows Teraburst to work without the machine init skip dipswitch enabled and generally makes the game more playable (previously only had keyboard controls). It's an HLE style emulation instead of trying to implement the CCD camera setup.