### PR TITLE
machine/via6522.cpp: Don't clear all interrupts on IFR writes with bit 7 set

### DIFF
--- a/src/devices/machine/6522via.cpp
+++ b/src/devices/machine/6522via.cpp
@@ -1058,12 +1058,8 @@ void via6522_device::write(offs_t offset, u8 data)
 		break;
 
 	case VIA_IFR:
-		if (data & INT_ANY)
-		{
-			data = 0x7f;
-		}
 		LOGINT("IFR INT ");
-		clear_int(data);
+		clear_int(data & 0x7f);
 		break;
 	}
 }


### PR DESCRIPTION
These 3 datasheets:

http://archive.6502.org/datasheets/mos_6522_preliminary_nov_1977.pdf http://archive.6502.org/datasheets/synertek_sy6522_via_1978_jan.pdf
http://archive.6502.org/datasheets/rockwell_r6522_via.pdf

state that:

The IFR bit 7 is not a flag. Therefore, this bit is not directly cleared by writing a logic 1 into it. It can only be cleared by clearing all the flags in the register or by disabling all the active interrupts as discussed in the next section.

but this is what current code does. If more updated datasheets are available, please share the links.