### PR TITLE
nintendo/punchout.cpp: Swap left and right speakers.

### DIFF
--- a/src/mame/nintendo/punchout.cpp
+++ b/src/mame/nintendo/punchout.cpp
@@ -659,8 +659,8 @@ void punchout_state::punchout(machine_config &config)
 
 	VLM5030(config, m_vlm, RP2A03_NTSC_XTAL/6);
 	m_vlm->set_addrmap(0, &punchout_state::punchout_vlm_map);
-	m_vlm->add_route(ALL_OUTPUTS, "lspeaker", 0.50);
-	m_audiocpu->add_route(ALL_OUTPUTS, "rspeaker", 0.50);
+	m_audiocpu->add_route(ALL_OUTPUTS, "lspeaker", 0.50);
+	m_vlm->add_route(ALL_OUTPUTS, "rspeaker", 0.50);
 }
 
 
@@ -929,7 +929,7 @@ ROM_END
 
 /* Italian bootleg set from an original board found in Italy,
    uses new program roms, 2 new gfx roms, and a mix of PunchOut and Super PunchOut graphic roms
-   Service mode is diaabled
+   Service mode is disabled
 */
 
 ROM_START( punchita )


### PR DESCRIPTION
Schematics have 2A03 audio going to MSOUND and VLM5030 going to SSOUND on the P5 edge connector. These in turn are routed to the sound boards on the lower and upper monitors respectively. Provided left speaker is connected to the lower monitor's boards and vice versa this change should be correct. The left/right layout of the diagram in the operator's manual also implies this positioning.