### PR TITLE
Fixed reading IER register

### DIFF
--- a/src/devices/machine/6522via.cpp
+++ b/src/devices/machine/6522via.cpp
@@ -800,7 +800,7 @@ u8 via6522_device::read(offs_t offset)
 		break;
 
 	case VIA_IER:
-		val = m_ier | 0x80;
+		val = m_ier & 0x7F;
 		break;
 
 	case VIA_IFR:


### PR DESCRIPTION
Accordingly to the VIA datasheet http://archive.6502.org/datasheets/mos_6522_preliminary_nov_1977.pdf) bit 7 of IER always reads as 0. It is probably never used by the reader, but this is picky and probably more accurate :)