### PR TITLE
Fix opening local 'socket.' files instead of actually opening a TCP socket

### DIFF
--- a/src/osd/modules/file/posixfile.cpp
+++ b/src/osd/modules/file/posixfile.cpp
@@ -403,6 +403,13 @@ std::error_condition osd_get_full_path(std::string &dst, std::string const &path
 {
 	try
 	{
+		if (posix_check_socket_path(path) ||
+		    posix_check_ptty_path(path)   ||
+		    posix_check_domain_path(path))
+		{
+			dst = path;
+			return std::error_condition();
+		}
 #if defined(_WIN32)
 		std::vector<char> path_buffer(MAX_PATH);
 		if (::_fullpath(&path_buffer[0], path.c_str(), MAX_PATH))

--- a/src/osd/modules/file/winfile.cpp
+++ b/src/osd/modules/file/winfile.cpp
@@ -407,6 +407,12 @@ std::error_condition osd_get_full_path(std::string &dst, std::string const &path
 {
 	try
 	{
+		if (win_check_socket_path(path) ||
+		    win_check_ptty_path(path))
+		{
+			dst = path;
+			return std::error_condition();
+		}
 		// get the length of the full path
 		std::wstring const w_path(osd::text::to_wstring(path));
 		DWORD const length(GetFullPathNameW(w_path.c_str(), 0, nullptr, nullptr));

--- a/src/osd/modules/file/winrtfile.cpp
+++ b/src/osd/modules/file/winrtfile.cpp
@@ -341,6 +341,12 @@ std::unique_ptr<osd::directory::entry> osd_stat(const std::string &path)
 
 osd_file::error osd_get_full_path(std::string &dst, std::string const &path)
 {
+	if (win_check_socket_path(path) ||
+	    win_check_ptty_path(path))
+	{
+		dst = path;
+		return std::error_condition();
+	}
 	// convert the path to TCHARs
 	osd::text::tstring t_path = osd::text::to_tstring(path);
 


### PR DESCRIPTION
When using a bitbanger device after resetting the machine it opens the file as a normal file instead of open a socket connection.

After doing some looking this is because when the image device opens a file it uses zippath_fopen and then sets the image filename to the revised path afterwards. This causes the the image to no longer start with 'socket.' since we now have the full path prepended to the original image. 

This fix updates the osd_get_full_path functions to detect if the filename is a socket,ptty, or domain device and simply return the original path if so.