### PR TITLE
ncr53c90: Add NCR53CF96 + bugfixes

### DIFF
--- a/src/devices/bus/nscsi/cd.cpp
+++ b/src/devices/bus/nscsi/cd.cpp
@@ -226,10 +226,10 @@ void nscsi_cdrom_device::scsi_command()
 		 * SUPPORTED.
 		 */
 		int page = scsi_cmdbuf[2];
-		int size = scsi_cmdbuf[4];
+		int size = (scsi_cmdbuf[3] << 8) | scsi_cmdbuf[4];
 		switch(page) {
 		case 0:
-			std::fill_n(scsi_cmdbuf, 36, 0);
+			std::fill_n(scsi_cmdbuf, size, 0);
 
 			if (lun != 0)
 				scsi_cmdbuf[0] = 0x7f;
@@ -249,8 +249,6 @@ void nscsi_cdrom_device::scsi_command()
 				if(scsi_cmdbuf[i] == 0)
 					scsi_cmdbuf[i] = 0x20;
 
-			if(size > 36)
-				size = 36;
 			scsi_data_in(SBUF_MAIN, size);
 			break;
 		}

--- a/src/devices/bus/nscsi/cd.cpp
+++ b/src/devices/bus/nscsi/cd.cpp
@@ -226,7 +226,7 @@ void nscsi_cdrom_device::scsi_command()
 		 * SUPPORTED.
 		 */
 		int page = scsi_cmdbuf[2];
-		int size = (scsi_cmdbuf[3] << 8) | scsi_cmdbuf[4];
+		int size = scsi_cmdbuf[4];
 		switch(page) {
 		case 0:
 			std::fill_n(scsi_cmdbuf, size, 0);

--- a/src/devices/machine/ncr53c90.cpp
+++ b/src/devices/machine/ncr53c90.cpp
@@ -788,7 +788,7 @@ uint8_t ncr53c90_device::tcounter_lo_r()
 
 void ncr53c90_device::tcount_lo_w(uint8_t data)
 {
-	tcount = (tcount & ~0xff) | data;
+	tcount = (tcount & ~uint32_t(0xff)) | data;
 	LOG("tcount_lo_w %02x (%s)\n", data, machine().describe_context());
 }
 
@@ -800,7 +800,7 @@ uint8_t ncr53c90_device::tcounter_hi_r()
 
 void ncr53c90_device::tcount_hi_w(uint8_t data)
 {
-	tcount = (tcount & ~0xff00) | (data << 8);
+	tcount = (tcount & ~uint32_t(0xff00)) | (uint32_t(data) << 8);
 	LOG("tcount_hi_w %02x (%s)\n", data, machine().describe_context());
 }
 
@@ -1389,6 +1389,6 @@ uint8_t ncr53c94_device::tcounter_hi2_r()
 
 void ncr53c94_device::tcount_hi2_w(uint8_t data)
 {
-	tcount = (tcount & ~0xff0000) | (data << 16);
+	tcount = (tcount & ~uint32_t(0xff0000)) | (uint32_t(data) << 16);
 	LOG("tcount_hi2_w %02x (%s)\n", data, machine().describe_context());
 }

--- a/src/devices/machine/ncr53c90.h
+++ b/src/devices/machine/ncr53c90.h
@@ -196,7 +196,7 @@ protected:
 	uint8_t clock_conv, sync_offset, sync_period, bus_id, select_timeout, seq;
 	uint8_t fifo[16];
 	uint32_t tcount;
-	uint32_t tcounter;
+	uint32_t tcounter, tcounter_mask;
 	int mode, fifo_pos, command_pos;
 	int state, xfr_phase;
 	int command_length;
@@ -231,7 +231,7 @@ protected:
 	void delay(int cycles);
 	void delay_cycles(int cycles);
 
-	virtual void decrement_tcounter(int count = 1);
+	void decrement_tcounter(int count = 1);
 
 	devcb_write_line m_irq_handler;
 	devcb_write_line m_drq_handler;
@@ -247,7 +247,7 @@ public:
 	virtual uint8_t status_r() override;
 
 	uint8_t conf2_r() { return config2; }
-	void conf2_w(uint8_t data) { config2 = data; }
+	virtual void conf2_w(uint8_t data) { config2 = data; }
 
 	virtual uint8_t read(offs_t offset) override;
 	virtual void write(offs_t offset, uint8_t data) override;
@@ -297,6 +297,8 @@ public:
 
 	virtual void map(address_map &map) override;
 
+	virtual void conf2_w(uint8_t data) override;
+
 	uint8_t conf3_r() { return config3; }
 	void conf3_w(uint8_t data) { config3 = data; }
 
@@ -327,8 +329,6 @@ protected:
 	virtual void device_start() override;
 	virtual void device_reset() override;
 	virtual void check_drq() override;
-
-	virtual void decrement_tcounter(int count = 1) override;
 
 private:
 	u8 config3;

--- a/src/devices/machine/ncr53c90.h
+++ b/src/devices/machine/ncr53c90.h
@@ -195,8 +195,8 @@ protected:
 	uint8_t command[2], config, status, istatus;
 	uint8_t clock_conv, sync_offset, sync_period, bus_id, select_timeout, seq;
 	uint8_t fifo[16];
-	uint16_t tcount;
-	uint16_t tcounter;
+	uint32_t tcount;
+	uint32_t tcounter;
 	int mode, fifo_pos, command_pos;
 	int state, xfr_phase;
 	int command_length;
@@ -231,7 +231,7 @@ protected:
 	void delay(int cycles);
 	void delay_cycles(int cycles);
 
-	void decrement_tcounter(int count = 1);
+	virtual void decrement_tcounter(int count = 1);
 
 	devcb_write_line m_irq_handler;
 	devcb_write_line m_drq_handler;
@@ -277,7 +277,7 @@ protected:
 		DAE   = 0x80, // data alignment enable
 	};
 
-private:
+protected:
 	u8 config2;
 };
 
@@ -299,6 +299,13 @@ public:
 
 	uint8_t conf3_r() { return config3; }
 	void conf3_w(uint8_t data) { config3 = data; }
+
+	uint8_t conf4_r() { return config4; }
+	void conf4_w(uint8_t data) { config4 = data; }
+
+	uint8_t tcounter_hi2_r();
+	void tcount_hi2_w(uint8_t data);
+
 	void fifo_align_w(uint8_t data) { fifo_align = data; }
 
 	virtual uint8_t read(offs_t offset) override;
@@ -321,9 +328,14 @@ protected:
 	virtual void device_reset() override;
 	virtual void check_drq() override;
 
+	virtual void decrement_tcounter(int count = 1) override;
+
 private:
 	u8 config3;
+	u8 config4;
 	u8 fifo_align;
+	u8 family_id;
+	u8 revision_level;
 	busmd_t m_busmd;
 };
 
@@ -333,9 +345,16 @@ public:
 	ncr53cf94_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
+class ncr53cf96_device : public ncr53c94_device
+{
+public:
+	ncr53cf96_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+};
+
 DECLARE_DEVICE_TYPE(NCR53C90, ncr53c90_device)
 DECLARE_DEVICE_TYPE(NCR53C90A, ncr53c90a_device)
 DECLARE_DEVICE_TYPE(NCR53C94, ncr53c94_device)
 DECLARE_DEVICE_TYPE(NCR53CF94, ncr53cf94_device)
+DECLARE_DEVICE_TYPE(NCR53CF96, ncr53cf96_device)
 
 #endif // MAME_MACHINE_NCR53C90_H


### PR DESCRIPTION
Discussion can be found in this commit: https://github.com/mamedev/mame/commit/8518c8421555e9ad7443e4537ea02ed6d4f4c441#r98926600

Basic NCR53CF96 was added in preparation for an upcoming PR to convert the Konami arcade drivers using AM53CF96 to use NSCSI.

The nscsi/cd change is required to fix sun4_60 booting because Solaris 2.6 requests 48 bytes from the SCSI INQUIRY command but only receives the hardcoded 36 bytes, so it would time out waiting for the remaining data.