### PR TITLE
sound/nes_apu.cpp: Can no longer read from anything but status register.

### DIFF
--- a/src/devices/cpu/m6502/rp2a03.cpp
+++ b/src/devices/cpu/m6502/rp2a03.cpp
@@ -16,17 +16,12 @@ DEFINE_DEVICE_TYPE(RP2A03_CORE, rp2a03_core_device, "rp2a03_core", "Ricoh RP2A03
 DEFINE_DEVICE_TYPE(RP2A03,      rp2a03_device,      "rp2a03",      "Ricoh RP2A03")      // earliest version, found in punchout, spnchout, dkong3, VS. systems, and some early Famicoms
 DEFINE_DEVICE_TYPE(RP2A03G,     rp2a03g_device,     "rp2a03g",     "Ricoh RP2A03G")     // later revision, found in front-loader NES
 
-void rp2a03_device::apu_w(offs_t offset, uint8_t data)
-{
-	m_apu->write(offset, data);
-}
-
 
 void rp2a03_device::rp2a03_map(address_map &map)
 {
-	map(0x4000, 0x4013).w(FUNC(rp2a03_device::apu_w));
-	map(0x4015, 0x4015).lw8(NAME([this](u8 data) { apu_w(0x15, data); }));
-	map(0x4017, 0x4017).lw8(NAME([this](u8 data) { apu_w(0x17, data); }));
+	map(0x4000, 0x4013).w(m_apu, FUNC(nesapu_device::write));
+	map(0x4015, 0x4015).lw8(NAME([this](u8 data) { m_apu->write(0x15, data); }));
+	map(0x4017, 0x4017).lw8(NAME([this](u8 data) { m_apu->write(0x17, data); }));
 	map(0x4015, 0x4015).r(m_apu, FUNC(nesapu_device::status_r));
 	// 0x4014 w -> NES sprite DMA (is this internal?)
 	// 0x4016 w -> d0-d2: RP2A03 OUT0,OUT1,OUT2

--- a/src/devices/cpu/m6502/rp2a03.cpp
+++ b/src/devices/cpu/m6502/rp2a03.cpp
@@ -21,18 +21,13 @@ void rp2a03_device::apu_w(offs_t offset, uint8_t data)
 	m_apu->write(offset, data);
 }
 
-uint8_t rp2a03_device::apu_status_r()
-{
-	return m_apu->read(0x15);
-}
-
 
 void rp2a03_device::rp2a03_map(address_map &map)
 {
 	map(0x4000, 0x4013).w(FUNC(rp2a03_device::apu_w));
 	map(0x4015, 0x4015).lw8(NAME([this](u8 data) { apu_w(0x15, data); }));
 	map(0x4017, 0x4017).lw8(NAME([this](u8 data) { apu_w(0x17, data); }));
-	map(0x4015, 0x4015).r(FUNC(rp2a03_device::apu_status_r));
+	map(0x4015, 0x4015).r(m_apu, FUNC(nesapu_device::status_r));
 	// 0x4014 w -> NES sprite DMA (is this internal?)
 	// 0x4016 w -> d0-d2: RP2A03 OUT0,OUT1,OUT2
 	// 0x4016 r -> d0-d4: RP2A03 IN0

--- a/src/devices/cpu/m6502/rp2a03.h
+++ b/src/devices/cpu/m6502/rp2a03.h
@@ -45,8 +45,6 @@ class rp2a03_device : public rp2a03_core_device, public device_mixer_interface {
 public:
 	rp2a03_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	void apu_w(offs_t offset, uint8_t data);
-
 	void rp2a03_map(address_map &map);
 
 protected:

--- a/src/devices/cpu/m6502/rp2a03.h
+++ b/src/devices/cpu/m6502/rp2a03.h
@@ -46,7 +46,6 @@ public:
 	rp2a03_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	void apu_w(offs_t offset, uint8_t data);
-	uint8_t apu_status_r();
 
 	void rp2a03_map(address_map &map);
 

--- a/src/devices/sound/nes_apu.cpp
+++ b/src/devices/sound/nes_apu.cpp
@@ -694,36 +694,31 @@ logerror("invalid apu write: $%02X at $%04X\n", value, offset);
 	}
 }
 
-/* READ VALUES FROM REGISTERS */
-u8 nesapu_device::read(offs_t offset)
+// Read status register at $4015
+u8 nesapu_device::status_r()
 {
-	if (offset == 0x15) /*FIXED* Address $4015 has different behaviour*/
-	{
-		m_stream->update();
+	m_stream->update();
 
-		int readval = 0;
-		if (m_APU.squ[0].vbl_length > 0)
-			readval |= 0x01;
+	u8 readval = 0;
+	if (m_APU.squ[0].vbl_length > 0)
+		readval |= 0x01;
 
-		if (m_APU.squ[1].vbl_length > 0)
-			readval |= 0x02;
+	if (m_APU.squ[1].vbl_length > 0)
+		readval |= 0x02;
 
-		if (m_APU.tri.vbl_length > 0)
-			readval |= 0x04;
+	if (m_APU.tri.vbl_length > 0)
+		readval |= 0x04;
 
-		if (m_APU.noi.vbl_length > 0)
-			readval |= 0x08;
+	if (m_APU.noi.vbl_length > 0)
+		readval |= 0x08;
 
-		if (m_APU.dpcm.enabled)
-			readval |= 0x10;
+	if (m_APU.dpcm.enabled)
+		readval |= 0x10;
 
-		if (m_APU.dpcm.irq_occurred)
-			readval |= 0x80;
+	if (m_APU.dpcm.irq_occurred)
+		readval |= 0x80;
 
-		return readval;
-	}
-	else
-		return 0xff; // FIXME: this should be open bus?
+	return readval;
 }
 
 

--- a/src/devices/sound/nes_apu.h
+++ b/src/devices/sound/nes_apu.h
@@ -52,7 +52,7 @@ public:
 	virtual void device_reset() override;
 	virtual void device_clock_changed() override;
 
-	u8 read(offs_t offset);
+	u8 status_r();
 	void write(offs_t offset, u8 data);
 
 protected:

--- a/src/mame/nintendo/dkong.cpp
+++ b/src/mame/nintendo/dkong.cpp
@@ -3687,21 +3687,21 @@ void dkong_state::init_dkongx()
 void dkong_state::init_dkong3()
 {
 	// RP2A03 bus conflict between internal APU and external RAM
-	m_dkong3_tap[0] = subdevice<cpu_device>("rp2a03a")->space(AS_PROGRAM).install_write_tap(
+	m_dkong3_tap[0] = m_dev_rp2a03a->space(AS_PROGRAM).install_write_tap(
 			0x4000, 0x400f,
 			"rp2a03a_conflict_w",
 			[this] (offs_t offset, u8 &data, u8 mem_mask)
 			{
-				subdevice<cpu_device>("rp2a03a")->space(AS_PROGRAM).write_byte(offset & 0x07ff, data);
+				m_dev_rp2a03a->space(AS_PROGRAM).write_byte(offset & 0x07ff, data);
 			},
 			&m_dkong3_tap[0]);
 
-	m_dkong3_tap[1] = subdevice<cpu_device>("rp2a03b")->space(AS_PROGRAM).install_write_tap(
+	m_dkong3_tap[1] = m_dev_rp2a03b->space(AS_PROGRAM).install_write_tap(
 			0x4000, 0x400f,
 			"rp2a03b_conflict_w",
 			[this] (offs_t offset, u8 &data, u8 mem_mask)
 			{
-				subdevice<cpu_device>("rp2a03b")->space(AS_PROGRAM).write_byte(offset & 0x07ff, data);
+				m_dev_rp2a03b->space(AS_PROGRAM).write_byte(offset & 0x07ff, data);
 			},
 			&m_dkong3_tap[1]);
 }
@@ -3774,7 +3774,7 @@ GAME( 1982, maguila,   dkongjr,  dkongjr,   dkongjr,  dkong_state, init_dkingjr,
 
 GAME( 1983, dkong3,    0,        dkong3,    dkong3,   dkong_state, init_dkong3,   ROT270, "Nintendo of America", "Donkey Kong 3 (US)",                                  MACHINE_SUPPORTS_SAVE )
 GAME( 1983, dkong3j,   dkong3,   dkong3,    dkong3,   dkong_state, init_dkong3,   ROT270, "Nintendo",            "Donkey Kong 3 (Japan)",                               MACHINE_SUPPORTS_SAVE )
-GAME( 1984, dkong3b,   dkong3,   dkong3b,   dkong3b,  dkong_state, init_dkong3,   ROT270, "bootleg",             "Donkey Kong 3 (bootleg on Donkey Kong Jr. hardware)", MACHINE_SUPPORTS_SAVE )
+GAME( 1984, dkong3b,   dkong3,   dkong3b,   dkong3b,  dkong_state, empty_init,    ROT270, "bootleg",             "Donkey Kong 3 (bootleg on Donkey Kong Jr. hardware)", MACHINE_SUPPORTS_SAVE )
 GAME( 1983, dkong3hs,  dkong3,   dk3_braze, dkong3,   dkong_state, init_dkong3hs, ROT270, "hack (Braze Technologies)", "Donkey Kong High Score Kit (hack,V1.0a)",       MACHINE_SUPPORTS_SAVE )
 
 GAME( 1983, pestplce,  mario,    pestplce,  pestplce, dkong_state, empty_init,    ROT0,   "bootleg", "Pest Place", MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/nintendo/nes_sh6578.cpp
+++ b/src/mame/nintendo/nes_sh6578.cpp
@@ -106,7 +106,6 @@ private:
 	uint8_t io0_r();
 	uint8_t io1_r();
 
-	void apu_w(offs_t offset, uint8_t data);
 	uint8_t apu_read_mem(offs_t offset);
 
 	DECLARE_WRITE_LINE_MEMBER(apu_irq);
@@ -449,11 +448,6 @@ void nes_sh6578_max10in1_state::extio_w(uint8_t data)
 
 
 
-void nes_sh6578_state::apu_w(offs_t offset, uint8_t data)
-{
-	m_apu->write(offset, data);
-}
-
 WRITE_LINE_MEMBER(nes_sh6578_state::apu_irq)
 {
 	// unimplemented
@@ -474,11 +468,11 @@ void nes_sh6578_state::nes_sh6578_map(address_map& map)
 
 	map(0x2040, 0x207f).rw(m_ppu, FUNC(ppu_sh6578_device::palette_read), FUNC(ppu_sh6578_device::palette_write));
 
-	map(0x4000, 0x4013).w(FUNC(nes_sh6578_state::apu_w));
+	map(0x4000, 0x4013).w(m_apu, FUNC(nesapu_device::write));
 	map(0x4014, 0x4014).w(FUNC(nes_sh6578_state::sprite_dma_w));
-	map(0x4015, 0x4015).r(m_apu, FUNC(nesapu_device::status_r)).lw8(NAME([this](u8 data) { apu_w(0x15, data); }));
+	map(0x4015, 0x4015).r(m_apu, FUNC(nesapu_device::status_r)).lw8(NAME([this](u8 data) { m_apu->write(0x15, data); }));
 	map(0x4016, 0x4016).rw(FUNC(nes_sh6578_state::io0_r), FUNC(nes_sh6578_state::io_w));
-	map(0x4017, 0x4017).r(FUNC(nes_sh6578_state::io1_r)).lw8(NAME([this](u8 data) { apu_w(0x17, data); }));
+	map(0x4017, 0x4017).r(FUNC(nes_sh6578_state::io1_r)).lw8(NAME([this](u8 data) { m_apu->write(0x17, data); }));
 
 	map(0x4020, 0x4020).w(FUNC(nes_sh6578_state::timing_setting_control_w));
 	//4021 write keyboard output port

--- a/src/mame/nintendo/nes_sh6578.cpp
+++ b/src/mame/nintendo/nes_sh6578.cpp
@@ -106,10 +106,7 @@ private:
 	uint8_t io0_r();
 	uint8_t io1_r();
 
-	uint8_t psg1_4014_r();
-	uint8_t psg1_4015_r();
-	void psg1_4015_w(uint8_t data);
-	void psg1_4017_w(uint8_t data);
+	void apu_w(offs_t offset, uint8_t data);
 	uint8_t apu_read_mem(offs_t offset);
 
 	DECLARE_WRITE_LINE_MEMBER(apu_irq);
@@ -452,24 +449,9 @@ void nes_sh6578_max10in1_state::extio_w(uint8_t data)
 
 
 
-uint8_t nes_sh6578_state::psg1_4014_r()
+void nes_sh6578_state::apu_w(offs_t offset, uint8_t data)
 {
-	return m_apu->read(0x14);
-}
-
-uint8_t nes_sh6578_state::psg1_4015_r()
-{
-	return m_apu->read(0x15);
-}
-
-void nes_sh6578_state::psg1_4015_w(uint8_t data)
-{
-	m_apu->write(0x15, data);
-}
-
-void nes_sh6578_state::psg1_4017_w(uint8_t data)
-{
-	m_apu->write(0x17, data);
+	m_apu->write(offset, data);
 }
 
 WRITE_LINE_MEMBER(nes_sh6578_state::apu_irq)
@@ -492,11 +474,11 @@ void nes_sh6578_state::nes_sh6578_map(address_map& map)
 
 	map(0x2040, 0x207f).rw(m_ppu, FUNC(ppu_sh6578_device::palette_read), FUNC(ppu_sh6578_device::palette_write));
 
-	map(0x4000, 0x4013).rw(m_apu, FUNC(nesapu_device::read), FUNC(nesapu_device::write));
-	map(0x4014, 0x4014).rw(FUNC(nes_sh6578_state::psg1_4014_r), FUNC(nes_sh6578_state::sprite_dma_w));
-	map(0x4015, 0x4015).rw(FUNC(nes_sh6578_state::psg1_4015_r), FUNC(nes_sh6578_state::psg1_4015_w));
+	map(0x4000, 0x4013).w(FUNC(nes_sh6578_state::apu_w));
+	map(0x4014, 0x4014).w(FUNC(nes_sh6578_state::sprite_dma_w));
+	map(0x4015, 0x4015).r(m_apu, FUNC(nesapu_device::status_r)).lw8(NAME([this](u8 data) { apu_w(0x15, data); }));
 	map(0x4016, 0x4016).rw(FUNC(nes_sh6578_state::io0_r), FUNC(nes_sh6578_state::io_w));
-	map(0x4017, 0x4017).rw(FUNC(nes_sh6578_state::io1_r), FUNC(nes_sh6578_state::psg1_4017_w));
+	map(0x4017, 0x4017).r(FUNC(nes_sh6578_state::io1_r)).lw8(NAME([this](u8 data) { apu_w(0x17, data); }));
 
 	map(0x4020, 0x4020).w(FUNC(nes_sh6578_state::timing_setting_control_w));
 	//4021 write keyboard output port

--- a/src/mame/nintendo/nes_sh6578.cpp
+++ b/src/mame/nintendo/nes_sh6578.cpp
@@ -468,11 +468,11 @@ void nes_sh6578_state::nes_sh6578_map(address_map& map)
 
 	map(0x2040, 0x207f).rw(m_ppu, FUNC(ppu_sh6578_device::palette_read), FUNC(ppu_sh6578_device::palette_write));
 
-	map(0x4000, 0x4013).w(m_apu, FUNC(nesapu_device::write));
+	map(0x4000, 0x4017).w(m_apu, FUNC(nesapu_device::write));
 	map(0x4014, 0x4014).w(FUNC(nes_sh6578_state::sprite_dma_w));
-	map(0x4015, 0x4015).r(m_apu, FUNC(nesapu_device::status_r)).lw8(NAME([this](u8 data) { m_apu->write(0x15, data); }));
+	map(0x4015, 0x4015).r(m_apu, FUNC(nesapu_device::status_r));
 	map(0x4016, 0x4016).rw(FUNC(nes_sh6578_state::io0_r), FUNC(nes_sh6578_state::io_w));
-	map(0x4017, 0x4017).r(FUNC(nes_sh6578_state::io1_r)).lw8(NAME([this](u8 data) { m_apu->write(0x17, data); }));
+	map(0x4017, 0x4017).r(FUNC(nes_sh6578_state::io1_r));
 
 	map(0x4020, 0x4020).w(FUNC(nes_sh6578_state::timing_setting_control_w));
 	//4021 write keyboard output port

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
@@ -101,12 +101,12 @@ void nes_vt369_soc_device::nes_vt369_map(address_map &map)
 	map(0x2000, 0x2007).rw(m_ppu, FUNC(ppu2c0x_device::read), FUNC(ppu2c0x_device::write));                      // standard PPU registers
 	map(0x2010, 0x201f).rw(m_ppu, FUNC(ppu_vt03_device::read_extended), FUNC(ppu_vt03_device::write_extended));  //  extra VT PPU registers
 
-	map(0x4000, 0x4013).rw(m_apu, FUNC(nesapu_device::read), FUNC(nesapu_device::write));
+	map(0x4000, 0x4013).w(FUNC(nes_vt369_soc_device::apu_w));
 
-	map(0x4014, 0x4014).r(FUNC(nes_vt369_soc_device::psg1_4014_r)).w(FUNC(nes_vt369_soc_device::vt_dma_w));
-	map(0x4015, 0x4015).rw(FUNC(nes_vt369_soc_device::psg1_4015_r), FUNC(nes_vt369_soc_device::psg1_4015_w)); // PSG status / first control register
+	map(0x4014, 0x4014).w(FUNC(nes_vt369_soc_device::vt_dma_w));
+	map(0x4015, 0x4015).r(m_apu, FUNC(nes_apu_vt_device::status_r)).lw8(NAME([this](u8 data) { apu_w(0x15, data); })); // PSG status / first control register
 	map(0x4016, 0x4016).rw(FUNC(nes_vt369_soc_device::in0_r), FUNC(nes_vt369_soc_device::in0_w));
-	map(0x4017, 0x4017).r(FUNC(nes_vt369_soc_device::in1_r)).w(FUNC(nes_vt369_soc_device::psg1_4017_w));
+	map(0x4017, 0x4017).r(FUNC(nes_vt369_soc_device::in1_r)).lw8(NAME([this](u8 data) { apu_w(0x17, data); }));
 
 	map(0x4034, 0x4034).w(FUNC(nes_vt369_soc_device::vt03_4034_w));  // secondary DMA
 

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
@@ -101,12 +101,12 @@ void nes_vt369_soc_device::nes_vt369_map(address_map &map)
 	map(0x2000, 0x2007).rw(m_ppu, FUNC(ppu2c0x_device::read), FUNC(ppu2c0x_device::write));                      // standard PPU registers
 	map(0x2010, 0x201f).rw(m_ppu, FUNC(ppu_vt03_device::read_extended), FUNC(ppu_vt03_device::write_extended));  //  extra VT PPU registers
 
-	map(0x4000, 0x4013).w(m_apu, FUNC(nes_apu_vt_device::write));
+	map(0x4000, 0x4017).w(m_apu, FUNC(nes_apu_vt_device::write));
 
 	map(0x4014, 0x4014).w(FUNC(nes_vt369_soc_device::vt_dma_w));
-	map(0x4015, 0x4015).r(m_apu, FUNC(nes_apu_vt_device::status_r)).lw8(NAME([this](u8 data) { m_apu->write(0x15, data); })); // PSG status / first control register
+	map(0x4015, 0x4015).r(m_apu, FUNC(nes_apu_vt_device::status_r)); // PSG status / first control register
 	map(0x4016, 0x4016).rw(FUNC(nes_vt369_soc_device::in0_r), FUNC(nes_vt369_soc_device::in0_w));
-	map(0x4017, 0x4017).r(FUNC(nes_vt369_soc_device::in1_r)).lw8(NAME([this](u8 data) { m_apu->write(0x17, data); }));
+	map(0x4017, 0x4017).r(FUNC(nes_vt369_soc_device::in1_r));
 
 	map(0x4034, 0x4034).w(FUNC(nes_vt369_soc_device::vt03_4034_w));  // secondary DMA
 

--- a/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown_soc.cpp
@@ -101,12 +101,12 @@ void nes_vt369_soc_device::nes_vt369_map(address_map &map)
 	map(0x2000, 0x2007).rw(m_ppu, FUNC(ppu2c0x_device::read), FUNC(ppu2c0x_device::write));                      // standard PPU registers
 	map(0x2010, 0x201f).rw(m_ppu, FUNC(ppu_vt03_device::read_extended), FUNC(ppu_vt03_device::write_extended));  //  extra VT PPU registers
 
-	map(0x4000, 0x4013).w(FUNC(nes_vt369_soc_device::apu_w));
+	map(0x4000, 0x4013).w(m_apu, FUNC(nes_apu_vt_device::write));
 
 	map(0x4014, 0x4014).w(FUNC(nes_vt369_soc_device::vt_dma_w));
-	map(0x4015, 0x4015).r(m_apu, FUNC(nes_apu_vt_device::status_r)).lw8(NAME([this](u8 data) { apu_w(0x15, data); })); // PSG status / first control register
+	map(0x4015, 0x4015).r(m_apu, FUNC(nes_apu_vt_device::status_r)).lw8(NAME([this](u8 data) { m_apu->write(0x15, data); })); // PSG status / first control register
 	map(0x4016, 0x4016).rw(FUNC(nes_vt369_soc_device::in0_r), FUNC(nes_vt369_soc_device::in0_w));
-	map(0x4017, 0x4017).r(FUNC(nes_vt369_soc_device::in1_r)).lw8(NAME([this](u8 data) { apu_w(0x17, data); }));
+	map(0x4017, 0x4017).r(FUNC(nes_vt369_soc_device::in1_r)).lw8(NAME([this](u8 data) { m_apu->write(0x17, data); }));
 
 	map(0x4034, 0x4034).w(FUNC(nes_vt369_soc_device::vt03_4034_w));  // secondary DMA
 

--- a/src/mame/nintendo/nes_vt_soc.cpp
+++ b/src/mame/nintendo/nes_vt_soc.cpp
@@ -851,25 +851,9 @@ void nes_vt02_vt03_soc_device::vt03_8000_mapper_w(offs_t offset, uint8_t data)
 
 /* APU plumbing, this is because we have a plain M6502 core in the VT03, otherwise this is handled in the core */
 
-uint8_t nes_vt02_vt03_soc_device::psg1_4014_r()
+void nes_vt02_vt03_soc_device::apu_w(offs_t offset, uint8_t data)
 {
-	//return m_apu->read(0x14);
-	return 0x00;
-}
-
-uint8_t nes_vt02_vt03_soc_device::psg1_4015_r()
-{
-	return m_apu->read(0x15);
-}
-
-void nes_vt02_vt03_soc_device::psg1_4015_w(uint8_t data)
-{
-	m_apu->write(0x15, data);
-}
-
-void nes_vt02_vt03_soc_device::psg1_4017_w(uint8_t data)
-{
-	m_apu->write(0x17, data);
+	m_apu->write(offset, data);
 }
 
 // early units (VT03?) have a DMA bug in NTSC mode
@@ -1066,13 +1050,11 @@ void nes_vt02_vt03_soc_device::nes_vt_map(address_map &map)
 	map(0x2000, 0x2007).mirror(0x00e0).rw(m_ppu, FUNC(ppu2c0x_device::read), FUNC(ppu2c0x_device::write));                      // standard PPU registers
 	map(0x2010, 0x201f).mirror(0x00e0).rw(m_ppu, FUNC(ppu_vt03_device::read_extended), FUNC(ppu_vt03_device::write_extended));  //  extra VT PPU registers
 
-	map(0x4000, 0x4013).rw(m_apu, FUNC(nesapu_device::read), FUNC(nesapu_device::write));
-
-	map(0x4014, 0x4014).r(FUNC(nes_vt02_vt03_soc_device::psg1_4014_r)).w(FUNC(nes_vt02_vt03_soc_device::vt_dma_w));
-	map(0x4015, 0x4015).rw(FUNC(nes_vt02_vt03_soc_device::psg1_4015_r), FUNC(nes_vt02_vt03_soc_device::psg1_4015_w)); // PSG status / first control register
+	map(0x4000, 0x4013).w(FUNC(nes_vt02_vt03_soc_device::apu_w));
+	map(0x4014, 0x4014).w(FUNC(nes_vt02_vt03_soc_device::vt_dma_w));
+	map(0x4015, 0x4015).r(m_apu, FUNC(nes_apu_vt_device::status_r)).lw8(NAME([this](u8 data) { apu_w(0x15, data); })); // PSG status / first control register
 	map(0x4016, 0x4016).rw(FUNC(nes_vt02_vt03_soc_device::in0_r), FUNC(nes_vt02_vt03_soc_device::in0_w));
-	map(0x4017, 0x4017).r(FUNC(nes_vt02_vt03_soc_device::in1_r)).w(FUNC(nes_vt02_vt03_soc_device::psg1_4017_w));
-
+	map(0x4017, 0x4017).r(FUNC(nes_vt02_vt03_soc_device::in1_r)).lw8(NAME([this](u8 data) { apu_w(0x17, data); }));
 
 	map(0x4034, 0x4034).w(FUNC(nes_vt02_vt03_soc_device::vt03_4034_w)); // secondary DMA
 

--- a/src/mame/nintendo/nes_vt_soc.cpp
+++ b/src/mame/nintendo/nes_vt_soc.cpp
@@ -1043,11 +1043,11 @@ void nes_vt02_vt03_soc_device::nes_vt_map(address_map &map)
 	map(0x2000, 0x2007).mirror(0x00e0).rw(m_ppu, FUNC(ppu2c0x_device::read), FUNC(ppu2c0x_device::write));                      // standard PPU registers
 	map(0x2010, 0x201f).mirror(0x00e0).rw(m_ppu, FUNC(ppu_vt03_device::read_extended), FUNC(ppu_vt03_device::write_extended));  //  extra VT PPU registers
 
-	map(0x4000, 0x4013).w(m_apu, FUNC(nes_apu_vt_device::write));
+	map(0x4000, 0x4017).w(m_apu, FUNC(nes_apu_vt_device::write));
 	map(0x4014, 0x4014).w(FUNC(nes_vt02_vt03_soc_device::vt_dma_w));
-	map(0x4015, 0x4015).r(m_apu, FUNC(nes_apu_vt_device::status_r)).lw8(NAME([this](u8 data) { m_apu->write(0x15, data); })); // PSG status / first control register
+	map(0x4015, 0x4015).r(m_apu, FUNC(nes_apu_vt_device::status_r)); // PSG status / first control register
 	map(0x4016, 0x4016).rw(FUNC(nes_vt02_vt03_soc_device::in0_r), FUNC(nes_vt02_vt03_soc_device::in0_w));
-	map(0x4017, 0x4017).r(FUNC(nes_vt02_vt03_soc_device::in1_r)).lw8(NAME([this](u8 data) { m_apu->write(0x17, data); }));
+	map(0x4017, 0x4017).r(FUNC(nes_vt02_vt03_soc_device::in1_r));
 
 	map(0x4034, 0x4034).w(FUNC(nes_vt02_vt03_soc_device::vt03_4034_w)); // secondary DMA
 

--- a/src/mame/nintendo/nes_vt_soc.cpp
+++ b/src/mame/nintendo/nes_vt_soc.cpp
@@ -849,13 +849,6 @@ void nes_vt02_vt03_soc_device::vt03_8000_mapper_w(offs_t offset, uint8_t data)
 	//logerror("%s: vt03_8000_mapper_w (%04x) %02x\n", machine().describe_context(), offset+0x8000, data );
 }
 
-/* APU plumbing, this is because we have a plain M6502 core in the VT03, otherwise this is handled in the core */
-
-void nes_vt02_vt03_soc_device::apu_w(offs_t offset, uint8_t data)
-{
-	m_apu->write(offset, data);
-}
-
 // early units (VT03?) have a DMA bug in NTSC mode
 void nes_vt02_vt03_soc_device::vt_dma_w(uint8_t data)
 {
@@ -1050,11 +1043,11 @@ void nes_vt02_vt03_soc_device::nes_vt_map(address_map &map)
 	map(0x2000, 0x2007).mirror(0x00e0).rw(m_ppu, FUNC(ppu2c0x_device::read), FUNC(ppu2c0x_device::write));                      // standard PPU registers
 	map(0x2010, 0x201f).mirror(0x00e0).rw(m_ppu, FUNC(ppu_vt03_device::read_extended), FUNC(ppu_vt03_device::write_extended));  //  extra VT PPU registers
 
-	map(0x4000, 0x4013).w(FUNC(nes_vt02_vt03_soc_device::apu_w));
+	map(0x4000, 0x4013).w(m_apu, FUNC(nes_apu_vt_device::write));
 	map(0x4014, 0x4014).w(FUNC(nes_vt02_vt03_soc_device::vt_dma_w));
-	map(0x4015, 0x4015).r(m_apu, FUNC(nes_apu_vt_device::status_r)).lw8(NAME([this](u8 data) { apu_w(0x15, data); })); // PSG status / first control register
+	map(0x4015, 0x4015).r(m_apu, FUNC(nes_apu_vt_device::status_r)).lw8(NAME([this](u8 data) { m_apu->write(0x15, data); })); // PSG status / first control register
 	map(0x4016, 0x4016).rw(FUNC(nes_vt02_vt03_soc_device::in0_r), FUNC(nes_vt02_vt03_soc_device::in0_w));
-	map(0x4017, 0x4017).r(FUNC(nes_vt02_vt03_soc_device::in1_r)).lw8(NAME([this](u8 data) { apu_w(0x17, data); }));
+	map(0x4017, 0x4017).r(FUNC(nes_vt02_vt03_soc_device::in1_r)).lw8(NAME([this](u8 data) { m_apu->write(0x17, data); }));
 
 	map(0x4034, 0x4034).w(FUNC(nes_vt02_vt03_soc_device::vt03_4034_w)); // secondary DMA
 

--- a/src/mame/nintendo/nes_vt_soc.h
+++ b/src/mame/nintendo/nes_vt_soc.h
@@ -87,7 +87,6 @@ protected:
 	void nt_w(offs_t offset, uint8_t data);
 	int calculate_real_video_address(int addr, int extended, int readtype);
 	void scrambled_8000_w(uint16_t offset, uint8_t data);
-	void apu_w(offs_t offset, uint8_t data);
 	void vt_dma_w(uint8_t data);
 	void do_dma(uint8_t data, bool has_ntsc_bug);
 	void vt03_4034_w(uint8_t data);

--- a/src/mame/nintendo/nes_vt_soc.h
+++ b/src/mame/nintendo/nes_vt_soc.h
@@ -87,10 +87,7 @@ protected:
 	void nt_w(offs_t offset, uint8_t data);
 	int calculate_real_video_address(int addr, int extended, int readtype);
 	void scrambled_8000_w(uint16_t offset, uint8_t data);
-	uint8_t psg1_4014_r();
-	uint8_t psg1_4015_r();
-	void psg1_4015_w(uint8_t data);
-	void psg1_4017_w(uint8_t data);
+	void apu_w(offs_t offset, uint8_t data);
 	void vt_dma_w(uint8_t data);
 	void do_dma(uint8_t data, bool has_ntsc_bug);
 	void vt03_4034_w(uint8_t data);


### PR DESCRIPTION
nintendo/nes_vt*: Aligned PnP APU code with core changes.
nintendo/dkong.cpp: Fixed dkong3b crash regression.