### PR TITLE
skeleton: Rename Vector 4 to Vector 3

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -43050,8 +43050,8 @@ pk6128c                         //
 vec1200                         //
 vector06                        //
 
-@source:skeleton/vector4.cpp
-vector4                         //
+@source:skeleton/vector3.cpp
+vector3                         //
 
 @source:miltonbradley/vectrex.cpp
 raaspec                         // (c) Roy Abel & Associates 1984

--- a/src/mame/mess.flt
+++ b/src/mame/mess.flt
@@ -980,7 +980,7 @@ skeleton/unistar.cpp
 skeleton/v6809.cpp
 skeleton/vanguardmk1.cpp
 skeleton/vd56sp.cpp
-skeleton/vector4.cpp
+skeleton/vector3.cpp
 skeleton/vectrix.cpp
 skeleton/vp415.cpp
 skeleton/vp60.cpp

--- a/src/mame/skeleton/vector3.cpp
+++ b/src/mame/skeleton/vector3.cpp
@@ -2,19 +2,22 @@
 // copyright-holders:Miodrag Milanovic
 /***************************************************************************
 
-Vector Graphic Vector 4. Vector Graphic was a Californian company that
-made a few popular computers until they were crushed flat by the IBM PC.
+Vector Graphic, Inc Vector 3 and Vector MZ. Vector Graphic was a Californian
+company that made a few popular computers until they were crushed flat by the
+IBM PC.
 
-2009-12-08 Skeleton driver.
+2009-12-08 Skeleton driver for "Vector 4".
+2022-12-03 Renamed driver to "Vector 3"
 
-According to the net the Vector 4 came out in 1982, but BIOS 0 has a date
-of 1979, so perhaps it's for some other model.
+This driver was based on the Vector 4 User Guide but accidentally with the
+Vector 3 or other ROMs, because of confusing naming. To get the ROMs to work
+required Vector 3 behavior.
 
-Although each bios set identifies as Vector Graphic, none of them align
-to what the user manual says.
+The Vector 3 and Vector MZ had similar internal hardware. Both are based on the
+ZCB, Flashwriter II, and Micropolis floppy controller.
 
-The manual gives a list of ports (listed in the i/o address map). There's
-no schematic.
+The 7100-0245-00-00 Extended Systems Monitor 4.3 Users Manual seems to
+correspond with BIOS 1.
 
 BIOS 0 only talks to UARTs at 2-7 and nothing else. It uses a terminal
 for all communications.
@@ -23,14 +26,16 @@ BIOS 1 and 2 only talk to UARTs at 0-7 and the undocumented port 40.
 They also write a video screen at F000-F7FF, but there's no writes
 to any video controller. Also, the chargen roms (2x 2716) are missing.
 
-The system contains a 8088-2 cpu for limited IBM compatibility, but
-the manual has no mention of it besides its existence.
-
-128K RAM (expandable to 256K).
-
+https://deramp.com/vector_graphic.html
+7200-0203-03-02: https://bitsavers.org/pdf/vectorGraphic/hardware/7200-0204-03-02_ZCB_Single_Board_Computer_Jun80.pdf
+https://bitsavers.org/pdf/vectorGraphic/hardware/Vector_Z80_Board_Users_Manual_May79.pdf
+https://bitsavers.org/pdf/vectorGraphic/software/7100-0245-00-00_Extended_Systems_Monitor_4.3_Users_Manual_Jul81.pdf
+https://bitsavers.org/pdf/vectorGraphic/hardware/Vector_Flashwriter_II_Mar79.pdf
+https://deramp.com/downloads/vector_graphic/hardware/Flashwriter%20II%20Manual.pdf
+https://deramp.com/downloads/vector_graphic/hardware/Flashwriter%20II%20Schematic%20Rev%204.tif
+https://bitsavers.org/pdf/vectorGraphic/hardware/Micropolis_Disk_Controller_Board.pdf
 
 TODO:
-- Need schematic
 - H command goes crazy
 - chargen roms
 - video
@@ -53,21 +58,21 @@ TODO:
 
 namespace {
 
-class vector4_state : public driver_device
+class vector3_state : public driver_device
 {
 public:
-	vector4_state(const machine_config &mconfig, device_type type, const char *tag)
+	vector3_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_rom(*this, "maincpu")
 		, m_ram(*this, "mainram")
 	{ }
 
-	void vector4(machine_config &config);
+	void vector3(machine_config &config);
 
 private:
-	void vector4_io(address_map &map);
-	void vector4_mem(address_map &map);
+	void vector3_io(address_map &map);
+	void vector3_mem(address_map &map);
 
 	memory_passthrough_handler m_rom_shadow_tap;
 	required_device<cpu_device> m_maincpu;
@@ -77,7 +82,7 @@ private:
 };
 
 
-void vector4_state::vector4_mem(address_map &map)
+void vector3_state::vector3_mem(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x0000, 0xffff).ram().share("mainram");
@@ -86,32 +91,24 @@ void vector4_state::vector4_mem(address_map &map)
 	map(0xf800, 0xf8ff).rom().region("maincpu", 0x1000);
 }
 
-void vector4_state::vector4_io(address_map &map)
+void vector3_state::vector3_io(address_map &map)
 {
 	map.unmap_value_high();
 	map.global_mask(0xff);
 	map(0x00, 0x01).rw("uart0", FUNC(i8251_device::read), FUNC(i8251_device::write)); // keyboard
 	map(0x02, 0x03).rw("uart1", FUNC(i8251_device::read), FUNC(i8251_device::write)); // terminal, bios 0 only
-	// map(0x02, 0x03)  rom enable and colour - bios 1,2 (bit 0 switches use of 0000-0FFF; LOW = ROM; HIGH = RAM)
-	map(0x04, 0x05).rw("uart2", FUNC(i8251_device::read), FUNC(i8251_device::write)); // modem
-	map(0x06, 0x07).rw("uart3", FUNC(i8251_device::read), FUNC(i8251_device::write)); // serial printer
-	map(0x08, 0x0b).rw("ppi", FUNC(i8255_device::read), FUNC(i8255_device::write));  // parallel/centronics printers
-	// map(0x0c, 0x0c)  select Z80
-	// map(0x0d, 0x0d)  select 8088
-	// map(0x0e, 0x0f)  video controller (uses 32.640 xtal)
-	map(0x10, 0x13).rw("pit", FUNC(pit8253_device::read), FUNC(pit8253_device::write));  // generate 2 baud rates and an interrupt source
-	// map(0x16, 0x17)  RAM address map
-	// map(0x18, 0x19)  Tone Generator
-	// map(0x1c, 0x1f)  Colour Map
+	map(0x04, 0x05).mirror(0x02).rw("uart2", FUNC(i8251_device::read), FUNC(i8251_device::write));
+	map(0x08, 0x0b).rw("ppi", FUNC(i8255_device::read), FUNC(i8255_device::write));
+	map(0x10, 0x13).rw("pit", FUNC(pit8253_device::read), FUNC(pit8253_device::write));
 	// map(0x40, 0x40)  undocumented
 }
 
 /* Input ports */
-static INPUT_PORTS_START( vector4 )
+static INPUT_PORTS_START( vector3 )
 INPUT_PORTS_END
 
 
-void vector4_state::machine_reset()
+void vector3_state::machine_reset()
 {
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 	program.install_rom(0x0000, 0x0fff, m_rom);   // do it here for F3
@@ -134,12 +131,12 @@ void vector4_state::machine_reset()
 }
 
 
-void vector4_state::vector4(machine_config &config)
+void vector3_state::vector3(machine_config &config)
 {
 	/* basic machine hardware */
-	Z80(config, m_maincpu, 5'100'000);   // manual says 5.1MHz (8088 uses this frequency too)
-	m_maincpu->set_addrmap(AS_PROGRAM, &vector4_state::vector4_mem);
-	m_maincpu->set_addrmap(AS_IO, &vector4_state::vector4_io);
+	Z80(config, m_maincpu, 4'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &vector3_state::vector3_mem);
+	m_maincpu->set_addrmap(AS_IO, &vector3_state::vector3_io);
 
 	/* video hardware */
 	clock_device &uart_clock(CLOCK(config, "uart_clock", 153600));
@@ -149,8 +146,6 @@ void vector4_state::vector4(machine_config &config)
 	uart_clock.signal_handler().append("uart1", FUNC(i8251_device::write_rxc));
 	uart_clock.signal_handler().append("uart2", FUNC(i8251_device::write_txc));
 	uart_clock.signal_handler().append("uart2", FUNC(i8251_device::write_rxc));
-	uart_clock.signal_handler().append("uart3", FUNC(i8251_device::write_txc));
-	uart_clock.signal_handler().append("uart3", FUNC(i8251_device::write_rxc));
 
 	I8251(config, "uart0", 0);
 
@@ -174,22 +169,12 @@ void vector4_state::vector4(machine_config &config)
 	rs232b.dsr_handler().set("uart2", FUNC(i8251_device::write_dsr));
 	rs232b.cts_handler().set("uart2", FUNC(i8251_device::write_cts));
 
-	i8251_device &uart3(I8251(config, "uart3", 0));
-	uart3.txd_handler().set("rs232c", FUNC(rs232_port_device::write_txd));
-	uart3.dtr_handler().set("rs232c", FUNC(rs232_port_device::write_dtr));
-	uart3.rts_handler().set("rs232c", FUNC(rs232_port_device::write_rts));
-
-	rs232_port_device &rs232c(RS232_PORT(config, "rs232c", default_rs232_devices, nullptr));
-	rs232c.rxd_handler().set("uart3", FUNC(i8251_device::write_rxd));
-	rs232c.dsr_handler().set("uart3", FUNC(i8251_device::write_dsr));
-	rs232c.cts_handler().set("uart3", FUNC(i8251_device::write_cts));
-
 	I8255A(config, "ppi");
 	PIT8253(config, "pit", 0);
 }
 
 /* ROM definition */
-ROM_START( vector4 )
+ROM_START( vector3 )
 	ROM_REGION( 0x1100, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD( "mfdc.bin", 0x1000, 0x0100, CRC(d82a40d6) SHA1(cd1ef5fb0312cd1640e0853d2442d7d858bc3e3b))
 
@@ -214,4 +199,4 @@ ROM_END
 /* Driver */
 
 //    YEAR  NAME     PARENT  COMPAT  MACHINE  INPUT    CLASS          INIT        COMPANY            FULLNAME    FLAGS
-COMP( 1982, vector4, 0,      0,      vector4, vector4, vector4_state, empty_init, "Vector Graphic", "Vector 4", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )
+COMP( 1979, vector3, 0,      0,      vector3, vector3, vector3_state, empty_init, "Vector Graphic", "Vector 3", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
It appears Vector Graphic Monitor 4 was confused with Vector 4. The majority of the functioning parts are for the Vector 3, as that is the source of the ROMs.

I've fixed some of the easier Vector 4-isms that were copied from the user guide, but it will need more thorough work. That should be a lot easier with the better understanding of which machine was running and the detailed documentation.

------

I'm familiar with the Vector 4, but not so much with the Vector 3. I have a follow-up to add Vector 4. It doesn't conflict except for mame.lst.