### PR TITLE
msx1_flop.xml: Add notes, mark double sided images for single sides releases as bad dumps, remove disk conversions for software present in other software lists.

### DIFF
--- a/hash/msx1_flop.xml
+++ b/hash/msx1_flop.xml
@@ -6,19 +6,6 @@ license:CC0-1.0
 <softwarelist name="msx1_flop" description="MSX1 disk images">
 
 <!--
-   Things listed here should have a requirement of BASIC 1.0 + Disk Basic 1.0 (ie a Standard MSX1 type system with FDD)
-   I've noticed some 'MSX1' floppy images in TOSEC seem to require a higher BASIC version?
-   Some also require more RAM? the driver currently isn't very flexible.
-
-   This for now is just a skeleton list for quick testing.
-
-   To use the floppy drive the disk basic ROM must be mounted, example use case.
-   msx -cart1 diskbas -flop1 ohshit
-
--->
-
-
-<!--
 System software
 
 The following floppies came with the machines.
@@ -35,7 +22,7 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="svi738" supported="partial">
+	<software name="svi738">
 		<description>Spectravideo SVI-738</description>
 		<year>1985</year>
 		<publisher>Spectravideo</publisher>
@@ -51,7 +38,8 @@ The following floppies came with the machines.
 		</part>
 		<part name="msxdos" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
-				<rom name="738msxdos.dsk" size="368640" crc="0430d57f" sha1="221faaf9fcbed0ecf82cb0f6b1965a384f952c8d" />
+				<!-- Starts a diskcopy utility in Dutch, very lkely not an original dump -->
+				<rom name="738msxdos.dsk" size="368640" crc="0430d57f" sha1="221faaf9fcbed0ecf82cb0f6b1965a384f952c8d" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -80,24 +68,14 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="msxdosb" cloneof="msxdos">
-		<description>MSX-DOS (USA)</description>
-		<year>1983</year>
-		<publisher>Microsoft</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="msx-dos (1983)(microsoft)(us).dsk" size="368640" crc="fdc7fbc7" sha1="b042d4b7391aec53567e08a7f29a9ab57093b0aa" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="msxdoshs">
 		<description>MSX-DOS Ayuda (Spain)</description>
 		<year>1989</year>
 		<publisher>Philips</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="msx-dos ayuda (1989)(philips)(es).dsk" size="737280" crc="81421eda" sha1="04753336ab52cdecfdaaace41f215e8745f69b6b" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="msx-dos ayuda (1989)(philips)(es).dsk" size="737280" crc="81421eda" sha1="04753336ab52cdecfdaaace41f215e8745f69b6b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -108,7 +86,8 @@ The following floppies came with the machines.
 		<publisher>Philips</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="msx-dos ayuda (1989)(philips)(es)[a].dsk" size="737280" crc="09bbf136" sha1="5163e2dbb10c0660f399698f001670da78b7bc0a" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="msx-dos ayuda (1989)(philips)(es)[a].dsk" size="737280" crc="09bbf136" sha1="5163e2dbb10c0660f399698f001670da78b7bc0a" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -119,7 +98,8 @@ The following floppies came with the machines.
 		<publisher>Philips</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="msx-dos hulp (1989)(philips)(nl).dsk" size="737280" crc="83b8297f" sha1="e9b0887e04480501f7f971e9ec08e1c6ac4d7832" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="msx-dos hulp (1989)(philips)(nl).dsk" size="737280" crc="83b8297f" sha1="e9b0887e04480501f7f971e9ec08e1c6ac4d7832" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -130,13 +110,14 @@ The following floppies came with the machines.
 		<publisher>Philips</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="msx-dos hulp (1989)(philips)(nl)[a].dsk" size="737280" crc="851df2c4" sha1="5b1d4fd571ef82e8fc55c1946b9a4c90b9661a90" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="msx-dos hulp (1989)(philips)(nl)[a].dsk" size="737280" crc="851df2c4" sha1="5b1d4fd571ef82e8fc55c1946b9a4c90b9661a90" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="msxdostba">
-		<description>MSX-DOS Tools (Bra, v2.1)</description>
+		<description>MSX-DOS Tools (Brazil, v2.1)</description>
 		<year>1984</year>
 		<publisher>Nemesis Informatica</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -165,7 +146,8 @@ The following floppies came with the machines.
 		<publisher>Nyan</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="ball 5 (19xx)(nyan)(jp).dsk" size="737280" crc="de8ff54c" sha1="655711d6cb713a74eba957708a838dd36a56e2d9" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="ball 5 (19xx)(nyan)(jp).dsk" size="737280" crc="de8ff54c" sha1="655711d6cb713a74eba957708a838dd36a56e2d9" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -174,13 +156,16 @@ The following floppies came with the machines.
 		<description>Aacko Draw &amp; Paint (Netherlands)</description>
 		<year>1985</year>
 		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8211" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="aacko draw &amp; paint (1985)(aackosoft)(nl).dsk" size="737280" crc="9d4408f7" sha1="6fd03e0515710d317be008d73104005a3905933e" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="aacko draw &amp; paint (1985)(aackosoft)(nl).dsk" size="737280" crc="9d4408f7" sha1="6fd03e0515710d317be008d73104005a3905933e" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this was (part of) the MSX Magazine cover disk for issue 92. -->
 	<software name="adonis">
 		<description>Adonis (Japan)</description>
 		<year>1988</year>
@@ -193,35 +178,40 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="alpine">
-		<description>Alpine Ski (Europe)</description>
+		<description>Alpine Ski (Netherlands)</description>
 		<year>1987</year>
 		<publisher>Methodic Solutions</publisher>
+		<info name="serial" value="8909" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="alpine ski (1987)(methodic solutions)(nl).dsk" size="737280" crc="b198fb54" sha1="372918cc166bd7685eb6cf3e2933621e3bbeba51" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="alpine ski (1987)(methodic solutions)(nl).dsk" size="737280" crc="b198fb54" sha1="372918cc166bd7685eb6cf3e2933621e3bbeba51" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="ablaster">
-		<description>Astro Blaster (Europe)</description>
+		<description>Astro Blaster (Europe, cracked)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8224" />
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
 			<dataarea name="flop" size="737280">
-				<rom name="astro blaster (1988)(eurosoft)(nl).dsk" size="737280" crc="b0fa7831" sha1="789ca057a3a9f2c4dd9db874fc2de33e936c3ad3" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="astro blaster (1988)(eurosoft)(nl).dsk" size="737280" crc="b0fa7831" sha1="789ca057a3a9f2c4dd9db874fc2de33e936c3ad3" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="bchopper">
-		<description>Battle Chopper (Europe)</description>
+		<description>Battle Chopper (Netherlands)</description>
 		<year>1985</year>
 		<publisher>Methodic Solutions</publisher>
+		<info name="serial" value="8465" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="battle chopper (1985)(methodic solutions)(nl).dsk" size="737280" crc="af98b557" sha1="10aea1840ae835437f862924359936044af5a3c5" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="battle chopper (1985)(methodic solutions)(nl).dsk" size="737280" crc="af98b557" sha1="10aea1840ae835437f862924359936044af5a3c5" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -230,9 +220,11 @@ The following floppies came with the machines.
 		<description>Beach-Head (Europe)</description>
 		<year>1985</year>
 		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8408" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="beach-head (1985)(us gold)(gb).dsk" size="737280" crc="4bb09fab" sha1="c4f663d810fa6b4b70b46931d8eb68e5cff35a7f" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="beach-head (1985)(us gold)(gb).dsk" size="737280" crc="4bb09fab" sha1="c4f663d810fa6b4b70b46931d8eb68e5cff35a7f" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -241,20 +233,24 @@ The following floppies came with the machines.
 		<description>Blow-Up (Europe)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8204" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="blow up (1988)(eurosoft)(nl).dsk" size="737280" crc="4e08bd31" sha1="d4d4e24e0e4e03ae69efc62c344e4b58fa659674" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="blow up (1988)(eurosoft)(nl).dsk" size="737280" crc="4e08bd31" sha1="d4d4e24e0e4e03ae69efc62c344e4b58fa659674" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="blowupa" cloneof="blowup">
+	<!-- Throws 'Disk I/O error' during loading. -->
+	<software name="blowupa" cloneof="blowup" supported="no">
 		<description>Blow-Up (Europe, alt)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8204" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
-				<rom name="blow up (1988)(eurosoft)(nl)[a].dsk" size="368640" crc="e2319cab" sha1="4ff46f12ba83d862036c5294dbc9eb5d7d4c36c6" />
+				<rom name="blow up (1988)(eurosoft)(nl)[a].dsk" size="368640" crc="e2319cab" sha1="4ff46f12ba83d862036c5294dbc9eb5d7d4c36c6" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -263,9 +259,11 @@ The following floppies came with the machines.
 		<description>Booty (Europe)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8212" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="booty (1988)(eurosoft)(nl).dsk" size="737280" crc="78cef13f" sha1="5cab1cbee756e656349791b968956b0485a4c280" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="booty (1988)(eurosoft)(nl).dsk" size="737280" crc="78cef13f" sha1="5cab1cbee756e656349791b968956b0485a4c280" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -274,38 +272,32 @@ The following floppies came with the machines.
 		<description>Breaker Breaker (Europe)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8211" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="breaker breaker (1988)(eurosoft)(nl).dsk" size="737280" crc="d4405935" sha1="76b74ab00cc59bd2eb9d8e5bb908d0e52a340267" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="breaker breaker (1988)(eurosoft)(nl).dsk" size="737280" crc="d4405935" sha1="76b74ab00cc59bd2eb9d8e5bb908d0e52a340267" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="burgkill">
-		<description>Burgerkill (Europe)</description>
+		<description>Burgerkill (Europe, cracked)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8216" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="burgerkill (1988)(eurosoft)(nl)[aka mac attack].dsk" size="737280" crc="cd87fd55" sha1="1cd27cbba9e69abe245a1e63e46280f456349f8b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="burgkilla" cloneof="burgkill">
-		<description>Burgerkill (Europe, alt)</description>
-		<year>1988</year>
-		<publisher>Eurosoft</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="burgerkill (1988)(eurosoft)(nl)[a][aka mac attack].dsk" size="368640" crc="db399184" sha1="1cf4790afe97416cfb4d3ec818de7fb8c5928f42" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="burgerkill (1988)(eurosoft)(nl)[aka mac attack].dsk" size="737280" crc="cd87fd55" sha1="1cd27cbba9e69abe245a1e63e46280f456349f8b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="catchgrl">
 		<description>Catch That Girl</description>
-		<year>198?</year>
+		<year>1986</year>
 		<publisher>WB-Soft</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
@@ -320,29 +312,34 @@ The following floppies came with the machines.
 		<publisher>Tynesoft</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="cetus (1986)(tynesoft)(gb).dsk" size="737280" crc="6fdd844c" sha1="c3154342b09b4be6f46963b9fabc676eaf6705aa" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="cetus (1986)(tynesoft)(gb).dsk" size="737280" crc="6fdd844c" sha1="c3154342b09b4be6f46963b9fabc676eaf6705aa" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="chessply">
-		<description>Chess Player (Europe)</description>
+		<description>Chess Player (Europe, cracked)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8222" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="chess player (1988)(eurosoft)(nl).dsk" size="737280" crc="e7369009" sha1="d1f07ce039ece76baacf74cf01f74ff51d7f38a4" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="chess player (1988)(eurosoft)(nl).dsk" size="737280" crc="e7369009" sha1="d1f07ce039ece76baacf74cf01f74ff51d7f38a4" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="macross">
-		<description>Choujikuu Yousai Macross (Japan)</description>
-		<year>1985</year>
-		<publisher>Bothtec</publisher>
+		<description>Choujikuu Yousai Macross (Europe)</description>
+		<year>1987</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8407" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="macross countdown (1985)(bothtec)(jp).dsk" size="737280" crc="6ad578c1" sha1="41eec65f5455025562c4876f81ab4771217fe546" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="macross countdown (1985)(bothtec)(jp).dsk" size="737280" crc="6ad578c1" sha1="41eec65f5455025562c4876f81ab4771217fe546" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -351,9 +348,11 @@ The following floppies came with the machines.
 		<description>Come On! Picot (Europe)</description>
 		<year>1986</year>
 		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8427" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="come on picot (1986)(pony canyon)(jp).dsk" size="737280" crc="22bff100" sha1="823a33351442d2efeded9cbe6053b643b9981ae8" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="come on picot (1986)(pony canyon)(jp).dsk" size="737280" crc="22bff100" sha1="823a33351442d2efeded9cbe6053b643b9981ae8" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -362,20 +361,24 @@ The following floppies came with the machines.
 		<description>Confused? (Europe)</description>
 		<year>1986</year>
 		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8213" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="confused (1986)(eaglesoft)(nl).dsk" size="737280" crc="0d20ed46" sha1="68bc6567e72d39ddfa14198b45f1f5f65b6b3a8f" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="confused (1986)(eaglesoft)(nl).dsk" size="737280" crc="0d20ed46" sha1="68bc6567e72d39ddfa14198b45f1f5f65b6b3a8f" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="crusader">
 		<description>Crusader (Europe)</description>
-		<year>1985</year>
+		<year>1987</year>
 		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8370" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="crusader (1985)(pony canyon)(jp).dsk" size="737280" crc="a26fbd20" sha1="ce265c6d10e8ffc5d9dca65675f3c563bd98ed7b" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="crusader (1985)(pony canyon)(jp).dsk" size="737280" crc="a26fbd20" sha1="ce265c6d10e8ffc5d9dca65675f3c563bd98ed7b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -384,37 +387,42 @@ The following floppies came with the machines.
 		<description>Curso de BASIC (Spain)</description>
 		<year>1985</year>
 		<publisher>Sony Spain</publisher>
+		<info name="serial" value="HBS-IE301" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="curso de basic (1985)(sony)(es).dsk" size="737280" crc="83af46fa" sha1="5776465824698162128b8137440fb98c72d5642a" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="curso de basic (1985)(sony)(es).dsk" size="737280" crc="83af46fa" sha1="5776465824698162128b8137440fb98c72d5642a" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="cursoing">
-		<description>Curso de Ingles (Spain)</description>
+		<description>Curso de Inglés (Spain)</description>
 		<year>1984</year>
 		<publisher>Plus Data</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="curso de ingles (1984)(plus data)(es).dsk" size="737280" crc="14639ecd" sha1="d5ff84e0c8bddc1d51a6a097aec62a8bc690ed4e" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="curso de ingles (1984)(plus data)(es).dsk" size="737280" crc="14639ecd" sha1="d5ff84e0c8bddc1d51a6a097aec62a8bc690ed4e" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="cyrus2ch">
-		<description>Cyrus II Chess (Europe)</description>
+		<description>Cyrus II Chess (United Kingdom)</description>
 		<year>1986</year>
 		<publisher>Alligata Software</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="cyrus ii (1986)(alligata software)(gb).dsk" size="737280" crc="0f509417" sha1="c36d13e44b62e1eaf5925840626495a001c2686f" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="cyrus ii (1986)(alligata software)(gb).dsk" size="737280" crc="0f509417" sha1="c36d13e44b62e1eaf5925840626495a001c2686f" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this software was only available as part of the MSX Board Games 1 compilation. This should not be here? -->
 	<software name="darts">
-		<description>Darts (UK, Orpheus)</description>
+		<description>Darts (United Kingdom, Orpheus)</description>
 		<year>1984</year>
 		<publisher>Orpheus</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -424,13 +432,16 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="dawnpatr">
+	<!-- Fails to start on an MSX1 machine. Reboots on an MSX2 machine. -->
+	<software name="dawnpatr" supported="no">
 		<description>Dawn Patrol (Europe)</description>
 		<year>1986</year>
 		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8287 or 8952" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="dawn patrol (1986)(eaglesoft)(nl).dsk" size="737280" crc="da04542f" sha1="75e46ea92fcd86806b753c1105b54cd16987dcd5" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="dawn patrol (1986)(eaglesoft)(nl).dsk" size="737280" crc="da04542f" sha1="75e46ea92fcd86806b753c1105b54cd16987dcd5" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -439,9 +450,11 @@ The following floppies came with the machines.
 		<description>Delta BASIC (Netherlands)</description>
 		<year>1987</year>
 		<publisher>Filosoft</publisher>
+		<info name="serial" value="385" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="delta basic (1988)(filosoft)(nl).dsk" size="737280" crc="1df20c0a" sha1="d979c5f649f4b631b74b2e0e82d2c385dc517b82" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="delta basic (1988)(filosoft)(nl).dsk" size="737280" crc="1df20c0a" sha1="d979c5f649f4b631b74b2e0e82d2c385dc517b82" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -450,6 +463,7 @@ The following floppies came with the machines.
 		<description>Devil Hunter (Japan)</description>
 		<year>1990</year>
 		<publisher>MSX Magazine</publisher>
+		<info name="alt_title" value="Ｄｅｖｉｌ Ｈｕｎｔｅｒいけにえの魔境" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="devil hunter (1990)(msx magazine)(jp).dsk" size="737280" crc="49016b1f" sha1="4c65f877ba13466fc052dc8d135940cb56fa6040" />
@@ -463,13 +477,15 @@ The following floppies came with the machines.
 		<publisher>Eurosoft</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="dr. archie (1989)(eurosoft)(nl).dsk" size="737280" crc="d9727092" sha1="954206f03a5ed8af44ced9aacf615962c1762e3a" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="dr. archie (1989)(eurosoft)(nl).dsk" size="737280" crc="d9727092" sha1="954206f03a5ed8af44ced9aacf615962c1762e3a" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this software was only available as part of the MSX Board Games 1 compilation. This should not be here? -->
 	<software name="draughts">
-		<description>Draughts (UK)</description>
+		<description>Draughts (United Kingdom)</description>
 		<year>1985</year>
 		<publisher>Orpheus</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -479,8 +495,11 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="elidon">
-		<description>Elidon (UK)</description>
+	<!-- According to generation-msx this software was only released on cassette. -->
+	<!-- Does not start on an MSX1 machine, but works on an MSX2 machine.-->
+	<!-- Text on the cassette loading screen seems to be patched out. -->
+	<software name="elidon" supported="partial">
+		<description>Elidon (United Kingdom)</description>
 		<year>1985</year>
 		<publisher>Orpheus</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -491,7 +510,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="elite">
-		<description>Elite (UK)</description>
+		<description>Elite (United Kingdom)</description>
 		<year>1987</year>
 		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -502,7 +521,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="elitea" cloneof="elite">
-		<description>Elite (UK, alt)</description>
+		<description>Elite (United Kingdom, alt)</description>
 		<year>1987</year>
 		<publisher>Firebird Software</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -516,9 +535,11 @@ The following floppies came with the machines.
 		<description>Exterminator (Europe)</description>
 		<year>1987</year>
 		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8551" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="exterminator (1987)(eaglesoft)(nl).dsk" size="737280" crc="aa036179" sha1="bd3bbd42fe7003b0821918c02804b224fd5be7fc" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="exterminator (1987)(eaglesoft)(nl).dsk" size="737280" crc="aa036179" sha1="bd3bbd42fe7003b0821918c02804b224fd5be7fc" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -529,7 +550,8 @@ The following floppies came with the machines.
 		<publisher>Microprose</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="f-15 strike eagle (1987)(microprose japan).dsk" size="737280" crc="5aec22f2" sha1="2c1305e05e33a371644647b6bd0503fb2281a3cd" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="f-15 strike eagle (1987)(microprose japan).dsk" size="737280" crc="5aec22f2" sha1="2c1305e05e33a371644647b6bd0503fb2281a3cd" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -538,9 +560,12 @@ The following floppies came with the machines.
 		<description>Flight Deck (Netherlands)</description>
 		<year>1984</year>
 		<publisher>Aackosoft</publisher>
+		<info name="serial" value="8980" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="flight deck (1984)(aackosoft)(nl).dsk" size="737280" crc="c607ab0f" sha1="5265b0c0fa52fa20e442ed05d4183cd429943e3f" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="flight deck (1984)(aackosoft)(nl).dsk" size="737280" crc="c607ab0f" sha1="5265b0c0fa52fa20e442ed05d4183cd429943e3f" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -549,6 +574,7 @@ The following floppies came with the machines.
 		<description>Galactic Mercenaries (France)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+		<info name="usage" value="Boot with CTRL pressed" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="galactic mercenaries (1985)(infogrames)(fr).dsk" size="737280" crc="313d94a0" sha1="ab16c1222770ecdb34e55b34c82605aec46071de" />
@@ -560,6 +586,7 @@ The following floppies came with the machines.
 		<description>Galactic Mercenaries (France, alt)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="galactic mercenaries (1985)(infogrames)(fr)[a].dsk" size="737280" crc="3cd926f3" sha1="b759baf9c3ba53831c658a3f004a086a7fbb9d91" />
@@ -571,6 +598,7 @@ The following floppies came with the machines.
 		<description>Galactic Mercenaries (France, alt 2)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="galactic mercenaries (1985)(infogrames)(fr)[a2].dsk" size="737280" crc="b1bd2832" sha1="d2e09134da388262753a6946074c57db77758bcc" />
@@ -579,12 +607,14 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="gberet">
-		<description>Green Beret (Japan)</description>
+		<description>Green Beret (Europe)</description>
 		<year>1986</year>
 		<publisher>Konami</publisher>
+		<info name="serial" value="KN350" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="green beret (1986)(konami)(jp).dsk" size="737280" crc="dfb82522" sha1="d6bffaa911471c5cd3c9a7c5c9157e9f101aff7e" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="green beret (1986)(konami)(jp).dsk" size="737280" crc="dfb82522" sha1="d6bffaa911471c5cd3c9a7c5c9157e9f101aff7e" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -593,9 +623,12 @@ The following floppies came with the machines.
 		<description>Gutt Blaster (Europe)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8201" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="guttblaster (1988)(eurosoft)(nl).dsk" size="737280" crc="715cc8f7" sha1="ebd0225342aa1045169993a7e027ee6c6cb2c04d" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="guttblaster (1988)(eurosoft)(nl).dsk" size="737280" crc="715cc8f7" sha1="ebd0225342aa1045169993a7e027ee6c6cb2c04d" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -604,9 +637,11 @@ The following floppies came with the machines.
 		<description>Hard Boiled (Netherlands)</description>
 		<year>1987</year>
 		<publisher>Methodic Solutions</publisher>
+		<info name="serial" value="8915" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="hard boiled (1987)(methodic solutions)(nl).dsk" size="737280" crc="010c5e6a" sha1="05b01d714f8ebf0dfa509e0321f78a3276098eba" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="hard boiled (1987)(methodic solutions)(nl).dsk" size="737280" crc="010c5e6a" sha1="05b01d714f8ebf0dfa509e0321f78a3276098eba" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -615,13 +650,17 @@ The following floppies came with the machines.
 		<description>Haunted House (Netherlands)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8202" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="haunted house (1988)(eurosoft)(nl).dsk" size="737280" crc="1aae174c" sha1="22c9d66d1f9d0b6dbd1fd69f365dd3638abe1cec" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="haunted house (1988)(eurosoft)(nl).dsk" size="737280" crc="1aae174c" sha1="22c9d66d1f9d0b6dbd1fd69f365dd3638abe1cec" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this was never released on floppy, but cartridge and cassette have not been dumped yet. -->
 	<software name="hercule">
 		<description>Hercule (France)</description>
 		<year>1984</year>
@@ -640,7 +679,8 @@ The following floppies came with the machines.
 		<info name="usage" value="needs MSX-DOS" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="l'heritage - panique a las vegas (1987)(infogrames)(fr)[needs msx-dos].dsk" size="737280" crc="a1672469" sha1="ae9f451432da589eb12f0bca98a4922f26778d40" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="l'heritage - panique a las vegas (1987)(infogrames)(fr)[needs msx-dos].dsk" size="737280" crc="a1672469" sha1="ae9f451432da589eb12f0bca98a4922f26778d40" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -649,9 +689,11 @@ The following floppies came with the machines.
 		<description>Hype (Netherlands, hacked)</description>
 		<year>1987</year>
 		<publisher>Methodic Solutions</publisher>
+		<info name="serial" value="8569" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="hype (1987)(methodic solutions)(nl)[h msx files].dsk" size="737280" crc="66d09012" sha1="7b06c5b52044f227c5a1a0fdc5662247f1b693c9" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="hype (1987)(methodic solutions)(nl)[h msx files].dsk" size="737280" crc="66d09012" sha1="7b06c5b52044f227c5a1a0fdc5662247f1b693c9" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -662,7 +704,8 @@ The following floppies came with the machines.
 		<publisher>Nice Ideas</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="illusions (1985)(nice ideas)(fr).dsk" size="737280" crc="47c5b762" sha1="57e31d8b62b9c586bd1a678e8fc784f9c49eed6d" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="illusions (1985)(nice ideas)(fr).dsk" size="737280" crc="47c5b762" sha1="57e31d8b62b9c586bd1a678e8fc784f9c49eed6d" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -671,9 +714,11 @@ The following floppies came with the machines.
 		<description>Inca I (Netherlands)</description>
 		<year>1987</year>
 		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8418" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="inca (1987)(eaglesoft)(nl).dsk" size="737280" crc="32e9da6a" sha1="c4c4387e81d0a5f7822e8c2d9779091b8965fbbe" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="inca (1987)(eaglesoft)(nl).dsk" size="737280" crc="32e9da6a" sha1="c4c4387e81d0a5f7822e8c2d9779091b8965fbbe" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -682,28 +727,34 @@ The following floppies came with the machines.
 		<description>Indy 500 (Netherlands)</description>
 		<year>1986</year>
 		<publisher>Methodic Solutions</publisher>
+		<info name="serial" value="8906" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="indy 500 (1986)(methodic solutions)(nl).dsk" size="737280" crc="a4113f0c" sha1="d8ecdfe3c3d4351cb8cd77f9a52a562932ee71de" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="indy 500 (1986)(methodic solutions)(nl).dsk" size="737280" crc="a4113f0c" sha1="d8ecdfe3c3d4351cb8cd77f9a52a562932ee71de" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="jetfight">
-		<description>Jet Fighter (Netherlands)</description>
+		<description>Jet Fighter (Netherlands, cracked)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8227" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="jet fighter (1988)(eurosoft)(nl).dsk" size="737280" crc="5e386605" sha1="35adb68bac9f609b326b22a52630583b78e5af5b" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="jet fighter (1988)(eurosoft)(nl).dsk" size="737280" crc="5e386605" sha1="35adb68bac9f609b326b22a52630583b78e5af5b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this was included in Konami Game Collection 1, but never released separately. This should not be here? -->
 	<software name="kingsva2">
 		<description>King's Valley Plus (Japan, hacked)</description>
 		<year>1985</year>
 		<publisher>Konami</publisher>
+		<info name="serial" value="RA002" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="king's valley plus (1985)(konami)(jp).dsk" size="737280" crc="025e9752" sha1="5588dfcff4938b0740b4c13616850a6df5062d52" />
@@ -712,17 +763,19 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="konagc1">
-		<description>Konami Game Collection Vol. 1 (Japan)</description>
+		<description>Konami Game Collection 1: Action Series (Japan)</description>
 		<year>1988</year>
 		<publisher>Konami</publisher>
+		<info name="alt_title" value="コナミゲームコレクションＶｏｌ．１ アクションシリーズ" />
+		<info name="serial" value="RA006" />
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
+			<feature name="part_id" value="Disk A"/>
 			<dataarea name="flop" size="737280">
 				<rom name="konami_game_collection_vol.1_(1988)_(konami)_(j)_(disk_1_of_2).dsk" size="737280" crc="bfab140f" sha1="37cfed5a5886637ca1dd866ea4e2e1ac23ab4841" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2"/>
+			<feature name="part_id" value="Disk B"/>
 			<dataarea name="flop" size="737280">
 				<rom name="konami_game_collection_vol.1_(1988)_(konami)_(j)_(disk_2_of_2).dsk" size="737280" crc="5f947098" sha1="d7ff2ec76ab2d198fdfe9bcbd9743c1e78939605" />
 			</dataarea>
@@ -730,9 +783,11 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="konagc2">
-		<description>Konami Game Collection Vol. 2 (Japan)</description>
+		<description>Konami Game Collection 2: Sports Series 1 (Japan)</description>
 		<year>1988</year>
 		<publisher>Konami</publisher>
+		<info name="alt_title" value="コナミゲームコレクションＶｏｌ．２ スポーツシリーズ１" />
+		<info name="serial" value="RA007" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="konami_game_collection_vol.2_(1988)_(konami)_(j).dsk" size="737280" crc="7f3987b0" sha1="eb1bfc4244ce01903472fdcb3d1f5fbe60cab62f" />
@@ -741,9 +796,11 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="konagc3">
-		<description>Konami Game Collection Vol. 3 (Japan)</description>
+		<description>Konami Game Collection 3: Shooting Series (Japan)</description>
 		<year>1988</year>
 		<publisher>Konami</publisher>
+		<info name="alt_title" value="コナミゲームコレクションＶｏｌ．３ シューティングシリーズ" />
+		<info name="serial" value="RA008" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="konami_game_collection_vol.3_(1988)_(konami)_(j).dsk" size="737280" crc="fa7b7c38" sha1="31c6e06051ab0bfe628f0f11e458f7e375ee5673" />
@@ -752,9 +809,11 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="konagc4">
-		<description>Konami Game Collection Vol. 4 (Japan)</description>
+		<description>Konami Game Collection 4: Sports Series 2 (Japan)</description>
 		<year>1988</year>
 		<publisher>Konami</publisher>
+		<info name="alt_title" value="コナミゲームコレクションＶｏｌ．４ スポーツシリーズ２" />
+		<info name="serial" value="RA009" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="konami_game_collection_vol.4_(1988)_(konami)_(j).dsk" size="737280" crc="9a277e94" sha1="65c2753114b3bb9b28fa0fd514e9dfca7694a2ae" />
@@ -766,6 +825,7 @@ The following floppies came with the machines.
 		<description>Ladra no Densetsu (Japan)</description>
 		<year>1988</year>
 		<publisher>MSX Magazine</publisher>
+		<info name="alt_title" value="ラドラの伝説" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="legend of ladra. radola fantasia (1988)(msx magazine)(jp).dsk" size="737280" crc="84c194c1" sha1="578fb6927fa7929d0ec32596fa600f07bd825a9a" />
@@ -777,6 +837,7 @@ The following floppies came with the machines.
 		<description>Ladra no Densetsu (Japan, alt)</description>
 		<year>1988</year>
 		<publisher>MSX Magazine</publisher>
+		<info name="alt_title" value="ラドラの伝説" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="legend of ladra. radola fantasia (1988)(msx magazine)(jp)[a].dsk" size="737280" crc="f61ced6c" sha1="13d25db9e0a88f41c23a5d592e00ee7e743e22e1" />
@@ -788,6 +849,7 @@ The following floppies came with the machines.
 		<description>Ladra no Densetsu (Japan, alt 2)</description>
 		<year>1988</year>
 		<publisher>MSX Magazine</publisher>
+		<info name="alt_title" value="ラドラの伝説" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="legend of ladra. radola fantasia (1988)(msx magazine)(jp)[a2].dsk" size="737280" crc="9b9a161e" sha1="da304f330aa7959df95d33ac23a8dc5a2bce5ee7" />
@@ -808,13 +870,15 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="lendagav">
+	<!-- Software does not load/start, blank screen. Hardcoded against microsol FDC but still does not start when using one. -->
+	<software name="lendagav" supported="no">
 		<description>A Lenda da Gávea (Brazil)</description>
 		<year>1988</year>
 		<publisher>Pro Kit</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="lenda da gavea, a (1987)(stop informatica)(br).dsk" size="737280" crc="b0470865" sha1="19b5a247bda7ea6c68f356f4914834e748cba4be" />
+				<!-- This was released on a 5.25" floppy -->
+				<rom name="lenda da gavea, a (1987)(stop informatica)(br).dsk" size="737280" crc="b0470865" sha1="19b5a247bda7ea6c68f356f4914834e748cba4be" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -823,26 +887,32 @@ The following floppies came with the machines.
 		<description>Life in the Fast Lane (Netherlands)</description>
 		<year>1987</year>
 		<publisher>Methodic Solutions</publisher>
+		<info name="serial" value="8432" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="life in the fast lane (1987)(methodic solutions)(nl).dsk" size="737280" crc="fe229727" sha1="b6962258cd8367c9d3835e1efe207c885aac3426" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="life in the fast lane (1987)(methodic solutions)(nl).dsk" size="737280" crc="fe229727" sha1="b6962258cd8367c9d3835e1efe207c885aac3426" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Does not autoboot. Should be removed? -->
 	<software name="lifefasta" cloneof="lifefast">
 		<description>Life in the Fast Lane (Netherlands, alt)</description>
 		<year>1987</year>
 		<publisher>Methodic Solutions</publisher>
+		<info name="serial" value="8432" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="life in the fast lane (1987)(methodic solutions)(nl)[a].dsk" size="737280" crc="b4297f5f" sha1="b08ba3eb3d64edc587838de25f2a06b7f2ea3f64" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="life in the fast lane (1987)(methodic solutions)(nl)[a].dsk" size="737280" crc="b4297f5f" sha1="b08ba3eb3d64edc587838de25f2a06b7f2ea3f64" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this was never released on a floppy. This should be removed? -->
 	<software name="lightcor">
-		<description>The Light Corridor (France, trainer)</description>
+		<description>The Light Corridor (France, trained)</description>
 		<year>1990</year>
 		<publisher>Infogrames</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -858,18 +928,21 @@ The following floppies came with the machines.
 		<publisher>Opera Soft</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="livingstone supongo (1986)(opera soft)(es).dsk" size="737280" crc="65228215" sha1="826078925b41628201209acaaa097b365d5ce972" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="livingstone supongo (1986)(opera soft)(es).dsk" size="737280" crc="65228215" sha1="826078925b41628201209acaaa097b365d5ce972" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Software does not autoboot. This should be removed? -->
 	<software name="livingsta" cloneof="livingst">
 		<description>Livingstone Supongo (Spain, alt)</description>
 		<year>1986</year>
 		<publisher>Opera Soft</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="livingstone supongo (1986)(opera soft)(es)[a].dsk" size="737280" crc="f6c61660" sha1="6cc5111f5f061476d1f42dbf85a6606c6c4a33f0" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="livingstone supongo (1986)(opera soft)(es)[a].dsk" size="737280" crc="f6c61660" sha1="6cc5111f5f061476d1f42dbf85a6606c6c4a33f0" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -878,6 +951,7 @@ The following floppies came with the machines.
 		<description>Lode Runner (Japan)</description>
 		<year>1984</year>
 		<publisher>Sony</publisher>
+		<info name="serial" value="HBS-G035D" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
 				<rom name="lode runner (1984)(sony)(jp).dsk" size="368640" crc="5748f314" sha1="ff21f68177b2ff8509312c1915cb38127bd3fd3e" />
@@ -885,10 +959,12 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Unknown whether the software was released separately or as a compilation. -->
 	<software name="pistolt1">
 		<description>Mayor Pistoletov - Pervaya Seriya: "Koshchey" (Russia)</description>
 		<year>1988</year>
 		<publisher>Crazysoft</publisher>
+		<info name="alt_title" value="Майор Пистолетов — Первая серия: «Кащей»" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="major 1. maliop nuctorejog (1988)(crazysoft)(ru).dsk" size="737280" crc="9dff6ee3" sha1="ea289b3abaac95558f7eda3dae3ba78b99663a49" />
@@ -896,10 +972,12 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Unknown whether the software was released separately or as a compilation. -->
 	<software name="pistolt2">
 		<description>Pistoletov na Zavode - Vtoraya Seriya (Russia)</description>
 		<year>1988</year>
 		<publisher>Crazysoft</publisher>
+		<info name="alt_title" value="Пистолетов на заводе (Вторая серия)" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="major 2. nuctoretog ha bagom (1988)(crazysoft)(ru).dsk" size="737280" crc="6ac3b2ef" sha1="fc9d0a5033b9bc72671ec2d6b9c933a4a5c7eeaa" />
@@ -907,10 +985,13 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Unknown whether the software was released separately or as a compilation. -->
+	<!-- Software does not autoboot -->
 	<software name="2pistolt">
 		<description>Mayor Pistoletov + Pistoletov na Zavode (Russia)</description>
 		<year>1988</year>
 		<publisher>Crazysoft</publisher>
+		<info name="usage" value="type MAJOR or MAJOR2. Software only works on an MSX1 machine." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="major 1. maliop nuctorejog + major 2. nuctoretog ha bagom (1988)(crazysoft)(ru).dsk" size="737280" crc="8ca36533" sha1="ab0a2ee8496b8f85987b6edf407710db34d9e54b" />
@@ -922,9 +1003,11 @@ The following floppies came with the machines.
 		<description>Maze Master (Netherlands)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8206" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="maze master (1988)(eurosoft)(nl).dsk" size="737280" crc="e5fbeab5" sha1="6eaaf870f73ee6c3695214e8dbc01eff78c3f051" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="maze master (1988)(eurosoft)(nl).dsk" size="737280" crc="e5fbeab5" sha1="6eaaf870f73ee6c3695214e8dbc01eff78c3f051" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -935,11 +1018,13 @@ The following floppies came with the machines.
 		<publisher>Infogrames</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="meurtres sur l'atlantique. murder on the atlantic (19xx)(infogrames)(fr).dsk" size="737280" crc="331c6be5" sha1="cbf401ff589538d348420b32f3908fab0b43ede2" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="meurtres sur l'atlantique. murder on the atlantic (19xx)(infogrames)(fr).dsk" size="737280" crc="331c6be5" sha1="cbf401ff589538d348420b32f3908fab0b43ede2" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this was not released in German. Game splash screen has the English title. Fan translation? -->
 	<software name="murdatlng" cloneof="meuratln">
 		<description>Murder on the Atlantic (Germany?)</description>
 		<year>1986</year>
@@ -955,31 +1040,36 @@ The following floppies came with the machines.
 		<description>Missile Command (Netherlands)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8207" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="missile command (1988)(eurosoft)(nl).dsk" size="737280" crc="a76da691" sha1="1ce1baab52d2953c7712849ab1e045af7eb69c09" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="missile command (1988)(eurosoft)(nl).dsk" size="737280" crc="a76da691" sha1="1ce1baab52d2953c7712849ab1e045af7eb69c09" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this was never released on a floppy, but no known cassette dump. -->
 	<software name="nachtwac">
 		<description>De Nachtwacht (Netherlands)</description>
 		<year>1986</year>
 		<publisher>Radarsoft</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="nachtwacht, de (1986)(radarsoft)(nl).dsk" size="737280" crc="e7dab992" sha1="deab15e91dd8b64a0e115c509f86cc9a82b843ee" />
+				<rom name="nachtwacht, de (1986)(radarsoft)(nl).dsk" size="737280" crc="e7dab992" sha1="deab15e91dd8b64a0e115c509f86cc9a82b843ee" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this was never released on a floppy, but no known cassette dump. -->
+	<!-- Does not autoboot. -->
 	<software name="nachtwaca" cloneof="nachtwac">
 		<description>De Nachtwacht (Netherlands, alt)</description>
 		<year>1986</year>
 		<publisher>Radarsoft</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="nachtwacht, de (1986)(radarsoft)(nl)[a].dsk" size="737280" crc="8af3e202" sha1="430ff641357f01bf472d00e761e9a2369cc74a8a" />
+				<rom name="nachtwacht, de (1986)(radarsoft)(nl)[a].dsk" size="737280" crc="8af3e202" sha1="430ff641357f01bf472d00e761e9a2369cc74a8a" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -989,9 +1079,11 @@ The following floppies came with the machines.
 		<description>Navy Moves (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
+		<info name="serial" value="MSD120072" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="navy moves (1988)(dinamic software)(es)[code 53817].dsk" size="737280" crc="335db5ff" sha1="3be20c1241a16d00384a2389a6ba73455d863ee2" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="navy moves (1988)(dinamic software)(es)[code 53817].dsk" size="737280" crc="335db5ff" sha1="3be20c1241a16d00384a2389a6ba73455d863ee2" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1000,20 +1092,23 @@ The following floppies came with the machines.
 		<description>Navy Moves (Spain, hacked)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
+		<info name="serial" value="MSD120072" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
-				<rom name="navy moves (1988)(dinamic software)(es)[h msx games box][code 53817].dsk" size="368640" crc="7ebf4dcc" sha1="911c6837e5d84fa64087d75c354d2563731435a0" />
+				<rom name="navy moves (1988)(dinamic software)(es)[h msx games box][code 53817].dsk" size="368640" crc="7ebf4dcc" sha1="911c6837e5d84fa64087d75c354d2563731435a0" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="nsheli">
-		<description>North Sea Helicopter (Netherlands)</description>
+		<description>North Sea Helicopter (Netherlands, hacked)</description>
 		<year>1987</year>
 		<publisher>Aackosoft</publisher>
+		<info name="serial" value="8722" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="northsea (1987)(aackosoft)(nl).dsk" size="737280" crc="815c2c75" sha1="00436f56e9fda6b2a67fee28ee94398c02308e8b" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="northsea (1987)(aackosoft)(nl).dsk" size="737280" crc="815c2c75" sha1="00436f56e9fda6b2a67fee28ee94398c02308e8b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1022,6 +1117,8 @@ The following floppies came with the machines.
 		<description>Ougon no Haka (Japan)</description>
 		<year>1984</year>
 		<publisher>MagicalZoo</publisher>
+		<info name="alt_title" value="黄金の墓" />
+		<info name="usage" value="Requires a Japanese system" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
 				<rom name="ougon no haka. golden tomb. mystery of egypt (1984)(magical zoo)(jp).dsk" size="368640" crc="25d63799" sha1="89a093052d0d39dae179c893a6e9558445878724" />
@@ -1029,46 +1126,53 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="outrun">
+	<!-- Boot program uses MSX2 statements. -->
+	<software name="outrun" supported="partial">
 		<description>Out Run (Netherlands)</description>
 		<year>1988</year>
 		<publisher>U.S. Gold</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep. Requires an MSX2 machine." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="out run (1988)(us gold)(gb).dsk" size="737280" crc="ef54465f" sha1="8966285d3387febe8eb54576acb0490fcb41757b" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="out run (1988)(us gold)(gb).dsk" size="737280" crc="ef54465f" sha1="8966285d3387febe8eb54576acb0490fcb41757b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="penguin">
-		<description>Penguin (Netherlands)</description>
+		<description>Penguin (Netherlands, cracked)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8217" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="penguin (1988)(eurosoft)(nl).dsk" size="737280" crc="69df3813" sha1="474a2511584ec1b4d1f3a68ecacc37ce6f2ae573" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="penguin (1988)(eurosoft)(nl).dsk" size="737280" crc="69df3813" sha1="474a2511584ec1b4d1f3a68ecacc37ce6f2ae573" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="penguina" cloneof="penguin">
-		<description>Penguin (Netherlands, alt)</description>
+		<description>Penguin (Netherlands, cracked, alt)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8217" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
-				<rom name="penguin (1988)(eurosoft)(nl)[a].dsk" size="368640" crc="14939708" sha1="53d6a340ae9c36faea06eb93eb105cbc7e331187" />
+				<rom name="penguin (1988)(eurosoft)(nl).dsk" size="368640" crc="d0252c04" sha1="8b5e5de08ce07b929e07be2d4eca84eb5bac1748" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this was never released on a floppy, but it also does not list the eurosoft release as a separate release. -->
 	<software name="pharaoh">
 		<description>Pharaoh's Revenge (Netherlands)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="pharaoh's revenge (1988)(eurosoft)(nl).dsk" size="737280" crc="8cc6bef2" sha1="09ae4aef768f52cf2d47035b9ece33f7cd2c67b8" />
+				<rom name="pharaoh's revenge (1988)(eurosoft)(nl).dsk" size="737280" crc="8cc6bef2" sha1="09ae4aef768f52cf2d47035b9ece33f7cd2c67b8" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1077,9 +1181,12 @@ The following floppies came with the machines.
 		<description>Pinball Blaster (Netherlands)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8203*1M" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="pinball blaster (1988)(eurosoft)(nl).dsk" size="737280" crc="03be7d31" sha1="e5860122901ab8bb6f5383e6384475064bad771e" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="pinball blaster (1988)(eurosoft)(nl).dsk" size="737280" crc="03be7d31" sha1="e5860122901ab8bb6f5383e6384475064bad771e" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1088,20 +1195,11 @@ The following floppies came with the machines.
 		<description>Playhouse Strippoker (Netherlands)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="playhouse strippoker (1988)(eurosoft)(nl).dsk" size="737280" crc="e98b3c5e" sha1="291c26bab53d06f25088bb0d472ef9b37acce0fe" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="phstripa" cloneof="phstrip">
-		<description>Playhouse Strippoker (Netherlands, alt)</description>
-		<year>1988</year>
-		<publisher>Eurosoft</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="playhouse strippoker (1988)(eurosoft)(nl)[a].dsk" size="368640" crc="79da5435" sha1="2d7686ad34e0218b5b530ba74d5f712aeae55c37" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="playhouse strippoker (1988)(eurosoft)(nl).dsk" size="737280" crc="e98b3c5e" sha1="291c26bab53d06f25088bb0d472ef9b37acce0fe" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1110,31 +1208,36 @@ The following floppies came with the machines.
 		<description>Police Academy II (Netherlands)</description>
 		<year>1987</year>
 		<publisher>Methodic Solutions</publisher>
+		<info name="serial" value="8912" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="police academy ii (1987)(methodic solutions)(nl).dsk" size="737280" crc="05a622d0" sha1="aa5302182eaf4ad4bb9dd1c342d68542c9b146bf" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="police academy ii (1987)(methodic solutions)(nl).dsk" size="737280" crc="05a622d0" sha1="aa5302182eaf4ad4bb9dd1c342d68542c9b146bf" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="printxpr">
-		<description>Print-X-Press (UK)</description>
+	<!-- Software does not boot. Single sided dump created cutting a double sided dump in half. Works after doubling the single sided image. -->
+	<software name="printxpr" supported="no">
+		<description>Print-X-Press (United Kingdom)</description>
 		<year>1986</year>
 		<publisher>Anglosoft</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
-				<rom name="print-x-press (19xx)(anglosoft)(gb).dsk" size="368640" crc="ef5442a6" sha1="7b17e7569ffccf39519996f78201e7d386ff22d8" />
+				<rom name="print-x-press (19xx)(anglosoft)(gb).dsk" size="368640" crc="ef5442a6" sha1="7b17e7569ffccf39519996f78201e7d386ff22d8" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="protectr">
-		<description>The Protector (Japan)</description>
+		<description>The Protector (Netherlands)</description>
 		<year>1985</year>
-		<publisher>Pony Canyon</publisher>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8371" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="protector, the (1985)(pony canyon)(jp).dsk" size="737280" crc="9843fdf9" sha1="190257ecb57c95a07041f48871acb0bd6f708800" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="protector, the (1985)(pony canyon)(jp).dsk" size="737280" crc="9843fdf9" sha1="190257ecb57c95a07041f48871acb0bd6f708800" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1145,40 +1248,48 @@ The following floppies came with the machines.
 		<publisher>Nice Ideas</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="pyro-man (1986)(nice ideas)(fr).dsk" size="737280" crc="cddf986b" sha1="a13db247ba354992255da4e5216ddd234acd5d69" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="pyro-man (1986)(nice ideas)(fr).dsk" size="737280" crc="cddf986b" sha1="a13db247ba354992255da4e5216ddd234acd5d69" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="quebert">
+	<!-- Software does not boot. Single sided dump created cutting a double sided dump in half. Works after doubling the single sided image. -->
+	<software name="quebert" supported="no">
 		<description>Quebert (Netherlands)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8223" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
-				<rom name="quebert (1988)(eurosoft)(nl).dsk" size="368640" crc="5ea46a2b" sha1="62bd026f287bdb31f808f947c3f71e67f8366aa6" />
+				<rom name="quebert (1988)(eurosoft)(nl).dsk" size="368640" crc="5ea46a2b" sha1="62bd026f287bdb31f808f947c3f71e67f8366aa6" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="regate">
+	<!-- Software does not boot on an MSX1 machine. Boots on an MSX2 machine. -->
+	<software name="regate" supported="partial">
 		<description>Régate - La Coupe de L'America (France)</description>
 		<year>1986</year>
 		<publisher>Philips</publisher>
+		<info name="usage" value="Requires an MSX2 machine." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="regate - la coupe de l'america (1986)(philips)(fr).dsk" size="737280" crc="69c953f2" sha1="d3306a04432ee57dd73bd7db62f65cbb0c9d6320" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="regate - la coupe de l'america (1986)(philips)(fr).dsk" size="737280" crc="69c953f2" sha1="d3306a04432ee57dd73bd7db62f65cbb0c9d6320" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="regatea" cloneof="regate">
+	<!-- Software does not boot -->
+	<software name="regatea" cloneof="regate" supported="no">
 		<description>Régate - La Coupe de L'America (France, alt)</description>
 		<year>1986</year>
 		<publisher>Philips</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="regate - la coupe de l'america (1986)(philips)(fr)[a].dsk" size="737280" crc="15ba4799" sha1="5714d2eda05000b477c58ba6666b2f6c2128473c" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="regate - la coupe de l'america (1986)(philips)(fr)[a].dsk" size="737280" crc="15ba4799" sha1="5714d2eda05000b477c58ba6666b2f6c2128473c" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1195,7 +1306,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="rescatla" cloneof="rescatl">
-		<description>Rescate Atlantida (Spain, alt)</description>
+		<description>Rescate Atlántida (Spain, alt)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -1209,9 +1320,11 @@ The following floppies came with the machines.
 		<description>Robot Wars (Netherlands)</description>
 		<year>1986</year>
 		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8363" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="robot wars (1986)(eaglesoft)(nl).dsk" size="737280" crc="0b2772e6" sha1="f6e51dc1a91d87fa247b13e2e60fe819e4f3f6e2" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="robot wars (1986)(eaglesoft)(nl).dsk" size="737280" crc="0b2772e6" sha1="f6e51dc1a91d87fa247b13e2e60fe819e4f3f6e2" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1222,7 +1335,8 @@ The following floppies came with the machines.
 		<publisher>Eaglesoft</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="roboy (1987)(methodic solutions)(nl).dsk" size="737280" crc="0ee0c684" sha1="86a02740e9eccaa531c0518365acc08b6a959b2b" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="roboy (1987)(methodic solutions)(nl).dsk" size="737280" crc="0ee0c684" sha1="86a02740e9eccaa531c0518365acc08b6a959b2b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1231,9 +1345,12 @@ The following floppies came with the machines.
 		<description>Sailor's Delight (Netherlands, cracked)</description>
 		<year>1987</year>
 		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8424" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="sailor's delight (1987)(eaglesoft)(nl)[cr barcelona msx club].dsk" size="737280" crc="9956140d" sha1="06d9c28b530dbc848935b662c9db047a6149d802" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="sailor's delight (1987)(eaglesoft)(nl)[cr barcelona msx club].dsk" size="737280" crc="9956140d" sha1="06d9c28b530dbc848935b662c9db047a6149d802" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1242,20 +1359,23 @@ The following floppies came with the machines.
 		<description>Scentipede (Netherlands)</description>
 		<year>1986</year>
 		<publisher>Aackosoft</publisher>
+		<info name="serial" value="8210" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="scentipede (1986)(aackosoft)(nl).dsk" size="737280" crc="c73cbbf6" sha1="770c209b56da8cb56a96156b697d0d5c4f51fb71" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="scentipede (1986)(aackosoft)(nl).dsk" size="737280" crc="c73cbbf6" sha1="770c209b56da8cb56a96156b697d0d5c4f51fb71" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="sar">
-		<description>Search and Rescue (Netherlands)</description>
+		<description>Search and Rescue (Netherlands, cracked)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="search and rescue (1988)(eurosoft)(nl).dsk" size="737280" crc="dc80cf50" sha1="fdf4cf45d59f952cf2c0214713093d3cdeb30c7b" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="search and rescue (1988)(eurosoft)(nl).dsk" size="737280" crc="dc80cf50" sha1="fdf4cf45d59f952cf2c0214713093d3cdeb30c7b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1264,13 +1384,16 @@ The following floppies came with the machines.
 		<description>Skooter (Netherlands)</description>
 		<year>1987</year>
 		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8433" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="skooter (1987)(eaglesoft)(nl).dsk" size="737280" crc="341b2e66" sha1="38625f2ab55a8f778f20244f37d79b0d81667c20" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="skooter (1987)(eaglesoft)(nl).dsk" size="737280" crc="341b2e66" sha1="38625f2ab55a8f778f20244f37d79b0d81667c20" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- This was only released as part of 'System demonstration plus smash out and othello' not as a separate release. This should be removed? -->
 	<software name="smashout">
 		<description>Smash Out (Japan)</description>
 		<year>19??</year>
@@ -1286,31 +1409,23 @@ The following floppies came with the machines.
 		<description>Space Rescue (Netherlands)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8225" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="space rescue (1988)(eurosoft)(nl).dsk" size="737280" crc="7bae1c33" sha1="d2c6ac52ad4f44c6321e6d1fa16d2e7dff052f26" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="space rescue (1988)(eurosoft)(nl).dsk" size="737280" crc="7bae1c33" sha1="d2c6ac52ad4f44c6321e6d1fa16d2e7dff052f26" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="spacewlk">
-		<description>Space Walk (Europe?)</description>
-		<year>1985</year>
-		<publisher>Mastertronic</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="space walk (1985)(mastertronic)(gb).dsk" size="368640" crc="3a7b7334" sha1="046b89b70509df073c98f3dc04472644869d3f03" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spacewlka" cloneof="spacewlk">
-		<description>Space Walk (Europe?, alt)</description>
+		<description>Space Walk (Europe)</description>
 		<year>1987</year>
 		<publisher>Mastertronic Added Dimension</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="space walk (1987)(mastertronic added dimension).dsk" size="737280" crc="647efb5d" sha1="d6324dd7c91a45bf0ad7d661a1253e4724b2e6d0" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="space walk (1987)(mastertronic added dimension).dsk" size="737280" crc="647efb5d" sha1="d6324dd7c91a45bf0ad7d661a1253e4724b2e6d0" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1319,24 +1434,30 @@ The following floppies came with the machines.
 		<description>Spy vs Spy II - The Island Caper (Netherlands)</description>
 		<year>1987</year>
 		<publisher>Aackosoft</publisher>
+		<info name="serial" value="8416" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="spy vs spy ii - the island caper (1987)(databyte).dsk" size="737280" crc="a9c05807" sha1="eda689b950d28442ed12cc1375a1ce245279b058" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="spy vs spy ii - the island caper (1987)(databyte).dsk" size="737280" crc="a9c05807" sha1="eda689b950d28442ed12cc1375a1ce245279b058" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="starbugg">
-		<description>Starbuggy (Netherlands)</description>
+		<description>Starbuggy (Netherlands, cracked)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8221" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="starbuggy (1988)(eurosoft)(nl).dsk" size="737280" crc="e4bf245f" sha1="e616acfd5102b9a479de4f5577617f65707ec29c" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="starbuggy (1988)(eurosoft)(nl).dsk" size="737280" crc="e4bf245f" sha1="e616acfd5102b9a479de4f5577617f65707ec29c" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this only had a cassette release but no cassette dump known. -->
 	<software name="strikefh">
 		<description>Strike Force Harrier (Europe?)</description>
 		<year>1988</year>
@@ -1352,6 +1473,8 @@ The following floppies came with the machines.
 		<description>Super Game Collection (Japan)</description>
 		<year>1985</year>
 		<publisher>Sony</publisher>
+		<info name="alt_title" value="スーパーゲームコレクション" />
+		<info name="serial" value="HBS-G031D" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
 				<rom name="super game collection (1985)(sony)(jp).dsk" size="368640" crc="bfcfaab8" sha1="72c5949821f5a490ce2a4ffe8130a2f920197752" />
@@ -1359,41 +1482,34 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="tmht">
-		<description>Teenage Mutant Hero Turtles (UK, cracked)</description>
+	<!-- Software does not start; cannot get past the initial splash screen. -->
+	<software name="tmht" supported="no">
+		<description>Teenage Mutant Hero Turtles (United Kingdom, cracked)</description>
 		<year>1990</year>
 		<publisher>Image Works</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="teenage mutant hero turtles (1990)(image works)(gb)[cr damian roman].dsk" size="737280" crc="1f5b3122" sha1="2f61a58001fbcabefcda3d4a9ba31775e88c1221" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="teenage mutant hero turtles (1990)(image works)(gb)[cr damian roman].dsk" size="737280" crc="1f5b3122" sha1="2f61a58001fbcabefcda3d4a9ba31775e88c1221" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="tmhta" cloneof="tmht">
-		<description>Teenage Mutant Hero Turtles (UK, hacked)</description>
+	<!-- Software does not start; cannot get past the initial splash screen. -->
+	<software name="tmhta" cloneof="tmht" supported="no">
+		<description>Teenage Mutant Hero Turtles (United Kingdom, hacked)</description>
 		<year>1990</year>
 		<publisher>Image Works</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="teenage mutant hero turtles (1990)(image works)(gb)[h msx files].dsk" size="737280" crc="f0f27a24" sha1="79ab419f0a03871a8c3aa09c0f160d5ca8ac1563" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="terramex">
-		<description>Terramex (Europe?)</description>
-		<year>1988</year>
-		<publisher>Grandslam Entertainments</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="terramex (1988)(grandslam entertainments)(gb).dsk" size="737280" crc="e1003910" sha1="beaad7f874b2b6149b6834002d5fbd35c00c00b4" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="teenage mutant hero turtles (1990)(image works)(gb)[h msx files].dsk" size="737280" crc="f0f27a24" sha1="79ab419f0a03871a8c3aa09c0f160d5ca8ac1563" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="thunderc">
-		<description>Thundercats (UK)[h MSX files]</description>
+		<description>Thundercats (United Kingdom, hacked)</description>
 		<year>1987</year>
 		<publisher>Elite Systems</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -1403,13 +1519,16 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="timebomb">
+	<!-- Software does not boot on an MSX1 machine. Boots on an MSX2 machine. -->
+	<software name="timebomb" supported="partial">
 		<description>Time Bomb (Netherlands)</description>
 		<year>1987</year>
 		<publisher>Methodic Solutions</publisher>
+		<info name="usage" value="Requires an MSX2 machine." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="time bomb (1987)(methodic solutions)(nl).dsk" size="737280" crc="764e9e91" sha1="f4e47ef73ab30e670e2c0d677c50e23befeeaa4b" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="time bomb (1987)(methodic solutions)(nl).dsk" size="737280" crc="764e9e91" sha1="f4e47ef73ab30e670e2c0d677c50e23befeeaa4b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1418,13 +1537,16 @@ The following floppies came with the machines.
 		<description>Time Curb (Netherlands)</description>
 		<year>1986</year>
 		<publisher>Aackosoft</publisher>
+		<info name="serial" value="8196" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="time curb (1986)(aackosoft)(nl).dsk" size="737280" crc="ef411e36" sha1="915fa05996ad0709b12ed166cdf03c6c7a192333" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="time curb (1986)(aackosoft)(nl).dsk" size="737280" crc="ef411e36" sha1="915fa05996ad0709b12ed166cdf03c6c7a192333" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- This was released as part of compilation 'MSX Board Games 1'. This should be removed? -->
 	<software name="triversi">
 		<description>Triversi (UK)</description>
 		<year>1986</year>
@@ -1440,20 +1562,23 @@ The following floppies came with the machines.
 		<description>TT Racer (Netherlands)</description>
 		<year>1987</year>
 		<publisher>Methodic Solutions</publisher>
+		<info name="serial" value="8908" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="tt racer (1987)(methodic solutions)(nl).dsk" size="737280" crc="1004f71e" sha1="9d622dc148586f5307ca41b1084ded26b21b75eb" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="tt racer (1987)(methodic solutions)(nl).dsk" size="737280" crc="1004f71e" sha1="9d622dc148586f5307ca41b1084ded26b21b75eb" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx this never had a floppy release, but no cassette dump known. -->
 	<software name="voitures">
 		<description>Les Voitures dans Autoroute (France)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="voitures dans autoroute, les (1985)(infogrames)(fr).dsk" size="737280" crc="dc64a43c" sha1="8590f83d99622730c3fb32d76fb50ac0f864b429" />
+				<rom name="voitures dans autoroute, les (1985)(infogrames)(fr).dsk" size="737280" crc="dc64a43c" sha1="8590f83d99622730c3fb32d76fb50ac0f864b429" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1462,6 +1587,7 @@ The following floppies came with the machines.
 		<description>Vozvrashcheniye na Zemlyu (Russia)</description>
 		<year>1988</year>
 		<publisher>Crazysoft</publisher>
+		<info name="alt_title" value="Возвращение на Землю — версия игры Star Track" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="earth (1988)(crazysoft)(ru).dsk" size="737280" crc="aff49530" sha1="e35cbecaff5c97eaf6891fc93e749fb6ca41fcc9" />
@@ -1469,10 +1595,12 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Software does not autoboot. This should be removed? -->
 	<software name="vozemlyua" cloneof="vozemlyu">
 		<description>Vozvrashcheniye na Zemlyu (Russia, alt)</description>
 		<year>1988</year>
 		<publisher>Crazysoft</publisher>
+		<info name="alt_title" value="Возвращение на Землю — версия игры Star Track" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="earth (1988)(crazysoft)(ru)[a].dsk" size="737280" crc="ba0b3fff" sha1="45fd8e919d56e496ec3398d134b89d6f2832a832" />
@@ -1480,19 +1608,22 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="vortexrd">
+	<!-- Software fails to start. Goes into lalaland on an MSX1 system; MSX2 system keeps rebooting. -->
+	<software name="vortexrd" supported="no">
 		<description>Vortex Raider (Netherlands)</description>
 		<year>1988</year>
 		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8209" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="vortex raider (1988)(eurosoft)(nl).dsk" size="737280" crc="02c44970" sha1="8fb9400c69c10965e43a6d9b3ba3bfc9441d158d" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="vortex raider (1988)(eurosoft)(nl).dsk" size="737280" crc="02c44970" sha1="8fb9400c69c10965e43a6d9b3ba3bfc9441d158d" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="2wbattak">
-		<description>Wallball + Attacked (UK)</description>
+		<description>Wallball + Attacked (United Kingdom)</description>
 		<year>19??</year>
 		<publisher>Tynesoft</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -1508,7 +1639,8 @@ The following floppies came with the machines.
 		<publisher>Discovery Informática</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="zorax (1990)(discovery informatica)(br).dsk" size="737280" crc="3e0abe66" sha1="08a92725a646045361bbb672db62ce4a5595c8cb" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="zorax (1990)(discovery informatica)(br).dsk" size="737280" crc="3e0abe66" sha1="08a92725a646045361bbb672db62ce4a5595c8cb" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1530,20 +1662,25 @@ The following floppies came with the machines.
 		<year>1987</year>
 		<publisher>&lt;coverdisk&gt;</publisher>
 		<info name="magazine" value="MSX Club Magazine 01?" />
+		<info name="serial" value="X01" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
+				<!-- According to generation-msx this was released on a single sided floppy -->
 				<rom name="dungeon mystery ii (1987)(scorpionsoft)(nl)[cr canal cracker].dsk" size="737280" crc="684fcfbf" sha1="7d2db556ea0efd41416e03f4eff8a0425eed56ac" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Software does not autoboot. -->
 	<software name="dungmys2a" cloneof="dungmys2">
 		<description>Dungeon Mystery II (Netherlands, cracked, alt)</description>
 		<year>1987</year>
 		<publisher>&lt;coverdisk&gt;</publisher>
 		<info name="magazine" value="MSX Club Magazine 01?" />
+		<info name="serial" value="X01" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
+				<!-- According to generation-msx this was released on a single sided floppy -->
 				<rom name="dungeon mystery ii (1987)(scorpionsoft)(nl)[cr canal cracker][a].dsk" size="737280" crc="e64d948c" sha1="70a1afd95bccdcc2e28d2148275c185d36cc0e81" />
 			</dataarea>
 		</part>
@@ -1570,8 +1707,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Software does not autoboot -->
 	<software name="bombjack">
-		<description>Bomb Jack (Brazil)</description>
+		<description>Bomb Jack (Brazil, Sega MyCard conversion)</description>
 		<year>2004</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="MSX Files" />
@@ -1583,6 +1721,7 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Software does not autoboot -->
 	<software name="colossm3">
 		<description>Colosseum III - Deluxe Pack (Japan)</description>
 		<year>2002</year>
@@ -1595,6 +1734,7 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Software does not autoboot, collection of software. -->
 	<software name="cyujigam">
 		<description>Cyuji Games (Japan)</description>
 		<year>1997</year>
@@ -1631,6 +1771,7 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Does not work on an MSX1 machine? This should be moved to MSX2 flop list? -->
 	<software name="fsengokk">
 		<description>Fuuun Sengoku Kokorozashi (Japan)</description>
 		<year>200?</year>
@@ -1655,11 +1796,13 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Does not work on an MSX1 machine. This should be moved to MSX2 flop list? -->
 	<software name="homebbal">
 		<description>Home Baseball (Japan)</description>
 		<year>2009</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="developer" value="tohohoti" />
+		<info name="usage" value="Hold CTRL at boot until the beep; requires a Japanese machine." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="homebase.dsk" size="737280" crc="78533f45" sha1="a687dbfbdc7c5f16b4eb4c9d6b89dab25d45a23f" />
@@ -1667,7 +1810,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="isloracl">
+	<!-- Does not work on an MSX1 machine. This should be moved to MSX2 flop list? -->
+	<!-- Throws a 'file not found' error when starting a game. -->
+	<software name="isloracl" supported="no">
 		<description>The Island of the Oracle (Spain?, v0.91)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
@@ -1691,11 +1836,13 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Software does not autoboot. -->
 	<software name="minirpg1">
-		<description>Mini RPG 1 (UK?)</description>
+		<description>Mini RPG 1 (United Kngdom?)</description>
 		<year>19??</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="jawsvsoft" />
+		<info name="usage" value="RUN&quot;MINIRPG1.BAS&quot;" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="minirpg1.dsk" size="737280" crc="871e174d" sha1="e796e3c7e01bf8a5ab298063d6c7653932823989" />
@@ -1703,6 +1850,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Does not work on an MSX1 machine. This should be moved to MSX2 flop list? -->
+	<!-- Software does not autoboot. -->
 	<software name="minocoll">
 		<description>Mino Soft's Game Collection (Japan)</description>
 		<year>199?</year>
@@ -1739,11 +1888,13 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Software does not autoboot -->
 	<software name="resurect">
 		<description>Resurection (Spain?)</description>
 		<year>2013</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Dakar Soft" />
+		<info name="usage" value="RUN&quot;RESDSK.BAS&quot;" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="resurection (dakar soft, 2013).dsk" size="737280" crc="46bf1b5f" sha1="f2b7f055aaec78461f58821b7ec02aa98fb5209f" />
@@ -1751,6 +1902,7 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Does not work on an MSX1 machine. This should be moved to MSX2 flop list? -->
 	<software name="sca">
 		<description>SCA - Score Attacker (Japan)</description>
 		<year>2009</year>
@@ -1763,8 +1915,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Software does not autoboot -->
 	<software name="silgcoll">
-		<description>Silgon Hagen Game Collection (UK?)</description>
+		<description>Silgon Hagen Game Collection (United Kingdom?)</description>
 		<year>2000?</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Silgon Hagen" />
@@ -1775,14 +1928,15 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="squeek">
+	<!-- Does not work on an MSX1 machine due to the crack. -->
+	<software name="squeek" supported="partial">
 		<description>Squeek - The Story of a Ninny (Netherlands, cracked)</description>
 		<year>1991</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Anma" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
-				<rom name="squeek (1991)(anma)(nl)[cr freesoft club].dsk" size="368640" crc="60f43ff4" sha1="6729f76cc1d6047937090f894c348c36c2fae654" />
+				<rom name="squeek (1991)(anma)(nl)[cr freesoft club].dsk" size="368640" crc="60f43ff4" sha1="6729f76cc1d6047937090f894c348c36c2fae654" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -1812,10 +1966,11 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="twinflez">
-		<description>Twin Fleaz (UK)</description>
+		<description>Twin Fleaz (United Kingdom)</description>
 		<year>2000</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="NAG" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="twin fleaz (2000)(johannesson).dsk" size="737280" crc="35a2ae7e" sha1="7a078db377c76a9beced280d17cdb911befa684b" />
@@ -1858,7 +2013,7 @@ The following floppies came with the machines.
 -->
 
 	<software name="3dko">
-		<description>3D Knockout! (Europe)</description>
+		<description>3D Knockout! (Europe, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -1869,10 +2024,9 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="3dwater">
-		<description>3D Water Driver (Japan)</description>
+		<description>3D Water Driver (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>   <!-- or maybe cart2disk -->
-
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="3d water driver (1984)(apollo technica)(jp).dsk" size="737280" crc="630d1c65" sha1="a01dcef169bee8cce4ae2b7c6df5d9689bd4b23a" />
@@ -1881,7 +2035,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="aardrijk">
-		<description>Aardrijkskunde (Netherlands)</description>
+		<description>Aardrijkskunde (Netherlands, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -1891,9 +2045,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-<!-- One of the titles is currently unavailable as tape file -->
+<!-- One of the titles (Formas Geometricas) is currently unavailable as tape file -->
 	<software name="abejasa">
-		<description>La Abeja Sabia (Spain)</description>
+		<description>La Abeja Sabia (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -1903,19 +2057,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="alcazar">
-		<description>Alcazar - The Forgotten Fortress (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="alcazar - the forgotten fortress (1985)(activision)(us).dsk" size="737280" crc="40fa2312" sha1="16af448dd4571be2b14befc0ec30ba10ffe67c12" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="amida">
-		<description>Amida (Japan)</description>
+		<description>Amida (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -1926,7 +2069,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="antares">
-		<description>Antares (Spain)</description>
+		<description>Antares (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -1937,7 +2080,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="antaresa" cloneof="antares">
-		<description>Antares (Spain, alt)</description>
+		<description>Antares (Spain, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -1946,41 +2089,23 @@ The following floppies came with the machines.
 			</dataarea>
 		</part>
 	</software>
+
+	<!-- This may be a disk conversion of the cassette release. -->
 	<software name="apeman">
-		<description>The Apeman Strikes Again (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>The Apeman Strikes Again (Netherlands)</description>
+		<year>198?</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="88282" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="apeman strikes again, the (1986)(eaglesoft)(nl).dsk" size="737280" crc="acb1efb9" sha1="54990a2328925e988b9840cb9ec733786956767c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bernard">
-		<description>Bernard in the City (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bernard in the city (19xx)(-)(es).dsk" size="737280" crc="d36ad505" sha1="cb6d2508691146a668cdbf07894909f70dc1abbd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="arkos123">
-		<description>Arkos I + II + III (Spain, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="arkos i + ii + iii (1988)(zigurat software)(es)[t].dsk" size="737280" crc="1fa81c23" sha1="ed0463f6f888ca165ae62518b5b38da5599e6710" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="apeman strikes again, the (1986)(eaglesoft)(nl).dsk" size="737280" crc="acb1efb9" sha1="54990a2328925e988b9840cb9ec733786956767c" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="arocks">
-		<description>Astro Rocks (Europe)</description>
+		<description>Astro Rocks (Europe, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -1991,7 +2116,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="astrowul">
-		<description>The Astrowulards (Spain)</description>
+		<description>The Astrowulards (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2002,7 +2127,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="astrowula" cloneof="astrowul">
-		<description>The Astrowulards (Spain, alt)</description>
+		<description>The Astrowulards (Spain, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2013,7 +2138,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="killtomt">
-		<description>Attack of the Killer Tomatoes (Europe)</description>
+		<description>Attack of the Killer Tomatoes (Europe, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2024,7 +2149,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="killtomta" cloneof="killtomt">
-		<description>Attack of the Killer Tomatoes (Europe, alt)</description>
+		<description>Attack of the Killer Tomatoes (Europe, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2035,7 +2160,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="avpaulis">
-		<description>Av. Paulista (Brazil)</description>
+		<description>Av. Paulista (Brazil, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<info name="alt_title" value="Avenida Paulista" />
@@ -2048,7 +2173,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="avpaulisa" cloneof="avpaulis">
-		<description>Av. Paulista (Brazil, alt)</description>
+		<description>Av. Paulista (Brazil, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<info name="alt_title" value="Avenida Paulista" />
@@ -2061,7 +2186,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="ballblaz">
-		<description>BallBlazer (Japan)</description>
+		<description>BallBlazer (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2071,19 +2196,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="ballblaza" cloneof="ballblaz">
-		<description>BallBlazer (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="ballblazer (1988)(pony canyon)(jp)[a].dsk" size="368640" crc="878bf130" sha1="b4770649d0183667a1946b48ed4f4bc2d4fe14ea" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="ballyhoo">
-		<description>Ballyhoo (Europe)</description>
+		<description>Ballyhoo (Europe, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2094,9 +2208,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="bswriter">
-		<description>Bank Street Writer (Japan)</description>
+		<description>Bank Street Writer (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="bank street writer (1983)(toshiba-emi)(jp).dsk" size="737280" crc="752adfdf" sha1="fbbb44360685b342848b800e3578f6cb3764c55a" />
@@ -2105,7 +2220,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="barnabas">
-		<description>Barnabasket (Spain)</description>
+		<description>Barnabasket (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2116,7 +2231,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="midway">
-		<description>Battle for Midway (Europe)</description>
+		<description>Battle for Midway (Europe, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2127,7 +2242,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="midwaya" cloneof="midway">
-		<description>Battle for Midway (Europe, alt)</description>
+		<description>Battle for Midway (Europe, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2138,7 +2253,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="elbingo">
-		<description>El Bingo (Spain)</description>
+		<description>El Bingo (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2149,7 +2264,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="bjacks">
-		<description>BlackJack (Spain)</description>
+		<description>BlackJack (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2160,7 +2275,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="bjacksa" cloneof="bjacks">
-		<description>BlackJack (Spain, alt)</description>
+		<description>BlackJack (Spain, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2171,7 +2286,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="bmxreken">
-		<description>BMX Rekencross (Netherlands)</description>
+		<description>BMX Rekencross (Netherlands, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2181,19 +2296,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="boom">
-		<description>Boom! (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="boom (1986)(aackosoft)(nl).dsk" size="737280" crc="27e79483" sha1="c2367f4c1b5a5af8c6ca6c68008477bf1268644a" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="brickbrk">
-		<description>Brick Breaker (Spain)</description>
+		<description>Brick Breaker (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2204,7 +2308,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="bridge">
-		<description>Bridge (France)</description>
+		<description>Bridge (France, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2215,7 +2319,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="brisca">
-		<description>Brisca (Spain)</description>
+		<description>La Brisca (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2226,7 +2330,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="briscaa" cloneof="brisca">
-		<description>Brisca (Spain, alt)</description>
+		<description>La Brisca (Spain, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2237,7 +2341,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="suprdoor">
-		<description>Super Doors (Japan)</description>
+		<description>Super Doors (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2247,19 +2351,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="ccosmo">
-		<description>Captain Cosmo (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="captain cosmo (1984)(ascii)(jp).dsk" size="737280" crc="b47cc759" sha1="02edd0a9dcca97580b4ded364defb390a86f4b4b" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="castgod">
-		<description>El Castillo de Godless (Spain)</description>
+		<description>El Castillo de Godless (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2270,7 +2363,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="chubbygr">
-		<description>Chubby Gristle (UK)</description>
+		<description>Chubby Gristle (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2281,7 +2374,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="ciencnt5">
-		<description>Ciencias de la Naturaleza - 5 E.G.B. (Spain)</description>
+		<description>Ciencias de la Naturaleza - 5 E.G.B. (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2292,7 +2385,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="ciencnt7">
-		<description>Ciencias de la Naturaleza - 7 E.G.B. (Spain)</description>
+		<description>Ciencias de la Naturaleza - 7 E.G.B. (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2303,7 +2396,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="ciencnt8">
-		<description>Ciencias de la Naturaleza - 8 E.G.B. (Spain)</description>
+		<description>Ciencias de la Naturaleza - 8 E.G.B. (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2314,7 +2407,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="classadv">
-		<description>Classic Adventure (UK)</description>
+		<description>Classic Adventure (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2325,7 +2418,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="cluedo">
-		<description>Cluedo (UK)</description>
+		<description>Cluedo (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2336,7 +2429,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="coconuts">
-		<description>Coconuts (Spain)</description>
+		<description>Coconuts (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2347,7 +2440,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="columbia">
-		<description>Columbia (Spain)</description>
+		<description>Simulador Columbia (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2357,19 +2450,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="cmpchess">
-		<description>Computer Chess (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="computer chess (1985)(sony)(jp).dsk" size="737280" crc="49bdd660" sha1="c94a983efbe026dbe779cd6cbfe5d897b476b2c4" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- Contains older 1983 version of msx1_cart:cothello -->
 	<software name="cmpothel">
-		<description>Computer Othello (Japan)</description>
+		<description>Computer Othello (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2380,7 +2463,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="cmpscrab">
-		<description>Computer Scrabble (UK)</description>
+		<description>Computer Scrabble (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2391,7 +2474,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="cosmestb">
-		<description>Cosme Estible (Spain)</description>
+		<description>Cosme Estible (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2402,7 +2485,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="cosmestba" cloneof="cosmestb">
-		<description>Cosme Estible (Spain, alt)</description>
+		<description>Cosme Estible (Spain, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2413,7 +2496,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="cosmotrv">
-		<description>Cosmo Traveler (Japan)</description>
+		<description>Cosmo Traveler (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2424,9 +2507,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="cribbage">
-		<description>Cribbage (UK)</description>
+		<description>Cribbage (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="cribbage (1986)(kuma computers)(gb).dsk" size="737280" crc="d5d4112a" sha1="6f8f82f085918b6531ef85f312d7f531acecf43e" />
@@ -2435,9 +2519,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="chu_scir">
-		<description>El Cuerpo Humano - Sistema Circulatorio (Spain, cracked)</description>
+		<description>El Cuerpo Humano - Sistema Circulatorio (Spain, disk conversion, cracked)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="cuerpo humano, el - sistema circulatorio (1985)(microgesa)(es)[cr chevan].dsk" size="737280" crc="518a30db" sha1="f172d656f41cdc0b605dac6ca39bdb514223aa72" />
@@ -2446,9 +2531,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="chu_sdig">
-		<description>El Cuerpo Humano - Sistema Digestivo (Spain, cracked)</description>
+		<description>El Cuerpo Humano - Sistema Digestivo (Spain, disk conversion, cracked)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="cuerpo humano, el - sistema digestivo (1985)(microgesa)(es).dsk" size="737280" crc="7cba03ab" sha1="ced435b46e8a5e320444a41cb5d7656ab969c6dc" />
@@ -2457,7 +2543,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="chu_srep">
-		<description>El Cuerpo Humano - Sistema Reproductor (Spain)</description>
+		<description>El Cuerpo Humano - Sistema Reproductor (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2468,7 +2554,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="descamer">
-		<description>El Descubrimiento de America (Spain)</description>
+		<description>El Descubrimiento de América (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2479,7 +2565,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="orsonwel">
-		<description>Detective Orson Welles (Spain)</description>
+		<description>Detective Orson Welles (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2490,9 +2576,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="devilcst">
-		<description>The Devil's Castle (Spain)</description>
+		<description>The Devil's Castle (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="devil's castle, the (1985)(manhattan transfer)(es).dsk" size="737280" crc="823bdd90" sha1="d6c0a662916bb22805c04e9ddc2a484556c30216" />
@@ -2501,9 +2588,9 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="diamond">
-		<description>Diamond Luis I (Japan)</description>
+		<description>Diamond Luis I (Japan, disk conversion)</description>
 		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="diamond luis i (1986)(ikesoft)(jp).dsk" size="737280" crc="6a2ec5e9" sha1="96fa644bd528bba9ceef6024e885b821198d985b" />
@@ -2512,7 +2599,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="diamine2">
-		<description>Diamond Mine II (UK)</description>
+		<description>Diamond Mine II (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2522,19 +2609,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="diamine2a" cloneof="diamine2">
-		<description>Diamond Mine II (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="diamond mine ii (1986)(blue ribbon software)(gb)[a].dsk" size="368640" crc="9cc4ef8f" sha1="77c41122021dd3fa4ebbd36f4649afb3c3787789" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="docgalax">
-		<description>Docteur Galaxie (France)</description>
+		<description>Docteur Galaxie (France, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2545,7 +2621,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="donpan">
-		<description>DonPan (Japan)</description>
+		<description>DonPan (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2556,7 +2632,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="eagle">
-		<description>Eagle (Spain)</description>
+		<description>Eagle (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2567,7 +2643,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="eatit">
-		<description>Eat It (Netherlands)</description>
+		<description>Eat It (Netherlands, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2578,9 +2654,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="eggy">
-		<description>Eggy (Japan)</description>
+		<description>Eggy (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Requires a Japanese machine." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="eggy (1985)(bothtec)(jp).dsk" size="737280" crc="ee86dc5c" sha1="db14fe498da9b19218e71e3c529248c983d6b66a" />
@@ -2589,7 +2666,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="emerisle">
-		<description>Emerald Isle (UK)</description>
+		<description>Emerald Isle (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2600,7 +2677,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="espsagrd">
-		<description>La Espada Sagrada (Spain, cracked)</description>
+		<description>La Espada Sagrada (Spain, disk conversion, cracked)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2611,7 +2688,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="espsagrda" cloneof="espsagrd">
-		<description>La Espada Sagrada (Spain, cracked, alt)</description>
+		<description>La Espada Sagrada (Spain, disk conversion, cracked, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2622,7 +2699,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="espsagrdb" cloneof="espsagrd">
-		<description>La Espada Sagrada (Spain, cracked, alt 2)</description>
+		<description>La Espada Sagrada (Spain, disk conversion, cracked, alt 2)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2633,7 +2710,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="eye">
-		<description>Eye (UK)</description>
+		<description>Eye (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2644,7 +2721,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="eyea" cloneof="eye">
-		<description>Eye (UK, alt)</description>
+		<description>Eye (United Kingdom, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2655,7 +2732,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="feyvida8">
-		<description>Fe y Vida - 8 E.G.B. (Spain)</description>
+		<description>Fe y Vida - 8 E.G.B. (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2666,7 +2743,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="fightrid">
-		<description>Fighting Rider (Japan)</description>
+		<description>Fighting Rider (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2677,7 +2754,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="finalwar">
-		<description>Final War (Spain)</description>
+		<description>Final War (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2688,7 +2765,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="finalwara" cloneof="finalwar">
-		<description>Final War (Spain, alt)</description>
+		<description>Final War (Spain, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2699,7 +2776,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="firestar">
-		<description>Fire Star (Spain)</description>
+		<description>Fire Star (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2710,7 +2787,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="firewarr">
-		<description>Fire Warrior (Spain)</description>
+		<description>Fire Warrior (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2721,7 +2798,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="flopchop">
-		<description>Flop Chop (Spain)</description>
+		<description>Flop Chop (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2732,7 +2809,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="flyboat">
-		<description>Fly-Boat (France)</description>
+		<description>Fly-Boat (France, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2743,7 +2820,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="fbmanger">
-		<description>Football Manager (Spain)</description>
+		<description>Football Manager (Europe, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2754,7 +2831,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="forajido">
-		<description>Forajidos (Spain)</description>
+		<description>Forajidos (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2765,9 +2842,11 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="frog">
-		<description>Frog (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>Frog (Netherlands, cracked)</description>
+		<year>1988</year>
+		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8213" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="frog (1988)(eurosoft)(nl).dsk" size="737280" crc="b67623fc" sha1="5a824cfd436448cb9075198b82c02aa307e28644" />
@@ -2775,8 +2854,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="fruityfr">
-		<description>Fruity Frank (UK)</description>
+	<!-- Does not work on an MSX1 machine. -->
+	<software name="fruityfr" supported="partial">
+		<description>Fruity Frank (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2787,7 +2867,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="funwords">
-		<description>Fun Words (UK)</description>
+		<description>Fun Words 1-4 (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2798,7 +2878,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="funwordsa" cloneof="funwords">
-		<description>Fun Words (UK, alt)</description>
+		<description>Fun Words (United Kingdom, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2810,11 +2890,14 @@ The following floppies came with the machines.
 
 	<software name="fuzzball">
 		<description>Fuzzball (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1986</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8278" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="fuzzball (1986)(eaglesoft)(nl).dsk" size="737280" crc="4b1a41ba" sha1="53a148277472193739a9e52988d85db00b178aeb" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="fuzzball (1986)(eaglesoft)(nl).dsk" size="737280" crc="4b1a41ba" sha1="53a148277472193739a9e52988d85db00b178aeb" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -2822,29 +2905,37 @@ The following floppies came with the machines.
 	<software name="fuzzballa" cloneof="fuzzball">
 		<description>Fuzzball (Netherlands, alt)</description>
 		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8278" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="fuzzball (1986)(eaglesoft)(nl)[a].dsk" size="737280" crc="36d341fd" sha1="78b5719eed2cb7b5265b90f5763c1b3ab56ae993" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="fuzzball (1986)(eaglesoft)(nl)[a].dsk" size="737280" crc="36d341fd" sha1="78b5719eed2cb7b5265b90f5763c1b3ab56ae993" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Software does not autoboot. This should be removed? -->
 	<software name="fuzzballb" cloneof="fuzzball">
 		<description>Fuzzball (Netherlands, alt 2)</description>
 		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8278" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="fuzzball (1986)(eaglesoft)(nl)[a2].dsk" size="737280" crc="221b17bb" sha1="6fa41c2663eaa27852d544e1a3d92931248e2adb" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="fuzzball (1986)(eaglesoft)(nl)[a2].dsk" size="737280" crc="221b17bb" sha1="6fa41c2663eaa27852d544e1a3d92931248e2adb" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="galaxia">
-		<description>Galaxia (UK)</description>
+		<description>Galaxia (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="galaxia (1985)(kuma computers)(gb).dsk" size="737280" crc="a339a49a" sha1="43b6cb149dbb9dc7dbe37f1c9dc0480096c82729" />
@@ -2853,7 +2944,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="globibld">
-		<description>Globiblood (Spain)</description>
+		<description>Globi-Blod (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2864,7 +2955,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="gfxartst">
-		<description>Graphic Artist (Japan)</description>
+		<description>Graphic Artist (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2875,7 +2966,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="hadess">
-		<description>Hades (Spain, hacked)</description>
+		<description>Hades (Spain, disk conversion, hacked)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2886,7 +2977,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="hipertrn">
-		<description>Hiper Tronic (Spain)</description>
+		<description>Hiper Tronic (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2897,7 +2988,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="hipertrna" cloneof="hipertrn">
-		<description>Hiper Tronic (Spain, alt)</description>
+		<description>Hiper Tronic (Spain, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2908,7 +2999,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="hiyofght">
-		<description>Hiyoko Fighter (Japan)</description>
+		<description>Hiyoko Fighter (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2918,10 +3009,12 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="hobbit">
-		<description>The Hobbit (UK)</description>
+	<!-- Software does not load on an MSX1 machine -->
+	<software name="hobbit" supported="no">
+		<description>The Hobbit (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Requires an MSX2 machine." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="hobbit, the (1985)(melbourne house)(gb).dsk" size="737280" crc="8cce9f21" sha1="278b22c672783cefe38049c9454b88b88296e333" />
@@ -2930,7 +3023,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="hollyhij">
-		<description>Hollywood Hijinx (UK?)</description>
+		<description>Hollywood Hijinx (United Kingdom?, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2941,7 +3034,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="huntkill">
-		<description>Hunter Killer (UK)</description>
+		<description>Hunter Killer (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2952,7 +3045,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="hypervip">
-		<description>Hyper Viper (UK)</description>
+		<description>Hyper Viper (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2963,7 +3056,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="hyperbal">
-		<description>Hyperball (Spain, cracked)</description>
+		<description>Hyperball (Spain, disk conversion, cracked)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2974,9 +3067,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="indoorac">
-		<description>Indoor Race (Spain)</description>
+		<description>Indoor Race (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="indoor race (1987)(mind games espana)(es).dsk" size="737280" crc="e56d512c" sha1="859bf5e5590d9d9590df534e486d1664d366e3f1" />
@@ -2985,7 +3079,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="infermin">
-		<description>Infernal Miner (France)</description>
+		<description>Infernal Miner (France, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -2996,7 +3090,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="inhumano">
-		<description>Los Inhumanos (Spain)</description>
+		<description>Los Inhumanos (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3007,7 +3101,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="jecompte">
-		<description>Je Compte (France)</description>
+		<description>Je Compte! (France, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3018,18 +3112,18 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="jetalfsb">
-		<description>Jetalfs Strikes Back (UK)</description>
+		<description>Jetalf Strikes Back (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="jetalfs strikes back (19xx)(-).dsk" size="737280" crc="652f55ca" sha1="58c8044f4fb076eff5f5fc184ce0acb54da0132d" />
+				<rom name="jetalf strikes back (19xx)(-).dsk" size="737280" crc="652f55ca" sha1="58c8044f4fb076eff5f5fc184ce0acb54da0132d" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="jonytdj">
-		<description>Jony y el Trono del Jaguar (Spain)</description>
+		<description>Jony y el Trono del Jaguar (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3040,7 +3134,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="juegaps">
-		<description>Juega... Pero Seguro (Spain)</description>
+		<description>Juega... Pero Seguro (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3051,7 +3145,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="jumpjet">
-		<description>Jump Jet (Brazil)</description>
+		<description>Jump Jet (Brazil, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3062,7 +3156,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="kaerusht">
-		<description>Kaeru Shooter (Japan)</description>
+		<description>Kaeru Shooter (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3073,7 +3167,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="kickit">
-		<description>Kick It (Netherlands)</description>
+		<description>Kick It (Netherlands, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3084,7 +3178,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="killerst">
-		<description>Killer Station (Japan)</description>
+		<description>Killer Station (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3095,7 +3189,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="leucocyt">
-		<description>Leucocyt (Netherlands)</description>
+		<description>Leucocyt (Netherlands, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3106,7 +3200,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="liberatr">
-		<description>Liberator (Spain, cracked)</description>
+		<description>Liberator (Spain, disk conversion, cracked)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3117,7 +3211,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="liberatra" cloneof="liberatr">
-		<description>Liberator (Spain, cracked, alt)</description>
+		<description>Liberator (Spain, disk conversion, cracked, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3128,7 +3222,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="lonesome">
-		<description>Lonesome Tank (Japan)</description>
+		<description>Lonesome Tank (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3139,7 +3233,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="loto">
-		<description>Loto (Spain)</description>
+		<description>Loto (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3149,19 +3243,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="mj05">
-		<description>MJ-05 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="mj-05 (1984)(hudson soft)(jp).dsk" size="368640" crc="e8393b40" sha1="db2805f8ddf00f95704ce89e49e24346f94ac799" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mj05a" cloneof="mj05">
-		<description>MJ-05 (Japan, alt)</description>
+	<!-- Software starts up by wanting to format the floppy? -->
+	<software name="mj05" supported="partial">
+		<description>MJ-05 (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3172,7 +3256,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="msxart">
-		<description>MSX Artist (UK)</description>
+		<description>MSX Artist (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3183,7 +3267,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="mach3">
-		<description>Mach 3 (Spain)</description>
+		<description>Mach 3 (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3194,7 +3278,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="magovola">
-		<description>El Mago Volador (Spain)</description>
+		<description>El Mago Volador (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3205,7 +3289,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="manchest">
-		<description>Manchester United (UK, cracked)</description>
+		<description>Manchester United (United Kingdom, disk conversion, cracked)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<info name="cracked" value="Damian Roman" />
@@ -3218,17 +3302,19 @@ The following floppies came with the machines.
 
 	<software name="meanlife">
 		<description>Meaning of Life (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1986</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8276" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="meaning of life (1986)(eaglesoft)(nl).dsk" size="737280" crc="716580d7" sha1="707415f426f668225d0a4cee14ca9f918b1fac9a" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="meaning of life (1986)(eaglesoft)(nl).dsk" size="737280" crc="716580d7" sha1="707415f426f668225d0a4cee14ca9f918b1fac9a" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="mikiesq">
-		<description>Miki Va a Esquiar (Spain)</description>
+		<description>Miki Va a Esquiar (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3239,7 +3325,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="minder">
-		<description>Minder (UK)</description>
+		<description>Minder (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3250,9 +3336,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="motormad">
-		<description>Motorbike Madness (UK)</description>
+		<description>Motorbike Madness (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="motorbike madness (1988)(mastertronic)(gb).dsk" size="737280" crc="b99f30e3" sha1="51c9c22dd8cfd6151a66bcf1ea0f0ba31bbde848" />
@@ -3261,7 +3348,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="multipzl">
-		<description>Multipuzzle (Spain)</description>
+		<description>Multipuzzle (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3272,7 +3359,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="munsters">
-		<description>The Munsters (UK)</description>
+		<description>The Munsters (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3283,7 +3370,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="munstersa" cloneof="munsters">
-		<description>The Munsters (UK, alt)</description>
+		<description>The Munsters (United Kingdom, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3294,7 +3381,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="musjuego">
-		<description>Musica en Juego I - Solfeo (Spain)</description>
+		<description>Musica en Juego I - Solfeo (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3305,7 +3392,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="nought">
-		<description>Noughts &amp; Crosses (UK)</description>
+		<description>Noughts &amp; Crosses (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3316,7 +3403,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="noughta" cloneof="nought">
-		<description>Noughts &amp; Crosses (UK, alt)</description>
+		<description>Noughts &amp; Crosses (United Kingdom, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3326,8 +3413,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="odysseyk">
-		<description>Odyssey-K</description>
+	<!-- Software does not start. -->
+	<software name="odysseyk" supported="no">
+		<description>Odyssey-K (disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3338,7 +3426,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="ohno" cloneof="ohshit">
-		<description>Oh No! (Europe)</description>
+		<description>Oh No! (Europe, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3349,7 +3437,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="palet">
-		<description>Palet (Netherlands)</description>
+		<description>Palet (Netherlands, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3359,8 +3447,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="pastepat">
-		<description>Pasteman Pat - Billboard (UK)</description>
+	<!-- Software does not start -->
+	<software name="pastepat" supported="no">
+		<description>Pasteman Pat - Billboard (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3370,30 +3459,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="patrxh63">
-		<description>Patrullera XH-63 (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="patrullera xh-63 (1987)(grupo de trabajo software)(es).dsk" size="737280" crc="7a118f01" sha1="f4ba982671803650a1955cbbe34c7fe392eafda5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="patrxh63a" cloneof="patrxh63">
-		<description>Patrullera XH-63 (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="patrullera xh-63 (1987)(grupo de trabajo software)(es)[a].dsk" size="737280" crc="fc8e5687" sha1="9e3d257503352de28d707be343c816c59277a821" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="pm1_afr">
-		<description>Paises del Mundo I - Africa (Spain)</description>
+		<description>Paises del Mundo I - Africa (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3404,7 +3471,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="pm1_eur">
-		<description>Paises del Mundo I - Europa (Spain)</description>
+		<description>Paises del Mundo I - Europa (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3415,7 +3482,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="pm2_amer">
-		<description>Paises del Mundo II - America (Spain)</description>
+		<description>Paises del Mundo II - America (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3425,8 +3492,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="pm1_asia">
-		<description>Paises del Mundo II - Asia (Spain)</description>
+	<software name="pm2_asia">
+		<description>Paises del Mundo II - Asia (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3437,7 +3504,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="pltvasca">
-		<description>Pelota Vasca (Spain)</description>
+		<description>Pelota Vasca (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3448,7 +3515,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="pltvascaa" cloneof="pltvasca">
-		<description>Pelota Vasca (Spain, alt)</description>
+		<description>Pelota Vasca (Spain, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3459,7 +3526,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="pisozero">
-		<description>Piso Zero (Spain)</description>
+		<description>Piso Zero (Spain, disk conversion, cracked)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3469,10 +3536,12 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="prodetec">
-		<description>Profesion Detective (Spain)</description>
+	<!-- Software does not work on an MSX1. -->
+	<software name="prodetec" supported="partial">
+		<description>Profesion Detective (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Requires an MSX2 machine." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
 				<rom name="profesion detective (1986)(idealogic)(es).dsk" size="368640" crc="dc7b10ee" sha1="4ea9a498e58cc38da107d99bc29d77a0e3923ca9" />
@@ -3480,10 +3549,12 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="prodeteca" cloneof="prodetec">
-		<description>Profesion Detective (Spain, alt)</description>
+	<!-- Software does not work on an MSX1. -->
+	<software name="prodeteca" cloneof="prodetec" supported="partial">
+		<description>Profesion Detective (Spain, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Requires an MSX2 machine." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="profesion detective (1986)(idealogic)(es)[a].dsk" size="737280" crc="135ecfc4" sha1="c52fe61a6d2647f077ae35ffaff24908caeae211" />
@@ -3492,7 +3563,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="puddles">
-		<description>Puddles - Exercices avec Formes (France)</description>
+		<description>Puddles - Exercices avec Formes (France, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3503,7 +3574,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="punchjud">
-		<description>Punch &amp; Judy (UK)</description>
+		<description>Punch &amp; Judy (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3514,7 +3585,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="quasar">
-		<description>Quasar (UK)</description>
+		<description>Quasar (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3524,10 +3595,12 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="queengjp">
-		<description>Queen's Golf Joy Pack (Japan)</description>
+	<!-- Software does not work on an MSX1. -->
+	<software name="queengjp" supported="partial">
+		<description>Queen's Golf Joy Pack (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Requires an MSX2 machine." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="queen's golf joy pack (1985)(ascii)(jp).dsk" size="737280" crc="f599e422" sha1="84ff1cae1141633d14492c79a98bebb31e6f28f4" />
@@ -3536,7 +3609,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="railway">
-		<description>Railway (Japan)</description>
+		<description>Railway (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3547,7 +3620,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="raththa">
-		<description>Rath-Tha (Spain)</description>
+		<description>Rath-Tha (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3557,19 +3630,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="raththaa" cloneof="raththa">
-		<description>Rath-Tha (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="rath-tha (1989)(positive)(es)[a].dsk" size="368640" crc="23abb67a" sha1="b9889d453ab7514c061a599b2af03028bbbbdac8" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="rexhard">
-		<description>Rex Hard (Spain)</description>
+		<description>Rex Hard (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3579,8 +3641,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Software does not autoboot -->
 	<software name="rexharda" cloneof="rexhard">
-		<description>Rex Hard (Spain, alt)</description>
+		<description>Rex Hard (Spain, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3591,9 +3654,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="roadwars">
-		<description>Road Wars (UK)</description>
+		<description>Road Wars (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="road wars (1988)(melbourne house)(gb).dsk" size="737280" crc="7eb11c0d" sha1="b6e9ed4558b54318f90e690cbbd1b30255bb3ab6" />
@@ -3602,7 +3666,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="safarix">
-		<description>Safari X (Japan)</description>
+		<description>Safari X (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3612,19 +3676,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="safarixa" cloneof="safarix">
-		<description>Safari X (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="safari x (1985)(policy)(jp)[a].dsk" size="368640" crc="dc627372" sha1="38294a5f127b951effd3f0aa10398d4060e866b3" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="sajedrez">
-		<description>Sajedrez (Spain)</description>
+		<description>Sajedrez (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3635,7 +3688,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="sajedreza" cloneof="sajedrez">
-		<description>Sajedrez (Spain, alt)</description>
+		<description>Sajedrez (Spain, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3646,7 +3699,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="seabattl">
-		<description>Sea Battle (Spain)</description>
+		<description>Sea Battle (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3656,19 +3709,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="sendasal">
-		<description>Senda Salvaje (Spain, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="senda salvaje (1990)(zigurat software)(es)[t].dsk" size="737280" crc="0ecc879c" sha1="14b9a54ea8e22b84f56c8c27dd560bf2785af41a" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="shopboy">
-		<description>Shop Boy (Spain)</description>
+		<description>Shop Boy (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3679,7 +3721,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="smalljon">
-		<description>Small Jones (Italy)</description>
+		<description>Small Jones (Italy, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3689,19 +3731,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="sokoban">
-		<description>Sokoban (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="soukoban (1984)(ascii)(jp).dsk" size="737280" crc="fec4f08a" sha1="ddc6d3be3acb24ba44ddc19c84b4ed760d07b788" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="spacesht">
-		<description>Space Shot (Spain)</description>
+		<description>Space Shot (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3712,7 +3743,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="spooklad">
-		<description>Spooks &amp; Ladders (UK)</description>
+		<description>Spooks &amp; Ladders (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3723,7 +3754,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="sprinter">
-		<description>De Sprinter (Netherlands)</description>
+		<description>De Sprinter (Netherlands, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3734,7 +3765,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="sprintera" cloneof="sprinter">
-		<description>De Sprinter (Netherlands, alt)</description>
+		<description>De Sprinter (Netherlands, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3744,8 +3775,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Software does not autoboot -->
 	<software name="sprinterb" cloneof="sprinter">
-		<description>De Sprinter (Netherlands, alt 2)</description>
+		<description>De Sprinter (Netherlands, disk conversion, alt 2)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3756,7 +3788,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="staravng">
-		<description>Star Avenger (UK)</description>
+		<description>Star Avenger (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3767,9 +3799,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="starseek">
-		<description>Star Seeker (UK)</description>
+		<description>Star Seeker (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="star seeker (1985)(mirrorsoft)(gb).dsk" size="737280" crc="5f4fd2b8" sha1="220688e8f99f1bb697f94c4020622761530b014c" />
@@ -3778,7 +3811,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="startrek">
-		<description>Star Trek - Strategic Operations Simulator (Japan)</description>
+		<description>Star Trek - Strategic Operations Simulator (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3788,10 +3821,12 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Software does not autoboot -->
 	<software name="subshoot">
-		<description>Submarine Shooter (Japan)</description>
+		<description>Submarine Shooter (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="RUN&quot;SUBMA.BAS&quot;" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="gunman. submarine shooter (1983)(hudson soft)(jp).dsk" size="737280" crc="18e7ccfd" sha1="e4e0ae38d6ff1c53316d8cd825c332ff0e5af8f2" />
@@ -3800,7 +3835,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="suprbaby">
-		<description>Super Baby (Japan)</description>
+		<description>Super Baby (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3811,7 +3846,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="suprmind">
-		<description>Supermind (UK)</description>
+		<description>Supermind (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3822,7 +3857,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="tarot">
-		<description>Tarot (France)</description>
+		<description>Tarot (France, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3833,7 +3868,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="timemag1">
-		<description>Time and Magik I - Lords of Time (UK)</description>
+		<description>Time and Magik I - Lords of Time (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3844,7 +3879,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="timemag2">
-		<description>Time and Magik II - Red Moon (UK)</description>
+		<description>Time and Magik II - Red Moon (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3855,9 +3890,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="timemag3">
-		<description>Time and Magik III - The Price of Magik (UK)</description>
+		<description>Time and Magik III - The Price of Magik (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="time and magik iii - the price of magik (1986)(level 9 computing)(gb).dsk" size="737280" crc="56609344" sha1="78a9dc8a9c1b633bed0178bd113053ac581e4eec" />
@@ -3867,28 +3903,19 @@ The following floppies came with the machines.
 
 	<software name="topogned">
 		<description>Topografie Nederland (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1986</year>
+		<publisher>Aackosoft</publisher>
+		<info name="serial" value="8321" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="topografie nederland (1986)(philips)(nl).dsk" size="737280" crc="92624423" sha1="b8fc53c71f93087f35672700298a5e6b82b4f9e1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="topogneda" cloneof="topogned">
-		<description>Topografie Nederland (Netherlands, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="topografie nederland (1986)(philips)(nl)[a].dsk" size="368640" crc="6ad117ed" sha1="3bfed22bc3141931dbfb4520c5fc84aefb7a0198" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="topografie nederland (1986)(philips)(nl).dsk" size="737280" crc="92624423" sha1="b8fc53c71f93087f35672700298a5e6b82b4f9e1" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="trashman">
-		<description>Trashman (UK)</description>
+		<description>Trashman (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3899,7 +3926,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="trashmana" cloneof="trashman">
-		<description>Trashman (UK, alt)</description>
+		<description>Trashman (United Kingdom, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3910,7 +3937,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="trigger">
-		<description>Trigger (Spain, cracked)</description>
+		<description>Trigger (Spain, disk conversion, cracked)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3921,7 +3948,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="tuma7">
-		<description>Tuma 7 (Spain)</description>
+		<description>Tuma 7 (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3932,7 +3959,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="turbo500">
-		<description>Turbo 5000 (Netherlands)</description>
+		<description>Turbo 5000 (Netherlands, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3943,9 +3970,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="veracruz">
-		<description>Vera Cruz (UK?)</description>
+		<description>Vera Cruz (United Kingdom?, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="vera cruz affair, the (1986)(infogrames)(fr)(en).dsk" size="737280" crc="5ea7f6a5" sha1="5c6cf0752032d6fb3d81d2c6bf2d7a97406b2ce2" />
@@ -3953,19 +3981,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="viajeesp">
-		<description>Viaje Espacial (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="viaje espacial (1985)(anaya multimedia)(es).dsk" size="737280" crc="594b6f00" sha1="a8c7a9e6872f13b0a11a6f82549ce028c2c8df06" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="xetra">
-		<description>Xetra (Spain)</description>
+		<description>Xetra (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3976,7 +3993,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="yahtzee">
-		<description>Y'ahtzee (Spain)</description>
+		<description>Y'ahtzee (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -3986,19 +4003,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="zaider">
-		<description>Zaider - Battle of Peguss (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="zaider - battle of peguss (1986)(cosmos computer)(jp).dsk" size="737280" crc="074b7856" sha1="539d297e9ce183e1c01e7ab0d1d946015bb2a1ea" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="zeta2000">
-		<description>Zeta 2000 (Japan)</description>
+		<description>Zeta 2000 (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -4009,7 +4015,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="zipper">
-		<description>Zipper (UK)</description>
+		<description>Zipper (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -4020,7 +4026,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="zork">
-		<description>Zork I - The Great Underground Empire (UK)</description>
+		<description>Zork I - The Great Underground Empire (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -4031,7 +4037,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="zork2">
-		<description>Zork II - The Wizard of Frobozz (UK)</description>
+		<description>Zork II - The Wizard of Frobozz (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -4042,7 +4048,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="zork3">
-		<description>Zork III - The Dungeon Master (UK)</description>
+		<description>Zork III - The Dungeon Master (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -4062,85 +4068,8 @@ The following floppies came with the machines.
 -->
 
 
-	<software name="007agesp">
-		<description>007 - Agente Especial (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="007 - agente especial (1985)(monser)(es).dsk" size="737280" crc="23475bcf" sha1="2ceac4902c00525693034397618b7886ed9741b0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="007tld">
-		<description>007 - The Living Daylights (Europe, trainer +2)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="007 - the living daylights (1987)(domark)(gb)[t +2].dsk" size="737280" crc="d0435225" sha1="40c79680da0639085fbc5106566e987e80463dba" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="10yard">
-		<description>10 Yard Fight (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="10 yard fight (1986)(irem)(jp).dsk" size="737280" crc="e89b608d" sha1="1af4a46b49f707fc898bbf6f6326442a39f9d885" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="10frame">
-		<description>10th Frame (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="10th frame (1986)(us gold)(gb).dsk" size="737280" crc="4fb87b3e" sha1="77990265142595969eb41bede7045804d4db1863" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="10framea" cloneof="10frame">
-		<description>10th Frame (Europe, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="10th frame (1986)(us gold)(gb)[a].dsk" size="737280" crc="f0cea3de" sha1="cde226d996691c33a2f8439ebcd056fc6fc4b657" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="180">
-		<description>180 (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="180 (1987)(mastertronic added dimension).dsk" size="737280" crc="a9f6571e" sha1="7dc126a5eca63863022bc7a9c9ce86e5b4d72343" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="1942">
-		<description>1942 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="1942 (1986)(ascii)(jp).dsk" size="737280" crc="e8c84954" sha1="fba6ef9488031c0d4253fb30c9a832c10a85da3f" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="3dgolf">
-		<description>3D Golf Simulation - High Speed Edition (Japan)</description>
+		<description>3D Golf Simulation - High Speed Edition (Japan, disk conversion?, hacked?)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -4150,52 +4079,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="poolchal">
-		<description>Maltese Joe's Pool Challenge (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="3d pool. maltese joe's pool challenge (1989)(firebird software)(gb).dsk" size="737280" crc="a55caf09" sha1="40e2a8902aca64248be15a9cef57d9a31c2549c9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="4x4offrd">
-		<description>4x4 Off-Road Racing (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="4x4 off-road racing (1988)(us gold)(gb).dsk" size="737280" crc="51dbc827" sha1="a8099b59a3d7a328df5f4cf49d72fc5c1ff6e9d0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="4x4offrda" cloneof="4x4offrd">
-		<description>4x4 Off-Road Racing (Europe, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="4x4 off-road racing (1988)(us gold)(gb)[a].dsk" size="737280" crc="139003df" sha1="9c597ec0a80efd25eb3a4e802f842f04e238b1d9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="7cardstd">
-		<description>7 Card Stud (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="7 card stud (1986)(martech games)(gb).dsk" size="737280" crc="e60c0c15" sha1="5cab68637e5e09ad59332642d819ead658b93abc" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="737sim">
-		<description>737 Flight Simulator (Spain)</description>
+		<description>737 Flight Simulator (Spain, disk conversion?)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -4205,65 +4090,11 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="747fs">
-		<description>747 400b Flight Simulator (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="747 400b flight simulator (1988)(eurosoft)(nl).dsk" size="737280" crc="bbe930e4" sha1="d14a8ed6005877538e6f3744241a8c7daa707737" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ateam">
-		<description>The A-Team (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="a-team, the (1988)(zafiro software division)(es).dsk" size="737280" crc="d748460e" sha1="15454df5d4602f77c35bd5f72973b501e6b53be1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ateama" cloneof="ateam">
-		<description>The A-Team (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="a-team, the (1988)(zafiro software division)(es)[a].dsk" size="737280" crc="28861280" sha1="c4e5784bd7798183a620f67f8135559d7e20cb5f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="anaza">
-		<description>A-na-za - Kaleidoscope Special (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="anaza. kaleidoscope special (1987)(hot-b)(jp).dsk" size="737280" crc="33c1cbf2" sha1="32f7201accfa4c122c5a7a9a24d78ca58c078b5e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ae">
-		<description>A.E. (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="a.e. (1983)(toshiba-emi)(jp).dsk" size="737280" crc="d4b7940c" sha1="4537d9a420a3d48deb828f90ee92a58c8a2a3b00" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- This might be a disk conversion from the cassette release. The cassette version has a white background, this disk version uses a black background. -->
 	<software name="abadcrim">
 		<description>La Abadia del Crimen (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1988</year>
+		<publisher>Mister Chip</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
 				<rom name="abadia del crimen, la (1988)(opera soft)(es).dsk" size="368640" crc="9480eeef" sha1="2831f16bbd62d0a51d7644fc3c337171ee261450" />
@@ -4271,364 +4102,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="abadcrima" cloneof="abadcrim">
-		<description>La Abadia del Crimen (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="abadia del crimen, la (1988)(opera soft)(es)[a].dsk" size="737280" crc="c1dff80f" sha1="5be83dc972537d2d43d4f98eb7dcc2c55ba3ad11" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="abadcrimb" cloneof="abadcrim">
-		<description>La Abadia del Crimen (Spain, alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="abadia del crimen, la (1988)(opera soft)(es)[a2].dsk" size="737280" crc="2806818d" sha1="3199bc44c210dc8888c88155b9df46d924e7c99c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="abadcrimc" cloneof="abadcrim">
-		<description>La Abadia del Crimen (Spain, alt 3)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="abadia del crimen, la (1988)(opera soft)(es)[a3].dsk" size="368640" crc="ae61cb2e" sha1="086f2af5b4cb1cfb0e1c3ba3d69b9f0abdf5200d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="abracada">
-		<description>Abracadabra (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="abracadabra (1988)(proein soft line)(es).dsk" size="737280" crc="d53e0066" sha1="f5996f427d76f33e83f4a3c39978a7ee9b39af52" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="abusimbl">
-		<description>Abu Simbel Profanation (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="abu simbel profanation (1986)(dinamic software)(es).dsk" size="737280" crc="f862e95c" sha1="3d767bfc3509d7ad32324c89fd13c48f774b4a97" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="abusimbla" cloneof="abusimbl">
-		<description>Abu Simbel Profanation (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="abu simbel profanation (1986)(dinamic software)(es)[a].dsk" size="737280" crc="1199e7c6" sha1="73bb15161d25366ca0b8c970656045c2bd899f42" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="aceoface">
-		<description>Ace of Aces (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ace of aces (1986)(us gold)(gb).dsk" size="737280" crc="2761a392" sha1="406d73e0e8a2217e6fa58f6896e7169a02b89c40" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="actman">
-		<description>Actman (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="actman (1984)(ascii)(jp).dsk" size="737280" crc="ebb79685" sha1="aac3deef61c6538e24bc49c2b7a20f7ae06d9df9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="addictbl">
-		<description>Addictaball (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="addictaball (1988)(alligata software)(gb).dsk" size="737280" crc="cefe7064" sha1="e4df1f2cad224ae315ca7cfd08003efd6059adb6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="adel">
-		<description>Adel (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="adel (1986)(mind games espana)(es).dsk" size="737280" crc="13604ebe" sha1="5d846557c17ab1e9c9c25c529e5d579d1b03c8ed" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="advenchu">
-		<description>Adven' Chuta! (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="adven'chuta (1983)(mia)(jp).dsk" size="737280" crc="05c18396" sha1="2e7f5acbdb27fdf147feec4002627bc4d0e512e2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="afrtrail">
-		<description>African Trail Simulator (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="african trail simulator (1990)(positive)(es).dsk" size="737280" crc="fe08e61a" sha1="20e8ed8c86c46f8b17bfb6d91a90ea6b49f846b8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="afrtraila" cloneof="afrtrail">
-		<description>African Trail Simulator (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="african trail simulator (1990)(positive)(es)[a].dsk" size="737280" crc="4b2c5a11" sha1="3a3ab8762e2038e95bad89164590070338205d8e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="afterwar">
-		<description>After the War (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="after the war (1989)(dinamic software)(es).dsk" size="368640" crc="499707ee" sha1="117efd7663cc4fbd6119556547df867802dd9a37" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="afterwara" cloneof="afterwar">
-		<description>After the War (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="after the war (1989)(dinamic software)(es)[a].dsk" size="737280" crc="1925976c" sha1="5dada0db2d25fd6a9a11f714dbe83c303a91d483" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="afterwarb" cloneof="afterwar">
-		<description>After the War (Spain, alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="after the war (1989)(dinamic software)(es)[a2].dsk" size="737280" crc="aee29011" sha1="c8a40486d6a85e25dababe65ea17a00e35f71756" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="aburner">
-		<description>Afterburner (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="afterburner (1988)(activision)(us).dsk" size="737280" crc="1939d4ad" sha1="d45c443f7ac64b13522b53b97b68ef1b6e712a29" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="aburnera" cloneof="aburner">
-		<description>Afterburner (Europe, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="afterburner (1988)(activision)(us)[a].dsk" size="737280" crc="5472743a" sha1="0992cf4fbe491d9f92517b5ff538d42754e922a7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="afteroid">
-		<description>Afteroids (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="afteroids (1988)(zigurat software)(es).dsk" size="737280" crc="5f7e0a28" sha1="652c0028935b59e1ccd26a90ad51a11f4ee30113" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="afteroida" cloneof="afteroid">
-		<description>Afteroids (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="afteroids (1988)(zigurat software)(es)[a].dsk" size="737280" crc="2fc1c8c4" sha1="28fc994a26c27fe20394cae45b7acfc5aaac21a2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="albatros">
-		<description>Albatross (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="arubatoros. albatross (1986)(telenet japan)(jp).dsk" size="737280" crc="1b810be0" sha1="816572b0eaae4053f87e53064327b23752f47464" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="alehop">
-		<description>Ale Hop! (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ale hop (1988)(topo soft)(es).dsk" size="737280" crc="03955c76" sha1="9d2175fee15ed92e4d82bc94d04036f1f60208ca" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="alehopa" cloneof="alehop">
-		<description>Ale Hop! (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ale hop (1988)(topo soft)(es)[a].dsk" size="737280" crc="679384b6" sha1="2857616a03d58b4e55020644d54df7adc74fcf3e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="alfamat">
-		<description>Alfamat (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="alfamat (1985)(anaya multimedia)(es).dsk" size="737280" crc="613db4da" sha1="aaa5d6fcddedb12cbc9c2388bcd581bff75b1883" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="alibaba">
-		<description>Alibaba and 40 Thieves</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="alibaba and 40 thieves (1984)(icm).dsk" size="737280" crc="956f6e1d" sha1="7be0eff85cdab0b01b942ef90bffd7587161d2be" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="alien8">
-		<description>Alien 8 (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="alien 8 (1985)(ultimate play the game)(gb).dsk" size="737280" crc="8f902c11" sha1="4113b1cc4230b10c3a44501c4a05bd3d2bc23024" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="asyndrom">
-		<description>Alien Syndrome (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="alien syndrome (1988)(dro soft)(es).dsk" size="368640" crc="9b96a1ed" sha1="c85e84e137563dcad727b431ff8561d04d9c7566" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="aliens">
-		<description>Aliens (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="aliens (1987)(mr. micro)(gb).dsk" size="737280" crc="5c42b612" sha1="03c465a271f2b83a67a1a086df9b318856f1ab8e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="aliensj">
-		<description>Aliens - Alien 2 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 256K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="aliens. alien 2 (1987)(square)(jp)[needs 256k].dsk" size="737280" crc="7f4793cb" sha1="20972ea6c2a6d0e01f3738891eaf0e4c2cdb18e4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="aliensja" cloneof="aliensj">
-		<description>Aliens - Alien 2 (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 256K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="aliens. alien 2 (1987)(square)(jp)[a][needs 256k].dsk" size="737280" crc="2795c76d" sha1="fcb5efed56e0b79f5d62928ec3c0788cfee336ed" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="aliensjb" cloneof="aliensj">
-		<description>Aliens - Alien 2 (Japan, alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 256K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="aliens. alien 2 (1987)(square)(jp)[a2][needs 256k].dsk" size="737280" crc="18458fb3" sha1="f14c1deadbfb128cb20299f2e7b303047d43c91d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ablast">
-		<description>Alpha Blaster (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="alpha blaster (1984)(aackosoft)(nl).dsk" size="737280" crc="d0e43dc6" sha1="f4b24a0be4972dd5821fe3db5c71d5f55151962d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<!-- According to generation-msx this had a disk release in Europe by Eaglesoft, but this seems to be a conversion from cart/tape of the Japanese version... -->
+	<!-- According to generation-msx this had a disk release in Europe by Eaglesoft, but this seems to be a conversion from cart/tape of the Japanese version. -->
 	<software name="aroid">
-		<description>αRoid (Japan)</description>
+		<description>αRoid (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -4638,342 +4114,47 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-
-	<software name="asquad">
-		<description>Alpha Squadron (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="alpha squadron (1985)(sony)(jp).dsk" size="737280" crc="534f453c" sha1="ab558d4799fc6d6576c174f759374d7701dbbda3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="amaurote">
-		<description>Amaurote (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="amaurote (1987)(mastertronic added dimension).dsk" size="737280" crc="8e614bce" sha1="321b65720ffc0b31eec3da11fff345666110c2b2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="amtruck">
-		<description>American Truck (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="american truck (1986)(telenet japan)(jp).dsk" size="737280" crc="986aa8ff" sha1="cc06734a0f535896bb2a7489b4f5a3f64b1fe891" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="amomundo">
-		<description>Amo del Mundo (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="amo del mundo (1990)(positive)(es).dsk" size="737280" crc="bb24dca7" sha1="9638ad154e3cf71b50cb805ec46283a7fab57302" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="amomundoa" cloneof="amomundo">
-		<description>Amo del Mundo (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="amo del mundo (1990)(positive)(es)[a].dsk" size="737280" crc="6466cfe5" sha1="70815fe989acdce1292ad917351b58ed4b45036b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="amotopuf">
-		<description>Amoto's Puf (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="amoto's puf (1988)(spe)(es).dsk" size="737280" crc="88dd742b" sha1="f312651b1ce27065d05ca03a8eb461afe75644a4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ang500cc">
-		<description>Angel Nieto Pole 500cc (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="angel nieto pole 500cc (1990)(opera soft)(es).dsk" size="737280" crc="a9e4ac47" sha1="ec05707870ccac99b1d52ac5c776b7e332dd02d7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ang500cca" cloneof="ang500cc">
-		<description>Angel Nieto Pole 500cc (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="angel nieto pole 500cc (1990)(opera soft)(es)[a].dsk" size="737280" crc="7638f1f4" sha1="e24dfee21968222729f4ded70e5ec706d15e338c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="angelo">
-		<description>Angelo (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="angelo (1984)(ascii)(jp).dsk" size="737280" crc="ad8bba77" sha1="db37be3979a3c3746d2a1679669e489a3f47e17b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="anglebal">
-		<description>Angleball (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="angleball (1987)(mastertronic added dimension).dsk" size="737280" crc="5de3690a" sha1="afb4e21b7aea325e395b290395e7b5a156316090" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="anty">
-		<description>Anty (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="anty (1984)(bothtec)(jp).dsk" size="737280" crc="223850c6" sha1="f2fe98e25dca38067f43b184a4c11d226f426f62" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="apring2">
-		<description>Aprendiendo Ingles 2 - Bernard goes to Mars (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="aprendiendo ingles 2. bernard goes to mars (1985)(sony spain)(es)(en).dsk" size="737280" crc="22aaecc5" sha1="3482d982e7cd768fa5b2019a25e631dbd649014e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="aramo">
-		<description>Aramo (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="aramo (1986)(xain)(jp).dsk" size="737280" crc="c39d3d6d" sha1="3cffa2e60ad3850f0512974175ce9dabfa1cf50b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="arctfox">
-		<description>ArcticFox (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="arctic fox (1989)(dro soft)(es).dsk" size="737280" crc="65c59243" sha1="16b21d3660aa5e7f390301651678b69897c6ecbf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="arkanoid">
-		<description>Arkanoid (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="arkanoid (1986)(taito)(jp).dsk" size="737280" crc="30e78661" sha1="cec8263c1af307ab367d47336d930d1e4ef7140f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="arkos1">
-		<description>Arkos I (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="arkos i (1988)(zigurat software)(es).dsk" size="737280" crc="a8259bce" sha1="bc5f91b4409b6891fb92659f1de2e5aa1be2fdd3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="arkos2">
-		<description>Arkos II (Spain, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="arkos ii (1988)(zigurat software)(es)[t].dsk" size="737280" crc="c9dc95f7" sha1="98b7bc16044704633b89617823166caec52580ea" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="armymove">
-		<description>Army Moves (Spain, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="army moves (1987)(dinamic software)(es)[t].dsk" size="737280" crc="a372ab4a" sha1="236b407ea09258e3924b0ab031974a0a6cd154e3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="arquimed">
-		<description>Arquimedes XXI (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="arquimedes xxi (1986)(dinamic software)(es).dsk" size="737280" crc="8f626320" sha1="5d3c5ddac68e24ab893e27f3e5a3a60d008488b2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="arquimeda" cloneof="arquimed">
-		<description>Arquimedes XXI (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="arquimedes xxi (1986)(dinamic software)(es)[a].dsk" size="737280" crc="d4f0a907" sha1="63290e5dc6956a4818812356035e44156d4e7657" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="aspargp">
-		<description>Aspar GP Master (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>Aspar GP Master (Spain, disk conversion)</description>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
+		<info name="serial" value="DMX 88008" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="aspar gp master (1988)(dinamic software)(es).dsk" size="737280" crc="4f615039" sha1="14785c7cc89bfd3c05b49db6a34dd9c2df6c0932" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="aspar gp master (1988)(dinamic software)(es).dsk" size="737280" crc="4f615039" sha1="14785c7cc89bfd3c05b49db6a34dd9c2df6c0932" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="amc">
-		<description>Astro Marine Corps (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="astro marine corps (1989)(dinamic software)(es).dsk" size="737280" crc="273b526f" sha1="ef74e4458d0cf4059de327f1bdf429825c6b3785" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="astroplm">
-		<description>Astro Plumber (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="astro plumber (1986)(blue ribbon software)(gb).dsk" size="737280" crc="010b6a1a" sha1="82f6d53f41fadd7ab54d59b857b594da47105fc7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="athlball">
-		<description>Athletic Ball (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="athletic ball. ghost flipper (1984)(ascii)(jp).dsk" size="737280" crc="96553d81" sha1="1e0cda3607bf5216febf2e57af9e4b2ebc545574" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="athland">
-		<description>Athletic Land (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="athletic land (1984)(konami)(jp).dsk" size="737280" crc="7ef14bb2" sha1="735677f1dbd33490df8d62960691c842e861dc2d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<!-- The real MSX disk release contained Attacked + Wallball, hence this is a conversion from the tape release!! -->
+	<!-- The real MSX disk release contained Attacked + Wallball, this must be conversion from the tape release -->
 	<software name="attacked">
-		<description>Attacked (Europe)</description>
+		<description>Attacked (Europe, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="attacked (19xx)(tynesoft)(gb).dsk" size="737280" crc="c9ed326b" sha1="89cb1d5f2ca20716d5b97dad3aeb422f8c446bf9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="awmonty">
-		<description>Auf Wiedersehen Monty (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="auf wiedersehen monty (1987)(gremlin graphics software)(gb).dsk" size="737280" crc="bd71c844" sha1="8aa7205246f485396234acbdaa20d7442d7b3b7e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="awmontya" cloneof="awmonty">
-		<description>Auf Wiedersehen Monty (Europe, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="auf wiedersehen monty (1987)(gremlin graphics software)(gb)[a].dsk" size="737280" crc="d925c398" sha1="36d95977b86d8dd91ad27fae57c0f4768e8887ed" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="avenger">
-		<description>Avenger (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="avenger (1986)(gremlin graphics software)(gb).dsk" size="737280" crc="f5e308b9" sha1="056720d74db73cef5a133b0c87b08ac499646641" />
+				<rom name="attacked (19xx)(tynesoft)(gb).dsk" size="737280" crc="c9ed326b" sha1="89cb1d5f2ca20716d5b97dad3aeb422f8c446bf9" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="avenspac">
-		<description>La Aventura Espacial (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>La Aventura Espacial (Spain, disk conversion?)</description>
+		<year>1990</year>
+		<publisher>Aventuras AD</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
-				<rom name="aventura espacial, la (1990)(aventuras ad)(es).dsk" size="368640" crc="9e151c2f" sha1="0b4a914705b7897d92d4e41dec5cbc9bfc145897" />
+				<!-- According to generation-msx this was released on a double sided floppy -->
+				<rom name="aventura espacial, la (1990)(aventuras ad)(es).dsk" size="368640" crc="9e151c2f" sha1="0b4a914705b7897d92d4e41dec5cbc9bfc145897" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="avenspaca" cloneof="avenspac">
-		<description>La Aventura Espacial (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>La Aventura Espacial (Spain, disk conversion?, alt)</description>
+		<year>1990</year>
+		<publisher>Aventuras AD</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="aventura espacial, la (1990)(aventuras ad)(es)[a].dsk" size="737280" crc="37a03e81" sha1="3d1376a168a3632d3824f49e38cb85249d747193" />
@@ -4981,75 +4162,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="avenorig">
-		<description>La Aventura Original (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="aventura original, la (1989)(aventuras ad)(es).dsk" size="737280" crc="7e4ff06a" sha1="af3d60a211179cadf9c5b8e4cb74557d52c89f64" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="avenoriga" cloneof="avenorig">
-		<description>La Aventura Original (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="aventura original, la (1989)(aventuras ad)(es)[a].dsk" size="737280" crc="1e51db48" sha1="3d911024cfa8adbe4b49473888170f0be3b18935" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="averno">
-		<description>Averno (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="averno (1989)(proein soft line)(es).dsk" size="737280" crc="d15976f1" sha1="0227e4a4aa7b5e58df537beffc62e09cc2a04d5f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="avernoa" cloneof="averno">
-		<description>Averno (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="averno (1989)(proein soft line)(es)[a].dsk" size="737280" crc="0e8cb026" sha1="22271c85e80bded528ef6588b138566ad0bf7114" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bcquest">
-		<description>B.C.'s Quest for Tires (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="b.c.'s quest for tires (1985)(toshiba-emi)(jp).dsk" size="737280" crc="a25d21ae" sha1="7da07b12986b6e6aade7395e5d39c27f14cb0b42" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bcquest2">
-		<description>B.C.'s Quest for Tires II - Grog's Revenge (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="b.c.'s quest for tires ii - grog's revenge (1985)(us gold)(gb).dsk" size="737280" crc="22a4269c" sha1="110ba2598f5f62e507736c8b7542feec7e970be9" />
-			</dataarea>
-		</part>
-	</software>
-
-<!-- In which format was this released? as a tape? -->
+	<!-- In which format was this released? as a tape? This might not be an official release. -->
 	<software name="bc2">
-		<description>Ruote e Cavenicoli (Italy)</description>
+		<description>Ruote e Cavenicoli (Italy, translated)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -5059,328 +4174,15 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="backtof">
-		<description>Back to the Future (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="back to the future (1985)(pony canyon)(jp).dsk" size="737280" crc="979149cd" sha1="76dc8c2c3e524036355196e541a251b7de98452c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="backgamm">
-		<description>Backgammon (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="backgammon (1984)(electric software)(gb).dsk" size="737280" crc="37a2a66a" sha1="9e55674ddeb3721a3b08aefbb448f75398eb95f2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="backgamj">
-		<description>Backgammon (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="backgammon (1985)(sony)(jp).dsk" size="737280" crc="a140fd7e" sha1="0f44393decaabfc4074c1411a975ffb23d6a3597" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="balance">
-		<description>Balance (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="balance (1984)(hal laboratory)(jp).dsk" size="737280" crc="c632ceca" sha1="51e401e2c0915db4b92240ad6be92547250b1338" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="banana">
-		<description>Banana (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="banana (1984)(ascii)(jp).dsk" size="737280" crc="ef17be2b" sha1="4004f0ef24b2bc6b1d65c43becbb2752a515b295" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bankp">
-		<description>Bank Panic (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bank panic (1985)(pony canyon)(jp).dsk" size="737280" crc="27ca3d9d" sha1="498522d2008ef36e5b165e32c0c3f5a574c56855" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="barb">
-		<description>Barbarian (Europe, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="barbarian (1988)(mastertronic)(gb)[t].dsk" size="737280" crc="b2f10a1b" sha1="b88290855345e94515bbd3bbf43ee49b0a381047" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="batman">
-		<description>Batman</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="batman (1986)(ocean software)(gb).dsk" size="737280" crc="50833604" sha1="a7c0d35ab8232f160f8fb5f5a92f7fd3df636208" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="btanuki">
-		<description>Batten Tanuki no Daibouken (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="batten tanuki no daibouken. raccoon dog (1986)(tecno soft).dsk" size="737280" crc="635e415b" sha1="349bba7156db9e884bba949191b2d4b0c090721b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="battlex">
-		<description>Battle Cross (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="battle cross (1984)(sony)(jp).dsk" size="737280" crc="357d6fa1" sha1="1df2e979c273d37c3584ea46ae72553b7c735d1d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="clapton2">
-		<description>Battleship Clapton II (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="battle ship clapton ii (1984)(t&amp;e soft)(jp).dsk" size="737280" crc="15444c10" sha1="ff49f71d11bd2e6844860bcbd52fa7ec09a933ba" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="beamridr">
-		<description>Beamrider (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="beamrider (1984)(activision)(us).dsk" size="737280" crc="45cdf95f" sha1="0f21bb62b0db8f61332d28cc2496c3fb31872da0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="beeflowr">
-		<description>Bee &amp; Flower</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bee &amp; flower (1983)(think soft).dsk" size="737280" crc="1850c313" sha1="f6ce52d693b3896c4acb27c46381b77db0b13de9" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- Converted from tape? -->
 	<software name="bestwarr">
 		<description>Bestial Warrior (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<info name="serial" value="MSD 890012" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="bestial warrior (1989)(dinamic software)(es).dsk" size="737280" crc="2d5ccf7c" sha1="904221f84b9c9a566a0554632d0240cc265507f7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bestwarra" cloneof="bestwarr">
-		<description>Bestial Warrior (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="bestial warrior (1989)(dinamic software)(es)[a].dsk" size="368640" crc="c03c1534" sha1="589597a909dd4133c5791f045ebf02131b74ec9d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="blkonyx">
-		<description>The Black Onyx (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1"/>
-			<dataarea name="flop" size="737280">
-				<rom name="black onyx, the (1985)(ascii)(jp)(jp).dsk" size="737280" crc="3438f8b6" sha1="e1758f98d1a89e36bee6654bd8c1774a123ef391" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1, Alt"/>
-			<dataarea name="flop" size="737280">
-				<rom name="black onyx, the (1985)(ascii)(jp)[a].dsk" size="737280" crc="ac1495b3" sha1="5508fc5c758567f5ccf427ab7327137f2faec4ad" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="blackbrd">
-		<description>Blackbeard (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="blackbeard (1988)(topo soft)(es).dsk" size="737280" crc="ecc3726f" sha1="3995bdb3c3c7c43e5a709101b7546b6a33e260d6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="blackbrda" cloneof="blackbrd">
-		<description>Blackbeard (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="blackbeard (1988)(topo soft)(es)[a].dsk" size="737280" crc="142cf31a" sha1="08178e83361367334d66047eeab8c4c19111841f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="blagger">
-		<description>Blagger (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="blagger (1984)(alligata software)(gb).dsk" size="737280" crc="c99d3f87" sha1="5b05e941ecd4c24c944dad301061d44d9c039c86" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="blstroid">
-		<description>Blasteroids (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="blasteroids (1987)(image works)(gb).dsk" size="737280" crc="19c96e75" sha1="66a535ae6e7364a5577b99f5668592cba6aefa4d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="blockrun">
-		<description>Blockade Runner (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="blockade runner (1984)(toshiba-emi)(jp).dsk" size="737280" crc="30942fce" sha1="562d785ef48fe74efdfbe61b76119338acba7c04" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bloody">
-		<description>Bloody (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bloody (1987)(p.j. software)(es).dsk" size="737280" crc="bd055d33" sha1="9114b80df67aade1f468f1c9e96840dfe4a1c0ab" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bloodya" cloneof="bloody">
-		<description>Bloody (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bloody (1987)(p.j. software)(es)[a].dsk" size="737280" crc="b0edf44b" sha1="e0187c62e37819d9adbed95d46578fe12cce8b5c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bmxsim">
-		<description>BMX Simulator (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bmx simulator (1987)(codemasters)(gb).dsk" size="737280" crc="610b4b10" sha1="f10f52fc3a169f74bc658e01e83330961494e4e2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bmxsima" cloneof="bmxsim">
-		<description>BMX Simulator (Europe, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bmx simulator (1987)(codemasters)(gb)[a].dsk" size="737280" crc="3f635c4c" sha1="5d5a296eab4c5d9065dcc3a13b860b773cabb5d5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="boardell">
-		<description>Boardello (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="boardelo (1995)(bubble bus)(gb).dsk" size="737280" crc="63ac9faa" sha1="1a441adf1066108d695544a1ba92663d97d418fd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="boggy84">
-		<description>Boggy '84 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="boggy '84 (1984)(nippon columbia - colpax - universal).dsk" size="737280" crc="46f6380c" sha1="2eb385313094135821e162c93d1827e0a5260654" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="boing2">
-		<description>Boing Boing (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="boing boing (1985)(idealogic)(es).dsk" size="737280" crc="426736aa" sha1="129df2d4dff43938b6b33b20bdd08e180e70f3e3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bokosuka">
-		<description>Bokosuka Wars (Japan, hacked)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bokosuka (1984)(ascii)(jp).dsk" size="737280" crc="c4f3eb40" sha1="305bafeab01896ee3f12827fe79bb7f58bf0440b" />
+				<rom name="bestial warrior (1989)(dinamic software)(es).dsk" size="737280" crc="2d5ccf7c" sha1="904221f84b9c9a566a0554632d0240cc265507f7" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -5396,121 +4198,37 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="bombersp">
-		<description>Bomber Man Special (Japan)</description>
-		<year>1986</year>
-		<publisher>Hudson Soft</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bomber man special (1986)(hudson soft)(jp).dsk" size="737280" crc="95ad2b98" sha1="b72b5921687c261e61fccd4a45b88ffe3072388f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="boogaboo">
-		<description>Booga-Boo (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="booga-boo. the flea (1986)(quicksilva)(gb).dsk" size="737280" crc="316a9e0d" sha1="4122bfc16d7d5694e37e749cdc3e9bab14eefe78" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="boogabooa" cloneof="boogaboo">
-		<description>Booga-Boo (Europe, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="booga-boo. the flea (1986)(quicksilva)(gb)[a].dsk" size="737280" crc="1a554c79" sha1="afd0e67b6e8787da838c20965fef13c625701b91" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="boogie">
-		<description>Boogie Woogi Jungle (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="boogie woogi jungle (1985)(ample software)(jp).dsk" size="737280" crc="2043e752" sha1="59fa8cb86cb71cef2fd324125eb09a8dedd324c1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="boomrang">
-		<description>Boomerang (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="boomerang (1984)(ascii)(jp).dsk" size="737280" crc="1e8cc576" sha1="9ad6f6c1ba8c3254b02f11304f837fa5fae86c37" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bop">
-		<description>Bop! (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bop (1986)(bug-byte software)(gb).dsk" size="737280" crc="05ab63a6" sha1="4f32214d3b744d31421466042fad4a45cbea6654" />
-			</dataarea>
-		</part>
-	</software>
-
-	<!-- This game had a disk release by Eaglesoft, but I think it shall have a different loading screen (as in the tape release) -->
+	<!-- This game had a disk release by Eaglesoft, but I think it should have a different loading screen (as in the tape release) -->
 	<software name="dota">
-		<description>Bouken Roman - Dota (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>Bouken Roman - Dota (Europe, disk conversion)</description>
+		<year>1986</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8417" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="bouken roman - dota (1986)(system soft)(jp).dsk" size="737280" crc="1101ac56" sha1="06765a7c03d9b7deb68471ab095dc3477caf929e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bdash">
-		<description>Boulder Dash (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="boulder dash (1985)(databyte)(gb).dsk" size="737280" crc="a3c81ef6" sha1="5842006a827a97377a49470679ab22af28d8b5b3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bdash2">
-		<description>Boulder Dash II - Rockford's Riot (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="boulder dash ii - rockford's riot (1986)(databyte)(gb).dsk" size="737280" crc="f8ad6e11" sha1="1921916142c26cbfc171501dbf31fdbb7797dc05" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="bouken roman - dota (1986)(system soft)(jp).dsk" size="737280" crc="1101ac56" sha1="06765a7c03d9b7deb68471ab095dc3477caf929e" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="bounce">
-		<description>Bounce (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>Bounce (Europe, disk conversion)</description>
+		<year>1987</year>
+		<publisher>Methodic Solutions</publisher>
+		<info name="serial" value="88550" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="bounce (1987)(methodic solutions)(nl).dsk" size="737280" crc="b2f73204" sha1="53e5b763ab965c08184a0892c2c68f521005b51e" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="bounce (1987)(methodic solutions)(nl).dsk" size="737280" crc="b2f73204" sha1="53e5b763ab965c08184a0892c2c68f521005b51e" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="bblock">
-		<description>Bouncing Block (Spain)</description>
+		<description>Bouncing Block (Spain, disk conversion)</description>
 		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="bouncing block (1988)(idealogic)(es)[aka igloo].dsk" size="737280" crc="f45dde47" sha1="6c7a38ffc8f26a8608f2c206914504ed370fa881" />
@@ -5519,9 +4237,9 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="bblocka" cloneof="bblock">
-		<description>Bouncing Block (Spain, alt)</description>
+		<description>Bouncing Block (Spain, disk conversion, alt)</description>
 		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="bouncing block (1988)(idealogic)(es)[a][aka igloo].dsk" size="737280" crc="ce19aa74" sha1="d9852a8eb5e21fc78d92af3507309fa2421230c9" />
@@ -5529,21 +4247,10 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="bounder">
-		<description>Bounder (Europe)</description>
+	<software name="btsos">
+		<description>Bousou Tokkyuu SOS - Stop the Express (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bounder (1987)(gremlin graphics software)(gb).dsk" size="737280" crc="0d4e7bdc" sha1="4173965d3a2bfcc74095493aa36bdf6cfce66a67" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="btsos">
-		<description>Bousou Tokkyuu SOS - Stop the Express (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="bousou tokkyuu sos. stop the express (1985)(hudson soft)(jp).dsk" size="737280" crc="ae5aabf1" sha1="328d18c7813808da40a26000653a94fc674c7a83" />
@@ -5553,250 +4260,21 @@ The following floppies came with the machines.
 
 	<software name="breakin">
 		<description>Break In (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1987</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8430" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="break in (1987)(eaglesoft)(nl).dsk" size="737280" crc="537df240" sha1="2ee3d703a217c65a99db9840a4dabaec63845ea8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="brijacks">
-		<description>Brian Jacks Superstar Challenge (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="brian jacks superstar challenge (1985)(martech games)(gb).dsk" size="737280" crc="859a40f9" sha1="4e6d23750d888cbbbec63ba0414920f45943631c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="brucelee">
-		<description>Bruce Lee (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bruce lee (1985)(comptiq)(jp).dsk" size="737280" crc="9df3bcb2" sha1="e56db52b8061ab9203799b51cdcc1ba6208ad531" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bubbler">
-		<description>Bubbler (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bubbler (1987)(ultimate play the game)(gb).dsk" size="737280" crc="6145622f" sha1="d759a8b3c8a8f99a94019f18229985cd31e6c431" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="buckrog">
-		<description>Buck Rogers - Planet of Zoom (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="buck rogers - planet of zoom (1983)(sega)(jp).dsk" size="737280" crc="a9da08a9" sha1="748b0928b6d156f721bb1f5c9bc42eedfdcb5e77" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="buggyrng">
-		<description>Buggy Ranger (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="buggy ranger (1990)(dinamic software)(es).dsk" size="737280" crc="edc6a9d2" sha1="37649515af008c29312348015f7ed00d55500ecc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="buggyrnga" cloneof="buggyrng">
-		<description>Buggy Ranger (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="buggy ranger (1990)(dinamic software)(es)[a].dsk" size="737280" crc="1008eea8" sha1="4f911387002942684af592050419f53034e42af3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bumpygts">
-		<description>Bumpy (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bumpy (19xx)(grupo de trabajo software)(es).dsk" size="737280" crc="e97fecef" sha1="d592be09fffe0133c811f226e83c2693d16fe953" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="buran">
-		<description>Buran (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="buran (1990)(omk software)(es).dsk" size="737280" crc="998ee113" sha1="0005708885e0826e82100c07fce16c979966edc3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bullmigt">
-		<description>Bull to Mighty Kiki Ippatsu (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="buru to marty kikiippatsu. inspecteur z (1986)(hal laboratory)(jp).dsk" size="737280" crc="b158b391" sha1="84f7a10c2cf0dd6f05e3c331f6a20fe60d0faad4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bustblck">
-		<description>Buster Block (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="buster block (1985)(kuma computers)(gb).dsk" size="737280" crc="00f419e2" sha1="f59ada93c5010940a86300cb7580dfddf70ddee2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="butampan">
-		<description>Butam Pants (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="butamaru pants. pig mock (1983)(hal laboratory)(jp).dsk" size="737280" crc="68cc087f" sha1="f120eb3453d7328181708774b425891c2073a24b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="buzzoff">
-		<description>Buzz Off! (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="buzz off (1984)(electric software)(gb).dsk" size="737280" crc="2b547aca" sha1="b557b30dae3ef1dc36e87b04f2a1cf2b26cb683a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bytebust">
-		<description>Bytebusters (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bytebusters (1984)(aackosoft)(nl).dsk" size="737280" crc="f4b44d4c" sha1="ededcb72afc06b9a16b4c4adf481c5f751eed77c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cso">
-		<description>C_So! (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="c so (1985)(pony canyon)(jp).dsk" size="737280" crc="5608cce4" sha1="480208cca4b8867d6a7466d27a0fa177efed7997" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cabbagep">
-		<description>Cabbage Patch Kids (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cabbage patch kids (1984)(konami)(jp).dsk" size="737280" crc="8fdff3d2" sha1="691efa58cc8cc10f68746ece5b393dc69f8ca3d6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="calgames">
-		<description>California Games (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="california games (1987)(us gold)(gb).dsk" size="737280" crc="85d4ffe7" sha1="6cd232b36222f131a22a1c6c20778e2d9488f14b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="calgamesa" cloneof="calgames">
-		<description>California Games (Europe, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="california games (1987)(us gold)(gb)[a].dsk" size="737280" crc="62b3da99" sha1="b46171c47d7d10dbc32a732efaae4c94d5ade2ac" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="camelot">
-		<description>Camelot Warriors (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="camelot warriors (1986)(dinamic software)(es).dsk" size="737280" crc="30368fc4" sha1="ad7602d8d60e3561ef0545e0136f37e88d16ef7e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="canworms">
-		<description>Can of Worms (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="can of worms (1986)(livewire software)(gb).dsk" size="368640" crc="c1da76de" sha1="0a14b3f2fdcef25cf19c3b8897f7630c4d6c0548" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="candoon">
-		<description>Candoo Ninja (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="candoo ninja (1983)(ascii)(jp).dsk" size="737280" crc="59f9c156" sha1="acc6fe3ccc8f2a3027520dd901c48dd0506e85c8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cannonbl">
-		<description>Cannon Ball (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cannon ball (1983)(hudson soft)(jp).dsk" size="737280" crc="9be2382f" sha1="0c22a1c7373ea9b93cfe415bc33621f1957e8a8b" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="break in (1987)(eaglesoft)(nl).dsk" size="737280" crc="537df240" sha1="2ee3d703a217c65a99db9840a4dabaec63845ea8" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="cannonfg">
-		<description>Cannon Fighter (Japan)</description>
+		<description>Cannon Fighter (Japan, disk conversion)</description>
 		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="cannon fighter (1984)(policy)(jp).dsk" size="737280" crc="8091560e" sha1="09cd7dd65d4f597fa486fd390be6429b33e5531f" />
@@ -5804,196 +4282,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="sevilla">
-		<description>Capitan Sevilla (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="capitan sevilla (1988)(dinamic software)(es).dsk" size="737280" crc="a6a9c79a" sha1="472f1f7c792776e4292e6a73982e9d1d5a67b87a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sevillaa" cloneof="sevilla">
-		<description>Capitan Sevilla (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="capitan sevilla (1988)(dinamic software)(es)[a].dsk" size="737280" crc="9d15daa3" sha1="aa1ada28c267469cc451cadb0cdb97c294a4ea9d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="trueno">
-		<description>Capitan Trueno (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="capitan trueno (1989)(dinamic software)(es).dsk" size="368640" crc="5f78f383" sha1="f48545629ee40b65afbc9f9dfcddebf5a2444e61" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="truenoa" cloneof="trueno">
-		<description>Capitan Trueno (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="capitan trueno (1989)(dinamic software)(es)[a].dsk" size="737280" crc="6ced96a5" sha1="1fc53b80dc2d1c240bba4760ccaa86cda9806cf7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="captchef">
-		<description>Captain Chef (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="captain chef (1984)(nippon columbia - colpax - universal).dsk" size="737280" crc="43d5ef89" sha1="66fe62369215f582b3006d65538831852f4b3417" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="casanova">
-		<description>Casanova (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="casanova (1989)(iber soft)(es).dsk" size="737280" crc="2a08e029" sha1="8e33cff3cee1f56db046279373ec3166858d70bd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="casanovaa" cloneof="casanova">
-		<description>Casanova (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="casanova (1989)(iber soft)(es)[cr knight software].dsk" size="737280" crc="7fcff347" sha1="8034b2ef9797fef73426524af5605691812130ee" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="castlecm">
-		<description>Castle Combat (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="castle combat (1985)(spectravideo)(gb).dsk" size="737280" crc="47e6a853" sha1="fb83e1d31750c3ba9a59453980c003cf01151b26" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="castlex">
-		<description>Castle Excellent (Japan, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="trainer" value="Damian Roman" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="castle excellent (1989)(ascii)(jp)[t damian roman].dsk" size="737280" crc="26c838b4" sha1="7a03b20aa305f9661a3e915f400654b616488d28" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="castle">
-		<description>The Castle (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="castle, the (1986)(ascii)(jp).dsk" size="737280" crc="669d7697" sha1="99ffcbf3e31edcbfab4c8c728c742a402d7252da" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cavdeath">
-		<description>Cavern of Death (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cavern of death (1987)(dro soft)(es).dsk" size="737280" crc="0dc959a6" sha1="22b0f82031e5e5ffc7694af719d3a6dc80ca1002" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="chackn">
-		<description>Chack'n Pop (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="chack 'n pop (1984)(taito)(jp).dsk" size="737280" crc="9733b027" sha1="8fcd9e39d7fdc6d1eb5d8942ee35cee6e06aaa35" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="champ">
-		<description>Champ (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="champ (1984)(pss)(gb).dsk" size="737280" crc="ae8b5aff" sha1="aca88410d5efb92cfdfad47828fc8c763c597ea7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="champbox">
-		<description>Champion Boxing (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="champion boxing (1985)(pony canyon)(jp).dsk" size="737280" crc="e9b38f07" sha1="8d26d1c08b8f9190d361f58009512c8d758b4078" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="champken">
-		<description>Champion Kendou (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="champion kendo (1986)(pony canyon)(jp).dsk" size="737280" crc="ef840033" sha1="1a997aaccdfcc16b62a5b65d82d061a564d5e0dc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="champpwr">
-		<description>Champion Pro Wrestling (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="champion pro wrestling (1985)(pony canyon)(jp).dsk" size="737280" crc="43869995" sha1="96f238ebc3f8cfb33b8aee696edfed41b8f97ebf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="champscr">
-		<description>Champion Soccer (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="champion soccer (1985)(pony canyon)(jp).dsk" size="737280" crc="52264e46" sha1="cf7010948aa006740566a2ebbfda252792f110c1" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="champion">
-		<description>Champions (Japan)</description>
+		<description>Champions (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -6003,53 +4293,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="cloderun">
-		<description>Championship Lode Runner (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="championship lode runner (1985)(sony)(jp).dsk" size="737280" crc="7ff74c3c" sha1="23a5a38ad1d33f68d4e8925ccc4bf81faf776d1b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="chasehq">
-		<description>Chase H.Q. (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="chase h.q. (1988)(ocean software)(gb).dsk" size="737280" crc="06d2f91a" sha1="4fb3456069d8c2e785273f6e41226147feb23abb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tantan">
-		<description>Checkers in Tan Tan Tanuki (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="checkers in tan tan (1985)(pony canyon)(jp).dsk" size="737280" crc="864963d3" sha1="d57438d16ffdc500c4493d9c505b6974afbf4535" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="checkmat">
-		<description>Checkmate! - First Moves in Chess (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<info name="usage" value="needs 64K in slot 2" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="checkmate first moves in chess (1985)(toshiba-emi)(jp)[needs 64k in slot 2].dsk" size="737280" crc="7edc36c9" sha1="1eda39a2de8057b4bc82ebe58c7295860162ccba" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="cheese">
-		<description>Cheese (Japan)</description>
+		<description>Cheese (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -6061,912 +4306,72 @@ The following floppies came with the machines.
 
 	<software name="chessgam">
 		<description>The Chess Game (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<year>1985</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="3123" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="chess game, the (1985)(eaglesoft)(nl).dsk" size="737280" crc="ecf773e1" sha1="188c7ef7f25d74f3caf299b0fcd8092233736577" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="chess game, the (1985)(eaglesoft)(nl).dsk" size="737280" crc="ecf773e1" sha1="188c7ef7f25d74f3caf299b0fcd8092233736577" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="chessgama" cloneof="chessgam">
 		<description>The Chess Game (Europe, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<year>1985</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="3123" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="chess game, the (1985)(eaglesoft)(nl)[a].dsk" size="737280" crc="dd5f241f" sha1="8063fdff350fdb5284d9277d702eeca1ed4456c6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cm2000">
-		<description>The Chessmaster 2000 (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="chessmaster 2000, the (1990)(dro soft)(es).dsk" size="737280" crc="fd85aba0" sha1="cb1764e5cbd1d73cb18fc1134194fc3db1027050" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="chicago">
-		<description>Chicago 30's (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="chicago 30's (1988)(topo soft)(es).dsk" size="737280" crc="41d6269a" sha1="21091b023b7b779c4e6a738405662ece926a0d52" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="chicagoa" cloneof="chicago">
-		<description>Chicago 30's (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="chicago 30's (1988)(topo soft)(es)[a].dsk" size="737280" crc="45d01cc4" sha1="0df5976a3cb87eb2501dfce11c18eb6210684d25" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="chicagob" cloneof="chicago">
-		<description>Chicago 30's (Spain, alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="chicago 30's (1988)(topo soft)(es)[a2].dsk" size="737280" crc="d7b3f6e8" sha1="d3f84235c8543a354a4efd8ad19b1d8bad6d7d9a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="chicken">
-		<description>Chicken Chase (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="chicken chase (1986)(bug-byte software)(gb).dsk" size="737280" crc="10d91160" sha1="c1d6f22c4a88460f518d1e56f967f21b82dcfe8d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="chiller1">
-		<description>Chiller (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="chiller (1985)(mastertronic)(gb).dsk" size="737280" crc="d1ad4ed7" sha1="1e15c9405cbfd8181b669a1683a0a82eba4e1926" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="choplift">
-		<description>Choplifter (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="choplifter (1985)(broderbound).dsk" size="737280" crc="fbad06a8" sha1="400eacf62667cb75cdaa3701c028758ded5d828c" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="chess game, the (1985)(eaglesoft)(nl)[a].dsk" size="737280" crc="dd5f241f" sha1="8063fdff350fdb5284d9277d702eeca1ed4456c6" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="chopper">
 		<description>Chopper (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1986</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="3370 / 8270" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="chopper (1986)(eaglesoft)(nl).dsk" size="737280" crc="5371891f" sha1="529bef21ccc5258b59bc069afbb28bd3d8529263" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="choroq">
-		<description>Choro Q (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="choro q (1984)(taito)(jp).dsk" size="737280" crc="0fc05ffe" sha1="f628e62660c325ad57728d546b76145621c24c4d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="choylee">
-		<description>Choy-Lee-Fut Kung-Fu Warrior (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="choy-lee-fut kung-fu warrior (1990)(positive)(es).dsk" size="737280" crc="5f73bac5" sha1="09ab38bd4690052ba27d599fed6aafbad54eb019" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="yeagraft">
-		<description>Chuck Yeager's Advanced Flight Trainer (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="chuck yeager's advanced flight trainer (1989)(dro soft)(es).dsk" size="737280" crc="579e4e5a" sha1="4b5410b5b706bb75b6cb7dfc270e219f5f19f7db" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="chuckie">
-		<description>Chuckie Egg (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="chuckie egg (1984)(a &amp; f software)(gb).dsk" size="737280" crc="18efaeef" sha1="d9e36f4e519d61e55574c56c6757aa443ccf04b4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cid">
-		<description>El Cid (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cid, el (1987)(dro soft)(es).dsk" size="737280" crc="30333049" sha1="6aeb530f0e41109b5c6adc7baf5b8ebb268ac6d5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cida" cloneof="cid">
-		<description>El Cid (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cid, el (1987)(dro soft)(es)[a].dsk" size="737280" crc="fc048ad3" sha1="a1d10d9e1856464eb6e1ec868bbfd02862fb944f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="circusc">
-		<description>Circus Charlie (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="circus charlie (1984)(konami)(jp).dsk" size="737280" crc="0b9dc028" sha1="22e4a5fda29f7a239eb8cde7fbc935885f1da0ab" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="citycon">
-		<description>City Connection (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="city connection (1986)(jaleco)(jp).dsk" size="737280" crc="4954d3ad" sha1="adc04934effeea43c3e3316bad851ff8085d6af5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="coastrac">
-		<description>Coaster Race (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="coaster race (1986)(sony)(jp).dsk" size="737280" crc="76d0c4c3" sha1="82be3cda649f7103bc855e2fa5f5a6821abbea43" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cobraarc">
-		<description>Cobra's Arc (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cobra's arc (1986)(dinamic software)(es).dsk" size="737280" crc="4dc1a449" sha1="a0895c41560bc427bfe9925cd5fe8c63a0fe8bae" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cobraarca" cloneof="cobraarc">
-		<description>Cobra's Arc (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cobra's arc (1986)(dinamic software)(es)[a].dsk" size="737280" crc="1c3af3a2" sha1="7dc0ecd6a91e7c81249a8f2b148396e45ca7e1fd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="coco">
-		<description>Coco Castle (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="coco castle (1984)(kuma computers)(gb).dsk" size="737280" crc="f823fd18" sha1="37430dab89e42307a22e4dbcc5625df950733b5d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="coliseum">
-		<description>Coliseum (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="coliseum (1988)(topo soft)(es).dsk" size="737280" crc="b8ba0608" sha1="02433af04a682f81a30bc4aa30762a35bd3418ba" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="coliseuma" cloneof="coliseum">
-		<description>Coliseum (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="coliseum (1988)(topo soft)(es)[a].dsk" size="737280" crc="58d31d99" sha1="0269d57c672e5279fa6ff40a526fd59404dfc39a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="colony">
-		<description>Colony</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="colony (1987)(bulldog).dsk" size="737280" crc="f0656fde" sha1="d5b774ec2b5ad3f1a18d337f4595ed7098dffcf5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="colonya" cloneof="colony">
-		<description>Colony (alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="colony (1987)(bulldog)[a].dsk" size="737280" crc="01195cb1" sha1="8d0232e25be2303f266cc164b0ef53c00bf7f879" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="colball">
-		<description>Color Ball (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="color ball (1984)(hudson soft)(jp).dsk" size="737280" crc="438a8577" sha1="6469e5924875cc81a266073ca2243565de460f4a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="colos4ch">
-		<description>Colossus 4 Chess (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="colossus 4 chess (1986)(cds micro systems)(gb).dsk" size="737280" crc="cb03436d" sha1="e841987a287994624c0f9dd11c47876eac0cfcd7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="colt36">
-		<description>Colt 36 (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="colt 36 (1987)(topo soft)(es).dsk" size="737280" crc="dbedf762" sha1="28aad62bfe306d17f6caba84a0d83e7990e7263f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="comando4">
-		<description>Comando Quatro (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="comando quatro (1989)(zigurat software)(es).dsk" size="737280" crc="8d1e6c57" sha1="ef335bbeb280744c35287f6294f3c33694100d20" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="comtrace">
-		<description>Comando Tracer (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="comando tracer (1989)(dinamic software)(es).dsk" size="737280" crc="3044da54" sha1="92a8eb197461e8fcec98a25b81b85f86cd1c44cb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="comtracea" cloneof="comtrace">
-		<description>Comando Tracer (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="comando tracer (1989)(dinamic software)(es)[a].dsk" size="368640" crc="e6f859c7" sha1="f6a8350a392d3b376055d7b5efdb58a9b16c54de" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="comecoco">
-		<description>Comecocos (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="comecocos (19xx)(idealogic)(es).dsk" size="737280" crc="7fbcc0b7" sha1="73a0955ac3ea02c72fe5590ad4e1d688353471aa" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cometail">
-		<description>Comet Tail (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="comet tail (1984)(qnix).dsk" size="737280" crc="b75bae94" sha1="9fb7dd35f00599d71fe22b50642d972228301ed8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="comicbak">
-		<description>Comic Bakery (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="comic bakery (1984)(konami)(jp).dsk" size="737280" crc="ceb5eab8" sha1="86f371e1e95aba43a8e5dfbb3e584d1d3275355b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cbilliar">
-		<description>Computer Billiards (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="computer billiards (1985)(sony)(jp).dsk" size="737280" crc="8817338c" sha1="73e273a176d572d08d77da626bf72bbd77287450" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cpachi">
-		<description>Computer Pachinko (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="computer pachinko (1984)(sony)(jp).dsk" size="737280" crc="b47e8f13" sha1="e2c1b27b1b408b16eb064d54c86777a9ab31a751" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="condori">
-		<description>Con-Dori (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="con-dori (1983)(cross talk)(jp).dsk" size="737280" crc="47c045c9" sha1="3392752642428d42c5cabd6d90d9a2338cba4340" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="congobon">
-		<description>Congo Bongo (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="congo bongo (1983)(sega)(jp).dsk" size="737280" crc="220404db" sha1="3f3859753a0c190b128e13cee47ec70dcf660c8f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cbridge">
-		<description>Contract Bridge (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="contract bridge (1985)(alligata software)(gb).dsk" size="737280" crc="c89c3b77" sha1="bbdcf1338acd04601e8c4dc83b289a5faeee9bf4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="corsario">
-		<description>Corsarios (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="corsarios (1989)(opera soft)(es).dsk" size="737280" crc="77c84a9a" sha1="7bbdfa7a464ed28bb07149ba53801f2b508dbbfb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="corsarioa" cloneof="corsario">
-		<description>Corsarios (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="corsarios (1989)(opera soft)(es)[a].dsk" size="737280" crc="879f8950" sha1="6ad5d7e2826a1243fc9787ba754c83160d18cfcb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cosanost">
-		<description>Cosa Nostra (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cosa nostra (1986)(opera soft)(es).dsk" size="737280" crc="869c98e0" sha1="fc5c21f8cd7858e8c531fd1065de0c0702be4230" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cosanosta" cloneof="cosanost">
-		<description>Cosa Nostra (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<info name="usage" value="needs 128K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cosa nostra (1986)(opera soft)(es)[needs 128k].dsk" size="737280" crc="7a9fa4a9" sha1="546a763791278aa5bf3cfaa9c1ccb8878d3b6397" />
+				<!-- According to generation-msx this was released on a single sided floppy -->
+				<rom name="chopper (1986)(eaglesoft)(nl).dsk" size="737280" crc="5371891f" sha1="529bef21ccc5258b59bc069afbb28bd3d8529263" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="csheriff">
-		<description>Cosmic Sheriff (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>Cosmic Sheriff (Spain, disk conversion)</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<info name="serial" value="MSD 890010" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="cosmic sheriff (1989)(dinamic software)(es)[gunstick].dsk" size="737280" crc="4583be73" sha1="1dac435ff5f48c96c3393aaa15838c56151eee0a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shockabs">
-		<description>Cosmic Shock Absorber (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cosmic shock absorber (1986)(martech games)(gb).dsk" size="737280" crc="e006e390" sha1="ca26001f6a0d2d2f19061f5f35bdd9f8026ec6d8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cosmoexp">
-		<description>Cosmo-Explorer (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cosmo explorer (1985)(sony)(jp).dsk" size="737280" crc="0e089b06" sha1="4c61480975e78bcdd5905a69a8b291632ec13cd5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cosmos">
-		<description>Cosmos (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cosmos (1987)(club msx)(es).dsk" size="737280" crc="7554a49c" sha1="535f2df3069afac090a698211e1e59bae5f2d97f" />
+				<!-- Gunstick version was only released on cassette, so this must be a cassette converted to disk -->
+				<rom name="cosmic sheriff (1989)(dinamic software)(es)[gunstick].dsk" size="737280" crc="4583be73" sha1="1dac435ff5f48c96c3393aaa15838c56151eee0a" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="perseus">
-		<description>Courageous Perseus (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<description>Courageous Perseus (Netherlands)</description>
+		<year>1987</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8406" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="courageous perseus (1985)(cosmos computer)(jp).dsk" size="737280" crc="7f1f12c3" sha1="9e9ce961068a79e470fccf727f41873abb08778c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="craze">
-		<description>Craze (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="craze (1988)(heart soft)(jp).dsk" size="737280" crc="8d40f26c" sha1="d52f5afc0ec145679782aa1040a8759b6cb40edc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="crazea" cloneof="craze">
-		<description>Craze (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="craze (1988)(heart soft)(jp)[a].dsk" size="737280" crc="3e2311b4" sha1="b79dc714726fdf9122ce6e69b48b3132a763ea78" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="crazybul">
-		<description>Crazy Bullet (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="crazy bullet (1983)(ascii)(jp).dsk" size="737280" crc="48646a2a" sha1="ad07bac1efa0e9cf9237a9cac9f290ec1f095738" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="crazycar">
-		<description>Crazy Cars (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="crazy cars (1988)(titus)(gb).dsk" size="737280" crc="f920bbbd" sha1="453ae3bbf31ccc5117487b506939d5f229173670" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="crazytrn">
-		<description>Crazy Train (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="crazy train (1983)(sony)(jp).dsk" size="737280" crc="797c7bb7" sha1="f4140821618ac7ebd6369e92c861b8edb98e2ed9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="crazytrna" cloneof="crazytrn">
-		<description>Crazy Train (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="crazy train (1983)(sony)(jp)[a].dsk" size="368640" crc="dda93a15" sha1="1f3d625818f2410f546d0fca0a2f1a69442aee09" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="crossblm">
-		<description>Cross Blaim (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cross blaim (1986)(db-soft)(jp).dsk" size="737280" crc="f7da673a" sha1="486f61c5463fe236338678f24b097e758cd05e5d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="crossblma" cloneof="crossblm">
-		<description>Cross Blaim (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cross blaim (1986)(db-soft)(jp)[a].dsk" size="737280" crc="edd3a303" sha1="e1874114459d5a8b439471d5d80629a9a96df0da" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cubik">
-		<description>Cubik - Cubo de Rubik (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cubik. cubo de rubik (1985)(monser)(es).dsk" size="737280" crc="c7e8df0e" sha1="387f0ec64dcdd5ef310c32f331beafa0d9233e32" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cubit">
-		<description>Cubit (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cubit (1986)(mr. micro)(gb).dsk" size="737280" crc="de31a500" sha1="94b6cb02f13f860aa1066651ca4905f9f3c21d0b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cubita" cloneof="cubit">
-		<description>Cubit (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cubit (1986)(mr. micro)(gb)[a].dsk" size="737280" crc="b058bf4e" sha1="0bda7b6fcf4f03f1fffc67f2c869af101cb193e0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="currojim">
-		<description>Curro Jimenez (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="curro jimenez (1989)(zigurat software)(es).dsk" size="737280" crc="ccf70bfb" sha1="0fc0fb8e0207ea48b500cf9f49cd66f4a86920fc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="currojima" cloneof="currojim">
-		<description>Curro Jimenez (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="curro jimenez (1989)(zigurat software)(es)[a].dsk" size="737280" crc="6980a434" sha1="b8343e1ce0875a011dff42a99d5d4433949b6118" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cyberbig">
-		<description>Cyberbig (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cyberbig (1989)(animagic).dsk" size="737280" crc="b1ebe889" sha1="1fe7907b50715812887900e854dd720c353ba404" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cyberbiga" cloneof="cyberbig">
-		<description>Cyberbig (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cyberbig (1989)(animagic)(es)[a].dsk" size="737280" crc="434c0b06" sha1="354f832a56a3d000b7b66337b5a0ec697dd23509" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cyberun">
-		<description>Cyberun (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="cyberun (1985)(ultimate play the game)(gb).dsk" size="737280" crc="f7aedab7" sha1="87438de1fc2f18873c37ba4339bfb91cce0198cf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dday">
-		<description>D-Day (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="d-day (1984)(jaleco)(jp).dsk" size="737280" crc="0ad039b4" sha1="f8d5e009a31b2e10e8c6191a746a2bdd42f5dd1b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="daiva4">
-		<description>Daiva Story 4: Asura's Bloodfeud (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="alt_title" value="ディーヴァ ストーリー4·アスラの血流" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="daiva story 4 - asura's bloodfeud (1987)(t&amp;e soft)(jp).dsk" size="737280" crc="bce30044" sha1="8a772f4be8258746655b9502df0d0e08a15279ea" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="daiva4b" cloneof="daiva4">
-		<description>Daiva Story 4: Asura's Bloodfeud (Japan, alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="alt_title" value="ディーヴァ ストーリー4·アスラの血流" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="daiva story 4 - asura's bloodfeud (1987)(t&amp;e soft)(jp)[a2].dsk" size="737280" crc="a4af31f2" sha1="805d2d7e924604414bbebcda74d4e94701a24b38" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="daiva4a" cloneof="daiva4">
-		<description>Daiva Story 4: Asura's Bloodfeud (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="alt_title" value="ディーヴァ ストーリー4·アスラの血流" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="daiva story 4 - asura's bloodfeud (1987)(t&amp;e soft)(jp)[a].dsk" size="737280" crc="f6007ab5" sha1="e717247b6558f1d7cd450cef138af736811fe45d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dambustr">
-		<description>The Dam Busters (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dam busters, the (1985)(us gold)(gb).dsk" size="737280" crc="8eaa0f21" sha1="36639b4ce7fe88995bb429a2daccffa497d418f4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="damas">
-		<description>Damas (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="damas (1985)(dimensionnew)(es).dsk" size="737280" crc="148c750e" sha1="4e4f3361d2f210e38168472d8cad50a0e493b652" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dangerx4">
-		<description>Danger X4 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="danger x4 (1984)(ascii)(jp).dsk" size="737280" crc="f5bf6114" sha1="b15fd5b7dcead0059e5535c6ed1411fd70cda05e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dartsbr">
-		<description>Darts (UK, Blue Ribbon)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="darts (1987)(blue ribbon software)(gb).dsk" size="737280" crc="f74ac6c5" sha1="cd8da56759e7f8438015e1843d12e9d7daf32f07" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="david2">
-		<description>David II (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="david ii (1984)(ascii)(jp).dsk" size="737280" crc="ca7031b8" sha1="d009d316fa5d6f76159d12af294f106ade0d06f0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="deathws3">
-		<description>Death Wish 3 (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="death wish 3 (1987)(gremlin graphics software)(gb).dsk" size="737280" crc="aa8892d2" sha1="28cd6e75ef35515dd6aaf3584f893fddc6dc42b3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="decathln">
-		<description>Decathlon (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="decathlon (1984)(activision)(us).dsk" size="737280" crc="c7633973" sha1="64e60c268b9ad5bab3775073c25af95bfd3824c9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="defcom1">
-		<description>Defcom 1 (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="defcom 1 (1989)(iber soft)(es).dsk" size="737280" crc="587898b6" sha1="24960396ddb7c0234440e2456e3764e69806a644" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="defcom1a" cloneof="defcom1">
-		<description>Defcom 1 (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="defcom 1 (1989)(iber soft)(es)[a].dsk" size="737280" crc="5d5464a0" sha1="7d949d67a549dbb74c302cabb8fb7de50c8c79c4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dcrystal">
-		<description>The Demon Crystal (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="demon crystal, the (1986)(radio wave newspaper publisher)(jp).dsk" size="737280" crc="9f83b2e4" sha1="691c49c42ab064e0a556dbaf0679415ef7c26024" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dcrystala" cloneof="dcrystal">
-		<description>The Demon Crystal (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="demon crystal, the (1986)(radio wave newspaper publisher)(jp)[a].dsk" size="368640" crc="2e4f1350" sha1="810ac39f48eaf09ccd1761a55eaf52710cb14a3c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="demonia">
-		<description>Demonia (France)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="demonia (1986)(microids)(gb)(fr).dsk" size="737280" crc="5716b14d" sha1="2a35932a0c6df7446f43797c329d43b8bddd246d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="demoniaa" cloneof="demonia">
-		<description>Demonia (France, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="demonia (1986)(microids)(gb)(fr)[a].dsk" size="737280" crc="551723ae" sha1="696ef2f9440cc8e9563f999d1f00bdf81aefef87" />
+				<!-- This is a disk conversion of the Japanese cartridge. -->
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="courageous perseus (1985)(cosmos computer)(jp).dsk" size="737280" crc="7f1f12c3" sha1="9e9ce961068a79e470fccf727f41873abb08778c" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="designer">
-		<description>The Designer's Pencil (US)</description>
+		<description>The Designer's Pencil (US, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -6976,96 +4381,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="desolatr">
-		<description>Desolator (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="desolator (1986)(gremlin graphics software)(gb).dsk" size="737280" crc="0c85cf12" sha1="80cbc6c1210f0af139993952f3d328c975d8dfeb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="desprado">
-		<description>Desperado (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="desperado (1987)(topo soft)(es).dsk" size="737280" crc="fc5c2df0" sha1="0d607d22cda9111737a6b4e0bdef42fdb3e1f3a3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="despradoa" cloneof="desprado">
-		<description>Desperado (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="desperado (1987)(topo soft)(es)[a].dsk" size="737280" crc="72f5b7ad" sha1="bd23f6080f675490346e9741e5e9835417e6a6e1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="despradob" cloneof="desprado">
-		<description>Desperado (Spain, alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="desperado (1987)(topo soft)(es)[a2].dsk" size="737280" crc="798c1bb9" sha1="f70f77c26ff8358db8f20081476fea917d4b3f12" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="destroyr">
-		<description>Destroyer (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="destroyer (1986)(mind games espana)(es).dsk" size="737280" crc="91bf9ee6" sha1="2ba745db89be2eb831dbfd38c5c6bfdda113e98f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="destroyra" cloneof="destroyr">
-		<description>Destroyer (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="destroyer (1986)(mind games espana)(es)[.a].dsk" size="737280" crc="6fb01591" sha1="8bf72c29cfda6de33a3311c546963253594945d1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="deusex">
-		<description>Deus Ex Machina (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="deus ex machina (1985)(mind games espana)(es).dsk" size="737280" crc="545d694f" sha1="475c22c492599b2a4c8dbd8eafdaacdbacfdf363" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="digdug">
-		<description>Dig Dug (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dig dug (1984)(namcot)(jp).dsk" size="737280" crc="98eef76c" sha1="800c1e54547d590cd5eef13cb6b07ba6644bfb5d" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="dipdip">
-		<description>Dip Dip (Spain)</description>
+		<description>Dip Dip (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -7075,272 +4392,19 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="discwarr">
-		<description>Disc Warrior (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="disc warrior (1984)(alligata software)(gb).dsk" size="737280" crc="afab7202" sha1="636ab4e185cb2b9f4ae1f447432b5c087084035c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="discover">
-		<description>Discovery (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="discovery (1988)(eurosoft)(nl).dsk" size="737280" crc="4df98737" sha1="2d4b7e44171ee8bd9d9f74da204e5f4cfce06bc2" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="dizzybal">
-		<description>Dizzy Ball (Japan)</description>
+		<description>Dizzy Ball (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="dizzy ball (1983)(pony canyon)(jp).dsk" size="737280" crc="5c4decca" sha1="118ce1269b81d14e1533f453c3e72ab258baada0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dizzydic">
-		<description>Dizzy Dice (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dizzy dice (1988)(players software)(gb).dsk" size="737280" crc="729c4199" sha1="417cdc07a73f01e977976495c911374804de3ae5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dogfight">
-		<description>Dog Fighter (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dog fighter (1986)(kuma computers)(gb).dsk" size="737280" crc="1f9a3622" sha1="00db7d0314901e22a02526edcf6ac68ff8b95b95" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dogfighta" cloneof="dogfight">
-		<description>Dog Fighter (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dog fighter (1986)(kuma computers)(gb)[a].dsk" size="737280" crc="d33474ce" sha1="486a2ece53c95e08e4608caa4fb3695279b2c5ee" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dokidoki">
-		<description>Doki Doki Penguin Land (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="doki doki penguin land (1985)(pony canyon)(jp).dsk" size="737280" crc="c0b945ff" sha1="c4ecdc91867449d24f17c0603f5dcc090a521648" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="domino">
-		<description>Domino (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="domino (1985)(dimensionnew)(es).dsk" size="737280" crc="f7ddd4f8" sha1="b5b46d3d48851fb6cdf1166a8a9fb4f090c962c3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dominoa" cloneof="domino">
-		<description>Domino (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="domino (1985)(dimensionnew)(es)[a].dsk" size="737280" crc="05da94d8" sha1="26a50460e32974f292f47e3c0671f6909d665924" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="quijote">
-		<description>Don Quijote (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="don quijote (1987)(dinamic software)(es).dsk" size="737280" crc="d18370f5" sha1="f23a7ada4808e7bfbfde41c28951aac164e9e837" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="quijotea" cloneof="quijote">
-		<description>Don Quijote (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="don quijote (1987)(dinamic software)(es)[a].dsk" size="737280" crc="7c59ed99" sha1="a2bd728b11d6f202fbce13f59c6dfe9d99436737" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dkong">
-		<description>Donkey Kong (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="donkey kong (1986)(erbe software)(es).dsk" size="737280" crc="518e246d" sha1="b08f54c1e1be9e9b6dcc155344f241d82dceec65" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="doordoor">
-		<description>DoorDoor (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="door door mk2 (1985)(enix).dsk" size="737280" crc="5ebffe39" sha1="8ca0a9f7def37e3425bbfdb9c3340620a8e9196e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dorodon">
-		<description>Dorodon (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dorodon (1984)(sony)(jp).dsk" size="737280" crc="e55437b1" sha1="0866bbeda94e6668077a4bf1718504c83c8ee287" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ddragon">
-		<description>Double Dragon (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="double dragon (1988)(dro soft)(es).dsk" size="737280" crc="74dc7fea" sha1="59a5450f5a377b02bdc4ebd2ca23e72d82612e0b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="drjackle">
-		<description>Dr. Jackle and Mr. Wide (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dr. jackle and mr. wide (1987)(bulldog).dsk" size="737280" crc="896cb209" sha1="d0092062d558ecd5c26263742c1a075f8ba336e1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="drgnatck">
-		<description>Dragon Attack (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dragon attack (1983)(hal laboratory)(jp).dsk" size="737280" crc="30f44bee" sha1="c99bb8b9a158fd57e84e001c0346a9eb9fdee021" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dninja">
-		<description>Dragon Ninja (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dragon ninja (1988)(imagine software)(gb).dsk" size="737280" crc="00bfb89b" sha1="f733bbb8763c00d1aa80690f9b02b98e261f8270" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dquest">
-		<description>Dragon Quest (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dragon quest (1986)(enix)(jp).dsk" size="737280" crc="324f8571" sha1="87967cf5db4acb01b0585da8d4dded64c27bda2c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dquest2">
-		<description>Dragon Quest II (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dragon quest ii (1988)(enix)(jp).dsk" size="737280" crc="b637c2c5" sha1="79d41ac8e703446d8aa059832e95301dc220d7e4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dquest2a" cloneof="dquest2">
-		<description>Dragon Quest II (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dragon quest ii (1988)(enix)(jp)[a].dsk" size="737280" crc="b614896e" sha1="4133b5e6b05c025b25eac1e5570f1401d5197314" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dslayer">
-		<description>Dragon Slayer (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dragon slayer (1985)(square)(jp).dsk" size="737280" crc="1de21cf2" sha1="26bc66448721c598a711d0a09e15b1afd03bcfdf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="petrovic">
-		<description>Drazen Petrovic Basket (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="drazen petrovic basket (1989)(topo soft)(es).dsk" size="737280" crc="c9c81d37" sha1="e3504d74d1b9a4ff380bb0ce54e34ae43c5b9bc1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="petrovica" cloneof="petrovic">
-		<description>Drazen Petrovic Basket (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="drazen petrovic basket (1989)(topo soft)(es)[a].dsk" size="737280" crc="9b8a8741" sha1="3238cd7e81e8d985630cc32af83c107f28ce1496" />
+				<rom name="dizzy ball (1983)(pony canyon)(jp).dsk" size="737280" crc="5c4decca" sha1="118ce1269b81d14e1533f453c3e72ab258baada0"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="driltank">
-		<description>Driller Tanks (Japan)</description>
+		<description>Driller Tanks (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -7351,7 +4415,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="driltanka" cloneof="driltank">
-		<description>Driller Tanks (Japan, alt)</description>
+		<description>Driller Tanks (Japan, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -7361,118 +4425,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="drome">
-		<description>Drome (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="drome (1987)(eaglesoft)(nl).dsk" size="737280" crc="b51ff032" sha1="9a3d675952732f38429ccecad82e4aabce0a5fe7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dmaster">
-		<description>Dungeon Master (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dungeon master (1986)(ascii)(jp).dsk" size="737280" crc="9298e688" sha1="060b540a961d708c46093784e330e3fab5e670f4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dunkshot">
-		<description>Dunk Shot (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dunk shot (1986)(hal laboratory)(jp).dsk" size="737280" crc="e3308015" sha1="719c1cd8f17e1aefb43d220ee4e542ba33a61c6c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dustin">
-		<description>Dustin (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dustin (1987)(dinamic software)(es).dsk" size="737280" crc="9a6a79ff" sha1="35f7b75c568ee52d374c37021a3934338daa552c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dustina" cloneof="dustin">
-		<description>Dustin (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dustin (1987)(dinamic software)(es)[a].dsk" size="737280" crc="9ca4b89e" sha1="077b7644b64d9f2e6f70790b74e979651a1d8c03" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dynadan">
-		<description>Dynamite Dan (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="dynamite dan (1986)(mirrorsoft)(gb).dsk" size="737280" crc="21fa2a03" sha1="526109ea73cfcb6ae10981850c2a0b3f5fdb6c5b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="exainnov">
-		<description>E.I. - Exa Innova (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="e.i. - exa innova (1984)(sony)(jp).dsk" size="737280" crc="9d2c3379" sha1="9a19c63376819d5f77be6cd2f2e4e3430ab98a2a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="eaglefgt">
-		<description>Eagle Fighter (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="eagle fighter (1985)(casio)(jp).dsk" size="737280" crc="7167ef54" sha1="0335a502ad8b5c77b90b3ee6a6cfc7b402b69eef" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="eddiekid">
-		<description>Eddie Kidd Jump Challenge (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="eddie kidd jump challenge (1985)(martech games)(gb).dsk" size="737280" crc="f336b2f9" sha1="5fb9eee28b251941a55d683eaec3957b2a04d522" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="eddiekida" cloneof="eddiekid">
-		<description>Eddie Kidd Jump Challenge (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="eddie kidd jump challenge (1985)(martech games)(gb)[a].dsk" size="737280" crc="d22a994c" sha1="a6baa38a866152739a8d4e8741b219b1df6901e9" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="eddy2">
-		<description>Eddy II (Japan)</description>
+		<description>Eddy II (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -7482,97 +4436,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="eggerlnd">
-		<description>Eggerland Mystery (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="eggerland mystery (1985)(hal laboratory)(jp).dsk" size="737280" crc="f26ea65a" sha1="28004d40ae049ee4d2bae549bab804c5133bf442" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="meikyush">
-		<description>Meikyuu Shinwa (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="eggerland mystery 2. meikyushinwa. labyrinth myth (1986)(hal laboratory)(jp).dsk" size="737280" crc="af84111f" sha1="0d109751a40c3e1a27057321e7034b6e6c96a3fd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="meikyusha" cloneof="meikyush">
-		<description>Meikyuu Shinwa (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 512K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="eggerland mystery 2. meikyushinwa. labyrinth myth (1986)(hal laboratory)(jp)[needs 512k].dsk" size="737280" crc="45ecd81c" sha1="ade926e8429fb19ad714e07ef22c8ce3fb44ee02" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="elevator">
-		<description>Elevator Action (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="elevator action (1985)(nidecom)(jp).dsk" size="737280" crc="5d08f8c5" sha1="34b694c9f1f25e0de659eea32828ffcb04a75846" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ebutrag">
-		<description>Emilio Butragueno Futbol (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="emilio butragueno futbol (1988)(topo soft - ocean software)(es-gb).dsk" size="737280" crc="ada6b68d" sha1="efff20239a9e8451eb1fad5b515e5faed7b4b3ed" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ebutrag2">
-		<description>Emilio Butragueno Futbol II (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="emilio butragueno futbol ii - campeonato (1989)(erbe software - ocean software)(es-gb).dsk" size="737280" crc="8dec65e5" sha1="767d2fecfc69b1898ded753d1acada66544ed4ae" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="esanchez">
-		<description>Emilio Sanchez Vicario Grand Slam (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="emilio sanchez vicario grand slam (1989)(zigurat software)(es).dsk" size="737280" crc="9f0e3b42" sha1="5c8f5bf2fb8b89841b2fffa04ee958921d96291d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="enchant">
-		<description>Enchanted (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="enchanted (1989)(positive)(es).dsk" size="737280" crc="5c3e4392" sha1="f7c21b87f6662bc907acc6cf4d58c5393fbe9fa6" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- Does not have 'BOMBERMAN 1983 HUDSONSOFT' at the bottom of the game screen like the cartridge version. -->
 	<software name="ericflo">
-		<description>Eric and the Floaters (Europe)</description>
+		<description>Eric and the Floaters (Europe, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -7582,340 +4448,20 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="eurogame">
-		<description>European Games (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="european games (1987)(tynesoft)(gb).dsk" size="737280" crc="55b76f05" sha1="3c07c7189440465af9b135cf2e8e3adfdcf4ac85" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="exchangr">
-		<description>Exchanger (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="exchanger (1983)(ascii)(jp).dsk" size="737280" crc="9845a716" sha1="eae19adbfdf30f7f6197605a5eeb6e93430ba718" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="exerion">
-		<description>Exerion (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="exerion (1984)(jaleco)(jp).dsk" size="737280" crc="2284ea42" sha1="545b09754c0b64075febcda76e86808238726d2a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="exerion2">
-		<description>Exerion II - Zorni (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="exerion ii - zorni (1984)(jaleco)(jp).dsk" size="737280" crc="f5ffddb8" sha1="6255326a92e0ad77c9c73b235b8800c555913b6c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="exoidez">
-		<description>Exoide-Z (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="exoide-z (1986)(casio)(jp).dsk" size="737280" crc="fb1b0135" sha1="a28271b9450463a9dd5fd4846286e6810ede2657" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="f1spirit">
-		<description>F-1 Spirit - The Way to Formula 1 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="f-1 spirit - the way to formula 1 (1987)(konami)(jp).dsk" size="737280" crc="11295667" sha1="d485f46463e1318d45e52fbf80dcd6d1af94c3a8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="f16ff">
-		<description>F16 Fighting Falcon (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="f16 fighting falcon (1985)(ascii)(jp).dsk" size="737280" crc="2b4164f1" sha1="38a94e0ac22af8c48c31eca864dbdf54ecb199f8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fairy">
-		<description>Fairy (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fairy (1985)(ascii)(jp).dsk" size="737280" crc="7de932f8" sha1="468bb735d41562ba0c18ff647ce999a0327b9100" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="flstory">
-		<description>The Fairyland Story (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fairyland story, the (1987)(hot-b)(jp).dsk" size="737280" crc="1763b947" sha1="c58103e8a68d8b4eb792df4b86760f4609f18ca0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="flstorya" cloneof="flstory">
-		<description>The Fairyland Story (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fairyland story, the (1987)(hot-b)(jp)[a].dsk" size="737280" crc="ab3404ea" sha1="dd0ae992c44096d821f62c354939b8548b0acd3a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fankpunk">
-		<description>Fanky Punky (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fanky punky (1987)(p.j. software)(es).dsk" size="737280" crc="734afaac" sha1="41db81d249d042d6b110a91d312211bfb95b58fb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fantzone">
-		<description>Fantasy Zone (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 128K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fantasy zone (1986)(pony canyon)(jp)[cr sma][needs 128k].dsk" size="737280" crc="16b05dc7" sha1="2599d8c8f36aad066dc7be05780c1e8b6008ee6c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fantzonea" cloneof="fantzone">
-		<description>Fantasy Zone (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 128K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fantasy zone (1986)(pony canyon)(jp)[cr sma][a][needs 128k].dsk" size="737280" crc="03c01f44" sha1="d1eb2f142fb1c2779a63fff0403c393b93ec8515" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="basketms">
-		<description>Fernando Martin Basket Master (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fernando martin basket master (1987)(dinamic software)(es).dsk" size="737280" crc="ff695762" sha1="efcce9d0ca8f9580248162ec776be02b31a969b9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="basketmsa" cloneof="basketms">
-		<description>Fernando Martin Basket Master (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fernando martin basket master (1987)(dinamic software)(es)[a].dsk" size="737280" crc="a291a461" sha1="eb5dac79a7a4059e0db97c7e50804e3748fd9302" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="basketmx">
 		<description>Fernando Martin Basket Master - Executive Version (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1988</year>
+		<publisher>Dinamic</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="fernando martin basket master - executive (1987)(dinamic software)(es).dsk" size="737280" crc="13f68d19" sha1="e15bd94ccd15ab4cdc9ce031bee072eea5084d9a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="basketmxa" cloneof="basketmx">
-		<description>Fernando Martin Basket Master - Executive Version (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fernando martin basket master - executive (1987)(dinamic software)(es)[a].dsk" size="737280" crc="c518b552" sha1="35b3fe0da162d77937a54f652c164d46b7db950d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fernand4">
-		<description>Fernando Martin Basket Master - Executive (Spain)[Martos]</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="fernando martin basket master - executive (1987)(dinamic software)(es)[martos].dsk" size="368640" crc="d049f875" sha1="d7a152de69296a3d63e1b7f13952b1da99f38a09" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="feud">
-		<description>Feud (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="feud (1987)(bulldog).dsk" size="737280" crc="e745f33a" sha1="de6b0fdf0a8fd8412c93ab2a1c17733322081595" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fjustice">
-		<description>Final Justice (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="final justice (1985)(pony canyon)(jp).dsk" size="737280" crc="dfdcf90d" sha1="754f0f83ff5718dee73fdaa90514a4e71f1a3e7d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fzone">
-		<description>Final Zone (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="final zone wolf (1986)(telenet japan)(jp).dsk" size="737280" crc="d720c5f0" sha1="5baeea737bde68ab4d1519648019cf91283b7ee4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fzonea" cloneof="fzone">
-		<description>Final Zone (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="final zone wolf (1986)(telenet japan)(jp)[a].dsk" size="737280" crc="a87b34b8" sha1="0c0ddff2ce24756b27f51fe39f021b2f5c314c5e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="findkeep">
-		<description>Finders Keepers (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="finders keepers (1986)(mastertronic)(gb).dsk" size="737280" crc="6a0d928d" sha1="f8299cfc0fa66b555458755951e234d2dc436a1d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fireresc">
-		<description>Fire Rescue (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fire rescue (1984)(hudson soft)(jp).dsk" size="737280" crc="6668f122" sha1="c7dc8895a6e8ca0f6f548a08bedd17734daa8956" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mrmen">
-		<description>First Steps with the Mr. Men (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="first steps with the mr. men (1985)(mirrorsoft)(gb).dsk" size="737280" crc="2d9cab69" sha1="9fbf9d4739c31285b219afd3761711840d692a1d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="flappy">
-		<description>Flappy (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="flappy (1984)(db-soft)(jp).dsk" size="737280" crc="1db4b486" sha1="1687d0af50d270d20b5bb8de2e9c1de4b6aa972f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="flappy85">
-		<description>Flappy - Limited 85 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="flappy limited 85 (1985)(db-soft)(jp).dsk" size="737280" crc="66c64c69" sha1="c56f03af177332cab97c1aa7f6b10de4377cd9f4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="flappy85a" cloneof="flappy85">
-		<description>Flappy Limited 85 (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="flappy limited 85 (1985)(db-soft)(jp)[a].dsk" size="368640" crc="e004a033" sha1="d8ca51b5da2b0154e1a5c627d44ed5290392f8c7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="flashgor">
-		<description>Flash Gordon</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="flash gordon (1987)(mastertronic added dimension).dsk" size="737280" crc="ad2fae74" sha1="a04ab9cabaf037f7e21ae1a35512ef8e6ef1e00b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fsplash">
-		<description>Flash Splash (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="flash splash (1984)(toshiba-emi)(jp).dsk" size="737280" crc="5aec721c" sha1="d88107de07afd601f32b90385c4cb09d76ca8193" />
+				<!-- Game was released on a double sided disk. Unsure if this is a disk conversion from cassette or a real disk dump. -->
+				<rom name="fernando martin basket master - executive (1987)(dinamic software)(es).dsk" size="737280" crc="13f68d19" sha1="e15bd94ccd15ab4cdc9ce031bee072eea5084d9a" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="lesflics">
-		<description>Les Flics (Spain)</description>
+		<description>Les Flics (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -7925,1595 +4471,62 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="flicky">
-		<description>Flicky (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="flicky (1985)(micronet)(jp).dsk" size="737280" crc="2571635b" sha1="876ed29ac7d1f976b46d67dd1453701b35cfb0f4" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="fdeck2">
 		<description>Flight Deck II (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1987</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8949*111M" />
+		<info name="usage" value="Hold CTRL at boot until the beep." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="flight deck ii (1986)(aackosoft)(nl).dsk" size="737280" crc="b9f06b5b" sha1="651c41863827034634c96ea999b93740ef47381b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fpath737">
-		<description>Flight Path 737 (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="flight path 737 (1985)(anirog software)(gb).dsk" size="737280" crc="2058a75e" sha1="5b138fe7e5a8a5492c566e73368e9a1bbf028075" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fsim">
-		<description>Flight Simulator (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="flight simulator (1986)(sublogic)(jp).dsk" size="737280" crc="9b700c82" sha1="522e1a09da6886b5188ad1ddd67842dcfe6c0697" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="flint">
-		<description>The Flintstones (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="flintstones, the (1988)(grandslam entertainments)(gb).dsk" size="737280" crc="aa5d87de" sha1="668ae8b5feb5c23b7028b461cf223bcf4abe37c3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="flipper">
-		<description>Flipper Slipper (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="flipper slipper (1984)(ascii)(jp).dsk" size="737280" crc="0f3c7e1a" sha1="b9e95ec6142f96a6d650485f29f39630c2fac1f6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="footvoll">
-		<description>Foot Volley (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="foot volley (1986)(players software)(gb).dsk" size="737280" crc="aeb19e97" sha1="9447110c3de84cb2151dfc92758613c1b2295ee7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fbmangwc">
-		<description>Football Manager - World Cup Edition (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="football manager - world cup edition (1990)(addictive games)(es-gb).dsk" size="737280" crc="27a024cb" sha1="aee270501ad21206494573b8202cf5be2249f123" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="foty">
-		<description>Footballer of the Year (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="footballer of the year (1987)(gremlin graphics software)(gb).dsk" size="737280" crc="a162b105" sha1="ac36bc5bd447b72cc35dba78d73061ed77ac2a24" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ffruit">
-		<description>Forbidden Fruit (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="forbidden fruit (1985)(mind games espana)(es).dsk" size="737280" crc="e8e59881" sha1="ac99e22683105d548dcf32cfa94314715db0ff0e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="formatz">
-		<description>Formation Z (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="formation z (1985)(nippon dexter)(jp).dsk" size="737280" crc="cff1b81d" sha1="e6c54a80e4a725cef78123ef40b2b90c43198e63" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="f1sim">
-		<description>Formula 1 Simulator (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="formula 1 simulator (1985)(mastertronic)(gb).dsk" size="737280" crc="780a3f2e" sha1="abe5213afab32dcdd5f5fa890639639cd38693d6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fredhard">
-		<description>Freddy Hardest (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="freddy hardest (1987)(dinamic software)(es).dsk" size="737280" crc="0c2b8183" sha1="2e83dd8f60278021f24bc0d1b80914648b1311bc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fredharda" cloneof="fredhard">
-		<description>Freddy Hardest (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="freddy hardest (1987)(dinamic software)(es)[a].dsk" size="737280" crc="6f611a97" sha1="c85c3dbacc52f1ba2aad385be3c972c5ba81d367" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fhardman">
-		<description>Freddy Hardest in South Manhattan (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="freddy hardest in south manhattan (1989)(dinamic software)(es).dsk" size="737280" crc="e1e55bfb" sha1="109ee515571c3c376543a7a62b9390d5ba567293" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="frogger">
-		<description>Frogger (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="frogger (1983)(konami)(jp).dsk" size="737280" crc="3a9b1b04" sha1="1dd9b64f2f9b6064f4ac39665ebdb2d67d9d8672" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="frontlin">
-		<description>Front Line (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="frontline (1984)(taito)(jp).dsk" size="737280" crc="16be81c2" sha1="535dabf70700afe11c11aa49eab5d121287829e6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fruitmac">
-		<description>Fruit Machine (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fruit machine (1985)(dk'tronics)(gb).dsk" size="737280" crc="34aab99c" sha1="dfe2b9540e98160e40ecc329cad3504ff56d253d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fpanic">
-		<description>Fruit Panic (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fruit panic (1984)(pony canyon)(jp).dsk" size="737280" crc="844f41af" sha1="160c9cef16e275f7eeafdf49a16cf89e5c16e604" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fruitsrc">
-		<description>Fruit Search (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="fruit search (1983)(hal laboratory)(jp).dsk" size="737280" crc="8fb83043" sha1="b5d1764a0ef3271b8d4bb7447d8feb27644065ea" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="funmouse">
-		<description>Funky Mouse (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="funky mouse (1984)(ascii)(jp).dsk" size="737280" crc="89dc5ac8" sha1="cb867b78605c4a9c049c716f7b38710bfb66654e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="futbol">
-		<description>Futbol (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="futbol (1985)(indescomp)(es).dsk" size="737280" crc="265db08e" sha1="663828de5cfa7753962a9ed55cb20345337620cd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fknight">
-		<description>Future Knight (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="future knight (1986)(gremlin graphics software)(gb).dsk" size="737280" crc="768f1d27" sha1="a7d8d6a23032186b22d45b68d14e8cfeadf9ab03" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fknighta" cloneof="fknight">
-		<description>Future Knight (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="future knight (1986)(gremlin graphics software)(gb)[a].dsk" size="737280" crc="03c6c200" sha1="359fd0b61dc8dee338068a269dcb4027d7daa7ce" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gpworld">
-		<description>GP World (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="g.p. world (1985)(pony canyon)(jp).dsk" size="737280" crc="77e9bd66" sha1="c5e0f42527424a3749372b3536ac7152a3eedaec" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="galaga">
-		<description>Galaga (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="galaga (1984)(namcot)(jp).dsk" size="737280" crc="3c712394" sha1="8d5cec760e25a26b4f3c93b80301332194bae4f0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="galaxian">
-		<description>Galaxian (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="galaxian (1984)(namcot)(jp).dsk" size="737280" crc="9888e258" sha1="8406acea6d5281cbe6a6d860bd20fbc2fb8d8ce3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="galforce">
-		<description>Gall Force - Defense of Chaos (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gall force - defense of chaos (1986)(sony)(jp).dsk" size="737280" crc="b881a220" sha1="c95ae30ca6a795dd466a583a1bc02cf6d132e175" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="galforcea" cloneof="galforce">
-		<description>Gall Force - Defense of Chaos (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gall force - defense of chaos (1986)(sony)(jp)[a].dsk" size="737280" crc="a5997a60" sha1="c0bdd3e3afbe03845304373a667fef1e26f7da38" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="galforceb" cloneof="galforce">
-		<description>Gall Force - Defense of Chaos (Japan, alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gall force - defense of chaos (1986)(sony)(jp)[a2].dsk" size="737280" crc="d9bf17b8" sha1="6e1b2e69e2b0b82e51ed2f1b5218729cfb6408c2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gameover">
-		<description>Game Over (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="game over (1988)(dinamic software)(es).dsk" size="737280" crc="cc50db33" sha1="256e65fa13fa78b58b95242603b8284502e0e9bc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gameovera" cloneof="gameover">
-		<description>Game Over (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="game over (1988)(dinamic software)(es)[a].dsk" size="737280" crc="a516ac12" sha1="955c65981200f714ae87bafd0419359dcfa4551d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gameswin">
-		<description>The Games - Winter Edition (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="games, the - winter edition (1988)(us gold)(gb).dsk" size="737280" crc="a1ed6ef4" sha1="6738f1873b25ac2a35417ab5196349c22847172c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gameswina" cloneof="gameswin">
-		<description>Games, The - Winter Edition (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="games, the - winter edition (1988)(us gold)(gb)[a].dsk" size="737280" crc="1c1a0b4a" sha1="8a9d8e016b7f66dc3d5aff53c861cad15b622b6a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gamesdes">
-		<description>Games Designer (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="games designer (1985)(quicksilva)(gb).dsk" size="737280" crc="3d55fff5" sha1="55b6d192703675f5ba8377ea71ee1eb80e40199f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gangman">
-		<description>Gangman (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gangman (1984)(hudson soft)(jp).dsk" size="737280" crc="ed599b29" sha1="abb52006ffb3a7bef861e18d2ac7e028d0c39134" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gauntlet">
-		<description>Gauntlet (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gauntlet (1986)(us gold)(gb).dsk" size="737280" crc="2302c4f5" sha1="50cfd56b4dbc19abc1befd81232089b74da81901" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="genghis">
-		<description>Genghis Khan (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="genghis khan (1991)(positive)(es).dsk" size="737280" crc="f95de2b7" sha1="7994ba46ddd9052700478bfc10d5993c88c6a858" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="genghisa" cloneof="genghis">
-		<description>Genghis Khan (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="genghis khan (1991)(positive)(es)[a].dsk" size="737280" crc="51903037" sha1="8661e92001d5524515546069f98af7eae96320bd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="genghisb" cloneof="genghis">
-		<description>Genghis Khan (Spain, alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="genghis khan (1991)(positive)(es)[a2].dsk" size="737280" crc="997eff44" sha1="8eaadd1acef3ddcea041bc37c66397640e1da18e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gerente">
-		<description>El Gerente (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gerente, el (1984)(dimensionnew)(es).dsk" size="737280" crc="3bf19d7a" sha1="b6c5bf529458e58bbd48faf2303873a1dcf11852" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ghostbst">
-		<description>Ghostbusters (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ghostbusters (1985)(activision)(us).dsk" size="737280" crc="13f5c44a" sha1="24f5170e96a5c74ed47c96ae239a731b90a0d450" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ghostbs2">
-		<description>Ghostbusters II (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ghostbusters ii (1989)(activision)(us).dsk" size="737280" crc="75795bdd" sha1="a658036c4889e439a9537e36214101477a955c4b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="glass">
-		<description>Glass (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="glass (1985)(quicksilva)(gb).dsk" size="737280" crc="75486cc5" sha1="b7a2cdbcd892b751dc07c0bf9fbc8dfdb69344e7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="glider">
-		<description>Glider (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="glider (1985)(ascii)(jp).dsk" size="737280" crc="5d09e0f9" sha1="3123b8d3cbb682e81e6ad29a7d4c8eef5dcfc90c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="godzilla">
-		<description>Godzilla (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gozira 3d. godzilla vs 3 major monsters (1984)(bandai)(jp).dsk" size="737280" crc="b620816f" sha1="a384202f2a36f86d9c8d6e71896755f31ce3c8b0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="nemesis3">
-		<description>Gopher no Yabou - Episode II (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 256K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="gofer no yabou episode ii. nemesis 3 - the eve of destruction (1988)(konami)(jp)[needs 256k][scc].dsk" size="368640" crc="6013f518" sha1="49029967bbefa58283b559b3cbe73f746710a2a7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gomokuna">
-		<description>Gomoku Narabe (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gomoku narabe - omo go (1984)(toshiba-emi)(jp).dsk" size="737280" crc="11bd2118" sha1="9cf0620604cec0732934019c74dbf2e34df6d873" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gonzalez">
-		<description>Gonzzalezz (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gonzzalezz (1989)(opera soft)(es).dsk" size="737280" crc="2d5d5641" sha1="44c11993f32e427cc047ee40f8014803e20b9fed" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gonzaleza" cloneof="gonzalez">
-		<description>Gonzzalezz (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gonzzalezz (1989)(opera soft)(es)[a].dsk" size="737280" crc="c323ff92" sha1="c27fb1481408bb95a9938c7eea659d405a2d0589" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="goody">
-		<description>Goody (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="goody (1987)(opera soft)(es).dsk" size="737280" crc="e4cba1a6" sha1="f270c6b36ab57cc2da98d6c6f8959f963f3fca15" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="goodya" cloneof="goody">
-		<description>Goody (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="goody (1987)(opera soft)(es)[a].dsk" size="737280" crc="fa3eb077" sha1="e8f402811e3bf9e1061186fbbe5ee526e4caef6e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="goonies">
-		<description>The Goonies (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="goonies, the (1986)(konami)(jp).dsk" size="737280" crc="066839fc" sha1="e4f8c6e413af1920301872f6c3cb14c2027149bd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gridtrap">
-		<description>Grid Trap (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="grid trap (1985)(livewire software)(gb).dsk" size="737280" crc="8867adbc" sha1="85514f0c23767451cf01d9a07cd678d7f7953d49" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="guardic">
-		<description>Guardic (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="guardic (1986)(compile).dsk" size="737280" crc="124c2ac8" sha1="da63aff325e28a73d985ba248aa35a3e706d6635" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gulkave">
-		<description>Gulkave (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gulkave (1986)(pony canyon)(jp).dsk" size="737280" crc="e0ea70fe" sha1="2327145f3c737fde7d74b377df61651007800440" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gunfrght">
-		<description>Gunfright (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gunfright (1985)(ultimate play the game)(gb).dsk" size="737280" crc="b382717a" sha1="5b868647cb0374efa5f45e744dd9233c27aa25d4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gyroadv">
-		<description>Gyro Adventure (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gyro adventure (1984)(nippon columbia - colpax - universal).dsk" size="737280" crc="2ac81d5d" sha1="ca6e3ec95afc120d43383790442b0431168d3ffe" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gyrodine">
-		<description>Gyrodine (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="gyrodine (1986)(taito)(jp).dsk" size="737280" crc="6210bd42" sha1="912608e33da1b0993c65beb3ece9999555ef7ee8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hero">
-		<description>H.E.R.O. (Japan?)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="h.e.r.o. (1984)(activision)(us).dsk" size="737280" crc="107b8515" sha1="a9fd19d599df0992c89784922141a3ae73c00a3f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="habilit">
-		<description>Habilit (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="habilit (1988)(iber soft)(es).dsk" size="737280" crc="971dc676" sha1="cfb59aeff07e5568be539c86c44dc931cb935be2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="habilita" cloneof="habilit">
-		<description>Habilit (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="habilit (1988)(iber soft)(es)[a].dsk" size="737280" crc="a7a28bfc" sha1="811413add12da80f9fe26f5fa32b96b3b76a46cf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hades">
-		<description>Yami no Ryuuou - Hades no Monshou (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hadesu no monshou. the seal of hades (1986)(casio)(jp).dsk" size="737280" crc="131cda47" sha1="c0512d918a76ca05b9646493b15a4afd53b14bbf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hanakoi">
-		<description>MSX Hanafuda Koi Koi (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hanafuda koi koi - gostop godori (1984)(ascii)(jp).dsk" size="737280" crc="b1dedd75" sha1="7d33d90505311883a953159dea0b9ee792df54c7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hanakoia" cloneof="hanakoi">
-		<description>MSX Hanafuda Koi Koi (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="hanafuda koi koi - gostop godori (1984)(ascii)(jp)[a].dsk" size="368640" crc="810cbb2c" sha1="84f44ef46dcbd022b6550da50d9e527ff8067f10" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hangon19">
-		<description>Hang-On (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hang-on (1986)(pony canyon)(jp).dsk" size="737280" crc="89c609fc" sha1="f5c1e0acf47034c5b45da2c7b01d33cd6829e946" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="flight deck ii (1986)(aackosoft)(nl).dsk" size="737280" crc="b9f06b5b" sha1="651c41863827034634c96ea999b93740ef47381b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="happyfrt">
-		<description>Happy Fret (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>Happy Fret (Netherlands)</description>
+		<year>1985</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8369" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="happy fret (1985)(micro cabin)(jp).dsk" size="737280" crc="79f604cd" sha1="7e5f7a6cd6994f43d9a298d44543381f8879a7e6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="showjump">
-		<description>Harvey Smith's Showjumper (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="harvey smith's showjumper (1985)(software projects)(gb)[passworded].dsk" size="737280" crc="3d5c9385" sha1="fea000491babae23d63c3ee3ad9a75f8c2ec4e1e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="headover">
-		<description>Head Over Heels (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="head over heels (1987)(ocean software)(gb).dsk" size="737280" crc="8b0f50bb" sha1="4a837e8e64afcc519f1e945cbfe09648e6dfa1ed" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="headovera" cloneof="headover">
-		<description>Head Over Heels (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="head over heels (1987)(ocean software)(gb)[a].dsk" size="737280" crc="b6d36814" sha1="209985976186f81f83b971e22a2b9e208d5ce0d1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="heatseek">
-		<description>Heat Seeker - Missil (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="heat seeker - missil (1986)(mind games espana)(es).dsk" size="737280" crc="153cf502" sha1="1b4ca51bfa290d85a6bf3be038034efa1dca0b7f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="heavybox">
-		<description>Heavy Boxing (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="heavy boxing (1983)(hal laboratory)(jp).dsk" size="737280" crc="daf651ca" sha1="daa11f0407c3c20169fde722ec2676481de268a8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="heist">
-		<description>The Heist (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="heist, the (1985)(aackosoft)(nl).dsk" size="737280" crc="bd753138" sha1="c1e588f946a309479cd83d63dd4a5829568982c4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="helitank">
-		<description>Heli Tank (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="heli tank (1984)(ascii)(jp).dsk" size="737280" crc="1d7f0a0b" sha1="2819d42972f95369733b21384302b3a452e7e8fb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hercules">
-		<description>Hercules - Slayer of the Damned (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hercules - slayer of the damned (1988)(gremlin graphics software)(gb)[m menu in spanish].dsk" size="737280" crc="3723166f" sha1="3e10b8613bd09875c31d6e83a2966cbc26438331" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="herether">
-		<description>Here &amp; There with the Mr. Men (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="here &amp; there with the mr. men (1985)(mirrorsoft)(gb).dsk" size="737280" crc="3f6dfc77" sha1="65851ae51712024cfa2b4d554bcb9c50bd9e36e9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="herencia">
-		<description>La Herencia (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="l'heritage - panique a las vegas (1987)(infogrames)(fr)(es)[aka inheritance, the].dsk" size="368640" crc="9e4887fa" sha1="7a22df6bbe99341a16af1b3395e4bc4f695a9459" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="herenciaa" cloneof="herencia">
-		<description>La Herencia (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="l'heritage - panique a las vegas (1987)(infogrames)(fr)(es)[a][aka inheritance, the].dsk" size="737280" crc="9a619255" sha1="246a439f08c06b2096d0c0bb9965d44875d102e0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="highway">
-		<description>High Way Star (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="high way star (1984)(ascii)(jp).dsk" size="737280" crc="cb9c4d06" sha1="1f19d183a2d279e8c8352685c73b754d2c6ea1e6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="highwen">
-		<description>Highway Encounter (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="highway encounter (1985)(dinamic software)(es).dsk" size="737280" crc="218272d5" sha1="9a151e861a370484a1a116676ed0fef14b314496" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hitsuji">
-		<description>Hitsuji Yaai (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hitsuji yai. pretty sheep (1984)(hudson soft)(jp).dsk" size="737280" crc="8ede57f1" sha1="7e056829e0f2c7dc1c542eeb45d796271062c409" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="holein1">
-		<description>Hole in One (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hole in one (1984)(hal laboratory)(jp).dsk" size="737280" crc="a68259c2" sha1="57a9ea3ea1cfb355c711e663bb18497c2fb4a1a1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="holein1p">
-		<description>Hole in One Professional (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hole in one professional (1986)(hal laboratory)(jp).dsk" size="737280" crc="60014587" sha1="a5b4427d36ee2757388ae146237dcddfeaff2156" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="homewrtr">
-		<description>Home Writer (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="home writer (1985)(sony)(jp).dsk" size="737280" crc="fe27e3a4" sha1="9a9b9c3f689c8a03c7dcbcd1709714b60ac0442f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hopper">
-		<description>Hopper (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hopper (1986)(eaglesoft)(nl).dsk" size="737280" crc="bac8fc3a" sha1="d0a05bea5d0ee36aff375544aa1219135b97cec4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hotshoe">
-		<description>Hot Shoe (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hot shoe (1984)(longman software)(gb).dsk" size="737280" crc="bb5037d6" sha1="69036e86816a804380cade1e911ec5c01e07bda2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="howard">
-		<description>Howard the Duck (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="howard the duck (1987)(activision)(us).dsk" size="737280" crc="04541947" sha1="efa759dbaf61b9c5bce5741eeaf7924293ceb63b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="humphrey">
-		<description>Humphrey (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="humphrey (1984)(mr. micro)(gb).dsk" size="737280" crc="af45cd59" sha1="cd6507ea8d34bc7a94f544f7cb1603313f7d6e94" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="humphrez">
-		<description>Humphrey (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="humphrey (1988)(zigurat software)(es).dsk" size="737280" crc="d39042b0" sha1="d3e9d662b8a6f55e3330dbedf41ac644930c7636" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="humphreza" cloneof="humphrez">
-		<description>Humphrey (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="humphrey (1988)(zigurat software)(es)[a].dsk" size="737280" crc="e28d8844" sha1="e48e9dde472712c0e9367e00162cdbaa433262d6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hnchback">
-		<description>Hunchback (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hunchback (1984)(ocean software)(gb).dsk" size="737280" crc="09eb3934" sha1="0f3974e134ae194579d7477cdead63d6a9a67425" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hundra">
-		<description>Hundra (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hundra (1988)(dinamic software)(es).dsk" size="737280" crc="00bb44ec" sha1="045177a7ab6bdb4128d573df3b57eb019b33d31c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="huntred">
-		<description>The Hunt for Red October (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hunt for red october, the (1988)(grandslam entertainments)(gb).dsk" size="737280" crc="cacaedd7" sha1="8ac23251dad584ed50644fcbc7cde0c98c2e9370" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="huntreda" cloneof="huntred">
-		<description>The Hunt for Red October (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hunt for red october, the (1988)(grandslam entertainments)(gb)[a].dsk" size="737280" crc="9a64f888" sha1="e5741f3244d9726d75b19d7ca4d59d6efeaa0fb9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hustle">
-		<description>Hustle Chumy (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hustle chumy (1983)(general)(jp).dsk" size="737280" crc="ddcd4d9a" sha1="1efca1390f5b275bfcca00e3cf99d29f5901134f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hustlrbb">
-		<description>Hustler (UK, Bubble Bus)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hustler (1984)(bubble bus)(gb).dsk" size="737280" crc="ddbb565e" sha1="a2ab06aa4d0d27f71d128391e0a543bbbb4df919" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hydlide">
-		<description>Hydlide (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hydlide (1985)(t&amp;e soft)(jp).dsk" size="737280" crc="1fa0bdd3" sha1="f181a735a54dfc019be486b59010407520721de3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hydlide2">
-		<description>Hydlide II - Shine of Darkness (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hydlide ii - shine of darkness (1986)(t&amp;e soft)(jp).dsk" size="737280" crc="e937cfb7" sha1="f343af238031714343fa11afd8ddeb965c1dff1c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hydlide2a" cloneof="hydlide2">
-		<description>Hydlide II - Shine of Darkness (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hydlide ii - shine of darkness (1986)(t&amp;e soft)(jp)[a].dsk" size="737280" crc="f0613c64" sha1="06ef35994f4c6cc92f41422a8e71e0a739f8b2d9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hydlide3">
-		<description>Hydlide III - The Space Memories (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hydlide iii - the space memories (1987)(t&amp;e soft)(jp).dsk" size="737280" crc="9e83a623" sha1="9db8896fb4fd87f7368483e620ca5b176d75f0f4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hyperol1">
-		<description>Hyper Olympic 1 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hyper olympic 1 (1984)(konami)(jp).dsk" size="737280" crc="ba969f05" sha1="6287fef728dd56ad2b1f0faf38bac761675c6c78" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hyperol2">
-		<description>Hyper Olympic 2 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hyper olympic 2 (1984)(konami)(jp).dsk" size="737280" crc="42ec8e02" sha1="c0e35f3288bdbd6b26f7745ece117f3aa0a3d401" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hyprally">
-		<description>Hyper Rally (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hyper rally (1985)(konami)(jp).dsk" size="737280" crc="94298559" sha1="8f2e8df3e1dc95bf25bed3b730e56ee7b56a2cf0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hyperspt">
-		<description>Hyper Sports 1 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hyper sports 1 (1984)(konami)(jp).dsk" size="737280" crc="cbaa8560" sha1="3156e3a41ec9683357a47fb7e7c5f5cf94007884" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hypersp2">
-		<description>Hyper Sports 2 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hyper sports 2 (1984)(konami)(jp).dsk" size="737280" crc="bec6e51f" sha1="d40acac239dc7179fcdaadfa193522a8a03c5108" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hypersp2a" cloneof="hypersp2">
-		<description>Hyper Sports 2 (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hyper sports 2 (1984)(konami)(jp)[a].dsk" size="737280" crc="aa28c7d9" sha1="4d01061ad9dc73e8dfb28960279c7480178f3f0b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hypersp3">
-		<description>Hyper Sports 3 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hyper sports 3 (1985)(konami)(jp).dsk" size="737280" crc="76e11c2b" sha1="6c70ce57eef0efa396960a805dbfcc0c232a91d1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ice">
-		<description>Ice (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ice (1986)(eaglesoft)(nl).dsk" size="737280" crc="8db2999e" sha1="dbc9f630b0475d55dcd834320164cc273b2ffc15" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="iceking">
-		<description>The Ice King (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ice king, the (1986)(cds micro systems)(gb).dsk" size="737280" crc="af034195" sha1="23c9b257b0215656690941e23534e563b459986a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="iceworld">
-		<description>Ice World (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ice world (1985)(casio)(jp).dsk" size="737280" crc="0e57bba6" sha1="4506def0d2e28b9baebe8aa0a78da99d4b80f090" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="icebreak">
-		<description>Ice-Breaker (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ice-breaker (1990)(topo soft)(es).dsk" size="737280" crc="5faa6156" sha1="b8a935a6d6a76465798a4d46a7215bd4a5e779dd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ideatype">
-		<description>IdeaType - Instructor Mecanografico (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ideatype - instructor mecanografico (1985)(idealogic)(es).dsk" size="737280" crc="373219b2" sha1="1d667cebd7375863a67157c0d9cde69f28739700" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="iganinp2">
-		<description>Iga Ninpouchou - Mangetsujou no Tatakai (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="iga ninpouten 2. small ninja 2 - the mooncastle (1986)(casio)(jp).dsk" size="737280" crc="770b8c8f" sha1="80f3819f7b504fa55543f7c993f4d879403ce9ad" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="iganinpo">
-		<description>Iga Ninpouchou (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="iga ninpouten. small ninja (1985)(casio)(jp).dsk" size="737280" crc="6379d185" sha1="92cdcd6d859627cb01d834b400d42fe706b96fc1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="igloo">
-		<description>Igloo (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="igloo (1985)(garbi soft)(es).dsk" size="737280" crc="fff6c973" sha1="bce22cb8cbe3982ea75be13ef0ebdea4529e2cf9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="theseus">
-		<description>Theseus - Iligks I (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="iligks episode i - theseus (1984)(ascii)(jp).dsk" size="737280" crc="e2ea126a" sha1="d427429dc806d7391b38a4495a7c57f6863ff648" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="iligks">
-		<description>Iligks (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="iligks episode iv - the maze of illegus (1984)(ascii)(jp).dsk" size="737280" crc="9a29d23a" sha1="ac5dad8cf0678e52b620c69a37eacd38cac13341" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="indianb">
-		<description>Indian no Bouken (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="indian no bouken. indian's adventure (1984)(hudson soft)(jp).dsk" size="737280" crc="3f7de79a" sha1="025a6a5e0658f80ba027d831750f07a9a10ecb52" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="indy">
-		<description>Indiana Jones and the Temple of Doom (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="indiana jones and the temple of doom (1987)(us gold)(gb).dsk" size="737280" crc="c18fb76c" sha1="75ffb804a14371ee1d163ddb440fd47dda05bb99" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ik">
-		<description>International Karate (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="international karate (1986)(endurance games)(gb).dsk" size="737280" crc="9d06453a" sha1="f5b0b32b5765e23c710c3c9ce431e84a5e97123d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ika">
-		<description>International Karate (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="international karate (1986)(endurance games)(gb)[a].dsk" size="737280" crc="13e8b81a" sha1="60167714d4ab3599d6d0f1fa3d869bd837655d69" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="intrepid">
-		<description>Intrepido (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="intrepido (1988)(mind games espana)(es).dsk" size="737280" crc="a6f7df53" sha1="550aef7b5acca541a4d974f9f958ac211a4d3efa" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="invasion">
-		<description>Invasion (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="invasion (1987)(bulldog)(gb).dsk" size="737280" crc="75757190" sha1="3545219d550b54c1198e3f4f638b128e6928fd07" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="invierte">
-		<description>Invierte y Gana (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="invierte y gana (1986)(dimensionnew)(es).dsk" size="737280" crc="cb96bf51" sha1="0ffbb40899078d4ef9a26477e7ed515db614c830" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jpwinkle">
-		<description>J.P. Winkle (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="j.p. winkle (1986)(msx magazine)(jp).dsk" size="737280" crc="22365722" sha1="f00682d7c6e5c5a215a51c0246a38ccdcb8d1ada" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="happy fret (1985)(micro cabin)(jp).dsk" size="737280" crc="79f604cd" sha1="7e5f7a6cd6994f43d9a298d44543381f8879a7e6" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="jabato">
-		<description>Jabato (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>Jabato (Spain, disk conversion)</description>
+		<year>1989</year>
+		<publisher>Dinamic</publisher>
+		<info name="serial" value="MSD 12890025" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
-				<rom name="jabato (1989)(aventuras ad)(es).dsk" size="368640" crc="2fdc140d" sha1="8fdfa9466c3ec73d2121cf2e314547c81f6c68b4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jabatoa" cloneof="jabato">
-		<description>Jabato (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jabato (1989)(aventuras ad)(es)[a].dsk" size="737280" crc="43ac3f98" sha1="0a95cb65c4d80bae69f4c3e484e9d9cdfce715ac" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jabatob" cloneof="jabato">
-		<description>Jabato (Spain, alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jabato (1989)(aventuras ad)(es)[a2].dsk" size="737280" crc="9526c8db" sha1="1e348b2ae14534a699862a644a390d302e27afc1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jacknip">
-		<description>Jack the Nipper (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jack the nipper (1986)(gremlin graphics software)(gb).dsk" size="737280" crc="217cd70b" sha1="b3dc19ad3cb381ef82257581f325fece12ab0665" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="projecta">
-		<description>Jackie Chan in Project A (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="project a (1984)(pony canyon)(jp).dsk" size="737280" crc="6bfca108" sha1="0bab5885b41bb2bd65550d7e0389d38076b9a1a9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="projectaa" cloneof="projecta">
-		<description>Jackie Chan in Project A (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="project a (1984)(pony canyon)(jp)[a].dsk" size="737280" crc="43b691ca" sha1="cebba116050f9dfbc7048f26323d9dd0252f6e25" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spartanx">
-		<description>Jackie Chan in Spartan X (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="spartan x (1985)(pony canyon)(jp).dsk" size="737280" crc="4810a30f" sha1="b540d3d84693a8ccac639943f99d291fc3650cf9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jagur">
-		<description>Jagur (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jagur (1987)(hudson soft)(jp).dsk" size="737280" crc="306030ee" sha1="0285208600a62d3bbaefbaf2a4d4c47d5893f44b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jagura" cloneof="jagur">
-		<description>Jagur (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jagur (1987)(hudson soft)(jp)[a].dsk" size="737280" crc="a3792ca0" sha1="25b501e9ec4c7f89282471f64ee511c5c3709c2d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jaws">
-		<description>Jaws (Spain?, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jaws (1989)(screen 7)[t].dsk" size="737280" crc="be3798d2" sha1="570eb8b5ab5903562cd1d63ccc29e7a915866db3" />
+				<rom name="jabato (1989)(aventuras ad)(es).dsk" size="368640" crc="2fdc140d" sha1="8fdfa9466c3ec73d2121cf2e314547c81f6c68b4" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="jetbomb">
 		<description>Jet Bomber (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1986</year>
+		<publisher>Aackosoft</publisher>
+		<info name="serial" value="8724" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="jet bomber (1985)(aackosoft)(nl).dsk" size="737280" crc="356335cb" sha1="5475956b19b7f1322e51ef908f34d98c9e851545" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jetsetw">
-		<description>Jet Set Willy (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jet set willy (1985)(software projects)(gb).dsk" size="737280" crc="e9bbe448" sha1="4964806ddea2c629419ca06b202874ec69c54cb0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jetsetwa" cloneof="jetsetw">
-		<description>Jet Set Willy (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jet set willy (1985)(software projects)(gb)[a].dsk" size="737280" crc="fc9393be" sha1="74acac67e3de2dfe63ac3501ac03dc572f3832f1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jetsetw2">
-		<description>Jet Set Willy II (Europe, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jet set willy ii - the final frontier (1985)(software projects)(gb)[t].dsk" size="737280" crc="af505b0c" sha1="80c9d7d113acbda75f92d10bec1b8f3322e62176" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="joeblade">
-		<description>Joe Blade (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="joe blade (1989)(players software)(gb).dsk" size="737280" crc="bf412145" sha1="dac97dea95af174b405119a82abd5d878cbf8a40" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="comomolo">
-		<description>Johny Comomolo in 3-2-1 Fire (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="johny comomolo in 3-2-1 fire (1986)(dro soft)(es).dsk" size="737280" crc="fc647958" sha1="3b32575e273a4369f95564b2d937b8d798f8396b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="j2cearth">
-		<description>Journey to the Centre of the Earth (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="journey to the centre of the earth (1985)(bug-byte software)(gb).dsk" size="737280" crc="077b548c" sha1="64ecb7ec427d94d293f2db27ff0897346c9a71ec" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jump">
-		<description>Jump (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="jump (1985)(ascii)(jp).dsk" size="368640" crc="480cd221" sha1="3ea22f11ad55cf7641f838d8dea7e42eec4c6b7b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jumpcstr">
-		<description>Jump Coaster (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jump coaster (1984)(nippon columbia - colpax - universal).dsk" size="737280" crc="1ee94a8b" sha1="0ace294811ab4a4142f5a308b5a167f354d58f7f" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="jet bomber (1985)(aackosoft)(nl).dsk" size="737280" crc="356335cb" sha1="5475956b19b7f1322e51ef908f34d98c9e851545" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="jumpland">
-		<description>Jump Land</description>
+		<description>Jump Land (Japan, disk conversion)</description>
 		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="jump land (1985)(nippon columbia - colpax - universal).dsk" size="737280" crc="4ae7652e" sha1="b4d401bcffd044ca2475d35d750dc7ff11fce6dd" />
@@ -9522,9 +4535,9 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="jumprabt">
-		<description>Jumping Rabbit (Japan)</description>
+		<description>Jumping Rabbit (Japan, disk conversion)</description>
 		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="jumping rabbit (1984)(mia)(jp).dsk" size="737280" crc="ee81386a" sha1="602601f88b2d9556ceef51bd4bb149ad23df47dc" />
@@ -9532,109 +4545,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="jungwarr">
-		<description>Jungle Warrior (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jungle warrior (1990)(zigurat software)(es).dsk" size="737280" crc="ffe15295" sha1="a0b560a6e8eceac84f412b166e162801166be733" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jungwarra" cloneof="jungwarr">
-		<description>Jungle Warrior (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="jungle warrior (1990)(zigurat software)(es)[a].dsk" size="737280" crc="ef11b1a9" sha1="ce510ace606bb3287ace4560b3533989164f64c5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="junofrst">
-		<description>Juno First (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="juno first (1983)(sony)(jp).dsk" size="737280" crc="67121d87" sha1="7f152c65db6f984cb8324ff9b76434af9fdde2d2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="legkage">
-		<description>Kage no Densetsu - The Legend of Kage (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="kage no densetsu. legend of kage (1986)(taito)(jp).dsk" size="737280" crc="b4b6014d" sha1="26300125a19d49dbd6af5668d57c70fa62a679a3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="karuizaw">
-		<description>Karuizawa Yuukai Annai (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 256K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="karuizawa kidnapping guidance, the (1986)(enix)(jp)[needs 256k].dsk" size="737280" crc="e7e4188e" sha1="458851b1e27666d57e5936fdc7d610465ee6f109" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="karuizawa" cloneof="karuizaw">
-		<description>Karuizawa Yuukai Annai (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 256K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="karuizawa kidnapping guidance, the (1986)(enix)(jp)[a][needs 256k].dsk" size="737280" crc="eb2071b9" sha1="ed4b81728d93bdeb0ccfb4e308063d50c858d942" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kerulen">
-		<description>Ke Rulen los Petas (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ke rulen los petas (1989)(iber soft)(es).dsk" size="737280" crc="3918007a" sha1="8a6e8df303a1662d4c89e9a7f978f672e56bdf2a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="stonewis">
-		<description>Kenja no Ishi - The Stone of Wisdom (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="kenja no ishi. the stone of wisdom (1986)(casio)(jp).dsk" size="737280" crc="9dc6d5cf" sha1="a130c79a320b9cc57fd125f47586a3778dfc4189" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="stonewisa" cloneof="stonewis">
-		<description>Kenja no Ishi - The Stone of Wisdom (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="kenja no ishi. the stone of wisdom (1986)(casio)(jp)[a].dsk" size="368640" crc="6a7df719" sha1="96f9accc7b509c364a26eb0064937f2accd3a3d7" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="keykaper">
-		<description>Keystone Kapers (UK)</description>
+		<description>Keystone Kapers (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -9644,417 +4556,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="kingball">
-		<description>King &amp; Balloon (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="king &amp; balloon (1984)(namcot)(jp).dsk" size="737280" crc="d59e099f" sha1="d361f9f98c0182279c4d7dfabfd5d00223fc23c8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kingleon">
-		<description>King Leonard (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="king leonard (1986)(mind games espana)(es).dsk" size="737280" crc="a607d7b0" sha1="09d3a0238e835614d9b59a5fb7172b96f956bce5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kingkngt">
-		<description>King's Knight (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 256K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="king's knight (1986)(square)(jp)[needs 256k].dsk" size="737280" crc="83addd48" sha1="31f012fb896957ff6d6ce6d254c7e67ee06de97f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kingkngta" cloneof="kingkngt">
-		<description>King's Knight (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 256K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="king's knight (1986)(square)(jp)[a][needs 256k].dsk" size="737280" crc="5440a600" sha1="d9458f74961f4a6b749a4a083318b7b728c8b7aa" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kingval">
-		<description>King's Valley (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="king's valley (1985)(konami)(jp).dsk" size="737280" crc="2bd7d6b3" sha1="68b867d558d495492ac3b9db02ac0a82aaadf1a3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kingval2">
-		<description>Ouke no Tani - El Giza no Fuuin (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="king's valley ii - the seal of el giza (1988)(konami)(jp)[cr sigma][scc].dsk" size="737280" crc="16b4d610" sha1="05aef43e408bff9fb1c1c74182397ab2b4519f8b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kinnikum">
-		<description>Kinnikuman - Colosseum Deathmatch (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="kinnikuman. muscle man (1985)(bandai)(jp).dsk" size="737280" crc="7a29d664" sha1="0f88e04b4d777a255ddf45d1ce439a40111489ae" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="klax1990">
-		<description>Klax (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="klax (1990)(domark)(gb).dsk" size="737280" crc="345cc9d1" sha1="78ec5762c75bf582c7055f79209ecaf95b4f25bf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="knighost">
-		<description>Knight Ghost (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="knight ghost (1987)(dro soft)(es)[m tape2dsk].dsk" size="737280" crc="776736a4" sha1="e27fffa3732f4de68ab0135ecd6d6b310e569983" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="knightlr">
-		<description>Knight Lore (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="knight lore (1985)(ultimate play the game)(gb).dsk" size="737280" crc="a0895dd8" sha1="0ee5f57b0b8385561c0752b8248036532ab5c83f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="knightym">
-		<description>Knight Tyme (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="knight tyme (1986)(mastertronic added dimension).dsk" size="737280" crc="2af051a4" sha1="5dbd1399f64d87ed39a9b890fb8eff9748f47362" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="knightmr">
-		<description>Knightmare - Majou Densetsu (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="knightmare. majyo densetsu (1986)(konami)(jp).dsk" size="737280" crc="ad065a09" sha1="c906439d545fdbc800bf650298d0b5c98614f44e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="knightm2">
-		<description>Knightmare II - The Maze of Galious (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="knightmare ii - the maze of galious (1987)(konami)(jp).dsk" size="737280" crc="9fac0941" sha1="b657839cd2bdebfa70029bda3e170d774fd21ebb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="knightm3">
-		<description>Knightmare III - Shalom (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="knightmare iii - shalom (1987)(konami)(jp).dsk" size="737280" crc="aaea37d5" sha1="5f53214d75372965c6f19772329faa04d09f1522" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="konbball">
-		<description>Konami's Baseball (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="konami's baseball (1984)(konami)(jp).dsk" size="737280" crc="a5aa0991" sha1="52c53de6defc7889f5c8d6bb7e2366addb607b91" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="konbill">
-		<description>Konami's Billiards (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="konami's billiards (1984)(konami)(jp).dsk" size="737280" crc="5b77650f" sha1="2f1954a72b8d3ab4b3e4eb5b363646a94051968c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kongolf">
-		<description>Konami's Golf (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="konami's golf (1985)(konami)(jp).dsk" size="737280" crc="76dd4fc0" sha1="9f8790472d19a405e6a2de49737174de75c56ad4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pingpong">
-		<description>Konami's Ping-Pong (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="konami's ping pong (1985)(konami)(jp).dsk" size="737280" crc="a4e6049f" sha1="b677ae9a1b917e7c002b8d00ede43c5d49cf02c3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="konsoccr">
-		<description>Konami's Soccer (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="konami's soccer (1985)(konami)(jp).dsk" size="737280" crc="f8f3b78b" sha1="6c82a8cf610d501a456b6697201af25ef8612a89" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kontenn">
-		<description>Konami's Tennis (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="konami's tennis (1984)(konami)(jp).dsk" size="737280" crc="23ed7935" sha1="0a1d22eb0cd95c7b92ed8159708b8c7bd35b75b3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gmaster">
-		<description>Game Master (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="konami's game master - european version (1986)(konami)(jp).dsk" size="737280" crc="f6771838" sha1="f7375683c425d6252fa71da753e237f73c0e1ac6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gmaster2">
-		<description>Konami no Game Master II (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="konami's game master ii (1988)(konami)(jp).dsk" size="737280" crc="c221a5d3" sha1="a5aa0a5f16dd6c55be9345aee83a75d335b741bb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="koneko">
-		<description>Koneko no Daibouken - Chibi-chan ga Iku (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="koneko no daibouken. kitty's great adventure. catboy (1986)(casio)(jp).dsk" size="737280" crc="8d446dfc" sha1="621f5504568d1a016ecad6d3b7c75e591e7fb294" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="krypton">
-		<description>Krypton (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="krypton (1986)(manhattan transfer)(es).dsk" size="737280" crc="e18c7a19" sha1="c59be5c3086d01e0b400650cbe83d8b0099b3d38" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kubus">
-		<description>Kubus (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="kubus (1985)(kuma computers)(gb).dsk" size="737280" crc="a432d986" sha1="03bed39a3c36079eb73a7114a5532e5ee0230fba" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kumalogo">
-		<description>Kuma Logo (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="kuma logo (1984)(kuma computers)(gb).dsk" size="737280" crc="48879bcf" sha1="85b774b9104772a7856b9df8777c141e3b2a3a21" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kungfum">
-		<description>Kung Fu Master (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="kung fu master (1984)(ascii)(jp).dsk" size="737280" crc="9be8e298" sha1="bbcbdab72a9e83830dc7fb44c5b947ef86c01a93" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="laberint">
-		<description>Laberinto (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="laberinto (1985)(advance)(es).dsk" size="737280" crc="fdb5b51b" sha1="e94e05a6e1cbe823baf061cdb661edde27fb888c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lsafary">
-		<description>Lady Safary (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="lady safary (1988)(omk software)(es).dsk" size="737280" crc="677b366b" sha1="6f2c82b9df01d85bc952546ea1c209f4092e8b8b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lsafarya" cloneof="lsafary">
-		<description>Lady Safary (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="lady safary (1988)(omk software)(es)[a].dsk" size="737280" crc="d09dfd5e" sha1="ed06a60362c4cc192b3ab9451f5472955616eead" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="laptick2">
-		<description>Laptick 2 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cat2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="laptick 2 (1985)(db-soft)(jp).dsk" size="737280" crc="eb9da871" sha1="06c00c821cee29841ab53dfe199dae01e9b0ea71" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lastmiss">
-		<description>The Last Mission (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="last mission, the (1987)(opera soft)(es).dsk" size="737280" crc="715d13e9" sha1="9384a5b9f79cb9c3437990594e538fd0f41cdd60" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lastmissa" cloneof="lastmiss">
-		<description>The Last Mission (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="last mission, the (1987)(opera soft)(es)[a].dsk" size="737280" crc="5c433913" sha1="f8a6f331abb61d28b8f299827832e24d9ec32269" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lazerbyk">
-		<description>Lazer Bykes (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="lazer bykes (1985)(pss)(gb).dsk" size="737280" crc="92592635" sha1="1393a054995cd750c9c695c8c11eeb82d0239ba3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lazerbyka" cloneof="lazerbyk">
-		<description>Lazer Bykes (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="lazer bykes (1985)(pss)(gb)[a].dsk" size="737280" crc="c6d1ce9c" sha1="e2a6696ec334a0b0d14a6e651bff1806ebdf42f2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lazyjon">
-		<description>Lazy Jones (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="lazy jones (1985)(terminal software)(gb).dsk" size="737280" crc="43cf5ee9" sha1="9e579752d716ba54cdda0f3bf4174c75fda38319" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lemans">
-		<description>Le Mans (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="le mans (1984)(electric software)(gb).dsk" size="737280" crc="1ead7cc4" sha1="479d23f851aa191061b5e1deabef4f8e71bc6fcd" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="lemans2">
-		<description>Le Mans 2 (UK)</description>
+		<description>Le Mans 2 (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -10064,96 +4567,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="legend">
-		<description>Legend (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="legend (1988)(iber soft)(es).dsk" size="737280" crc="1b8d87be" sha1="cd2f27b200d541041a015f3e1378a61975b20354" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="legends">
-		<description>Legends (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="legends - leyendas (19xx)(mind games espana)(es).dsk" size="737280" crc="5d9daca2" sha1="d3db4e2f1dd2d09579fdc3c1624b445621b86501" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lic2kill">
-		<description>Licence to Kill (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="007 - licence to kill (1989)(domark)(gb).dsk" size="737280" crc="449bab0f" sha1="e752308c3d2bcbb987daa92a3fb454bc5d1f475c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ldrun2">
-		<description>Lode Runner II (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="lode runner ii (1985)(sony)(jp).dsk" size="737280" crc="8f3d5cd7" sha1="e0eb10be6ccd3907f5195daa2fb3b9a753724fa9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="loteriap">
-		<description>Loteria Primitiva (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="loteria primitiva (1985)(loto lar)(es).dsk" size="737280" crc="cf63ebef" sha1="cca27963489d9ea75f4b201654e0d6db61152b8b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lunarbal">
-		<description>Lunar Ball (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="lunar ball (1985)(pony canyon)(jp).dsk" size="737280" crc="6e14da29" sha1="45d6357b57ad85dcb8d37985942f14bdf2b3cdf1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="macattac">
-		<description>Mac Attack (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mac attack (1986)(eaglesoft)(nl).dsk" size="737280" crc="76074e29" sha1="b8bbac5cbf9528918201c20f8a1d5ee6b6e308c9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="macadam">
-		<description>Macadam Bumper (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="macadam bumper (1985)(sony)(jp).dsk" size="737280" crc="9df875c0" sha1="08a8a6c69352c7488d2c3013357f3b2206dcdcd7" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- Generation-msx only has images of a cassette release, but only a dump of a cartridge and this possible disk conversion are known. -->
 	<software name="mgunjoe">
-		<description>Machinegun Joe vs The Mafia (Japan)</description>
+		<description>Machinegun Joe vs The Mafia (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -10163,846 +4579,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="madmix">
-		<description>Mad Mix Game (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mad mix game (1988)(topo soft)(es).dsk" size="737280" crc="39f5b47c" sha1="683dac6d070403944efbfab9dd78d8e15b1a6542" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="madmixa" cloneof="madmix">
-		<description>Mad Mix Game (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mad mix game (1988)(topo soft)(es)[a].dsk" size="737280" crc="29d99c3c" sha1="5809930fba76bd1f04bcc406ff02af0ec97c91e9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="magicjbb">
-		<description>Magic Johnson's Basketball (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="magic johnson's basketball (1990)(dro soft)(es).dsk" size="737280" crc="52efe0e6" sha1="ac4f214e9bd47d4b2dddbf45bc770cd59f8fda6b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="magicpin">
-		<description>Magic Pinball (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="magic pinball (1987)(omk software)(es).dsk" size="737280" crc="06d3cccd" sha1="cd7ea60143ea7cd452534c73bf5950a3a0091671" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mkidwiz">
-		<description>Magical Kid Wiz (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="magical kid wiz (1986)(sony)(jp).dsk" size="737280" crc="5a566a05" sha1="9f6db10d6d780ccb2973dd81bcfbfd46c0eca26a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="magtree">
-		<description>Magical Tree (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="magical tree (1984)(konami)(jp).dsk" size="737280" crc="9f8ca813" sha1="11bfffbdc758190ca681f3704b7de97774ffb042" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="empcity">
-		<description>Magnum Kiki Ippatsu - Empire City 1931 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="magunam. kiki ippatsu. magnum prohibition 1931 (1988)(toshiba-emi)(jp).dsk" size="737280" crc="d04262e0" sha1="49ff0fd21cc86b1c314f4d6a1feedd75298d1eb8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="empcitya" cloneof="empcity">
-		<description>Magnum Kiki Ippatsu - Empire City 1931 (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="magunam. kiki ippatsu. magnum prohibition 1931 (1988)(toshiba-emi)(jp)[a].dsk" size="737280" crc="6ee4a8a8" sha1="36aceb03157f4e1bb65adc54bbb84ffa9a04bcaf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mjdojo">
-		<description>Mahjong Dojo (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mahjong (1984)(konami)(jp).dsk" size="737280" crc="396b74f0" sha1="e83d8d3a4699d7d7c559eaeecdb1ae849f0f2858" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mambo">
-		<description>Mambo (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mambo (1989)(positive)(es).dsk" size="737280" crc="83411f57" sha1="c6dc757c9e42c6a3a1a96fd95c0561f2982a3e27" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mamboa" cloneof="mambo">
-		<description>Mambo (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mambo (1989)(positive)(es)[a].dsk" size="737280" crc="40dcc9da" sha1="86576500f537001684681918d0fab230d077eaef" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mandragr">
-		<description>Mandragore (France)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mandragore (1986)(infogrames)(fr)(fr).dsk" size="737280" crc="e3bfb380" sha1="38015e19d6d4a970f5961d99514599044523795d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="manes">
-		<description>Manes (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="manes (1984)(ascii)(jp).dsk" size="737280" crc="3c987a56" sha1="ce180893b044120817d98f79bef25c1550b8cf64" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="manicmin">
-		<description>Manic Miner (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="manic miner (1984)(software projects)(gb).dsk" size="737280" crc="95d35093" sha1="e27e95236b4cf23333df7bd12655221819b4058d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mapgame">
-		<description>Map Game (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="map game (1985)(erbe software)(es).dsk" size="737280" crc="c47d852c" sha1="6c8df72ee02e0f3e2d2e7a8bde138f716215adc4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mapgamea" cloneof="mapgame">
-		<description>Map Game (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="map game (1985)(erbe software)(es)[a].dsk" size="737280" crc="d050732b" sha1="7240be5da18bdf3b42c9873792ef45b92d8996b4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mappy">
-		<description>Mappy (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mappy (1984)(namcot)(jp).dsk" size="737280" crc="4d6fc601" sha1="3ca5e209d633aba8baf80d250b9047ad32b6d378" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="marinbat">
-		<description>Marine Battle (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="marine battle (1983)(ascii)(jp).dsk" size="737280" crc="c48eb822" sha1="c42da58f5c8bf1eec9924217d98cb30122d10227" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="martian">
-		<description>Martianoids (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="martianoids (1987)(ultimate play the game)(gb).dsk" size="737280" crc="6ce501e3" sha1="f6aae705a2bcf19a124a7fbceac48b06e6675f53" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mask2">
-		<description>Mask II (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mask ii (1987)(gremlin graphics software)(gb).dsk" size="737280" crc="baaa608e" sha1="2e5a1ec2bd64a3d44c6badbb2d881e07d72220c6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mask2a" cloneof="mask2">
-		<description>Mask II (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mask ii (1987)(gremlin graphics software)(gb)[a].dsk" size="737280" crc="535aec9a" sha1="a5f6d392898538adc9a1a0f4c1e2b4ad31d7da15" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mastches">
-		<description>Master Chess (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="master chess (1987)(mastertronic)(gb).dsk" size="737280" crc="45cd2e82" sha1="10c7bf557ad8909fc42e7f4085a13c8cc680d375" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mastlamp">
-		<description>Master of the Lamps (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="master of the lamps (1985)(activision)(us).dsk" size="737280" crc="8c1ec2bb" sha1="3a78463fbff471438de8a19d8474b6a30470dfc6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mastvoic">
-		<description>Master Voice (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="master voice (1985)(aackosoft)(nl).dsk" size="737280" crc="702f07ca" sha1="6a7ad3a77e1897223f045c0a7f2edaa0932e75cb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="matchda2">
-		<description>Match Day II (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="match day ii (1987)(ocean software)(gb).dsk" size="737280" crc="ba15c1f9" sha1="9f3cc2d583855abe8cbac8bc50fe72c6a7177bdb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="matchda2a" cloneof="matchda2">
-		<description>Match Day II (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="match day ii (1987)(ocean software)(gb)[a].dsk" size="737280" crc="c2442311" sha1="1e9197dd4dbaf76af31285789d6953d1a57c00d1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mathsinv">
-		<description>Maths Invaders (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="maths invaders (1985)(aackosoft)(nl).dsk" size="737280" crc="99e37fd2" sha1="f68740cdc9f5915747ad3aabd526d5834285ab8f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="maxima">
-		<description>Maxima (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="maxima (1984)(pss)(gb).dsk" size="737280" crc="f0b3ad23" sha1="b3cd4d6558789ec6be7e2025ea7fd2d2160d873b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mazesunl">
-		<description>Mazes Unlimited (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mazes unlimited (1986)(eaglesoft)(nl).dsk" size="737280" crc="6281156e" sha1="b4b97cad5d936f33f3a43e45327395bf953b74f9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="maziacs">
-		<description>Maziacs (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="maziacs (1985)(dk'tronics)(gb).dsk" size="737280" crc="3129db49" sha1="83388f6fdac64551de50444d79d82e240756676a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mecom">
-		<description>Mecom (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mecom (1988)(iber soft)(es)[aka mekong].dsk" size="737280" crc="7f682ee5" sha1="21c3e27c4670b8546573f0be70bdeed1951306d3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="megaches">
-		<description>Mega Chess (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mega chess (1988)(iber soft)(es)[aka super chess].dsk" size="737280" crc="d869e27e" sha1="a0ed66a5c66c0bd1ce5f41d9fc9f07f220721f4c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="megalsos">
-		<description>Megalopolis SOS (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="megalopolis sos (1986)(compile).dsk" size="737280" crc="f042e2dc" sha1="afb824cb818cfb1e29e4a0ebe8b13e6660b6b44f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="meganova">
-		<description>Meganova (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="meganova (1988)(dinamic software)(es).dsk" size="737280" crc="21922d91" sha1="46d8c7af079aa95cc4a773fdd524e18c0f6037e1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="meganovaa" cloneof="meganova">
-		<description>Meganova (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="meganova (1988)(dinamic software)(es)[a].dsk" size="737280" crc="b05d57f6" sha1="9580a233fb82f99850b3e3bd05a5e0f2ef382062" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="megaphx">
-		<description>Megaphoenix (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="megaphoenix (1991)(dinamic software)(es).dsk" size="737280" crc="503e40ac" sha1="c3d2cf0075f914e76512fbb7206f0c4ab7b4a46d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="megaphxa" cloneof="megaphx">
-		<description>Megaphoenix (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="megaphoenix (1991)(dinamic software)(es)[a].dsk" size="737280" crc="295ab8de" sha1="7aeb4dc05b73473344dd5f1fda20426eeed17fc3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="merlin">
-		<description>Merlin (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="merlin (1987)(mind games espana)(es).dsk" size="737280" crc="1cf5c264" sha1="612ed6dd52067afb75ba1987b543769c00c5ef84" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="metropol">
-		<description>Metropolis (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="metropolis (1989)(topo soft)(es).dsk" size="737280" crc="49413262" sha1="239d02eca74a44008ad8a3607f96d4d8dd27056f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="metropola" cloneof="metropol">
-		<description>Metropolis (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="metropolis (1989)(topo soft)(es)[a].dsk" size="737280" crc="d5c54e66" sha1="f8cdc960bb04b3a870d06abdcf458ea5f72e2c30" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="michel">
-		<description>Michel Futbol Master (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="michel futbol master (1989)(dinamic software)(es).dsk" size="368640" crc="8ade9434" sha1="515ed586374f0864f731aa6f592ba3ee95ac2d3c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="michela" cloneof="michel">
-		<description>Michel Futbol Master (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="michel futbol master (1989)(dinamic software)(es)[a].dsk" size="737280" crc="4aed10e9" sha1="4ba1ed443ae97fa074bb9cd25fbb9db4a5445bce" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="midbros">
-		<description>Midnight Brothers (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="midnight brothers (1986)(sony)(jp).dsk" size="737280" crc="a2c72802" sha1="ca83aa48042c8eedf3881e8802849e8572093f1d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="midbuild">
-		<description>Midnight Building (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="midnight building (1984)(ascii)(jp).dsk" size="737280" crc="314e217d" sha1="99fe639f85ad828baca2486afc374c7d707011d4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mikegunn">
-		<description>Mike Gunner (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mike gunner (1988)(dinamic software)(es)[gunstick].dsk" size="737280" crc="1c9df0de" sha1="8ef6f37252879143342b210ed1cad2e1f4447390" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mikegunna" cloneof="mikegunn">
-		<description>Mike Gunner (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mike gunner (1988)(dinamic software)(es)[a][gunstick].dsk" size="737280" crc="ab5e79aa" sha1="3e231cca04784ecd15f0457ab0d8198f07a0f461" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="milcaras">
-		<description>Mil Caras (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mil caras (1985)(idealogic)(es).dsk" size="737280" crc="4815eac7" sha1="0430c4c5003be750a220888a62a27f7bb42a7bed" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="milkrace">
-		<description>Milk Race (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="milk race (1987)(mastertronic)(gb).dsk" size="737280" crc="5a5da238" sha1="74b9e018d923850c185b5345009699384a8d33ab" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="minigolf">
-		<description>Mini Golf (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mini golf (1985)(namcot)(jp).dsk" size="737280" crc="dd62d386" sha1="e4f9c2b289db1901156f03b0e0cdbc967b7b5c70" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mirai">
-		<description>Mirai (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mirai. future (1987)(xain)(jp).dsk" size="737280" crc="dc7bc9be" sha1="5e5435fa6b715cc75c13f9cea223c586fe00e680" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="miraia" cloneof="mirai">
-		<description>Mirai. Future (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mirai. future (1987)(xain)(jp)[a].dsk" size="737280" crc="618a069a" sha1="41fd6e52aeced7acbde0ce2680f707d3a26c219d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="misionre">
-		<description>Mision Rescate (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mision rescate (1986)(anaya multimedia)(es).dsk" size="737280" crc="ae55b0d1" sha1="b801fbbf572906fba8f0973d0dbcb641b287a47d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="misionrea" cloneof="misionre">
-		<description>Mision Rescate (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mision rescate (1986)(anaya multimedia)(es)[a].dsk" size="737280" crc="e48a4dc4" sha1="73f19cf73547759b4cdd59941a87b87b0eeb4707" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mistnilo">
-		<description>El Misterio del Nilo (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="misterio del nilo, el (1987)(zigurat software)(es).dsk" size="737280" crc="7f05a273" sha1="55c185944989533f8997c2b0ff49f3571a748c2b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mistniloa" cloneof="mistnilo">
-		<description>El Misterio del Nilo (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="misterio del nilo, el (1987)(zigurat software)(es)[a].dsk" size="737280" crc="7e174026" sha1="77b043af03b066fa6638f00a4706e3a8335cd601" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mitsumgt">
-		<description>Mitsume ga Tooru - The Three-Eyed One Comes Here (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 128K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mitsume ga tooru. the three-eyed one comes here (1989)(natsume)(jp)[needs 128k].dsk" size="737280" crc="97cf0350" sha1="f4aca91714f872d39c85f3df55364aa2c249d824" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mitsumgta" cloneof="mitsumgt">
-		<description>Mitsume ga Tooru - The Three-Eyed One Comes Here (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<info name="usage" value="needs 128K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mitsume ga tooru. the three-eyed one comes here (1989)(natsume)(jp)[a][needs 128k].dsk" size="737280" crc="32f8fbea" sha1="bce66b3acb6d7fb36e52091d90cbc9d2a634c31e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mokarima">
-		<description>Mokari Makka? Bochibochi Denna! (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mo-karimakka. bochibochidenna sport (1986)(leben pro)(jp).dsk" size="737280" crc="b6f19c38" sha1="122ca778ee8ddb2bea4b6f7a74b62a819f7d8d60" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="moaihiho">
-		<description>Moai no Hihou (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="moai no hihou. secret treasure of moai (1986)(casio)(jp).dsk" size="737280" crc="051ccfdc" sha1="6920e4e265bbd5a94ac1282edef931bdbef23240" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="suthir">
-		<description>Mobile Planet Suthirus - Approach from the Westgate (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mobile planet stylus - approach from the westgate (1986)(hal laboratory)(jp).dsk" size="737280" crc="2ba3aba7" sha1="e1c09469a7828227c4e9afd4047bf39f34695813" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gundam">
-		<description>Mobile-Suit Gundam - Last Shooting (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mobile suit gundam (1984)(bandai)(jp).dsk" size="737280" crc="7610dc91" sha1="3b9d4271c2f189fbb4e1d421a3c798719c2f97d3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="molecule">
-		<description>Molecule Man (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="molecule man (1986)(mastertronic)(gb).dsk" size="737280" crc="e85beabc" sha1="5c6df152634f96dade8ed442944a4ec79d6581da" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="monkeyac">
-		<description>Monkey Academy (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="monkey academy (1984)(konami)(jp).dsk" size="737280" crc="3879ebed" sha1="fdc60908083520781dcfd185b9c4869cd0d40d76" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="megamit">
-		<description>Digital Devil Monogatari - Megami Tensei (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="monogatari megami tensei. digital devil story (1987)(telenet japan)(jp).dsk" size="737280" crc="2df548e1" sha1="370a8fa4f4474399d799e8e37df7386306176b3b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="megamita" cloneof="megamit">
-		<description>Digital Devil Monogatari - Megami Tensei (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="monogatari megami tensei. digital devil story (1987)(telenet japan)(jp)[a].dsk" size="737280" crc="3703362e" sha1="dc8d471a0e7c52d280466bab18c2e3e63d932644" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="monopoly">
-		<description>Monopoly (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="monopoly (1986)(leisure genius)(gb).dsk" size="737280" crc="9f273c23" sha1="9ef9609ffed1efc7dcb9923e59f657de54a50fe9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mnstfair">
-		<description>Monster's Fair (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="monster's fair (1984)(toho)(jp).dsk" size="368640" crc="0a6eed7d" sha1="6074ceed602612ae6e46ddd26e9bde19f2b32814" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mnstfaira" cloneof="mnstfair">
-		<description>Monster's Fair (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="monster's fair (1984)(toho)(jp)[a].dsk" size="737280" crc="4b2b9ccb" sha1="17a87541351c28d5c815fcc8ddf86f219d9ae572" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mpatrol">
-		<description>Moon Patrol (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="moon patrol (1984)(irem)(jp).dsk" size="737280" crc="d4dee6fe" sha1="7735a75c4f47b5278d0f080183084279efd4097b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="moonridr">
-		<description>Moon Rider (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="moon rider (1986)(eaglesoft)(nl).dsk" size="737280" crc="701a6c70" sha1="937c65ae57f4e4a9a0417099d4a2471e80a4c7de" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="moonswep">
-		<description>Moonsweeper (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="hayabusa. moonsweeper (1985)(toshiba-emi)(jp).dsk" size="737280" crc="28ed57ed" sha1="59c24757dc1aac5512e1ac869111da4652700cdd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="moonwalk">
-		<description>Moonwalker (UK, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="moonwalker (1989)(us gold)(gb)[t].dsk" size="737280" crc="537b4723" sha1="3a746ede44cab624aed3af55537e751b58fbd3a8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mopirang">
-		<description>Mopiranger (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mopi ranger (1985)(konami)(jp).dsk" size="737280" crc="d2996df5" sha1="ee2938fcd06240035a275a3b5556a8dbf3adda2e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mortadel">
-		<description>Mortadelo y Filemon (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mortadelo y filemon (1988)(dro soft)(es).dsk" size="737280" crc="a056d0ed" sha1="287851ad894f257acf4f51e0d68bc23f3e31f6dc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mortade2">
-		<description>Mortadelo y Filemon II - Safari Callejero (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mortadelo y filemon ii - safari callejero (1990)(dro soft)(es).dsk" size="737280" crc="f3e82233" sha1="dcf666041418a7f457aeb41e92463e2780f34e0f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mortade2a" cloneof="mortade2">
-		<description>Mortadelo y Filemon II - Safari Callejero (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mortadelo y filemon ii - safari callejero (1990)(dro soft)(es)[a].dsk" size="737280" crc="bfb09167" sha1="62dd77b978a24a220a121db581274a2d3f020200" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- According to generation msx this was only released on a cartridge but only cassette and disk dumps exist -->
 	<software name="amazmem">
-		<description>The Most Amazing Memory Game (Spain)</description>
+		<description>The Most Amazing Memory Game (Spain, disk conversion?)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -11012,19 +4591,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="mot">
-		<description>Mot (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="mot (1989)(opera soft)(es).dsk" size="368640" crc="a01b5041" sha1="f32562ba7777cb17b15363f0aaa0efb5348609e7" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- Cassette version of part 1 is dumped, part 2 is not. -->
 	<software name="sideral">
-		<description>El Motorista Sideral (Spain)</description>
+		<description>El Motorista Sideral 1 + 2 (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -11034,184 +4603,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="siderala" cloneof="sideral">
-		<description>El Motorista Sideral (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="motorista sideral, el (1986)(anaya multimedia)(es)[a].dsk" size="737280" crc="76f81108" sha1="2b3618e8525b4e58e85436c336d33473a11dd807" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mountbik">
-		<description>Mountain Bike Racer (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mountain bike racer (1990)(positive)(es).dsk" size="737280" crc="3924e60a" sha1="02f3f9a712df1625176eaa0c790b493926c616d7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mountbika" cloneof="mountbik">
-		<description>Mountain Bike Racer (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mountain bike racer (1990)(positive)(es)[a].dsk" size="737280" crc="8d53e02d" sha1="bf7a2fd77ccef10fd29fb15c43436f13d8bea7d2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mouser">
-		<description>Mouser (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mouser (1983)(sony)(jp).dsk" size="737280" crc="4a4482c8" sha1="f3f68b24172ea2fd85470fe5a46a031f9c514735" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mrchin">
-		<description>Mr. Chin (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mr. chin (1984)(hal laboratory)(jp).dsk" size="737280" crc="862d9f8b" sha1="3ccb29045267642069b260220b60d0ca534c8973" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mrdovsun">
-		<description>Mr. Do! vs Unicorns (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mr. do vs unicorns (1984)(sony)(jp).dsk" size="737280" crc="52be0090" sha1="e846fceaf36ffbb850aaad0e081c24631951010d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mrdowild">
-		<description>Mr. Do's Wild Ride (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mr. do's wildride (1985)(nippon columbia - colpax - universal).dsk" size="737280" crc="52a44314" sha1="422073cb62618fcb3b90650aa9c44a3314a487ce" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mrwong">
-		<description>Mr. Wong's Loopy Laundry (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mr. wong's loopy laundry (1984)(artic computing)(gb).dsk" size="737280" crc="464d56bc" sha1="11a2cc9aa0a8f3b4c6e8c68f8807639cf8aa50d2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mrwonga" cloneof="mrwong">
-		<description>Mr. Wong's Loopy Laundry (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="mr. wong's loopy laundry (1984)(artic computing)(gb)[a].dsk" size="368640" crc="7a43aa19" sha1="b18bafe9602a3629f10198544282d7419b287c08" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="msx21">
-		<description>MSX 21 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="msx-21 (1983)(ascii)(jp).dsk" size="737280" crc="7b8cebe1" sha1="41b997522b5f11b2adbbd7007ee6c284e7bb9061" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="msxbball">
-		<description>MSX Baseball (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="msx baseball (1984)(panasoft)(jp).dsk" size="737280" crc="0e1097d7" sha1="e30aebbdb3e1c74a0b2dbc0e6c8cbd935c03d344" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="suptenn">
-		<description>MSX Super Tennis (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="super tennis (1985)(sony)(jp).dsk" size="737280" crc="8a160391" sha1="ef94e747ecaae575eabc4fe0c933ea309430dd37" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="musicedi">
-		<description>Music Editor - MUE (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mue - music editor (1984)(hal laboratory)(jp).dsk" size="737280" crc="55a08e0d" sha1="c4e0ef932f2c4acf95815302482fe815c60fa6ec" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mundifut">
-		<description>Mundial de Futbol (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mundial de futbol (1990)(opera soft)(es).dsk" size="737280" crc="138000c8" sha1="5c692f842cf18a2c2da6b14a8645e492e2a6d1b9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mundoper">
-		<description>El Mundo Perdido (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mundo perdido, el (1988)(topo soft)(es).dsk" size="737280" crc="40a1348b" sha1="42fd874cc7ea6fc5f5bdcce4f00d70d0006a2f42" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mundopera" cloneof="mundoper">
-		<description>El Mundo Perdido (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mundo perdido, el (1988)(topo soft)(es)[a].dsk" size="737280" crc="a6ffdb6c" sha1="a1c19f6411e04f7e8bb0b313579f90f5c3a0dc81" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- Contains only the cartridge data, not the cassette part of Music Studio G7 -->
 	<software name="musicg7">
-		<description>Music Studio G7 (Japan)</description>
+		<description>Music Studio G7 (Japan, disk conersion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -11221,8 +4615,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Contains only the cartridge data, not the cassette part of Music Studio G7 -->
 	<software name="musicg7a" cloneof="musicg7">
-		<description>Music Studio G7 (Japan, alt)</description>
+		<description>Music Studio G7 (Japan, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -11232,171 +4627,20 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="mutanzon">
-		<description>Mutan Zone (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="mutan zone (1989)(opera soft)(es).dsk" size="368640" crc="b436e42b" sha1="ff4d43f0247258bafcf06d6f365a60f3e1bed4c4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mutanzona" cloneof="mutanzon">
-		<description>Mutan Zone (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mutan zone (1989)(opera soft)(es)[a].dsk" size="737280" crc="ae7413f9" sha1="9bc3ec37ecda05fe96d999c87784bfc21baddfb4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mutmonty">
-		<description>Mutant Monty (UK, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="mutant monty (1985)(artic computing)(gb)[t +1].dsk" size="737280" crc="21b4704e" sha1="a76161e34f0ea23586903676d80dbabf8f8d69bf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="nkoshien">
-		<description>Nessen Koushien (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="nessen koushiyen. exciting baseball (1984)(casio)(jp).dsk" size="737280" crc="acc3f9b6" sha1="b59988f4303317a2a193318a4ac470b45acb5ff6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="nflight">
-		<description>Night Flight (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="night flight (1982)(nippon columbia - colpax - universal).dsk" size="737280" crc="3f858bea" sha1="976aa402adb7d75e6e02018e7b319ea2ac08ac9f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="nightshd">
-		<description>Nightshade (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="nightshade (1985)(ultimate play the game)(gb).dsk" size="737280" crc="d812172d" sha1="1ccb2c280f157a3431d4be79458131b6db4118be" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="ninjajaj">
-		<description>Ninja Jajamaru-kun (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<description>Ninja Jajamaru-kun (Europe)</description>
+		<year>1986</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8950" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="ninja jaja maru kun (1986)(nippon dexter)(jp).dsk" size="737280" crc="76ff8584" sha1="a0194f12800e932f9e1394026187f19aeefeaea8" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="ninja jaja maru kun (1986)(nippon dexter)(jp).dsk" size="737280" crc="76ff8584" sha1="a0194f12800e932f9e1394026187f19aeefeaea8" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="ninjakmb">
-		<description>Ninja-kun - Majou no Bouken (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ninja kun. majyo no bouken (1985)(nippon dexter)(jp).dsk" size="737280" crc="5e3b725a" sha1="04dcc7fddb5d892e72907464a4f15224020e7cd9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ninjapri">
-		<description>Ninja Princess (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ninja princess (1986)(pony canyon)(jp).dsk" size="737280" crc="1afd6605" sha1="e6848392c30e6cd64065dc0bdf05a4f2f186db25" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ninjakag">
-		<description>Ninjya Kage (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ninjya kage (1984)(hudson soft)(jp).dsk" size="737280" crc="4d814132" sha1="f6575ce16f065c3f657b10ae855344aab48d60f9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="nonamed">
-		<description>Nonamed (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="nonamed (1986)(dinamic software)(es).dsk" size="737280" crc="8cf33438" sha1="942d15eac606f93be9d6c3e7bcca8959c823206e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="nonameda" cloneof="nonamed">
-		<description>Nonamed (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="nonamed (1986)(dinamic software)(es)[a].dsk" size="737280" crc="ddbdc3a2" sha1="73d5e115779af8ce05da28a283253fd3f6fae2b7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="nucbowls">
-		<description>Nuclear Bowls (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="nuclear bowls (1986)(zigurat software)(es).dsk" size="737280" crc="84aa6f3a" sha1="42dd975d576e2fa237473d6338e1096aa41ecc4d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="nucbowlsa" cloneof="nucbowls">
-		<description>Nuclear Bowls (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="nuclear bowls (1986)(zigurat software)(es)[a].dsk" size="737280" crc="37f378ab" sha1="2672fe206abf9d8cf155814e44819a7fb0441a89" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="numpaint">
-		<description>Number Painter (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="number painter (19xx)(ask)(gb).dsk" size="737280" crc="05e0c920" sha1="d9f8f31054ad2a2db89a33c6035c42aadb742083" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- According to generation-msx only released on cassette, but only a cartridge and this disk dump/conversion found? -->
 	<software name="nutsmilk">
 		<description>Nuts &amp; Milk (Japan)</description>
 		<year>19??</year>
@@ -11408,206 +4652,34 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="omacfarm">
-		<description>O'Mac Farmer (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="o'mac farmer (1984)(ascii)(jp).dsk" size="737280" crc="95ff94ee" sha1="68f4f6bf2fae4f494e4941296522fcce6e7a54ea" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="obliter">
-		<description>Obliterator (Spain, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="obliterator (1989)(dro soft)(es)[t].dsk" size="737280" crc="0807689e" sha1="ea4ddd87978b1325a6af0d06a760f8fea93a0c94" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="oceancnq">
-		<description>Ocean Conqueror (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ocean conqueror (1987)(mastertronic)(gb).dsk" size="737280" crc="41762e1f" sha1="4fd0397c59975654d06a940003f4a71da06d1786" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="octagon">
-		<description>Octagon Squad (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="octagon squad (1986)(mastertronic)(gb).dsk" size="737280" crc="6dd78e32" sha1="852d89706053f9e9261c3d8faafbb5abe5ae1718" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="octagona" cloneof="octagon">
-		<description>Octagon Squad (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="octagon squad (1986)(mastertronic)(gb)[a].dsk" size="737280" crc="73f180f5" sha1="d8d5feb4b69a067bb01038c9dcf31a3cc8cd4969" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ohmummy">
-		<description>Oh Mummy!! (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="oh mummy (1984)(longman software)(gb).dsk" size="737280" crc="9cf775cc" sha1="cd7db0faf25ae33699b1708a19a874e3662e158a" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="ohshit">
-		<description>Oh Shit! (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>Oh Shit! (Netherlands)</description>
+		<year>1985</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8355" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="oh shit (1986)(aackosoft)(nl).dsk" size="737280" crc="735ebc21" sha1="7de3f69a8a5136e0dd25214d36b1194a6506b377" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="oh shit (1986)(aackosoft)(nl).dsk" size="737280" crc="735ebc21" sha1="7de3f69a8a5136e0dd25214d36b1194a6506b377" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="oilswell">
-		<description>Oil's Well (Netherlands)</description>
+		<description>Oil's Well (Europe))</description>
 		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8183" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="oil's well (1985)(eaglesoft)(nl).dsk" size="737280" crc="312ac7a2" sha1="d3e55c98f08247f91c4a77ed9899565585738ff8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ole">
-		<description>Ole! (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ole (1986)(bug-byte software)(gb)(fr).dsk" size="737280" crc="4be9ec52" sha1="516d6c6403528c996b465564f147e4723fc78bce" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="opwolf">
-		<description>Operation Wolf (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="operation wolf (1988)(ocean software)(gb).dsk" size="737280" crc="6db00bf1" sha1="0d5d3854098059fcffbbc065ba276649a3b10866" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ormuz">
-		<description>Ormuz (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ormuz (1988)(iber soft)(es).dsk" size="737280" crc="99ceb487" sha1="77657a23a04ff9d2990a312aa96e60632b1dd189" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ormuza" cloneof="ormuz">
-		<description>Ormuz (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ormuz (1988)(iber soft)(es)[a].dsk" size="737280" crc="10a29788" sha1="e9153c0ec0609a02a7a37f298c503797e3e98bfc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="outroyd">
-		<description>Outroyd (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="outroyd (1985)(magical zoo)(jp).dsk" size="737280" crc="8c6b2cc7" sha1="64f170fd8cdc0d611494bdc3e83c8d84c9e14077" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pacland">
-		<description>Pac-Land (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pac-land (1988)(grandslam entertainments)(gb).dsk" size="737280" crc="1dea6b7f" sha1="31ea900f3ac0de505f7958b45cf7cb35b74066dc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pacmania">
-		<description>Pac-Mania (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pac-mania (1988)(grandslam entertainments)(gb).dsk" size="737280" crc="13a53309" sha1="8a62f143c837185edce4c3796180ffa8f2755cff" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="paipanic">
-		<description>Pai Panic (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pai panic (1983)(ascii)(jp).dsk" size="737280" crc="a28496e9" sha1="f8901c1893204f13d119e0191aa4f7ec0f41a740" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pairs">
-		<description>Pairs (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pairs (1983)(ascii)(jp).dsk" size="737280" crc="fb4a4c4b" sha1="7770479c8452e092bbe5e969fe2b8c34ea68dc7f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="panelpan">
-		<description>Panel Panic (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="panelpan (19xx)(eaglesoft)(nl).dsk" size="737280" crc="cec2fee3" sha1="036ad083ed0f9ee2c5eb0972f249b78a4fe98a1f" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="oil's well (1985)(eaglesoft)(nl).dsk" size="737280" crc="312ac7a2" sha1="d3e55c98f08247f91c4a77ed9899565585738ff8" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="panicjun">
-		<description>Panic Junction (UK)</description>
+		<description>Panic Junction (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -11617,283 +4689,21 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="panique">
-		<description>Panique (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="panique (1986)(eaglesoft)(nl).dsk" size="737280" crc="dde9129d" sha1="0d23b576db02839a86f38f5e711ac78aa001add3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="panzerat">
-		<description>Panzer Attack (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="panzer attack (1985)(mc lothlorien)(gb).dsk" size="737280" crc="93c9e98b" sha1="5f0269c6f9bdd8bcb2c19209fd22e4b49cb15ef8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pdakar">
-		<description>Paris-Dakar (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="paris-dakar (1988)(zigurat software)(es).dsk" size="737280" crc="a41710f9" sha1="828ab992cb3f20916915cc956d5a89a2668923f7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pdakara" cloneof="pdakar">
-		<description>Paris-Dakar (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="paris-dakar (1988)(zigurat software)(es)[a].dsk" size="737280" crc="b1d0ec79" sha1="15c1b4164fcc534f77d3cf419ee516fb67815530" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="parodius">
-		<description>Parodius - Tako wa Chikyuu wo Sukuu (Japan, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="parodius - tako saves earth (1988)(konami)(jp)[t martos][scc].dsk" size="737280" crc="c9710edb" sha1="5fd9f036a0c8a668896626ba22b9852d3d99bb5c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="passshot">
-		<description>Passing Shot (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="passing shot (1989)(image works)(gb).dsk" size="737280" crc="fb805e63" sha1="0433c8cdf3ba57f8eb860df2655918af3a5cec2e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pastfind">
-		<description>Pastfinder (US)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pastfinder (1984)(activision)(us).dsk" size="737280" crc="01c7685d" sha1="bf8e6d36a42b3ec109ad7261455c2c940fe83f21" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="payload">
-		<description>Pay Load (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="payload (1985)(sony)(jp).dsk" size="737280" crc="4da87d1e" sha1="20696a5a0c1482f01af96269902264a41186fccd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="peetan">
-		<description>Peetan (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="peetan (1984)(nippon columbia - colpax - universal).dsk" size="737280" crc="32ad1450" sha1="f574e239fe36783f4d24eb3b07a6736970c3de77" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="penguinw">
-		<description>Penguin-kun Wars (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="penguin kun wars (1985)(ascii)(jp).dsk" size="737280" crc="30c75413" sha1="91441130d0d5626b2014ef40a542f39f90806414" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pentagrm">
-		<description>Pentagram (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pentagram (1986)(ultimate play the game)(gb).dsk" size="737280" crc="68368237" sha1="fd1a785abc47b1bd40d661dabd7dac6fbdb43c2b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pepesalt">
-		<description>Pepe Saltarin (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pepe saltarin (1986)(grupo de trabajo software)(es).dsk" size="737280" crc="e8933f18" sha1="e2a38b46e068535bffea9fe70c1a88255fcfd803" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="beardsif">
-		<description>Peter Beardsley's International Football (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="peter beardsley's international football (1988)(grandslam entertainments)(gb).dsk" size="737280" crc="75360cca" sha1="e169b030d33f8e3fc157e9ed2c2eb0ef8e16036e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="phantis">
-		<description>Phantis (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="phantis (1987)(dinamic software)(es).dsk" size="737280" crc="dbe194ce" sha1="480717ef558400910f20b1b7ee07cc0896a8be1e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="phantom2">
-		<description>Phantomas 2 (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="phantomas 2 (1987)(dinamic software)(es).dsk" size="737280" crc="aab8805e" sha1="00690bb52dc10c45f450ef381d57f8487446cd2e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="phantom2a" cloneof="phantom2">
-		<description>Phantomas 2 (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="phantomas 2 (1987)(dinamic software)(es)[a].dsk" size="737280" crc="8bcce975" sha1="a426a48939e278c81e89d7045b74b1db69a3e775" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pillbox">
-		<description>Pillbox (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="color tochika. pillbox (1983)(magic software)(jp).dsk" size="737280" crc="43375fc3" sha1="3863c0c5ec472996ca9c72d3c778ee9bc55f2b89" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="picopico">
-		<description>Pico Pico (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<description>Pico Pico (Netherlands)</description>
+		<year>1986</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8368" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="pico pico (1983)(micro cabin)(jp).dsk" size="737280" crc="da1e51cc" sha1="22bfe1f8f951a7c5abd0addf17881661dca7209d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pictpuzl">
-		<description>Picture Puzzle (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="picture puzzle (1983)(hal laboratory)(jp).dsk" size="737280" crc="c1893ac9" sha1="564f6414b410c2890ed159c625e2ae40cfa10dd3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pineappl">
-		<description>Pine Applin (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pine applin (1984)(canon sale)(jp).dsk" size="737280" crc="32f86066" sha1="5a3dcd011cafa5784cdcd8eee1f1e7cd80748907" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pingball">
-		<description>Pingball Maker (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pinball maker. ball blitz (1985)(nippon columbia - colpax - universal).dsk" size="737280" crc="2dc51097" sha1="bb3edd427c29f1d8c29d44c9aeb7bc53fae34aa2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pink">
-		<description>Pink Panther (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pink panther (1988)(dro soft)(es).dsk" size="737280" crc="a6c7bfe3" sha1="d757c1d06eb314b7c6b8a04c0498b072786943cc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pinkychs">
-		<description>Pinky Chase (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pinky chase (1984)(nippon columbia - colpax - universal).dsk" size="737280" crc="8e2c104e" sha1="2bd679f9824da8e5f9ca01a85c991633f7956fbf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pipi">
-		<description>Pipi (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pipi (1985)(nippon dexter)(jp).dsk" size="737280" crc="e5c46cce" sha1="62173ceb05ddf5025fe33957da4d9a8340c481ff" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pippols">
-		<description>Pippols (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pippols (1985)(konami)(jp).dsk" size="737280" crc="e89d9539" sha1="b910531c278051fb824b44e54970f1bd0efe358f" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="pico pico (1983)(micro cabin)(jp).dsk" size="737280" crc="da1e51cc" sha1="22bfe1f8f951a7c5abd0addf17881661dca7209d" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="pitfall">
-		<description>Pitfall (UK)</description>
+		<description>Pitfall (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -11903,641 +4713,15 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="pitfall2">
-		<description>Pitfall II - Lost Caverns (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pitfall ii - lost caverns (1985)(activision)(us).dsk" size="737280" crc="91e163e8" sha1="8bcf6bfe462d6e5e2504e5efaf9ee034efba0819" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="playball">
-		<description>Play Ball (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="play ball (1986)(sony)(jp).dsk" size="737280" crc="9f2e4019" sha1="28e64d52290a32dc975de130021a8085779ee58b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="poderosc">
-		<description>El Poder Oscuro (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="poder oscuro, el (1988)(zigurat software)(es).dsk" size="737280" crc="3c7af4a6" sha1="99cb1e58e222d5a26631aff0cf9ed5ddbafe1b6d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="poderosca" cloneof="poderosc">
-		<description>El Poder Oscuro (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="poder oscuro, el (1988)(zigurat software)(es)[a].dsk" size="737280" crc="09c0cd2d" sha1="92f6a8f03170221bd81c63cbfdbbc2c8e28b02df" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="polstar">
-		<description>Polar Star (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="polar star (1984)(micro cabin)(jp).dsk" size="737280" crc="1281d982" sha1="5400cc1a64e5290814370b6d89d8bc8e9dacf3fa" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="police">
 		<description>Police Academy (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1986</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8233" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="police academy (1986)(eaglesoft)(nl).dsk" size="737280" crc="d8c92c2d" sha1="29c5aca5a37e3be6c488d31eaddbb52c245c0c74" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="policest">
-		<description>The Police Story (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="police story, the (1985)(pony canyon)(jp).dsk" size="737280" crc="42149c24" sha1="54f63ee2b177e277e5d2c060fa871788d0cc93b1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pooyan">
-		<description>Pooyan (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="konami's pooyan (1985)(hudson soft)(jp).dsk" size="737280" crc="1735c4e2" sha1="a8a26cde9b4038979c89a9c8667201446ec55a25" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="psyched">
-		<description>Psychedelia (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="psychedelia (1984)(aackosoft)(nl).dsk" size="737280" crc="53cb0187" sha1="71cf7a03d9a01eea3386f6916df9b21f09c76175" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="psycheda" cloneof="psyched">
-		<description>Psychedelia (Netherlands, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="psychedelia (1984)(aackosoft)(nl)[a].dsk" size="737280" crc="3b385818" sha1="6f530550c75804635ea61ca9d8afb7313efde4fc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="psychpig">
-		<description>Psycho Pig U.X.B. (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="psycho pig u.x.b. (1988)(us gold)(gb).dsk" size="737280" crc="0fe3d048" sha1="417b9170f1e7bee9fe9a589f73f54e1d6899b10d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="punchy">
-		<description>Punchy (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="punchy (1984)(mr. micro)(gb).dsk" size="737280" crc="0dae7528" sha1="9100ae3808ebaa8c98ec22098a6484f101ae6e74" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pyramidw">
-		<description>Pyramid Warp (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="pyramid warp (1983)(t&amp;e soft)(jp).dsk" size="737280" crc="2a10be3d" sha1="7bf625345b799ad910c116b07e19e401e179cb58" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="qbert">
-		<description>Q*Bert (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="q-bert (1986)(konami)(jp).dsk" size="737280" crc="1db8959c" sha1="12aa458d99f9a21d6f4a7856663471e4614097ff" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="queenglf">
-		<description>Queen's Golf (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="queen's golf (1984)(ascii)(jp).dsk" size="737280" crc="2608daf8" sha1="35ee0e4cbf569603fcb07e34ecdd116634a2622a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rtype">
-		<description>R-Type (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="r-type (1988)(irem)(jp).dsk" size="368640" crc="7f395883" sha1="42f4b136c32eb5e2eb4070b4aec196e8d648efc0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ram">
-		<description>R.A.M. (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="r.a.m. (1990)(topo soft)(es).dsk" size="737280" crc="e5fe2c1f" sha1="ce54b67798ed22330598de5dc53105bcbf690855" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rama" cloneof="ram">
-		<description>R.A.M. (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="r.a.m. (1990)(topo soft)(es)[a].dsk" size="737280" crc="5898baf6" sha1="21e2cf16f8ae7e5aafe44f7323df12f2f1f16747" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="racecity">
-		<description>Race City (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="race city (1988)(iber soft)(es).dsk" size="737280" crc="721cc612" sha1="feef29035e8ded1a2c6bf73df30b1bd05465834a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="raidbung">
-		<description>Raid on Bungeling Bay (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="raid on bungeling bay (1985)(sony)(jp).dsk" size="737280" crc="a4d9ea27" sha1="e7728a2d3431299c23ad897a36f836e632af8d02" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rallyx">
-		<description>Rally-X (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rally-x (1984)(namcot)(jp).dsk" size="737280" crc="ffae3fbc" sha1="05ac81f6bc496857df75134a2ca797a686c3c931" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rallyxa" cloneof="rallyx">
-		<description>Rally-X (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="rally-x (1984)(namcot)(jp)[a].dsk" size="368640" crc="2fa21b4b" sha1="10443674628553bc33d5557a4aff0b66e18ea6a1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rambo">
-		<description>Rambo (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rambo (1985)(pack in video)(jp).dsk" size="737280" crc="33e283c2" sha1="cab7680c6b9bf38cbfb878e5c028e741c9147720" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rambo3">
-		<description>Rambo III (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rambo iii (1988)(ocean software)(gb).dsk" size="737280" crc="8faf04ac" sha1="168a1411f0e3c9e5d7258cfbb3c316fe444fc215" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rambo3a" cloneof="rambo3">
-		<description>Rambo III (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rambo iii (1988)(ocean software)(gb)[a].dsk" size="737280" crc="1bc59c52" sha1="3d8839db88916ebd866a130bb187af95fd4932b6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rampart">
-		<description>The Rampart (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rampart, the (1988)(iber soft)(es).dsk" size="737280" crc="08b07fa8" sha1="6a04e78272bdd5e399910c25526f827ccdcf6444" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rastscan">
-		<description>RasterScan (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rasterscan (1987)(mastertronic)(gb).dsk" size="737280" crc="17e65e41" sha1="4e37a7ae38323f3d87c39516abd8c7f32b8430f4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="redzone">
-		<description>Red Zone (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="red zone (1985)(ascii)(jp).dsk" size="737280" crc="d91caef3" sha1="a663781df187dd7894285b049000db42e70f3a7b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="reflex">
-		<description>Reflex (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="reflex (1987)(players software)(gb).dsk" size="737280" crc="dc1805bc" sha1="b90941bf30f313892a78811ef2db5073f71b6bd3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="renegad3">
-		<description>Renegade III - The Final Chapter (UK, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="renegade iii - the final chapter (1989)(imagine software)(gb)[cr pau d'aci][t].dsk" size="737280" crc="f9a17de9" sha1="cec308b68f08bf93bd4f4fd9664a1699278f54b4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="risedung">
-		<description>Rise Out from Dungeons (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rise out from dungeons (1983)(ascii)(jp).dsk" size="737280" crc="5935f09b" sha1="7d13db855e2d8be9a4c8fd28b6a7258ee1f6872c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="risedunga" cloneof="risedung">
-		<description>Rise Out from Dungeons (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rise out from dungeons (1983)(ascii)(jp)[a].dsk" size="737280" crc="50a36f2c" sha1="daab9a48d4b57421d7e117014994a0505206f90b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="riskhold">
-		<description>Risky Holding (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="risky holding (1986)(dimensionnew)(es).dsk" size="737280" crc="35da2051" sha1="728d0115ad14dd251b3f6a281551c6d19dbe7d3d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="riveraid">
-		<description>River Raid (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="river raid (1984)(activision)(us).dsk" size="737280" crc="8dea4345" sha1="33ed1fa10bb71977bc4f7788c3fb5be550e55001" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="roadfght">
-		<description>Road Fighter (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="road fighter (1985)(konami)(jp).dsk" size="737280" crc="a20cb167" sha1="d77482048a09553cb9eb103b5e5549e4a92ede68" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="robocop">
-		<description>Robocop (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<info name="usage" value="needs 128K" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="robocop (1988)(ocean software)(gb)[needs 128k].dsk" size="737280" crc="a421d529" sha1="327ff431ba8b7c9d4eb9de49080d4a06cec7afcc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="robofrog">
-		<description>Robofrog (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="robofrog (1985)(ascii)(jp).dsk" size="737280" crc="81f2f2db" sha1="527bc12594f7cbe1b22d4a7437f14741b18688f5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rockbolt">
-		<description>Rock'n Bolt (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rock 'n bolt (1985)(activision)(us).dsk" size="737280" crc="61ffe6f0" sha1="7a15582b8c7e9f4ac0cab3b183897f9f9895a4dc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rockroll">
-		<description>Rock 'n Roller (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rock 'n roller (1988)(topo soft)(es).dsk" size="737280" crc="bbe757c7" sha1="3f99bf10e5e0f0c76a24a5986ecf6ecb37e3485a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rockrolla" cloneof="rockroll">
-		<description>Rock 'n Roller (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rock 'n roller (1988)(topo soft)(es)[a].dsk" size="737280" crc="6883fd56" sha1="373d918140ba846570d76e9631cd22609695ec10" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rroger">
-		<description>Rocket Roger (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rocket roger (1987)(alligata software)(gb).dsk" size="737280" crc="4dd75217" sha1="5b18e26e596243507f2aeb4d12268e27e6b79ccc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rrogera" cloneof="rroger">
-		<description>Rocket Roger (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rocket roger (1987)(alligata software)(gb)[a].dsk" size="737280" crc="5532d5ff" sha1="9fe2517faff322609684b8e7a5ad502cf9304879" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rocky">
-		<description>Rocky (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rocky (1985)(dinamic software)(es).dsk" size="737280" crc="02fac296" sha1="ec01d74690a1347694b9a59343c623f8d1d885ae" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rockya" cloneof="rocky">
-		<description>Rocky (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rocky (1985)(dinamic software)(es)[a].dsk" size="737280" crc="f2ea7580" sha1="5af01a5247fd2400385db31da7f5023f0fb82943" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rogerrub">
-		<description>Roger Rubbish (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="roger rubbish (1985)(spectravideo)(gb).dsk" size="737280" crc="664a50da" sha1="7809d7fe86e1c698b65226a1f69792a44882d315" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rollerbl">
-		<description>Roller Ball (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="roller ball (1984)(hal laboratory)(jp).dsk" size="737280" crc="df924002" sha1="0cd1e462d225fbf8724703c91035f8823577ee00" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="roma">
-		<description>Roma - La Conquista del Imperio (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="roma - la conquista del imperio (1986)(idealogic)(es).dsk" size="737280" crc="a83a4f1e" sha1="13d9c3e2c4a839343aa98e1863a1cbd9dc44f708" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rotors">
-		<description>Rotors (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="rotors (1984)(ascii)(jp).dsk" size="737280" crc="f9ca2566" sha1="a7f7b84c9a1a422f0791ef55222db108cc8fabee" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="runner">
-		<description>Runner (France)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="runner (1986)(loriciels)(fr).dsk" size="737280" crc="1690b90c" sha1="5baba81b458e82419356299df8c2b21b9957a624" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="runnera" cloneof="runner">
-		<description>Runner (France, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="runner (1986)(loriciels)(fr)[a].dsk" size="737280" crc="f36a36e7" sha1="cc60d9bccf2109ed7931789e518ad2363629dcfa" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sabotaje">
-		<description>Sabotaje (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sabotaje (1988)(p.j. software)(es).dsk" size="737280" crc="480ee93b" sha1="741b673dea0b091affd3e6c3eed3344944c71c44" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sabrina">
-		<description>Sabrina (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sabrina (1989)(iber soft)(es).dsk" size="737280" crc="6e411cdb" sha1="76928fa474259ab3aed9ccc9d4fb2f6a17320f97" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sabrinaa" cloneof="sabrina">
-		<description>Sabrina (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sabrina (1989)(iber soft)(es)[a].dsk" size="737280" crc="90b010fd" sha1="ba66a26e68d8aae7dd3c43afd659a2316b407e7a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="salvage">
-		<description>Salvage (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="salvage (1986)(livewire software)(gb).dsk" size="737280" crc="0fdc6ea5" sha1="9ee5669e66a812c9d239bfb4e0d2c406c4eedf7f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="samantha">
-		<description>Samantha Fox Strip Poker (UK, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="samantha fox strip poker (1986)(martech games)(gb)[t].dsk" size="737280" crc="ed5ce735" sha1="93807150089dfab1e0a5af0300649784f3a339e3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sasa">
-		<description>Sasa (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sasa (1983)(ascii)(jp).dsk" size="737280" crc="340dc089" sha1="37e573277a990d815c87564a73f0e02224b51275" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="saurus">
-		<description>Saurusland (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="saurusland (1982)(nippon columbia - colpax - universal).dsk" size="737280" crc="4c668122" sha1="aa5ba581be09a649f3a00cd9a407b973ab14ca2a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="scarlet7">
-		<description>Scarlet 7 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="scarlet 7 (1986)(toshiba-emi)(jp).dsk" size="737280" crc="ac2c719a" sha1="2b9818c8f1a12091ebe3bc4e4ff64b1aeeb69adf" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="police academy (1986)(eaglesoft)(nl).dsk" size="737280" crc="d8c92c2d" sha1="29c5aca5a37e3be6c488d31eaddbb52c245c0c74" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -12545,93 +4729,18 @@ The following floppies came with the machines.
 	<software name="scifi">
 		<description>Science Fiction (Netherlands)</description>
 		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="88304" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="science fiction (1986)(eaglesoft)(nl).dsk" size="737280" crc="37c55bb3" sha1="ba63ff53d98bc5513b9e05e4abc403dd7f3b4e3b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="scion">
-		<description>Scion (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="scion (1985)(sony)(jp).dsk" size="737280" crc="5d56a0b9" sha1="ab7a81d0ffc431afd577624c2c0e7d48531b5f04" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="scopeon">
-		<description>Scope On - Fight in Space (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="scope on - fight in space (1983)(ascii)(jp).dsk" size="737280" crc="2a2f63f7" sha1="82dd932bb7f4977ac686d17d21283b71d746a7ec" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="scor3020">
-		<description>Score 3020 (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="score 3020 (1988)(topo soft)(es).dsk" size="737280" crc="fe04ac82" sha1="47e634c4d21721104e8dd3cb630e2c816556bfe1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="scor3020a" cloneof="scor3020">
-		<description>Score 3020 (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="score 3020 (1988)(topo soft)(es)[a].dsk" size="737280" crc="582336fa" sha1="e7c0dde4be9f69caf96146120542dffc7ae93f82" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="scramegg">
-		<description>Scramble Eggs (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="scramble eggs (1983)(ample software)(jp).dsk" size="737280" crc="2a677582" sha1="5829ab7423906aa36242f4082b5777a94e41fc5a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="seahuntr">
-		<description>Sea Hunter (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sea hunter (1985)(spectravideo)(gb).dsk" size="737280" crc="e07e2233" sha1="e6d734f296459b1ce36265d7eeb3f211bb17b989" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="seaking1">
-		<description>Sea King (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sea king (1986)(players software)(gb).dsk" size="737280" crc="5d647c67" sha1="7149c53fa29c431b000bc2ddd47b4da4e5607705" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="science fiction (1986)(eaglesoft)(nl).dsk" size="737280" crc="37c55bb3" sha1="ba63ff53d98bc5513b9e05e4abc403dd7f3b4e3b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="sdadrian">
-		<description>The Secret Diary of Adrian Mole (UK)</description>
+		<description>The Secret Diary of Adrian Mole (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -12641,164 +4750,10 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="seikacho">
-		<description>Seiken Achou (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="seiken acho. kung-fu master taekwondo (1985)(irem - ascii)(jp).dsk" size="737280" crc="60e0c8ed" sha1="dcdf32969d7a92e2af9bca3eef21e52b3d5b0c63" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="senjyo">
-		<description>Senjyo (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="senjyo (1984)(sony)(jp).dsk" size="737280" crc="3bf4de82" sha1="394a961e8a273e00036256aa859a7518760b0d4a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sewersam">
-		<description>Sewer Sam (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sewer sam (1984)(toshiba-emi)(jp).dsk" size="737280" crc="7771b249" sha1="a8b679a5585d35e7bca3f6a1a50aa659b55204e0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sewersama" cloneof="sewersam">
-		<description>Sewer Sam (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="sewer sam (1984)(toshiba-emi)(jp)[a].dsk" size="368640" crc="3e20d255" sha1="c7264b36d6aeb08d3d85efa75e226ac8024c179e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sharkh">
-		<description>Shark Hunter (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="shark hunter (1984)(electric software)(gb).dsk" size="737280" crc="702e90dc" sha1="92994de7c3f5775a573a7ca63813195e9bd240d1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="konsynth">
-		<description>ShinyoSizer - Konami's Synthesizer (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="konami's synthesizer (1986)(konami)(jp).dsk" size="737280" crc="98aed887" sha1="441a1cda3b142ddf8daa2e04c833d533750951fb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sinbad">
-		<description>Sinbad - Nanatsu no Bouken (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="shindobaddo nanatsu no bouken. the seven adventures of sindbad (1986)(casio)(jp).dsk" size="737280" crc="6194451f" sha1="1af8e40d524c59bc7a042a8c031b2af351616774" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shnax">
-		<description>Shnax (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="shnax (1985)(kuma computers)(gb).dsk" size="737280" crc="77184b8d" sha1="45a08cd188b68fad242864a547c1d4d9d8d11055" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shoutmat">
-		<description>Shout Match (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="shout match (1987)(victor)(jp).dsk" size="737280" crc="0f0c3e8e" sha1="6b2e45685b8a7042e81dde550e34dfe0867fe410" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shup">
-		<description>Shup - Trebol (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="shup - trebol (1986)(mind games espana)(es).dsk" size="737280" crc="137de218" sha1="67a10ab8f397d1c3fbdebcc268fca5250fc2d3f2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sshadow">
-		<description>Silent Shadow (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="silent shadow (1988)(topo soft)(es).dsk" size="737280" crc="2049a4db" sha1="01c135c6f5218f9319790f334e8f4d87a3c32ca1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sshadowa" cloneof="sshadow">
-		<description>Silent Shadow (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="silent shadow (1988)(topo soft)(es)[a].dsk" size="737280" crc="355fde9a" sha1="f8457d22dd7dbada88c47939de15562fe6006869" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="silfi">
-		<description>Silfi (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="silfi (1988)(iber soft)(es)[copy from elidon].dsk" size="737280" crc="f6888753" sha1="dedd8dbfc506a1f548e535ebbf3ce29d07807c1c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="simten">
-		<description>Simulador Profesional de Tenis (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="simulador profesional de tenis (1990)(dinamic software)(es).dsk" size="368640" crc="2aa62ec4" sha1="35d1ceb3bbbe15ef0abaa3b299882d54e82bdde0" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="protenn">
 		<description>Profesional Tennis Simulator (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1990</year>
+		<publisher>Dinamic</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="proffesional tennis simulator (1990)(dinamic software)(es).dsk" size="737280" crc="04b36c79" sha1="76352b2f791ad041cda9181357e3941ca4bf5cc0" />
@@ -12806,415 +4761,21 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="sirfred">
-		<description>Sir Fred (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sir fred (1986)(zigurat software)(es).dsk" size="737280" crc="27357cfa" sha1="edea0963bcb86657e8ee48757f902151844e8f0d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sirfreda" cloneof="sirfred">
-		<description>Sir Fred (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sir fred (1986)(zigurat software)(es)[a].dsk" size="737280" crc="46e01552" sha1="99705aacbd50ec167704cfe4049f2a45502506be" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="skdragon">
-		<description>Skate Dragon (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="skate dragon (1986)(idealogic)(es).dsk" size="737280" crc="9ff9d108" sha1="44509003020b9feb0e8ebf97965a5a865cbbbdcd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="skicomm">
-		<description>Ski Command (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ski command (1984)(casio)(jp).dsk" size="737280" crc="bbc7a544" sha1="91e4b9dbccd2e0a37f25e2297d2e199fe15282fe" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="skramble">
-		<description>Skramble (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="skramble (1985)(aackosoft)(nl).dsk" size="737280" crc="d7609735" sha1="74971a96efbe1f1b8540c851cb2e1e8480a29cb9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="skulexil">
-		<description>Skull Exilon (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="skull exilon (1988)(iber soft)(es)[aka safari x].dsk" size="737280" crc="9f9b56d3" sha1="d571253a6edf6ad3ac4f186f9eea64f52e7e1537" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="skyjag">
-		<description>Sky Jaguar (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sky jaguar (1984)(konami)(jp).dsk" size="737280" crc="18a83a73" sha1="593416d7d97900cc274b1444e7bf7007dc7f1141" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="skyvis">
-		<description>Sky Vision (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sky vision (1987)(eaglesoft)(nl).dsk" size="737280" crc="9a59c892" sha1="21216fdaf5ae2280127cec358b5c0e8dd0a2c72e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="skygaldo">
-		<description>Skygaldo (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="skygaldo (1986)(magical zoo)(jp).dsk" size="737280" crc="ffd94d8e" sha1="ed023a13a8f7f401c3ff3827d06e47ae3be338b7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="skyhawk">
-		<description>Skyhawk (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="skyhawk (1986)(bug-byte software)(gb).dsk" size="737280" crc="2c278f7e" sha1="1a10e1c572f75a088df5e221f0571f33ce342f3a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="slapshot">
-		<description>Slapshot (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="slapshot (1985)(anirog software)(gb).dsk" size="737280" crc="d4206f64" sha1="5c4d043face732ecde1852a42322f1bd6c815cc9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="slapshota" cloneof="slapshot">
-		<description>Slapshot (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="slapshot (1985)(anirog software)(gb)[a].dsk" size="737280" crc="30f7b9b8" sha1="9d821fc3dfd9a19fbd626ec87b61c8aa9f7b7f26" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="smackwac">
-		<description>Smack Wacker (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="smack wacker (1986)(eaglesoft)(nl).dsk" size="737280" crc="725fa45d" sha1="51f015f1967490a78a9145120e825d7fa8dcaee1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="smaily">
-		<description>Smaily (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="smaily (1990)(zigurat software)(es).dsk" size="737280" crc="96fab7c7" sha1="acf0e93fa5ec1e552d706c4a6b6dbde8be428a33" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="smailya" cloneof="smaily">
-		<description>Smaily (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="smaily (1990)(zigurat software)(es)[a].dsk" size="737280" crc="dcd83fc0" sha1="45d3ae44fc38e066d12aa627812286afc7016921" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="smailyb" cloneof="smaily">
-		<description>Smaily (Spain, alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="smaily (1990)(zigurat software)(es)[a2].dsk" size="737280" crc="0c544e2c" sha1="d6e471a6ec4209be3595aff7ecd06ab3f553a2d1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="snakeit">
-		<description>Snake It (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="snake it (1986)(eaglesoft)(nl).dsk" size="737280" crc="c3b7348d" sha1="2c8b6a3d1c9b428424dbb01a8493559ea1852c43" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="snowman">
-		<description>The Snowman (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="snowman, the (1984)(quicksilva)(gb).dsk" size="737280" crc="575744c0" sha1="237754d87f1eac768b0d332795060ab54d3d1f49" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sofia">
-		<description>Sofia (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sofia (1988)(radio wave newspaper publisher)(jp).dsk" size="737280" crc="a1ed05bb" sha1="2044a049e306a34d15f89a456ba3983aae6ae0ef" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sofiaa" cloneof="sofia">
-		<description>Sofia (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sofia (1988)(radio wave newspaper publisher)(jp)[a].dsk" size="737280" crc="66099c97" sha1="f079bb2c9489a18908801c6af545a3c26cf83840" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="solnegro">
-		<description>Sol Negro (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="sol negro (1989)(opera soft)(es).dsk" size="368640" crc="987a0489" sha1="7f60159c3f76033e77a3114b34f37abe00888dc3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="solnegroa" cloneof="solnegro">
-		<description>Sol Negro (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sol negro (1989)(opera soft)(es)[a].dsk" size="737280" crc="84e2fbe8" sha1="dbe7d94887e1fc2b9163539c2e7bd4ceefe0d26c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="solnegrob" cloneof="solnegro">
-		<description>Sol Negro (Spain, alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sol negro (1989)(opera soft)(es)[a2].dsk" size="737280" crc="73616eff" sha1="55a8a50bd24e722ed4bb0b85bb29198fd590c21f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="soldlght">
-		<description>Soldier of Light (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="soldier of light (1989)(dro soft)(es).dsk" size="737280" crc="25262d5a" sha1="46ac7c4aaab6673106ea8856c435a7813cdda75c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sorcery">
-		<description>Sorcery (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sorcery (1985)(virgin games)(gb).dsk" size="737280" crc="2168bf7c" sha1="09c1a61e6e37f8ce354fb0984ae112cb152f878c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="soulrobo">
-		<description>Soul of a Robot (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="soul of a robot (1987)(mastertronic)(gb).dsk" size="737280" crc="8c94f9f2" sha1="9acf26a3cbeab2411a876d6e4b90d1752d19df80" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sbustera">
-		<description>Space Busters (Netherlands, Aackosoft)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="space busters (1985)(aackosoft)(nl).dsk" size="737280" crc="a6496fb8" sha1="ceb1295fdd0588b53aae2bbe7984f1238cba4882" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sbusters">
-		<description>Space Busters (Netherlands, Eaglesoft)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="space busters (1986)(eaglesoft)(nl).dsk" size="737280" crc="843a587f" sha1="0ce2c31d11f0c37baad97f0479659748717312b3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spacecmp">
-		<description>Space Camp (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="space camp (1986)(pack in video)(jp).dsk" size="737280" crc="ef0bbfb7" sha1="debb22299b994b2946c54ff4b9d25a137f3a4491" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spaceinv">
-		<description>Space Invaders (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="space invaders (1985)(taito)(jp).dsk" size="737280" crc="51d0895d" sha1="f0450f3b4c9b9e781d0bfd3dc47e64effe850c42" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spacmaze">
-		<description>Space Maze Attack (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="space maze attack (1983)(hal laboratory)(jp).dsk" size="737280" crc="0121e896" sha1="cfd6d6b9e23c8ebb561ec5899e4df956d2963923" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spacetrb">
-		<description>Space Trouble (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="space trouble (1984)(hal laboratory)(jp).dsk" size="737280" crc="bc3436df" sha1="acb778bcbee9a9ddeff9377b7dd9872d8c2b2578" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sparkie">
-		<description>Sparkie (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sparkie (1983)(sony)(jp).dsk" size="737280" crc="4f732dc8" sha1="af54e5535f7ce00efb3a9a972734b5b8fdf4bec6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="specops">
-		<description>Special Operations (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="special operations (1985)(mc lothlorien)(gb).dsk" size="737280" crc="5e234692" sha1="ae5e9cfd44b9f74288f56a93e761b1d87f756b77" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spedking">
-		<description>Speed King (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="speed king (1986)(mastertronic)(gb).dsk" size="737280" crc="59d0aff3" sha1="e5ae7c7634b5b3d4721719d759bbe05bacffaf87" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="sbracer">
 		<description>Speedboat Racer (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1987</year>
+		<publisher>Methodic Solutions</publisher>
+		<info name="serial" value="8910" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="speedboat racer (1987)(methodic solutions)(nl).dsk" size="737280" crc="8ef8d04e" sha1="6aa2634eb77940c233cbe3136488b21ec68888f9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spelunkr">
-		<description>Spelunker (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="spelunker (1986)(irem)(jp).dsk" size="737280" crc="7306c0e2" sha1="11b83483051d900f2e1525dd8bb1fb7bf95b441b" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="speedboat racer (1987)(methodic solutions)(nl).dsk" size="737280" crc="8ef8d04e" sha1="6aa2634eb77940c233cbe3136488b21ec68888f9" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="spider">
-		<description>The Spider (Japan)</description>
+		<description>The Spider (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -13224,52 +4785,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="spirits">
-		<description>Spirits (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="spirits (1987)(topo soft)(es).dsk" size="737280" crc="2ed4321e" sha1="846e7b15e140ca784ca4f483492c171b6266dbe9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spiritsa" cloneof="spirits">
-		<description>Spirits (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="spirits (1987)(topo soft)(es)[a].dsk" size="737280" crc="bf5a6b07" sha1="6391c30e242e0442f8d2c9775224041619bd68ef" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spitfire">
-		<description>Spitfire '40 (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="spitfire '40 (1986)(mirrorsoft)(gb).dsk" size="737280" crc="26b37fb0" sha1="2d193722de746d3db7c7974ff055352caa84c33c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="splash">
-		<description>Splash (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="splash (1986)(mind games espana)(es).dsk" size="737280" crc="380b9168" sha1="dbec2391963c0cf9ea7d41a670e8e0abcd6d70c7" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="spreadsh">
-		<description>Spread Sheet (UK?)</description>
+		<description>Spread Sheet (United Kingdom?, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -13279,228 +4796,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="spystory">
-		<description>Spy Story (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="spy story (1986)(aackosoft)(nl).dsk" size="737280" crc="3954ee42" sha1="b48676ff40f2dc00656e383ed2730cb8a6470be8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="squishem">
-		<description>Squish'em (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="squish'em (1984)(ascii)(jp).dsk" size="737280" crc="e2ad2570" sha1="56e8cb15018283f853cf2613f7259df498bdb259" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="starblaz">
-		<description>Star Blazer (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="star blazer (1985)(sony)(jp).dsk" size="737280" crc="026d50ac" sha1="283077cc1a4881941b0033c53e5fc1e1ee425441" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bosco">
-		<description>Star Destroyer Bosconian (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="bosconian (1984)(namcot)(jp).dsk" size="737280" crc="5a9f9f01" sha1="b413773576726ec6be72c9874f4eb28e149a7e92" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="starfght">
-		<description>Star Fighter (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="star fighter (1986)(eaglesoft)(nl).dsk" size="737280" crc="0683c391" sha1="37a0bb2797a60a6f2f4043d858974cb45636889c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="starrun">
-		<description>Star Runner (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="star runner (1986)(manhattan transfer)(es).dsk" size="737280" crc="541c85d8" sha1="b5f6f4c9abbba4fa63a1cb6e978056c2def54c18" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="starsold">
-		<description>Star Soldier (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="star soldier (1986)(hudson soft)(jp).dsk" size="737280" crc="109bf1f8" sha1="18409f698ad6d2256888ded2783e5c13bbebd27b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="starwars">
-		<description>Star Wars (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="star wars (1986)(eaglesoft)(nl).dsk" size="737280" crc="0765dc8a" sha1="3d34079ecb45f0958b481dc2d006b758cc4f403b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="starbyte">
-		<description>Starbyte (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="starbyte (1987)(mister chip)(es).dsk" size="737280" crc="ff26fe00" sha1="e863f9eca0babae1b2d4ebd2e6b9a9f426714334" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="stardust">
-		<description>Stardust (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="stardust (1987)(topo soft)(es).dsk" size="737280" crc="9d5366c3" sha1="77d1ad62e5c5e87df2d3694fdca05f71a093c286" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="starquak">
-		<description>Starquake (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="starquake (1986)(bubble bus)(gb).dsk" size="737280" crc="53b19228" sha1="0849fd82a441899c8068bfda48a3be1c32fa21fa" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="starship">
-		<description>Starship Simulator (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="starship simulator (1984)(ascii)(jp).dsk" size="737280" crc="a3db1cb1" sha1="8e4a6f5a550410774ecbb14548dffdfe800946d4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="stepup">
-		<description>Step Up (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="step up (1983)(hal laboratory)(jp).dsk" size="737280" crc="c2a59d8e" sha1="11761c4d43d0c9f528f9ebf33d73f185b241c7c4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sdsnookr">
-		<description>Steve Davis Snooker (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="steve davis snooker (1985)(cds micro systems)(gb).dsk" size="737280" crc="eef4cc2e" sha1="aa7d508ea68b61d96cb14f2350837c2252a35496" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="stopball">
-		<description>Stop Ball (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="stop ball (1987)(dro soft)(es).dsk" size="737280" crc="d31746c8" sha1="a941611723863f8f9b7375f4a73be63ac12558fd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="storm">
-		<description>Storm - Una's Lair (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="storm - una's lair (1986)(mastertronic)(gb).dsk" size="737280" crc="b9997817" sha1="28b6b60d3ef0131d00407380bd0ae1b2cf9104df" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sbringer">
-		<description>Stormbringer (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="stormbringer (1987)(mastertronic added dimension).dsk" size="737280" crc="fd6c0cd1" sha1="b6a21506ab8697fa1dbead688b0624e4186bd5a5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="stranglp">
-		<description>Strange Loop (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="strangeloop (1987)(nippon dexter)(jp).dsk" size="737280" crc="5260e092" sha1="00ed3b9f38807f820784e7112d1f1486d4bb4e01" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="streaker">
-		<description>Streaker (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="streaker (1987)(bulldog).dsk" size="737280" crc="ba5ea425" sha1="96be3f4912972cc92c2253d6b3d8dff951885c5c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="strpok2p">
-		<description>Strip Poker II+ (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="strip poker ii+ (1988)(anco software).dsk" size="737280" crc="a425c9b3" sha1="f334e48394ee0dad06a1aa90cb3bf7928b19eadc" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- According to generation-msx only released on cassette, but only a cartridge and this disk dump/conversion found? -->
 	<software name="suparobo">
-		<description>Suparobo (Japan)</description>
+		<description>Suparobo (Japan, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;cart2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -13510,987 +4808,22 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="sbillard">
-		<description>Super Billiards (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="super billiards (1983)(hal laboratory)(jp).dsk" size="737280" crc="3823a919" sha1="31e54bba21c482fc6a89610272e618588c1d2c3f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sbillarda" cloneof="sbillard">
-		<description>Super Billiards (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="super billiards (1983)(hal laboratory)(jp)[a].dsk" size="368640" crc="03d8992f" sha1="6ed4475d7e67a51178accf6bcb0ca30f7c900d72" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="schess">
-		<description>Super Chess (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="super chess (1984)(kuma computers)(gb).dsk" size="737280" crc="9d511be1" sha1="ed646f8311d4f247f2ea5f61a36ba09dca56da39" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="scobra">
-		<description>Super Cobra (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="super cobra (1983)(konami)(jp).dsk" size="737280" crc="72803a77" sha1="7e0c917147787ea85222da1616677f504f37c7b7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="supxfrce">
-		<description>Super Cross Force (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="super cross force (1983)(spectravideo)(gb).dsk" size="737280" crc="7aea37d4" sha1="1f62f71312ccb8e6ee324224b7db1acbd1f45e9a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="supdrink">
-		<description>Super Drinker (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="super drinker (1983)(ample software)(jp).dsk" size="737280" crc="f60eba36" sha1="990bf7b343a76b745aa52587882c89ed28b43a9f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="superglf">
-		<description>Super Golf (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="super golf (1985)(sony)(jp).dsk" size="737280" crc="6aaa32b0" sha1="22f070da8c39e2d1f5a1806a9e58c9bed53e55f9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="slaydock">
-		<description>Super Laydock - Mission Striker (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="super laydock - mission striker (1987)(t&amp;e soft)(jp).dsk" size="368640" crc="a76f375e" sha1="342e1b09a7fe97d7daa37bf81624552596d3108b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="supsnake">
-		<description>Super Snake (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="super snake (1983)(hal laboratory)(jp).dsk" size="737280" crc="4bdf5d78" sha1="265acbc5b87f3f155360fe6565116f4c317b7851" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="supsoccr">
-		<description>Super Soccer (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="super soccer (1985)(sony)(jp).dsk" size="737280" crc="e3eac7c9" sha1="74c9b4dad839312506fad302c00f6e4043ae1951" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="supersyn">
-		<description>Super Synth (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="super synthesizer (1984)(victor)(jp).dsk" size="737280" crc="fa60d18f" sha1="9cc8f434cc002b36950c51b391458eafc21b32f1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="suptrip">
-		<description>Supertripper (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="supertripper (1985)(indescomp)(es).dsk" size="737280" crc="1f00c7e3" sha1="19c71051d63f8c6d99c62da978f266b3427dd558" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="survivor">
-		<description>Survivor (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="survivor (1987)(topo soft)(es).dsk" size="737280" crc="747cbd8c" sha1="f7329cc3efc651c082bda6666903eca50a5556e4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="survivrs">
-		<description>Survivors (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="survivors (1986)(atlantis software)(gb).dsk" size="737280" crc="016be493" sha1="ae2348e82df5b745d5c97dbac3cf78df5bbd9326" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sweetacr">
-		<description>Sweet Acorn (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="sweet acorn (1985)(taito)(jp).dsk" size="737280" crc="93918fdc" sha1="dd941fe8dcc3190639a6af2d76a00f82bd81577c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="taipan">
-		<description>Tai-Pan (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tai-pan (1987)(ocean software)(gb).dsk" size="737280" crc="257a82cb" sha1="693421e1fe15e90534d6e0cad2ff954ab3b8b530" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="takameij">
-		<description>Takahashi Meijin no Boukenjima (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="takahasi meijin no boukenjima. wonder boy (1986)(hudson soft)(jp).dsk" size="737280" crc="c9c9e404" sha1="7a3f9b86274f0a11cc4efabf28b8ca122632d695" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="takeru">
-		<description>Takeru Densetsu (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="takeru densetsu. legend of takeru (1987)(brother industries)(jp).dsk" size="737280" crc="cd926818" sha1="acb1c4e1c6bc92a4fa45660c39c9218730270792" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tankbatt">
-		<description>Tank Battalion (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tank battalion (1984)(namcot)(jp).dsk" size="737280" crc="031e31d3" sha1="30987b68c1fceb144d09ba5941ffb5030c9a243b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="targetp">
-		<description>Target Plus (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="target plus (1988)(dinamic software)(es)[gunstick].dsk" size="737280" crc="f0fdcfe2" sha1="9a78ae2b05cb59643780842baa8de8e3e00ddbb5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="targetpa" cloneof="targetp">
-		<description>Target Plus (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="target plus (1988)(dinamic software)(es)[a][gunstick].dsk" size="737280" crc="0c14caa2" sha1="0aec008b90e9137327196c13cab5331f3499ecbf" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tawarakn">
-		<description>Tawara-kun (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tawara (1984)(ascii)(jp).dsk" size="737280" crc="717c19d2" sha1="a73c02f343556262f449149bea3c53c6ca47a2fc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="telebunn">
-		<description>Telebunnie (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="telebunnie (1983)(ascii)(jp).dsk" size="737280" crc="2fdde2ef" sha1="11734ba3271a590498d16abe778c809e3831aa98" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="temptat">
-		<description>Temptations (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="temptations (1988)(topo soft)(es).dsk" size="737280" crc="143dc0e7" sha1="3aa3f282a3e2d2df8c4b78e4696b214f448cf1b0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tensaird">
-		<description>Tensai Rabbian Daifunsen (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tensai rabbian daifunsen (1986)(toshiba-emi)(jp).dsk" size="737280" crc="70222474" sha1="03b2d0777b1b415779c25b965538520b4477a52a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tension">
-		<description>Tension (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tension (1988)(system 4)(es).dsk" size="737280" crc="e3095948" sha1="f5ccf9ca117592f853d4838b9140c5825dd46b7b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tensiona" cloneof="tension">
-		<description>Tension (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tension (1988)(system 4)(es)[a].dsk" size="737280" crc="03cf3adb" sha1="1db3758bf33d11dc383d30c1be35bccef7982f9d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="terminus">
-		<description>Terminus - Prison Planet (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="terminus - the prison planet (1986)(mastertronic added dimension).dsk" size="737280" crc="60cfe841" sha1="ac0696497754b90c5734f336e3e4f5355235d221" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="testdrv2">
-		<description>Test Drive II - The Duel (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="test drive ii - the duel (1989)(dro soft)(es).dsk" size="737280" crc="50649ed6" sha1="aa00915de166f70b4729f05d22e26a25ed8ba7d9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tetrahor">
-		<description>Tetra Horror (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tetra horror (1984)(ascii)(jp).dsk" size="737280" crc="c62acfd3" sha1="b7f7c880c188d1fefbbc59474519748c0e578ac0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tetris">
-		<description>Tetris (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tetris (1987)(mirrorsoft)(gb).dsk" size="737280" crc="1a9b8af2" sha1="89d5943d836ca85029634eb26e0bada4f22d0b13" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="thexder">
-		<description>Thexder (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="thexder (1986)(game arts)(jp).dsk" size="737280" crc="16571eb2" sha1="e0a71fd44d4c75887db2bbac85f29005b678b820" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="thingbb">
-		<description>Thing Bounces Back (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="thing bounces back (1987)(gremlin graphics software)(gb).dsk" size="737280" crc="84670151" sha1="eb155888454e775c0268f792eb1fc8c5ccfd4a3c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="thor">
-		<description>Thor (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="thor (1988)(proein soft line)(es).dsk" size="737280" crc="b47c2f98" sha1="1c511e01422f70de93ed610814b6cc403ed3bb11" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="thora" cloneof="thor">
-		<description>Thor (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="thor (1988)(proein soft line)(es)[a].dsk" size="737280" crc="6ffa84fc" sha1="d5b41cb80d400d3d41b4f0da0f165b5b39a45403" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="thndrbal">
-		<description>Thunder Ball (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="thunder ball (1985)(ascii)(jp).dsk" size="737280" crc="6b450291" sha1="9650a26509cc5a6edc74ff42bb1197fea2103f12" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tblade">
-		<description>Thunder Blade (UK, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="thunder blade (1988)(us gold)(gb)[t].dsk" size="737280" crc="7b9c9728" sha1="27a58f17dd3f0dac0700185c20484f42c714595d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tbladea" cloneof="tblade">
-		<description>Thunder Blade (UK, trainer, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="thunder blade (1988)(us gold)(gb)[t][a].dsk" size="737280" crc="21498f05" sha1="c9e07a71634f6dcbb3b0478dcd5867ad93a4ece5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tbirds">
-		<description>Thunderbirds (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="thunderbirds (1989)(grandslam entertainments)(gb)[m menu].dsk" size="737280" crc="f2ce81cb" sha1="225d97e6f3168aa45a47b6f5547dcce81239d4e7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="timeband">
-		<description>Time Bandits (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="time bandits (1984)(pss)(gb).dsk" size="737280" crc="9921a30e" sha1="235f0c53ca3ef765dfb80c3acdc611f734b49da2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="timeout">
-		<description>Time Out (Spain, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="time out (1988)(zafiro software division)(es)[cr damian roman][t].dsk" size="737280" crc="a91629d5" sha1="10daa6da1e083df04662ba7e12409d188a89909f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="timeouta" cloneof="timeout">
-		<description>Time Out (Spain, trainer, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="time out (1988)(zafiro software division)(es)[cr damian roman][t][a].dsk" size="737280" crc="f23e35de" sha1="37b24ab4f54f5a8bcd8e2b64f2ea894c573111a4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="timeplt">
-		<description>Time Pilot (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="time pilot (1983)(konami)(jp).dsk" size="737280" crc="c8032ee7" sha1="c4a5962d4b4e0b22ead71fbdbf01b6aabc574ded" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="timeridr">
 		<description>Time Rider (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
+		<year>1988</year>
+		<publisher>Eurosoft</publisher>
+		<info name="serial" value="8214" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="time rider (1988)(eurosoft)(nl).dsk" size="737280" crc="301256e9" sha1="948cb883716b415e9d28f05bfc9810f046cc5894" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="time rider (1988)(eurosoft)(nl).dsk" size="737280" crc="301256e9" sha1="948cb883716b415e9d28f05bfc9810f046cc5894" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="timetrax">
-		<description>Time Trax (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="time trax (1986)(bug-byte software)(gb).dsk" size="737280" crc="9b8f22b2" sha1="7d1f7517b15ea7191aabee66734680477a74ef93" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="titanic">
-		<description>Titanic (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="titanic (1988)(topo soft)(es).dsk" size="737280" crc="ca618137" sha1="059b3ac3c3963c35185a9d298ad92b57ea26a6fa" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="titanica" cloneof="titanic">
-		<description>Titanic (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="titanic (1988)(topo soft)(es)[a].dsk" size="737280" crc="6c2f4bfe" sha1="a880204066bf2efae2aea7d9998e24ee69cedeff" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="toiacid">
-		<description>Toi Acid Game (Spain, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="toi acid game (1989)(iber soft)(es)[cr damian roman][t cinema soft].dsk" size="737280" crc="16ea0029" sha1="242424fa9a804f6648979b014ee4bf62820b1a59" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="toiacida" cloneof="toiacid">
-		<description>Toi Acid Game (Spain, trainer, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="toi acid game (1989)(iber soft)(es)[cr damian roman][t cinema soft][a].dsk" size="737280" crc="597bc5b9" sha1="40618658e2a53a12b65e0d45690b64cee32aa8b1" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tomjerry">
-		<description>Tom &amp; Jerry (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tom &amp; jerry (1989)(erbe software)(es).dsk" size="737280" crc="06caf614" sha1="f7c04ebca461b3768cfdaa0367696c12bacad26f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="becky">
-		<description>Becky (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tomboyish becky's large adventure (1983)(mia)(jp).dsk" size="737280" crc="57018ff8" sha1="b0b3b1f55e35501a276e8e37b20bba22b48e1bfa" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="toobin">
-		<description>Toobin' (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="toobin' (1989)(domark)(gb).dsk" size="737280" crc="d5727734" sha1="6f73b4193b9173ea618bdc0a61f59c76db72a173" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="toprollr">
-		<description>Top Roller! (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="top roller (1984)(jaleco)(jp).dsk" size="737280" crc="f224a7ed" sha1="8a82b5d6bb69eea5a00e497d0149f6aa96eebc02" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="topzip">
-		<description>Topple Zip (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="topple zip (1986)(bothtec)(jp)[a].dsk" size="737280" crc="c28dd54f" sha1="92bc3ca763923f30b51e9a5ff0b119c3183dca86" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="druaga">
-		<description>The Tower of Druaga (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tower of druaga, the (1984)(namcot)(jp).dsk" size="737280" crc="31dac3a4" sha1="00a13582baf7bdb4caeca1b5d75a14d4e1af0925" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="trackfld">
-		<description>Track &amp; Field 1 (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="track &amp; field 1. hyper olympic 1 (1984)(konami)(jp).dsk" size="737280" crc="361783ff" sha1="031d5a8923c7eb7e233ec578398247e92b33eed9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="trackfl2">
-		<description>Track &amp; Field 2 (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="track &amp; field 2. hyper olympic 2 (1984)(konami)(jp).dsk" size="737280" crc="a7aa03a2" sha1="f8670dcc6094b91f5f4e56a9349296198d6660f2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="traffic">
-		<description>Traffic (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="traffic (1986)(sony)(jp).dsk" size="737280" crc="426f4014" sha1="db8c4820afcf5a16f8b5c5239112e3f5164f0002" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="trailblz">
-		<description>Trailblazer (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="trailblazer (1986)(gremlin graphics software)(gb).dsk" size="737280" crc="234b613e" sha1="d713a9d87ebe303eec0c0e8e7b40f235aaed8c17" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="trantor">
-		<description>Trantor - The Last Stormtrooper (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="trantor - the last stormtrooper (1987)(go).dsk" size="737280" crc="846fff32" sha1="86412b8e43d07e35c533c31b5e21ef6a2adc4ff7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lucesglr">
-		<description>Les Tres Luces de Glaurung (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tres luces de glaurung, las (1986)(erbe software)(es).dsk" size="737280" crc="03a97dc6" sha1="751f5d56b76475dbf674b6bf7bead495db73c575" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="trialski">
-		<description>Trial Ski (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="trial ski (1984)(ascii)(jp).dsk" size="737280" crc="6d184ffb" sha1="ab0e53d9118fd9d19f39fa14c88d2a5c5c4d92c0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="trickboy">
-		<description>Trick Boy (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="trick boy. pinball (1984)(t&amp;e soft)(jp).dsk" size="737280" crc="88bee9c2" sha1="b092ed454dc50508fb847d67b5c1786365a90926" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="trickboya" cloneof="trickboy">
-		<description>Trick Boy (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="trick boy. pinball (1984)(t&amp;e soft)(jp)[a].dsk" size="737280" crc="9435e628" sha1="8f7104f329930e1e905c3d99047115fb2693f7f3" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tripcom">
-		<description>Triple Comando (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="triple comando (1988)(dro soft)(es).dsk" size="737280" crc="c89cd7e5" sha1="9674ef392093617db715ad5bb219ddece0d24d99" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tripcoma" cloneof="tripcom">
-		<description>Triple Comando (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="triple comando (1988)(dro soft)(es)[a].dsk" size="737280" crc="f4b241a7" sha1="8240409e50fdd5619d37dd03cce5a5213b0108cd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="triton">
-		<description>Triton (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tritorn (1986)(xain)(jp).dsk" size="737280" crc="587161e0" sha1="6fbfc0a247624b3baebc3278903b49cee72fda34" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tritona" cloneof="triton">
-		<description>Tritorn (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tritorn (1986)(xain)(jp)[a].dsk" size="737280" crc="d976fb31" sha1="50bfb2811291a6d41a76149befbd8f1fc38c5477" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="trivial">
-		<description>Trivial Pursuit (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="trivial pursuit (1986)(domark)(es-gb).dsk" size="737280" crc="0080b979" sha1="75f7cd0ab46314c945ac3629263819b76b9035bb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="triviala" cloneof="trivial">
-		<description>Trivial Pursuit (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="trivial pursuit (1986)(domark)(es-gb)[a].dsk" size="737280" crc="eb776701" sha1="74d68b7c1bfb648f5a2ae2eea3c216acfede1b6a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="trumpaid">
-		<description>Trump Aid (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="trump aid (1986)(toshiba-emi)(jp).dsk" size="737280" crc="b43d6530" sha1="f1eb6f898aa9022de0d1163529bbd6b73196a80e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tuareg">
-		<description>Tuareg (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tuareg (1988)(topo soft)(es).dsk" size="737280" crc="5af682c8" sha1="f602caddd76434243c5863f29a809628bb2141f7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tuarega" cloneof="tuareg">
-		<description>Tuareg (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="tuareg (1988)(topo soft)(es)[a].dsk" size="737280" crc="6cab678a" sha1="bcd04e5ca8def3a2c8d560e7e537e642118975a2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="turbogrl">
-		<description>Turbo Girl (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="turbo girl (1988)(dinamic software)(es).dsk" size="737280" crc="bf1e2dde" sha1="a2bf3ee3fd6538255bc3f8418610c2583432220f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="turbogrla" cloneof="turbogrl">
-		<description>Turbo Girl (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="turbo girl (1988)(dinamic software)(es)[a].dsk" size="737280" crc="cc19d501" sha1="7c34523695e9c49275754737a88c6b320bea79a7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="turboat">
-		<description>Turboat (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="turboat (1984)(ascii)(jp).dsk" size="737280" crc="c8071538" sha1="77f377637fb53f4f00692faac141bb1eea94cdd9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="turmoil">
-		<description>Turmoil (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="turmoil (1986)(bug-byte software)(gb).dsk" size="737280" crc="5dd7f8a8" sha1="cab6953dfe69674424ef3b040c50356b17fff53b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="twinbee">
-		<description>Twin Bee (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="twin bee (1986)(konami)(jp).dsk" size="737280" crc="bba83201" sha1="81db28f1b393e1a7c4ec1ef363cdb830eb5983db" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="uboot">
-		<description>U-Boot (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="u-boot (1985)(manhattan transfer)(es).dsk" size="737280" crc="17626e6b" sha1="82cfc1a04c78e11f533941e10f362966849269da" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="uchimata">
-		<description>Uchi Mata (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="uchi mata (1987)(martech games)(gb).dsk" size="737280" crc="834af6bb" sha1="4f1ba8e4d9bb3dc4a4b40a2b45ca0209174b314e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ulises">
-		<description>Ulises (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ulises (1989)(opera soft)(es).dsk" size="737280" crc="57f2e14d" sha1="1f2b692e494c71298e5e36d41a258c4b4a83c241" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ulisesa" cloneof="ulises">
-		<description>Ulises (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ulises (1989)(opera soft)(es)[a].dsk" size="737280" crc="d30dfa2a" sha1="b53ebe975b786b3661f5238e92a5902ef59f0b22" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ultchess">
-		<description>Ultra Chess (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ultra chess (1985)(aackosoft)(nl).dsk" size="737280" crc="01a9c118" sha1="561170c6d11396c6ffb52a0f437ec7baabfe4449" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ultraman">
-		<description>Ultraman (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="ultra-man (1984)(bandai)(jp).dsk" size="737280" crc="7e3249ad" sha1="72a26622d0bf45ada88fd3250792752b2e67acb0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="undergnd">
-		<description>Underground (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="underground (1988)(system 4)(es).dsk" size="737280" crc="e24be8a2" sha1="73ef2de20831ff79fc11562c5f919da2e0c7e949" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="undergnda" cloneof="undergnd">
-		<description>Underground (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="underground (1988)(system 4)(es)[a].dsk" size="737280" crc="ff38e577" sha1="2f1c382bfc6e952aeef3dceb870b2b97f2d231d0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="vacuuman">
-		<description>Vacuumania (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="vacuumania (1984)(pss)(gb).dsk" size="737280" crc="46d91b69" sha1="828378f7d225085fcc417e4e9678ff4f8efca718" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="vacuumana" cloneof="vacuuman">
-		<description>Vacuumania (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="vacuumania (1984)(pss)(gb)[a].dsk" size="737280" crc="5508a9f2" sha1="68295e3e5a7a2ad115bc9454864502792958e11b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="valkyr">
-		<description>Valkyr (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="valkyr (1985)(gremlin graphics software)(gb).dsk" size="737280" crc="ee56b718" sha1="85094b3305a4f1b6ae328730f6816d7f8fd82ca5" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- Only the Manhattan Transfer cassette version has been dumped. -->
 	<software name="vampire">
-		<description>Vampire (Spain?)</description>
+		<description>Vampire (Europe, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -14500,8 +4833,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<!-- Only the Manhattan Transfer cassette version has been dumped. -->
 	<software name="vampirea" cloneof="vampire">
-		<description>Vampire (Spain?, alt)</description>
+		<description>Vampire (Europe, disk conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -14511,151 +4845,9 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="venganza">
-		<description>La Venganza de Johny Comomolo (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="venganza de johny comomolo, la (1986)(dro soft)(es).dsk" size="737280" crc="c911ac9a" sha1="51b1acb4e9f63d0a5b3fc3b13e9982e6e6c9c11e" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="venusfir">
-		<description>Venus Fire (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="venus fire (1987)(victor)(jp).dsk" size="737280" crc="0635b55a" sha1="310040c3fca5ad88bbf21d71dec319289eae3d0a" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="vestron">
-		<description>Vestron (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="vestron (1986)(players software)(gb).dsk" size="737280" crc="18fe97db" sha1="0bc7ba4be60dfc10660f9ef2e37d37a66ccebf63" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="vestrona" cloneof="vestron">
-		<description>Vestron (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="vestron (1986)(players software)(gb)[a].dsk" size="737280" crc="f996e5c4" sha1="45a70b62c1b5bd3eff79fadf2b718b8f8326c55c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="vviper">
-		<description>Vicious Viper (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="vicious viper (1985)(sanyo)(jp).dsk" size="737280" crc="1c3383a0" sha1="e2db9b8b766fbfc3c0e1f6d93e55d82c22a47759" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hustler">
-		<description>Video Hustler (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="video hustler. konami's billiards (1984)(konami)(jp).dsk" size="737280" crc="6ee5dde2" sha1="1fb43ad3fff5fef279cf5819aae8908c2437af40" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="vidpoker">
-		<description>Video Poker (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="video poker - las vegas (1986)(mastertronic)(gb).dsk" size="737280" crc="97da8999" sha1="be3b2c2a87f47a7d74a6b3b802a31cdff7f968f7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="avtak">
-		<description>A View to a Kill (Europe)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="007 - a view to a kill (1986)(domark)(gb).dsk" size="737280" crc="5212709d" sha1="8a68b31ac5999bc06afd1e0c3640d2e4122497e7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="visitor">
-		<description>Visitor - Bazar Catalunya (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="visitor - bazar catalunya (1988)(mind games espana)(es).dsk" size="737280" crc="fbb54af3" sha1="bc68b26c36da46a02f7c88009450150c77af37c5" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="voidrun">
-		<description>Void Runner (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="voidrunner (1987)(mastertronic added dimension).dsk" size="737280" crc="ec097371" sha1="6c0415484b826f7bd4682809a508832dda695e2d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="volguard">
-		<description>Volguard (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="volguard (1985)(db-soft)(jp).dsk" size="737280" crc="6dfd6d0f" sha1="e5fe7962fe8da5cebcb95f10f3980f01f8de1ae0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wall">
-		<description>The Wall (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="wall, the (1987)(erbe software)(es).dsk" size="737280" crc="64634343" sha1="0e1402db5d5b8c5cdaa2990234668ee934931255" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wecleman">
-		<description>WEC Le Mans (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="wec le mans (1988)(imagine software)(gb).dsk" size="737280" crc="45df7c64" sha1="ed1c433dbe9cf7ef8f3d4e02f5e203bb5b1c0406" />
-			</dataarea>
-		</part>
-	</software>
-
+	<!-- generation-msx only lists a cartridge release but only a cassette dump and this disk conversion are known. -->
 	<software name="warchess">
-		<description>War Chess (Spain)</description>
+		<description>War Chess (Spain, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -14665,228 +4857,8 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="warpwarp">
-		<description>Warp &amp; Warp (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="warp &amp; warp (1984)(namcot)(jp).dsk" size="737280" crc="bf778e9b" sha1="749ee3df73a83e572a3558f13b07df9718bd5719" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="warroid">
-		<description>Warroid (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="warroid (1985)(ascii)(jp).dsk" size="737280" crc="fa42e100" sha1="f973ccdb2aa4de148e7bc074a8e659ec96acb8ee" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="waytiger">
-		<description>The Way of the Tiger (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="way of the tiger, the (1986)(gremlin graphics software)(gb).dsk" size="737280" crc="860d145c" sha1="e80e18ba57a13da0a52626a85163551834bfdf53" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wbells">
-		<description>Wedding Bells</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="wedding bells (1984)(nippon columbia - colpax - universal).dsk" size="737280" crc="45ac34c3" sha1="8c4eab40855a703dbe4e47462af7884a56159b0d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wellsfar">
-		<description>Wells &amp; Fargo (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="wells &amp; fargo (1988)(topo soft)(es).dsk" size="737280" crc="965a2044" sha1="3f3f3800a91e6391ad027dacf3309c0e7664ccc6" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wellsfara" cloneof="wellsfar">
-		<description>Wells &amp; Fargo (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="wells &amp; fargo (1988)(topo soft)(es)[a].dsk" size="737280" crc="a7395ce4" sha1="b9f8d8d76d1ae2671528e9f95bbfbee9f51972bd" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="whodare2">
-		<description>Who Dares Wins 2 (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="who dares wins ii (1986)(alligata software)(gb).dsk" size="737280" crc="1426c1ea" sha1="0c30c38b1b3de303d5851c28a2a568d32100a8e8" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="whopper">
-		<description>Whopper Chase (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="whopper chase (1987)(erbe software)(es).dsk" size="737280" crc="a756833e" sha1="1a21ee6a2ae954318d52e3e624a2473e2eb6af59" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="whoppera" cloneof="whopper">
-		<description>Whopper Chase (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="whopper chase (1987)(erbe software)(es)[a].dsk" size="737280" crc="79bd9ba6" sha1="9330eba3b343f8a54313de224c389f8e0030a6e0" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wintevnt">
-		<description>Winter Events (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="winter events (1987)(anco software)(gb).dsk" size="737280" crc="5e72d657" sha1="5dfd9bb0d2c098219e78dc8db557a4b0ccbbffdc" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wingames">
-		<description>Winter Games (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="winter games (1986)(us gold)(gb).dsk" size="737280" crc="f20ef4bb" sha1="4805d8e1d092c5110dee4e97a8c885ecaf26b792" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wintol">
-		<description>Winter Olympics (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="winter olympics (1986)(tynesoft)(gb).dsk" size="737280" crc="91470ac4" sha1="2c9761ef5b2072ffbad009d6b63059e68c109d20" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="winthawk">
-		<description>Winterhawk (Netherlands)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="winterhawk (1988)(eurosoft)(nl).dsk" size="737280" crc="596909f0" sha1="c5ee67d309a5c4411e3da126e2e8849e50531e0b" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="winthawka" cloneof="winthawk">
-		<description>Winterhawk (Netherlands, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="winterhawk (1988)(eurosoft)(nl)[a].dsk" size="737280" crc="12a07e4c" sha1="6615f671d036a0d35377ee90c9a8fb23aeebce10" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wizlair">
-		<description>Wizard's Lair (UK, trainer)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="wizard's lair (1986)(bubble bus)(gb)(m3)[h jon navarro][t].dsk" size="737280" crc="d8aeaf87" sha1="15f090acb18ad6a782c9e17623db1e0b8fc54041" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="italia90">
-		<description>World Cup Italia 90 (Spain, hacked)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="italia '90 - world cup soccer (1989)(dro soft)(es)[h msx files].dsk" size="737280" crc="e102f746" sha1="0136924f5801d67d83cd974742a93c3b5d44df5f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wldgames">
-		<description>World Games (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="world games (1987)(us gold)(gb).dsk" size="737280" crc="c39327d6" sha1="9be6f2ae4a5b0cc293844c3758795675496cbb9f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wldgamesa" cloneof="wldgames">
-		<description>World Games (UK, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="world games (1987)(us gold)(gb)[a].dsk" size="737280" crc="94adbf2a" sha1="f43b324a028496ac5ae0a294e55b459e45d228ac" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wrangler">
-		<description>Wrangler (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="wrangler (1985)(indescomp)(es).dsk" size="737280" crc="999c1fe0" sha1="1168db9d18bed74de1d08f6a3f2e999e7cd36c49" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wranglera" cloneof="wrangler">
-		<description>Wrangler (Spain, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="wrangler (1985)(indescomp)(es)[a].dsk" size="737280" crc="cd35d961" sha1="fde95775f0b5f68cdb69749ca9c9d0eb3b3cf52c" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="wreck">
-		<description>The Wreck (UK)</description>
+		<description>The Wreck (United Kingdom, disk conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;tape2disk hack&gt;</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -14896,204 +4868,17 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="xenon">
-		<description>Xenon (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="xenon (1988)(dro soft)(es).dsk" size="737280" crc="0295eba2" sha1="7842801ae5098f2df28659b768284509c58a1c93" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="xybots">
-		<description>Xybots (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="xybots (1989)(domark)(gb).dsk" size="737280" crc="da983415" sha1="f5e0c6251988e285c71cae698187de485fb8d59f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="xyzolog">
-		<description>Xyzolog (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="xyxolog. xyzolog (1985)(nidecom)(jp).dsk" size="737280" crc="402eb1ff" sha1="81634205cdb6c279242447c5756add5036101aca" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="yellowsb">
-		<description>Yellow Submarine (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="yellow submarin (1988)(cat).dsk" size="737280" crc="4fdd28dc" sha1="dc23333cf082a65493c849db8ce4071eaf247029" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="yiear">
-		<description>Yie Ar Kung-Fu (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="yie ar kung-fu (1985)(konami)(jp).dsk" size="737280" crc="829a03d5" sha1="eea5ff59cb27bca4fd1cf2efba5037b60d26a479" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="yiear2">
-		<description>Yie Ar Kung-Fu II - The Emperor Yie-Gah (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="yie ar kung-fu ii - the emperor yie-gah (1985)(konami)(jp).dsk" size="737280" crc="30bd900e" sha1="b7fbcc37041650e8e0412071b5835e8df87bf856" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="youkaiya">
-		<description>Youkai Yashiki (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="youkai yashiki. boynight. haunted house (1986)(casio)(jp).dsk" size="737280" crc="e81695a9" sha1="958f43145333fef2479e18793b6a6a0d09a04116" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ysherlck">
-		<description>Young Sherlock - Doyle no Isan (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="young sherlock - the legacy of doyle (1985)(pack in video)(jp).dsk" size="737280" crc="601406ad" sha1="6f3404a866aa2c266a8eec6de5177a65eadd1f8e" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="zanac">
-		<description>Zanac (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
+		<description>Zanac (Netherlands)</description>
+		<year>1986</year>
+		<publisher>Eaglesoft</publisher>
+		<info name="serial" value="8425" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="zanac (1986)(pony canyon)(jp).dsk" size="737280" crc="f4fd8a99" sha1="3576937c461d5ef5c25d749b46d035c33deb23d4" />
+				<!-- According to generation-msx this was released on a single sided floppy. -->
+				<rom name="zanac (1986)(pony canyon)(jp).dsk" size="737280" crc="f4fd8a99" sha1="3576937c461d5ef5c25d749b46d035c33deb23d4" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
-
-	<software name="zanac2">
-		<description>Zanac 2nd Version (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="zanac - 2nd version (1987)(pony canyon)(jp).dsk" size="737280" crc="bf794d91" sha1="0c16a2af3089cec00135cb99ca80a23290cd7edb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zanac2a" cloneof="zanac2">
-		<description>Zanac 2nd Version (Japan, alt)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="zanac - 2nd version (1987)(pony canyon)(jp)[a].dsk" size="368640" crc="58e70588" sha1="733ce0d0718af6f26aca71acfefe7379cdc319a4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zaxxon">
-		<description>Zaxxon (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="zaxxon (1985)(electric software)(gb).dsk" size="737280" crc="8e1ad699" sha1="f9efe547dd1cbe2df3a9cd3e70055715fbff5b7c" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zaxxonj">
-		<description>Zaxxon (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="zaxxon (1985)(pony canyon)(jp).dsk" size="737280" crc="455d0806" sha1="07d6009cc597760502c85906a067d98f84bc9d95" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zexas">
-		<description>Zexas (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="zexas (1984)(db-soft)(jp).dsk" size="737280" crc="c31392c1" sha1="d227ee348f4dad00cbb8c051e8634a89966e3cf7" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zexasltd">
-		<description>Zexas Limited (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="zexas limited (1985)(db-soft)(jp).dsk" size="737280" crc="24e65147" sha1="2463516fc7a5fda9b76c1dd63db812bf6a6a3fa2" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zond">
-		<description>Zond (Spain)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="zond (1988)(iber soft)(es)[aka zexas].dsk" size="737280" crc="071d3d29" sha1="c53cfd69d20204dba4b5513254f22f1ff58c2c7f" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zoom909">
-		<description>Zoom 909 (Japan)</description>
-		<year>19??</year>
-		<publisher>&lt;cart2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="zoom 909 (1985)(sega)(jp).dsk" size="737280" crc="918244d8" sha1="47f1c03c9ce4d00fe0b305e6be5c065dd81a8db4" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="zoot">
-		<description>Zoot (UK)</description>
-		<year>19??</year>
-		<publisher>&lt;tape2disk hack&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="zoot (1986)(bug-byte software)(gb).dsk" size="737280" crc="49d1ab0a" sha1="e378fdad0febc0a5bdc4bdecb55ae9ff416cae77" />
-			</dataarea>
-		</part>
-	</software>
-
-
 
 </softwarelist>


### PR DESCRIPTION
msx1_flop.xml
- Marked double sided images for single sided releases as bad dumps.
- Add notes and serial numbers.
- Add ‘disk conversion’ to the titles of disk conversions.
- Removed disk conversions for software entries which are present in their original software list(s).
- Removed entries that were made single sided by cutting a double sided dump in half (and thus resulted in not working images): msxdosb, burgkilla, spacewlk, ballblaza, diamine2a, mj05, phstripa, raththaa, safarixa.
- Renamed spacewlka to spacewlk, mj05a to mj05, and pm1_asia to pm2_asia.

Software list items promoted to working (msx1_flop.xml)
---------------------------------------
Spectravideo SVI-738 [Wilbert Pol]
