### PR TITLE
decocass.cpp - remove names of some bad actors from thanks list

### DIFF
--- a/src/mame/dataeast/decocass.cpp
+++ b/src/mame/dataeast/decocass.cpp
@@ -7,7 +7,7 @@
 
     with contributions by: David Widel, Nicola Salmoria, Aaron Giles, Brian Troha,
     Fabio Priuli, Lord Nightmare, The Dumping Union, Team Japump!!!, Hau,
-    Jean-Francois Del Nero, Omar Cornut, Game Preservation Society, Joseph Redon
+    Jean-Francois Del Nero, Omar Cornut
 
 
     The DECO cassette system consists of three PCBs in a card cage:


### PR DESCRIPTION
These people are doing more harm than good, they're not copyright holders, so this shouldn't be a problem.