### PR TITLE
taito/taito_f2.cpp: Use screen_vblank_partial_buffer_delayed for Mega Blast (MT08543)

### DIFF
--- a/src/mame/taito/taito_f2.cpp
+++ b/src/mame/taito/taito_f2.cpp
@@ -2923,6 +2923,7 @@ void taitof2_state::megab(machine_config &config)
 	/* video hardware */
 	MCFG_VIDEO_START_OVERRIDE(taitof2_state,megab)
 	m_screen->set_screen_update(FUNC(taitof2_state::screen_update_pri));
+	m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_partial_buffer_delayed));
 
 	TC0100SCN(config, m_tc0100scn[0], 0);
 	m_tc0100scn[0]->set_offsets(3, 0);


### PR DESCRIPTION
Fixes MT08543 – megablst and clones: Shield powerup aura on option is missing.

Many other games in the driver use `m_screen->screen_vblank().set(FUNC(taitof2_state::screen_vblank_partial_buffer_delayed));` and there's a long explanation about the game software and how they buffers things and why it is needed in those cases.  I don't know why it wasn't set for this game however, so please check for new issues elsewhere.