### PR TITLE
Yamaha DX9: Resolve issue with incoming MIDI clock

### DIFF
--- a/src/mame/yamaha/ymdx9.cpp
+++ b/src/mame/yamaha/ymdx9.cpp
@@ -133,7 +133,9 @@ private:
 
 	void mem_map(address_map &map);
 
-	WRITE_LINE_MEMBER(midi_r) { m_rx_data = state; }
+	WRITE_LINE_MEMBER(midi_r) {
+		m_rx_data = state;
+	}
 
 	WRITE_LINE_MEMBER(midiclock_w) { if (state) m_maincpu->m6801_clock_serial(); }
 
@@ -159,6 +161,14 @@ private:
 	 * @return uint8_t The value read from the port.
 	 */
 	uint8_t p1_r(offs_t offset);
+
+	/**
+	 * @brief Handle a read from the synth's IO Port 2.
+	 * This function is used to handle incoming serial data.
+	 * @param offset The offset into the memory mapped region being read.
+	 * @return uint8_t The value read from the port.
+	 */
+	uint8_t p2_r(offs_t offset);
 };
 
 
@@ -242,6 +252,7 @@ void yamaha_dx9_state::dx9(machine_config &config)
 	// Unlike the DX7 only IO port 1 is used.
 	// The direction flags of other ports are set, however they are never read, or written.
 	m_maincpu->in_p1_cb().set(FUNC(yamaha_dx9_state::p1_r));
+	m_maincpu->in_p2_cb().set(FUNC(yamaha_dx9_state::p2_r));
 	m_maincpu->out_p1_cb().set(FUNC(yamaha_dx9_state::p1_w));
 
 	NVRAM(config, "ram1", nvram_device::DEFAULT_ALL_0);
@@ -255,7 +266,7 @@ void yamaha_dx9_state::dx9(machine_config &config)
 	m_adc->in_callback<4>().set_constant(0x80);
 
 	// Configure MIDI.
-	auto &midiclock(CLOCK(config, "midiclock", 500_kHz_XTAL));
+	auto &midiclock(CLOCK(config, "midiclock", 500_kHz_XTAL / 2));
 	midiclock.signal_handler().set(FUNC(yamaha_dx9_state::midiclock_w));
 
 	MIDI_PORT(config, "mdin", midiin_slot, "midiin").rxd_handler().set(FUNC(yamaha_dx9_state::midi_r));
@@ -323,6 +334,13 @@ uint8_t yamaha_dx9_state::p1_r(offs_t offset)
 	return m_adc->eoc_r() << 4;
 }
 
+/**
+ * yamaha_dx9_state::p2_r
+ */
+uint8_t yamaha_dx9_state::p2_r(offs_t offset)
+{
+	return m_rx_data << 3;
+}
 
 /**
  * yamaha_dx9_state::p1_w

--- a/src/mame/yamaha/ymdx9.cpp
+++ b/src/mame/yamaha/ymdx9.cpp
@@ -133,10 +133,7 @@ private:
 
 	void mem_map(address_map &map);
 
-	WRITE_LINE_MEMBER(midi_r)
-	{
-		m_rx_data = state;
-	}
+	WRITE_LINE_MEMBER(midi_r) { m_rx_data = state; }
 
 	WRITE_LINE_MEMBER(midiclock_w) { if (state) m_maincpu->m6801_clock_serial(); }
 

--- a/src/mame/yamaha/ymdx9.cpp
+++ b/src/mame/yamaha/ymdx9.cpp
@@ -133,7 +133,8 @@ private:
 
 	void mem_map(address_map &map);
 
-	WRITE_LINE_MEMBER(midi_r) {
+	WRITE_LINE_MEMBER(midi_r)
+	{
 		m_rx_data = state;
 	}
 
@@ -334,6 +335,7 @@ uint8_t yamaha_dx9_state::p1_r(offs_t offset)
 	return m_adc->eoc_r() << 4;
 }
 
+	
 /**
  * yamaha_dx9_state::p2_r
  */
@@ -342,6 +344,7 @@ uint8_t yamaha_dx9_state::p2_r(offs_t offset)
 	return m_rx_data << 3;
 }
 
+	
 /**
  * yamaha_dx9_state::p1_w
  */


### PR DESCRIPTION
This PR resolves an issue with handling incoming MIDI on the Yamaha DX9 driver.
I made a mistake in my original analysis of the schematics. There's a divider on the 500 kHz crystal attached to the MIDI clock. I also forgot to finalise the reading of MIDI.
This PR should resolve those issues.