### PR TITLE
Changed CoCo Raw format to be anonymous

### DIFF
--- a/src/lib/formats/all.cpp
+++ b/src/lib/formats/all.cpp
@@ -372,10 +372,6 @@
 #include "os9_dsk.h"
 #endif
 
-#ifdef HAS_FORMATS_COCO_RAWDSK
-#include "coco_rawdsk.h"
-#endif
-
 #ifdef HAS_FORMATS_FS_COCO_RSDOS
 #include "fs_coco_rsdos.h"
 #endif
@@ -1137,9 +1133,6 @@ void mame_formats_full_list(mame_formats_enumerator &en)
 #ifdef HAS_FORMATS_TRS80_DSK
 	en.add(FLOPPY_JV1_FORMAT); // trs80_dsk.h
 	en.add(FLOPPY_JV3_FORMAT); // trs80_dsk.h
-#endif
-#ifdef HAS_FORMATS_COCO_RAWDSK
-	en.add(FLOPPY_COCO_RAWDSK_FORMAT); // coco_rawdsk.h
 #endif
 #ifdef HAS_FORMATS_FS_COCO_RSDOS
 	en.add(fs::COCO_RSDOS); // fs_coco_rsdos.h

--- a/src/lib/formats/coco_rawdsk.cpp
+++ b/src/lib/formats/coco_rawdsk.cpp
@@ -4,29 +4,55 @@
 
     CoCo Raw Disk
 
+	Anonymous format for internal use by CoCo file systems
+
 ***************************************************************************/
 
 #include "coco_rawdsk.h"
 
 
+//-------------------------------------------------
+//  ctor
+//-------------------------------------------------
+
 coco_rawdsk_format::coco_rawdsk_format() : wd177x_format(formats)
 {
 }
 
+
+//-------------------------------------------------
+//  name
+//-------------------------------------------------
+
 const char *coco_rawdsk_format::name() const
 {
-	return "coco_rawdsk";
+	return nullptr;	// "raw" disk is anonymous
 }
+
+
+//-------------------------------------------------
+//  description
+//-------------------------------------------------
 
 const char *coco_rawdsk_format::description() const
 {
-	return "CoCo Raw Disk";
+	return nullptr;	// "raw" disk is anonymous
 }
+
+
+//-------------------------------------------------
+//  extensions
+//-------------------------------------------------
 
 const char *coco_rawdsk_format::extensions() const
 {
-	return "raw";
+	return nullptr;	// "raw" disk is anonymous
 }
+
+
+//-------------------------------------------------
+//  formats
+//-------------------------------------------------
 
 const coco_rawdsk_format::format coco_rawdsk_format::formats[] =
 {
@@ -41,5 +67,9 @@ const coco_rawdsk_format::format coco_rawdsk_format::formats[] =
 	{}
 };
 
+
+//-------------------------------------------------
+//  FLOPPY_COCO_RAWDSK_FORMAT
+//-------------------------------------------------
 
 const coco_rawdsk_format FLOPPY_COCO_RAWDSK_FORMAT;


### PR DESCRIPTION
This is an experimental change to make the "CoCo Raw Disk" format be anonymous; not to be exposed to external users but rather to be an intermediate format for use by the CoCo file system modules.  In practice, this was quite easy - it was just a question of removing `FLOPPY_COCO_RAWDSK_FORMAT` from global listings and changing the various methods that only need to exist for public formats (name/description/extensions) to return `nullptr`.

I do not think that this is the ideal approach.  For anonymous formats name/description/extensions become farcical baggage and a better approach might be to create a base class (e.g. - `anonymous_floppy_image_format_t`) that omits this baggage.  I'm looking forward to hearing ideas!