### PR TITLE
Add SX-Window 3.1 alternate dump

### DIFF
--- a/hash/x68k_flop.xml
+++ b/hash/x68k_flop.xml
@@ -16388,7 +16388,7 @@ Typing "CD PACMAN" and enter key, Typing "PAC" (or "PAC.BAT") and enter key. The
 	</software>
 
 	<software name="sxwin31b" cloneof="sxwin31">
-		<description>SX-Window v3.1 (Alt 2)</description>
+		<description>SX-Window v3.1 (alt 2)</description>
 		<year>1994</year>
 		<publisher>Sharp</publisher>
 		<part name="flop1" interface="floppy_5_25">

--- a/hash/x68k_flop.xml
+++ b/hash/x68k_flop.xml
@@ -16352,7 +16352,7 @@ Typing "CD PACMAN" and enter key, Typing "PAC" (or "PAC.BAT") and enter key. The
 	</software>
 
 	<software name="sxwin31a" cloneof="sxwin31">
-		<description>SX-Window v3.1 (Alt)</description>
+		<description>SX-Window v3.1 (alt)</description>
 		<year>1993</year>
 		<publisher>Sharp</publisher>
 		<part name="flop1" interface="floppy_5_25">

--- a/hash/x68k_flop.xml
+++ b/hash/x68k_flop.xml
@@ -16387,6 +16387,54 @@ Typing "CD PACMAN" and enter key, Typing "PAC" (or "PAC.BAT") and enter key. The
 		</part>
 	</software>
 
+	<software name="sxwin31b" cloneof="sxwin31">
+		<description>SX-Window v3.1 (Alt 2)</description>
+		<year>1994</year>
+		<publisher>Sharp</publisher>
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="SX-Window System Disk" />
+			<dataarea name="flop" size="1261824">
+				<rom name="sxwindow-31-system-disk.dim" size="1261824" crc="23ed2194" sha1="c8283da6b63de6c84e708b3cd886ca78ff344f4d" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Human68k System Disk" />
+			<dataarea name="flop" size="1261824">
+				<rom name="sxwindow-31-human-68k-system-disk.dim" size="1261824" crc="5c75926c" sha1="17f12907bccdc90a8a5ca7771973f4379d4dd01b" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Application Disk 1" />
+			<dataarea name="flop" size="1261824">
+				<rom name="sxwindow-31-application-disk-1.dim" size="1261824" crc="0d4da5ec" sha1="8ecc69fee353bad716a9c885559a9c1c7128244f" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Application Disk 2" />
+			<dataarea name="flop" size="1261824">
+				<rom name="sxwindow-31-application-disk-2.dim" size="1261824" crc="de2642dd" sha1="087fc8effe96b696f1463f7595cd726756b195b8" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Application Disk 3" />
+			<dataarea name="flop" size="1261824">
+				<rom name="sxwindow-31-application-disk-3.dim" size="1261824" crc="47eaed0b" sha1="c5ac4f5e275da7e357c24789f1a031a44b044b27" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Kakuchou Disk" />
+			<dataarea name="flop" size="1261824">
+				<rom name="sxwindow-31-expansion-disk.dim" size="1261824" crc="049cbf8b" sha1="e10ccb9636baa56efb9415e6db10c03f9f5c5d6b" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Jisho Disk" />
+			<dataarea name="flop" size="1261824">
+				<rom name="sxwindow-31-dictionary-disk.dim" size="1261824" crc="0c1a44bd" sha1="95071af45e005e9f9dbf2b521cf67f37b6ea7251" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="sxwin30" cloneof="sxwin31">
 		<description>SX-Window v3.0</description>
 		<year>1993</year>


### PR DESCRIPTION
I found a boxed SX-Window 3.1 set that had two extra disks not in the already existing dumps. These images were dumped directly from the pictured floppy disks using a Greaseweazle and a Mitsumi 5.25" drive.

Images: https://archive.org/details/sxwindow-31.tar
![IMG_4309](https://user-images.githubusercontent.com/32155223/209404393-0624e48e-4f57-4aeb-b7bb-080da5459484.jpeg)

I've never updated a software list before, so let me know if I made any mistakes :)