### PR TITLE
sun4c, SPARC, and NCR53C90 bugfixes

### DIFF
--- a/scripts/src/machine.lua
+++ b/scripts/src/machine.lua
@@ -4034,13 +4034,13 @@ end
 
 ---------------------------------------------------
 --
---@src/devices/machine/ncr5390.h,MACHINES["NCR5390"] = true
+--@src/devices/machine/ncr53c90.h,MACHINES["NCR53C90"] = true
 ---------------------------------------------------
 
-if (MACHINES["NCR5390"]~=null) then
+if (MACHINES["NCR53C90"]~=null) then
 	files {
-		MAME_DIR .. "src/devices/machine/ncr5390.cpp",
-		MAME_DIR .. "src/devices/machine/ncr5390.h",
+		MAME_DIR .. "src/devices/machine/ncr53c90.cpp",
+		MAME_DIR .. "src/devices/machine/ncr53c90.h",
 	}
 end
 

--- a/src/devices/bus/archimedes/podule/scsi_morley.cpp
+++ b/src/devices/bus/archimedes/podule/scsi_morley.cpp
@@ -15,7 +15,7 @@
 #include "emu.h"
 #include "scsi_morley.h"
 #include "machine/7200fifo.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "bus/nscsi/devices.h"
 
 

--- a/src/devices/bus/archimedes/podule/scsi_vti.cpp
+++ b/src/devices/bus/archimedes/podule/scsi_vti.cpp
@@ -16,7 +16,7 @@
 #include "scsi_vti.h"
 #include "machine/6522via.h"
 #include "machine/eepromser.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "bus/bbc/userport/userport.h"
 #include "bus/nscsi/devices.h"
 

--- a/src/devices/bus/isa/bt54x.cpp
+++ b/src/devices/bus/isa/bt54x.cpp
@@ -18,7 +18,7 @@
 #include "bt54x.h"
 
 #include "bus/nscsi/devices.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 //#include "machine/ncr86c05.h"
 
 DEFINE_DEVICE_TYPE(BT542B, bt542b_device, "bt542b", "BusTek BT-542B SCSI Host Adapter") // Rev. G or earlier

--- a/src/devices/bus/isa/tekram_dc820.cpp
+++ b/src/devices/bus/isa/tekram_dc820.cpp
@@ -26,7 +26,7 @@
 #include "bus/nscsi/devices.h"
 #include "cpu/i86/i186.h"
 #include "machine/i82355.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "machine/nscsi_bus.h"
 
 DEFINE_DEVICE_TYPE(TEKRAM_DC320B, tekram_dc320b_device, "dc320b", "Tekram DC-320B SCSI Controller")

--- a/src/devices/bus/isa/ultra14f.cpp
+++ b/src/devices/bus/isa/ultra14f.cpp
@@ -11,7 +11,7 @@
 
 #include "bus/nscsi/devices.h"
 #include "cpu/m68000/m68008.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "machine/nscsi_bus.h"
 
 DEFINE_DEVICE_TYPE(ULTRA14F, ultra14f_device, "ultra14f", "Ultra-14F SCSI Host Adapter")

--- a/src/devices/bus/isa/ultra24f.cpp
+++ b/src/devices/bus/isa/ultra24f.cpp
@@ -11,7 +11,7 @@
 
 #include "bus/nscsi/devices.h"
 #include "cpu/m68000/m68000.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "machine/nscsi_bus.h"
 
 DEFINE_DEVICE_TYPE(ULTRA24F, ultra24f_device, "ultra24f", "Ultra-24F SCSI Host Adapter")

--- a/src/devices/bus/nscsi/cdd2000.cpp
+++ b/src/devices/bus/nscsi/cdd2000.cpp
@@ -9,7 +9,7 @@
 #include "emu.h"
 #include "bus/nscsi/cdd2000.h"
 #include "cpu/mc68hc11/mc68hc11.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 
 DEFINE_DEVICE_TYPE(CDD2000, cdd2000_device, "cdd2000", "Philips CDD2000 CD-R")
 

--- a/src/devices/bus/nscsi/cdu415.h
+++ b/src/devices/bus/nscsi/cdu415.h
@@ -8,7 +8,7 @@
 
 #include "machine/nscsi_bus.h"
 #include "cpu/h8/h83032.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 
 class cdu415_device : public device_t, public nscsi_slot_card_interface
 {

--- a/src/devices/bus/nscsi/cdu75s.h
+++ b/src/devices/bus/nscsi/cdu75s.h
@@ -8,7 +8,7 @@
 
 #include "machine/nscsi_bus.h"
 #include "cpu/h8/h83032.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 
 class cdu75s_device : public device_t, public nscsi_slot_card_interface
 {

--- a/src/devices/bus/nscsi/crd254sh.h
+++ b/src/devices/bus/nscsi/crd254sh.h
@@ -8,7 +8,7 @@
 
 #include "machine/nscsi_bus.h"
 #include "cpu/h8/h83042.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 
 class crd254sh_device : public device_t, public nscsi_slot_card_interface
 {

--- a/src/devices/bus/nscsi/cw7501.cpp
+++ b/src/devices/bus/nscsi/cw7501.cpp
@@ -8,7 +8,7 @@
 
 #include "emu.h"
 #include "bus/nscsi/cw7501.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 
 DEFINE_DEVICE_TYPE(CW7501, cw7501_device, "cw7501", "Panasonic CW-7501 CD-R")
 DEFINE_DEVICE_TYPE(CDR4210, cdr4210_device, "cdr4210", "Creative Technology Blaster CD-R 4210")

--- a/src/devices/bus/qbus/qtx.h
+++ b/src/devices/bus/qbus/qtx.h
@@ -8,7 +8,7 @@
 
 #include "qbus.h"
 #include "machine/mc68901.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 
 
 //**************************************************************************

--- a/src/devices/cpu/sparc/sparc.cpp
+++ b/src/devices/cpu/sparc/sparc.cpp
@@ -59,8 +59,8 @@ DEFINE_DEVICE_TYPE(MB86930, mb86930_device, "mb86930", "Fujitsu MB86930 'SPARCli
 
 namespace
 {
-const sparc_disassembler::asi_desc_map::value_type mb86930_asi_desc[] = {
-
+const sparc_disassembler::asi_desc_map::value_type mb86930_asi_desc[] =
+{
 	{ 0x01, { nullptr, "Control Registers"          } },
 	{ 0x02, { nullptr, "Instruction Cache Lock"     } },
 	{ 0x03, { nullptr, "Data Cache Lock"            } },
@@ -73,7 +73,13 @@ const sparc_disassembler::asi_desc_map::value_type mb86930_asi_desc[] = {
 	{ 0x0e, { nullptr, "Data Cache Tag RAM"         } },
 	{ 0x0f, { nullptr, "Data Cache Data RAM"        } }
 };
-}
+} // anonymous namespace
+
+const char *const sparc_base_device::DEFAULT_ASI_NAMES[16] =
+{
+	"asi0",  "asi1",  "asi2",  "asi3",  "asi4",  "asi5",  "asi6",  "asi7",
+	"asi8",  "asi9",  "asi10", "asi11", "asi12", "asi13", "asi14", "asi15"
+};
 
 //-------------------------------------------------
 //  sparc_base_device - constructor
@@ -89,8 +95,7 @@ sparc_base_device::sparc_base_device(const machine_config &mconfig, device_type 
 	{
 		for (int i = 0; i < 0x10; i++)
 		{
-			m_asi_names[i] = util::string_format("asi%x", i);
-			m_asi_config[i] = address_space_config(m_asi_names[i].c_str(), ENDIANNESS_BIG, 32, 32);
+			m_asi_config[i] = address_space_config(DEFAULT_ASI_NAMES[i], ENDIANNESS_BIG, 32, 32);
 		}
 	}
 }
@@ -136,39 +141,22 @@ mb86930_device::mb86930_device(const machine_config &mconfig, const char *tag, d
 	, m_cs_r(*this)
 	, m_cs_w(*this)
 {
-	m_asi_names[0x00] = "debugger";
-	m_asi_names[0x01] = "system_control";
-	m_asi_names[0x02] = "icache_lock";
-	m_asi_names[0x03] = "dcache_lock";
-	m_asi_names[0x04] = "asi4";
-	m_asi_names[0x05] = "asi5";
-	m_asi_names[0x06] = "asi6";
-	m_asi_names[0x07] = "asi7";
-	m_asi_names[0x08] = "user_insn";
-	m_asi_names[0x09] = "super_insn";
-	m_asi_names[0x0a] = "user_data";
-	m_asi_names[0x0b] = "super_data";
-	m_asi_names[0x0c] = "icache_tag";
-	m_asi_names[0x0d] = "icache_data";
-	m_asi_names[0x0e] = "dcache_tag";
-	m_asi_names[0x0f] = "dcache_data";
-
-	m_asi_config[0x00] = address_space_config(m_asi_names[0x00].c_str(), ENDIANNESS_BIG, 32, 32);
-	m_asi_config[0x01] = address_space_config(m_asi_names[0x01].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::control_map), this));
-	m_asi_config[0x02] = address_space_config(m_asi_names[0x02].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::icache_lock_map), this));
-	m_asi_config[0x03] = address_space_config(m_asi_names[0x03].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::dcache_lock_map), this));
-	m_asi_config[0x04] = address_space_config(m_asi_names[0x04].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<4>), this));
-	m_asi_config[0x05] = address_space_config(m_asi_names[0x05].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<5>), this));
-	m_asi_config[0x06] = address_space_config(m_asi_names[0x06].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<6>), this));
-	m_asi_config[0x07] = address_space_config(m_asi_names[0x07].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<7>), this));
-	m_asi_config[0x08] = address_space_config(m_asi_names[0x08].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<8>), this));
-	m_asi_config[0x09] = address_space_config(m_asi_names[0x09].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<9>), this));
-	m_asi_config[0x0a] = address_space_config(m_asi_names[0x0a].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<10>), this));
-	m_asi_config[0x0b] = address_space_config(m_asi_names[0x0b].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<11>), this));
-	m_asi_config[0x0c] = address_space_config(m_asi_names[0x0c].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::icache_tag_map), this));
-	m_asi_config[0x0d] = address_space_config(m_asi_names[0x0d].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::icache_data_map), this));
-	m_asi_config[0x0e] = address_space_config(m_asi_names[0x0e].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::dcache_tag_map), this));
-	m_asi_config[0x0f] = address_space_config(m_asi_names[0x0f].c_str(), ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::dcache_data_map), this));
+	m_asi_config[0x00] = address_space_config("debugger",       ENDIANNESS_BIG, 32, 32);
+	m_asi_config[0x01] = address_space_config("system_control", ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::control_map), this));
+	m_asi_config[0x02] = address_space_config("icache_lock",    ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::icache_lock_map), this));
+	m_asi_config[0x03] = address_space_config("dcache_lock",    ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::dcache_lock_map), this));
+	m_asi_config[0x04] = address_space_config("asi4",           ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<4>), this));
+	m_asi_config[0x05] = address_space_config("asi5",           ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<5>), this));
+	m_asi_config[0x06] = address_space_config("asi6",           ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<6>), this));
+	m_asi_config[0x07] = address_space_config("asi7",           ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<7>), this));
+	m_asi_config[0x08] = address_space_config("user_insn",      ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<8>), this));
+	m_asi_config[0x09] = address_space_config("super_insn",     ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<9>), this));
+	m_asi_config[0x0a] = address_space_config("user_data",      ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<10>), this));
+	m_asi_config[0x0b] = address_space_config("super_data",     ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::mmu_map<11>), this));
+	m_asi_config[0x0c] = address_space_config("icache_tag",     ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::icache_tag_map), this));
+	m_asi_config[0x0d] = address_space_config("icache_data",    ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::icache_data_map), this));
+	m_asi_config[0x0e] = address_space_config("dcache_tag",     ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::dcache_tag_map), this));
+	m_asi_config[0x0f] = address_space_config("dcache_data",    ENDIANNESS_BIG, 32, 32, 0, address_map_constructor(FUNC(mb86930_device::dcache_data_map), this));
 
 	add_asi_desc([](sparc_disassembler *dasm) { dasm->add_asi_desc(mb86930_asi_desc); });
 }

--- a/src/devices/cpu/sparc/sparc.h
+++ b/src/devices/cpu/sparc/sparc.h
@@ -155,7 +155,6 @@ protected:
 	optional_device<sparc_mmu_interface> m_mmu;
 
 	// address spaces
-	std::string m_asi_names[0x10];
 	address_space_config m_debugger_config;
 	address_space_config m_asi_config[0x10];
 	memory_access<32, 2, 0, ENDIANNESS_BIG>::specific m_asi[0x20];
@@ -268,6 +267,7 @@ protected:
 #endif
 
 	std::function<void (sparc_disassembler *)> m_asi_desc_adder;
+	static const char *const DEFAULT_ASI_NAMES[16];
 };
 
 class sparcv7_device : public sparc_base_device

--- a/src/devices/machine/ncr53c90.cpp
+++ b/src/devices/machine/ncr53c90.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "emu.h"
-#include "ncr5390.h"
+#include "ncr53c90.h"
 
 #define LOG_GENERAL (1U << 0)
 #define LOG_STATE   (1U << 1)
@@ -20,27 +20,27 @@
 
 #define DELAY_HACK
 
-DEFINE_DEVICE_TYPE(NCR5390, ncr5390_device, "ncr5390", "NCR 5390 SCSI Controller")
+DEFINE_DEVICE_TYPE(NCR53C90, ncr53c90_device, "ncr53c90", "NCR 53C90 SCSI Controller")
 DEFINE_DEVICE_TYPE(NCR53C90A, ncr53c90a_device, "ncr53c90a", "NCR 53C90A Advanced SCSI Controller")
 DEFINE_DEVICE_TYPE(NCR53C94, ncr53c94_device, "ncr53c94", "NCR 53C94 Advanced SCSI Controller")
 DEFINE_DEVICE_TYPE(NCR53CF94, ncr53cf94_device, "ncr53cf94", "NCR 53CF94-2 Fast SCSI Controller") // TODO: differences not emulated
 
-void ncr5390_device::map(address_map &map)
+void ncr53c90_device::map(address_map &map)
 {
-	map(0x0, 0x0).rw(FUNC(ncr5390_device::tcounter_lo_r), FUNC(ncr5390_device::tcount_lo_w));
-	map(0x1, 0x1).rw(FUNC(ncr5390_device::tcounter_hi_r), FUNC(ncr5390_device::tcount_hi_w));
-	map(0x2, 0x2).rw(FUNC(ncr5390_device::fifo_r), FUNC(ncr5390_device::fifo_w));
-	map(0x3, 0x3).rw(FUNC(ncr5390_device::command_r), FUNC(ncr5390_device::command_w));
-	map(0x4, 0x4).rw(FUNC(ncr5390_device::status_r), FUNC(ncr5390_device::bus_id_w));
-	map(0x5, 0x5).rw(FUNC(ncr5390_device::istatus_r), FUNC(ncr5390_device::timeout_w));
-	map(0x6, 0x6).rw(FUNC(ncr5390_device::seq_step_r), FUNC(ncr5390_device::sync_period_w));
-	map(0x7, 0x7).rw(FUNC(ncr5390_device::fifo_flags_r), FUNC(ncr5390_device::sync_offset_w));
-	map(0x8, 0x8).rw(FUNC(ncr5390_device::conf_r), FUNC(ncr5390_device::conf_w));
-	map(0xa, 0xa).w(FUNC(ncr5390_device::test_w));
-	map(0x9, 0x9).w(FUNC(ncr5390_device::clock_w));
+	map(0x0, 0x0).rw(FUNC(ncr53c90_device::tcounter_lo_r), FUNC(ncr53c90_device::tcount_lo_w));
+	map(0x1, 0x1).rw(FUNC(ncr53c90_device::tcounter_hi_r), FUNC(ncr53c90_device::tcount_hi_w));
+	map(0x2, 0x2).rw(FUNC(ncr53c90_device::fifo_r), FUNC(ncr53c90_device::fifo_w));
+	map(0x3, 0x3).rw(FUNC(ncr53c90_device::command_r), FUNC(ncr53c90_device::command_w));
+	map(0x4, 0x4).rw(FUNC(ncr53c90_device::status_r), FUNC(ncr53c90_device::bus_id_w));
+	map(0x5, 0x5).rw(FUNC(ncr53c90_device::istatus_r), FUNC(ncr53c90_device::timeout_w));
+	map(0x6, 0x6).rw(FUNC(ncr53c90_device::seq_step_r), FUNC(ncr53c90_device::sync_period_w));
+	map(0x7, 0x7).rw(FUNC(ncr53c90_device::fifo_flags_r), FUNC(ncr53c90_device::sync_offset_w));
+	map(0x8, 0x8).rw(FUNC(ncr53c90_device::conf_r), FUNC(ncr53c90_device::conf_w));
+	map(0xa, 0xa).w(FUNC(ncr53c90_device::test_w));
+	map(0x9, 0x9).w(FUNC(ncr53c90_device::clock_w));
 }
 
-uint8_t ncr5390_device::read(offs_t offset)
+uint8_t ncr53c90_device::read(offs_t offset)
 {
 	switch (offset)
 	{
@@ -57,7 +57,7 @@ uint8_t ncr5390_device::read(offs_t offset)
 	}
 }
 
-void ncr5390_device::write(offs_t offset, uint8_t data)
+void ncr53c90_device::write(offs_t offset, uint8_t data)
 {
 	switch (offset)
 	{
@@ -78,7 +78,7 @@ void ncr5390_device::write(offs_t offset, uint8_t data)
 
 void ncr53c90a_device::map(address_map &map)
 {
-	ncr5390_device::map(map);
+	ncr53c90_device::map(map);
 
 	map(0xb, 0xb).rw(FUNC(ncr53c90a_device::conf2_r), FUNC(ncr53c90a_device::conf2_w));
 }
@@ -87,14 +87,14 @@ uint8_t ncr53c90a_device::read(offs_t offset)
 {
 	if (offset == 11)
 		return conf2_r();
-	return ncr5390_device::read(offset);
+	return ncr53c90_device::read(offset);
 }
 
 void ncr53c90a_device::write(offs_t offset, uint8_t data)
 {
 	if (offset == 11)
 		return conf2_w(data);
-	ncr5390_device::write(offset, data);
+	ncr53c90_device::write(offset, data);
 }
 
 void ncr53c94_device::map(address_map &map)
@@ -122,7 +122,7 @@ void ncr53c94_device::write(offs_t offset, uint8_t data)
 		ncr53c90a_device::write(offset, data);
 }
 
-ncr5390_device::ncr5390_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
+ncr53c90_device::ncr53c90_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
 	: nscsi_device(mconfig, type, tag, owner, clock)
 	, nscsi_slot_card_interface(mconfig, *this, DEVICE_SELF)
 	, tm(nullptr), config(0), status(0), istatus(0), clock_conv(0), sync_offset(0), sync_period(0), bus_id(0)
@@ -133,13 +133,13 @@ ncr5390_device::ncr5390_device(const machine_config &mconfig, device_type type, 
 }
 
 ncr53c90a_device::ncr53c90a_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
-	: ncr5390_device(mconfig, type, tag, owner, clock)
+	: ncr53c90_device(mconfig, type, tag, owner, clock)
 	, config2(0)
 {
 }
 
-ncr5390_device::ncr5390_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: ncr5390_device(mconfig, NCR5390, tag, owner, clock)
+ncr53c90_device::ncr53c90_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: ncr53c90_device(mconfig, NCR53C90, tag, owner, clock)
 {
 }
 
@@ -165,7 +165,7 @@ ncr53cf94_device::ncr53cf94_device(const machine_config &mconfig, const char *ta
 {
 }
 
-void ncr5390_device::device_start()
+void ncr53c90_device::device_start()
 {
 	nscsi_device::device_start();
 
@@ -199,10 +199,10 @@ void ncr5390_device::device_start()
 	config = 0;
 	bus_id = 0;
 	select_timeout = 0;
-	tm = timer_alloc(FUNC(ncr5390_device::update_tick), this);
+	tm = timer_alloc(FUNC(ncr53c90_device::update_tick), this);
 }
 
-void ncr5390_device::device_reset()
+void ncr53c90_device::device_reset()
 {
 	fifo_pos = 0;
 	memset(fifo, 0, sizeof(fifo));
@@ -230,7 +230,7 @@ void ncr5390_device::device_reset()
 	reset_disconnect();
 }
 
-void ncr5390_device::reset_disconnect()
+void ncr53c90_device::reset_disconnect()
 {
 	scsi_bus->ctrl_w(scsi_refid, 0, ~S_RST);
 
@@ -240,7 +240,7 @@ void ncr5390_device::reset_disconnect()
 	mode = MODE_D;
 }
 
-void ncr5390_device::scsi_ctrl_changed()
+void ncr53c90_device::scsi_ctrl_changed()
 {
 	uint32_t ctrl = scsi_bus->ctrl_r();
 	if(ctrl & S_RST) {
@@ -251,12 +251,12 @@ void ncr5390_device::scsi_ctrl_changed()
 	step(false);
 }
 
-TIMER_CALLBACK_MEMBER(ncr5390_device::update_tick)
+TIMER_CALLBACK_MEMBER(ncr53c90_device::update_tick)
 {
 	step(true);
 }
 
-void ncr5390_device::step(bool timeout)
+void ncr53c90_device::step(bool timeout)
 {
 	uint32_t ctrl = scsi_bus->ctrl_r();
 	uint32_t data = scsi_bus->data_r();
@@ -296,7 +296,7 @@ void ncr5390_device::step(bool timeout)
 		if(win != scsi_id) {
 			scsi_bus->data_w(scsi_refid, 0);
 			scsi_bus->ctrl_w(scsi_refid, 0, S_ALL);
-			fatalerror("ncr5390_device::step need to wait for bus free\n");
+			fatalerror("ncr53c90_device::step need to wait for bus free\n");
 		}
 		state = (state & STATE_MASK) | (ARB_ASSERT_SEL << SUB_SHIFT);
 		scsi_bus->ctrl_w(scsi_refid, S_SEL, S_SEL);
@@ -677,10 +677,10 @@ void ncr5390_device::step(bool timeout)
 	}
 }
 
-void ncr5390_device::send_byte()
+void ncr53c90_device::send_byte()
 {
 	if(!fifo_pos)
-		fatalerror("ncr5390_device::send_byte - !fifo_pos\n");
+		fatalerror("ncr53c90_device::send_byte - !fifo_pos\n");
 
 	state = (state & STATE_MASK) | (SEND_WAIT_SETTLE << SUB_SHIFT);
 	if((state & STATE_MASK) != INIT_XFR_SEND_PAD &&
@@ -695,14 +695,14 @@ void ncr5390_device::send_byte()
 	delay_cycles(sync_period);
 }
 
-void ncr5390_device::recv_byte()
+void ncr53c90_device::recv_byte()
 {
 	scsi_bus->ctrl_wait(scsi_refid, S_REQ, S_REQ);
 	state = (state & STATE_MASK) | (RECV_WAIT_REQ_1 << SUB_SHIFT);
 	step(false);
 }
 
-void ncr5390_device::function_bus_complete()
+void ncr53c90_device::function_bus_complete()
 {
 	LOG("function_bus_complete\n");
 	state = IDLE;
@@ -712,7 +712,7 @@ void ncr5390_device::function_bus_complete()
 	check_irq();
 }
 
-void ncr5390_device::function_complete()
+void ncr53c90_device::function_complete()
 {
 	LOG("function_complete\n");
 	state = IDLE;
@@ -722,7 +722,7 @@ void ncr5390_device::function_complete()
 	check_irq();
 }
 
-void ncr5390_device::bus_complete()
+void ncr53c90_device::bus_complete()
 {
 	LOG("bus_complete\n");
 	state = IDLE;
@@ -732,7 +732,7 @@ void ncr5390_device::bus_complete()
 	check_irq();
 }
 
-void ncr5390_device::delay(int cycles)
+void ncr53c90_device::delay(int cycles)
 {
 	if(!clock_conv)
 		return;
@@ -740,36 +740,36 @@ void ncr5390_device::delay(int cycles)
 	tm->adjust(clocks_to_attotime(cycles));
 }
 
-void ncr5390_device::delay_cycles(int cycles)
+void ncr53c90_device::delay_cycles(int cycles)
 {
 	tm->adjust(clocks_to_attotime(cycles));
 }
 
-uint8_t ncr5390_device::tcounter_lo_r()
+uint8_t ncr53c90_device::tcounter_lo_r()
 {
 	LOG("tcounter_lo_r %02x (%s)\n", tcounter & 0xff, machine().describe_context());
 	return tcounter;
 }
 
-void ncr5390_device::tcount_lo_w(uint8_t data)
+void ncr53c90_device::tcount_lo_w(uint8_t data)
 {
 	tcount = (tcount & 0xff00) | data;
 	LOG("tcount_lo_w %02x (%s)\n", data, machine().describe_context());
 }
 
-uint8_t ncr5390_device::tcounter_hi_r()
+uint8_t ncr53c90_device::tcounter_hi_r()
 {
 	LOG("tcounter_hi_r %02x (%s)\n", tcounter >> 8, machine().describe_context());
 	return tcounter >> 8;
 }
 
-void ncr5390_device::tcount_hi_w(uint8_t data)
+void ncr53c90_device::tcount_hi_w(uint8_t data)
 {
 	tcount = (tcount & 0x00ff) | (data << 8);
 	LOG("tcount_hi_w %02x (%s)\n", data, machine().describe_context());
 }
 
-uint8_t ncr5390_device::fifo_pop()
+uint8_t ncr53c90_device::fifo_pop()
 {
 	uint8_t r = fifo[0];
 	fifo_pos--;
@@ -778,13 +778,13 @@ uint8_t ncr5390_device::fifo_pop()
 	return r;
 }
 
-void ncr5390_device::fifo_push(uint8_t val)
+void ncr53c90_device::fifo_push(uint8_t val)
 {
 	fifo[fifo_pos++] = val;
 	check_drq();
 }
 
-uint8_t ncr5390_device::fifo_r()
+uint8_t ncr53c90_device::fifo_r()
 {
 	uint8_t r;
 	if(fifo_pos) {
@@ -797,20 +797,20 @@ uint8_t ncr5390_device::fifo_r()
 	return r;
 }
 
-void ncr5390_device::fifo_w(uint8_t data)
+void ncr53c90_device::fifo_w(uint8_t data)
 {
 	LOGMASKED(LOG_FIFO, "fifo_w 0x%02x fifo_pos %d (%s)\n", data, fifo_pos, machine().describe_context());
 	if(fifo_pos != 16)
 		fifo[fifo_pos++] = data;
 }
 
-uint8_t ncr5390_device::command_r()
+uint8_t ncr53c90_device::command_r()
 {
 	LOG("command_r (%s)\n", machine().describe_context());
 	return command[0];
 }
 
-void ncr5390_device::command_w(uint8_t data)
+void ncr53c90_device::command_w(uint8_t data)
 {
 	LOG("command_w %02x command_pos %d (%s)\n", data, command_pos, machine().describe_context());
 	if(command_pos == 2) {
@@ -830,7 +830,7 @@ void ncr5390_device::command_w(uint8_t data)
 		start_command();
 }
 
-void ncr5390_device::command_pop_and_chain()
+void ncr53c90_device::command_pop_and_chain()
 {
 	if(command_pos) {
 		command_pos--;
@@ -841,7 +841,7 @@ void ncr5390_device::command_pop_and_chain()
 	}
 }
 
-void ncr5390_device::start_command()
+void ncr53c90_device::start_command()
 {
 	uint8_t c = command[0] & 0x7f;
 	if(!check_valid_command(c)) {
@@ -969,11 +969,11 @@ void ncr5390_device::start_command()
 		break;
 
 	default:
-		fatalerror("ncr5390_device::start_command unimplemented command %02x\n", c);
+		fatalerror("ncr53c90_device::start_command unimplemented command %02x\n", c);
 	}
 }
 
-bool ncr5390_device::check_valid_command(uint8_t cmd)
+bool ncr53c90_device::check_valid_command(uint8_t cmd)
 {
 	int subcmd = cmd & 15;
 	switch((cmd >> 4) & 7) {
@@ -985,7 +985,7 @@ bool ncr5390_device::check_valid_command(uint8_t cmd)
 	return false;
 }
 
-void ncr5390_device::arbitrate()
+void ncr53c90_device::arbitrate()
 {
 	state = (state & STATE_MASK) | (ARB_COMPLETE << SUB_SHIFT);
 	scsi_bus->data_w(scsi_refid, 1 << scsi_id);
@@ -993,7 +993,7 @@ void ncr5390_device::arbitrate()
 	delay(11);
 }
 
-void ncr5390_device::check_irq()
+void ncr53c90_device::check_irq()
 {
 	bool oldirq = irq;
 	irq = istatus != 0;
@@ -1002,7 +1002,7 @@ void ncr5390_device::check_irq()
 
 }
 
-uint8_t ncr5390_device::status_r()
+uint8_t ncr53c90_device::status_r()
 {
 	uint32_t ctrl = scsi_bus->ctrl_r();
 	uint8_t res = status | (ctrl & S_MSG ? 4 : 0) | (ctrl & S_CTL ? 2 : 0) | (ctrl & S_INP ? 1 : 0);
@@ -1011,13 +1011,13 @@ uint8_t ncr5390_device::status_r()
 	return res;
 }
 
-void ncr5390_device::bus_id_w(uint8_t data)
+void ncr53c90_device::bus_id_w(uint8_t data)
 {
 	bus_id = data & 7;
 	LOG("bus_id=%d\n", bus_id);
 }
 
-uint8_t ncr5390_device::istatus_r()
+uint8_t ncr53c90_device::istatus_r()
 {
 	uint8_t res = istatus;
 
@@ -1035,39 +1035,39 @@ uint8_t ncr5390_device::istatus_r()
 	return res;
 }
 
-void ncr5390_device::timeout_w(uint8_t data)
+void ncr53c90_device::timeout_w(uint8_t data)
 {
 	LOG("timeout_w 0x%02x\n", data);
 	select_timeout = data;
 }
 
-uint8_t ncr5390_device::seq_step_r()
+uint8_t ncr53c90_device::seq_step_r()
 {
 	LOG("seq_step_r %d (%s)\n", seq, machine().describe_context());
 	return seq;
 }
 
-void ncr5390_device::sync_period_w(uint8_t data)
+void ncr53c90_device::sync_period_w(uint8_t data)
 {
 	sync_period = data & 0x1f;
 }
 
-uint8_t ncr5390_device::fifo_flags_r()
+uint8_t ncr53c90_device::fifo_flags_r()
 {
 	return fifo_pos;
 }
 
-void ncr5390_device::sync_offset_w(uint8_t data)
+void ncr53c90_device::sync_offset_w(uint8_t data)
 {
 	sync_offset = data & 0x0f;
 }
 
-uint8_t ncr5390_device::conf_r()
+uint8_t ncr53c90_device::conf_r()
 {
 	return config;
 }
 
-void ncr5390_device::conf_w(uint8_t data)
+void ncr53c90_device::conf_w(uint8_t data)
 {
 	config = data;
 	scsi_id = data & 7;
@@ -1077,18 +1077,18 @@ void ncr5390_device::conf_w(uint8_t data)
 		test_mode = true;
 }
 
-void ncr5390_device::test_w(uint8_t data)
+void ncr53c90_device::test_w(uint8_t data)
 {
 	if (test_mode)
 		logerror("test_w %d (%s) - test mode not implemented\n", data, machine().describe_context());
 }
 
-void ncr5390_device::clock_w(uint8_t data)
+void ncr53c90_device::clock_w(uint8_t data)
 {
 	clock_conv = data & 0x07;
 }
 
-void ncr5390_device::dma_set(int dir)
+void ncr53c90_device::dma_set(int dir)
 {
 	dma_dir = dir;
 
@@ -1097,7 +1097,7 @@ void ncr5390_device::dma_set(int dir)
 		decrement_tcounter(fifo_pos);
 }
 
-void ncr5390_device::dma_w(uint8_t val)
+void ncr53c90_device::dma_w(uint8_t val)
 {
 	fifo_push(val);
 	decrement_tcounter();
@@ -1105,7 +1105,7 @@ void ncr5390_device::dma_w(uint8_t val)
 	step(false);
 }
 
-uint8_t ncr5390_device::dma_r()
+uint8_t ncr53c90_device::dma_r()
 {
 	uint8_t r = fifo_pop();
 	decrement_tcounter();
@@ -1114,7 +1114,7 @@ uint8_t ncr5390_device::dma_r()
 	return r;
 }
 
-void ncr5390_device::check_drq()
+void ncr53c90_device::check_drq()
 {
 	bool drq_state = drq;
 
@@ -1138,7 +1138,7 @@ void ncr5390_device::check_drq()
 	}
 }
 
-void ncr5390_device::decrement_tcounter(int count)
+void ncr53c90_device::decrement_tcounter(int count)
 {
 	if (!dma_command)
 		return;
@@ -1173,14 +1173,14 @@ void ncr53c90a_device::device_start()
 
 	config2 = 0;
 
-	ncr5390_device::device_start();
+	ncr53c90_device::device_start();
 }
 
 void ncr53c90a_device::device_reset()
 {
 	config2 = 0;
 
-	ncr5390_device::device_reset();
+	ncr53c90_device::device_reset();
 }
 
 uint8_t ncr53c90a_device::status_r()
@@ -1284,5 +1284,5 @@ void ncr53c94_device::check_drq()
 		}
 	}
 	else
-		ncr5390_device::check_drq();
+		ncr53c90_device::check_drq();
 }

--- a/src/devices/machine/ncr53c90.cpp
+++ b/src/devices/machine/ncr53c90.cpp
@@ -549,7 +549,7 @@ void ncr53c90_device::step(bool timeout)
 				break;
 
 			// if it's the last message byte, deassert ATN before sending
-			if (xfr_phase == S_PHASE_MSG_OUT && fifo_pos == 1)
+			if (xfr_phase == S_PHASE_MSG_OUT && ((!dma_command && fifo_pos == 1) || (dma_command && tcounter == 1)))
 				scsi_bus->ctrl_w(scsi_refid, 0, S_ATN);
 
 			send_byte();

--- a/src/devices/machine/ncr53c90.h
+++ b/src/devices/machine/ncr53c90.h
@@ -1,16 +1,16 @@
 // license:BSD-3-Clause
 // copyright-holders:Olivier Galibert
-#ifndef MAME_MACHINE_NCR5390_H
-#define MAME_MACHINE_NCR5390_H
+#ifndef MAME_MACHINE_NCR53C90_H
+#define MAME_MACHINE_NCR53C90_H
 
 #pragma once
 
 #include "machine/nscsi_bus.h"
 
-class ncr5390_device : public nscsi_device, public nscsi_slot_card_interface
+class ncr53c90_device : public nscsi_device, public nscsi_slot_card_interface
 {
 public:
-	ncr5390_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	ncr53c90_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	// configuration helpers
 	auto irq_handler_cb() { return m_irq_handler.bind(); }
@@ -48,7 +48,7 @@ public:
 	void dma_w(uint8_t val);
 
 protected:
-	ncr5390_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	ncr53c90_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
 	virtual void device_start() override;
 	virtual void device_reset() override;
@@ -237,7 +237,7 @@ protected:
 	devcb_write_line m_drq_handler;
 };
 
-class ncr53c90a_device : public ncr5390_device
+class ncr53c90a_device : public ncr53c90_device
 {
 public:
 	ncr53c90a_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
@@ -333,9 +333,9 @@ public:
 	ncr53cf94_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
-DECLARE_DEVICE_TYPE(NCR5390, ncr5390_device)
+DECLARE_DEVICE_TYPE(NCR53C90, ncr53c90_device)
 DECLARE_DEVICE_TYPE(NCR53C90A, ncr53c90a_device)
 DECLARE_DEVICE_TYPE(NCR53C94, ncr53c94_device)
 DECLARE_DEVICE_TYPE(NCR53CF94, ncr53cf94_device)
 
-#endif // MAME_MACHINE_NCR5390_H
+#endif // MAME_MACHINE_NCR53C90_H

--- a/src/devices/machine/spifi3.cpp
+++ b/src/devices/machine/spifi3.cpp
@@ -7,7 +7,7 @@
  * References:
  * - https://github.com/NetBSD/src/blob/trunk/sys/arch/newsmips/apbus/spifireg.h
  * - https://github.com/NetBSD/src/blob/trunk/sys/arch/newsmips/apbus/spifi.c
- * - https://github.com/mamedev/mame/blob/master/src/devices/machine/ncr5390.cpp
+ * - https://github.com/mamedev/mame/blob/master/src/devices/machine/ncr53c90.cpp
  *
  * TODO:
  *  - NetBSD compatibility

--- a/src/devices/machine/spifi3.h
+++ b/src/devices/machine/spifi3.h
@@ -15,12 +15,12 @@
  * In its current state, this driver is unlikely to work out of the box with any other machines.
  *
  * Register definitions were derived from the NetBSD source code, copyright (c) 2000 Tsubai Masanari.
- * SCSI state machine code was derived from the MAME NCR5390 driver, copyright (c) Olivier Galibert
+ * SCSI state machine code was derived from the MAME NCR53C90 driver, copyright (c) Olivier Galibert
  *
  * References:
  * - https://github.com/NetBSD/src/blob/trunk/sys/arch/newsmips/apbus/spifireg.h
  * - https://github.com/NetBSD/src/blob/trunk/sys/arch/newsmips/apbus/spifi.c
- * - https://github.com/mamedev/mame/blob/master/src/devices/machine/ncr5390.cpp
+ * - https://github.com/mamedev/mame/blob/master/src/devices/machine/ncr53c90.cpp
  */
 
 #ifndef MAME_MACHINE_SPIFI3_H

--- a/src/devices/machine/sun4c_mmu.cpp
+++ b/src/devices/machine/sun4c_mmu.cpp
@@ -533,7 +533,7 @@ uint32_t sun4_mmu_base_device::insn_data_r(const uint32_t offset, const uint32_t
 	}
 
 	// it's translation time
-	const uint32_t pmeg = m_curr_segmap_masked[(offset >> 16) & 0xfff];// & m_pmeg_mask;
+	const uint32_t pmeg = m_curr_segmap_masked[(offset >> 16) & 0xfff];
 	const uint32_t entry_index = pmeg | ((offset >> m_seg_entry_shift) & m_seg_entry_mask);
 
 	if (m_page_valid[entry_index])
@@ -684,21 +684,16 @@ void sun4_mmu_base_device::insn_data_w(const uint32_t offset, const uint32_t dat
 
 void sun4_mmu_base_device::l2p_command(const std::vector<std::string_view> &params)
 {
-	uint64_t addr, offset;
-
+	uint64_t addr;
 	if (!machine().debugger().console().validate_number_parameter(params[0], addr)) return;
 
 	addr &= 0xffffffff;
-	offset = addr >> 2;
+	uint64_t offset = addr >> 2;
 
-	uint8_t pmeg = 0;
-	uint32_t entry_index = 0, tmp = 0;
-	uint32_t entry_value = 0;
-
-	pmeg = m_curr_segmap_masked[(offset >> 16) & 0xfff];
-	entry_index = pmeg | ((offset >> m_seg_entry_shift) & m_seg_entry_mask);
-	tmp = m_pagemap[entry_index].page | (offset & m_page_mask);
-	entry_value = page_entry_to_uint(entry_index);
+	const uint32_t pmeg = m_curr_segmap_masked[(offset >> 16) & 0xfff];
+	const uint32_t entry_index = pmeg | ((offset >> m_seg_entry_shift) & m_seg_entry_mask);
+	const uint32_t tmp = m_pagemap[entry_index].page | (offset & m_page_mask);
+	const uint32_t entry_value = page_entry_to_uint(entry_index);
 
 	if (m_page_valid[entry_index])
 	{
@@ -706,7 +701,7 @@ void sun4_mmu_base_device::l2p_command(const std::vector<std::string_view> &para
 	}
 	else
 	{
-		machine().debugger().console().printf("logical %08x points to an invalid PTE! (pmeg %d, entry %d PTE %08x)\n", addr, tmp << 2, pmeg, entry_index, entry_value);
+		machine().debugger().console().printf("logical %08x points to an invalid PTE! (tmp %08x, pmeg %d, entry %d PTE %08x)\n", addr, tmp << 2, pmeg, entry_index, entry_value);
 	}
 }
 

--- a/src/mame/apple/macpdm.cpp
+++ b/src/mame/apple/macpdm.cpp
@@ -11,7 +11,7 @@
 #include "cuda.h"
 #include "macadb.h"
 #include "machine/mv_sonora.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "machine/ram.h"
 #include "machine/swim3.h"
 #include "machine/timer.h"

--- a/src/mame/apple/macquadra700.cpp
+++ b/src/mame/apple/macquadra700.cpp
@@ -23,7 +23,7 @@
 #include "machine/6522via.h"
 #include "machine/applefdintf.h"
 #include "machine/dp83932c.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "machine/nscsi_bus.h"
 #include "machine/ram.h"
 #include "machine/swim1.h"

--- a/src/mame/dec/decstation.cpp
+++ b/src/mame/dec/decstation.cpp
@@ -64,7 +64,7 @@
 #include "decioga.h"
 #include "machine/mc146818.h"
 #include "machine/z80scc.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 //#include "machine/dc7061.h"
 #include "machine/nscsi_bus.h"
 #include "bus/nscsi/cd.h"

--- a/src/mame/intergraph/interpro.cpp
+++ b/src/mame/intergraph/interpro.cpp
@@ -243,7 +243,7 @@
 #include "machine/upd765.h"
 #include "machine/i82586.h"
 
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "machine/nscsi_bus.h"
 #include "bus/nscsi/cd.h"
 #include "bus/nscsi/hd.h"
@@ -1126,7 +1126,7 @@ static void interpro_scsi_devices(device_slot_interface &device)
 
 void interpro_state::interpro_scsi_adapter(device_t *device)
 {
-	ncr5390_device &adapter = downcast<ncr5390_device &>(*device);
+	ncr53c90_device &adapter = downcast<ncr53c90_device &>(*device);
 
 	adapter.set_clock(24_MHz_XTAL);
 

--- a/src/mame/microsoft/jazz.cpp
+++ b/src/mame/microsoft/jazz.cpp
@@ -68,7 +68,7 @@
 #include "machine/dp83932c.h"
 #include "machine/mc146818.h"
 #include "machine/ins8250.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "machine/upd765.h"
 #include "machine/at_keybc.h"
 #include "machine/pc_lpt.h"

--- a/src/mame/mips/mips.cpp
+++ b/src/mame/mips/mips.cpp
@@ -218,7 +218,7 @@
 
 // i/o devices (rx3230)
 #include "machine/timekpr.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "mips_rambo.h"
 
 // busses and connectors

--- a/src/mame/nec/ews4800.cpp
+++ b/src/mame/nec/ews4800.cpp
@@ -22,7 +22,7 @@
 #include "machine/z80scc.h"
 #include "machine/am79c90.h"
 #include "machine/timekpr.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 
 // busses and connectors
 #include "machine/nscsi_bus.h"

--- a/src/mame/next/next.cpp
+++ b/src/mame/next/next.cpp
@@ -583,7 +583,7 @@ void next_state::scsictrl_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 				scsictrl & 0x08 ? "read" : "write",
 				scsictrl & 0x04 ? " flush" : "",
 				scsictrl & 0x02 ? " reset" : "",
-				scsictrl & 0x01 ? "wd3392" : "ncr5390",
+				scsictrl & 0x01 ? "wd3392" : "ncr53c90",
 				maincpu->pc());
 	}
 	if(ACCESSING_BITS_16_23) {
@@ -912,7 +912,7 @@ void next_state::next_mem(address_map &map)
 	map(0x0200e000, 0x0200e00b).mirror(0x300000).m(keyboard, FUNC(nextkbd_device::amap));
 //  map(0x0200f000, 0x0200f003).mirror(0x300000); printer
 //  map(0x02010000, 0x02010003).mirror(0x300000); brightness
-	map(0x02014000, 0x0201400f).mirror(0x300000).m(scsi, FUNC(ncr5390_device::map));
+	map(0x02014000, 0x0201400f).mirror(0x300000).m(scsi, FUNC(ncr53c90_device::map));
 	map(0x02014020, 0x02014023).mirror(0x300000).rw(FUNC(next_state::scsictrl_r), FUNC(next_state::scsictrl_w));
 	map(0x02016000, 0x02016003).mirror(0x300000).rw(FUNC(next_state::timer_data_r), FUNC(next_state::timer_data_w));
 	map(0x02016004, 0x02016007).mirror(0x300000).rw(FUNC(next_state::timer_ctrl_r), FUNC(next_state::timer_ctrl_w));
@@ -1015,12 +1015,12 @@ static void next_scsi_devices(device_slot_interface &device)
 {
 	device.option_add("cdrom", NSCSI_CDROM);
 	device.option_add("harddisk", NSCSI_HARDDISK);
-	device.option_add_internal("ncr5390", NCR5390);
+	device.option_add_internal("ncr53c90", NCR53C90);
 }
 
-void next_state::ncr5390(device_t *device)
+void next_state::ncr53c90(device_t *device)
 {
-	ncr5390_device &adapter = downcast<ncr5390_device &>(*device);
+	ncr53c90_device &adapter = downcast<ncr53c90_device &>(*device);
 
 	adapter.set_clock(10000000);
 	adapter.irq_handler_cb().set(*this, FUNC(next_state::scsi_irq));
@@ -1058,7 +1058,7 @@ void next_state::next_base(machine_config &config)
 	NSCSI_CONNECTOR(config, "scsibus:4", next_scsi_devices, nullptr);
 	NSCSI_CONNECTOR(config, "scsibus:5", next_scsi_devices, nullptr);
 	NSCSI_CONNECTOR(config, "scsibus:6", next_scsi_devices, nullptr);
-	NSCSI_CONNECTOR(config, "scsibus:7", next_scsi_devices, "ncr5390", true).set_option_machine_config("ncr5390", [this] (device_t *device) { ncr5390(device); });
+	NSCSI_CONNECTOR(config, "scsibus:7", next_scsi_devices, "ncr53c90", true).set_option_machine_config("ncr53c90", [this] (device_t *device) { ncr53c90(device); });
 
 	MB8795(config, net, 0);
 	net->tx_irq().set(FUNC(next_state::net_tx_irq));

--- a/src/mame/next/next.h
+++ b/src/mame/next/next.h
@@ -13,7 +13,7 @@
 #include "machine/8530scc.h"
 #include "nextkbd.h"
 #include "machine/upd765.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "machine/mb8795.h"
 #include "nextmo.h"
 #include "imagedev/chd_cd.h"
@@ -29,7 +29,7 @@ public:
 			scc(*this, "scc"),
 			keyboard(*this, "keyboard"),
 			scsibus(*this, "scsibus"),
-			scsi(*this, "scsibus:7:ncr5390"),
+			scsi(*this, "scsibus:7:ncr53c90"),
 			net(*this, "net"),
 			mo(*this, "mo"),
 			fdc(*this, "fdc"),
@@ -68,7 +68,7 @@ private:
 	required_device<scc8530_legacy_device> scc;
 	required_device<nextkbd_device> keyboard;
 	required_device<nscsi_bus_device> scsibus;
-	required_device<ncr5390_device> scsi;
+	required_device<ncr53c90_device> scsi;
 	required_device<mb8795_device> net;
 	optional_device<nextmo_device> mo; // cube only
 	optional_device<n82077aa_device> fdc; // 040 only
@@ -146,7 +146,7 @@ private:
 
 	DECLARE_WRITE_LINE_MEMBER(vblank_w);
 
-	void ncr5390(device_t *device);
+	void ncr53c90(device_t *device);
 	void next_0b_m_mem(address_map &map);
 	void next_0b_m_mo_mem(address_map &map);
 	void next_0b_m_nofdc_mem(address_map &map);

--- a/src/mame/sun/sun4.cpp
+++ b/src/mame/sun/sun4.cpp
@@ -558,7 +558,7 @@ public:
 		, m_floppy(*this, "fdc:0")
 		, m_lance(*this, "lance")
 		, m_scsibus(*this, "scsibus")
-		, m_scsi(*this, "scsibus:7:ncr53c90a")
+		, m_scsi(*this, "scsibus:7:ncr53c90")
 		, m_type1space(*this, "type1")
 		, m_ram(*this, RAM_TAG)
 		, m_rom(*this, "user1")
@@ -601,7 +601,7 @@ protected:
 
 	DECLARE_WRITE_LINE_MEMBER(fdc_irq);
 
-	void ncr53c90a(device_t *device);
+	void ncr53c90(device_t *device);
 
 	void debugger_map(address_map &map);
 	void system_asi_map(address_map &map);
@@ -636,7 +636,7 @@ protected:
 	required_device<floppy_connector> m_floppy;
 	required_device<am79c90_device> m_lance;
 	required_device<nscsi_bus_device> m_scsibus;
-	required_device<ncr53c90a_device> m_scsi;
+	required_device<ncr5390_device> m_scsi;
 
 	required_device<address_map_bank_device> m_type1space;
 	required_device<ram_device> m_ram;
@@ -776,7 +776,7 @@ void sun4_base_state::type1space_base_map(address_map &map)
 	map(0x08400000, 0x08400003).rw(FUNC(sun4_base_state::dma_ctrl_r), FUNC(sun4_base_state::dma_ctrl_w));
 	map(0x08400004, 0x08400007).rw(FUNC(sun4_base_state::dma_addr_r), FUNC(sun4_base_state::dma_addr_w));
 	map(0x08400008, 0x0840000b).rw(FUNC(sun4_base_state::dma_count_r), FUNC(sun4_base_state::dma_count_w));
-	map(0x08800000, 0x0880002f).m(m_scsi, FUNC(ncr53c90a_device::map)).umask32(0xff000000);
+	map(0x08800000, 0x0880002f).m(m_scsi, FUNC(ncr5390_device::map)).umask32(0xff000000);
 	map(0x08c00000, 0x08c00003).rw(m_lance, FUNC(am79c90_device::regs_r), FUNC(am79c90_device::regs_w));
 }
 
@@ -1244,7 +1244,7 @@ u32 sun4_base_state::dma_ctrl_r()
 		dma_check_interrupts();
 	}
 	LOGMASKED(LOG_DMA_CTRL_READS, "%s: dma_ctrl_r: %08x\n", machine().describe_context(), m_dma_ctrl);
-	return m_dma_ctrl;
+	return (m_dma_ctrl & ~(DMA_WRITE_ONLY | DMA_BYTE_ADDR)) | DMA_DEV_ID;
 }
 
 u32 sun4_base_state::dma_addr_r()
@@ -1292,6 +1292,7 @@ void sun4_base_state::dma_ctrl_w(offs_t offset, u32 data, u32 mem_mask)
 			m_dma_addr++;
 		}
 		m_dma_pack_register = 0;
+
 		m_dma_ctrl &= ~DMA_PACK_CNT;
 	}
 
@@ -1369,13 +1370,13 @@ static void sun_scsi_devices(device_slot_interface &device)
 {
 	device.option_add("cdrom", NSCSI_CDROM);
 	device.option_add("harddisk", NSCSI_HARDDISK);
-	device.option_add_internal("ncr53c90a", NCR53C90A);
+	device.option_add_internal("ncr53c90", NCR5390);
 	device.set_option_machine_config("cdrom", sun4_cdrom);
 }
 
-void sun4_base_state::ncr53c90a(device_t *device)
+void sun4_base_state::ncr53c90(device_t *device)
 {
-	ncr53c90a_device &adapter = downcast<ncr53c90a_device &>(*device);
+	ncr5390_device &adapter = downcast<ncr5390_device &>(*device);
 
 	adapter.set_clock(10000000);
 	adapter.irq_handler_cb().set(*this, FUNC(sun4_base_state::scsi_irq));
@@ -1443,7 +1444,7 @@ void sun4_base_state::sun4_base(machine_config &config)
 	NSCSI_CONNECTOR(config, "scsibus:4", sun_scsi_devices, nullptr);
 	NSCSI_CONNECTOR(config, "scsibus:5", sun_scsi_devices, nullptr);
 	NSCSI_CONNECTOR(config, "scsibus:6", sun_scsi_devices, "cdrom");
-	NSCSI_CONNECTOR(config, "scsibus:7", sun_scsi_devices, "ncr53c90a", true).set_option_machine_config("ncr53c90a", [this] (device_t *device) { ncr53c90a(device); });
+	NSCSI_CONNECTOR(config, "scsibus:7", sun_scsi_devices, "ncr53c90", true).set_option_machine_config("ncr53c90", [this] (device_t *device) { ncr53c90(device); });
 }
 
 void sun4_state::sun4(machine_config &config)

--- a/src/mame/sun/sun4.cpp
+++ b/src/mame/sun/sun4.cpp
@@ -422,7 +422,7 @@
 #include "imagedev/floppy.h"
 #include "machine/am79c90.h"
 #include "machine/bankdev.h"
-#include "machine/ncr5390.h"
+#include "machine/ncr53c90.h"
 #include "machine/nscsi_bus.h"
 #include "machine/nvram.h"
 #include "machine/ram.h"
@@ -636,7 +636,7 @@ protected:
 	required_device<floppy_connector> m_floppy;
 	required_device<am79c90_device> m_lance;
 	required_device<nscsi_bus_device> m_scsibus;
-	required_device<ncr5390_device> m_scsi;
+	required_device<ncr53c90_device> m_scsi;
 
 	required_device<address_map_bank_device> m_type1space;
 	required_device<ram_device> m_ram;
@@ -776,7 +776,7 @@ void sun4_base_state::type1space_base_map(address_map &map)
 	map(0x08400000, 0x08400003).rw(FUNC(sun4_base_state::dma_ctrl_r), FUNC(sun4_base_state::dma_ctrl_w));
 	map(0x08400004, 0x08400007).rw(FUNC(sun4_base_state::dma_addr_r), FUNC(sun4_base_state::dma_addr_w));
 	map(0x08400008, 0x0840000b).rw(FUNC(sun4_base_state::dma_count_r), FUNC(sun4_base_state::dma_count_w));
-	map(0x08800000, 0x0880002f).m(m_scsi, FUNC(ncr5390_device::map)).umask32(0xff000000);
+	map(0x08800000, 0x0880002f).m(m_scsi, FUNC(ncr53c90_device::map)).umask32(0xff000000);
 	map(0x08c00000, 0x08c00003).rw(m_lance, FUNC(am79c90_device::regs_r), FUNC(am79c90_device::regs_w));
 }
 
@@ -1370,13 +1370,13 @@ static void sun_scsi_devices(device_slot_interface &device)
 {
 	device.option_add("cdrom", NSCSI_CDROM);
 	device.option_add("harddisk", NSCSI_HARDDISK);
-	device.option_add_internal("ncr53c90", NCR5390);
+	device.option_add_internal("ncr53c90", NCR53C90);
 	device.set_option_machine_config("cdrom", sun4_cdrom);
 }
 
 void sun4_base_state::ncr53c90(device_t *device)
 {
-	ncr5390_device &adapter = downcast<ncr5390_device &>(*device);
+	ncr53c90_device &adapter = downcast<ncr53c90_device &>(*device);
 
 	adapter.set_clock(10000000);
 	adapter.irq_handler_cb().set(*this, FUNC(sun4_base_state::scsi_irq));


### PR DESCRIPTION
-ncr5390: Fixed 'Select w/ ATN and Stop' command in DMA mode. [Ryan Holtz]

-ncr5390: Renamed to ncr53c90 to avoid confusion about the actual NCR part name. [Ryan Holtz]

-sun4c_mmu: Fixed l2p debugger command by removing inadvertent narrowing conversion. [Ryan Holtz]

-sparc: Avoid using temporary C-strings as address space names. [Ryan Holtz]

-sun4: Switched to NCR 53C90 from 53C90A, and fixed DMA byte-address masking. Along with 53c90 fix above, allows Solaris 2.4 to boot. [Ryan Holtz]
