### PR TITLE
Fixed issue with incorrect PC address in "Stopped at watchpoint"

### DIFF
--- a/src/emu/debug/points.cpp
+++ b/src/emu/debug/points.cpp
@@ -408,7 +408,7 @@ void debug_watchpoint::triggered(read_or_write type, offs_t address, u64 data, u
 		const device_state_interface *state;
 		if (debug.cpu().live_cpu() == &m_debugInterface->device() && m_debugInterface->device().interface(state))
 		{
-			debug.console().printf("%s (PC=%s)\n", buffer, state->state_string(STATE_GENPCBASE));
+			debug.console().printf("%s (PC=%X)\n", buffer, state->pcbase());
 			m_debugInterface->compute_debug_flags();
 		}
 		else if (!was_stopped)


### PR DESCRIPTION
Issue report edby D-Type on the MAME discord
PC address is incorrect in "Stopped at watchpoint" string in debugger. Example:
mame c64
wp d020,1,w (when debugger pops up)
F12
It will stop at E5AD (or instruction after it), but it will report a PC in the range fd6e-fd81 (it varies when you reset). Weird....