### PR TITLE
hp80: Fixed keyboard issue on hp86b_001 & hp86b_004

### DIFF
--- a/src/mame/hp/hp80.cpp
+++ b/src/mame/hp/hp80.cpp
@@ -203,6 +203,7 @@ protected:
 
 	// State of keyboard
 	ioport_value m_kb_state[ 3 ];
+	bool m_int_kb_enabled;
 	bool m_kb_enable;
 	bool m_kb_pressed;
 	bool m_kb_flipped;
@@ -325,6 +326,7 @@ void hp80_base_state::machine_start()
 	save_item(NAME(m_halt_lines));
 	save_pointer(NAME(m_kb_state) , 3);
 	save_item(NAME(m_kb_enable));
+	save_item(NAME(m_int_kb_enabled));
 	save_item(NAME(m_kb_pressed));
 	save_item(NAME(m_kb_flipped));
 	save_item(NAME(m_kb_lang_readout));
@@ -346,6 +348,7 @@ void hp80_base_state::machine_reset()
 	m_kb_state[ 2 ] = 0;
 	m_kb_keycode = 0xff;
 	m_kb_enable = true;
+	m_int_kb_enabled = false;
 	m_kb_pressed = false;
 	m_kb_flipped = false;
 	m_kb_lang_readout = false;
@@ -463,6 +466,9 @@ void hp80_base_state::keysts_w(uint8_t data)
 	if (m_has_int_keyb) {
 		m_kb_lang_readout = BIT(data , 2);
 		m_kb_raw_readout = BIT(data , 3);
+		if (!m_int_kb_enabled && (data & 0x0f) == 1) {
+			m_int_kb_enabled = true;
+		}
 	}
 	m_dac->write(BIT(data , 5));
 	m_beep->set_state(BIT(data , 6));
@@ -717,7 +723,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(hp80_base_state::kb_scan)
 	input[ 1 ] = m_io_key1->read();
 	input[ 2 ] = m_io_key2->read();
 
-	if (m_kb_enable) {
+	if (m_kb_enable && (!m_has_int_keyb || m_int_kb_enabled)) {
 		uint8_t row;
 		uint8_t col;
 


### PR DESCRIPTION
Hi,
I'm opening this PR because I fixed the long-standing keyboard problem on `hp86b_001` and `hp86b_004`.
The bug was apparently due to the keyboard controller being enabled too early during the boot process.
Thanks.
--F.Ulivi