### PR TITLE
bus/a7800/rom.cpp: Use proper bank order for Activision 128K cartridges.

### DIFF
--- a/hash/a7800.xml
+++ b/hash/a7800.xml
@@ -863,8 +863,8 @@ type of rom dumps.  Effort will be made at a later date to split them and docume
 		<sharedfeat name="compatibility" value="NTSC"/>
 		<part name="cart" interface="a7800_cart">
 			<feature name="slot" value="a78_act" />
-			<dataarea name="rom" size="131072">
-				<rom name="dbledrgn.bin" size="131072" crc="aa265865" sha1="c3fb140836a4ed84cda7a999832703e8b72c0d21"/>
+			<dataarea name="rom" size="0x20000">
+				<rom name="dbledrgn.bin" size="0x20000" crc="f20773d5" sha1="df67dad8bbf3813e7b96362c55ed4af40d831277"/>
 			</dataarea>
 		</part>
 	</software>
@@ -877,8 +877,8 @@ type of rom dumps.  Effort will be made at a later date to split them and docume
 		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="cart" interface="a7800_cart">
 			<feature name="slot" value="a78_act" />
-			<dataarea name="rom" size="131072">
-				<rom name="dbledreu.bin" size="131072" crc="f29abdb2" sha1="210f3ac989549e89425e7677127715aee713af32"/>
+			<dataarea name="rom" size="0x20000">
+				<rom name="dbledreu.bin" size="0x20000" crc="4d634bf5" sha1="da7d495ac858c3b1f66aeb6e981c25bd08d44bd8"/>
 			</dataarea>
 		</part>
 	</software>
@@ -891,8 +891,8 @@ type of rom dumps.  Effort will be made at a later date to split them and docume
 		<sharedfeat name="compatibility" value="NTSC"/>
 		<part name="cart" interface="a7800_cart">
 			<feature name="slot" value="a78_abs" />
-			<dataarea name="rom" size="65536">
-				<rom name="f18hornt.bin" size="65536" crc="63d1c7c1" sha1="13a18a6b85db6222b01d37800e5e57db616a85a6"/>
+			<dataarea name="rom" size="0x10000">
+				<rom name="dei353am-hornt.u4" size="0x10000" crc="63d1c7c1" sha1="13a18a6b85db6222b01d37800e5e57db616a85a6"/>
 			</dataarea>
 		</part>
 	</software>
@@ -1633,8 +1633,8 @@ Saarna for debugging the problem)
 		<sharedfeat name="compatibility" value="NTSC"/>
 		<part name="cart" interface="a7800_cart">
 			<feature name="slot" value="a78_sg" />
-			<dataarea name="rom" size="131072">
-				<rom name="midmutnt.bin" size="131072" crc="187ec84e" sha1="db5ea4c1456f3b403f6b8978432ecbcdac89d432"/>
+			<dataarea name="rom" size="0x20000">
+				<rom name="c300051-089a.u1" size="0x20000" crc="187ec84e" sha1="db5ea4c1456f3b403f6b8978432ecbcdac89d432"/>
 			</dataarea>
 		</part>
 	</software>
@@ -2019,8 +2019,8 @@ almost nothing like the prototype.
 		<sharedfeat name="compatibility" value="NTSC"/>
 		<part name="cart" interface="a7800_cart">
 			<feature name="slot" value="a78_act" />
-			<dataarea name="rom" size="131072">
-				<rom name="rampage.bin" size="131072" crc="39a316aa" sha1="13745b5eaaab7e2c992f3312285e112cdeb424f6"/>
+			<dataarea name="rom" size="0x20000">
+				<rom name="rampage.bin" size="0x20000" crc="d2876ee2" sha1="17401f85fe8b453a6b43b3d0035d993b90568efc"/>
 			</dataarea>
 		</part>
 	</software>

--- a/src/devices/bus/a7800/rom.cpp
+++ b/src/devices/bus/a7800/rom.cpp
@@ -444,13 +444,12 @@ void a78_rom_abs_device::write_40xx(offs_t offset, uint8_t data)
 
  Carts with Activision bankswitch:
  128K games. 8 x 16K banks (0-7) to be mapped at
- 0xa000-0xdfff. Bank is selected depending on the
- address written in 0xff80-0xff87.
+ 0xa000-0xdfff. Bank is selected by writing above
+ 0xe000 and depends on A2-A0.
  The rest of the memory is as follows:
- 0x4000-0x5fff second 8kb of bank 6
- 0x6000-0x7fff first 8kb of bank 6
- 0x8000-0x9fff second 8kb of bank 7
- 0xe000-0xffff first 8kb of bank 7
+ 0x4000-0x7fff bank 6
+ 0x8000-0x9fff first 8K of bank 7
+ 0xe000-0xffff second 8K of bank 7
 
  GAMES: Double Dragon, Rampage.
 
@@ -458,38 +457,25 @@ void a78_rom_abs_device::write_40xx(offs_t offset, uint8_t data)
 
 uint8_t a78_rom_act_device::read_40xx(offs_t offset)
 {
-	uint8_t data = 0xff;
-	uint16_t addr = offset & 0x1fff;
-
-	// offset goes from 0 to 0xc000
+	// offset goes from 0 to 0xbfff
 	switch (offset & 0xe000)
 	{
+		default: // unreachable: appease compiler
 		case 0x0000:
-			data = m_rom[addr + 0x1a000];
-			break;
 		case 0x2000:
-			data = m_rom[addr + 0x18000];
-			break;
-		case 0x4000:
-			data = m_rom[addr + 0x1e000];
-			break;
+			return m_rom[offset | 0x18000];
 		case 0x6000:
-			data = m_rom[addr + (m_bank * 0x4000)];
-			break;
 		case 0x8000:
-			data = m_rom[addr + (m_bank * 0x4000) + 0x2000];
-			break;
+			return m_rom[(offset & 0x3fff) | (m_bank * 0x4000)];
+		case 0x4000:
 		case 0xa000:
-			data = m_rom[addr + 0x1c000];
-			break;
+			return m_rom[offset | 0x1c000];
 	}
-
-	return data;
 }
 
 void a78_rom_act_device::write_40xx(offs_t offset, uint8_t data)
 {
-	if (offset >= 0xbf80 && offset <= 0xbf8f)
+	if (offset >= 0xa000)
 		m_bank = offset & 7;
 }
 


### PR DESCRIPTION
The current ROMs don't work when put back on an original cartridge due to pairs of 8K blocks being swapped. This corrects that and other minor details.