### PR TITLE
Updated FME alphanumeric emulation

### DIFF
--- a/src/devices/machine/roc10937.cpp
+++ b/src/devices/machine/roc10937.cpp
@@ -148,7 +148,7 @@ void rocvfd_device::device_start()
 
 	m_sclk = 0;
 	m_data = 0;
-	m_por = 1;
+	m_por = 0;
 
 	save_item(NAME(m_cursor_pos));
 	save_item(NAME(m_window_size));
@@ -161,11 +161,16 @@ void rocvfd_device::device_start()
 	save_item(NAME(m_data));
 	save_item(NAME(m_por));
 	save_item(NAME(m_duty));
-	save_item(NAME(m_disp));
+
+	std::fill(std::begin(m_chars), std::end(m_chars), 0);
+	std::fill(std::begin(*m_outputs), std::end(*m_outputs), 0);
+
 }
 
 void rocvfd_device::device_reset()
 {
+	//We don't clear the buffers on reset as JPM games rely on the buffers being intact after POR
+	//On real hardware, garbage patterns can appear unless specifically cleared, so this makes sense.
 	m_cursor_pos = 0;
 	m_window_size = 16;
 	m_shift_count = 0;
@@ -173,13 +178,8 @@ void rocvfd_device::device_reset()
 	m_pcursor_pos = 0;
 	m_count = 0;
 	m_duty = 0;
-	m_disp = 0;
-
-	std::fill(std::begin(m_chars), std::end(m_chars), 0);
-	std::fill(std::begin(*m_outputs), std::end(*m_outputs), 0);
 
 	(*m_brightness)[0] = 0;
-
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -207,7 +207,14 @@ WRITE_LINE_MEMBER( rocvfd_device::sclk )
 
 WRITE_LINE_MEMBER( rocvfd_device::data )
 {
-	m_data = state;
+	if (state)
+	{
+		m_data = 1;
+	}
+	else
+	{
+		m_data = 0;
+	}
 }
 
 WRITE_LINE_MEMBER( rocvfd_device::por )
@@ -239,10 +246,9 @@ void rocvfd_device::shift_clock(int state)
 				m_shift_data  = 0;
 			}
 			update_display();
-
 		}
+		m_sclk = state;
 	}
-	m_sclk = state;
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -294,12 +300,11 @@ void rocvfd_device::write_char(int data)
 		else if ( (data & 0xE0) == 0x80 ) // 100x ---
 		{ // 100x xxxx Test mode
 			popmessage("TEST MODE ENABLED!");
-			m_duty = 4;
 		}
 	}
 	else
 	{ // Display data
-//      data &= 0x3F;
+		data &= 0x3F;
 
 		switch ( data )
 		{

--- a/src/devices/machine/roc10937.h
+++ b/src/devices/machine/roc10937.h
@@ -40,7 +40,6 @@ protected:
 	int m_count;
 	int m_data;
 	int m_duty;
-	int m_disp;
 	int m_sclk;
 	int m_por;
 	uint8_t m_cursor;

--- a/src/mame/bfm/bfm_bd1.cpp
+++ b/src/mame/bfm/bfm_bd1.cpp
@@ -173,50 +173,61 @@ void bfm_bd1_device::device_post_load()
 
 void bfm_bd1_device::update_display()
 {
-	  if ( m_flash_timer ) {
+	if (m_flash_timer)
+	{
 		m_flash_timer--;
-		if ( !m_flash_timer ) {
-		  m_flash_timer = 20;
-		  if ( !m_flash ) {
-			switch ( m_flash_control ) {
-			  case 1:    // Flash Inside Window
-				for ( int i = 0; i < 16; i++ ) {
-				  if ( (i >= m_window_start) && (i <= m_window_end) )
-					  m_attrs[i] = AT_FLASH;
-				  else
-					  m_attrs[i] = AT_NORMAL;
+		if (!m_flash_timer)
+		{
+			m_flash_timer = 20;
+			if (!m_flash)
+			{
+				switch (m_flash_control)
+				{
+					case 1:    // Flash Inside Window
+						for (int i = 0; i < 16; i++)
+						{
+						  if ((i >= m_window_start) && (i <= m_window_end))
+							  m_attrs[i] = AT_FLASH;
+						  else
+							  m_attrs[i] = AT_NORMAL;
+						}
+						m_flash = true;
+					break;
+					case 2:    // Flash Outside Window
+						for (int i = 0; i < 16; i++)
+						{
+						  if ((i < m_window_start) || (i > m_window_end))
+							  m_attrs[i] = AT_FLASH;
+						  else
+							  m_attrs[i] = AT_NORMAL;
+						}
+						m_flash = true;
+					break;
+					case 3:    // Flash All
+						for ( int i = 0; i < 16; i++ )
+							m_attrs[i] = AT_FLASH;
+						m_flash = true;
+					break;
 				}
-				m_flash = true;
-				break;
-			  case 2:    // Flash Outside Window
-				for ( int i = 0; i < 16; i++ ) {
-				  if ( (i < m_window_start) || (i > m_window_end) )
-					  m_attrs[i] = AT_FLASH;
-				  else
-					  m_attrs[i] = AT_NORMAL;
-				}
-				m_flash = true;
-				break;
-			  case 3:    // Flash All
-				for ( int i = 0; i < 16; i++ )
-					m_attrs[i] = AT_FLASH;
-				m_flash = true;
-				break;
-			}
-		  } else {
+		  }
+		  else
+		  {
 			m_flash_rate--;
-			if ( !m_flash_rate ) {
-			  m_flash_timer = 0;
-				for ( int i = 0; i < 16; i++ ) {
-					  m_attrs[i] = AT_NORMAL;
+			if (!m_flash_rate)
+			{
+				m_flash_timer = 0;
+				for (int i = 0; i < 16; i++)
+				{
+					m_attrs[i] = AT_NORMAL;
 				}
 			}
-			if ( m_flash_control ) {
-			  m_flash = false;
+			if (m_flash_control)
+			{
+				m_flash = false;
 			}
 		  }
 		}
-	  }
+	}
 
 	for (int i = 0; i < 16; i++)
 		(*m_outputs)[i] = (m_attrs[i] == AT_NORMAL) ? set_display(m_chars[i]) : 0;
@@ -234,7 +245,7 @@ void bfm_bd1_device::blank(int data)
 		break;
 
 	case 0x01:  // blank inside window
-		if ( m_window_size > 0 )
+		if (m_window_size > 0)
 		{
 			for (int i = m_window_start; i < m_window_end ; i++)
 			{
@@ -244,9 +255,9 @@ void bfm_bd1_device::blank(int data)
 		break;
 
 	case 0x02:  // blank outside window
-		if ( m_window_size > 0 )
+		if (m_window_size > 0)
 		{
-			if ( m_window_start > 0 )
+			if (m_window_start > 0)
 			{
 				for (int i = 0; i < m_window_start; i++)
 				{
@@ -275,14 +286,14 @@ void bfm_bd1_device::blank(int data)
 
 int bfm_bd1_device::write_char(int data)
 {
-	if ( m_user_def )
+	if (m_user_def)
 	{
 		m_user_def--;
 
 		m_user_data <<= 8;
 		m_user_data |= data;
 
-		if ( m_user_def )
+		if (m_user_def)
 		{
 			return 0;
 		}
@@ -302,7 +313,7 @@ int bfm_bd1_device::write_char(int data)
 		}
 		else
 		{
-			switch ( data & 0xf0 )
+			switch (data & 0xf0)
 			{
 			case 0x80:  // 0x80 - 0x8F Set display blanking
 				blank(data&0x03);//use the blanking data
@@ -316,9 +327,9 @@ int bfm_bd1_device::write_char(int data)
 			case 0x90:  // 0x90 - 0x9F Set cursor pos
 				m_cursor_pos = data & 0x0f;
 				m_scroll_active = false;
-				if ( m_display_mode == 2 )
+				if (m_display_mode == 2)
 				{
-					if ( m_cursor_pos >= m_window_end) m_scroll_active = 1;
+					if (m_cursor_pos >= m_window_end) m_scroll_active = 1;
 				}
 				break;
 
@@ -328,13 +339,13 @@ int bfm_bd1_device::write_char(int data)
 
 			case 0xb0:  // 0xB0 - 0xBF Clear display area
 
-				switch ( data & 0x03 )
+				switch (data & 0x03)
 				{
 				case 0x00:  // clr nothing
 					break;
 
 				case 0x01:  // clr inside window
-					if ( m_window_size > 0 )
+					if (m_window_size > 0)
 					{
 						std::fill_n(m_chars + m_window_start, m_window_size, 0);
 						std::fill_n(m_attrs + m_window_start, m_window_size, 0);
@@ -343,9 +354,9 @@ int bfm_bd1_device::write_char(int data)
 					break;
 
 				case 0x02:  // clr outside window
-					if ( m_window_size > 0 )
+					if (m_window_size > 0)
 					{
-						if ( m_window_start > 0 )
+						if (m_window_start > 0)
 						{
 							for (int i = 0; i < m_window_start; i++)
 							{
@@ -354,7 +365,7 @@ int bfm_bd1_device::write_char(int data)
 							}
 						}
 
-						if (m_window_end < 15 )
+						if (m_window_end < 15)
 						{
 							for (int i = m_window_end; i < 15- m_window_end ; i++)
 							{
@@ -373,9 +384,8 @@ int bfm_bd1_device::write_char(int data)
 
 			case 0xc0:  // 0xC0 - 0xCF Set flash rate
 				m_flash_rate = data & 0x0f;
-				if ( !m_flash_rate && m_flash )
+				if (!m_flash_rate && m_flash)
 				{
-					m_flash_timer = 0;
 					m_flash = false;
 				}
 				m_flash_timer = 20;
@@ -383,8 +393,8 @@ int bfm_bd1_device::write_char(int data)
 
 			case 0xd0:  // 0xD0 - 0xDF Set Flash control
 				m_flash_control = data & 0x03;
-				if ( m_flash_control == 0 && m_flash ) {
-					m_flash_timer = 0;
+				if (m_flash_control == 0 && m_flash)
+				{
 					m_flash = false;
 				}
 				break;
@@ -398,9 +408,9 @@ int bfm_bd1_device::write_char(int data)
 				m_window_end   = data &0x0f;
 				m_window_size  = (m_window_end - m_window_start)+1;
 				m_scroll_active = 0;
-				if ( m_display_mode == 2 )
+				if (m_display_mode == 2)
 				{
-					if ( m_cursor_pos >= m_window_end)
+					if (m_cursor_pos >= m_window_end)
 					{
 						m_scroll_active = 1;
 						m_cursor_pos    = m_window_end;
@@ -423,7 +433,7 @@ void bfm_bd1_device::setdata(int segdata, int data)
 {
 	int move = 0;
 	int change =0;
-	switch ( data )
+	switch (data)
 	{
 	case 0x25:  // flash
 		if(m_chars[m_pcursor_pos] & (1<<8))
@@ -442,7 +452,7 @@ void bfm_bd1_device::setdata(int segdata, int data)
 
 	case 0x2c:  // semicolon
 	case 0x2e:  // decimal point
-		if( m_chars[m_pcursor_pos] & (1<<12))
+		if (m_chars[m_pcursor_pos] & (1<<12))
 		{
 			move++;
 		}
@@ -466,7 +476,7 @@ void bfm_bd1_device::setdata(int segdata, int data)
 		change++;
 	}
 
-	if ( move )
+	if (move)
 	{
 		int mode = m_display_mode;
 
@@ -474,40 +484,40 @@ void bfm_bd1_device::setdata(int segdata, int data)
 
 		if ( m_window_size <= 0 || (m_window_size > 16))
 		{ // if no window selected default to equivalent rotate mode
-				if ( mode == 2 )      mode = 0;
-				else if ( mode == 3 ) mode = 1;
+				if (mode == 2)      mode = 0;
+				else if (mode == 3) mode = 1;
 		}
 
-		switch ( mode )
+		switch (mode)
 		{
 		case 0: // rotate left
 			m_cursor_pos &= 0x0f;
 
-			if ( change )
+			if (change)
 			{
 				m_chars[m_cursor_pos] = segdata;
 			}
 			m_cursor_pos++;
-			if ( m_cursor_pos >= 16 ) m_cursor_pos = 0;
+			if (m_cursor_pos >= 16) m_cursor_pos = 0;
 			break;
 
 
 		case 1: // Rotate right
 			m_cursor_pos &= 0x0f;
 
-			if ( change )
+			if (change)
 			{
 				m_chars[m_cursor_pos] = segdata;
 			}
 			m_cursor_pos--;
-			if ( m_cursor_pos < 0  ) m_cursor_pos = 15;
+			if (m_cursor_pos < 0) m_cursor_pos = 15;
 			break;
 
 		case 2: // Scroll left
 			if ( m_cursor_pos < m_window_end )
 			{
 				m_scroll_active = 0;
-				if ( change )
+				if (change)
 				{
 					m_chars[m_cursor_pos] = segdata;
 				}
@@ -515,12 +525,12 @@ void bfm_bd1_device::setdata(int segdata, int data)
 			}
 			else
 			{
-				if ( move )
+				if (move)
 				{
-					if  ( m_scroll_active )
+					if  (m_scroll_active)
 					{
 						int i = m_window_start;
-						while ( i < m_window_end )
+						while (i < m_window_end)
 						{
 							m_chars[i] = m_chars[i+1];
 							i++;
@@ -529,7 +539,7 @@ void bfm_bd1_device::setdata(int segdata, int data)
 					else   m_scroll_active = 1;
 				}
 
-				if ( change )
+				if (change)
 				{
 					m_chars[m_window_end] = segdata;
 				}
@@ -541,24 +551,24 @@ void bfm_bd1_device::setdata(int segdata, int data)
 			break;
 
 		case 3: // Scroll right
-			if ( m_cursor_pos > m_window_start )
+			if (m_cursor_pos > m_window_start)
 			{
-				if ( change )
+				if (change)
 				{
 					m_chars[m_cursor_pos] = segdata;
 				}
 				m_cursor_pos--;
-				if ( m_cursor_pos > 15  ) m_cursor_pos = 0;
+				if (m_cursor_pos > 15) m_cursor_pos = 0;
 			}
 			else
 			{
-				if ( move )
+				if (move)
 				{
-					if  ( m_scroll_active )
+					if (m_scroll_active)
 					{
 						int i = m_window_end;
 
-						while ( i > m_window_start )
+						while (i > m_window_start)
 						{
 							m_chars[i] = m_chars[i-1];
 							i--;
@@ -566,13 +576,13 @@ void bfm_bd1_device::setdata(int segdata, int data)
 					}
 					else   m_scroll_active = 1;
 				}
-				if ( change )
+				if (change)
 				{
-						m_chars[m_window_start] = segdata;
-					}
+					m_chars[m_window_start] = segdata;
+				}
 				else
 				{
-						m_chars[m_window_start] = 0;
+					m_chars[m_window_start] = 0;
 				}
 			}
 			break;

--- a/src/mame/bfm/bfm_bd1.cpp
+++ b/src/mame/bfm/bfm_bd1.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:James Wallace
 /**********************************************************************
 
-    Bellfruit BD1 VFD module interface and emulation 
+    Bellfruit BD1 VFD module interface and emulation
 
     TODO: Verify flashing (our only datasheet has that section
     completely illegible)
@@ -150,8 +150,8 @@ void bfm_bd1_device::device_reset()
 	m_display_mode = 0;
 	m_flash_rate = 0;
 	m_flash_control = 0;
-    m_flash = false;
-    m_flash_timer = 0;
+	m_flash = false;
+	m_flash_timer = 0;
 	m_user_data = 0;
 	m_user_def = 0;
 	m_sclk = 0;
@@ -217,7 +217,7 @@ void bfm_bd1_device::update_display()
 		  }
 		}
 	  }
-	
+
 	for (int i = 0; i < 16; i++)
 		(*m_outputs)[i] = (m_attrs[i] == AT_NORMAL) ? set_display(m_chars[i]) : 0;
 }
@@ -373,7 +373,7 @@ int bfm_bd1_device::write_char(int data)
 
 			case 0xc0:  // 0xC0 - 0xCF Set flash rate
 				m_flash_rate = data & 0x0f;
-				if ( !m_flash_rate && m_flash ) 
+				if ( !m_flash_rate && m_flash )
 				{
 					m_flash_timer = 0;
 					m_flash = false;

--- a/src/mame/bfm/bfm_bd1.cpp
+++ b/src/mame/bfm/bfm_bd1.cpp
@@ -183,30 +183,30 @@ void bfm_bd1_device::update_display()
 			{
 				switch (m_flash_control)
 				{
-					case 1:    // Flash Inside Window
-						for (int i = 0; i < 16; i++)
-						{
-						  if ((i >= m_window_start) && (i <= m_window_end))
-							  m_attrs[i] = AT_FLASH;
-						  else
-							  m_attrs[i] = AT_NORMAL;
-						}
-						m_flash = true;
-					break;
-					case 2:    // Flash Outside Window
-						for (int i = 0; i < 16; i++)
-						{
-						  if ((i < m_window_start) || (i > m_window_end))
-							  m_attrs[i] = AT_FLASH;
-						  else
-							  m_attrs[i] = AT_NORMAL;
-						}
-						m_flash = true;
-					break;
-					case 3:    // Flash All
-						for ( int i = 0; i < 16; i++ )
+				case 1:    // Flash Inside Window
+					for (int i = 0; i < 16; i++)
+					{
+						if ((i >= m_window_start) && (i <= m_window_end))
 							m_attrs[i] = AT_FLASH;
-						m_flash = true;
+						else
+							m_attrs[i] = AT_NORMAL;
+					}
+					m_flash = true;
+					break;
+				case 2:    // Flash Outside Window
+					for (int i = 0; i < 16; i++)
+					{
+					  if ((i < m_window_start) || (i > m_window_end))
+						  m_attrs[i] = AT_FLASH;
+					  else
+						  m_attrs[i] = AT_NORMAL;
+					}
+					m_flash = true;
+					break;
+				case 3:    // Flash All
+					for ( int i = 0; i < 16; i++ )
+						m_attrs[i] = AT_FLASH;
+					m_flash = true;
 					break;
 				}
 		  }

--- a/src/mame/bfm/bfm_bd1.h
+++ b/src/mame/bfm/bfm_bd1.h
@@ -45,24 +45,26 @@ private:
 	std::unique_ptr<output_finder<16> > m_outputs;
 	uint8_t m_port_val;
 
-	int m_cursor_pos = 0;
-	int m_window_start = 0;     // display window start pos 0-15
-	int m_window_end = 0;       // display window end   pos 0-15
-	int m_window_size = 0;      // window  size
-	int m_shift_count = 0;
-	int m_shift_data = 0;
-	int m_pcursor_pos = 0;
-	int m_scroll_active = 0;
-	int m_display_mode = 0;
-	int m_flash_rate = 0;
-	int m_flash_control = 0;
-	int m_sclk = 0;
-	int m_data = 0;
+	uint8_t m_cursor_pos = 0;
+	uint8_t m_window_start = 0;     // display window start pos 0-15
+	uint8_t m_window_end = 0;       // display window end   pos 0-15
+	uint8_t m_window_size = 0;      // window  size
+	uint8_t m_shift_count = 0;
+	uint8_t m_shift_data = 0;
+	uint8_t m_pcursor_pos = 0;
+	bool m_scroll_active = false;
+	uint8_t m_display_mode = 0;
+	bool m_flash = false;
+	uint8_t m_flash_rate = 0;
+	uint8_t m_flash_control = 0;
+	uint8_t m_flash_timer = 0;
+	uint8_t m_sclk = 0;
+	uint8_t m_data = 0;
 
 	uint8_t m_cursor = 0;
 	uint16_t m_chars[16]{};
 	uint8_t m_attrs[16]{};
-	uint16_t m_user_data = 0;             // user defined character data (16 bit)
+	uint16_t m_user_data = 0;         // user defined character data (16 bit)
 	uint16_t m_user_def = 0;          // user defined character state
 };
 

--- a/src/mame/bfm/bfm_bda.cpp
+++ b/src/mame/bfm/bfm_bda.cpp
@@ -247,7 +247,7 @@ int bfm_bda_device::write_char(int data)
 			{
 				if (data > 0x3F)
 				{
-					logerror(" BDA Undefined character %x, %u \n", data, data);
+					logerror("BDA Undefined character, needs populating 0x%1$02X\n", data);
 				}
 
 				setdata(BDAcharset[(data & 0x3F)], data);
@@ -323,7 +323,7 @@ int bfm_bda_device::write_char(int data)
 				else
 				{
 					m_flash_rate = data & 0x0F;
-					logerror(" BDA flash %x", m_flash_rate);
+					logerror("BDA flash %x", m_flash_rate);
 				}
 				break;
 

--- a/src/mame/bfm/bfm_bda.cpp
+++ b/src/mame/bfm/bfm_bda.cpp
@@ -165,19 +165,16 @@ void bfm_bda_device::blank(int data)
 {
 	switch ( data & 0x03 ) // TODO: wrong case values???
 	{
-
-		case 0x00:  //blank all
+	case 0x00:  //blank all
+		for (int i = 0; i < 15; i++)
 		{
-			for (int i = 0; i < 15; i++)
-			{
-				m_attrs[i] = AT_BLANK;
-			}
+			m_attrs[i] = AT_BLANK;
 		}
 		break;
 
 
-		case 0x01:  // blank inside window
-		if ( m_window_size > 0 )
+	case 0x01:  // blank inside window
+		if (m_window_size > 0)
 		{
 			for (int i = m_window_start; i < m_window_end ; i++)
 			{
@@ -186,8 +183,8 @@ void bfm_bda_device::blank(int data)
 		}
 		break;
 
-		case 0x02:  // blank outside window
-		if ( m_window_size > 0 )
+	case 0x02:  // blank outside window
+		if (m_window_size > 0)
 		{
 			if ( m_window_start > 0 )
 			{
@@ -207,12 +204,10 @@ void bfm_bda_device::blank(int data)
 		}
 		break;
 
-		case 0x03:  // clear blanking
+	case 0x03:  // clear blanking
+		for (int i = 0; i < 15; i++)
 		{
-			for (int i = 0; i < 15; i++)
-			{
-				m_attrs[i] = 0;
-			}
+			m_attrs[i] = 0;
 		}
 		break;
 	}
@@ -220,7 +215,7 @@ void bfm_bda_device::blank(int data)
 
 int bfm_bda_device::write_char(int data)
 {
-	if ( m_user_def )
+	if (m_user_def)
 	{
 		m_user_def--;
 
@@ -255,47 +250,46 @@ int bfm_bda_device::write_char(int data)
 		}
 		else
 		{
-			switch ( data & 0xF0 )
+			switch (data & 0xf0)
 			{
 			case 0x80:  // 0x80 - 0x8F Set display blanking
-				if (data==0x84)// duty setup
+				if (data == 0x84)// duty setup
 				{
 					m_blank_flag = 1;
 					m_flash_flag = 0;
 				}
 				else
 				{
-					blank(data&0x03);//use the blanking data
+					blank(data & 0x03);//use the blanking data
 				}
 				break;
 
 			case 0x90:  // 0x90 - 0x9F Set cursor pos
-				m_cursor_pos = data & 0x0F;
+				m_cursor_pos = data & 0x0f;
 				m_scroll_active = 0;
-				if ( m_display_mode == 2 )
+				if (m_display_mode == 2)
 				{
 					if ( m_cursor_pos >= m_window_end) m_scroll_active = 1;
 				}
 				break;
 
-			case 0xA0:  // 0xA0 - 0xAF Set display mode
-				if (data==0xa8)// userdef
+			case 0xa0:  // 0xA0 - 0xAF Set display mode
+				if (data == 0xa8)// userdef
 				{
 					m_user_def = 2;
 				}
-				else if (data==0xac)
+				else if (data == 0xac)
 				{
 					popmessage("TEST MODE");
 				}
 				else
 				{
-					m_display_mode = data &0x03;
+					m_display_mode = data & 0x03;
 				}
 				break;
 
-			case 0xB0:  // 0xB0 - 0xBF Clear display area
-
-				if (data==0xbc)
+			case 0xb0:  // 0xB0 - 0xBF Clear display area
+				if (data == 0xbc)
 				{
 					popmessage("CLEAR USERDEF");
 				}
@@ -303,44 +297,46 @@ int bfm_bda_device::write_char(int data)
 				{
 					switch (data & 0x03)
 					{
-						case 0x00:  // clr nothing
-							break;
+					case 0x00:  // clr nothing
+						break;
 
-						case 0x01:  // clr inside window
-							if ( m_window_size > 0 )
-							{
-								std::fill_n(m_chars + m_window_start, m_window_size, 0);
-								std::fill_n(m_attrs + m_window_start, m_window_size, 0);
-							}
+					case 0x01:  // clr inside window
+						if (m_window_size > 0)
+						{
+							std::fill_n(m_chars + m_window_start, m_window_size, 0);
+							std::fill_n(m_attrs + m_window_start, m_window_size, 0);
+						}
+						break;
+					}
 				}
 				break;
 
-			case 0xC0:
-				if (data==0xc8)
+			case 0xc0:
+				if (data == 0xc8)
 				{
 					m_flash_flag = 1;
 				}
 				else
 				{
-					m_flash_rate = data & 0x0F;
+					m_flash_rate = data & 0x0f;
 					logerror("BDA flash %x", m_flash_rate);
 				}
 				break;
 
-			case 0xD0:  // 0xD0 - 0xDF Set Flash control
+			case 0xd0:  // 0xD0 - 0xDF Set Flash control
 				m_flash_control = data & 0x03;
 				break;
 
-			case 0xE0:  // 0xE0 - 0xEF Set window start pos
-				m_window_start = data &0x0F;
+			case 0xe0:  // 0xE0 - 0xEF Set window start pos
+				m_window_start = data & 0x0f;
 				m_window_size  = (m_window_end - m_window_start)+1;
 				break;
 
-			case 0xF0:  // 0xF0 - 0xFF Set window end pos
-				m_window_end   = data &0x0F;
-				m_window_size  = (m_window_end - m_window_start)+1;
+			case 0xf0:  // 0xF0 - 0xFF Set window end pos
+				m_window_end   = data & 0x0f;
+				m_window_size  = (m_window_end - m_window_start) + 1;
 				m_scroll_active = 0;
-				if ( m_display_mode == 2 )
+				if (m_display_mode == 2)
 				{
 					if ( m_cursor_pos >= m_window_end)
 					{
@@ -351,7 +347,6 @@ int bfm_bda_device::write_char(int data)
 				break;
 			}
 		}
-	}
 	}
 	update_display();
 

--- a/src/mame/bfm/bfm_bda.h
+++ b/src/mame/bfm/bfm_bda.h
@@ -40,6 +40,7 @@ private:
 	static const uint8_t AT_FLASHED = 0x80;   // set when character should be blinked off
 
 	std::unique_ptr<output_finder<16> > m_outputs;
+	std::unique_ptr<output_finder<1> > m_brightness;
 	uint8_t m_port_val;
 
 	int m_cursor_pos = 0;
@@ -55,6 +56,7 @@ private:
 	int m_display_mode = 0;
 	int m_flash_rate = 0;
 	int m_flash_control = 0;
+	int m_duty;
 
 	uint8_t m_cursor = 0;
 	uint16_t m_chars[16]{};

--- a/src/mame/jpm/jpmimpct.cpp
+++ b/src/mame/jpm/jpmimpct.cpp
@@ -248,6 +248,17 @@ void jpmimpct_state::machine_start()
 {
 	m_digits.resolve();
 	m_lamp_output.resolve();
+
+	save_item(NAME(m_optic_pattern));
+	save_item(NAME(m_payen));
+	save_item(NAME(m_hopinhibit));
+	save_item(NAME(m_slidesout));
+	save_item(NAME(m_hopper));
+	save_item(NAME(m_motor));
+	save_item(NAME(m_volume_latch));
+	save_item(NAME(m_global_volume));
+	save_item(NAME(m_coinstate));
+
 }
 
 void jpmimpct_state::machine_reset()

--- a/src/mame/jpm/jpmimpct.h
+++ b/src/mame/jpm/jpmimpct.h
@@ -154,14 +154,14 @@ private:
 	void impact_non_video_map(address_map &map);
 
 	uint8_t m_Lamps[256]{};
-	int m_optic_pattern = 0;
-	int m_payen = 0;
-	int m_hopinhibit = 0;
-	int m_slidesout = 0;
-	int m_hopper[3]{};
-	int m_motor[3]{};
-	int m_volume_latch = 0;
-	int m_global_volume = 0;
+	uint8_t m_optic_pattern = 0;
+	bool m_payen = false;
+	uint8_t m_hopinhibit = 0;
+	uint8_t m_slidesout = 0;
+	uint8_t m_hopper[3]{};
+	uint8_t m_motor[3]{};
+	uint8_t m_volume_latch = 0;
+	uint8_t m_global_volume = 0;
 	uint16_t m_coinstate = 0;
 	required_device_array<timer_device, 6> m_cointimer;
 

--- a/src/mame/layout/connect4.lay
+++ b/src/mame/layout/connect4.lay
@@ -800,7 +800,14 @@ license:CC0
 		<repeat count="16">
 			<param name="i" start="15" increment="-1"/>
 			<param name="x" start="0" increment="9"/>
+			<element name="vfdblank~i~" ref="vfd0">
+				<color red="0.14" green="0.14" blue="0.14"/>
+				<bounds x="~x~" y="120" width="9" height="14"/>
+			</element>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0" />
+				<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="120" width="9" height="14"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/ecoinf2.lay
+++ b/src/mame/layout/ecoinf2.lay
@@ -839,14 +839,7 @@ license:CC0
 	<repeat count="14">
 		<param name="i" start="0" increment="1"/>
 		<param name="x" start="17" increment="7"/>
-		<element name="vfdblank~i~" ref="vfd0">
-			<color red="0.14" green="0.14" blue="0.14"/>
-			<bounds x="~x~" y="280" width="7" height="10"/>
-		</element>
 		<element name="vfd~i~" ref="vfd0">
-			<animate name="vfdduty0" />
-			<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
-			<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
 			<bounds x="~x~" y="280" width="7" height="10"/>
 		</element>
 	</repeat>

--- a/src/mame/layout/ecoinf2.lay
+++ b/src/mame/layout/ecoinf2.lay
@@ -836,48 +836,20 @@ license:CC0
 		<bounds x="120" y="120" width="7" height="7"/>
 	</element>
 
-	<element name="vfd0" ref="vfd0" state="0">
-		<bounds x="17" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd1" ref="vfd0" state="0">
-		<bounds x="24" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd2" ref="vfd0" state="0">
-		<bounds x="31" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd3" ref="vfd0" state="0">
-		<bounds x="38" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd4" ref="vfd0" state="0">
-		<bounds x="45" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd5" ref="vfd0" state="0">
-		<bounds x="52" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd6" ref="vfd0" state="0">
-		<bounds x="59" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd7" ref="vfd0" state="0">
-		<bounds x="66" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd8" ref="vfd0" state="0">
-		<bounds x="73" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd9" ref="vfd0" state="0">
-		<bounds x="80" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd10" ref="vfd0" state="0">
-		<bounds x="87" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd11" ref="vfd0" state="0">
-		<bounds x="94" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd12" ref="vfd0" state="0">
-		<bounds x="101" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd13" ref="vfd0" state="0">
-		<bounds x="108" y="280" width="7" height="10"/>
-	</element>
+	<repeat count="14">
+		<param name="i" start="0" increment="1"/>
+		<param name="x" start="17" increment="7"/>
+		<element name="vfdblank~i~" ref="vfd0">
+			<color red="0.14" green="0.14" blue="0.14"/>
+			<bounds x="~x~" y="280" width="7" height="10"/>
+		</element>
+		<element name="vfd~i~" ref="vfd0">
+			<animate name="vfdduty0" />
+			<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
+			<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
+			<bounds x="~x~" y="280" width="7" height="10"/>
+		</element>
+	</repeat>
 
 	<element name="sreel1" ref="SteppersReel1" state="0">
 		<bounds x="17" y="300" width="32" height="32"/>

--- a/src/mame/layout/ecoinf3.lay
+++ b/src/mame/layout/ecoinf3.lay
@@ -839,14 +839,7 @@ license:CC0
 	<repeat count="14">
 		<param name="i" start="0" increment="1"/>
 		<param name="x" start="17" increment="7"/>
-		<element name="vfdblank~i~" ref="vfd0">
-			<color red="0.14" green="0.14" blue="0.14"/>
-			<bounds x="~x~" y="280" width="7" height="10"/>
-		</element>
 		<element name="vfd~i~" ref="vfd0">
-			<animate name="vfdduty0" />
-			<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
-			<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
 			<bounds x="~x~" y="280" width="7" height="10"/>
 		</element>
 	</repeat>

--- a/src/mame/layout/ecoinf3.lay
+++ b/src/mame/layout/ecoinf3.lay
@@ -836,48 +836,20 @@ license:CC0
 		<bounds x="120" y="120" width="7" height="7"/>
 	</element>
 
-	<element name="vfd0" ref="vfd0" state="0">
-		<bounds x="17" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd1" ref="vfd0" state="0">
-		<bounds x="24" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd2" ref="vfd0" state="0">
-		<bounds x="31" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd3" ref="vfd0" state="0">
-		<bounds x="38" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd4" ref="vfd0" state="0">
-		<bounds x="45" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd5" ref="vfd0" state="0">
-		<bounds x="52" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd6" ref="vfd0" state="0">
-		<bounds x="59" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd7" ref="vfd0" state="0">
-		<bounds x="66" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd8" ref="vfd0" state="0">
-		<bounds x="73" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd9" ref="vfd0" state="0">
-		<bounds x="80" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd10" ref="vfd0" state="0">
-		<bounds x="87" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd11" ref="vfd0" state="0">
-		<bounds x="94" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd12" ref="vfd0" state="0">
-		<bounds x="101" y="280" width="7" height="10"/>
-	</element>
-	<element name="vfd13" ref="vfd0" state="0">
-		<bounds x="108" y="280" width="7" height="10"/>
-	</element>
+	<repeat count="14">
+		<param name="i" start="0" increment="1"/>
+		<param name="x" start="17" increment="7"/>
+		<element name="vfdblank~i~" ref="vfd0">
+			<color red="0.14" green="0.14" blue="0.14"/>
+			<bounds x="~x~" y="280" width="7" height="10"/>
+		</element>
+		<element name="vfd~i~" ref="vfd0">
+			<animate name="vfdduty0" />
+			<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
+			<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
+			<bounds x="~x~" y="280" width="7" height="10"/>
+		</element>
+	</repeat>
 
 	<element name="sreel1" ref="SteppersReel1" state="0">
 		<bounds x="17" y="300" width="32" height="32"/>

--- a/src/mame/layout/globalfr.lay
+++ b/src/mame/layout/globalfr.lay
@@ -10,54 +10,20 @@ license:CC0
 	</element>
 
 	<view name="VFD">
-		<element name="vfd0" ref="vfd0" state="0">
-			<bounds x="0" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd1" ref="vfd0" state="0">
-			<bounds x="9" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd2" ref="vfd0" state="0">
-			<bounds x="18" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd3" ref="vfd0" state="0">
-			<bounds x="27" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd4" ref="vfd0" state="0">
-			<bounds x="36" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd5" ref="vfd0" state="0">
-			<bounds x="45" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd6" ref="vfd0" state="0">
-			<bounds x="54" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd7" ref="vfd0" state="0">
-			<bounds x="63" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd8" ref="vfd0" state="0">
-			<bounds x="72" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd9" ref="vfd0" state="0">
-			<bounds x="81" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd10" ref="vfd0" state="0">
-			<bounds x="90" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd11" ref="vfd0" state="0">
-			<bounds x="99" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd12" ref="vfd0" state="0">
-			<bounds x="108" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd13" ref="vfd0" state="0">
-			<bounds x="117" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd14" ref="vfd0" state="0">
-			<bounds x="126" y="280" width="9" height="14"/>
-		</element>
-		<element name="vfd15" ref="vfd0" state="0">
-			<bounds x="135" y="280" width="9" height="14"/>
-		</element>
-	</view>
+		<repeat count="16">
+			<param name="i" start="0" increment="1"/>
+			<param name="x" start="0" increment="9"/>
+			<element name="vfdblank~i~" ref="vfd0">
+				<color red="0.14" green="0.14" blue="0.14"/>
+				<bounds x="~x~" y="280" width="9" height="14"/>
+			</element>
+			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0" />
+				<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
+				<bounds x="~x~" y="280" width="9" height="14"/>
+			</element>
+		</repeat>
 
+	</view>
 </mamelayout>

--- a/src/mame/layout/j5ar80cla.lay
+++ b/src/mame/layout/j5ar80cla.lay
@@ -2706,9 +2706,9 @@
 		</led7seg>
 	</element>
 	<element name="vfd0">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
@@ -2844,9 +2844,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5cira.lay
+++ b/src/mame/layout/j5cira.lay
@@ -2173,9 +2173,9 @@
 		</led7seg>
 	</element>
 	<element name="vfd0">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
@@ -2355,9 +2355,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5fairp.lay
+++ b/src/mame/layout/j5fairp.lay
@@ -2842,9 +2842,9 @@
 	</element>
 	<element name="vfd0">
 		<!-- if these are really 14 segs, and the hookups are meant to be compaible with the 16segs then the MAME bit order is incorrect -->
-		<!--<led14segsc>
+		<!--<led16segsc>
 		    <color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>-->
+		</led16segsc>-->
 		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>

--- a/src/mame/layout/j5firebl.lay
+++ b/src/mame/layout/j5firebl.lay
@@ -726,9 +726,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5hollyc.lay
+++ b/src/mame/layout/j5hollyc.lay
@@ -2567,9 +2567,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5hotdoga.lay
+++ b/src/mame/layout/j5hotdoga.lay
@@ -2961,9 +2961,9 @@
 		</led7seg>
 	</element>
 	<element name="vfd0">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
@@ -3101,9 +3101,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5indsum.lay
+++ b/src/mame/layout/j5indsum.lay
@@ -958,9 +958,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5intr.lay
+++ b/src/mame/layout/j5intr.lay
@@ -2317,9 +2317,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5movie.lay
+++ b/src/mame/layout/j5movie.lay
@@ -2370,9 +2370,9 @@
 		</led7seg>
 	</element>
 	<element name="vfd0">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
@@ -2600,9 +2600,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5nite.lay
+++ b/src/mame/layout/j5nite.lay
@@ -2246,9 +2246,9 @@
 		</led7seg>
 	</element>
 	<element name="vfd0">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
@@ -2390,9 +2390,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5palma.lay
+++ b/src/mame/layout/j5palma.lay
@@ -977,9 +977,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5popeye.lay
+++ b/src/mame/layout/j5popeye.lay
@@ -3538,9 +3538,9 @@
 	</element>
 	<element name="vfd0">
 		<!-- if these are really 14 segs, and the hookups are meant to be compaible with the 16segs then the MAME bit order is incorrect -->
-		<!--<led14segsc>
+		<!--<led16segsc>
 		    <color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>-->
+		</led16segsc>-->
 		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
 		</led16segsc>
@@ -3705,9 +3705,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5sizl.lay
+++ b/src/mame/layout/j5sizl.lay
@@ -834,9 +834,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5supbara.lay
+++ b/src/mame/layout/j5supbara.lay
@@ -1315,9 +1315,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5suphi.lay
+++ b/src/mame/layout/j5suphi.lay
@@ -2511,9 +2511,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5swop.lay
+++ b/src/mame/layout/j5swop.lay
@@ -1601,9 +1601,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5term.lay
+++ b/src/mame/layout/j5term.lay
@@ -1355,9 +1355,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5topshp.lay
+++ b/src/mame/layout/j5topshp.lay
@@ -1875,9 +1875,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5trail.lay
+++ b/src/mame/layout/j5trail.lay
@@ -1984,9 +1984,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5ujb.lay
+++ b/src/mame/layout/j5ujb.lay
@@ -704,9 +704,9 @@
 		</led7seg>
 	</element>
 	<element name="vfd0">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="vfd0_background">
 		<rect>
@@ -888,9 +888,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j5wsc.lay
+++ b/src/mame/layout/j5wsc.lay
@@ -2210,9 +2210,9 @@
 		</element>
 	</repeat>
 	<element name="debug_vfd">
-		<led14segsc>
+		<led16segsc>
 			<color red="0.0" green="1.0" blue="1.0"/>
-		</led14segsc>
+		</led16segsc>
 	</element>
 	<element name="debug_stepper_value" defstate="0">
 		<simplecounter maxstate="999" digits="3">

--- a/src/mame/layout/j6aceclb.lay
+++ b/src/mame/layout/j6aceclb.lay
@@ -4320,6 +4320,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="300" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="391" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6bnza.lay
+++ b/src/mame/layout/j6bnza.lay
@@ -4394,9 +4394,9 @@
 		<repeat count="16">
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="295" increment="17"/>
-			<element name="vfd~i~" ref="vfd0">
+			<element name="vfd~i~" ref="vfd0" blend="add">
 				<animate name="vfdduty0"/>
-				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="0" red="0.14" green="0.14" blue="0.14" alpha="1.0"/>
 				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="320" width="17" height="30"/>
 			</element>

--- a/src/mame/layout/j6bnza.lay
+++ b/src/mame/layout/j6bnza.lay
@@ -4395,6 +4395,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="295" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="320" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6btbwd.lay
+++ b/src/mame/layout/j6btbwd.lay
@@ -2285,6 +2285,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="54" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="391" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6camelt.lay
+++ b/src/mame/layout/j6camelt.lay
@@ -3803,6 +3803,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="149" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="347" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6casclaf.lay
+++ b/src/mame/layout/j6casclaf.lay
@@ -4783,6 +4783,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="228" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="427" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6cascze.lay
+++ b/src/mame/layout/j6cascze.lay
@@ -3621,6 +3621,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="160" increment="22"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="410" width="22" height="28"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6colcsh.lay
+++ b/src/mame/layout/j6colcsh.lay
@@ -5944,6 +5944,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="189" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="497" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6cpal.lay
+++ b/src/mame/layout/j6cpal.lay
@@ -2548,6 +2548,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="130" increment="15"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="327" width="15" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6crack.lay
+++ b/src/mame/layout/j6crack.lay
@@ -4038,6 +4038,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="102" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="440" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6euphor.lay
+++ b/src/mame/layout/j6euphor.lay
@@ -5329,6 +5329,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="136" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="482" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6ewn.lay
+++ b/src/mame/layout/j6ewn.lay
@@ -2405,6 +2405,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="144" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="472" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6fastfr.lay
+++ b/src/mame/layout/j6fastfr.lay
@@ -5537,6 +5537,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="289" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="352" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6ffce.lay
+++ b/src/mame/layout/j6ffce.lay
@@ -4185,6 +4185,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="227" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="438" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6frtpot.lay
+++ b/src/mame/layout/j6frtpot.lay
@@ -4684,6 +4684,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="253" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="247" width="17" height="26"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6gidogh.lay
+++ b/src/mame/layout/j6gidogh.lay
@@ -4331,6 +4331,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="188" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="479" width="17" height="31"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6gldclb.lay
+++ b/src/mame/layout/j6gldclb.lay
@@ -4872,6 +4872,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="277" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="381" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6gogold.lay
+++ b/src/mame/layout/j6gogold.lay
@@ -3467,6 +3467,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="183" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="458" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6goldgla.lay
+++ b/src/mame/layout/j6goldgla.lay
@@ -5958,6 +5958,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="103" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="441" width="17" height="31"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6guabc.lay
+++ b/src/mame/layout/j6guabc.lay
@@ -3460,6 +3460,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="434" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="423" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6guabcl.lay
+++ b/src/mame/layout/j6guabcl.lay
@@ -4266,6 +4266,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="344" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="274" width="17" height="26"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6impuls.lay
+++ b/src/mame/layout/j6impuls.lay
@@ -3270,6 +3270,9 @@
 			<param name="x" start="143" increment="17" />
 
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="435" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6impuls15.lay
+++ b/src/mame/layout/j6impuls15.lay
@@ -3282,6 +3282,9 @@
 			<param name="x" start="143" increment="17" />
 
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="435" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6kfc.lay
+++ b/src/mame/layout/j6kfc.lay
@@ -3295,6 +3295,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="268" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="381" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6kungfu.lay
+++ b/src/mame/layout/j6kungfu.lay
@@ -2578,6 +2578,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="281" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="382" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6megbck.lay
+++ b/src/mame/layout/j6megbck.lay
@@ -5354,6 +5354,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="371" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="415" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6mono60.lay
+++ b/src/mame/layout/j6mono60.lay
@@ -3648,6 +3648,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="260" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="383" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6mono6010.lay
+++ b/src/mame/layout/j6mono6010.lay
@@ -3648,6 +3648,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="260" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="383" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6mono608.lay
+++ b/src/mame/layout/j6mono608.lay
@@ -3648,6 +3648,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="260" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="383" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6monst.lay
+++ b/src/mame/layout/j6monst.lay
@@ -3697,6 +3697,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="197" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="409" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6montlk.lay
+++ b/src/mame/layout/j6montlk.lay
@@ -3329,6 +3329,9 @@
 			<param name="x" start="117" increment="17" />
 
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="319" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6montlk6.lay
+++ b/src/mame/layout/j6montlk6.lay
@@ -3329,6 +3329,9 @@
 			<param name="x" start="117" increment="17" />
 
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="319" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6quick.lay
+++ b/src/mame/layout/j6quick.lay
@@ -3229,6 +3229,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="94" increment="15"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="281" width="15" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6ra.lay
+++ b/src/mame/layout/j6ra.lay
@@ -3499,6 +3499,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="267" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="382" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6redarwf.lay
+++ b/src/mame/layout/j6redarwf.lay
@@ -4034,6 +4034,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="202" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="479" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6rh6cld.lay
+++ b/src/mame/layout/j6rh6cld.lay
@@ -2281,6 +2281,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="54" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="391" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6rhchil.lay
+++ b/src/mame/layout/j6rhchil.lay
@@ -3224,6 +3224,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="230" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="433" width="17" height="31"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6roller10.lay
+++ b/src/mame/layout/j6roller10.lay
@@ -3475,6 +3475,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="270" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="379" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6roller15.lay
+++ b/src/mame/layout/j6roller15.lay
@@ -3584,6 +3584,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="270" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="379" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6roller8.lay
+++ b/src/mame/layout/j6roller8.lay
@@ -3475,6 +3475,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="270" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="379" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6slagng.lay
+++ b/src/mame/layout/j6slagng.lay
@@ -4514,6 +4514,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="183" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="444" width="17" height="31"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6snakes.lay
+++ b/src/mame/layout/j6snakes.lay
@@ -5004,6 +5004,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="252" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="382" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6sonic10.lay
+++ b/src/mame/layout/j6sonic10.lay
@@ -3973,7 +3973,7 @@
 			</element>
 			<element name="vfd~i~" ref="vfd0">
 				<animate name="vfdduty0"/>
-				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="0" red="0.14" green="0.14" blue="0.14" alpha="1.0"/>
 				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="364" width="17" height="29"/>
 			</element>

--- a/src/mame/layout/j6swpdrp.lay
+++ b/src/mame/layout/j6swpdrp.lay
@@ -2991,6 +2991,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="99" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="485" width="17" height="31"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6tombc.lay
+++ b/src/mame/layout/j6tombc.lay
@@ -3265,6 +3265,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="272" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="382" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6topflg.lay
+++ b/src/mame/layout/j6topflg.lay
@@ -6030,6 +6030,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="237" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="421" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6twst.lay
+++ b/src/mame/layout/j6twst.lay
@@ -2621,6 +2621,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="194" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="434" width="17" height="31"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6untch.lay
+++ b/src/mame/layout/j6untch.lay
@@ -4148,6 +4148,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="299" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="297" width="17" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6vindal.lay
+++ b/src/mame/layout/j6vindal.lay
@@ -3905,6 +3905,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="200" increment="12"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="457" width="12" height="24"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6vivark.lay
+++ b/src/mame/layout/j6vivark.lay
@@ -4151,6 +4151,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="164" increment="20"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="478" width="20" height="28"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/j6wizardd.lay
+++ b/src/mame/layout/j6wizardd.lay
@@ -3056,6 +3056,9 @@
 			<param name="i" start="0" increment="1"/>
 			<param name="x" start="88" increment="17"/>
 			<element name="vfd~i~" ref="vfd0">
+				<animate name="vfdduty0"/>
+				<color state="0" red="0.00" green="1.00" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="1.00" blue="1.00" alpha="1.0"/>
 				<bounds x="~x~" y="256" width="15" height="30"/>
 			</element>
 		</repeat>

--- a/src/mame/layout/m4actbnk.lay
+++ b/src/mame/layout/m4actbnk.lay
@@ -2147,54 +2147,18 @@
 		<element ref="vfd0_background">
 			<bounds x="683" y="559" width="272" height="30"/>
 		</element>
-		<element name="vfd15" ref="vfd0" state="0">
-			<bounds x="683" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd14" ref="vfd0" state="0">
-			<bounds x="700" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd13" ref="vfd0" state="0">
-			<bounds x="717" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd12" ref="vfd0" state="0">
-			<bounds x="734" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd11" ref="vfd0" state="0">
-			<bounds x="751" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd10" ref="vfd0" state="0">
-			<bounds x="768" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd9" ref="vfd0" state="0">
-			<bounds x="785" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd8" ref="vfd0" state="0">
-			<bounds x="802" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd7" ref="vfd0" state="0">
-			<bounds x="819" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd6" ref="vfd0" state="0">
-			<bounds x="836" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd5" ref="vfd0" state="0">
-			<bounds x="853" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd4" ref="vfd0" state="0">
-			<bounds x="870" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd3" ref="vfd0" state="0">
-			<bounds x="887" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd2" ref="vfd0" state="0">
-			<bounds x="904" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd1" ref="vfd0" state="0">
-			<bounds x="921" y="559" width="17" height="30"/>
-		</element>
-		<element name="vfd0" ref="vfd0" state="0">
-			<bounds x="938" y="559" width="17" height="30"/>
-		</element>
+
+		<repeat count="16">
+			<param name="n" start="15" increment="-1"/>
+			<param name="x" start="683" increment="17"/>
+			<element name="vfd~n~" ref="vfd0" state="0">
+				<animate name="vfdduty0" />
+				<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
+				<bounds x="~x~" y="559" width="17" height="30"/>
+			</element>
+		</repeat>
+
 		<element name="label38" ref="label_38">
 			<bounds x="130" y="569" width="51" height="24"/>
 		</element>

--- a/src/mame/layout/m4addr.lay
+++ b/src/mame/layout/m4addr.lay
@@ -3260,54 +3260,18 @@
 		<element ref="vfd0_background">
 			<bounds x="105" y="305" width="272" height="30"/>
 		</element>
-		<element name="vfd15" ref="vfd0" state="0">
-			<bounds x="105" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd14" ref="vfd0" state="0">
-			<bounds x="122" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd13" ref="vfd0" state="0">
-			<bounds x="139" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd12" ref="vfd0" state="0">
-			<bounds x="156" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd11" ref="vfd0" state="0">
-			<bounds x="173" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd10" ref="vfd0" state="0">
-			<bounds x="190" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd9" ref="vfd0" state="0">
-			<bounds x="207" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd8" ref="vfd0" state="0">
-			<bounds x="224" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd7" ref="vfd0" state="0">
-			<bounds x="241" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd6" ref="vfd0" state="0">
-			<bounds x="258" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd5" ref="vfd0" state="0">
-			<bounds x="275" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd4" ref="vfd0" state="0">
-			<bounds x="292" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd3" ref="vfd0" state="0">
-			<bounds x="309" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd2" ref="vfd0" state="0">
-			<bounds x="326" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd1" ref="vfd0" state="0">
-			<bounds x="343" y="305" width="17" height="30"/>
-		</element>
-		<element name="vfd0" ref="vfd0" state="0">
-			<bounds x="360" y="305" width="17" height="30"/>
-		</element>
+
+		<repeat count="16">
+			<param name="n" start="15" increment="-1"/>
+			<param name="x" start="105" increment="17"/>
+			<element name="vfd~n~" ref="vfd0" state="0">
+				<animate name="vfdduty0" />
+				<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
+				<bounds x="~x~" y="305" width="17" height="30"/>
+			</element>
+		</repeat>
+
 		<element name="label11" ref="label_11">
 			<bounds x="507" y="199" width="184" height="28"/>
 		</element>

--- a/src/mame/layout/m4alpha.lay
+++ b/src/mame/layout/m4alpha.lay
@@ -3353,54 +3353,18 @@
 		<element ref="vfd0_background">
 			<bounds x="413" y="433" width="272" height="30"/>
 		</element>
-		<element name="vfd15" ref="vfd0" state="0">
-			<bounds x="413" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd14" ref="vfd0" state="0">
-			<bounds x="430" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd13" ref="vfd0" state="0">
-			<bounds x="447" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd12" ref="vfd0" state="0">
-			<bounds x="464" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd11" ref="vfd0" state="0">
-			<bounds x="481" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd10" ref="vfd0" state="0">
-			<bounds x="498" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd9" ref="vfd0" state="0">
-			<bounds x="515" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd8" ref="vfd0" state="0">
-			<bounds x="532" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd7" ref="vfd0" state="0">
-			<bounds x="549" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd6" ref="vfd0" state="0">
-			<bounds x="566" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd5" ref="vfd0" state="0">
-			<bounds x="583" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd4" ref="vfd0" state="0">
-			<bounds x="600" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd3" ref="vfd0" state="0">
-			<bounds x="617" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd2" ref="vfd0" state="0">
-			<bounds x="634" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd1" ref="vfd0" state="0">
-			<bounds x="651" y="433" width="17" height="30"/>
-		</element>
-		<element name="vfd0" ref="vfd0" state="0">
-			<bounds x="668" y="433" width="17" height="30"/>
-		</element>
+
+		<repeat count="16">
+			<param name="n" start="15" increment="-1"/>
+			<param name="x" start="413" increment="17"/>
+			<element name="vfd~n~" ref="vfd0" state="0">
+				<animate name="vfdduty0" />
+				<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
+				<bounds x="~x~" y="433" width="17" height="30"/>
+			</element>
+		</repeat>
+
 		<element name="label105" ref="label_105">
 			<bounds x="349" y="532" width="58" height="20"/>
 		</element>

--- a/src/mame/layout/m4andybt.lay
+++ b/src/mame/layout/m4andybt.lay
@@ -4682,54 +4682,17 @@
 		<element ref="vfd0_background">
 			<bounds x="261" y="381" width="272" height="30"/>
 		</element>
-		<element name="vfd15" ref="vfd0" state="0">
-			<bounds x="261" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd14" ref="vfd0" state="0">
-			<bounds x="278" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd13" ref="vfd0" state="0">
-			<bounds x="295" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd12" ref="vfd0" state="0">
-			<bounds x="312" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd11" ref="vfd0" state="0">
-			<bounds x="329" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd10" ref="vfd0" state="0">
-			<bounds x="346" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd9" ref="vfd0" state="0">
-			<bounds x="363" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd8" ref="vfd0" state="0">
-			<bounds x="380" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd7" ref="vfd0" state="0">
-			<bounds x="397" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd6" ref="vfd0" state="0">
-			<bounds x="414" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd5" ref="vfd0" state="0">
-			<bounds x="431" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd4" ref="vfd0" state="0">
-			<bounds x="448" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd3" ref="vfd0" state="0">
-			<bounds x="465" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd2" ref="vfd0" state="0">
-			<bounds x="482" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd1" ref="vfd0" state="0">
-			<bounds x="499" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd0" ref="vfd0" state="0">
-			<bounds x="516" y="381" width="17" height="30"/>
-		</element>
+
+		<repeat count="16">
+			<param name="n" start="15" increment="-1"/>
+			<param name="x" start="261" increment="17"/>
+			<element name="vfd~n~" ref="vfd0" state="0">
+				<animate name="vfdduty0" />
+				<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
+				<bounds x="~x~" y="381" width="17" height="30"/>
+			</element>
+		</repeat>
 		<element name="label5" ref="label_5">
 			<bounds x="2" y="2" width="91" height="44"/>
 		</element>

--- a/src/mame/layout/m4andycp.lay
+++ b/src/mame/layout/m4andycp.lay
@@ -2379,54 +2379,18 @@
 		<element ref="vfd0_background">
 			<bounds x="210" y="252" width="200" height="30"/>
 		</element>
-		<element name="vfd15" ref="vfd0" state="0">
-			<bounds x="210" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd14" ref="vfd0" state="0">
-			<bounds x="223" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd13" ref="vfd0" state="0">
-			<bounds x="236" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd12" ref="vfd0" state="0">
-			<bounds x="249" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd11" ref="vfd0" state="0">
-			<bounds x="262" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd10" ref="vfd0" state="0">
-			<bounds x="275" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd9" ref="vfd0" state="0">
-			<bounds x="288" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd8" ref="vfd0" state="0">
-			<bounds x="301" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd7" ref="vfd0" state="0">
-			<bounds x="314" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd6" ref="vfd0" state="0">
-			<bounds x="327" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd5" ref="vfd0" state="0">
-			<bounds x="340" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd4" ref="vfd0" state="0">
-			<bounds x="353" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd3" ref="vfd0" state="0">
-			<bounds x="366" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd2" ref="vfd0" state="0">
-			<bounds x="379" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd1" ref="vfd0" state="0">
-			<bounds x="392" y="252" width="13" height="30"/>
-		</element>
-		<element name="vfd0" ref="vfd0" state="0">
-			<bounds x="405" y="252" width="13" height="30"/>
-		</element>
+
+		<repeat count="16">
+			<param name="n" start="15" increment="-1"/>
+			<param name="x" start="210" increment="13"/>
+			<element name="vfd~n~" ref="vfd0" state="0">
+				<animate name="vfdduty0" />
+				<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
+				<bounds x="~x~" y="252" width="13" height="30"/>
+			</element>
+		</repeat>
+
 		<element name="label28" ref="label_28">
 			<bounds x="223" y="236" width="64" height="19"/>
 		</element>

--- a/src/mame/layout/m4andyge.lay
+++ b/src/mame/layout/m4andyge.lay
@@ -1839,54 +1839,18 @@
 		<element ref="vfd0_background">
 			<bounds x="268" y="362" width="272" height="30"/>
 		</element>
-		<element name="vfd15" ref="vfd0" state="0">
-			<bounds x="268" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd14" ref="vfd0" state="0">
-			<bounds x="285" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd13" ref="vfd0" state="0">
-			<bounds x="302" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd12" ref="vfd0" state="0">
-			<bounds x="319" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd11" ref="vfd0" state="0">
-			<bounds x="336" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd10" ref="vfd0" state="0">
-			<bounds x="353" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd9" ref="vfd0" state="0">
-			<bounds x="370" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd8" ref="vfd0" state="0">
-			<bounds x="387" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd7" ref="vfd0" state="0">
-			<bounds x="404" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd6" ref="vfd0" state="0">
-			<bounds x="421" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd5" ref="vfd0" state="0">
-			<bounds x="438" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd4" ref="vfd0" state="0">
-			<bounds x="455" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd3" ref="vfd0" state="0">
-			<bounds x="472" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd2" ref="vfd0" state="0">
-			<bounds x="489" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd1" ref="vfd0" state="0">
-			<bounds x="506" y="362" width="17" height="30"/>
-		</element>
-		<element name="vfd0" ref="vfd0" state="0">
-			<bounds x="523" y="362" width="17" height="30"/>
-		</element>
+
+		<repeat count="16">
+			<param name="n" start="15" increment="-1"/>
+			<param name="x" start="268" increment="17"/>
+			<element name="vfd~n~" ref="vfd0" state="0">
+				<animate name="vfdduty0" />
+				<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
+				<bounds x="~x~" y="362" width="17" height="30"/>
+			</element>
+		</repeat>
+
 		<element name="label109" ref="label_109">
 			<bounds x="876" y="75" width="83" height="13"/>
 		</element>

--- a/src/mame/layout/m4apachg.lay
+++ b/src/mame/layout/m4apachg.lay
@@ -2884,54 +2884,18 @@
 		<element ref="vfd0_background">
 			<bounds x="259" y="381" width="272" height="30"/>
 		</element>
-		<element name="vfd15" ref="vfd0" state="0">
-			<bounds x="259" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd14" ref="vfd0" state="0">
-			<bounds x="276" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd13" ref="vfd0" state="0">
-			<bounds x="293" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd12" ref="vfd0" state="0">
-			<bounds x="310" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd11" ref="vfd0" state="0">
-			<bounds x="327" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd10" ref="vfd0" state="0">
-			<bounds x="344" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd9" ref="vfd0" state="0">
-			<bounds x="361" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd8" ref="vfd0" state="0">
-			<bounds x="378" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd7" ref="vfd0" state="0">
-			<bounds x="395" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd6" ref="vfd0" state="0">
-			<bounds x="412" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd5" ref="vfd0" state="0">
-			<bounds x="429" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd4" ref="vfd0" state="0">
-			<bounds x="446" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd3" ref="vfd0" state="0">
-			<bounds x="463" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd2" ref="vfd0" state="0">
-			<bounds x="480" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd1" ref="vfd0" state="0">
-			<bounds x="497" y="381" width="17" height="30"/>
-		</element>
-		<element name="vfd0" ref="vfd0" state="0">
-			<bounds x="514" y="381" width="17" height="30"/>
-		</element>
+
+		<repeat count="16">
+			<param name="n" start="15" increment="-1"/>
+			<param name="x" start="259" increment="17"/>
+			<element name="vfd~n~" ref="vfd0" state="0">
+				<animate name="vfdduty0" />
+				<color state="0" red="0.00" green="0.6" blue="1.00" alpha="0.0"/>
+				<color state="31" red="0.00" green="0.6" blue="1.00" alpha="1.0"/>
+				<bounds x="~x~" y="381" width="17" height="30"/>
+			</element>
+		</repeat>
+
 		<element name="label4" ref="label_4">
 			<bounds x="464" y="9" width="60" height="24"/>
 		</element>


### PR DESCRIPTION
ROC10937 and clones: Added duty effects to built in FME layouts

BFM_BD1: Added flash mode, corrected character table

JPM IMPACT: Registered variables for state saving

BFM_BDA: Added brightness and flash controls

ROC10937 and clones: Preserved internal data buffers on POR, fixes blanked display in JPM IMPACT