### PR TITLE
png.py: use real itertools, not _dummy_itertools polyfill

### DIFF
--- a/scripts/build/png.py
+++ b/scripts/build/png.py
@@ -148,10 +148,7 @@ from __future__ import generators,print_function
 __version__ = "0.0.17"
 
 from array import array
-try:
-    from itertools import imap
-except ImportError:
-    imap = map
+import itertools
 import math
 # http://www.python.org/doc/2.4.4/lib/module-operator.html
 import operator
@@ -1654,7 +1651,7 @@ class Reader:
             for o in raw:
                 out.extend(list(map(lambda i: mask&(o>>i), shifts)))
             return out[:width]
-        return itertools.imap(asvalues, rows)
+        return map(asvalues, rows)
 
     def serialtoflat(self, bytes, width=None):
         """Convert serial format (byte stream) pixel data to flat row
@@ -1951,7 +1948,7 @@ class Reader:
             arraycode = 'BH'[self.bitdepth>8]
             # Like :meth:`group` but producing an array.array object for
             # each row.
-            pixels = itertools.imap(lambda *row: array(arraycode, row),
+            pixels = map(lambda *row: array(arraycode, row),
                        *[iter(self.deinterlace(raw))]*self.width*self.planes)
         else:
             pixels = self.iterboxed(self.iterstraight(raw))
@@ -2362,22 +2359,6 @@ except NameError:
         l.reverse()
         for x in l:
             yield x
-
-try:
-    itertools
-except NameError:
-    class _dummy_itertools:
-        pass
-    itertools = _dummy_itertools()
-    def _itertools_imap(f, seq):
-        for x in seq:
-            yield f(x)
-    itertools.imap = _itertools_imap
-    def _itertools_chain(*iterables):
-        for it in iterables:
-            for element in it:
-                yield element
-    itertools.chain = _itertools_chain
 
 
 # === Support for users without Cython ===


### PR DESCRIPTION
A fix intended for Python 2/3 compatibility removed the import of `itertools` but didn't remove references to it. The library happened to include a itertools polyfill for compatibility with Python 2.2, and that ended up being used on all Python versions.

I noticed this because I have a sitecustomize.py that adds itertools to the builtins, which causes the real itertools to be used, which fails because the real itertools doesn't have `imap` (it was removed in Python 3).

I guess I'm the first person to suffer from this bug since it was checked in 8 years ago, but it is a bug so may as well fix it.

This library is used to read exactly one file during the build process (`src/frontend/mame/ui/uicmd14.png`, the only `png` file in the `src` tree), so a more elaborate solution, like upgrading the library, doesn't seem worth it. I verified that the output of that build step is the same before and after this change.