### PR TITLE
bus/coco: minor cleanup of interfaces

### DIFF
--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -678,8 +678,8 @@ device_cococart_interface::~device_cococart_interface()
 void device_cococart_interface::interface_config_complete()
 {
 	m_host = m_owning_slot
-		? dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner())
-		: nullptr;
+			? dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner())
+			: nullptr;
 }
 
 

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -141,10 +141,6 @@ cococart_slot_device::cococart_slot_device(const machine_config &mconfig, const 
 
 void cococart_slot_device::device_start()
 {
-	m_cart_callback.resolve_safe();
-	m_nmi_callback.resolve_safe();
-	m_halt_callback.resolve_safe();
-
 	for(int i=0; i < TIMER_POOL; i++ )
 	{
 		m_cart_line.timer[i]    = timer_alloc(FUNC(cococart_slot_device::cart_line_timer_tick), this);
@@ -157,7 +153,7 @@ void cococart_slot_device::device_start()
 	m_cart_line.value           = line_value::CLEAR;
 	m_cart_line.line            = 0;
 	m_cart_line.q_count         = 0;
-	m_cart_callback.resolve();
+	m_cart_callback.resolve_safe();
 	m_cart_line.callback = &m_cart_callback;
 
 	m_nmi_line.timer_index      = 0;
@@ -165,7 +161,7 @@ void cococart_slot_device::device_start()
 	m_nmi_line.value            = line_value::CLEAR;
 	m_nmi_line.line             = 0;
 	m_nmi_line.q_count          = 0;
-	m_nmi_callback.resolve();
+	m_nmi_callback.resolve_safe();
 	m_nmi_line.callback = &m_nmi_callback;
 
 	m_halt_line.timer_index     = 0;
@@ -173,7 +169,7 @@ void cococart_slot_device::device_start()
 	m_halt_line.value           = line_value::CLEAR;
 	m_halt_line.line            = 0;
 	m_halt_line.q_count         = 0;
-	m_halt_callback.resolve();
+	m_halt_callback.resolve_safe();
 	m_halt_line.callback = &m_halt_callback;
 
 	m_cart = get_card_device();

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -677,7 +677,9 @@ device_cococart_interface::~device_cococart_interface()
 
 void device_cococart_interface::interface_config_complete()
 {
-	m_host = dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner());
+	m_host = m_owning_slot
+		? dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner())
+		: nullptr;
 }
 
 

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -141,6 +141,10 @@ cococart_slot_device::cococart_slot_device(const machine_config &mconfig, const 
 
 void cococart_slot_device::device_start()
 {
+	m_cart_callback.resolve_safe();
+	m_nmi_callback.resolve_safe();
+	m_halt_callback.resolve_safe();
+
 	for(int i=0; i < TIMER_POOL; i++ )
 	{
 		m_cart_line.timer[i]    = timer_alloc(FUNC(cococart_slot_device::cart_line_timer_tick), this);
@@ -346,9 +350,8 @@ void cococart_slot_device::set_line(line ln, coco_cartridge_line &line, cococart
 				break;
 		}
 
-		/* invoke the callback, if present */
-		if (!(*line.callback).isnull())
-			(*line.callback)(line.line);
+		/* invoke the callback */
+		(*line.callback)(line.line);
 	}
 }
 
@@ -657,7 +660,7 @@ template class device_finder<device_cococart_interface, true>;
 
 device_cococart_interface::device_cococart_interface(const machine_config &mconfig, device_t &device)
 	: device_interface(device, "cococart")
-	, m_owning_slot(nullptr)
+	, m_owning_slot(dynamic_cast<cococart_slot_device *>(device.owner()))
 	, m_host(nullptr)
 {
 }
@@ -678,7 +681,6 @@ device_cococart_interface::~device_cococart_interface()
 
 void device_cococart_interface::interface_config_complete()
 {
-	m_owning_slot = dynamic_cast<cococart_slot_device *>(device().owner());
 	m_host = m_owning_slot
 			? dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner())
 			: nullptr;

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -681,9 +681,7 @@ device_cococart_interface::~device_cococart_interface()
 
 void device_cococart_interface::interface_config_complete()
 {
-	m_host = m_owning_slot
-			? dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner())
-			: nullptr;
+	m_host = dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner());
 }
 
 

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -221,7 +221,7 @@ protected:
 
 private:
 	cococart_base_update_delegate    m_update;
-	cococart_slot_device *           m_owning_slot;
+	cococart_slot_device *           const m_owning_slot;
 	device_cococart_host_interface * m_host;
 };
 

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -221,7 +221,7 @@ protected:
 
 private:
 	cococart_base_update_delegate    m_update;
-	cococart_slot_device           * const m_owning_slot;
+	cococart_slot_device * const     m_owning_slot;
 	device_cococart_host_interface * m_host;
 };
 

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -221,7 +221,7 @@ protected:
 
 private:
 	cococart_base_update_delegate    m_update;
-	cococart_slot_device *           const m_owning_slot;
+	cococart_slot_device           * const m_owning_slot;
 	device_cococart_host_interface * m_host;
 };
 


### PR DESCRIPTION
Move device initialization to constructor. Added resolve_safe() to remove some checks.