### PR TITLE
discrete: fix DISC_OP_AMP_OSCILLATOR_VCO_3

### DIFF
--- a/src/devices/sound/disc_wav.hxx
+++ b/src/devices/sound/disc_wav.hxx
@@ -746,7 +746,7 @@ DISCRETE_STEP(dss_op_amp_osc)
 			}
 			/* we need to mix any bias and all modulation voltages together. */
 			v = DSS_OP_AMP_OSC__VMOD1 - OP_AMP_NORTON_VBE;
-			if (v < 0) v = 0;
+			// if (v < 0) v = 0; /* no clipping. this voltage can be minus, for charging +/- to "C" */
 			charge[0] += v / info->r1;
 			if (info->r6 != 0)
 			{


### PR DESCRIPTION
Hello there,  
I play the Space Invaders on mame, but these sound .... bit differ.  
  
Perhaps this fix the part of the Space Invaders' "TRIGGER SOUND", a beam sound.  
  
This is my first Pull requests. I would be glad to point out any problems.