### PR TITLE
pinball/inder.cpp: Fix date in note about "Mundial 90"

### DIFF
--- a/src/mame/pinball/inder.cpp
+++ b/src/mame/pinball/inder.cpp
@@ -1597,7 +1597,7 @@ ROM_END
 / sent a letter (dated June 1990) with an updated program ROM and
 / recalling the buggy one. It is unclear if the supported set is the
 / fixed or the older one, as it matches one dumped from an EEPROM
-/ with an original Inder label dated 18-June-1990.
+/ with an original Inder label dated 18-April-1990.
 /-------------------------------------------------------------------*/
 ROM_START(mundial)
 	ROM_REGION(0x4000, "maincpu", ROMREGION_ERASEFF)


### PR DESCRIPTION
![86bb2c9d-45be-4879-9155-bf2ff5c6b920](https://user-images.githubusercontent.com/5889052/214444630-897fd4f4-7121-4446-9c44-9005035895e6.jpg)
