### PR TITLE
pacman/pengo.cpp: Sorted Pengo sets, and changed scheme for short names

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -34901,13 +34901,13 @@ pengadvb2                       // (c) 1988 Comet
 @source:pacman/pengo.cpp
 jrpacmbl                        // bootleg on Pengo HW
 pengo                           // 834-0386 (c) 1982 Sega
-pengo2                          // 834-0386 (c) 1982 Sega
-pengo2u                         // 834-0386 (c) 1982 Sega
-pengo3u                         // 834-0386 (c) 1982 Sega
-pengo4                          // 834-0386 (c) 1982 Sega
-pengo5                          // 834-0386 (c) 1982 Sega
-pengo6                          // 834-0386 (c) 1982 Sega
-pengob                          // bootleg
+pengoa                          // 834-0386 (c) 1982 Sega
+pengob                          // 834-0386 (c) 1982 Sega
+pengoc                          // 834-0386 (c) 1982 Sega
+pengoj                          // 834-0386 (c) 1982 Sega
+pengoja                         // 834-0386 (c) 1982 Sega
+pengojb                         // 834-0386 (c) 1982 Sega
+pengojbl                        // bootleg
 penta                           // bootleg
 
 @source:handheld/pensebem.cpp

--- a/src/mame/pacman/pengo.cpp
+++ b/src/mame/pacman/pengo.cpp
@@ -825,10 +825,10 @@ void pengo_state::init_pengo6()
 
 // World / Export releases do the pre-maze curtain effect instantly, draw the maze more quickly, have a short demo, and do not feature the 'popcorn' music.
 GAME( 1982, pengo,    0,        pengou,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, not encrypted, rev A)",    MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5092 PENGO REV.A
-GAME( 1982, pengoa,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, 315-5010 type) (set 1)",   MACHINE_SUPPORTS_SAVE )
-GAME( 1982, pengob,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, 315-5010 type) (set 2)",   MACHINE_SUPPORTS_SAVE ) // for Bally?
+GAME( 1982, pengoa,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, 315-5010 type, set 1)",    MACHINE_SUPPORTS_SAVE )
+GAME( 1982, pengob,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, 315-5010 type, set 2)",    MACHINE_SUPPORTS_SAVE ) // for Bally?
 // this set is closest to the Japanese sets, with longer demo mode, and slower 'curtain draw' before the maze draw
-GAME( 1982, pengoc,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, 315-5010 type) (set 3)",   MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5081 PENGO
+GAME( 1982, pengoc,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, 315-5010 type, set 3)",    MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5081 PENGO
 
 
 // Japan releases draw the maze slowly, use the better known 'popcorn' music and have default high score of 20,000. Most bootlegs were based off these versions.
@@ -836,7 +836,7 @@ GAME( 1982, pengoj,   pengo,    pengou,   pengo,    pengo_state, empty_init,  RO
 // sets below have high score names spelling out AKIRA and use 'ACT' instead of 'RD'
 GAME( 1982, pengoja,  pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (Japan, 315-5010 type, rev C)",    MACHINE_SUPPORTS_SAVE )
 GAME( 1982, pengojb,  pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "Sega",                     "Pengo (Japan, 315-5007 type, rev A)",    MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5078 PENGO REV.A
-GAME( 1982, pengojbl, pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "bootleg",                  "Pengo (Japan) (bootleg)",                MACHINE_SUPPORTS_SAVE ) // bootleg of pengojb with cloned encryption
+GAME( 1982, pengojbl, pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "bootleg",                  "Pengo (Japan, bootleg)",                 MACHINE_SUPPORTS_SAVE ) // bootleg of pengojb with cloned encryption
 GAME( 1982, penta,    pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "bootleg (Grinbee Shouji)", "Penta (bootleg)",                        MACHINE_SUPPORTS_SAVE ) // Grinbee Shouji was a subsidiary of Orca
 
-GAME( 1983, jrpacmbl, jrpacman, jrpacmbl, jrpacmbl, pengo_state, empty_init,  ROT90, "bootleg",                  "Jr. Pac-Man (Pengo hardware) (bootleg)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1983, jrpacmbl, jrpacman, jrpacmbl, jrpacmbl, pengo_state, empty_init,  ROT90, "bootleg",                  "Jr. Pac-Man (Pengo hardware, bootleg)",  MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/pacman/pengo.cpp
+++ b/src/mame/pacman/pengo.cpp
@@ -448,62 +448,7 @@ void pengo_state::jrpacmbl(machine_config &config)
  *
  *************************************/
 
-
-ROM_START( pengo ) // Uses Sega 315-5010 encrypted Z80 CPU
-	ROM_REGION( 0x10000, "maincpu", 0 )
-	ROM_LOAD( "epr-1689c.ic8",  0x0000, 0x1000, CRC(f37066a8) SHA1(0930de17a763a527057f60783a92662b09554426) )
-	ROM_LOAD( "epr-1690b.ic7",  0x1000, 0x1000, CRC(baf48143) SHA1(4c97529e61eeca5d94938b1dfbeac41bf8cbaf7d) )
-	ROM_LOAD( "epr-1691b.ic15", 0x2000, 0x1000, CRC(adf0eba0) SHA1(c8949fbdbfe5023ee17a789ef60205e834a76c81) )
-	ROM_LOAD( "epr-1692b.ic14", 0x3000, 0x1000, CRC(a086d60f) SHA1(7079769d14dfe3873ffe29623ba0a93413706c6d) )
-	ROM_LOAD( "epr-1693b.ic21", 0x4000, 0x1000, CRC(b72084ec) SHA1(c0508951c2ad8dc31481be8b3bfee2063e3fb0d7) )
-	ROM_LOAD( "epr-1694b.ic20", 0x5000, 0x1000, CRC(94194a89) SHA1(7b47aec61593efd758e2a031f72a854bb0ba8af1) )
-	ROM_LOAD( "epr-5118b.ic32", 0x6000, 0x1000, CRC(af7b12c4) SHA1(207ed466546f40ca60a38031b83aef61446902e2) )
-	ROM_LOAD( "epr-5119c.ic31", 0x7000, 0x1000, CRC(933950fe) SHA1(fec7236b3dee2ea6e39c68440a6d2d9e3f72675a) )
-
-	ROM_REGION( 0x4000, "gfx1", 0 )
-	ROM_LOAD( "epr-1640.ic92",  0x0000, 0x1000, CRC(d7eec6cd) SHA1(e542bcc28f292be9a0a29d949de726e0b55e654a) ) // tiles (bank 1)
-	ROM_CONTINUE(               0x2000, 0x1000 ) // sprites (bank 1)
-	ROM_LOAD( "epr-1695.ic105", 0x1000, 0x1000, CRC(5bfd26e9) SHA1(bdec535e486b43a8f5550334beff423eeace10b2) ) // tiles (bank 2)
-	ROM_CONTINUE(               0x3000, 0x1000 ) // sprites (bank 2)
-
-	ROM_REGION( 0x0420, "proms", 0 )
-	ROM_LOAD( "pr1633.ic78",    0x0000, 0x0020, CRC(3a5844ec) SHA1(680eab0e1204c9b74adc11588461651b474021bb) ) // color palette
-	ROM_LOAD( "pr1634.ic88",    0x0020, 0x0400, CRC(766b139b) SHA1(3fcd66610fcaee814953a115bf5e04788923181f) ) // color lookup
-
-	ROM_REGION( 0x0200, "namco", 0 )
-	ROM_LOAD( "pr1635.ic51",    0x0000, 0x0100, CRC(c29dea27) SHA1(563c9770028fe39188e62630711589d6ed242a66) ) // waveform
-	ROM_LOAD( "pr1636.ic70",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) ) // timing - not used
-ROM_END
-
-
-ROM_START( pengo2 ) // Uses Sega 315-5010 encrypted Z80 CPU
-	ROM_REGION( 0x10000, "maincpu", 0 )
-	ROM_LOAD( "ic8.2",          0x0000, 0x1000, CRC(e4924b7b) SHA1(44297658af8f8c884eba02b792346c5008137dfe) )
-	ROM_LOAD( "ic7.2",          0x1000, 0x1000, CRC(72e7775d) SHA1(49e04178ee171f727dd023c019395679cfbad452) )
-	ROM_LOAD( "ic15.2",         0x2000, 0x1000, CRC(7410ef1e) SHA1(7ed8e16c6ce401904c0da9758e2a405d7b9b451b) )
-	ROM_LOAD( "ic14.2",         0x3000, 0x1000, CRC(55b3f379) SHA1(bc244f97132f0514adb3d6ceda8afbd45c1c587a) )
-	ROM_LOAD( "epr-1693b.ic21", 0x4000, 0x1000, CRC(b72084ec) SHA1(c0508951c2ad8dc31481be8b3bfee2063e3fb0d7) )
-	ROM_LOAD( "ic20.2",         0x5000, 0x1000, CRC(770570cf) SHA1(43ead8236f53d39041ffc21bdeef10b3a77ce7f2) )
-	ROM_LOAD( "epr-5118b.ic32", 0x6000, 0x1000, CRC(af7b12c4) SHA1(207ed466546f40ca60a38031b83aef61446902e2) )
-	ROM_LOAD( "ic31.2",         0x7000, 0x1000, CRC(669555c1) SHA1(50d5cf8022af6d6bd022235ab06015cb5c8aa433) )
-
-	ROM_REGION( 0x4000, "gfx1", 0 )
-	ROM_LOAD( "epr-1640.ic92",  0x0000, 0x1000, CRC(d7eec6cd) SHA1(e542bcc28f292be9a0a29d949de726e0b55e654a) ) // tiles (bank 1)
-	ROM_CONTINUE(               0x2000, 0x1000 ) // sprites (bank 1)
-	ROM_LOAD( "epr-1695.ic105", 0x1000, 0x1000, CRC(5bfd26e9) SHA1(bdec535e486b43a8f5550334beff423eeace10b2) ) // tiles (bank 2)
-	ROM_CONTINUE(               0x3000, 0x1000 ) // sprites (bank 2)
-
-	ROM_REGION( 0x0420, "proms", 0 )
-	ROM_LOAD( "pr1633.ic78",    0x0000, 0x0020, CRC(3a5844ec) SHA1(680eab0e1204c9b74adc11588461651b474021bb) ) // color palette
-	ROM_LOAD( "pr1634.ic88",    0x0020, 0x0400, CRC(766b139b) SHA1(3fcd66610fcaee814953a115bf5e04788923181f) ) // color lookup
-
-	ROM_REGION( 0x0200, "namco", 0 )
-	ROM_LOAD( "pr1635.ic51",    0x0000, 0x0100, CRC(c29dea27) SHA1(563c9770028fe39188e62630711589d6ed242a66) ) // waveform
-	ROM_LOAD( "pr1636.ic70",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) ) // timing - not used
-ROM_END
-
-
-ROM_START( pengo2u ) // Sega game ID# 834-5092 PENGO REV.A
+ROM_START( pengo ) // Sega game ID# 834-5092 PENGO REV.A
 	ROM_REGION( 0x10000, "maincpu", 0 )
 	ROM_LOAD( "epr-5128.ic8",   0x0000, 0x1000, CRC(3dfeb20e) SHA1(a387b72501da77bf38b58619d2099083a0463e1f) )
 	ROM_LOAD( "epr-5129.ic7",   0x1000, 0x1000, CRC(1db341bd) SHA1(d1c66bb9cf479e6960dbcd35c820097a81eaa555) )
@@ -530,16 +475,18 @@ ROM_START( pengo2u ) // Sega game ID# 834-5092 PENGO REV.A
 ROM_END
 
 
-ROM_START( pengo3u ) //  Sega game ID# 834-5091 PENGO
+ROM_START( pengoa ) // Uses Sega 315-5010 encrypted Z80 CPU
+	// TODO: verify labels for this set, similar to pengoja current labeled ROMs seem to suggest a mix
+	//       of higher revision 1xxx roms, with a final pair of 51xx ROMs
 	ROM_REGION( 0x10000, "maincpu", 0 )
-	ROM_LOAD( "epr-5120.ic8",     0x0000, 0x1000, CRC(f01afb60) SHA1(1db732a17a9f79f8f1751f80c77889142928e41b) )
-	ROM_LOAD( "epr-5121.ic7",     0x1000, 0x1000, CRC(2eb38353) SHA1(d351347f93a3ed01c8b5274ec19352dd611a8dd4) )
-	ROM_LOAD( "epr-5122.ic15",    0x2000, 0x1000, CRC(c33400d7) SHA1(7b9617d22a9de8d3658abe34b5d2171ce37acc39) )
-	ROM_LOAD( "epr-5123.ic14",    0x3000, 0x1000, CRC(6a85c6a2) SHA1(444acc08607c892bb20b3a02753169addf5b11de) )
-	ROM_LOAD( "epr-5124.ic21",    0x4000, 0x1000, CRC(95f354ff) SHA1(fdebc68a6d87f8ecdf52a57a34ae5ae844a13510) )
-	ROM_LOAD( "epr-5125.ic20",    0x5000, 0x1000, CRC(1a42310f) SHA1(fef20385299a709ee17ed16510ac5702bd5cc257) )
-	ROM_LOAD( "epr-5126.ic32",    0x6000, 0x1000, CRC(e5920728) SHA1(0ac5ffdad7bdcb32e630b9582e1b1aaece5198c9) )
-	ROM_LOAD( "epr-5127.ic31",    0x7000, 0x1000, CRC(a7d3d1d6) SHA1(20e4353208c3803d8879b25f821ea617e9a19cc4) )
+	ROM_LOAD( "ic8.2",          0x0000, 0x1000, CRC(e4924b7b) SHA1(44297658af8f8c884eba02b792346c5008137dfe) )
+	ROM_LOAD( "ic7.2",          0x1000, 0x1000, CRC(72e7775d) SHA1(49e04178ee171f727dd023c019395679cfbad452) )
+	ROM_LOAD( "ic15.2",         0x2000, 0x1000, CRC(7410ef1e) SHA1(7ed8e16c6ce401904c0da9758e2a405d7b9b451b) )
+	ROM_LOAD( "ic14.2",         0x3000, 0x1000, CRC(55b3f379) SHA1(bc244f97132f0514adb3d6ceda8afbd45c1c587a) )
+	ROM_LOAD( "epr-1693b.ic21", 0x4000, 0x1000, CRC(b72084ec) SHA1(c0508951c2ad8dc31481be8b3bfee2063e3fb0d7) )
+	ROM_LOAD( "ic20.2",         0x5000, 0x1000, CRC(770570cf) SHA1(43ead8236f53d39041ffc21bdeef10b3a77ce7f2) )
+	ROM_LOAD( "epr-5118b.ic32", 0x6000, 0x1000, CRC(af7b12c4) SHA1(207ed466546f40ca60a38031b83aef61446902e2) )
+	ROM_LOAD( "ic31.2",         0x7000, 0x1000, CRC(669555c1) SHA1(50d5cf8022af6d6bd022235ab06015cb5c8aa433) )
 
 	ROM_REGION( 0x4000, "gfx1", 0 )
 	ROM_LOAD( "epr-1640.ic92",  0x0000, 0x1000, CRC(d7eec6cd) SHA1(e542bcc28f292be9a0a29d949de726e0b55e654a) ) // tiles (bank 1)
@@ -556,32 +503,6 @@ ROM_START( pengo3u ) //  Sega game ID# 834-5091 PENGO
 	ROM_LOAD( "pr1636.ic70",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) ) // timing - not used
 ROM_END
 
-
-ROM_START( pengo4 ) // Sega game ID# 834-5081 PENGO (REV.A of this set known to exist, but not currently dumped) - Uses Sega 315-5010 encrypted Z80 CPU
-	ROM_REGION( 0x10000, "maincpu", 0 )
-	ROM_LOAD( "epr-1738.ic8",    0x0000, 0x1000, CRC(68ba25ea) SHA1(ce937831b7b210b4a625514bd4e6b3a7a36d008e) )
-	ROM_LOAD( "epr-1739.ic7",    0x1000, 0x1000, CRC(41e7b5b3) SHA1(d512d41ee3f5716070250e7ab63342e4fbf92875) )
-	ROM_LOAD( "epr-1740.ic15",   0x2000, 0x1000, CRC(27f05f59) SHA1(c0d40328a7dff34f6b84c991d9c88b240e55b4f3) )
-	ROM_LOAD( "epr-1741.ic14",   0x3000, 0x1000, CRC(27d93ec1) SHA1(925e59878342af58106d5b11ebb6c86cbb69ae91) )
-	ROM_LOAD( "epr-1742.ic21",   0x4000, 0x1000, CRC(b72084ec) SHA1(c0508951c2ad8dc31481be8b3bfee2063e3fb0d7) )
-	ROM_LOAD( "epr-1743.ic20",   0x5000, 0x1000, CRC(770570cf) SHA1(43ead8236f53d39041ffc21bdeef10b3a77ce7f2) )
-	ROM_LOAD( "epr-1744.ic32",   0x6000, 0x1000, CRC(af7b12c4) SHA1(207ed466546f40ca60a38031b83aef61446902e2) )
-	ROM_LOAD( "epr-1745.ic31",   0x7000, 0x1000, CRC(507e18b9) SHA1(e169e4c9c6350fb5e4020222dbcaa6f5ce41849c) )
-
-	ROM_REGION( 0x4000, "gfx1", 0 )
-	ROM_LOAD( "epr-1640.ic92",  0x0000, 0x1000, CRC(d7eec6cd) SHA1(e542bcc28f292be9a0a29d949de726e0b55e654a) ) // tiles (bank 1)
-	ROM_CONTINUE(               0x2000, 0x1000 ) // sprites (bank 1)
-	ROM_LOAD( "epr-1695.ic105", 0x1000, 0x1000, CRC(5bfd26e9) SHA1(bdec535e486b43a8f5550334beff423eeace10b2) ) // tiles (bank 2)
-	ROM_CONTINUE(               0x3000, 0x1000 ) // sprites (bank 2)
-
-	ROM_REGION( 0x0420, "proms", 0 )
-	ROM_LOAD( "pr1633.ic78",    0x0000, 0x0020, CRC(3a5844ec) SHA1(680eab0e1204c9b74adc11588461651b474021bb) ) // color palette
-	ROM_LOAD( "pr1634.ic88",    0x0020, 0x0400, CRC(766b139b) SHA1(3fcd66610fcaee814953a115bf5e04788923181f) ) // color lookup
-
-	ROM_REGION( 0x0200, "namco", 0 )
-	ROM_LOAD( "pr1635.ic51",    0x0000, 0x0100, CRC(c29dea27) SHA1(563c9770028fe39188e62630711589d6ed242a66) ) // waveform
-	ROM_LOAD( "pr1636.ic70",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) ) // timing - not used
-ROM_END
 
 /*
 A PCB (not dumped) with dated ROMs like the set below has been seen with later dates:
@@ -596,7 +517,7 @@ A PCB (not dumped) with dated ROMs like the set below has been seen with later d
 
 PCB labeled as 834-5081 PENGO REV.A
 */
-ROM_START( pengo5 ) // Sega game ID# 834-5081 PENGO - PCB has an additional label Bally N.E. - Uses Sega 315-5010 encrypted Z80 CPU
+ROM_START( pengob ) // Sega game ID# 834-5081 PENGO - PCB has an additional label Bally N.E. - Uses Sega 315-5010 encrypted Z80 CPU
 	ROM_REGION( 0x10000, "maincpu", 0 )
 	ROM_LOAD( "0_oct6-82.ic8",    0x0000, 0x1000, CRC(43e45441) SHA1(e94a9f9971e57cd53fe425059a6cb7cadbd206f1) )
 	ROM_LOAD( "1_oct11-82.ic7",   0x1000, 0x1000, CRC(30a52a90) SHA1(e5ff7e16f40b42e56847d63ecbf4a0793f510c42) )
@@ -622,7 +543,88 @@ ROM_START( pengo5 ) // Sega game ID# 834-5081 PENGO - PCB has an additional labe
 	ROM_LOAD( "pr1636.ic70",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) ) // timing - not used
 ROM_END
 
-ROM_START( pengo6 ) // Sega game ID# 834-5078 PENGO  REV.A - Uses Sega 315-5007 encrypted Z80 CPU
+ROM_START( pengoc ) // Sega game ID# 834-5081 PENGO (REV.A of this set known to exist, but not currently dumped) - Uses Sega 315-5010 encrypted Z80 CPU
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "epr-1738.ic8",    0x0000, 0x1000, CRC(68ba25ea) SHA1(ce937831b7b210b4a625514bd4e6b3a7a36d008e) )
+	ROM_LOAD( "epr-1739.ic7",    0x1000, 0x1000, CRC(41e7b5b3) SHA1(d512d41ee3f5716070250e7ab63342e4fbf92875) )
+	ROM_LOAD( "epr-1740.ic15",   0x2000, 0x1000, CRC(27f05f59) SHA1(c0d40328a7dff34f6b84c991d9c88b240e55b4f3) )
+	ROM_LOAD( "epr-1741.ic14",   0x3000, 0x1000, CRC(27d93ec1) SHA1(925e59878342af58106d5b11ebb6c86cbb69ae91) )
+	ROM_LOAD( "epr-1742.ic21",   0x4000, 0x1000, CRC(b72084ec) SHA1(c0508951c2ad8dc31481be8b3bfee2063e3fb0d7) )
+	ROM_LOAD( "epr-1743.ic20",   0x5000, 0x1000, CRC(770570cf) SHA1(43ead8236f53d39041ffc21bdeef10b3a77ce7f2) )
+	ROM_LOAD( "epr-1744.ic32",   0x6000, 0x1000, CRC(af7b12c4) SHA1(207ed466546f40ca60a38031b83aef61446902e2) )
+	ROM_LOAD( "epr-1745.ic31",   0x7000, 0x1000, CRC(507e18b9) SHA1(e169e4c9c6350fb5e4020222dbcaa6f5ce41849c) )
+
+	ROM_REGION( 0x4000, "gfx1", 0 )
+	ROM_LOAD( "epr-1640.ic92",  0x0000, 0x1000, CRC(d7eec6cd) SHA1(e542bcc28f292be9a0a29d949de726e0b55e654a) ) // tiles (bank 1)
+	ROM_CONTINUE(               0x2000, 0x1000 ) // sprites (bank 1)
+	ROM_LOAD( "epr-1695.ic105", 0x1000, 0x1000, CRC(5bfd26e9) SHA1(bdec535e486b43a8f5550334beff423eeace10b2) ) // tiles (bank 2)
+	ROM_CONTINUE(               0x3000, 0x1000 ) // sprites (bank 2)
+
+	ROM_REGION( 0x0420, "proms", 0 )
+	ROM_LOAD( "pr1633.ic78",    0x0000, 0x0020, CRC(3a5844ec) SHA1(680eab0e1204c9b74adc11588461651b474021bb) ) // color palette
+	ROM_LOAD( "pr1634.ic88",    0x0020, 0x0400, CRC(766b139b) SHA1(3fcd66610fcaee814953a115bf5e04788923181f) ) // color lookup
+
+	ROM_REGION( 0x0200, "namco", 0 )
+	ROM_LOAD( "pr1635.ic51",    0x0000, 0x0100, CRC(c29dea27) SHA1(563c9770028fe39188e62630711589d6ed242a66) ) // waveform
+	ROM_LOAD( "pr1636.ic70",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) ) // timing - not used
+ROM_END
+
+
+ROM_START( pengoj ) //  Sega game ID# 834-5091 PENGO
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "epr-5120.ic8",     0x0000, 0x1000, CRC(f01afb60) SHA1(1db732a17a9f79f8f1751f80c77889142928e41b) )
+	ROM_LOAD( "epr-5121.ic7",     0x1000, 0x1000, CRC(2eb38353) SHA1(d351347f93a3ed01c8b5274ec19352dd611a8dd4) )
+	ROM_LOAD( "epr-5122.ic15",    0x2000, 0x1000, CRC(c33400d7) SHA1(7b9617d22a9de8d3658abe34b5d2171ce37acc39) )
+	ROM_LOAD( "epr-5123.ic14",    0x3000, 0x1000, CRC(6a85c6a2) SHA1(444acc08607c892bb20b3a02753169addf5b11de) )
+	ROM_LOAD( "epr-5124.ic21",    0x4000, 0x1000, CRC(95f354ff) SHA1(fdebc68a6d87f8ecdf52a57a34ae5ae844a13510) )
+	ROM_LOAD( "epr-5125.ic20",    0x5000, 0x1000, CRC(1a42310f) SHA1(fef20385299a709ee17ed16510ac5702bd5cc257) )
+	ROM_LOAD( "epr-5126.ic32",    0x6000, 0x1000, CRC(e5920728) SHA1(0ac5ffdad7bdcb32e630b9582e1b1aaece5198c9) )
+	ROM_LOAD( "epr-5127.ic31",    0x7000, 0x1000, CRC(a7d3d1d6) SHA1(20e4353208c3803d8879b25f821ea617e9a19cc4) )
+
+	ROM_REGION( 0x4000, "gfx1", 0 )
+	ROM_LOAD( "epr-1640.ic92",  0x0000, 0x1000, CRC(d7eec6cd) SHA1(e542bcc28f292be9a0a29d949de726e0b55e654a) ) // tiles (bank 1)
+	ROM_CONTINUE(               0x2000, 0x1000 ) // sprites (bank 1)
+	ROM_LOAD( "epr-1695.ic105", 0x1000, 0x1000, CRC(5bfd26e9) SHA1(bdec535e486b43a8f5550334beff423eeace10b2) ) // tiles (bank 2)
+	ROM_CONTINUE(               0x3000, 0x1000 ) // sprites (bank 2)
+
+	ROM_REGION( 0x0420, "proms", 0 )
+	ROM_LOAD( "pr1633.ic78",    0x0000, 0x0020, CRC(3a5844ec) SHA1(680eab0e1204c9b74adc11588461651b474021bb) ) // color palette
+	ROM_LOAD( "pr1634.ic88",    0x0020, 0x0400, CRC(766b139b) SHA1(3fcd66610fcaee814953a115bf5e04788923181f) ) // color lookup
+
+	ROM_REGION( 0x0200, "namco", 0 )
+	ROM_LOAD( "pr1635.ic51",    0x0000, 0x0100, CRC(c29dea27) SHA1(563c9770028fe39188e62630711589d6ed242a66) ) // waveform
+	ROM_LOAD( "pr1636.ic70",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) ) // timing - not used
+ROM_END
+
+ROM_START( pengoja ) // Uses Sega 315-5010 encrypted Z80 CPU
+	// NOTE: while the first 6 program ROMs are 16xx marked, suggesting the oldest release, they're higher revisions
+	//       of those ROMs, and the final 2 program ROMs are much newer, with 51xx codes.
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "epr-1689c.ic8",  0x0000, 0x1000, CRC(f37066a8) SHA1(0930de17a763a527057f60783a92662b09554426) )
+	ROM_LOAD( "epr-1690b.ic7",  0x1000, 0x1000, CRC(baf48143) SHA1(4c97529e61eeca5d94938b1dfbeac41bf8cbaf7d) )
+	ROM_LOAD( "epr-1691b.ic15", 0x2000, 0x1000, CRC(adf0eba0) SHA1(c8949fbdbfe5023ee17a789ef60205e834a76c81) )
+	ROM_LOAD( "epr-1692b.ic14", 0x3000, 0x1000, CRC(a086d60f) SHA1(7079769d14dfe3873ffe29623ba0a93413706c6d) )
+	ROM_LOAD( "epr-1693b.ic21", 0x4000, 0x1000, CRC(b72084ec) SHA1(c0508951c2ad8dc31481be8b3bfee2063e3fb0d7) )
+	ROM_LOAD( "epr-1694b.ic20", 0x5000, 0x1000, CRC(94194a89) SHA1(7b47aec61593efd758e2a031f72a854bb0ba8af1) )
+	ROM_LOAD( "epr-5118b.ic32", 0x6000, 0x1000, CRC(af7b12c4) SHA1(207ed466546f40ca60a38031b83aef61446902e2) )
+	ROM_LOAD( "epr-5119c.ic31", 0x7000, 0x1000, CRC(933950fe) SHA1(fec7236b3dee2ea6e39c68440a6d2d9e3f72675a) )
+
+	ROM_REGION( 0x4000, "gfx1", 0 )
+	ROM_LOAD( "epr-1640.ic92",  0x0000, 0x1000, CRC(d7eec6cd) SHA1(e542bcc28f292be9a0a29d949de726e0b55e654a) ) // tiles (bank 1)
+	ROM_CONTINUE(               0x2000, 0x1000 ) // sprites (bank 1)
+	ROM_LOAD( "epr-1695.ic105", 0x1000, 0x1000, CRC(5bfd26e9) SHA1(bdec535e486b43a8f5550334beff423eeace10b2) ) // tiles (bank 2)
+	ROM_CONTINUE(               0x3000, 0x1000 ) // sprites (bank 2)
+
+	ROM_REGION( 0x0420, "proms", 0 )
+	ROM_LOAD( "pr1633.ic78",    0x0000, 0x0020, CRC(3a5844ec) SHA1(680eab0e1204c9b74adc11588461651b474021bb) ) // color palette
+	ROM_LOAD( "pr1634.ic88",    0x0020, 0x0400, CRC(766b139b) SHA1(3fcd66610fcaee814953a115bf5e04788923181f) ) // color lookup
+
+	ROM_REGION( 0x0200, "namco", 0 )
+	ROM_LOAD( "pr1635.ic51",    0x0000, 0x0100, CRC(c29dea27) SHA1(563c9770028fe39188e62630711589d6ed242a66) ) // waveform
+	ROM_LOAD( "pr1636.ic70",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) ) // timing - not used
+ROM_END
+
+ROM_START( pengojb ) // Sega game ID# 834-5078 PENGO  REV.A - Uses Sega 315-5007 encrypted Z80 CPU
 	ROM_REGION( 0x10000, "maincpu", 0 )
 	ROM_LOAD( "epr-1701a.ic8",  0x0000, 0x1000, CRC(6ad6b227) SHA1(818f061009597d467af0156aa7e6e367369c421b) )
 	ROM_LOAD( "epr-1702.ic7",   0x1000, 0x1000, CRC(cea1e8d1) SHA1(ac04d55c8cf20db9edc80788424b5c0c3b4ff446) )
@@ -648,7 +650,7 @@ ROM_START( pengo6 ) // Sega game ID# 834-5078 PENGO  REV.A - Uses Sega 315-5007 
 	ROM_LOAD( "pr1636.ic70",    0x0100, 0x0100, CRC(77245b66) SHA1(0c4d0bee858b97632411c440bea6948a74759746) ) // timing - not used
 ROM_END
 
-ROM_START( pengob ) // based on pengo6, uses daughterboard with a Z80 plus additional circuitry to replicate Sega's 315-5007 encryption
+ROM_START( pengojbl ) // based on pengojb, uses daughterboard with a Z80 plus additional circuitry to replicate Sega's 315-5007 encryption
 	ROM_REGION( 0x10000, "maincpu", 0 )
 	ROM_LOAD( "1", 0x0000, 0x2000, CRC(e04064db) SHA1(6689066b443807646894a357317f468bfc92368a) ) // == epr-1701a.ic8 + epr-1702.ic7
 	ROM_LOAD( "2", 0x2000, 0x2000, CRC(75752424) SHA1(634e696a692c7245dfa5c5dfd4ce87755c2a90d4) ) //           (2/2) == epr-1704.ic14
@@ -821,13 +823,20 @@ void pengo_state::init_pengo6()
  *
  *************************************/
 
-GAME( 1982, pengo,    0,        pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (set 1 rev C, encrypted)",      MACHINE_SUPPORTS_SAVE )
-GAME( 1982, pengo2,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (set 2, encrypted)",            MACHINE_SUPPORTS_SAVE )
-GAME( 1982, pengo2u,  pengo,    pengou,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (set 2, rev A, not encrypted)", MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5092 PENGO REV.A
-GAME( 1982, pengo3u,  pengo,    pengou,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (set 3, not encrypted)",        MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5091 PENGO
-GAME( 1982, pengo4,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (set 4, encrypted)",            MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5081 PENGO
-GAME( 1982, pengo5,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (set 5, encrypted)",            MACHINE_SUPPORTS_SAVE )
-GAME( 1982, pengo6,   pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "Sega",                     "Pengo (set 6, encrypted)",            MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5078 PENGO REV.A
-GAME( 1982, pengob,   pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "bootleg",                  "Pengo (bootleg)",                     MACHINE_SUPPORTS_SAVE )
-GAME( 1982, penta,    pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "bootleg (Grinbee Shouji)", "Penta",                               MACHINE_SUPPORTS_SAVE ) // Grinbee Shouji was a subsidiary of Orca
-GAME( 1983, jrpacmbl, jrpacman, jrpacmbl, jrpacmbl, pengo_state, empty_init,  ROT90, "bootleg",                  "Jr. Pac-Man (Pengo hardware)",        MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+// World / Export releases do the pre-maze curtain effect instantly, draw the maze more quickly, have a short demo, and do not feature the 'popcorn' music.
+GAME( 1982, pengo,    0,        pengou,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, not encrypted, rev A)",    MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5092 PENGO REV.A
+GAME( 1982, pengoa,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, 315-5010 type) (set 1)",   MACHINE_SUPPORTS_SAVE )
+GAME( 1982, pengob,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, 315-5010 type) (set 2)",   MACHINE_SUPPORTS_SAVE ) // for Bally?
+// this set is closest to the Japanese sets, with longer demo mode, and slower 'curtain draw' before the maze draw
+GAME( 1982, pengoc,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, 315-5010 type) (set 3)",   MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5081 PENGO
+
+
+// Japan releases draw the maze slowly, and use the better known 'popcorn' music.  Most bootlegs were based off these versions.
+GAME( 1982, pengoj,   pengo,    pengou,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (Japan, not encrypted)",           MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5091 PENGO
+GAME( 1982, pengoja,  pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (Japan, 315-5010 type, rev C)",    MACHINE_SUPPORTS_SAVE )
+// sets below have default high score of 20,000 and high score names spelling out AKIRA and use 'ACT' instead of 'RD'
+GAME( 1982, pengojb,  pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "Sega",                     "Pengo (Japan, 315-5007 type, rev A)",    MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5078 PENGO REV.A
+GAME( 1982, pengojbl, pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "bootleg",                  "Pengo (Japan) (bootleg)",                MACHINE_SUPPORTS_SAVE ) // bootleg of pengojb with cloned encryption
+GAME( 1982, penta,    pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "bootleg (Grinbee Shouji)", "Penta (bootleg)",                        MACHINE_SUPPORTS_SAVE ) // Grinbee Shouji was a subsidiary of Orca
+
+GAME( 1983, jrpacmbl, jrpacman, jrpacmbl, jrpacmbl, pengo_state, empty_init,  ROT90, "bootleg",                  "Jr. Pac-Man (Pengo hardware) (bootleg)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/pacman/pengo.cpp
+++ b/src/mame/pacman/pengo.cpp
@@ -833,8 +833,8 @@ GAME( 1982, pengoc,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  RO
 
 // Japan releases draw the maze slowly, and use the better known 'popcorn' music.  Most bootlegs were based off these versions.
 GAME( 1982, pengoj,   pengo,    pengou,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (Japan, not encrypted)",           MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5091 PENGO
-GAME( 1982, pengoja,  pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (Japan, 315-5010 type, rev C)",    MACHINE_SUPPORTS_SAVE )
 // sets below have default high score of 20,000 and high score names spelling out AKIRA and use 'ACT' instead of 'RD'
+GAME( 1982, pengoja,  pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (Japan, 315-5010 type, rev C)",    MACHINE_SUPPORTS_SAVE )
 GAME( 1982, pengojb,  pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "Sega",                     "Pengo (Japan, 315-5007 type, rev A)",    MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5078 PENGO REV.A
 GAME( 1982, pengojbl, pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "bootleg",                  "Pengo (Japan) (bootleg)",                MACHINE_SUPPORTS_SAVE ) // bootleg of pengojb with cloned encryption
 GAME( 1982, penta,    pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "bootleg (Grinbee Shouji)", "Penta (bootleg)",                        MACHINE_SUPPORTS_SAVE ) // Grinbee Shouji was a subsidiary of Orca

--- a/src/mame/pacman/pengo.cpp
+++ b/src/mame/pacman/pengo.cpp
@@ -831,9 +831,9 @@ GAME( 1982, pengob,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  RO
 GAME( 1982, pengoc,   pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (World, 315-5010 type) (set 3)",   MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5081 PENGO
 
 
-// Japan releases draw the maze slowly, and use the better known 'popcorn' music.  Most bootlegs were based off these versions.
+// Japan releases draw the maze slowly, use the better known 'popcorn' music and have default high score of 20,000. Most bootlegs were based off these versions.
 GAME( 1982, pengoj,   pengo,    pengou,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (Japan, not encrypted)",           MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5091 PENGO
-// sets below have default high score of 20,000 and high score names spelling out AKIRA and use 'ACT' instead of 'RD'
+// sets below have high score names spelling out AKIRA and use 'ACT' instead of 'RD'
 GAME( 1982, pengoja,  pengo,    pengoe,   pengo,    pengo_state, empty_init,  ROT90, "Sega",                     "Pengo (Japan, 315-5010 type, rev C)",    MACHINE_SUPPORTS_SAVE )
 GAME( 1982, pengojb,  pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "Sega",                     "Pengo (Japan, 315-5007 type, rev A)",    MACHINE_SUPPORTS_SAVE ) // Sega game ID# 834-5078 PENGO REV.A
 GAME( 1982, pengojbl, pengo,    pengo,    pengo,    pengo_state, init_pengo6, ROT90, "bootleg",                  "Pengo (Japan) (bootleg)",                MACHINE_SUPPORTS_SAVE ) // bootleg of pengojb with cloned encryption


### PR DESCRIPTION
reorganized the Pengo sets a little
- The Export versions are the versions with replaced music / faster maze drawing
- The Japan versions have slow maze drawing and the 'popcorn' music
- The unencrypted sets are the newest releases we have of both versions - for Japan that is ROMs 5120-5127 and for export that is ROMs 5128 - 5135 (suggesting these unencrypted versions were both released at the same time)
- see https://tcrf.net/Pengo_(Arcade) for some research