### PR TITLE
Apple II: fix Video-7 RGB card double hi-res modes

### DIFF
--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -779,7 +779,9 @@ void a2_video_device::dhgr_update(screen_device &screen, bitmap_ind16 &bitmap, c
 			{
 				case 0:
 					for (int b = 0; b < 7; b++)
+					{
 						*p++ = rotl4((w >> (b + 7-1)) & 0x0F, col * 7 + b);
+					}
 					break;
 
 				case 1:
@@ -838,14 +840,18 @@ void a2_video_device::dhgr_update(screen_device &screen, bitmap_ind16 &bitmap, c
 					if (m_rgbmode == 1 && !(vram_row[col+1] & 0x80))  // monochrome
 					{
 						for (int b = 0; b < 7; b++)
+						{
 							*p++ = ((w >> (b + 7)) & 1) ? WHITE : BLACK;
+						}
 					}
 					else  // color
 					{
 						// In column 0 get the color from w bits 7-10 or 11-14,
 						// in column 1 get the color from w bits 4-7 or 8-11, etc.
 						for (int b = 0; b < 7; b++)
+						{
 							*p++ = rotl4((w >> (b - ((b - col) & 3) + 7)) & 0x0F, 1);
+						}
 					}
 					break;
 			}


### PR DESCRIPTION
Fix an off-by-1 error in the 160-column mode that caused the rightmost 2 pixels to be omitted. In 140-column color and mixed modes, use custom logic to make 140 wide pixels instead of simulating blurry artifact color. In mixed mode, each high bit controls 7 narrow pixels according to the manual.

With these changes, the card seems to pass all of the tests on the official demo disk, except that foreground-background hires remains unimplemented, "Color Mouse Draw" seems to hang/crash, and some demos sometimes set the wrong mode when run after other demos (including themselves). The last could be a bug in the demos.