### PR TITLE
Merge copies of text_update and plot_text_character in a2_video_device

### DIFF
--- a/src/mame/apple/apple2.cpp
+++ b/src/mame/apple/apple2.cpp
@@ -119,7 +119,7 @@ public:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
-	template <bool invert, bool flip>
+	template <bool Invert, bool Flip>
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_jp(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	u32 screen_update_ultr(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
@@ -373,7 +373,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(apple2_state::apple2_interrupt)
 	}
 }
 
-template <bool invert, bool flip>
+template <bool Invert, bool Flip>
 u32 apple2_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// always update the flash timer here so it's smooth regardless of mode switches
@@ -386,7 +386,7 @@ u32 apple2_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, con
 			if (m_video->m_mix)
 			{
 				m_video->hgr_update(screen, bitmap, cliprect, 0, 159);
-				m_video->text_update<false, invert, flip>(screen, bitmap, cliprect, 160, 191);
+				m_video->text_update<a2_video_device::model::II, Invert, Flip>(screen, bitmap, cliprect, 160, 191);
 			}
 			else
 			{
@@ -398,7 +398,7 @@ u32 apple2_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, con
 			if (m_video->m_mix)
 			{
 				m_video->lores_update(screen, bitmap, cliprect, 0, 159);
-				m_video->text_update<false, invert, flip>(screen, bitmap, cliprect, 160, 191);
+				m_video->text_update<a2_video_device::model::II, Invert, Flip>(screen, bitmap, cliprect, 160, 191);
 			}
 			else
 			{
@@ -408,7 +408,7 @@ u32 apple2_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, con
 	}
 	else
 	{
-		m_video->text_update<false, invert, flip>(screen, bitmap, cliprect, 0, 191);
+		m_video->text_update<a2_video_device::model::II, Invert, Flip>(screen, bitmap, cliprect, 0, 191);
 	}
 
 	return 0;
@@ -426,7 +426,7 @@ u32 apple2_state::screen_update_jp(screen_device &screen, bitmap_ind16 &bitmap, 
 			if (m_video->m_mix)
 			{
 				m_video->hgr_update(screen, bitmap, cliprect, 0, 159);
-				m_video->text_update_jplus(screen, bitmap, cliprect, 160, 191);
+				m_video->text_update<a2_video_device::model::II_J_PLUS, true, true>(screen, bitmap, cliprect, 160, 191);
 			}
 			else
 			{
@@ -438,7 +438,7 @@ u32 apple2_state::screen_update_jp(screen_device &screen, bitmap_ind16 &bitmap, 
 			if (m_video->m_mix)
 			{
 				m_video->lores_update(screen, bitmap, cliprect, 0, 159);
-				m_video->text_update_jplus(screen, bitmap, cliprect, 160, 191);
+				m_video->text_update<a2_video_device::model::II_J_PLUS, true, true>(screen, bitmap, cliprect, 160, 191);
 			}
 			else
 			{
@@ -448,7 +448,7 @@ u32 apple2_state::screen_update_jp(screen_device &screen, bitmap_ind16 &bitmap, 
 	}
 	else
 	{
-		m_video->text_update_jplus(screen, bitmap, cliprect, 0, 191);
+		m_video->text_update<a2_video_device::model::II_J_PLUS, true, true>(screen, bitmap, cliprect, 0, 191);
 	}
 
 	return 0;
@@ -466,7 +466,7 @@ u32 apple2_state::screen_update_ultr(screen_device &screen, bitmap_ind16 &bitmap
 			if (m_video->m_mix)
 			{
 				m_video->hgr_update(screen, bitmap, cliprect, 0, 159);
-				m_video->text_update_ultr(screen, bitmap, cliprect, 160, 191);
+				m_video->text_update<a2_video_device::model::IVEL_ULTRA, true, false>(screen, bitmap, cliprect, 160, 191);
 			}
 			else
 			{
@@ -478,7 +478,7 @@ u32 apple2_state::screen_update_ultr(screen_device &screen, bitmap_ind16 &bitmap
 			if (m_video->m_mix)
 			{
 				m_video->lores_update(screen, bitmap, cliprect, 0, 159);
-				m_video->text_update_ultr(screen, bitmap, cliprect, 160, 191);
+				m_video->text_update<a2_video_device::model::IVEL_ULTRA, true, false>(screen, bitmap, cliprect, 160, 191);
 			}
 			else
 			{
@@ -488,7 +488,7 @@ u32 apple2_state::screen_update_ultr(screen_device &screen, bitmap_ind16 &bitmap
 	}
 	else
 	{
-		m_video->text_update_ultr(screen, bitmap, cliprect, 0, 191);
+		m_video->text_update<a2_video_device::model::IVEL_ULTRA, true, false>(screen, bitmap, cliprect, 0, 191);
 	}
 
 	return 0;

--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -290,7 +290,7 @@ public:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
-	template <bool invert, bool flip>
+	template <bool Invert, bool Flip>
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	u32 screen_update_ff(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect) { return screen_update<false, false>(screen, bitmap, cliprect); }
@@ -1351,7 +1351,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(apple2e_state::apple2_interrupt)
 	}
 }
 
-template<bool invert, bool flip>
+template <bool Invert, bool Flip>
 u32 apple2e_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bool old_page2 = m_video->m_page2;
@@ -1380,7 +1380,7 @@ u32 apple2e_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, co
 					m_video->hgr_update(screen, bitmap, cliprect, 0, 159);
 				}
 
-				m_video->text_update<true, invert, flip>(screen, bitmap, cliprect, 160, 191);
+				m_video->text_update<a2_video_device::model::IIE, Invert, Flip>(screen, bitmap, cliprect, 160, 191);
 			}
 			else
 			{
@@ -1407,7 +1407,7 @@ u32 apple2e_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, co
 					m_video->lores_update(screen, bitmap, cliprect, 0, 159);
 				}
 
-				m_video->text_update<true, invert, flip>(screen, bitmap, cliprect, 160, 191);
+				m_video->text_update<a2_video_device::model::IIE, Invert, Flip>(screen, bitmap, cliprect, 160, 191);
 			}
 			else
 			{
@@ -1424,7 +1424,7 @@ u32 apple2e_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, co
 	}
 	else
 	{
-		m_video->text_update<true, invert, flip>(screen, bitmap, cliprect, 0, 191);
+		m_video->text_update<a2_video_device::model::IIE, Invert, Flip>(screen, bitmap, cliprect, 0, 191);
 	}
 
 	m_video->m_page2 = old_page2;

--- a/src/mame/apple/apple2video.h
+++ b/src/mame/apple/apple2video.h
@@ -51,12 +51,12 @@ public:
 	DECLARE_WRITE_LINE_MEMBER(dhires_w);
 	DECLARE_WRITE_LINE_MEMBER(an2_w);
 
-	template<bool iie, bool invert, bool flip>
+	// Models with different text-mode behavior. II includes the II+ and IIE includes the IIc and IIc Plus.
+	enum class model { II, IIE, IIGS, II_J_PLUS, IVEL_ULTRA };
+
+	template <model Model, bool Invert, bool Flip>
 	void text_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 
-	void text_update_ultr(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
-	void text_update_jplus(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
-	void text_updateGS(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 	void lores_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 	void dlores_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 	void hgr_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
@@ -73,11 +73,8 @@ protected:
 	void init_palette();
 
 private:
-	template <bool iie, bool invert, bool flip>
+	template <model Model, bool Invert, bool Flip>
 	void plot_text_character(bitmap_ind16 &bitmap, int xpos, int ypos, int xscale, uint32_t code, int fg, int bg);
-	void plot_text_character_ultr(bitmap_ind16 &bitmap, int xpos, int ypos, int xscale, uint32_t code, int fg, int bg);
-	void plot_text_character_jplus(bitmap_ind16 &bitmap, int xpos, int ypos, int xscale, uint32_t code, int fg, int bg);
-	void plot_text_characterGS(bitmap_ind16 &bitmap, int xpos, int ypos, int xscale, uint32_t code, int fg, int bg);
 };
 
 // device type definition


### PR DESCRIPTION
a2_video_device::{text_update,plot_text_character} already had a template parameter to distinguish II/II+ from IIe/IIc. Extending it enables {text_update,plot_text_character}{_ultr,_jplus,GS} to be merged in as well.

I preserved all of the logic of the old functions even where I suspect it's wrong. Behavior that seems suspicious to me: not masking by 0x3f on II/II+ (isn't their character ROM only 0.5K?); logic for the range 60..7f on IIe/c not applied on GS; and inconsistent use of m_aux_mask in aux_page accesses.

One exception to the previous paragraph: text_update_{jplus,ultr} didn't calculate startcol and stopcol, which seems to be just a missed optimization opportunity, and they tested row <= stoprow instead of row < stoprow, which is a bug that would make them emit 25 lines instead of 24. I removed those differences.

This commit doesn't merge the screen_update_* functions, but they should also be merged.