### PR TITLE
QA cleanups for various PC-based Arcade skeleton drivers

### DIFF
--- a/src/mame/funworld/photoplys.cpp
+++ b/src/mame/funworld/photoplys.cpp
@@ -7,9 +7,9 @@ Motherboard 6WEV0:
 
 CPU: Intel CELERON FV524RX366 128 SL36C
 RAM: 64MB
-PCB: Intel FW82801AA, IT8888F PCI-to-ISA Bridge, CMI8738 audio
+PCB: Intel FW82801AA (ICH), IT8888F PCI-to-ISA Bridge, CMI8738 audio
 I/O: Winbond W83977, Winbond W83627HF
-BIOS: Intel N82802AB
+BIOS: Intel N82802AB (FWH)
 Dongle: Parallel port + keyboard DIN (uses both ports) with a SX28AC/DP MCU (Parallax, Ubicom, etc.). On some versions there's also a SEEPROM (93C46LN, etc.).
 Net: Optional Ethernet PCI card with RTL8139C
 
@@ -17,7 +17,7 @@ Net: Optional Ethernet PCI card with RTL8139C
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 namespace {
 
@@ -31,26 +31,11 @@ public:
 
 	void photoplays(machine_config &config);
 
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-
 private:
 	required_device<cpu_device> m_maincpu;
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void photoplays_map(address_map &map);
 };
-
-void photoplays_state::video_start()
-{
-}
-
-uint32_t photoplays_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void photoplays_state::photoplays_map(address_map &map)
 {
@@ -60,27 +45,14 @@ static INPUT_PORTS_START( photoplays )
 INPUT_PORTS_END
 
 
-void photoplays_state::machine_start()
-{
-}
-
-void photoplays_state::machine_reset()
-{
-}
-
 void photoplays_state::photoplays(machine_config &config)
 {
-	// Basic machine hardware
 	PENTIUM2(config, m_maincpu, 366'000'000); // Actually an Intel CELERON FV524RX366 128 SL36C
 	m_maincpu->set_addrmap(AS_PROGRAM, &photoplays_state::photoplays_map);
+	m_maincpu->set_disable();
 
-	// Video hardware
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
-	screen.set_screen_update(FUNC(photoplays_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************

--- a/src/mame/funworld/photoplysx.cpp
+++ b/src/mame/funworld/photoplysx.cpp
@@ -26,7 +26,7 @@ A single wrong login attempt locks the token.
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 namespace {
 
@@ -40,56 +40,29 @@ public:
 
 	void photoplaysx(machine_config &config);
 
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-
 private:
 	required_device<cpu_device> m_maincpu;
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void photoplaysx_map(address_map &map);
 };
 
-void photoplaysx_state::video_start()
-{
-}
-
-uint32_t photoplaysx_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
-
 void photoplaysx_state::photoplaysx_map(address_map &map)
 {
+	map(0x00000000, 0x0009ffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0x60000);
+	map(0xfff80000, 0xffffffff).rom().region("bios", 0);
 }
 
 static INPUT_PORTS_START( photoplaysx )
 INPUT_PORTS_END
 
-
-void photoplaysx_state::machine_start()
-{
-}
-
-void photoplaysx_state::machine_reset()
-{
-}
-
 void photoplaysx_state::photoplaysx(machine_config &config)
 {
-	// Basic machine hardware
-	PENTIUM4(config, m_maincpu, 100000000); // Actually an Intel CELERON 2 GHz / 128 / 400 (SL6VR)
+	PENTIUM4(config, m_maincpu, 100'000'000); // Actually an Intel CELERON 2 GHz / 128 / 400 (SL6VR)
 	m_maincpu->set_addrmap(AS_PROGRAM, &photoplaysx_state::photoplaysx_map);
 
-	// Video hardware
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
-	screen.set_screen_update(FUNC(photoplaysx_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************
@@ -99,7 +72,7 @@ void photoplaysx_state::photoplaysx(machine_config &config)
 ***************************************************************************/
 
 ROM_START( photopsxsp )
-	ROM_REGION(0x80000, "bios", 0)
+	ROM_REGION32_LE(0x80000, "bios", 0)
 	ROM_LOAD("photoplay_bios_pm49fl004t.bin", 0x00000, 0x80000, CRC(50bf84fe) SHA1(d0afe83b57f822d4fdb96dc1e0c6eedeccbfce7b) ) // 03/11/2009-I865G-6A79AD4EC-00
 
 	ROM_REGION(0xe540, "dongle", 0)
@@ -112,7 +85,7 @@ ROM_START( photopsxsp )
 ROM_END
 
 ROM_START( photopsxusp )
-	ROM_REGION(0x80000, "bios", 0)
+	ROM_REGION32_LE(0x80000, "bios", 0)
 	ROM_LOAD("photoplay_bios_pm49fl004t.bin", 0x00000, 0x80000, CRC(50bf84fe) SHA1(d0afe83b57f822d4fdb96dc1e0c6eedeccbfce7b) ) // 03/11/2009-I865G-6A79AD4EC-00
 
 	ROM_REGION(0xe540, "dongle", 0)

--- a/src/mame/gaelco/gaelcopc.cpp
+++ b/src/mame/gaelco/gaelcopc.cpp
@@ -15,14 +15,14 @@ Intel 82801 (PCI 2.3 + integrated LAN + IDE + USB 2.0 + AC'97 + LPC +
              ACPI 2.0 + Flash BIOS control + SMBus + GPIO)
 Intel 82562 (LAN)
 RTM 560-25R (Audio)
-Nvidia GeForce 4 TI4200 128Mb AGP
+nVidia GeForce 4 TI4200 128Mb AGP
 256 Mb PC133
 Pentium 4 (??? XXXXMhz), <- contradicts 82815 datasheet and an internal BIOS string at $ce (Socket 370),
                             expect Celeron or Pentium 3 at very least.
 
 I/O Board with Altera Flex EPF15K50EQC240-3
 
-The graphics cards are swappable between Nvidia cards from
+The graphics cards are swappable between nVidia cards from
 the era. There is no protection on the games, you can just swap out
 hard drives to change games, though they do seem to have their own
 motherboard bioses.

--- a/src/mame/gaelco/gaelcopc.cpp
+++ b/src/mame/gaelco/gaelcopc.cpp
@@ -15,14 +15,14 @@ Intel 82801 (PCI 2.3 + integrated LAN + IDE + USB 2.0 + AC'97 + LPC +
              ACPI 2.0 + Flash BIOS control + SMBus + GPIO)
 Intel 82562 (LAN)
 RTM 560-25R (Audio)
-nVidia GeForce 4 TI4200 128Mb AGP
+Nvidia GeForce 4 TI4200 128Mb AGP
 256 Mb PC133
 Pentium 4 (??? XXXXMhz), <- contradicts 82815 datasheet and an internal BIOS string at $ce (Socket 370),
                             expect Celeron or Pentium 3 at very least.
 
 I/O Board with Altera Flex EPF15K50EQC240-3
 
-The graphics cards are swappable between nVidia cards from
+The graphics cards are swappable between Nvidia cards from
 the era. There is no protection on the games, you can just swap out
 hard drives to change games, though they do seem to have their own
 motherboard bioses.
@@ -73,7 +73,7 @@ void gaelcopc_state::gaelcopc(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &gaelcopc_state::gaelcopc_map); // TODO: remove me
 
 	PCI_ROOT(config, "pci", 0);
-	// TODO: everything else
+	// ...
 }
 
 // TODO: All of the provided BIOSes just have different ACFG table configs at $10000, investigate

--- a/src/mame/ice/frenzyxprss.cpp
+++ b/src/mame/ice/frenzyxprss.cpp
@@ -32,7 +32,7 @@
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 namespace {
 
@@ -46,56 +46,30 @@ public:
 
 	void frenzyxprss(machine_config &config);
 
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-
 private:
 	required_device<cpu_device> m_maincpu;
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void frenzyxprss_map(address_map &map);
 };
 
-void frenzyxprss_state::video_start()
-{
-}
-
-uint32_t frenzyxprss_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void frenzyxprss_state::frenzyxprss_map(address_map &map)
 {
+	map(0x00000000, 0x0009ffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0x20000);
+	map(0xfffc0000, 0xffffffff).rom().region("bios", 0);
 }
 
 static INPUT_PORTS_START( frenzyxprss )
 INPUT_PORTS_END
 
-
-void frenzyxprss_state::machine_start()
-{
-}
-
-void frenzyxprss_state::machine_reset()
-{
-}
-
 void frenzyxprss_state::frenzyxprss(machine_config &config)
 {
-	// Basic machine hardware
-	PENTIUM3(config, m_maincpu, 100000000); // Intel Celeron SL5ZF 1GHz
+	PENTIUM3(config, m_maincpu, 100'000'000); // Intel Celeron SL5ZF 1GHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &frenzyxprss_state::frenzyxprss_map);
 
-	// Video hardware
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(800, 600); // Guess
-	screen.set_visarea(0, 800-1, 0, 600-1);
-	screen.set_screen_update(FUNC(frenzyxprss_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************
@@ -105,7 +79,7 @@ void frenzyxprss_state::frenzyxprss(machine_config &config)
 ***************************************************************************/
 
 ROM_START( frenzyxprss )
-	ROM_REGION( 0x40000, "bios", 0 )
+	ROM_REGION32_LE( 0x40000, "bios", 0 )
 	ROM_SYSTEM_BIOS( 0, "750", "2002-04-19" )
 	ROMX_LOAD( "a6309vms_2002-04-19.750.u24", 0x00000, 0x40000, CRC(a227ff2a) SHA1(eea6b336082bf8091f120b6c4cc9bb61c3c3c234), ROM_BIOS(0) )
 	ROM_SYSTEM_BIOS( 1, "740", "2002-02-28" )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -23991,6 +23991,8 @@ livequiz                        // (c) 1999 Andamiro
 @source:midway/midqslvr.cpp
 arctthnd                        // (c) 2001 Midway Games
 hydrthnd                        // (c) 1999 Midway Games
+hydrthnd100d                    // (c) 1999 Midway Games
+hydrthnd101b                    // (c) 1999 Midway Games
 offrthnd                        // (c) 2000 Midway Games
 ultarctc                        // (c) 2001 Midway Games
 ultarctcup                      // (c) 2001 Midway Games

--- a/src/mame/misc/bntyhunt.cpp
+++ b/src/mame/misc/bntyhunt.cpp
@@ -7,7 +7,7 @@ Ending can be seen at: https://www.youtube.com/watch?v=xa7GQC8Phfk
 
 https://www.arcade-museum.com/game_detail.php?game_id=13327
 - Pentium III 1 GHz
-- Nvidia GeForce 2 MX200
+- nVidia GeForce 2 MX200
 No other info about the MB used, most notable folders in the HDD dump:
 - C:\bh:
 \- *.gci files in data folder
@@ -25,7 +25,7 @@ No other info about the MB used, most notable folders in the HDD dump:
    "VIA Power Management Controller" / "VIA PCI to PCI Bridge Controller" /
    "VIA I/O APIC Interrupt Controller"
 \- viaudio.inf / viaudoem.inf "VIA AC'97 Enhanced Audio Controller (WDM)"
-\- nvaml.inf "NVIDIA Windows 95/98/ME Display Drivers"
+\- nvaml.inf "nVidia Windows 95/98/ME Display Drivers"
 \- monitor.pnf (custom DDC setup?)
 
 Running this in pcipc will successfully boot a custom Korean Windows 98SE (no Microsoft splash boot screen), will try to install drivers, punts to a DOS sub-window requiring at least a 256 color mode.

--- a/src/mame/misc/bntyhunt.cpp
+++ b/src/mame/misc/bntyhunt.cpp
@@ -10,9 +10,9 @@ https://www.arcade-museum.com/game_detail.php?game_id=13327
 - Nvidia GeForce 2 MX200
 No other info about the MB used, most notable folders in the HDD dump:
 - C:\bh:
-\- *.gci files in data/* folder
+\- *.gci files in data folder
   "Global Challanger Image Data Ver1.0.0 Copyright (C) 2002 by GC-Tech CO, LTD"
-\- Several logs for *.pro files in data/* folder, generated with
+\- Several logs for *.pro files in data folder, generated with
    "3D Studio MAX PowerRender Exporter v1.05"
 - C:\drv:
 \- Korean setup files for Windows 98SE

--- a/src/mame/misc/bntyhunt.cpp
+++ b/src/mame/misc/bntyhunt.cpp
@@ -1,52 +1,60 @@
 // license:BSD-3-Clause
-// copyright-holders:Angelo Salese
+// copyright-holders:
 /* Bounty Hunter
 
- PC hardware.. no dumps of the bios roms are currently available
+Konami's Boxing Mania clone with punch & kick pads.
+Ending can be seen at: https://www.youtube.com/watch?v=xa7GQC8Phfk
+
+https://www.arcade-museum.com/game_detail.php?game_id=13327
+- Pentium III 1 GHz
+- Nvidia GeForce 2 MX200
+No other info about the MB used, most notable folders in the HDD dump:
+- C:\bh:
+\- *.gci files in data/* folder
+  "Global Challanger Image Data Ver1.0.0 Copyright (C) 2002 by GC-Tech CO, LTD"
+\- Several logs for *.pro files in data/* folder, generated with
+   "3D Studio MAX PowerRender Exporter v1.05"
+- C:\drv:
+\- Korean setup files for Windows 98SE
+\- VIA VT82C686A/VT82C686B/VT8231/VT8233/VT8233A/VT8233B/VT8235 audio driver files (ComboAudio_a1u300a)
+\- VIA Hyperion 4in1 chipset driver (VIA_4IN1_V440V(a)P3)
+\- VIA IDE miniport (IDE_MPD3014, VIA Bus Master (Ultra DMA) driver)
+- C:\windows:
+\- viagart.inf "VIA CPU to AGP controller"
+\- viamach.inf "VIA Standard CPU to PCI Bridge" / "VIA Standard PCI to ISA Bridge" /
+   "VIA Power Management Controller" / "VIA PCI to PCI Bridge Controller" /
+   "VIA I/O APIC Interrupt Controller"
+\- viaudio.inf / viaudoem.inf "VIA AC'97 Enhanced Audio Controller (WDM)"
+\- nvaml.inf "NVIDIA Windows 95/98/ME Display Drivers"
+\- monitor.pnf (custom DDC setup?)
+
+Running this in pcipc will successfully boot a custom Korean Windows 98SE (no Microsoft splash boot screen), will try to install drivers, punts to a DOS sub-window requiring at least a 256 color mode.
 
 */
 
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "emupal.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 
 class bntyhunt_state : public driver_device
 {
 public:
 	bntyhunt_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-			m_maincpu(*this, "maincpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
-	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-
 	void bntyhunt(machine_config &config);
-	void bntyhunt_map(address_map &map);
-protected:
 
-	// devices
+private:
 	required_device<cpu_device> m_maincpu;
-
-	// driver_device overrides
-	virtual void video_start() override;
+	void bntyhunt_map(address_map &map);
 };
-
-
-void bntyhunt_state::video_start()
-{
-}
-
-uint32_t bntyhunt_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void bntyhunt_state::bntyhunt_map(address_map &map)
 {
-	map(0x00000000, 0x0001ffff).rom();
 }
 
 static INPUT_PORTS_START( bntyhunt )
@@ -55,30 +63,22 @@ INPUT_PORTS_END
 
 void bntyhunt_state::bntyhunt(machine_config &config)
 {
-	/* basic machine hardware */
-	PENTIUM(config, m_maincpu, 200000000); /* Probably a Pentium or higher .. ?? Mhz*/
+	PENTIUM3(config, m_maincpu, 200'000'000); // unknown CPU
 	m_maincpu->set_addrmap(AS_PROGRAM, &bntyhunt_state::bntyhunt_map);
+	m_maincpu->set_disable();
 
-	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_screen_update(FUNC(bntyhunt_state::screen_update));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(64*8, 32*8);
-	screen.set_visarea_full();
-	screen.set_palette("palette");
-
-	PALETTE(config, "palette").set_entries(0x100);
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 
 ROM_START(bntyhunt)
-	ROM_REGION32_LE(0x20000, "maincpu", 0)  /* motherboard bios */
-	ROM_LOAD("bntyhunt.pcbios", 0x000000, 0x10000, NO_DUMP )
+	ROM_REGION32_LE(0x40000, "bios", 0)
+	ROM_LOAD("bntyhunt.pcbios", 0x000000, 0x40000, NO_DUMP )
 
 	DISK_REGION( "disks" )
 	DISK_IMAGE( "bntyhunt", 0, SHA1(e50937d14d5c6adfb5e0012db5a7df090eebc2e1) )
 ROM_END
 
 
-GAME( 200?, bntyhunt, 0, bntyhunt, bntyhunt, bntyhunt_state, empty_init, ROT0, "GCTech Co., LTD", "Bounty Hunter (GCTech Co., LTD)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+GAME( 2002?, bntyhunt, 0, bntyhunt, bntyhunt, bntyhunt_state, empty_init, ROT0, "GC-Tech Co., LTD", "Bounty Hunter (GC-Tech Co., LTD)", MACHINE_IS_SKELETON )

--- a/src/mame/misc/cavepc.cpp
+++ b/src/mame/misc/cavepc.cpp
@@ -1,11 +1,14 @@
 // license:BSD-3-Clause
 // copyright-holders:David Haywood
-/***************************************************************************
+/**************************************************************************************************
 
     CAVE PC hardware
     placeholder file for information
 
-***************************************************************************
+TODO:
+- Cannot continue without a proper Athlon 64 X2 core (uses lots of unsupported RDMSR / WRMSR)
+
+***************************************************************************************************
 
  Cave used a one-off PC platform for
 
@@ -52,45 +55,33 @@
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "emupal.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 
 class cavepc_state : public driver_device
 {
 public:
 	cavepc_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
-	required_device<cpu_device> m_maincpu;
 
-	void init_cavepc();
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-	uint32_t screen_update_cavepc(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void cavepc(machine_config &config);
+
+private:
+	required_device<cpu_device> m_maincpu;
 	void cavepc_io(address_map &map);
 	void cavepc_map(address_map &map);
 };
-
-void cavepc_state::video_start()
-{
-}
-
-uint32_t cavepc_state::screen_update_cavepc(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 /*****************************************************************************/
 
 void cavepc_state::cavepc_map(address_map &map)
 {
-	map(0x000f0000, 0x000fffff).bankr("bank1");
-	map(0xfffc0000, 0xffffffff).rom().region("bios", 0);    /* System BIOS */
+	map(0x00000000, 0x0009ffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0xe0000);
+	map(0xfff00000, 0xffffffff).rom().region("bios", 0);
 }
 
 void cavepc_state::cavepc_io(address_map &map)
@@ -103,39 +94,17 @@ void cavepc_state::cavepc_io(address_map &map)
 static INPUT_PORTS_START(cavepc)
 INPUT_PORTS_END
 
-void cavepc_state::machine_start()
-{
-}
-
-void cavepc_state::machine_reset()
-{
-	membank("bank1")->set_base(memregion("bios")->base() + 0x30000);
-}
 
 void cavepc_state::cavepc(machine_config &config)
 {
-	/* basic machine hardware */
-	PENTIUM3(config, m_maincpu, 200000000); /*  AMD Athlon 64 X2 5050e Brisbane 2.60GHz, 1024KB L2 Cache ! */
+	PENTIUM3(config, m_maincpu, 200'000'000); /*  AMD Athlon 64 X2 5050e Brisbane 2.60GHz, 1024KB L2 Cache ! */
 	m_maincpu->set_addrmap(AS_PROGRAM, &cavepc_state::cavepc_map);
 	m_maincpu->set_addrmap(AS_IO, &cavepc_state::cavepc_io);
 
-	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 639, 0, 199);
-	screen.set_screen_update(FUNC(cavepc_state::screen_update_cavepc));
-	screen.set_palette("palette");
-
-	PALETTE(config, "palette").set_entries(16);
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
-
-
-void cavepc_state::init_cavepc()
-{
-}
 
 /*****************************************************************************/
 
@@ -181,4 +150,4 @@ ROM_END
 
 /*****************************************************************************/
 
-GAME(2009, deathsm2, 0, cavepc, cavepc, cavepc_state, init_cavepc, ROT0, "Cave", "Deathsmiles II: Makai no Merry Christmas (2009/10/14 MASTER VER 4.00)", MACHINE_IS_SKELETON )
+GAME(2009, deathsm2, 0, cavepc, cavepc, cavepc_state, empty_init, ROT0, "Cave", "Deathsmiles II: Makai no Merry Christmas (2009/10/14 MASTER VER 4.00)", MACHINE_IS_SKELETON )

--- a/src/mame/misc/chameleonrx1.cpp
+++ b/src/mame/misc/chameleonrx1.cpp
@@ -9,6 +9,10 @@
     SUMA GFX 5600X 128MB (Model SV3MDN0)
     Sound Blaster Live! 5.1 Digital (Model SB0220)
     Samsung SP6003H/OMD REV. A PUMA 60.0 GB
+
+    TODO:
+    - in shutms11 loads Windows 2000 fine but MAME throws "Caught unhandled exception" as soon
+      as progress bar completes.
 */
 
 #include "emu.h"

--- a/src/mame/misc/chameleonrx1.cpp
+++ b/src/mame/misc/chameleonrx1.cpp
@@ -13,7 +13,7 @@
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 namespace {
 
@@ -21,62 +21,38 @@ class chameleonrx1_state : public driver_device
 {
 public:
 	chameleonrx1_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
 	void chameleonrx1(machine_config &config);
 
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-
 private:
 	required_device<cpu_device> m_maincpu;
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void chameleonrx1_map(address_map &map);
 };
 
-void chameleonrx1_state::video_start()
-{
-}
 
-uint32_t chameleonrx1_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void chameleonrx1_state::chameleonrx1_map(address_map &map)
 {
+	map(0x00000000, 0x0009ffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0x20000);
+	map(0xfffc0000, 0xffffffff).rom().region("bios", 0);
 }
 
 static INPUT_PORTS_START( chameleonrx1 )
 INPUT_PORTS_END
 
-
-void chameleonrx1_state::machine_start()
-{
-}
-
-void chameleonrx1_state::machine_reset()
-{
-}
-
 void chameleonrx1_state::chameleonrx1(machine_config &config)
 {
 	/* basic machine hardware */
-	PENTIUM4(config, m_maincpu, 100000000); // actually 2.66 GHz
+	PENTIUM4(config, m_maincpu, 100'000'000); // actually 2.66 GHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &chameleonrx1_state::chameleonrx1_map);
 
-	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
-	screen.set_screen_update(FUNC(chameleonrx1_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************
@@ -86,7 +62,7 @@ void chameleonrx1_state::chameleonrx1(machine_config &config)
 ***************************************************************************/
 
 ROM_START( chamrx1 )
-	ROM_REGION(0x40000, "bios", 0)
+	ROM_REGION32_LE(0x40000, "bios", 0)
 	ROM_LOAD("p45m6_1010_c728_gm_u5_sst49lf002a.u26", 0x00000, 0x40000, CRC(2dd3d3eb) SHA1(5bf639442807cc1aa2ad910817a2e8d2a80e7226) )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Samsung SP6003H/OMD Rev.A. LBA 117,304,992 60GB PUMA

--- a/src/mame/misc/comebaby.cpp
+++ b/src/mame/misc/comebaby.cpp
@@ -4,9 +4,13 @@
   (c) 2000 ExPotato Co. Ltd (Excellent Potato)
 
 TODO:
-Nearly everything.
-- [:maincpu] WRMSR: invalid MSR write 00000250 (0404040404040404) at 0002e3b6
-  then jumps to 0?
+- skeleton driver;
+- Throws "Primary master hard disk fail" in shutms11. Disk has a non canonical -chs of 524,255,63.
+  winimage will throw plenty of errors on manual file extraction.
+- In pcipc with a manually rebuilt image will throw an exception in "Internat" module once it loads
+  Windows 98 (and installs the diff drivers).
+
+===================================================================================================
 
   There also appears to be a sequel which may be running on the same hardware, but which does not seem to have been released.
   Come On Baby - Ballympic Heroes!  (c) 2001
@@ -132,7 +136,7 @@ Nearly everything.
 
   --
 
-  The donor PC looks like a standard Windows 98 setup.
+  The donor PC looks like a standard Korean Windows 98 setup.
   The only exceptions we see are that there's a game logo.sys/logo.bmp in the
   root directory to hide the Windows 98 startup screen, and a shortcut to
   the game in the startup programs.
@@ -183,56 +187,32 @@ Nearly everything.
 
 
 #include "emu.h"
-
-#include "pcshare.h"
-
 #include "cpu/i386/i386.h"
-
-#include "emupal.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 
-class comebaby_state : public pcat_base_state
+class comebaby_state : public driver_device
 {
 public:
 	comebaby_state(const machine_config &mconfig, device_type type, const char *tag)
-		: pcat_base_state(mconfig, type, tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
-	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-
 	void comebaby(machine_config &config);
-	void comebaby_io(address_map &map);
+
+private:
+	required_device<cpu_device> m_maincpu;
+
 	void comebaby_map(address_map &map);
-protected:
-
-	// devices
-
-	// driver_device overrides
-	virtual void video_start() override;
 };
-
-
-void comebaby_state::video_start()
-{
-}
-
-uint32_t comebaby_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void comebaby_state::comebaby_map(address_map &map)
 {
 	map(0x00000000, 0x0009ffff).ram();
-	map(0x000a0000, 0x000bffff).ram();
-	map(0x000c0000, 0x000fffff).rom().region("bios", 0);
+//  map(0x000a0000, 0x000bffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0x20000);
 	map(0xfffc0000, 0xffffffff).rom().region("bios", 0);
-}
-
-void comebaby_state::comebaby_io(address_map &map)
-{
-	pcat32_io_common(map);
 }
 
 static INPUT_PORTS_START( comebaby )
@@ -242,32 +222,21 @@ INPUT_PORTS_END
 void comebaby_state::comebaby(machine_config &config)
 {
 	/* basic machine hardware */
-	PENTIUM2(config, m_maincpu, (66666666*19)/2); /* Actually a Celeron */
+	PENTIUM2(config, m_maincpu, 66'666'666); /* Actually a Celeron (66'666'666 * 19) / 2 */
 	m_maincpu->set_addrmap(AS_PROGRAM, &comebaby_state::comebaby_map);
-	m_maincpu->set_addrmap(AS_IO, &comebaby_state::comebaby_io);
 
-	pcat_common(config);
-
-	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_screen_update(FUNC(comebaby_state::screen_update));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(64*8, 32*8);
-	screen.set_visarea_full();
-	screen.set_palette("palette");
-
-	PALETTE(config, "palette").set_entries(0x100);
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 
 ROM_START(comebaby)
-	ROM_REGION32_LE(0x80000, "bios", 0)  /* motherboard bios */
+	ROM_REGION32_LE(0x40000, "bios", 0)  /* motherboard bios */
 	ROM_LOAD("b1120iag.bin", 0x000000, 0x40000, CRC(9b6f95f1) SHA1(65d6a2fea9911593f093b2e2a43d1534b54d60b3) )
 
 	DISK_REGION( "disks" )
-	DISK_IMAGE( "comebaby", 0, SHA1(ea57919319c0b6a1d4abd7822cff028855bf082f) )
+	DISK_IMAGE( "comebaby", 0, BAD_DUMP SHA1(ea57919319c0b6a1d4abd7822cff028855bf082f) )
 ROM_END
 
 
-GAME( 2000, comebaby, 0, comebaby, comebaby, comebaby_state, empty_init, ROT0, "ExPotato", "Come On Baby", MACHINE_NOT_WORKING|MACHINE_NO_SOUND )
+GAME( 2000, comebaby, 0, comebaby, comebaby, comebaby_state, empty_init, ROT0, "ExPotato", "Come On Baby", MACHINE_IS_SKELETON )

--- a/src/mame/misc/ez2d.cpp
+++ b/src/mame/misc/ez2d.cpp
@@ -96,7 +96,7 @@ ROM_START( ez2d2m )
 	ROM_LOAD("ez2dancer2ndmove_motherboard_v29c51002t_award_bios", 0x00000, 0x40000, CRC(02a5e84b) SHA1(94b341d268ce9d42597c68bc98c3b8b62e137205) ) // 29f020
 
 	ROM_REGION( 0x10000, "vbios", 0 )
-	// NVIDIA TNT2 Model 64 video BIOS (not from provided dump)
+	// nVidia TNT2 Model 64 video BIOS (not from provided dump)
 	// TODO: move to PCI device once we have one
 	ROM_LOAD( "62090211.rom", 0x000000, 0x00b000, CRC(5669135b) SHA1(b704ce0d20b71e40563d12bcc45bd1240227be74) )
 

--- a/src/mame/misc/ez2d.cpp
+++ b/src/mame/misc/ez2d.cpp
@@ -1,6 +1,11 @@
 // license:BSD-3-Clause
 // copyright-holders:Ivan Vangelista
 /*
+
+TODO:
+- Jumps to PC=0xfb000 after the first 2 PCI dword configs, which points to empty 0xff opcodes.
+  $3a000 contains an "= Award Decompression Bios =" header
+
 Thanks to Guru for hardware infos and pics for Ez2dancer 2nd Move.
 Later games in the series might run on newer, beefier hardware.
 
@@ -40,7 +45,7 @@ Ez2DJ series:
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 class ez2d_state : public driver_device
 {
@@ -55,51 +60,29 @@ public:
 private:
 	required_device<cpu_device> m_maincpu;
 
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void ez2d_map(address_map &map);
 };
 
-void ez2d_state::video_start()
-{
-}
-
-uint32_t ez2d_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void ez2d_state::ez2d_map(address_map &map)
 {
+	map(0x00000000, 0x0009ffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0x20000);
+	map(0xfffc0000, 0xffffffff).rom().region("bios", 0);
 }
 
 static INPUT_PORTS_START( ez2d )
 INPUT_PORTS_END
 
 
-void ez2d_state::machine_start()
-{
-}
-
-void ez2d_state::machine_reset()
-{
-}
-
 void ez2d_state::ez2d(machine_config &config)
 {
 	/* basic machine hardware */
-	PENTIUM3(config, m_maincpu, 100000000); // actually a Celeron at 533 MHz
+	PENTIUM3(config, m_maincpu, 100'000'000); // actually a Celeron at 533 MHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &ez2d_state::ez2d_map);
 
-	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(640, 480);
-	screen.set_visarea_full();
-	screen.set_screen_update(FUNC(ez2d_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************
@@ -109,10 +92,12 @@ void ez2d_state::ez2d(machine_config &config)
 ***************************************************************************/
 
 ROM_START( ez2d2m )
-	ROM_REGION(0x40000, "bios", 0) \
+	ROM_REGION32_LE(0x40000, "bios", 0) \
 	ROM_LOAD("ez2dancer2ndmove_motherboard_v29c51002t_award_bios", 0x00000, 0x40000, CRC(02a5e84b) SHA1(94b341d268ce9d42597c68bc98c3b8b62e137205) ) // 29f020
 
-	ROM_REGION( 0x10000, "vbios", 0 )   // video card BIOS, not dumped but downloaded from internet
+	ROM_REGION( 0x10000, "vbios", 0 )
+	// NVIDIA TNT2 Model 64 video BIOS (not from provided dump)
+	// TODO: move to PCI device once we have one
 	ROM_LOAD( "62090211.rom", 0x000000, 0x00b000, CRC(5669135b) SHA1(b704ce0d20b71e40563d12bcc45bd1240227be74) )
 
 	DISK_REGION( "ide:0:hdd:image" )

--- a/src/mame/misc/funkball.cpp
+++ b/src/mame/misc/funkball.cpp
@@ -5,11 +5,6 @@
 // MEDIAGX CPU + 3dFX VooDoo chipset
 /***************************************************************************
 
-driver by Angelo Salese & Phil Bennett
-
-Notes:
--
-
 Funky Ball
 dgPIX, 1998
 

--- a/src/mame/misc/gfamily.cpp
+++ b/src/mame/misc/gfamily.cpp
@@ -11,17 +11,20 @@ PC with Chinese Windows 2000 Pro and several emulators, including (programs may 
  -FB Alpha v0.2.94.98
  -ZiNc 1.1
 
-PC motherboard plus an additional PCB for JAMMA, inputs and basic config (and protection) with:
+SiS651/SiS962 based chipset plus an additional PCB for JAMMA, inputs and basic config (and protection) with:
  Atmel AT89C2051 (near a 4 dipswitches bank and a 6.000 MHz xtal)
  Microchip CF745 (near another 4 dipswitches bank and a 4.000 MHz xtal)
  2 x Microchip PIC12F508
  Altera Max EPM7128SQC100-10 CPLD
 
+TODO:
+- Move to sis630.cpp or a derived state (kinda boots with existing driver)
+
 */
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 namespace {
 
@@ -35,56 +38,31 @@ public:
 
 	void gfamily(machine_config &config);
 
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-
 private:
 	required_device<cpu_device> m_maincpu;
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void gfamily_map(address_map &map);
 };
 
-void gfamily_state::video_start()
-{
-}
-
-uint32_t gfamily_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void gfamily_state::gfamily_map(address_map &map)
 {
+	map(0x00000000, 0x0009ffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0x60000);
+	map(0xfff80000, 0xffffffff).rom().region("bios", 0);
 }
 
 static INPUT_PORTS_START( gfamily )
 INPUT_PORTS_END
 
-
-void gfamily_state::machine_start()
-{
-}
-
-void gfamily_state::machine_reset()
-{
-}
-
 void gfamily_state::gfamily(machine_config &config)
 {
-	// Basic machine hardware
+	// Socket 478
 	PENTIUM4(config, m_maincpu, 1'700'000'000); // Actually an Intel Celeron SL6SC 1.7GHz (with the config found with the default BIOS)
 	m_maincpu->set_addrmap(AS_PROGRAM, &gfamily_state::gfamily_map);
 
-	// Video hardware
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
-	screen.set_screen_update(FUNC(gfamily_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************
@@ -97,7 +75,7 @@ ROM_START( gmfamily )
 
 	/* Different PC motherboards with different configurations.
 	   By now, we're throwing all known BIOSes here. */
-	ROM_REGION(0x80000, "bios", 0)
+	ROM_REGION32_LE(0x80000, "bios", 0)
 
 	/* CPU: Intel Celeron 1.7GHz / 128kb / 400MHz SL6SC
 	   RAM: 256MB-DDR400

--- a/src/mame/misc/gfamily.cpp
+++ b/src/mame/misc/gfamily.cpp
@@ -18,7 +18,7 @@ SiS651/SiS962 based chipset plus an additional PCB for JAMMA, inputs and basic c
  Altera Max EPM7128SQC100-10 CPLD
 
 TODO:
-- Move to sis630.cpp or a derived state (kinda boots with existing driver)
+- Move to sis630.cpp or a derived state (BIOS kinda boots with existing driver)
 
 */
 

--- a/src/mame/misc/globalvr.cpp
+++ b/src/mame/misc/globalvr.cpp
@@ -6,8 +6,38 @@ Skeleton only at this time holding info regarding Install Disks
 for Games/Operating System for Global VR produced games.
 Specific hardware outlays are unknown per game at this time.
 
-Game List                                        Year
------------------------------------------------------
+The install disks contains PowerQuest DeployCenter 5.0 images.
+Those aren't El Torito complaint so they expects at very least a
+bootable MSDOS 5.0 (according to Pq_debug.txt file found in gvrxpsys).
+The nfsgt is a Windows XP HDD image, containing:
+- C:\Program Files:
+\- C-Media 3D Audio driver (C-Media AC97 Audio Device / CMI8738/C3DX PCI Audio Device)
+\- Intel 82865G/PE/P, 82875P (GMCH)
+\- Ligos Indeo XP codec package (Indeo Video 5.2)
+\- ALi USB2.0 Driver
+- C:\temp
+\- NVIDIA Display Driver 45.23 for Windows 2000 to XP (GeForce 256 up to GeForce 4)
+\- DirectX 9.0
+- C:\windows:
+\- aksubs.inf: Aladdin Knowledge Systems HASP/Hardlock USB driver
+\- akspccard.inf: Aladdin Knowledge Systems Hasp & Hardlock PCMCIA (PC-Card)
+- C:\windows\inf:
+\- 865.inf: driver for 8265
+\- ich5core.inf/ich5ide.inf: Intel 82801EB Ultra ATA Storage Controllers
+- C:\Gvr:
+\- A full install of Need For Speed: Hot Pursuit 2
+- C:\GvrRoot:
+\- Data for nfsgt (overlay for above?), including screen for NoDongle.
+- Footprints in C:\Documents and Settings\Administrator, reported just for
+  completeness sake (read: likely not important):
+\- "Local Settings\temp" for an unknown installer data
+\- "Temporary Internet Files" for a failed Microsoft download log.
+
+
+TODO:
+- nfsgt hard disk crashes MAME with uncaught exception in both pcipc and shutms11
+
+Game List                                        Year-----------------------------------------------------
 Aliens: Extermination                            2006
 America's Army                                   2007
 Beach Head 2000                                  2000
@@ -58,28 +88,27 @@ UltraPin                                         2006
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
+#include "machine/pci.h"
 
 class globalvr_state : public driver_device
 {
 public:
 	globalvr_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-			m_maincpu(*this, "maincpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
 	void globalvr(machine_config &config);
-	void globalvr_map(address_map &map);
 private:
-
-	// devices
 	required_device<cpu_device> m_maincpu;
+
+	void globalvr_map(address_map &map);
 };
 
 
 
 void globalvr_state::globalvr_map(address_map &map)
 {
-	map(0x00000000, 0xffffff).ram();
 }
 
 
@@ -89,70 +118,110 @@ INPUT_PORTS_END
 
 void globalvr_state::globalvr(machine_config &config)
 {
-	/* basic machine hardware */
-	PENTIUM(config, m_maincpu, 100000000);      /* ? MHz */
+	// TODO: identify CPU socket
+	// Logs inside gvrxpsys claims that it expects a "GenuineIntel"
+	// with CPU features 0x0383f9ff (no SSE2, MMX, SSE, no Procesor Serial Number)
+	// Socket 370 Celeron/Pentium 3?
+	PENTIUM3(config, m_maincpu, 100'000'000);      /* ? MHz */
 	m_maincpu->set_addrmap(AS_PROGRAM, &globalvr_state::globalvr_map);
+	m_maincpu->set_disable();
+
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 
 ROM_START( hyperv2 )
-	DISK_REGION( "ide:0:hdd:image" )
+	ROM_REGION32_LE(0x80000, "bios", 0)
+	ROM_LOAD("mb.bios", 0x00000, 0x80000, NO_DUMP )
+
+	DISK_REGION( "ide:1:cdrom:image" )
 	DISK_IMAGE_READONLY( "hyperv2_pqi_6-12-02", 0, SHA1(44473f2950c0e108acb0961579a46f4765e379f7) )
 ROM_END
 
 ROM_START( hyperv2a )
-	ROM_REGION( 0x168000, "bootdisk", 0 ) /* Win98/DOS bootdisk from folder made into .IMA with WinImage */
-	ROM_LOAD( "hyperv2_pqi_9-30-01.ima", 0x000000, 0x168000, CRC(964d8e00) SHA1(efefcfcca85328df8445a4ba482cd7d5b584ae05) )
+	ROM_REGION32_LE(0x80000, "bios", 0)
+	ROM_LOAD("mb.bios", 0x00000, 0x80000, NO_DUMP )
 
-	DISK_REGION( "ide:0:hdd:image" )
+	ROM_REGION( 0x168000, "bootdisk", 0 ) /* Win98/DOS bootdisk from folder made into .IMA with WinImage */
+	// "not-bootable system disk", but contains autoexec.bat / config.sys ...
+	ROM_LOAD( "hyperv2_pqi_9-30-01.ima", 0x000000, 0x168000, BAD_DUMP CRC(964d8e00) SHA1(efefcfcca85328df8445a4ba482cd7d5b584ae05) )
+
+	DISK_REGION( "ide:1:cdrom:image" )
 	DISK_IMAGE_READONLY( "hyperv2_pqi_9-30-01", 0, SHA1(7a8c201a83a45609d0242a20441891f5204d7dd1) )
 ROM_END
 
 ROM_START( gvrxpsys )
-	DISK_REGION( "ide:0:hdd:image" )
+	ROM_REGION32_LE(0x80000, "bios", 0)
+	ROM_LOAD("mb.bios", 0x00000, 0x80000, NO_DUMP )
+
+	DISK_REGION( "ide:1:cdrom:image" )
 	DISK_IMAGE_READONLY( "globalvr_xp_system", 0, SHA1(83a784fe038acbd651544b3fa3b17ceb11bbeeab) )
 ROM_END
 
 ROM_START( gvrxpsup )
-	DISK_REGION( "ide:0:hdd:image" )
+	ROM_REGION32_LE(0x80000, "bios", 0)
+	ROM_LOAD("mb.bios", 0x00000, 0x80000, NO_DUMP )
+
+	DISK_REGION( "ide:1:cdrom:image" )
 	DISK_IMAGE_READONLY( "vr_xp_system_6-11-2002", 0, SHA1(c2b586a0106632bcaddc1df8077ee9c226537d2b) )
 ROM_END
 
 ROM_START( bhead2k )
-	DISK_REGION( "ide:0:hdd:image" )
+	ROM_REGION32_LE(0x80000, "bios", 0)
+	ROM_LOAD("mb.bios", 0x00000, 0x80000, NO_DUMP )
+
+	DISK_REGION( "ide:1:cdrom:image" )
 	DISK_IMAGE_READONLY( "beachhead2000_5-27-2003", 0, SHA1(d4473a7fb9820f2e517a1e0609ec9e12f326fc06) )
 ROM_END
 
 ROM_START( bhead2ka )
-	DISK_REGION( "ide:0:hdd:image" )
+	ROM_REGION32_LE(0x80000, "bios", 0)
+	ROM_LOAD("mb.bios", 0x00000, 0x80000, NO_DUMP )
+
+	DISK_REGION( "ide:1:cdrom:image" )
 	DISK_IMAGE_READONLY( "beachhead2000_9-16-2001", 0, SHA1(2151c0aff39a5279adb422e97f00c610d21c48e8) )
 ROM_END
 
 ROM_START( bhead2k2 )
-	DISK_REGION( "ide:0:hdd:image" )
+	ROM_REGION32_LE(0x80000, "bios", 0)
+	ROM_LOAD("mb.bios", 0x00000, 0x80000, NO_DUMP )
+
+	DISK_REGION( "ide:1:cdrom:image" )
 	DISK_IMAGE_READONLY( "beachhead2002_5-27-2003", 0, SHA1(c58e62363387b76b4f03432b543498d4560d27a9) )
 ROM_END
 
 ROM_START( bhead2k3 )
-	DISK_REGION( "ide:0:hdd:image" )
+	ROM_REGION32_LE(0x80000, "bios", 0)
+	ROM_LOAD("mb.bios", 0x00000, 0x80000, NO_DUMP )
+
+	DISK_REGION( "ide:1:cdrom:image" )
 	DISK_IMAGE_READONLY( "beachhead2003desertwar_5-27-2003", 0, SHA1(fed23a6496836050eb1d4f69b91da09adbd9d973) )
 ROM_END
 
 ROM_START( nfs )
+	ROM_REGION32_LE(0x80000, "bios", 0)
+	ROM_LOAD("mb.bios", 0x00000, 0x80000, NO_DUMP )
+
+	// HDD dumps, likely belonging to individual HDD with separate partitions
 	DISK_REGION( "drive_1" )
-	DISK_IMAGE_READONLY( "need for speed disk 1 version 1.0.1 rev b", 0, SHA1(799017103c46712534e4bd9c04695fb8241a7ba4) )
+	DISK_IMAGE( "need for speed disk 1 version 1.0.1 rev b", 0, SHA1(799017103c46712534e4bd9c04695fb8241a7ba4) )
 
 	DISK_REGION( "drive_2" )
-	DISK_IMAGE_READONLY( "need for speed disk 2 version 1.0.1 rev b", 0, SHA1(800d1786bb9d2a2448c03c19ea6626af487aed90) )
+	DISK_IMAGE( "need for speed disk 2 version 1.0.1 rev b", 0, SHA1(800d1786bb9d2a2448c03c19ea6626af487aed90) )
 
 	DISK_REGION( "recovery" )
-	DISK_IMAGE_READONLY( "emergency recovery disk 11.11.2003 rev a", 0, SHA1(38656b9da94150e5e8ed8a4183d2cc149e96aedd) )
+	DISK_IMAGE( "emergency recovery disk 11.11.2003 rev a", 0, SHA1(38656b9da94150e5e8ed8a4183d2cc149e96aedd) )
 ROM_END
 
 ROM_START( nfsgt )
-	DISK_REGION( "ide:0:hdd:image" )
-	DISK_IMAGE_READONLY( "need for speed gt", 0, SHA1(58bb2b47e30b65f2f09d2c2f2d7f300cf420b18a) )
+	ROM_REGION32_LE(0x80000, "bios", 0)
+	ROM_LOAD("mb.bios", 0x00000, 0x80000, NO_DUMP )
 
+	DISK_REGION( "ide:0:hdd:image" )
+	DISK_IMAGE( "need for speed gt", 0, SHA1(58bb2b47e30b65f2f09d2c2f2d7f300cf420b18a) )
+
+	// CD-ROMs
 	DISK_REGION( "drive_1" )
 	DISK_IMAGE_READONLY( "need for speed gt disk 1 1.1.0 rev c", 0, SHA1(49d967a808f415d3ceb59a5758ee5b3fc4cfb551) )
 
@@ -161,6 +230,10 @@ ROM_START( nfsgt )
 ROM_END
 
 ROM_START( nfsug )
+	ROM_REGION32_LE(0x80000, "bios", 0)
+	ROM_LOAD("mb.bios", 0x00000, 0x80000, NO_DUMP )
+
+	// CD-ROMs
 	DISK_REGION( "drive_1" )
 	DISK_IMAGE_READONLY( "nfsug1_1-disc1", 0, SHA1(25a9f0606ac3909bd7c4f3f3a59c6782e3c84712) )
 

--- a/src/mame/misc/globalvr.cpp
+++ b/src/mame/misc/globalvr.cpp
@@ -16,7 +16,7 @@ The nfsgt is a Windows XP HDD image, containing:
 \- Ligos Indeo XP codec package (Indeo Video 5.2)
 \- ALi USB2.0 Driver
 - C:\temp
-\- NVIDIA Display Driver 45.23 for Windows 2000 to XP (GeForce 256 up to GeForce 4)
+\- nVidia Display Driver 45.23 for Windows 2000 to XP (GeForce 256 up to GeForce 4)
 \- DirectX 9.0
 - C:\windows:
 \- aksubs.inf: Aladdin Knowledge Systems HASP/Hardlock USB driver

--- a/src/mame/misc/neomania.cpp
+++ b/src/mame/misc/neomania.cpp
@@ -16,11 +16,22 @@ The "NEO MANIA ADAPTER BOARD" contains:
     JMP3 (three positions) - Unknown function
    2 x Coin acceptors ports
    1 x Bank of 8 dipswitches (unknown function)
+
+C:\Neomania folder contains ppm.exe, which is the driver for the parallel port device.
+It also contains a password protected "Guard.zip", copy protection?
+C:\Windows has driver installs for a PCI Sound Blaster and an ATI mach 64 / Bt829 derivative.
+
+
+TODO:
+- HDD image doesn't boot in neither shutms11 nor pcipc, mangled MBR boot record;
+- Extract "Guard.zip" and understand what is for;
+
+
 */
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 namespace {
 
@@ -28,32 +39,19 @@ class neomania_state : public driver_device
 {
 public:
 	neomania_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
 	void neomania(machine_config &config);
 
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
 
 private:
 	required_device<cpu_device> m_maincpu;
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void neomania_map(address_map &map);
 };
 
-void neomania_state::video_start()
-{
-}
-
-uint32_t neomania_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void neomania_state::neomania_map(address_map &map)
 {
@@ -63,27 +61,16 @@ static INPUT_PORTS_START( neomania )
 INPUT_PORTS_END
 
 
-void neomania_state::machine_start()
-{
-}
-
-void neomania_state::machine_reset()
-{
-}
-
 void neomania_state::neomania(machine_config &config)
 {
 	// Basic machine hardware
-	PENTIUM3(config, m_maincpu, 600'000'000); // Exact hardware not specified
+	// Neoemu.exe requires a processor with at least MMX features
+	PENTIUM3(config, m_maincpu, 100'000'000); // Exact hardware not specified
 	m_maincpu->set_addrmap(AS_PROGRAM, &neomania_state::neomania_map);
+	m_maincpu->set_disable();
 
-	// Video hardware
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
-	screen.set_screen_update(FUNC(neomania_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************
@@ -94,11 +81,11 @@ ROM_START( neomania )
 
 	// Different PC motherboards with different configurations.
 	ROM_REGION(0x80000, "bios", 0)
-	ROM_LOAD("pcbios.bin", 0x00000, 0x80000, NO_DUMP) // MB BIOS
+	ROM_LOAD("pcbios.bin", 0x00000, 0x80000, NO_DUMP)
 
 	// Portuguese version with 48 games, from 2003
 	DISK_REGION( "ide:0:hdd:image" ) // From a Norton Ghost recovery image
-	DISK_IMAGE( "neomania", 0, SHA1(4a865d1ed67901b98b37f94cfdd591fad38b404a) )
+	DISK_IMAGE( "neomania", 0, BAD_DUMP SHA1(4a865d1ed67901b98b37f94cfdd591fad38b404a) )
 ROM_END
 
 } // Anonymous namespace

--- a/src/mame/misc/neomania.cpp
+++ b/src/mame/misc/neomania.cpp
@@ -23,7 +23,8 @@ C:\Windows has driver installs for a PCI Sound Blaster and an ATI mach 64 / Bt82
 
 
 TODO:
-- HDD image doesn't boot in neither shutms11 nor pcipc, mangled MBR boot record;
+- HDD image doesn't boot in neither shutms11 nor pcipc, mangled MBR boot record or geometry params (has -chs 3532,16,38 but WinImage reports back ~20 GB partition?);
+- (With manually c&p files in a CHD that works) SIGABRT in pcipc trying to execute ppm.exe, in shutms11 will draw "Parallel Port Manager v4.0" then fail on device check;
 - Extract "Guard.zip" and understand what is for;
 
 

--- a/src/mame/misc/odyssey.cpp
+++ b/src/mame/misc/odyssey.cpp
@@ -67,7 +67,7 @@
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 class odyssey_state : public driver_device
 {
@@ -82,70 +82,28 @@ public:
 private:
 	required_device<cpu_device> m_maincpu;
 
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void odyssey_map(address_map &map);
 };
 
-void odyssey_state::video_start()
-{
-}
 
-u32 odyssey_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
-
-
-/**************************************
-*             Memory Map              *
-**************************************/
 
 void odyssey_state::odyssey_map(address_map &map)
 {
+	map(0x00000000, 0x0009ffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("pmb", 0x60000);
+	map(0xfff80000, 0xffffffff).rom().region("pmb", 0);
 }
-
-
-/**************************************
-*            Input Ports              *
-**************************************/
 
 static INPUT_PORTS_START( odyssey )
 INPUT_PORTS_END
 
-
-/**************************************
-*        Machine Start/Reset          *
-**************************************/
-
-void odyssey_state::machine_start()
-{
-}
-
-void odyssey_state::machine_reset()
-{
-}
-
-
-/**************************************
-*           Machine Config            *
-**************************************/
-
 void odyssey_state::odyssey(machine_config &config)
 {
-	/* basic machine hardware */
-	PENTIUM(config, m_maincpu, 133000000); // a Celeron at 1.70 GHz on the MB I checked.
+	PENTIUM(config, m_maincpu, 133'000'000); // a Celeron at 1.70 GHz on the MB I checked. <- doesn't match being a Triton/Triton-II ... -AS
 	m_maincpu->set_addrmap(AS_PROGRAM, &odyssey_state::odyssey_map);
 
-	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
-	screen.set_screen_update(FUNC(odyssey_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 
@@ -174,7 +132,8 @@ ROM_START( odyssey )
 
 //  ODYSSEY_BIOS
 
-	ROM_REGION( 0x80000, "maincpu", 0 )  // main BIOS
+	ROM_REGION( 0x80000, "bios", 0 )  // main BIOS
+	// TODO: doesn't seem to have valid x86 boot vectors, may be reused later.
 	ROM_LOAD( "sgi_bios_76.bin", 0x000000, 0x80000, CRC(00592222) SHA1(29281d25aaf2051e0794dece8be146bb63d5c488) )
 
 	ROM_REGION( 0x500000, "other", 0 )  // remaining BIOS
@@ -184,7 +143,7 @@ ROM_START( odyssey )
 	ROM_LOAD( "sgi_bios_31.bin", 0x180000, 0x80000, CRC(0954278b) SHA1(dc04a0604159ddd3d24bdd292b2947cc443054f8) )
 	ROM_LOAD( "sgi_bios_00.bin", 0x200000, 0x80000, CRC(41480fb5) SHA1(073596d3ba40ae67e3be3f410d7b29c77988df47) )
 
-	ROM_REGION( 0x100000, "pmb", 0 )   // Peripheral Memory Board (II) ROMS
+	ROM_REGION32_LE( 0x100000, "pmb", ROMREGION_ERASE00 )   // Peripheral Memory Board (II) ROMS
 	ROM_LOAD( "sgi_u13_165_0017_0_rev_a_l97_1352.bin", 0x00000, 0x80000, CRC(31ca868c) SHA1(d1db4ef12add336e25374fcf5d3238b8fbca05dd) )  // U13 - 165-0017 BIOS (27C040/27C4001 EPROM)
 	ROM_LOAD( "sgi_u5_165_0030_0_at28c010.bin",        0x80000, 0x20000, CRC(75a80169) SHA1(a8ece0f82a49f721fb178dbe25fc859bd65ce44f) )  // U5 - 165-0030 CONFIG (Atmel 28C010-12PC EEPROM)
 

--- a/src/mame/misc/playcenter.cpp
+++ b/src/mame/misc/playcenter.cpp
@@ -23,11 +23,17 @@
     is unique for each single machine (and these hardware parts are not
     replaceble by the user / operator).
 
+Dump contains a raw image for a (c) 1998 Trident video card (C:\videorom.bin)
+
+TODO:
+- HDD image doesn't boot in neither shutms11 nor pcipc. The dump contains a
+  windows partition (named "u") and no autoexec.bat / config.sys ...
+
 *******************************************************************************/
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "speaker.h"
+#include "machine/pci.h"
 
 namespace {
 
@@ -44,7 +50,6 @@ public:
 
 private:
 	void mem_map(address_map &map);
-	void io_map(address_map &map);
 
 	required_device<cpu_device> m_maincpu;
 };
@@ -52,11 +57,8 @@ private:
 void playcenter_state::mem_map(address_map &map)
 {
 	map(0x00000000, 0x0009ffff).ram();
-	map(0xfffc0000, 0xffffffff).rom().region("mb_bios", 0);
-}
-
-void playcenter_state::io_map(address_map &map)
-{
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0x20000);
+	map(0xfffc0000, 0xffffffff).rom().region("bios", 0);
 }
 
 static INPUT_PORTS_START(playcenter)
@@ -66,15 +68,17 @@ void playcenter_state::playcenter(machine_config &config)
 {
 	PENTIUM(config, m_maincpu, 166'000'000); // Actually an AMD K6, frequency unknown
 	m_maincpu->set_addrmap(AS_PROGRAM, &playcenter_state::mem_map);
-	m_maincpu->set_addrmap(AS_IO, &playcenter_state::io_map);
+
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 ROM_START(plycntrchtr)
-	ROM_REGION32_LE(0x40000, "mb_bios", 0) // Bios date: 03/13/2001
+	ROM_REGION32_LE(0x40000, "bios", 0) // Bios date: 03/13/2001
 	ROM_LOAD("vp4f1313.bin", 0x00000, 0x40000, CRC(bd4b155f) SHA1(3eafe71e89bf84b72a42e933187676fe08db0492))
 
 	DISK_REGION( "ide:0:hdd:image" )
-	DISK_IMAGE("playcenter_epox_9.3_tournament", 0, SHA1(64a88d4ab10d82ba0bd175511242ba6771cfc5ce))
+	DISK_IMAGE("playcenter_epox_9.3_tournament", 0, BAD_DUMP SHA1(64a88d4ab10d82ba0bd175511242ba6771cfc5ce))
 ROM_END
 
 } // Anonymous namespace

--- a/src/mame/misc/playcenter.cpp
+++ b/src/mame/misc/playcenter.cpp
@@ -1,6 +1,6 @@
 // license:BSD-3-Clause
 // copyright-holders:
-/*******************************************************************************
+/**************************************************************************************************
 
     Skeleton driver for "PlayCenter" PC-based touch games
 
@@ -24,12 +24,26 @@
     replaceble by the user / operator).
 
 Dump contains a raw image for a (c) 1998 Trident video card (C:\videorom.bin)
+The EPoX EP-MVP4F is a Socket 7 MB with VIA Apollo MVP4 AGP, built-in Trident AGP,
+VT82C686A, built-in SoundBlaster Pro with AC'97 codec support
 
 TODO:
 - HDD image doesn't boot in neither shutms11 nor pcipc. The dump contains a
-  windows partition (named "u") and no autoexec.bat / config.sys ...
+  Spanish windows partition (named "u") and no autoexec.bat / config.sys.
+  The CHD has -chs 3644,16,58 but WinImage reports back a ~4 GB partition.
+- In pcipc it shows a '1' logo then on first boot it tries to install basically
+  everything it can possibly install from scratch. Once done it tries to boot the
+  main program but it either do one of the following things:
+  - fails with a '2', resets the machine;
+  - fails with a Spanish popup: "Detected a problem with the machine.
+    Please call tech service Ref.: ICRP/E-3R" then it shows a '2' and reset;
+  - fails with above but instead of resetting will show a '3' and hangs there,
+    with a Spanish message about detecting a power failure;
+  Notice you can't neither enter in Safe Mode nor install from CD-Rom since there's no
+  CD drive installed. Also that the main program will kick in if you try to auto PnP the missing
+  devices.
 
-*******************************************************************************/
+**************************************************************************************************/
 
 #include "emu.h"
 #include "cpu/i386/i386.h"

--- a/src/mame/misc/playcenter.cpp
+++ b/src/mame/misc/playcenter.cpp
@@ -42,6 +42,9 @@ TODO:
   Notice you can't neither enter in Safe Mode nor install from CD-Rom since there's no
   CD drive installed. Also that the main program will kick in if you try to auto PnP the missing
   devices.
+  The ICRP/E-3R error appears if "C:\Play.Center\RPCDR.dat" is newer than 24 hours, it contains
+  the number of reboots and if it's >= 3 it shows the message.
+  Error '2' appears if Windows is set on anything that isn't 800x600x16bpp.
 
 **************************************************************************************************/
 

--- a/src/mame/misc/radikaldarts.cpp
+++ b/src/mame/misc/radikaldarts.cpp
@@ -13,11 +13,13 @@
     -IDE connector.
     -DVI connector.
     -AD9288 ADC + Altera Cyclone EP1C3T144C8N FPGA + 2 x ALVCH16374 + PCM1725U + DS90C385AMT
+
+    Note: Similar specs as gaelco/gaelcopc.cpp, including a BIOS with just different ACFG data ...
 */
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 namespace {
 
@@ -25,62 +27,38 @@ class radikaldarts_state : public driver_device
 {
 public:
 	radikaldarts_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
 	void radikaldarts(machine_config &config);
 
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
 
 private:
 	required_device<cpu_device> m_maincpu;
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void radikaldarts_map(address_map &map);
 };
 
-void radikaldarts_state::video_start()
-{
-}
-
-uint32_t radikaldarts_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
-
 void radikaldarts_state::radikaldarts_map(address_map &map)
 {
+	map(0x00000000, 0x0009ffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0x60000);
+	map(0xfff80000, 0xffffffff).rom().region("bios", 0);
 }
 
 static INPUT_PORTS_START( radikaldarts )
 INPUT_PORTS_END
 
 
-void radikaldarts_state::machine_start()
-{
-}
-
-void radikaldarts_state::machine_reset()
-{
-}
-
 void radikaldarts_state::radikaldarts(machine_config &config)
 {
 	// Basic machine hardware
-	PENTIUM3(config, m_maincpu, 120000000); // Celeron SL6C8 1.2 GHz
+	PENTIUM3(config, m_maincpu, 120'000'000); // Celeron SL6C8 1.2 GHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &radikaldarts_state::radikaldarts_map);
 
-	// Video hardware
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(1440, 900);
-	screen.set_visarea(0, 1440-1, 0, 900-1);
-	screen.set_screen_update(FUNC(radikaldarts_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************
@@ -90,7 +68,7 @@ void radikaldarts_state::radikaldarts(machine_config &config)
 ***************************************************************************/
 
 ROM_START( radikaldrt )
-	ROM_REGION(0x80000, "bios", 0)
+	ROM_REGION32_LE(0x80000, "bios", 0)
 	ROM_LOAD("sst49lf004b_plcc32.u10", 0x00000, 0x80000, CRC(53ab9628) SHA1(5cd54ecb03e29352d8acd3e2e9be5dfbc4dd4064) ) // BIOS string: "10/16/2002-i815EP-627-6A69RPAVC-00 00"
 
 	DISK_REGION( "ide:0:hdd:image" ) // Hitachi HTS541040G9AT00

--- a/src/mame/misc/rawthrillspc.cpp
+++ b/src/mame/misc/rawthrillspc.cpp
@@ -12,8 +12,8 @@
         · Microtel w/ASRock N68C-GS FX AM3+ motherboard.
     - Video GeForce GT730.
       * Other supported setups are:
-        · Nvidia 8400GS (256MB+).
-        · Nvidia 7300GS.
+        · nVidia 8400GS (256MB+).
+        · nVidia 7300GS.
     -Custom I/O boards (outside the PC, depending on each game).
     -Security dongle (HASP, USB or parallel port).
 */

--- a/src/mame/misc/rawthrillspc.cpp
+++ b/src/mame/misc/rawthrillspc.cpp
@@ -16,11 +16,15 @@
         · nVidia 7300GS.
     -Custom I/O boards (outside the PC, depending on each game).
     -Security dongle (HASP, USB or parallel port).
+
+TODO:
+- Cannot continue without a proper Athlon 64 X2 core (uses lots of unsupported RDMSR / WRMSR)
+
 */
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 namespace {
 
@@ -28,62 +32,38 @@ class rawthrillspc_state : public driver_device
 {
 public:
 	rawthrillspc_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
 	void rawthrillspc(machine_config &config);
 
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-
 private:
 	required_device<cpu_device> m_maincpu;
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void rawthrillspc_map(address_map &map);
 };
 
-void rawthrillspc_state::video_start()
-{
-}
-
-uint32_t rawthrillspc_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void rawthrillspc_state::rawthrillspc_map(address_map &map)
 {
+	map(0x00000000, 0x0009ffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0);
+	map(0xfffe0000, 0xffffffff).rom().region("bios", 0);
 }
 
 static INPUT_PORTS_START( rawthrillspc )
 INPUT_PORTS_END
 
 
-void rawthrillspc_state::machine_start()
-{
-}
-
-void rawthrillspc_state::machine_reset()
-{
-}
-
 void rawthrillspc_state::rawthrillspc(machine_config &config)
 {
 	// Basic machine hardware
-	PENTIUM4(config, m_maincpu, 120000000); // Actually an Athlon 64 X2
+	PENTIUM4(config, m_maincpu, 120'000'000); // Actually an Athlon 64 X2
 	m_maincpu->set_addrmap(AS_PROGRAM, &rawthrillspc_state::rawthrillspc_map);
 
-	// Video hardware
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(800, 600); // Guess
-	screen.set_visarea(0, 800-1, 0, 600-1);
-	screen.set_screen_update(FUNC(rawthrillspc_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************
@@ -93,7 +73,7 @@ void rawthrillspc_state::rawthrillspc(machine_config &config)
 ***************************************************************************/
 
 #define OPTIPLEX740_BIOS \
-	ROM_REGION( 0x20000, "bios", 0 ) \
+	ROM_REGION32_LE( 0x20000, "bios", 0 ) \
 	ROM_SYSTEM_BIOS( 0, "122", "v1.2.2" ) \
 	ROMX_LOAD( "1.2.2_4m.bin", 0x00000, 0x20000, CRC(43d5b4c8) SHA1(6307050961da5d647ca2fa787fd67c5ac9c690c9), ROM_BIOS(0) ) \
 	ROM_SYSTEM_BIOS( 1, "104", "v1.0.3" ) \

--- a/src/mame/misc/skopro.cpp
+++ b/src/mame/misc/skopro.cpp
@@ -1,6 +1,5 @@
 // license:BSD-3-Clause
 // copyright-holders:
-
 /*
     Skonec SkoPro v1.0 PC hardware
 
@@ -20,19 +19,19 @@
     Dragon Dance
     Exception
     Otenami Haiken Ritaanzu!
-    Shangai
+    Shanghai
 */
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 class skopro_state : public driver_device
 {
 public:
 	skopro_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
 	void skopro(machine_config &config);
@@ -40,21 +39,8 @@ public:
 private:
 	required_device<cpu_device> m_maincpu;
 
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void skopro_map(address_map &map);
 };
-
-void skopro_state::video_start()
-{
-}
-
-uint32_t skopro_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void skopro_state::skopro_map(address_map &map)
 {
@@ -63,28 +49,15 @@ void skopro_state::skopro_map(address_map &map)
 static INPUT_PORTS_START( skopro )
 INPUT_PORTS_END
 
-
-void skopro_state::machine_start()
-{
-}
-
-void skopro_state::machine_reset()
-{
-}
-
 void skopro_state::skopro(machine_config &config)
 {
 	/* basic machine hardware */
-	PENTIUM4(config, m_maincpu, 100000000); // actually a Pentium E2160 at 1.80 GHz
+	PENTIUM4(config, m_maincpu, 100'000'000); // actually a Pentium E2160 at 1.80 GHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &skopro_state::skopro_map);
+	m_maincpu->set_disable();
 
-	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
-	screen.set_screen_update(FUNC(skopro_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************
@@ -93,10 +66,9 @@ void skopro_state::skopro(machine_config &config)
 
 ***************************************************************************/
 
-ROM_START( drgdance)
+ROM_START( drgdance )
 	ROM_REGION(0x20000, "bios", 0) \
 	ROM_LOAD("mbbios", 0x10000, 0x10000, NO_DUMP )
-
 
 	DISK_REGION( "ide:0:hdd:image" )
 	DISK_IMAGE( "dragon_dance", 0, SHA1(73868dd9354d936100ba56f460e872087ede012c) )

--- a/src/mame/misc/voyager.cpp
+++ b/src/mame/misc/voyager.cpp
@@ -11,7 +11,7 @@ All of these games run Linux.
 
 Motherboard is FIC AZIIEA with AMD Duron processor of unknown speed
 Chipset: VIA KT133a with VT8363A Northbridge and VT82C686B Southbridge
-Video: Jaton 3DForce2MX-32, based on Nvidia GeForce 2MX chipset w/32 MB of VRAM
+Video: Jaton 3DForce2MX-32, based on nVidia GeForce 2MX chipset w/32 MB of VRAM
 I/O: JAMMA adapter board connects to parallel port, VGA out, audio out.
     Labelled "MEGAJAMMA 101 REV A2" for the stand-up Voyager
 

--- a/src/mame/misc/xtom3d.cpp
+++ b/src/mame/misc/xtom3d.cpp
@@ -1,13 +1,14 @@
 // license:BSD-3-Clause
 // copyright-holders:Guru
-/***************************************************************************
+/**************************************************************************************************
 
 X Tom 3D
 
 TODO:
 - clears a work RAM snippet then jumps to that snippet ... it doesn't do
   that if you soft reset emulation.
-- understand how to load game ROMs
+- understand how to load game ROMs. u3 contains a FAT12 file system for DOS/Windows
+partition.
 
 This game runs on PC-based hardware.
 Major components are....
@@ -15,7 +16,7 @@ Major components are....
 MAIN BOARD
 ----------
     CPU: Intel Celeron (socket 370) 333MHz
-Chipset: Intel AGPset FW822443ZX, PCIset FW82371EB
+Chipset: Intel AGPset FW82443ZX, PCIset FW82371EB
     RAM: Samsung KMM366S823CTS 8M x 64-bit SDRAM DIMM
   Video: 3DFX 500-0013-04 PCB-mounted BGA
          EliteMT M32L1632512A video RAM (x4)
@@ -37,7 +38,7 @@ ROM BOARD
 ---------
 MX29F1610MC 16M FlashROM (x7)
 
-***************************************************************************/
+**************************************************************************************************/
 
 
 #include "emu.h"
@@ -426,7 +427,6 @@ void xtom3d_state::xtom3d(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &xtom3d_state::xtom3d_map);
 	m_maincpu->set_addrmap(AS_IO, &xtom3d_state::xtom3d_io);
 	m_maincpu->set_irq_acknowledge_callback("pic8259_1", FUNC(pic8259_device::inta_cb));
-
 
 	pcat_common(config);
 

--- a/src/mame/namco/rbowlorama.cpp
+++ b/src/mame/namco/rbowlorama.cpp
@@ -35,7 +35,7 @@
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 namespace {
 
@@ -49,56 +49,30 @@ public:
 
 	void rbowlorama(machine_config &config);
 
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-
 private:
 	required_device<cpu_device> m_maincpu;
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void rbowlorama_map(address_map &map);
 };
 
-void rbowlorama_state::video_start()
-{
-}
-
-uint32_t rbowlorama_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
-
 void rbowlorama_state::rbowlorama_map(address_map &map)
 {
+	map(0x00000000, 0x0009ffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0x60000);
+	map(0xfff80000, 0xffffffff).rom().region("bios", 0);
 }
 
 static INPUT_PORTS_START( rbowlorama )
 INPUT_PORTS_END
 
-
-void rbowlorama_state::machine_start()
-{
-}
-
-void rbowlorama_state::machine_reset()
-{
-}
-
 void rbowlorama_state::rbowlorama(machine_config &config)
 {
 	// Basic machine hardware
-	PENTIUM4(config, m_maincpu, 120000000); // Celeron, socket 478, 800/533MHz
+	PENTIUM4(config, m_maincpu, 120'000'000); // Celeron, socket 478, 800/533MHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &rbowlorama_state::rbowlorama_map);
 
-	// Video hardware
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(800, 600); // Guess
-	screen.set_visarea(0, 800-1, 0, 600-1);
-	screen.set_screen_update(FUNC(rbowlorama_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************
@@ -108,7 +82,7 @@ void rbowlorama_state::rbowlorama(machine_config &config)
 ***************************************************************************/
 
 ROM_START( rbowlorama )
-	ROM_REGION(0x80000, "bios", 0)
+	ROM_REGION32_LE(0x80000, "bios", 0)
 	ROM_LOAD("p4m8p478.rom", 0x00000, 0x80000, CRC(a43b33c6) SHA1(1633273f9f06862b63aeb10899006b10fab4f4af) )
 
 	// I/O PCB
@@ -167,4 +141,4 @@ ROM_END
 
 } // Anonymous namespace
 
-GAME(2008, rbowlorama, 0, rbowlorama, rbowlorama, rbowlorama_state, empty_init, ROT0, "Namco / Cosmodog", "Rockin' Bowl-O-Rama (v2.1.1)", MACHINE_IS_SKELETON)
+GAME(2008, rbowlorama, 0, rbowlorama, rbowlorama, rbowlorama_state, empty_init, ROT0, "Namco / Cosmodog", "Rockin' Bowl-O-Rama (v2.1.1)", MACHINE_IS_SKELETON )

--- a/src/mame/pc/nforcepc.cpp
+++ b/src/mame/pc/nforcepc.cpp
@@ -16,7 +16,7 @@
   - A keyboard
   - A ddr dimm memory module
   Later add:
-  - A Nvidia NV25 based AGP video card
+  - A nVidia NV25 based AGP video card
 
 */
 

--- a/src/mame/pc/quakeat.cpp
+++ b/src/mame/pc/quakeat.cpp
@@ -9,8 +9,11 @@
  We've also seen CDs of this for sale, so maybe there should be a CD too, for the music?
 
 TODO:
-can't be emulated without proper mb bios
+- Throws "Primary master hard disk fail" in shutms11. Disk has a non canonical -chs of 263,255,63.
+  Recompressing as -chs 4150,16,63 fixes it.
+- In pcipc throws "E0409 -- Security key not found." in glquake.exe when it starts running.
 
+===================================================================================================
  -- set info
 
 Quake Arcade Tournament by Lazer-Tron
@@ -22,12 +25,12 @@ Created .chd with version 0.125
 It found the following disk paramaters...
 
 Input offset    511
-Cyclinders  263
+Cylinders   263
 Heads       255
 Sectors     63
 Byte/Sector 512
 Sectors/Hunk    8
-Logical size    2,1163,248,864
+Logical size    2,163,248,864
 
 The "backup" directory on hard disk was created by the dumper.
 
@@ -72,22 +75,13 @@ Note: Quantum3D Quicksilver QS233G configuration seem very similar to the HM233G
 
 Dongle: Rainbow Technologies parallel-port security dongle (at least 1024 bytes)
 
-===============================================================================
-TODO:
-    * Add BIOS dump (standard NX440LX motherboard)
-    * Hook up PC hardware
-    * Hook up the Quantum3D GCI-2 (details? ROMs?)
-    * What's the dongle do?
-===============================================================================
+HDD image contains remnants of an Actua Soccer Arcade installation.
+
 */
 
 #include "emu.h"
-
-#include "pcshare.h"
-
 #include "cpu/i386/i386.h"
-#include "emupal.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 
 namespace {
@@ -96,91 +90,48 @@ class quakeat_state : public pcat_base_state
 {
 public:
 	quakeat_state(const machine_config &mconfig, device_type type, const char *tag)
-		: pcat_base_state(mconfig, type, tag)
-		{ }
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+	{ }
 
 	void quake(machine_config &config);
 
 private:
-	virtual void machine_start() override;
-	virtual void video_start() override;
-	uint32_t screen_update_quake(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void quake_io(address_map &map);
+
 	void quake_map(address_map &map);
 };
 
 
-void quakeat_state::video_start()
-{
-}
-
-uint32_t quakeat_state::screen_update_quake(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
-
 void quakeat_state::quake_map(address_map &map)
 {
-	map(0x00000000, 0x0000ffff).rom().region("pc_bios", 0); /* BIOS */
 }
 
-void quakeat_state::quake_io(address_map &map)
-{
-	pcat32_io_common(map);
-	map(0x00e8, 0x00eb).noprw();
-//  map(0x01f0, 0x01f7).rw("ide", FUNC(ide_controller_device::read_cs0), FUNC(ide_controller_device::write_cs0));
-	map(0x0300, 0x03af).noprw();
-	map(0x03b0, 0x03df).noprw();
-//  map(0x0278, 0x027b).w(FUNC(quakeat_state::pnp_config_w));
-//  map(0x03f0, 0x03f7).rw("ide", FUNC(ide_controller_device::read_cs1), FUNC(ide_controller_device::write_cs1));
-//  map(0x0a78, 0x0a7b).w(FUNC(quakeat_state::pnp_data_w));
-//  map(0x0cf8, 0x0cff).rw("pcibus", FUNC(pci_bus_device::read), FUNC(pci_bus_device::write));
-}
-
-/*************************************************************/
 
 static INPUT_PORTS_START( quake )
 INPUT_PORTS_END
 
-/*************************************************************/
-
-void quakeat_state::machine_start()
-{
-}
-/*************************************************************/
 
 void quakeat_state::quake(machine_config &config)
 {
-	/* basic machine hardware */
-	PENTIUM2(config, m_maincpu, 233000000); /* Pentium II, 233MHz */
+	PENTIUM2(config, m_maincpu, 233'000'000); /* Pentium II, 233MHz */
 	m_maincpu->set_addrmap(AS_PROGRAM, &quakeat_state::quake_map);
-	m_maincpu->set_addrmap(AS_IO, &quakeat_state::quake_io);
-	m_maincpu->set_irq_acknowledge_callback("pic8259_1", FUNC(pic8259_device::inta_cb));
+	m_maincpu->set_disable();
 
-	pcat_common(config);
-
-	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(64*8, 32*8);
-	screen.set_visarea(0*8, 64*8-1, 0*8, 32*8-1);
-	screen.set_screen_update(FUNC(quakeat_state::screen_update_quake));
-	screen.set_palette("palette");
-
-	PALETTE(config, "palette").set_entries(0x100);
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 
 ROM_START(quake)
 	ROM_REGION32_LE(0x20000, "pc_bios", 0)  /* motherboard bios */
-	ROM_LOAD("quakearcadetournament.pcbios", 0x000000, 0x10000, NO_DUMP )
+	ROM_LOAD("quakearcadetournament.pcbios", 0x000000, 0x20000, NO_DUMP )
 
 	DISK_REGION( "disks" )
-	DISK_IMAGE( "quakeat", 0, SHA1(c44695b9d521273c9d3c0e18c88f0dca0185bd7b) )
+	DISK_IMAGE( "quakeat", 0, BAD_DUMP SHA1(c44695b9d521273c9d3c0e18c88f0dca0185bd7b) )
 ROM_END
 
 } // anonymous namespace
 
 
 GAME( 1998, quake,  0,   quake, quake, quakeat_state, empty_init, ROT0, "Lazer-Tron / iD Software", "Quake Arcade Tournament (Release Beta 2)", MACHINE_IS_SKELETON )
+// Actua Soccer Arcade

--- a/src/mame/pc/quakeat.cpp
+++ b/src/mame/pc/quakeat.cpp
@@ -86,7 +86,7 @@ HDD image contains remnants of an Actua Soccer Arcade installation.
 
 namespace {
 
-class quakeat_state : public pcat_base_state
+class quakeat_state : public driver_device
 {
 public:
 	quakeat_state(const machine_config &mconfig, device_type type, const char *tag)
@@ -97,6 +97,7 @@ public:
 	void quake(machine_config &config);
 
 private:
+	required_device<cpu_device> m_maincpu;
 
 	void quake_map(address_map &map);
 };

--- a/src/mame/pinball/newcanasta.cpp
+++ b/src/mame/pinball/newcanasta.cpp
@@ -10,7 +10,7 @@
 #include "emu.h"
 #include "cpu/i386/i386.h"
 //#include "cpu/mcs51/mcs51.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 namespace {
 
@@ -18,47 +18,31 @@ class newcanasta_state : public driver_device
 {
 public:
 	newcanasta_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
 	void newcanasta(machine_config &config);
 
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-
 private:
 	required_device<cpu_device> m_maincpu;
 
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void newcanasta_map(address_map &map);
 };
 
-void newcanasta_state::video_start()
-{
-}
 
-uint32_t newcanasta_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void newcanasta_state::newcanasta_map(address_map &map)
 {
+	map(0x00000000, 0x0009ffff).ram();
+	map(0x000e0000, 0x000fffff).rom().region("bios", 0x60000);
+	map(0xfff80000, 0xffffffff).rom().region("bios", 0);
 }
 
 static INPUT_PORTS_START( newcanasta )
 INPUT_PORTS_END
 
-void newcanasta_state::machine_start()
-{
-}
 
-void newcanasta_state::machine_reset()
-{
-}
 
 void newcanasta_state::newcanasta(machine_config &config)
 {
@@ -66,13 +50,8 @@ void newcanasta_state::newcanasta(machine_config &config)
 	PENTIUM4(config, m_maincpu, 100'000'000); // 775-pin LGA "Socket T" CPU, exact model unknown
 	m_maincpu->set_addrmap(AS_PROGRAM, &newcanasta_state::newcanasta_map);
 
-	// Video hardware
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(800, 600);
-	screen.set_visarea(0, 800-1, 0, 600-1);
-	screen.set_screen_update(FUNC(newcanasta_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 
 	// I/O board
 	//I80C51(config, m_maincpu, 24.0000_MHz_XTAL); // USB-DIO-96 with a CY7C68013A MCU (MCS51 core)
@@ -85,7 +64,7 @@ void newcanasta_state::newcanasta(machine_config &config)
 ***************************************************************************/
 
 ROM_START(newcanasta)
-	ROM_REGION(0x80000, "bios", 0)
+	ROM_REGION32_LE(0x80000, "bios", 0)
 	ROM_SYSTEM_BIOS( 0, "110", "v1.10")
 	ROMX_LOAD("p4f136_1.10.bin", 0x00000, 0x80000, CRC(88e558e7) SHA1(ea4305cf7a6373711dad21e1de0e208b62f2d7de), ROM_BIOS(0))
 	ROM_SYSTEM_BIOS( 1, "100", "v1.00")

--- a/src/mame/sega/chihiro.cpp
+++ b/src/mame/sega/chihiro.cpp
@@ -172,7 +172,7 @@ In order from top to bottom they are....
 The 2 boxes join together via the Base Board upper connector and Media Board lower connector.
 
 The Microsoft-manufactured XBox board is the lowest board. It's mostly the same as the V1 XBox retail
-board with the exception that it has 128MB of RAM and a NVidia MCPX X2 chip. The retail XBox board has a
+board with the exception that it has 128MB of RAM and a nVidia MCPX X2 chip. The retail XBox board has a
 MCPX X3 chip. The board was probably released to Sega very early in development and the chip was updated
 in the mass-produced retail version.
 

--- a/src/mame/sega/lindbergh.cpp
+++ b/src/mame/sega/lindbergh.cpp
@@ -17,7 +17,7 @@ Sega 2005-2009
 This is a "PC-based" arcade system. Different configurations have different colored boxes.
 The version documented here is the red box. The PC part of it is mostly just the CPU,
 Intel North/South-bridge chipset and AGP/PCI card slots etc. The main board is still
-a typically custom-made Sega arcade PCB using a custom nVIDIA GeForce video card.
+a typically custom-made Sega arcade PCB using a custom nVidia GeForce video card.
 The main board also has a slot for a compact flash card. Primary storage media is HDD.
 Games are installed from a DVD. Both the CF and HDD are locked and unreadable on a regular PC.
 

--- a/src/mame/taito/taitotx.cpp
+++ b/src/mame/taito/taitotx.cpp
@@ -1,36 +1,58 @@
 // license:BSD-3-Clause
 // copyright-holders:David Haywood
+// thanks-to: sampson
 /* Taito Type X Skeleton
  - PC based platforms
 
  (insert original hardware specs, plus any other details here)
+ https://wiki.arcadeotaku.com/w/Taito_Type_X
+ https://wiki.arcadeotaku.com/w/Taito_Type_X%C2%B2
 
- todo: everything..
+TODO:
+ - Undumped custom BIOSes, at least regular Type X uses a Springdale spinoff.
+   Type X: Intel 865G
+   Type X+: as above plus better PCI video/sound cards
+   Type X7: Intel 855GME + ICH4
+   Type X2 & Satellite Terminal: Intel Q965 + ICH8
+   Type X Zero: MCP7A-ION
+   Type X3: Intel Q67 express
 
- - there is no bios dump
+ - GPUs also uses custom BIOSes, again undumped;
+
+ - To access BIOS menu needs to hold CTRL+ALT+F9 on POST. The menu is password
+   protected in plaintext ...
+
+ - The BIOS cannot load any OS that isn't the intended ones, non canonical MBR
+   checks? investigate;
 
  - there are a lot of hacked versions of the games designed to run on PCs
    this driver is for storing information about the unmodified versions only,
    the 'hacked to run on PC' versions are of no interest to MAME, only proper
    drive images.
 
- - some of the games are said to be encrypted, how does this work, how do we
-   get the keys? some images are copies of the files from an already mounted
+ - For copy protection most if not all games uses a USB dongle with sim card that
+   is necessary for decrypting game containers inside HDD cfr. page 12 of the Type X2
+   manual
+
+ - (old note) some of the games are said to be encrypted, how does this work,
+   how do we get the keys? some images are copies of the files from an already mounted
    filesystem, again this isn't suitable for MAME.
 
- - hardware specs can differ from game to game as well as between the platform
-   types, I'm currently not sure what constitutes a new platform (different
-   security?)  need Guru style readmes for each platform.
+ - Taito's NESiCAxLive platform requires a live connection to a dedicated
+   Taito Type X Zero in-store "server", that will pass the info to a intranet
+   connected Type X/X2. Notice that the Type X Zero will eventually try to connect thru
+   "strict" ssl pinning, which will refuse any connection that isn't the internally
+   defined CA.
 
- - Taito's NESiCA Live platform probably comes after this, but as it's likely
-   impossible to ever emulate it.
+ - Type X Zero can also be used on specific cab setups, for example connecting two
+   Type X3 usf4 for versus mode.
 
  - Preliminary game lists (mainly from system16.com)
 
     Taito Type X games
 
     Chaos Breaker / Dark Awake
-    Datacarddass Dragon Ball Z
+    Data Carddass Dragon Ball Z
     Dinoking III Allosaurus
     Dinomax
     Dragon Quest - Monster Battle Road
@@ -111,6 +133,17 @@
 
     Taito Type X Zero games
 
+    Card de Renketsu! Densha de Go!
+    Groove Coaster
+    Groove Coaster 2 Heavenly Festival
+    Groove Coaster 3 Link Fever
+    Groove Coaster 3 EX Dream Party
+    Groove Coaster 4 Starlight Road
+    Groove Coaster 4 EX Infinity Highway
+    Groove Coaster 4 MAX Diamond Galaxy
+    Groove Coaster EX
+    Kickthrough Racers
+    Mogutte Horehore
     Spin Gear
 
 */
@@ -118,15 +151,14 @@
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "emupal.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 class taito_type_x_state : public driver_device
 {
 public:
 	taito_type_x_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
 	void taito_type_x(machine_config &config);
@@ -134,59 +166,27 @@ public:
 private:
 	required_device<cpu_device> m_maincpu;
 
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-	uint32_t screen_update_taito_type_x(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void taito_type_x_map(address_map &map);
 };
 
 
-
-
-void taito_type_x_state::video_start()
-{
-}
-
-
-uint32_t taito_type_x_state::screen_update_taito_type_x(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
-
 void taito_type_x_state::taito_type_x_map(address_map &map)
 {
-	map(0x00, 0x0f).rom();
 }
 
 static INPUT_PORTS_START( taito_type_x )
 INPUT_PORTS_END
 
-
-void taito_type_x_state::machine_start()
-{
-}
-
-void taito_type_x_state::machine_reset()
-{
-}
-
 // todo: different configs for the different machine types.
 void taito_type_x_state::taito_type_x(machine_config &config)
 {
-	/* basic machine hardware */
-	PENTIUM3(config, m_maincpu, 733333333); /* Wrong, much newer processors, much faster. */
+	// Socket 478
+	PENTIUM4(config, m_maincpu, 100'000'000); /* Wrong, much newer processors, much faster. */
 	m_maincpu->set_addrmap(AS_PROGRAM, &taito_type_x_state::taito_type_x_map);
+	m_maincpu->set_disable();
 
-	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
-	screen.set_screen_update(FUNC(taito_type_x_state::screen_update_taito_type_x));
-
-	PALETTE(config, "palette").set_entries(0x10000);
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 
@@ -200,63 +200,84 @@ void taito_type_x_state::taito_type_x(machine_config &config)
 // Type X
 
 ROM_START( chaosbrk )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 40GB drive
 	DISK_IMAGE( "chaosbreaker_v2_02j", 0, SHA1(8fe7bdc20a8d9e81f08cef60324ed9ac978a16e9) )
 ROM_END
 
 ROM_START( goketsuj )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 160GB drive
 	DISK_IMAGE( "goketsuji_v200906230", 0, SHA1(f0733fbb42994208e18c6afe67f1e9746351a3a2) )
 ROM_END
 
 ROM_START( gwinggen )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 40GB drive
 	DISK_IMAGE( "gigawing_v2_02j", 0, SHA1(e09a2e5019111765689cb205cc94e7868c55e9ca) )
 ROM_END
 
 ROM_START( homura )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 40GB drive
 	DISK_IMAGE( "homura_v2_04jpn", 0, SHA1(0d9d24583fa786b82bf27447408111bd4686033e) )
 ROM_END
 
 ROM_START( hotgmkmp )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 40GB drive
 	DISK_IMAGE( "wdc wd400eb-11cpf0", 0, SHA1(15f8cf77b5bdc516a891022462a42521be1d7553) )
 ROM_END
 
 ROM_START( kof98um )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 40GB drive
 	DISK_IMAGE( "kof98um_v1_00", 0, SHA1(cf21747ddcdf802d766a2bd6a3d75a965e89b2cf) )
 ROM_END
 
 ROM_START( kofskyst)
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" )
 	// Single 40GB drive(KOF SKY STAGE - M9008134A - Ver.1.00J - 40.0 GB WD - WD400BB-22JHCO)
@@ -266,36 +287,48 @@ ROM_START( kofskyst)
 ROM_END
 
 ROM_START( raiden3 )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 40GB drive
 	DISK_IMAGE( "raiden3_v2_01j", 0, SHA1(60142f765a0706e938b91cc41dc14eb67bd78615) )
 ROM_END
 
 ROM_START( raiden4 )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 40GB drive
 	DISK_IMAGE( "raiden4_v1_00j", 0, SHA1(f5ad509f57067089e0217df6d05036484b06a41a) )
 ROM_END
 
 ROM_START( shikiga3 )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 20GB drive
 	DISK_IMAGE( "shikigami3_v2_06jpn", 0, SHA1(4bf41ab1a3f2cd51cd2b1e6183959d2a4878449d) )
 ROM_END
 
 ROM_START( spicaadv )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 40GB drive
 	DISK_IMAGE( "spicaadventure_v2_03j", 0, SHA1(218ee0670a7b895f42480f0fe6719ecd4f4ba9e6) )
@@ -307,37 +340,43 @@ ROM_END
 //
 //           USAGI   M9006613A  VER.2.04JPN     40.0GB  WD  WD400BB-22JHCO
 ROM_START( usagiol )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 40GB drive, WD Caviar model WD400BB, LBA 78165360
 	DISK_IMAGE( "usagionline_v2_04j", 0, SHA1(6d4a780c40ee5c9b0192932e926f144d76b87262) )
 ROM_END
 
 ROM_START( trbwtchs )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 160GB drive
 	DISK_IMAGE( "troublewitches_ac_v1.00j", 0, SHA1(733ecbae040dd32447230d3fc81e6f8614715ee5) )
 ROM_END
 
 
-GAME( 2004, chaosbrk,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Taito Corporation", "Chaos Breaker (v2.02J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2004, gwinggen,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Takumi Corporation", "Giga Wing Generations (v2.02J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2005, homura,    0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "SKonec Entertainment", "Homura (v2.04J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2005, hotgmkmp,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "XNauts", "Taisen Hot Gimmick Mix Party",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2005, raiden3,   0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "MOSS / Seibu Kaihatsu", "Raiden III (v2.01J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2005, spicaadv,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Taito Corporation", "Spica Adventure (v2.03J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2005, usagiol,   0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Taito Corporation/Warashi", "Usagi Online (v2.04J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2006, shikiga3,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Alfa System/SKonec Entertainment", "Shikigami no Shiro III (v2.06J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2007, raiden4,   0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "MOSS / Seibu Kaihatsu", "Raiden IV (v1.00J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2008, kof98um,   0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "SNK", "The King of Fighters '98: Ultimate Match (v1.00)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2008, trbwtchs,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Adventure Planning Service/Studio SiestA", "Trouble Witches AC (v1.00J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2009, goketsuj,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Atlus", "Gouketsuji Ichizoku: Senzo Kuyou (v200906230)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2010, kofskyst,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Moss / SNK Playmore", "KOF Sky Stage (v1.00J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+GAME( 2004, chaosbrk,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Taito Corporation", "Chaos Breaker (v2.02J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2004, gwinggen,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Takumi Corporation", "Giga Wing Generations (v2.02J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2005, homura,    0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "SKonec Entertainment", "Homura (v2.04J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2005, hotgmkmp,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "XNauts", "Taisen Hot Gimmick Mix Party",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2005, raiden3,   0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "MOSS / Seibu Kaihatsu", "Raiden III (v2.01J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2005, spicaadv,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Taito Corporation", "Spica Adventure (v2.03J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2005, usagiol,   0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Taito Corporation/Warashi", "Usagi: Yasei no Topai Online (v2.04J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2006, shikiga3,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Alfa System/SKonec Entertainment", "Shikigami no Shiro III (v2.06J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2007, raiden4,   0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "MOSS / Seibu Kaihatsu", "Raiden IV (v1.00J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2008, kof98um,   0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "SNK", "The King of Fighters '98: Ultimate Match (v1.00)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2008, trbwtchs,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Adventure Planning Service/Studio SiestA", "Trouble Witches AC (v1.00J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2009, goketsuj,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Atlus", "Gouketsuji Ichizoku: Senzo Kuyou (v200906230)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2010, kofskyst,  0,    taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Moss / SNK Playmore", "KOF Sky Stage (v1.00J)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
 
 
 // Type X+
@@ -348,9 +387,12 @@ GAME( 2010, kofskyst,  0,    taito_type_x, taito_type_x, taito_type_x_state, emp
 //
 //           ****   M9006981A  VER.1.00   40.0GB  WD  WD400BB-22JHCO
 ROM_START( wontmuch )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x2_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 40GB drive
 	// 5BC6813ADBE1525BAFED792FC12C27AB
@@ -358,15 +400,18 @@ ROM_START( wontmuch )
 ROM_END
 
 
-GAME( 2006, wontmuch, 0, taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Capcom", "Won!Tertainment Music Channel (v1.00)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+GAME( 2006, wontmuch, 0, taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Capcom", "Won!Tertainment Music Channel (v1.00)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
 
 
 // Type X2
 
 ROM_START( chasehq2 )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x2_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 80GB drive
 	// 2188b8d76766c34580d99bf5ab0848fc 696092ff8467034acc4b34702006b3afbcb90082 chase_hq_2_v2.0.6.jp.001
@@ -374,9 +419,12 @@ ROM_START( chasehq2 )
 ROM_END
 
 ROM_START( samspsen )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x2_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 80GB drive
 	//e19435da2cd417d1e2949d14a043d6e1 50ef9af80b11984c56e4f765a6f827fa5d22b404 samurai spirits sen.v1.00.001
@@ -384,9 +432,12 @@ ROM_START( samspsen )
 ROM_END
 
 ROM_START( kofxii )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASEFF )
+	ROM_REGION32_LE( 0x10000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD("taito_type_x2_bios.bin", 0x00, 0x10000, NO_DUMP ) // size unknown.
 	/* bios, video bios etc. not dumped */
+
+	ROM_REGION( 0x1000, "dongle", ROMREGION_ERASEFF )
+	ROM_LOAD("dongle.pic", 0, 0x1000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // Single 80GB drive
 	//2ff6b2d33ab7e915733a4328c73695de xii_ver.1.img
@@ -394,6 +445,6 @@ ROM_START( kofxii )
 ROM_END
 
 
-GAME( 2006, chasehq2, 0, taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Taito Corporation", "Chase H.Q. 2 (v2.0.6.JP)",         MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2008, samspsen, 0, taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "SNK Playmore",      "Samurai Spirits Sen (v1.00)",      MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-GAME( 2009, kofxii,   0, taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "SNK Playmore",      "The King of Fighters XII (v1.00)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+GAME( 2006, chasehq2, 0, taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "Taito Corporation", "Chase H.Q. 2 (v2.0.6.JP)",         MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2008, samspsen, 0, taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "SNK Playmore",      "Samurai Spirits Sen (v1.00)",      MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )
+GAME( 2009, kofxii,   0, taito_type_x, taito_type_x, taito_type_x_state, empty_init, ROT0, "SNK Playmore",      "The King of Fighters XII (v1.00)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_UNEMULATED_PROTECTION )

--- a/src/mame/unico/unianapc.cpp
+++ b/src/mame/unico/unianapc.cpp
@@ -3,6 +3,10 @@
 /*
     Uniana PC hardware (shared by other Korean companies)
 
+    TODO:
+    - both dhunting and hogwild dumps looks bad, it gets recognized by shutms11 in BIOS but throws "Missing Operating System" on boot. hogwild will also lots of write errors in winimage,
+    eventually causing a crash in the program.
+
     Intel Celeron CPU, 1.70GHz
     MSI MS-6566E VER: 2 motherboard
     Samsung 256MB DDR PC2100 CL2.5 RAM
@@ -15,7 +19,7 @@
     It also sports a gun IO board. Two version exist (CGA and VGA). Currently only VGA is dumped.
 
     Other games believed to run on this hardware (* denotes a copy is in MAME friendly hands):
-    Frenzy Express(Uniana, 2001) *
+    Frenzy Express (Uniana, 2001) *
     S.A.P.T. (Uniana, 2004)
 
     Possibly on other hardware (Crystal System ?)
@@ -25,14 +29,14 @@
 
 #include "emu.h"
 #include "cpu/i386/i386.h"
-#include "screen.h"
+#include "machine/pci.h"
 
 class unianapc_state : public driver_device
 {
 public:
 	unianapc_state(const machine_config &mconfig, device_type type, const char *tag)
-		: driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu")
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
 	{ }
 
 	void unianapc(machine_config &config);
@@ -40,21 +44,8 @@ public:
 private:
 	required_device<cpu_device> m_maincpu;
 
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void unianapc_map(address_map &map);
 };
-
-void unianapc_state::video_start()
-{
-}
-
-uint32_t unianapc_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
-{
-	return 0;
-}
 
 void unianapc_state::unianapc_map(address_map &map)
 {
@@ -63,28 +54,15 @@ void unianapc_state::unianapc_map(address_map &map)
 static INPUT_PORTS_START( unianapc )
 INPUT_PORTS_END
 
-
-void unianapc_state::machine_start()
-{
-}
-
-void unianapc_state::machine_reset()
-{
-}
-
 void unianapc_state::unianapc(machine_config &config)
 {
 	/* basic machine hardware */
-	PENTIUM3(config, m_maincpu, 100000000); // actually a Celeron at 1.70 GHz
+	PENTIUM3(config, m_maincpu, 100'000'000); // actually a Celeron at 1.70 GHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &unianapc_state::unianapc_map);
+	m_maincpu->set_disable();
 
-	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(640, 480);
-	screen.set_visarea(0, 640-1, 0, 480-1);
-	screen.set_screen_update(FUNC(unianapc_state::screen_update));
+	PCI_ROOT(config, "pci", 0);
+	// ...
 }
 
 /***************************************************************************
@@ -94,7 +72,7 @@ void unianapc_state::unianapc(machine_config &config)
 ***************************************************************************/
 
 ROM_START( dhunting )
-	ROM_REGION(0x20000, "bios", 0) \
+	ROM_REGION32_LE( 0x20000, "bios", 0)
 	ROM_LOAD("mbbios", 0x10000, 0x10000, NO_DUMP )
 
 	ROM_REGION( 0x10000, "vbios", 0 )   // video card BIOS
@@ -104,18 +82,18 @@ ROM_START( dhunting )
 	ROM_LOAD( "u2.at89c52", 0x0000, 0x2000, CRC(afb0e1c7) SHA1(2f621be62f935eafa9ff3c14de2096119132a973) )
 
 	DISK_REGION( "ide:0:hdd:image" ) // DM Storage DM2560V00 IDE flash storage
-	DISK_IMAGE( "dream hunting", 0, SHA1(3515c0617c52c7e8b7e5dba8de22e363cce00e10) )
+	DISK_IMAGE( "dream hunting", 0, BAD_DUMP SHA1(3515c0617c52c7e8b7e5dba8de22e363cce00e10) )
 ROM_END
 
 ROM_START( hogwild )
-	ROM_REGION(0x20000, "bios", 0) \
+	ROM_REGION32_LE( 0x20000, "bios", 0)
 	ROM_LOAD("mbbios", 0x10000, 0x10000, NO_DUMP )
 
 	ROM_REGION( 0x10000, "vbios", 0 )   // video card BIOS
 	ROM_LOAD( "videobios", 0x000000, 0x00d000, NO_DUMP )
 
 	DISK_REGION( "ide:0:hdd:image" ) // DM Storage DM2560V00 IDE flash storage
-	DISK_IMAGE( "hog wild", 0, SHA1(f05b7f64830d995db2e2a2f7f95ae0100de5dab1) )
+	DISK_IMAGE( "hog wild", 0, BAD_DUMP SHA1(f05b7f64830d995db2e2a2f7f95ae0100de5dab1) )
 ROM_END
 
 GAME( 2002, dhunting,  0,   unianapc, unianapc, unianapc_state, empty_init, ROT0, "Game Box Entertainment", "Dream Hunting (US)",  MACHINE_IS_SKELETON ) // Ver 1007?


### PR DESCRIPTION
New clones marked not working
-----------------------------
Hydro Thunder (1.01b) [archive.org]
Hydro Thunder (1.00d) [archive.org]

- gaelco/gaelcopc.cpp: add an alternate BIOS set for tokyocop [Gerald (COY), The Dumping Union]

- misc/neomania.cpp, misc/playcenter.cpp, pc/quakeat.cpp, midway/midqslvr.cpp, misc/comebaby.cpp, unico/unianapc.cpp: demote HDD images to BAD_DUMP having bad chs geometries.

- funworld/photoplys.cpp, funworld/photoplysx.cpp, ice/frenzyxprss.cpp ,misc/bntyhunt.cpp, misc/cavepc.cpp, misc/chameleonrx1.cpp, misc/ez2d.cpp, misc/gfamily.cpp, misc/globalvr.cpp, misc/neomania.cpp, misc/odyssey.cpp, misc/playcenter.cpp, misc/radikaldarts.cpp, misc/rawthrillspc.cpp, misc/rfslotspcpent.cpp, misc/silverball.cpp, misc/skopro.cpp, misc/startouch.cpp, misc/xtom3d.cpp, namco/rbowlorama.cpp, pc/quakeat.cpp, pinball/newcanasta.cpp, taito/taitotx.cpp, unico/unianapc.cpp, midway/midqslvr.cpp, misc/comebaby.cpp: rearrange driver base setup and QA notes, for future conversion to PCI drivers.
