### PR TITLE
ibm5170_cdrom.xml: Typo correction

### DIFF
--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -96,7 +96,7 @@ Demo/Shareware: "Bodycount", "Zone 66", "Save Our Pizzas", "Dangerous Dave", "Ca
 		<notes><![CDATA[
 CD-ROM includes
 Complete Game: "TV Sports Football"
-Demo/Shareware: "Ranger Fox", "Monster Bash", "Onesimus", "Turoid", "Peristroka"
+Demo/Shareware: "Ranger Fox", "Monster Bash", "Onesimus", "Turoid", "Perestroika"
 ]]></notes>
 		<info name="region" value="Europe" />
 		<sharedfeat name="platform" value="DOS" />


### PR DESCRIPTION
Corrected "Peristroka" to "Perestroika" on "5plus1_25" notes