### PR TITLE
Fixed a crash when toggling fullscreen w/ NES Gyromite on Windows

### DIFF
--- a/src/osd/windows/window.cpp
+++ b/src/osd/windows/window.cpp
@@ -1403,7 +1403,10 @@ void win_window_info::draw_video_contents(HDC dc, bool update)
 		{
 			// update DC
 			m_dc = dc;
-			renderer().draw(update);
+			if (has_renderer())
+			{
+				renderer().draw(update);
+			}
 		}
 	}
 }


### PR DESCRIPTION
-osd/windows/window.cpp: Check for a non-null renderer before issuing a draw request to the renderer. [Ryan Holtz]