### PR TITLE
Reset vector without deleting elements

### DIFF
--- a/src/devices/machine/ym3802.cpp
+++ b/src/devices/machine/ym3802.cpp
@@ -45,7 +45,7 @@ void ym3802_device::device_start()
 
 void ym3802_device::device_reset()
 {
-	m_reg.clear();
+	m_reg.assign(REG_MAX, 0);
 	reset_irq(0xff);
 	transmit_register_reset();
 	receive_register_reset();


### PR DESCRIPTION
MIDI on X68000 triggers assertion on out-of-bounds vector.

ym3802_device::device_reset() (line 48) does a std::vector::clear() then moves into ym3802_device::reset_midi_timer() (line 132) which tries to access the vector.

Surely the intention isn't to destroy the vector elements?  It's only initialized in the constructor, nowhere else.  This change just sets all values to 0, much like how it starts out from the constructor.

Original error (from SteamOS device):

flatpak run org.mamedev.MAME x68000 -exp1 x68k_midi -midiout "Midi Through Port-0"

/usr/include/c++/12.1.0/bits/stl_vector.h:1123: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>; reference = unsigned char&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
