### PR TITLE
Revised vcs_ctrl/paddles to use one input definition

### DIFF
--- a/src/devices/bus/vcs_ctrl/paddles.cpp
+++ b/src/devices/bus/vcs_ctrl/paddles.cpp
@@ -31,30 +31,13 @@ static INPUT_PORTS_START( vcs_paddles )
 	PORT_BIT( 0xff, 0x80, IPT_PADDLE) PORT_PLAYER(2) PORT_SENSITIVITY(30) PORT_KEYDELTA(20) PORT_MINMAX(0, 255) PORT_REVERSE // pin 9
 INPUT_PORTS_END
 
-static INPUT_PORTS_START( vcs_paddles_reversed )
-	PORT_START("JOY")
-	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1) // pin 3
-	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2) // pin 4
-	PORT_BIT( 0xf3, IP_ACTIVE_LOW, IPT_UNUSED )
-
-	PORT_START("POTX")
-	PORT_BIT( 0xff, 0x80, IPT_PADDLE) PORT_PLAYER(2) PORT_SENSITIVITY(30) PORT_KEYDELTA(20) PORT_MINMAX(0, 255) PORT_REVERSE // pin 5
-
-	PORT_START("POTY")
-	PORT_BIT( 0xff, 0x80, IPT_PADDLE) PORT_PLAYER(1) PORT_SENSITIVITY(30) PORT_KEYDELTA(20) PORT_MINMAX(0, 255) PORT_REVERSE // pin 9
-INPUT_PORTS_END
-
-
 //-------------------------------------------------
 //  input_ports - device-specific input ports
 //-------------------------------------------------
 
 ioport_constructor vcs_paddles_device::device_input_ports() const
 {
-	if (m_reverse_players)
-		return INPUT_PORTS_NAME( vcs_paddles_reversed );
-	else
-		return INPUT_PORTS_NAME( vcs_paddles );
+	return INPUT_PORTS_NAME( vcs_paddles );
 }
 
 
@@ -93,7 +76,8 @@ void vcs_paddles_device::device_start()
 
 uint8_t vcs_paddles_device::vcs_joy_r()
 {
-	return m_joy->read();
+	uint8_t const data = m_joy->read();
+	return m_reverse_players ? bitswap<8>(data, 7, 6, 5, 4, 2, 3, 1, 0) : data;
 }
 
 
@@ -103,7 +87,7 @@ uint8_t vcs_paddles_device::vcs_joy_r()
 
 uint8_t vcs_paddles_device::vcs_pot_x_r()
 {
-	return m_potx->read();
+	return m_reverse_players ? m_poty->read() : m_potx->read();
 }
 
 
@@ -113,5 +97,5 @@ uint8_t vcs_paddles_device::vcs_pot_x_r()
 
 uint8_t vcs_paddles_device::vcs_pot_y_r()
 {
-	return m_poty->read();
+	return m_reverse_players ? m_potx->read() : m_poty->read();
 }


### PR DESCRIPTION
-vcs_ctrl/paddles: Swap ports and button bits at runtime. Avoids multiple input defs per-device. [Ryan Holtz]