### PR TITLE
BFM_BDA.cpp : Restore window code to fix SC5 graphical glitches

### DIFF
--- a/src/mame/bfm/bfm_bd1.cpp
+++ b/src/mame/bfm/bfm_bd1.cpp
@@ -238,48 +238,27 @@ void bfm_bd1_device::blank(int data)
 	switch ( data & 0x03 )
 	{
 	case 0x00:  //blank all
-		for (int i = 0; i < 15; i++)
-		{
-			m_attrs[i] = AT_BLANK;
-		}
+		std::fill(std::begin(m_attrs), std::end(m_attrs), AT_BLANK);
 		break;
 
 	case 0x01:  // blank inside window
 		if (m_window_size > 0)
 		{
-			for (int i = m_window_start; i < m_window_end ; i++)
-			{
-				m_attrs[i] = AT_BLANK;
-			}
+			std::fill_n(m_attrs + m_window_start, m_window_size, AT_BLANK);
 		}
 		break;
 
 	case 0x02:  // blank outside window
 		if (m_window_size > 0)
 		{
-			if (m_window_start > 0)
-			{
-				for (int i = 0; i < m_window_start; i++)
-				{
-					m_attrs[i] = AT_BLANK;
-				}
-			}
+			std::fill_n(m_attrs, m_window_start, AT_BLANK);
 
-			if (m_window_end < 15 )
-			{
-				for (int i = m_window_end; i < 15- m_window_end ; i++)
-				{
-					m_attrs[i] = AT_BLANK;
-				}
-			}
+			std::fill_n(m_attrs + m_window_end, (16 - m_window_end), AT_BLANK);
 		}
 		break;
 
 	case 0x03:  // clear blanking
-		for (int i = 0; i < 15; i++)
-		{
-			m_attrs[i] = 0;
-		}
+		std::fill(std::begin(m_attrs), std::end(m_attrs), AT_NORMAL);
 		break;
 	}
 }
@@ -348,7 +327,7 @@ int bfm_bd1_device::write_char(int data)
 					if (m_window_size > 0)
 					{
 						std::fill_n(m_chars + m_window_start, m_window_size, 0);
-						std::fill_n(m_attrs + m_window_start, m_window_size, 0);
+						std::fill_n(m_attrs + m_window_start, m_window_size, AT_NORMAL);
 					}
 
 					break;
@@ -356,29 +335,17 @@ int bfm_bd1_device::write_char(int data)
 				case 0x02:  // clr outside window
 					if (m_window_size > 0)
 					{
-						if (m_window_start > 0)
-						{
-							for (int i = 0; i < m_window_start; i++)
-							{
-								memset(m_chars+i,0,i);
-								memset(m_attrs+i,0,i);
-							}
-						}
+						std::fill_n(m_chars, m_window_start, 0);
+						std::fill_n(m_attrs, m_window_start, 0);
 
-						if (m_window_end < 15)
-						{
-							for (int i = m_window_end; i < 15- m_window_end ; i++)
-							{
-								memset(m_chars+i,0,i);
-								memset(m_attrs+i,0,i);
-							}
-						}
+						std::fill_n(m_chars + m_window_end, (16 - m_window_end), 0);
+						std::fill_n(m_attrs + m_window_end, (16 - m_window_end), AT_NORMAL);
 					}
 					break;
 
 				case 0x03:  // clr entire display
 					std::fill(std::begin(m_chars), std::end(m_chars), 0);
-					std::fill(std::begin(m_attrs), std::end(m_attrs), 0);
+					std::fill(std::begin(m_attrs), std::end(m_attrs), AT_NORMAL);
 				}
 				break;
 

--- a/src/mame/bfm/bfm_bda.cpp
+++ b/src/mame/bfm/bfm_bda.cpp
@@ -186,17 +186,9 @@ void bfm_bda_device::blank(int data)
 	case 0x02:  // blank outside window
 		if (m_window_size > 0)
 		{
-			if ( m_window_start > 0 )
+			for (int i = 0; i < 15; i++)
 			{
-				for (int i = 0; i < m_window_start; i++)
-				{
-					m_attrs[i] = AT_BLANK;
-				}
-			}
-
-			if (m_window_end < 15 )
-			{
-				for (int i = m_window_end; i < 15- m_window_end ; i++)
+				if ((i < m_window_start) || (i > m_window_end))
 				{
 					m_attrs[i] = AT_BLANK;
 				}
@@ -311,21 +303,12 @@ int bfm_bda_device::write_char(int data)
 					case 0x02:  // clr outside window
 						if (m_window_size > 0)
 						{
-							if (m_window_start > 0)
+							for (int i = 0; i < 15; i++)
 							{
-								for (int i = 0; i < m_window_start; i++)
+								if ((i < m_window_start) || (i > m_window_end))
 								{
-									memset(m_chars+i,0,i);
-									memset(m_attrs+i,0,i);
-								}
-							}
-
-							if (m_window_end < 15)
-							{
-								for (int i = m_window_end; i < 15- m_window_end ; i++)
-								{
-									memset(m_chars+i,0,i);
-									memset(m_attrs+i,0,i);
+									memset(m_chars+i, 0 ,i);
+									memset(m_attrs+i, 0, i);
 								}
 							}
 						}
@@ -336,8 +319,9 @@ int bfm_bda_device::write_char(int data)
 						std::fill(std::begin(m_attrs), std::end(m_attrs), 0);
 					}
 					break;
-			}
-			break;
+				}
+				break;
+
 			case 0xc0:
 				if (data == 0xc8)
 				{

--- a/src/mame/bfm/bfm_bda.cpp
+++ b/src/mame/bfm/bfm_bda.cpp
@@ -307,10 +307,37 @@ int bfm_bda_device::write_char(int data)
 							std::fill_n(m_attrs + m_window_start, m_window_size, 0);
 						}
 						break;
-					}
-				}
-				break;
 
+					case 0x02:  // clr outside window
+						if (m_window_size > 0)
+						{
+							if (m_window_start > 0)
+							{
+								for (int i = 0; i < m_window_start; i++)
+								{
+									memset(m_chars+i,0,i);
+									memset(m_attrs+i,0,i);
+								}
+							}
+
+							if (m_window_end < 15)
+							{
+								for (int i = m_window_end; i < 15- m_window_end ; i++)
+								{
+									memset(m_chars+i,0,i);
+									memset(m_attrs+i,0,i);
+								}
+							}
+						}
+						break;
+
+					case 0x03:  // clr entire display
+						std::fill(std::begin(m_chars), std::end(m_chars), 0);
+						std::fill(std::begin(m_attrs), std::end(m_attrs), 0);
+					}
+					break;
+			}
+			break;
 			case 0xc0:
 				if (data == 0xc8)
 				{

--- a/src/mame/bfm/bfm_bda.cpp
+++ b/src/mame/bfm/bfm_bda.cpp
@@ -141,7 +141,7 @@ void bfm_bda_device::device_reset()
 	(*m_brightness)[0] = 0;
 
 	std::fill(std::begin(m_chars), std::end(m_chars), 0);
-	std::fill(std::begin(m_attrs), std::end(m_attrs), 0);
+	std::fill(std::begin(m_attrs), std::end(m_attrs), AT_NORMAL);
 }
 
 uint16_t bfm_bda_device::set_display(uint16_t segin)
@@ -166,41 +166,27 @@ void bfm_bda_device::blank(int data)
 	switch ( data & 0x03 ) // TODO: wrong case values???
 	{
 	case 0x00:  //blank all
-		for (int i = 0; i < 15; i++)
-		{
-			m_attrs[i] = AT_BLANK;
-		}
+		std::fill(std::begin(m_attrs), std::end(m_attrs), AT_BLANK);
 		break;
-
 
 	case 0x01:  // blank inside window
 		if (m_window_size > 0)
 		{
-			for (int i = m_window_start; i < m_window_end ; i++)
-			{
-				m_attrs[i] = AT_BLANK;
-			}
+			std::fill_n(m_attrs + m_window_start, m_window_size, AT_BLANK);
 		}
 		break;
 
 	case 0x02:  // blank outside window
 		if (m_window_size > 0)
 		{
-			for (int i = 0; i < 15; i++)
-			{
-				if ((i < m_window_start) || (i > m_window_end))
-				{
-					m_attrs[i] = AT_BLANK;
-				}
-			}
+			//Do a blank from 0 to the window start, then one from the window end to the display end
+			std::fill_n(m_attrs + 0, m_window_start, AT_BLANK);
+			std::fill_n(m_attrs + m_window_end, (16 - m_window_end), AT_BLANK);
 		}
 		break;
 
 	case 0x03:  // clear blanking
-		for (int i = 0; i < 15; i++)
-		{
-			m_attrs[i] = 0;
-		}
+		std::fill(std::begin(m_attrs), std::end(m_attrs), AT_NORMAL);
 		break;
 	}
 }
@@ -296,27 +282,24 @@ int bfm_bda_device::write_char(int data)
 						if (m_window_size > 0)
 						{
 							std::fill_n(m_chars + m_window_start, m_window_size, 0);
-							std::fill_n(m_attrs + m_window_start, m_window_size, 0);
+							std::fill_n(m_attrs + m_window_start, m_window_size, AT_NORMAL);
 						}
 						break;
 
 					case 0x02:  // clr outside window
 						if (m_window_size > 0)
 						{
-							for (int i = 0; i < 15; i++)
-							{
-								if ((i < m_window_start) || (i > m_window_end))
-								{
-									memset(m_chars+i, 0 ,i);
-									memset(m_attrs+i, 0, i);
-								}
-							}
+							std::fill_n(m_chars, m_window_start, 0);
+							std::fill_n(m_attrs, m_window_start, AT_NORMAL);
+
+							std::fill_n(m_chars + m_window_end, (16 - m_window_end), 0);
+							std::fill_n(m_attrs + m_window_end, (16 - m_window_end), AT_NORMAL);
 						}
 						break;
 
 					case 0x03:  // clr entire display
 						std::fill(std::begin(m_chars), std::end(m_chars), 0);
-						std::fill(std::begin(m_attrs), std::end(m_attrs), 0);
+						std::fill(std::begin(m_attrs), std::end(m_attrs), AT_NORMAL);
 					}
 					break;
 				}


### PR DESCRIPTION
This should fix the regressions noted here (https://github.com/mamedev/mame/commit/6e5d7328cb152e56612bb5bc20ddb0ec3434c617#commitcomment-95293594)

In short, the window code for BDA still uses the clear all method that was missed out before.

There's more that needs to be done, but this restores the behaviour on error currently seen