### PR TITLE
nabupc: Add support for hdd controller

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -5158,6 +5158,8 @@ if (BUSES["NABU"]~=null) then
 		MAME_DIR .. "src/devices/bus/nabupc/adapter.h",
 		MAME_DIR .. "src/devices/bus/nabupc/fdc.cpp",
 		MAME_DIR .. "src/devices/bus/nabupc/fdc.h",
+		MAME_DIR .. "src/devices/bus/nabupc/hdd.cpp",
+		MAME_DIR .. "src/devices/bus/nabupc/hdd.h",
 		MAME_DIR .. "src/devices/bus/nabupc/option.cpp",
 		MAME_DIR .. "src/devices/bus/nabupc/option.h",
 	}

--- a/src/devices/bus/nabupc/hdd.cpp
+++ b/src/devices/bus/nabupc/hdd.cpp
@@ -1,0 +1,112 @@
+// license:BSD-3-Clause
+// copyright-holders:Brian Johnson
+/*******************************************************************
+ *
+ * NABU PC HDD Card
+ *
+ *******************************************************************/
+
+#include "emu.h"
+#include "hdd.h"
+
+#include "machine/wd1000.h"
+
+//**************************************************************************
+//  NABU PC HDD DEVICE
+//**************************************************************************
+
+
+namespace {
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+/* NABU PC HDD Device */
+
+class hdd_device : public device_t, public bus::nabupc::device_option_expansion_interface
+{
+public:
+	// construction/destruction
+	hdd_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual uint8_t read(offs_t offset) override;
+	virtual void write(offs_t offset, uint8_t data) override;
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+private:
+	required_device<wd1000_device>              m_hdd;
+};
+
+//-------------------------------------------------
+//  hdd_device - constructor
+//-------------------------------------------------
+hdd_device::hdd_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, NABUPC_OPTION_HDD, tag, owner, clock),
+	device_option_expansion_interface(mconfig, *this),
+	m_hdd(*this, "hdd")
+{
+}
+
+//-------------------------------------------------
+//  device_add_mconfig - device-specific config
+//-------------------------------------------------
+void hdd_device::device_add_mconfig(machine_config &config)
+{
+	WD1000(config, m_hdd, 0);
+
+	HARDDISK(config, "hdd:0", 0);
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+void hdd_device::device_start()
+{
+}
+
+uint8_t hdd_device::read(offs_t offset)
+{
+	uint8_t result = 0xff;
+
+	switch(offset) {
+	case 0x00:
+	case 0x01:
+	case 0x02:
+	case 0x03:
+	case 0x04:
+	case 0x05:
+	case 0x06:
+	case 0x07:
+		result = m_hdd->read(offset);
+		break;
+	case 0x0f:
+		result = 0xe8;
+		break;
+	}
+	return result;
+}
+
+void hdd_device::write(offs_t offset, uint8_t data)
+{
+	switch(offset) {
+	case 0x00:
+	case 0x01:
+	case 0x02:
+	case 0x03:
+	case 0x04:
+	case 0x05:
+	case 0x06:
+	case 0x07:
+		m_hdd->write(offset, data);
+		break;
+	}
+}
+
+} // anonymous namespace
+
+DEFINE_DEVICE_TYPE_PRIVATE(NABUPC_OPTION_HDD, bus::nabupc::device_option_expansion_interface, hdd_device, "nabupc_option_hdd", "NABU PC Hard Disk Controller")

--- a/src/devices/bus/nabupc/hdd.cpp
+++ b/src/devices/bus/nabupc/hdd.cpp
@@ -30,16 +30,17 @@ public:
 	// construction/destruction
 	hdd_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
+	// device_option_expansion_interface implementation
 	virtual uint8_t read(offs_t offset) override;
 	virtual void write(offs_t offset, uint8_t data) override;
+
 protected:
-	// device-level overrides
+	// device_t implementation
+	virtual void device_add_mconfig(machine_config &config) override;
 	virtual void device_start() override;
 
-	// optional information overrides
-	virtual void device_add_mconfig(machine_config &config) override;
 private:
-	required_device<wd1000_device>              m_hdd;
+	required_device<wd1000_device> m_hdd;
 };
 
 //-------------------------------------------------

--- a/src/devices/bus/nabupc/hdd.h
+++ b/src/devices/bus/nabupc/hdd.h
@@ -1,0 +1,19 @@
+// license:BSD-3-Clause
+// copyright-holders:Brian Johnson
+/*******************************************************************
+ *
+ * NABU PC Hard Drive Controller
+ *
+ *******************************************************************/
+
+#ifndef MAME_BUS_NABUPC_HDD_H
+#define MAME_BUS_NABUPC_HDD_H
+
+#pragma once
+
+#include "option.h"
+
+// device type definition
+DECLARE_DEVICE_TYPE_NS(NABUPC_OPTION_HDD, bus::nabupc, device_option_expansion_interface)
+
+#endif // MAME_BUS_NABUPC_HDD_H

--- a/src/devices/bus/nabupc/option.cpp
+++ b/src/devices/bus/nabupc/option.cpp
@@ -10,6 +10,7 @@
 #include "option.h"
 
 #include "fdc.h"
+#include "hdd.h"
 
 DEFINE_DEVICE_TYPE(NABUPC_OPTION_BUS_SLOT, bus::nabupc::option_slot_device, "nabupc_option_slot", "NABU PC Option slot")
 DEFINE_DEVICE_TYPE(NABUPC_OPTION_BUS, bus::nabupc::option_bus_device, "nabupc_option_bus", "NABU PC Option Bus")
@@ -127,6 +128,7 @@ void device_option_expansion_interface::interface_pre_start()
 void option_bus_devices(device_slot_interface &device)
 {
 	device.option_add("fdc", NABUPC_OPTION_FDC);
+	device.option_add("hdd", NABUPC_OPTION_HDD);
 }
 
 }  // namespace bus::nabupc


### PR DESCRIPTION
This adds support for hard drive emulation to the nabupc system. 