### PR TITLE
Make all clients of a2_video_device use screen_update

### DIFF
--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -73,9 +73,10 @@ void a2_video_device::device_start()
 
 void a2_video_device::device_reset()
 {
+	// Start in fullscreen hires if there is no character ROM. This is used
+	// by the superga2 and tk2000 drivers, which support no other modes.
+	m_graphics = m_hires = (m_char_ptr == nullptr);
 	m_page2 = false;
-	m_graphics = false;
-	m_hires = false;
 	m_80col = false;
 	m_altcharset = false;
 	m_dhires = false;

--- a/src/mame/apple/apple2video.h
+++ b/src/mame/apple/apple2video.h
@@ -72,9 +72,6 @@ public:
 
 	uint32_t screen_update_GS(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	// This is called directly by the superga2 and tk2000 drivers.
-	void hgr_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
-
 protected:
 	virtual void device_reset() override;
 	virtual void device_start() override;
@@ -91,6 +88,7 @@ private:
 
 	void lores_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 	void dlores_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
+	void hgr_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 	void dhgr_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int beginrow, int endrow);
 
 	bool use_page_2() const;

--- a/src/mame/apple/superga2.cpp
+++ b/src/mame/apple/superga2.cpp
@@ -66,8 +66,6 @@ public:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
-	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-
 	uint8_t ram_r(offs_t offset);
 	void ram_w(offs_t offset, uint8_t data);
 	uint8_t speaker_toggle_r();
@@ -103,7 +101,7 @@ void superga2_state::machine_start()
 
 	// setup video pointers
 	m_video->set_ram_pointers(m_ram_ptr, m_ram_ptr);
-	m_video->set_char_pointer(memregion("gfx1")->base(), memregion("gfx1")->bytes());
+	m_video->set_char_pointer(nullptr, 0);  // no text modes on this machine
 	m_video->set_sysconfig(0);
 }
 
@@ -112,17 +110,6 @@ void superga2_state::machine_reset()
 	uint8_t *user1 = memregion("maincpu")->base();
 
 	memcpy(&m_ram_ptr[0x1100], user1, 0x8000);
-}
-
-/***************************************************************************
-    VIDEO
-***************************************************************************/
-
-uint32_t superga2_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
-{
-	m_video->hgr_update(screen, bitmap, cliprect, 0, 191);
-
-	return 0;
 }
 
 /***************************************************************************
@@ -222,7 +209,7 @@ void superga2_state::superga2(machine_config &config)
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(1021800*14, (65*7)*2, 0, (40*7)*2, 262, 0, 192);
-	m_screen->set_screen_update(FUNC(superga2_state::screen_update));
+	m_screen->set_screen_update(m_video, NAME((&a2_video_device::screen_update<a2_video_device::model::II, false, false>)));
 	m_screen->set_palette(m_video);
 
 	/* sound hardware */
@@ -231,10 +218,11 @@ void superga2_state::superga2(machine_config &config)
 
 	/* soft switches */
 	F9334(config, m_softlatch);
-	m_softlatch->q_out_cb<0>().set(m_video, FUNC(a2_video_device::txt_w));
-	m_softlatch->q_out_cb<1>().set(m_video, FUNC(a2_video_device::mix_w));
 	m_softlatch->q_out_cb<2>().set(m_video, FUNC(a2_video_device::scr_w));
-	m_softlatch->q_out_cb<3>().set(m_video, FUNC(a2_video_device::res_w));
+	// these don't cause mode changes
+	// m_softlatch->q_out_cb<0>().set(m_video, FUNC(a2_video_device::txt_w));
+	// m_softlatch->q_out_cb<1>().set(m_video, FUNC(a2_video_device::mix_w));
+	// m_softlatch->q_out_cb<3>().set(m_video, FUNC(a2_video_device::res_w));
 
 	RAM(config, RAM_TAG).set_default_size("48K").set_default_value(0x00);
 }
@@ -246,8 +234,6 @@ void superga2_state::superga2(machine_config &config)
 ***************************************************************************/
 
 ROM_START(kuzmich)
-	ROM_REGION(0x0800,"gfx1",0)
-	ROM_FILL(0, 0x800, 0)
 	ROM_REGION(0x8000,"maincpu",0)
 	ROM_LOAD("ke.bin", 0x0000, 0x8000, CRC(102d246b) SHA1(492dcdf0cc31190a97057a69010e2c9c23b6e59d))
 ROM_END

--- a/src/mame/apple/tk2000.cpp
+++ b/src/mame/apple/tk2000.cpp
@@ -98,8 +98,6 @@ private:
 
 	TIMER_DEVICE_CALLBACK_MEMBER(apple2_interrupt);
 
-	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-
 	uint8_t ram_r(offs_t offset);
 	void ram_w(offs_t offset, uint8_t data);
 
@@ -176,12 +174,6 @@ TIMER_DEVICE_CALLBACK_MEMBER(tk2000_state::apple2_interrupt)
 	{
 		m_video->set_sysconfig(m_sysconfig->read());
 	}
-}
-
-uint32_t tk2000_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
-{
-	m_video->hgr_update(screen, bitmap, cliprect, 0, 191);
-	return 0;
 }
 
 /***************************************************************************
@@ -594,7 +586,7 @@ void tk2000_state::tk2000(machine_config &config)
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
 	m_screen->set_size(280*2, 262);
 	m_screen->set_visarea(0, (280*2)-1,0,192-1);
-	m_screen->set_screen_update(FUNC(tk2000_state::screen_update));
+	m_screen->set_screen_update(m_video, NAME((&a2_video_device::screen_update<a2_video_device::model::II, false, false>)));
 	m_screen->set_palette(m_video);
 
 	/* sound hardware */


### PR DESCRIPTION
The superga2 and tk2000 drivers called hgr_update directly. Instead set the appropriate mode and call screen_update, and make hgr_update private along with the other mode-specific functions.