### PR TITLE
machine/6522via.cpp: Make input ports read transparently when corresponding interrupt flag is clear

### DIFF
--- a/src/devices/machine/6522via.cpp
+++ b/src/devices/machine/6522via.cpp
@@ -630,13 +630,13 @@ u8 via6522_device::read(offs_t offset)
 	{
 	case VIA_PB:
 		/* update the input */
-		if (PB_LATCH_ENABLE(m_acr) == 0)
+		if ((PB_LATCH_ENABLE(m_acr) != 0) && ((m_ifr & INT_CB1) != 0))
 		{
-			val = input_pb();
+			val = m_latch_b;
 		}
 		else
 		{
-			val = m_latch_b;
+			val = input_pb();
 		}
 
 		if (!machine().side_effects_disabled())
@@ -648,13 +648,12 @@ u8 via6522_device::read(offs_t offset)
 
 	case VIA_PA:
 		/* update the input */
-		if (PA_LATCH_ENABLE(m_acr) == 0)
-		{
-			val = input_pa();
+		if ((PA_LATCH_ENABLE(m_acr) != 0) && ((m_ifr & INT_CA1) != 0))
+			val = m_latch_a;
 		}
 		else
 		{
-			val = m_latch_a;
+			val = input_pa();
 		}
 
 		if (!machine().side_effects_disabled())
@@ -676,13 +675,12 @@ u8 via6522_device::read(offs_t offset)
 
 	case VIA_PANH:
 		/* update the input */
-		if (PA_LATCH_ENABLE(m_acr) == 0)
-		{
-			val = input_pa();
+		if ((PA_LATCH_ENABLE(m_acr) != 0) && ((m_ifr & INT_CA1) != 0))
+			val = m_latch_a;
 		}
 		else
 		{
-			val = m_latch_a;
+			val = input_pa();
 		}
 		break;
 

--- a/src/devices/machine/6522via.cpp
+++ b/src/devices/machine/6522via.cpp
@@ -11,17 +11,6 @@
 
 **********************************************************************/
 
-/*
-  1999-Dec-22 PeT
-   vc20 random number generation only partly working
-   (reads (uninitialized) timer 1 and timer 2 counter)
-   timer init, reset, read changed
-
-  2017-Feb-15 Edstrom
-   Fixed shift registers to be more accurate, eg 50/50 duty cycle, latching
-   on correct edges and leading and trailing edges added + logging.
- */
-
 #include "emu.h"
 #include "6522via.h"
 

--- a/src/devices/machine/6522via.cpp
+++ b/src/devices/machine/6522via.cpp
@@ -649,6 +649,7 @@ u8 via6522_device::read(offs_t offset)
 	case VIA_PA:
 		/* update the input */
 		if ((PA_LATCH_ENABLE(m_acr) != 0) && ((m_ifr & INT_CA1) != 0))
+		{
 			val = m_latch_a;
 		}
 		else
@@ -676,6 +677,7 @@ u8 via6522_device::read(offs_t offset)
 	case VIA_PANH:
 		/* update the input */
 		if ((PA_LATCH_ENABLE(m_acr) != 0) && ((m_ifr & INT_CA1) != 0))
+		{
 			val = m_latch_a;
 		}
 		else


### PR DESCRIPTION
**** ***THIS IS UNTESTED*** ******

*I have created this pull request to address the below and document a possible fix.*

----------------------

From http://archive.6502.org/datasheets/mos_6522_preliminary_nov_1977.pdf and http://archive.6502.org/datasheets/synertek_sy6522_via_1978_jan.pdf

MCS6522/SYS6522 OPERATION
-------------------------
[...]

C. PORT A REGISTERS, PORT B REGISTERS
[...] With input latching enabled, IRA will reflect the contents of the Port A prior to setting the CA1 Interrupt Flag (IFRl) by an active transition on CA1 [...] With input latching enabled on Port B, setting CB1 interrupt flag will cause IRB to latch this combination of input data and ORB data **until the interrupt flag is cleared** [...]

Auxiliary Control Register
--------------------------
[...]

.1. PA Latch Enable
The MCS6522/SYS6522 provides input latching on both the PA and PB ports. In this mode, the data present on the peripheral A input pins will be latched within the chip **when the CA1 interrupt flag is set**. Reading the PA port will result in these latches being transferred into the processor. **As long as the CA1 interrupt flag is set**, the data on the peripheral pins can change without affecting the data in the latches. This input latching can be used with any of the CA2 input or output modes [...]

.2. PB Latch Enable
Input latching on the PB port is controlled in the same manner as that described for the PA port[...]

----------------------

From: http://archive.6502.org/datasheets/rockwell_r6522_via.pdf

FUNCTIONAL DESCRIPTION
----------------------

PORT A AND PORT B OPERATION
[...] With input latching enabled, IRA will reflect the levels on the PA pins at the time the latching occurred (via CA1). The IRB register operates similar to the IRA register [...]



From: http://archive.6502.org/datasheets/synertek_sy6522.pdf

2.0 Port A and Port B
[...] **Not until CA1 or CB1 has transitioned (as programmed in the PCR) will any data be latched**. Now a read of the input register will reflect the data that was on the port line at the time of the latching transition. **After this read the input registers will again appear transparent until the next CA1 or CB1 transition.** See Figure 2 [...]

----------------------

This  means, accordingly to the data sheets (as I understand it):

1a) Even if input latching is set, unless a active transition happens on CA1/CA2, reading a port will return the  same result as if latching is disabled (that is, it will read input pins for port A and a combination of input pins/ORA for port b). See Figure 2 Read A in http://archive.6502.org/datasheets/synertek_sy6522.pdf.

2a) An active transition on CA1/CB1 while in latching mode will latch the input. This, at the same time, sets  corresponding flags in IFR. Therefore "active transition on CA1/CB1" and "setting IFR flags for CA1/CB1" are synonyms.

3a) As long as latching is enabled **AND corresponding bits in IFR are set**, reading a port will return the latched value. Note that, depending on how PCR is set, reading/writing ports also clears corresponding bit in IFR, disabling latching (mode 000 and 010 for CA2/CB2 control) which will cause next read to read actual inputs and not latched values.

Current MAME behavior (again, as I understand it) is:

1b) If input latching is set, always read the latched value. Note this happens even if no positive transition on CA1/CB1 has happened yet, so I think the latch might not be properly initialized.

2b) Works same as 2a)

3a) As long as latching is enabled, reading a port will return the latched value. Clearing IFR flags for CA1/CB1 has no effect on latching. This means if a read/write is performed in mode 000 and 010, which clears IFR bits, next read will still return the latched value. This contrasts with Figure 2 Read C, D in http://archive.6502.org/datasheets/synertek_sy6522.pdf.