### PR TITLE
hd6309: Fix STBT instruction

### DIFF
--- a/src/devices/cpu/m6809/hd6309.lst
+++ b/src/devices/cpu/m6809/hd6309.lst
@@ -1049,13 +1049,14 @@ LDBT:
 STBT:
 	%IMM_IM;
 	%DIRECT;
-	@m_temp.b.l = read_operand();
+	@m_temp.b.l = bittest_register();
+	@m_temp.b.h = read_operand();
 	if (bittest_source())
-		m_temp.b.l |= (1 << ((m_temp_im >> 0) & 0x07));
+		m_temp.b.h |= (1 << (m_temp_im & 0x07));
 	else
-		m_temp.b.l &= ~(1 << ((m_temp_im >> 0) & 0x07));
+		m_temp.b.h &= ~(1 << (m_temp_im & 0x07));
 	@eat(2);
-	write_operand(m_temp.b.l);
+	write_operand(m_temp.b.h);
 	return;
 
 MULD:


### PR DESCRIPTION
This is a weird instruction that can copy a bit from a register to a memory location.

Previously it was not reading the value of the memory of the location before modifying it.