### PR TITLE
nabupc: Add extra bioses

### DIFF
--- a/src/mame/misc/nabupc.cpp
+++ b/src/mame/misc/nabupc.cpp
@@ -514,11 +514,20 @@ void nabupc_state::io_map(address_map &map)
 
 ROM_START( nabupc )
 	ROM_REGION( 0x2000, "bios", 0 )
-	ROM_SYSTEM_BIOS( 0, "reva", "4k BIOS" )
+	ROM_DEFAULT_BIOS("reva")
+	ROM_SYSTEM_BIOS( 0, "reva", "4k BIOS (Rev A)" )
 	ROMX_LOAD( "nabupc-u53-90020060-reva-2732.bin", 0x0000, 0x1000, CRC(8110bde0) SHA1(57e5f34645df06d7cb6c202a6d35a442776af2cb), ROM_BIOS(0) )
 	ROM_RELOAD(0x1000, 0x1000)
-	ROM_SYSTEM_BIOS( 1, "revb", "8k BIOS - Floppy support" )
-	ROMX_LOAD( "nabupc-u53-90020060-revb-2764.bin", 0x0000, 0x2000, CRC(3088f21b) SHA1(bf2f1eb5d9f5a8e9d022ce0056f2a5a8526b830e), ROM_BIOS(1) )
+	ROM_SYSTEM_BIOS( 1, "ver14", "4k BIOS - Floppy support (Ver 14)" )
+	ROMX_LOAD( "nabupc-u53-ver14-2732.bin", 0x0000, 0x1000, CRC(ca5e1ae9) SHA1(d713abd5d387a63a287d4ea51196ba5de42db052), ROM_BIOS(1) )
+	ROM_RELOAD(0x1000, 0x1000)
+	ROM_SYSTEM_BIOS( 2, "ver17", "4k BIOS - Floppy support (Ver 17)" )
+	ROMX_LOAD( "nabupc-u53-ver17-2732.bin", 0x0000, 0x1000, CRC(24d4f1fa) SHA1(1b9533c709604a21aa5fcc32071d0b0630e89c20), ROM_BIOS(2) )
+	ROM_RELOAD(0x1000, 0x1000)
+	ROM_SYSTEM_BIOS( 3, "revb", "8k BIOS - Floppy support (Rev B)" )
+	ROMX_LOAD( "nabupc-u53-90020060-revb-2764.bin", 0x0000, 0x2000, CRC(3088f21b) SHA1(bf2f1eb5d9f5a8e9d022ce0056f2a5a8526b830e), ROM_BIOS(3) )
+	ROM_SYSTEM_BIOS( 4, "ver29", "8k BIOS - Floppy support (Ver 29)" )
+	ROMX_LOAD( "nabupc-u53-90037150-ver29-2764.bin", 0x0000, 0x2000, CRC(3c484e3d) SHA1(dd10ad6e0a59c54561335272d3c808b0543ba0ef), ROM_BIOS(4) )
 ROM_END
 
 


### PR DESCRIPTION
This adds three additional roms/bioses to the nabupc emulator. 

Two new 4k roms (ver 14 and ver 17), which support floppy and hdd booting.
One new 8k rom (ver 29), which supports floppy and hdd booting.

