### PR TITLE
msx1_cart.xml: Hexadecimal sizes, explicitly configure loading for smaller images, add information and usage notes.

### DIFF
--- a/hash/msx1_cart.xml
+++ b/hash/msx1_cart.xml
@@ -5981,7 +5981,7 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ゴルフゲーム" />
 		<info name="serial" value="00040"/>
-		<info name="4871489086"/>
+		<info name="isbn" value="4871489086"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="start_page" value="2"/>
 			<dataarea name="rom" size="0x4000">

--- a/hash/msx1_cart.xml
+++ b/hash/msx1_cart.xml
@@ -132,6 +132,7 @@ Fighting Rider - Sony Spain
 Financiële administratie - [VG 8181] Philips
 Financiële administratie 2 - [VG 8183] Philips
 GranSoft TXT - Editor de Texto - GranSoft
+Hercules - Sony Spain
 Holland Bingo - Reveal Automation
 Kuma Forth - Kuma
 Logo MSX - Idealogic
@@ -319,65 +320,68 @@ Xyzolog - Electric Software
 		<description>1942 (Japan)</description>
 		<year>1986</year>
 		<publisher>ASCII</publisher>
+		<info name="serial" value="2019001"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="nc81820-g30 japan 8649" size="131072" crc="a27787af" sha1="0733cd627467a866846e15caf1770a5594eaf4cc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nc81820-g30 japan 8649" size="0x20000" crc="a27787af" sha1="0733cd627467a866846e15caf1770a5594eaf4cc" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="animllnd">
 		<description>Animal Land - Satsujin Jiken (Japan)</description>
 		<year>1987</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="E-G192" />
 		<info name="alt_title" value="アニマルランド殺人事件" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh231077" size="131072" crc="15a0f98a" sha1="495876c504bdc4de24860ea15b25dda8f3b06c49" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh231077" size="0x20000" crc="15a0f98a" sha1="495876c504bdc4de24860ea15b25dda8f3b06c49" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="genghis">
 		<description>Aoki Ookami to Shiroki Mejika - Genghis Khan (Japan)</description>
 		<year>1986</year>
 		<publisher>Koei</publisher>
 		<info name="alt_title" value="蒼き狼と白き牝鹿 ジンギスカン" />
+		<info name="gtin" value="04988615000225"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-621 KAGA" />
 			<feature name="slot" value="ascii8_sram" />
 			<feature name="mapper" value="M60002-0125SP" /> <!-- 42 pin -->
 			<feature name="sram" value="LH5164L-15" /> <!-- battery backed -->
 			<feature name="other" value="HD74LS138P" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh532077" size="262144" crc="4ead5098" sha1="12b3c31f0fd10ff5823dcc8bf6dfeb785a8af2f7" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh532077" size="0x40000" crc="4ead5098" sha1="12b3c31f0fd10ff5823dcc8bf6dfeb785a8af2f7" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="blckony2">
 		<description>The Black Onyx II - Search For The Fire Crystal (Japan)</description>
 		<year>1986</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ザ・ブラックオニキスII" />
+		<info name="serial" value="2016803"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh231013" size="131072" crc="67bf8337" sha1="2588b9ade775b93f03fd4b17fd3f78ba70b556d6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh231013" size="0x20000" crc="67bf8337" sha1="2588b9ade775b93f03fd4b17fd3f78ba70b556d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -387,12 +391,13 @@ Xyzolog - Electric Software
 		<year>1987</year>
 		<publisher>Xtal Soft</publisher>
 		<info name="alt_title" value="ボルフェスと5人の悪魔" />
+		<info name="serial" value="MXXA-11001"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh231066" size="131072" crc="e040e8a1" sha1="16c3ced0fb2e360bc7c43d372a0a30eb6bd3963d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh231066" size="0x20000" crc="e040e8a1" sha1="16c3ced0fb2e360bc7c43d372a0a30eb6bd3963d" />
 			</dataarea>
 		</part>
 	</software>
@@ -403,12 +408,14 @@ Xyzolog - Electric Software
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TEX-75" />
 		<info name="alt_title" value="ディーヴァ ストーリー4·アスラの血流" />
+		<info name="serial" value="TEX-75"/>
+		<info name="gtin" value="049886049030752"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA6228" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh532020" size="262144" crc="99198ed9" sha1="2418c0302abbce8b0f8556b63169c60a849f60ee" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh532020" size="0x40000" crc="99198ed9" sha1="2418c0302abbce8b0f8556b63169c60a849f60ee" />
 			</dataarea>
 		</part>
 	</software>
@@ -418,12 +425,13 @@ Xyzolog - Electric Software
 		<year>1987</year>
 		<publisher>Nihon Telenet</publisher>
 		<info name="alt_title" value="デジタルデビル物語 女神転生" />
+		<info name="gtin" value="04988624920019"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh231089" size="131072" crc="25fc11fa" sha1="7dc7f7e3966943280f34836656a7d1bd3ace67cd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh231089" size="0x20000" crc="25fc11fa" sha1="7dc7f7e3966943280f34836656a7d1bd3ace67cd" />
 			</dataarea>
 		</part>
 	</software>
@@ -434,12 +442,13 @@ Xyzolog - Electric Software
 		<publisher>Enix</publisher>
 		<info name="serial" value="E-G186" />
 		<info name="alt_title" value="ドラゴンクエスト" />
+		<info name="gtin" value="04988601001861"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="cxk381000" size="131072" crc="49f5478b" sha1="7b94a728a5945a53d518c18994e1e09a09ec3c1b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="cxk381000" size="0x20000" crc="49f5478b" sha1="7b94a728a5945a53d518c18994e1e09a09ec3c1b" />
 			</dataarea>
 		</part>
 	</software>
@@ -454,8 +463,8 @@ Xyzolog - Electric Software
 			<feature name="pcb" value="TAS-4M-008M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="LZ93A13" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh532060" size="262144" crc="8076fec6" sha1="3df7c19f739d74d6efdfd8151343e5a55d4ac842" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh532060" size="0x40000" crc="8076fec6" sha1="3df7c19f739d74d6efdfd8151343e5a55d4ac842" />
 			</dataarea>
 		</part>
 	</software>
@@ -470,23 +479,26 @@ Xyzolog - Electric Software
 			<feature name="pcb" value="TA6228" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh5320z5" size="262144" crc="87dcd309" sha1="f100a76117e95ab0335e89a901e47d844bbc0ab6" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh5320z5" size="0x40000" crc="87dcd309" sha1="f100a76117e95ab0335e89a901e47d844bbc0ab6" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="dngnhntr">
+	<!-- Released with ASCII Light Gun -->
+	<!-- Light gun is not supported yet. -->
+	<software name="dngnhntr" supported="no">
 		<description>Dungeon Hunter (Japan)</description>
 		<year>1989</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ダンジョンハンター" />
+		<info name="usage" value="Light gun required."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M016S" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="LZ93A13-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="rp231026d" size="131072" crc="2526e568" sha1="d1fbdbdf2e830139584d7dc796806aa3327720dd" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rp231026d" size="0x20000" crc="2526e568" sha1="d1fbdbdf2e830139584d7dc796806aa3327720dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -497,28 +509,29 @@ Xyzolog - Electric Software
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R55X5812" />
 		<info name="alt_title" value="ファンタジーゾーン" />
+		<info name="gtin" value="04988013008694"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh531057" size="131072" crc="3e96d005" sha1="048737f995eecb1dd8dd341d750efd005267796f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh531057" size="0x20000" crc="3e96d005" sha1="048737f995eecb1dd8dd341d750efd005267796f" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="fzone">
 		<description>Final Zone (Japan)</description>
 		<year>1986</year>
 		<publisher>Nihon Telenet</publisher>
 		<info name="alt_title" value="ファイナル・ゾーン" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="fzr-2001" size="131072" crc="14e2efcc" sha1="a553c3f204c105c23b227a1e5aeb290671ccdbeb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="fzr-2001" size="0x20000" crc="14e2efcc" sha1="a553c3f204c105c23b227a1e5aeb290671ccdbeb" />
 			</dataarea>
 		</part>
 	</software>
@@ -533,8 +546,8 @@ Xyzolog - Electric Software
 			<feature name="pcb" value="1M-8KB" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="NEOS MR6401" />   <!-- MR6401 -->
-			<dataarea name="rom" size="131072">
-				<rom name="rp231024d" size="131072" crc="a6165bd4" sha1="453eac7568d5d04c8cf7da86f2e8dc79777343da" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rp231024d" size="0x20000" crc="a6165bd4" sha1="453eac7568d5d04c8cf7da86f2e8dc79777343da" />
 			</dataarea>
 		</part>
 	</software>
@@ -545,12 +558,13 @@ Xyzolog - Electric Software
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G053C" />
 		<info name="alt_title" value="ガルフォース カオスの攻防" />
+		<info name="gtin" value="04901780056651"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh31434" size="131072" crc="99ef860e" sha1="e8ab46785e75e19dac497c4a82ac2f5b37ac0580" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh31434" size="0x20000" crc="99ef860e" sha1="e8ab46785e75e19dac497c4a82ac2f5b37ac0580" />
 			</dataarea>
 		</part>
 	</software>
@@ -564,8 +578,8 @@ Xyzolog - Electric Software
 			<feature name="pcb" value="2M-8KB" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="NEOS MR6401" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh53210a game arts" size="262144" crc="91955bcd" sha1="89073c052b0fe29b6de077c8bdf5373474081edf" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh53210a game arts" size="0x40000" crc="91955bcd" sha1="89073c052b0fe29b6de077c8bdf5373474081edf" />
 			</dataarea>
 		</part>
 	</software>
@@ -575,12 +589,13 @@ Xyzolog - Electric Software
 		<year>1987</year>
 		<publisher>Dempa</publisher>
 		<info name="alt_title" value="迷宮への扉 ~ Meikyuu e no Tobira (Box)" />
+		<info name="serial" value="DP-3912036"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="1M-16KB" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="MR6401" />    <!-- NEOS MR6401 -->
-			<dataarea name="rom" size="131072">
-				<rom name="dempa labyrinth rp231024d" size="131072" crc="2c2020a0" sha1="0cb11c766bd357d203879bd6bee041a4690cc3df" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dempa labyrinth rp231024d" size="0x20000" crc="2c2020a0" sha1="0cb11c766bd357d203879bd6bee041a4690cc3df" />
 			</dataarea>
 		</part>
 	</software>
@@ -595,76 +610,82 @@ Xyzolog - Electric Software
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="compile ia-8701" size="131072" crc="5eac55df" sha1="7a4126934f9e68c34bf00dd3d9a9e753c05ee73f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="compile ia-8701" size="0x20000" crc="5eac55df" sha1="7a4126934f9e68c34bf00dd3d9a9e753c05ee73f" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="hajafuin">
 		<description>Haja no Fuuin (Japan)</description>
 		<year>1987</year>
 		<publisher>Kogado</publisher>
 		<info name="alt_title" value="覇邪の封印" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="1mrom" size="131072" crc="6a603b8c" sha1="44b23a175d04ca21236a5fef18600b01b12aaf4d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="1mrom" size="0x20000" crc="6a603b8c" sha1="44b23a175d04ca21236a5fef18600b01b12aaf4d" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Can create character, but starting the game with that character does not work. -->
+	<!-- Generation-msx only mentions 2KB SRAM. -->
 	<software name="hydlide2" supported="partial">
 		<description>Hydlide II - Shine of Darkness (Japan)</description>
 		<year>1986</year>
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TEX-70" />
 		<info name="alt_title" value="ハイドライドII" />
+		<info name="gtin" value="04988604030707"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-621M" />
 			<feature name="slot" value="ascii8_sram" />
 			<feature name="mapper" value="M60002-0125SP" />
 			<feature name="sram" value="HM6116LP-3" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh531043" size="131072" crc="d8055f5f" sha1="da4b44c734029f60388b7cea4ab97c3d5c6a09e9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh531043" size="0x20000" crc="d8055f5f" sha1="da4b44c734029f60388b7cea4ab97c3d5c6a09e9" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
 
+
+	<!-- Was released with a cassette tape containing the soundtrack of other games. -->
 	<software name="hydlide3">
 		<description>Hydlide 3 - The Space Memories (Japan)</description>
 		<year>1987</year>
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TEX-79" />
 		<info name="alt_title" value="ハイドライド3" />
+		<info name="gtin" value="04988604030790"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TAS-4M008M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="LZ93A13" />
-			<dataarea name="rom" size="524288">
-				<rom name="hydlide3 4m-rom" size="524288" crc="00c5d5b5" sha1="74e9ea381e2fed07d989d1056002de5737125aaf" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="hydlide3 4m-rom" size="0x80000" crc="00c5d5b5" sha1="74e9ea381e2fed07d989d1056002de5737125aaf" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="jagur">
 		<description>Jagur (Japan)</description>
 		<year>1987</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="XR-1040" />
 		<info name="alt_title" value="ジャガー5 ~ Jagur 5 (Box?)" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="rp231024d" size="131072" crc="d6465702" sha1="6fefbe448674b6ea846d0c6b9c8a0d57a11aa410" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rp231024d" size="0x20000" crc="d6465702" sha1="6fefbe448674b6ea846d0c6b9c8a0d57a11aa410" />
 			</dataarea>
 		</part>
 	</software>
@@ -678,11 +699,11 @@ Xyzolog - Electric Software
 			<feature name="pcb" value="MSX WRITE 900178B" />
 			<feature name="slot" value="msxwrite" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="524288">
-				<rom name="225 aa 8716 zoo" size="524288" crc="ef02e4f3" sha1="4180544158a57c99162269e33e4f2c77c9fce84e" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="225 aa 8716 zoo" size="0x80000" crc="ef02e4f3" sha1="4180544158a57c99162269e33e4f2c77c9fce84e" />
 			</dataarea>
-			<dataarea name="kanji" size="131072">
-				<rom name="kanjifont.rom" size="131072" crc="3b8fdf44" sha1="fc71561a64f73da0e0043d256f67fd18d7fc3a7f" />
+			<dataarea name="kanji" size="0x20000">
+				<rom name="kanjifont.rom" size="0x20000" crc="3b8fdf44" sha1="fc71561a64f73da0e0043d256f67fd18d7fc3a7f" />
 			</dataarea>
 		</part>
 	</software>
@@ -693,12 +714,14 @@ Xyzolog - Electric Software
 		<publisher>Enix</publisher>
 		<info name="serial" value="E-G187" />
 		<info name="alt_title" value="軽井沢誘拐案内" />
+		<info name="usage" value="Requires a Japanese system."/>
+		<info name="gtin" value="04988601001878"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh231024" size="131072" crc="6a30c707" sha1="1c462c3629d43297a006ba9055b39a2dccba9f6c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh231024" size="0x20000" crc="6a30c707" sha1="1c462c3629d43297a006ba9055b39a2dccba9f6c" />
 			</dataarea>
 		</part>
 	</software>
@@ -712,24 +735,24 @@ Xyzolog - Electric Software
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="643103" size="131072" crc="a0481321" sha1="122f659250a0ae10ce0be0dde626dd3e384affa7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="643103" size="0x20000" crc="a0481321" sha1="122f659250a0ae10ce0be0dde626dd3e384affa7" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="marchen">
 		<description>Märchen Veil I (Japan)</description>
 		<year>1987</year>
 		<publisher>System Sacom</publisher>
 		<info name="alt_title" value="メルヘン・ヴェール I" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="cxk381000" size="131072" crc="44aa5422" sha1="f7dd6841d280cbffa9f0f2da7af3549f23270ddb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="cxk381000" size="0x20000" crc="44aa5422" sha1="f7dd6841d280cbffa9f0f2da7af3549f23270ddb" />
 			</dataarea>
 		</part>
 	</software>
@@ -744,8 +767,8 @@ Xyzolog - Electric Software
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="rp231024d" size="131072" crc="72eb9d0e" sha1="7abf89652396a648a84ae06e6dabc09735a75798" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rp231024d" size="0x20000" crc="72eb9d0e" sha1="7abf89652396a648a84ae06e6dabc09735a75798" />
 			</dataarea>
 		</part>
 	</software>
@@ -755,61 +778,64 @@ Xyzolog - Electric Software
 		<year>1989</year>
 		<publisher>Hi-Score Software</publisher>
 		<info name="alt_title" value="MSX英和辞典" />
+		<info name="serial" value="M-2012"/>
+		<info name="gtin" value="04988002146970"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TAS-1M008S" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="LZ93A13" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh230927" size="131072" crc="1b10cf79" sha1="473bc0ea85ed1b218974796d819416e711ac193f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh230927" size="0x20000" crc="1b10cf79" sha1="473bc0ea85ed1b218974796d819416e711ac193f" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="fandom1">
 		<description>MSX-FAN Fandom Library 1 (Japan)</description>
 		<year>1988</year>
 		<publisher>Tecnopolis</publisher>
 		<info name="alt_title" value="MSXプログラムコレクション ファンダムライブラリ1" />
+		<info name="serial" value="58TSX-4"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA6228" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh532046" size="262144" crc="519be53e" sha1="8557dcdb4cf1e15180d17acc8e6d515bf7bf7e7c" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh532046" size="0x40000" crc="519be53e" sha1="8557dcdb4cf1e15180d17acc8e6d515bf7bf7e7c" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="fandom2">
 		<description>MSX-FAN Fandom Library 2 (Japan)</description>
 		<year>1988</year>
 		<publisher>Tecnopolis</publisher>
 		<info name="alt_title" value="MSXプログラムコレクション ファンダムライブラリ2" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TAS-4M-008M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="LZ93A13" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh532061" size="262144" crc="53c25b6b" sha1="7752b6624fb80d9499aaad28dd5776ec74565576" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh532061" size="0x40000" crc="53c25b6b" sha1="7752b6624fb80d9499aaad28dd5776ec74565576" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="fandom3">
 		<description>MSX-FAN Fandom Library 3 (Japan)</description>
 		<year>1988</year>
 		<publisher>Tecnopolis</publisher>
 		<info name="serial" value="58TSX-6" />
 		<info name="alt_title" value="MSXプログラムコレクション ファンダムライブラリ3" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TAS-4M-008M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="LZ93A13" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh532075" size="262144" crc="790d5335" sha1="c2f4df1bd91f7dee1536774b9d7089086b9bf835" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh532075" size="0x40000" crc="790d5335" sha1="c2f4df1bd91f7dee1536774b9d7089086b9bf835" />
 			</dataarea>
 		</part>
 	</software>
@@ -823,8 +849,8 @@ Xyzolog - Electric Software
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="831000-440 20 bk z86" size="131072" crc="309d996c" sha1="2b10234debd2a6a9a02e0750ba6563768bc4a2f3" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="831000-440 20 bk z86" size="0x20000" crc="309d996c" sha1="2b10234debd2a6a9a02e0750ba6563768bc4a2f3" />
 			</dataarea>
 		</part>
 	</software>
@@ -834,15 +860,17 @@ Xyzolog - Electric Software
 		<year>1987</year>
 		<publisher>Koei</publisher>
 		<info name="alt_title" value="信長の野望 全国版" />
+		<info name="gtin" value="04988615000126"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-621 KAGA" />
 			<feature name="slot" value="ascii8_sram" />
 			<feature name="mapper" value="M60002-0125SP" />
 			<feature name="sram" value="LH5164L-15" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh532038" size="262144" crc="3aa33a30" sha1="e6de8bbd60123444de2a90928853985ceb0b4cbf" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh532038" size="0x40000" crc="3aa33a30" sha1="e6de8bbd60123444de2a90928853985ceb0b4cbf" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -857,8 +885,8 @@ Xyzolog - Electric Software
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="cxk381000" size="131072" crc="b612d79a" sha1="74ae85d44cb8ef1bae428c90200cb74be6d56d3a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="cxk381000" size="0x20000" crc="b612d79a" sha1="74ae85d44cb8ef1bae428c90200cb74be6d56d3a" />
 			</dataarea>
 		</part>
 	</software>
@@ -873,8 +901,8 @@ Xyzolog - Electric Software
 			<feature name="pcb" value="" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="BS6101-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="831000-20" size="131072" crc="387c1de7" sha1="2f0db48fbcf3444f52b9c7c76ba9c4bd38bc2a15" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="831000-20" size="0x20000" crc="387c1de7" sha1="2f0db48fbcf3444f52b9c7c76ba9c4bd38bc2a15" />
 			</dataarea>
 		</part>
 	</software>
@@ -891,14 +919,15 @@ kept for now until finding out what those bytes affect...
 		<year>1988</year>
 		<publisher>Irem</publisher>
 		<info name="serial" value="IM-04" />
+		<info name="gtin" value="04962891300040"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="MSX-004" />
 			<feature name="slot" value="rtype" />
 			<feature name="mapper" value="IREM TAM-S1" />
-			<dataarea name="rom" size="524288">
-				<rom name="lh532163" size="262144" crc="c4c12176" sha1="07fb300ce49b2d50a99ea0a2a25148900d2035ea" />
-				<rom name="lh2309hb" size="131072" crc="8a5c4661" sha1="1bdb41ecbbb9e5819380ab33dc473a57ffa9d254" offset="0x40000" />
-				<rom size="131072" offset="0x60000" loadflag="reload" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="lh532163" size="0x40000" crc="c4c12176" sha1="07fb300ce49b2d50a99ea0a2a25148900d2035ea" />
+				<rom name="lh2309hb" size="0x20000" crc="8a5c4661" sha1="1bdb41ecbbb9e5819380ab33dc473a57ffa9d254" offset="0x40000" />
+				<rom size="0x20000" offset="0x60000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -908,47 +937,52 @@ kept for now until finding out what those bytes affect...
 		<year>1988</year>
 		<publisher>Irem</publisher>
 		<info name="serial" value="IM-04" />
+		<info name="gtin" value="04962891300040"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="rtype" />
 			<feature name="mapper" value="IREM TAM-S1" />
-			<dataarea name="rom" size="524288">
-				<rom name="r-type (japan) (alt 2).rom" size="524288" crc="827919e4" sha1="9c886fff02779267041efe45dadefc5fd7f4b9a2" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="r-type (japan) (alt 2).rom" size="0x80000" crc="827919e4" sha1="9c886fff02779267041efe45dadefc5fd7f4b9a2" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
+	<!-- Release also contains a cassette, does it have data or is it intended for save games? -->
 	<software name="sangoku">
 		<description>Sangokushi (Japan)</description>
 		<year>1986</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="MXKN11008" />
 		<info name="alt_title" value="三國志" />
+		<info name="gtin" value="04988615000003"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA6228" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh532033" size="262144" crc="10621440" sha1="14ff6fe464362c6b7dbb47b2ecda3a8c5f05ef79" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh532033" size="0x40000" crc="10621440" sha1="14ff6fe464362c6b7dbb47b2ecda3a8c5f05ef79" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
+	<!-- Release also contains a cassette, does it have data or is it intended for save games? -->
 	<software name="sangokua" cloneof="sangoku">
 		<description>Sangokushi (Japan, alt)</description>
 		<year>1986</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="MXKN11008" />
 		<info name="alt_title" value="三國志" />
+		<info name="gtin" value="04988615000003"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-2M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="262144">
+			<dataarea name="rom" size="0x40000">
 				<!-- Rom labels are likely to be wrong -->
-				<rom name="cxk381000" size="131072" crc="6441bb28" sha1="481f5ceafc56085babaa021b52b4aab182a80e3d" />
-				<rom name="cxk38100" size="131072" crc="851f71fb" sha1="004bca21757d55951f1a1211128c69982f7a91b8" offset="0x20000" />
+				<rom name="cxk381000" size="0x20000" crc="6441bb28" sha1="481f5ceafc56085babaa021b52b4aab182a80e3d" />
+				<rom name="cxk38100" size="0x20000" crc="851f71fb" sha1="004bca21757d55951f1a1211128c69982f7a91b8" offset="0x20000" />
 			</dataarea>
 		</part>
 	</software>
@@ -958,31 +992,33 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="戦場の狼" />
+		<info name="serial" value="2019101"/>
+		<info name="gtin" value="04988606200191"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh231073" size="131072" crc="427b3f14" sha1="2b255c3e5615b2f5e2365419a35e4115a060e93c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh231073" size="0x20000" crc="427b3f14" sha1="2b255c3e5615b2f5e2365419a35e4115a060e93c" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="shogun">
 		<description>Shougun (Japan)</description>
 		<year>1987</year>
 		<publisher>Nihon Dexter</publisher>
 		<info name="serial" value="ND-07MR" />
 		<info name="alt_title" value="将軍" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TAS-621-64K" />
 			<feature name="slot" value="ascii8_sram" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh23100y" size="131072" crc="0e691c47" sha1="16351e6a7d7fc38c23b54ee15ac6f0275621ba96" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh23100y" size="0x20000" crc="0e691c47" sha1="16351e6a7d7fc38c23b54ee15ac6f0275621ba96" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -993,12 +1029,13 @@ kept for now until finding out what those bytes affect...
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TEX-76" />
 		<info name="alt_title" value="スーパーレイドック" />
+		<info name="gtin" value="04988604030769"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA6228" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh532072" size="262144" crc="5dc45624" sha1="2dfbca8f5cc3a9e9d151382ebe0da410f5393eaf" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh532072" size="0x40000" crc="5dc45624" sha1="2dfbca8f5cc3a9e9d151382ebe0da410f5393eaf" />
 			</dataarea>
 		</part>
 	</software>
@@ -1013,8 +1050,8 @@ kept for now until finding out what those bytes affect...
             <feature name="pcb" value="TA6228" />
             <feature name="slot" value="ascii8" />
             <feature name="mapper" value="M60002-0125SP" />
-            <dataarea name="rom" size="262144">
-                <rom name="lh532045" size="262144" crc="" sha1="" status="nodump" />
+            <dataarea name="rom" size="0x40000">
+                <rom name="lh532045" size="0x40000" crc="" sha1="" status="nodump" />
             </dataarea>
         </part>
     </software>
@@ -1030,8 +1067,8 @@ kept for now until finding out what those bytes affect...
 			<feature name="pcb" value="1M-16KB" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="MR6401" />
-			<dataarea name="rom" size="131072">
-				<rom name="lh23106j" size="131072" crc="f00b4bbc" sha1="0d2f86dbb70f4b4a4e4dc1bc95df232f48856037" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="lh23106j" size="0x20000" crc="f00b4bbc" sha1="0d2f86dbb70f4b4a4e4dc1bc95df232f48856037" />
 			</dataarea>
 		</part>
 	</software>
@@ -1046,8 +1083,8 @@ kept for now until finding out what those bytes affect...
             <feature name="pcb" value="TAS-1M-008S" />
             <feature name="slot" value="ascii8" />
             <feature name="mapper" value="LZ93A13" />
-            <dataarea name="rom" size="131072">
-                <rom name="m5m27512p" size="131072" crc="" sha1="" status="nodump" />
+            <dataarea name="rom" size="0x20000">
+                <rom name="m5m27512p" size="0x20000" crc="" sha1="" status="nodump" />
             </dataarea>
         </part>
     </software>
@@ -1063,26 +1100,27 @@ kept for now until finding out what those bytes affect...
             <feature name="pcb" value="TAS-2M008-E2M" />
             <feature name="slot" value="ascii8" />
             <feature name="mapper" value="LZ93A13" />
-            <dataarea name="rom" size="262144">
-                <rom name="m5m27512p" size="131072" crc="" sha1="" status="nodump" />
-                <rom name="a27512zb" size="65536" crc="" sha1="" offset="0x20000" status="nodump" />
+            <dataarea name="rom" size="0x40000">
+                <rom name="m5m27512p" size="0x20000" crc="" sha1="" status="nodump" />
+                <rom name="a27512zb" size="0x10000" crc="" sha1="" offset="0x20000" status="nodump" />
             </dataarea>
         </part>
     </software>
 -->
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="tsumego">
 		<description>Tsumego 120 (Japan)</description>
 		<year>1987</year>
 		<publisher>Champion Soft</publisher>
+		<info name="serial" value="MXCP-11006"/>
 		<info name="alt_title" value="詰碁120" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="rp231024d" size="131072" crc="b9b69a43" sha1="bfe8046f8ccc6d6016d7752c04f0654420ef81e7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rp231024d" size="0x20000" crc="b9b69a43" sha1="bfe8046f8ccc6d6016d7752c04f0654420ef81e7" />
 			</dataarea>
 		</part>
 	</software>
@@ -1097,8 +1135,8 @@ kept for now until finding out what those bytes affect...
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="rp231024d" size="131072" crc="fea70207" sha1="4340a2580c949d498d2c8e71699fff860214e9ea" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rp231024d" size="0x20000" crc="fea70207" sha1="4340a2580c949d498d2c8e71699fff860214e9ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -1108,12 +1146,14 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Enix</publisher>
 		<info name="alt_title" value="ウイングマン2 キータクラーの復活" />
+		<info name="serial" value="E-G191"/>
+		<info name="gtin" value="04988601001915"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="enix wing2 rp231024d 0408" size="131072" crc="5c9d8f62" sha1="818d91505ad39bba2eaf7f4857c7d41e95fcb233" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="enix wing2 rp231024d 0408" size="0x20000" crc="5c9d8f62" sha1="818d91505ad39bba2eaf7f4857c7d41e95fcb233" />
 			</dataarea>
 		</part>
 	</software>
@@ -1128,10 +1168,10 @@ kept for now until finding out what those bytes affect...
 			<feature name="pcb" value="TA-621 KAGA" />
 			<feature name="slot" value="ascii8_sram" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="262144">
-				<rom name="lh532051" size="262144" crc="d640deaf" sha1="6c1814c70d69a50ec60e39ef281f0b8cd7bf8598" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="lh532051" size="0x40000" crc="d640deaf" sha1="6c1814c70d69a50ec60e39ef281f0b8cd7bf8598" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -1142,12 +1182,13 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pack-In-Video</publisher>
 		<info name="serial" value="MS-7" />
 		<info name="alt_title" value="ヤングシャーロック・ドイルの遺産" />
+		<info name="gtin" value="04988110800078"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="MSX-2MX" />
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="BS6101" />
-			<dataarea name="rom" size="131072">
-				<rom name="rp231024d" size="131072" crc="bdf332f2" sha1="97e173dac64dbde7d6a60de7606cba0c860813db" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="rp231024d" size="0x20000" crc="bdf332f2" sha1="97e173dac64dbde7d6a60de7606cba0c860813db" />
 			</dataarea>
 		</part>
 	</software>
@@ -1163,9 +1204,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Irem</publisher>
 		<info name="serial" value="IM-02" />
 		<info name="alt_title" value="１０ヤードファイト" />
+		<info name="gtin" value="04988891300026"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="10-yard fight (japan).rom" size="32768" crc="4e20d256" sha1="33536dac686b375ba13faf76a3baf2d6978904e0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="10-yard fight (japan).rom" size="0x8000" crc="4e20d256" sha1="33536dac686b375ba13faf76a3baf2d6978904e0" />
 			</dataarea>
 		</part>
 	</software>
@@ -1176,9 +1219,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Irem</publisher>
 		<info name="serial" value="IM-02" />
 		<info name="alt_title" value="１０ヤードファイト" />
+		<info name="gtin" value="04988891300026"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="10-yard fight (japan) (alt 1).rom" size="32768" crc="879e6ddb" sha1="fd15698518172bcde3318f08ee032531cbbb9f5d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="10-yard fight (japan) (alt 1).rom" size="0x8000" crc="879e6ddb" sha1="fd15698518172bcde3318f08ee032531cbbb9f5d" />
 			</dataarea>
 		</part>
 	</software>
@@ -1190,8 +1235,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="1942 (japan) (alt 1).rom" size="131072" crc="e54ee601" sha1="da397e783d677d1a78fff222d9d6cb48b915dada" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="1942 (japan) (alt 1).rom" size="0x20000" crc="e54ee601" sha1="da397e783d677d1a78fff222d9d6cb48b915dada" />
 			</dataarea>
 		</part>
 	</software>
@@ -1203,36 +1248,40 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="1942 (zemina).rom" size="131072" crc="10d97b9e" sha1="ba07b1b585386f887d4c7e457210b3fce819709a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="1942 (zemina).rom" size="0x20000" crc="10d97b9e" sha1="ba07b1b585386f887d4c7e457210b3fce819709a" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="3dgolf">
 		<description>3-D Golf Simulation (Japan)</description>
 		<year>1983</year>
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TEX-01" />
+		<info name="serial" value="MXTR11001"/>
 		<info name="alt_title" value="３Ｄゴルフシミュレーション" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="3-d golf simulation (japan).rom" size="16384" crc="0c989ad1" sha1="f8164d3872b5d54eaeafc6de3bb98a472f0c828d" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="3-d golf simulation (japan).rom" size="0x4000" crc="0c989ad1" sha1="f8164d3872b5d54eaeafc6de3bb98a472f0c828d" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="3dgolfa" cloneof="3dgolf">
 		<description>3-D Golf Simulation (Japan, alt)</description>
 		<year>1983</year>
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TEX-01" />
+		<info name="serial" value="MXTR11001"/>
 		<info name="alt_title" value="３Ｄゴルフシミュレーション" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="3-d golf simulation (japan) (alt 1).rom" size="16384" crc="f83d4b0d" sha1="6fe8c1725c35d85a5e489c0c8d21134def09ecfb" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="3-d golf simulation (japan) (alt 1).rom" size="0x4000" crc="f83d4b0d" sha1="6fe8c1725c35d85a5e489c0c8d21134def09ecfb" />
 			</dataarea>
 		</part>
 	</software>
@@ -1242,38 +1291,44 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TEX-01" />
+		<info name="serial" value="MXTR11005"/>
 		<info name="alt_title" value="３Ｄゴルフシミュレーション・高速版" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="3-d golf simulation (japan) (high speed).rom" size="16384" crc="cb935a50" sha1="9a63d48c4fc05e76c9de25e5c5f2a0c99b5d1be4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="3-d golf simulation (japan) (high speed).rom" size="0x4000" crc="cb935a50" sha1="9a63d48c4fc05e76c9de25e5c5f2a0c99b5d1be4" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="3dtennis">
 		<description>3D Tennis (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="３Ｄテニス" />
+		<info name="serial" value="00080"/>
+		<info name="isbn" value="4871489116"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="3d tennis (japan).rom" size="16384" crc="fb00f21b" sha1="8f71dddd429173df7ce52c5245af1a76b482a901" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="3d tennis (japan).rom" size="0x4000" crc="fb00f21b" sha1="8f71dddd429173df7ce52c5245af1a76b482a901" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
-	<software name="m36">
+	<!-- Software does not start. -->
+	<software name="m36" supported="no">
 		<description>A Life Planet - M36 - Mother Brain has been aliving (Japan)</description>
 		<year>1987</year>
 		<publisher>Pixel</publisher>
 		<info name="alt_title" value="生命惑星Ｍ３６生きていたマザーブレイン" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="m36 - a life planet (japan).rom" size="131072" crc="fa8f9bbc" sha1="6bde4e6761286a2909858ecef04155e17072996e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="m36 - a life planet (japan).rom" size="0x20000" crc="fa8f9bbc" sha1="6bde4e6761286a2909858ecef04155e17072996e" />
 			</dataarea>
 		</part>
 	</software>
@@ -1283,9 +1338,12 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>GA-Yume / HOT・B</publisher>
 		<info name="alt_title" value="ア・ナ・ザ" />
+		<info name="serial" value="MXHB21002"/>
+		<info name="gtin" value="04967948000027"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="anaza - kaleidoscope special (japan).rom" size="32768" crc="7dc880eb" sha1="27c40ec7013c1ad1f9a7e1ac1e0c8be99f1e703f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="anaza - kaleidoscope special (japan).rom" size="0x8000" crc="7dc880eb" sha1="27c40ec7013c1ad1f9a7e1ac1e0c8be99f1e703f" />
 			</dataarea>
 		</part>
 	</software>
@@ -1294,14 +1352,17 @@ kept for now until finding out what those bytes affect...
 		<description>A.E. (Japan)</description>
 		<year>1982</year>
 		<publisher>Toshiba EMI</publisher>
+		<info name="alt_title" value="エー・イー"/>
 		<info name="serial" value="PS-2001G" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="a.e. (japan).rom" size="16384" crc="2e1b3dd4" sha1="6b8a684ddbadd798a8e599449b823bceca9cdb58" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="a.e. (japan).rom" size="0x4000" crc="2e1b3dd4" sha1="6b8a684ddbadd798a8e599449b823bceca9cdb58" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Bundled with FS-JH1 steering wheel. -->
 	<software name="a1spirit">
 		<description>A1 Spirit - The Way to Formula-1 (Japan)</description>
 		<year>1987</year>
@@ -1309,8 +1370,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="a1 spirit - the way to formula-1 (japan).rom" size="131072" crc="2608c959" sha1="937464eb371c68add2236bcef91d24a8ce7c4ed1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="a1 spirit - the way to formula-1 (japan).rom" size="0x20000" crc="2608c959" sha1="937464eb371c68add2236bcef91d24a8ce7c4ed1" />
 			</dataarea>
 		</part>
 	</software>
@@ -1320,9 +1381,12 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="アクトマン" />
+		<info name="serial" value="20161"/>
+		<info name="isbn" value="4871488292"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="actman (japan).rom" size="16384" crc="e4dbcdbd" sha1="cb48969f27eaebf24c61f651399ec2433d85bcbc" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="actman (japan).rom" size="0x4000" crc="e4dbcdbd" sha1="cb48969f27eaebf24c61f651399ec2433d85bcbc" />
 			</dataarea>
 		</part>
 	</software>
@@ -1332,35 +1396,41 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="アクトマン" />
+		<info name="serial" value="20161"/>
+		<info name="isbn" value="4871488292"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="actman (japan) (alt 1).rom" size="16384" crc="7179a4bd" sha1="3ca4a1ab35b3cbe3ddb238ce88ca9df258ae37d6" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="actman (japan) (alt 1).rom" size="0x4000" crc="7179a4bd" sha1="3ca4a1ab35b3cbe3ddb238ce88ca9df258ae37d6" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="advenchu">
 		<description>Adven' Chuta! (Japan)</description>
 		<year>1983</year>
 		<publisher>MIA</publisher>
 		<info name="serial" value="MM-6, MX-X8" />
 		<info name="alt_title" value="アドベン・チュー太" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="adven' chuta (japan).rom" size="16384" crc="96e02df3" sha1="ae0c0b0c9468e137eba5b52f96241acd55d9746a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="adven' chuta (japan).rom" size="0x4000" crc="96e02df3" sha1="ae0c0b0c9468e137eba5b52f96241acd55d9746a" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="albatros"> <!-- +tape for extended course? -->
+	<!-- + 2 tapes for extended courses -->
+	<software name="albatros">
 		<description>Albatross (Japan)</description>
 		<year>1986</year>
 		<publisher>Nihon Telenet</publisher>
 		<info name="alt_title" value="アルバトロス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="albatros (japan).rom" size="32768" crc="847fc6e2" sha1="13d38cc80112baa9bcbf03569988c163015d434c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="albatros (japan).rom" size="0x8000" crc="847fc6e2" sha1="13d38cc80112baa9bcbf03569988c163015d434c" />
 			</dataarea>
 		</part>
 	</software>
@@ -1371,8 +1441,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Nihon Telenet</publisher>
 		<info name="alt_title" value="アルバトロス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="albatros (japan) (alt 1).rom" size="32768" crc="e27f41df" sha1="ec5111e3b06d64ef51196ff87448e1c62be4cdd8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="albatros (japan) (alt 1).rom" size="0x8000" crc="e27f41df" sha1="ec5111e3b06d64ef51196ff87448e1c62be4cdd8" />
 			</dataarea>
 		</part>
 	</software>
@@ -1383,12 +1454,13 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R48X5513" />
 		<info name="alt_title" value="アルカザール" />
+		<info name="gtin" value="04988013001091"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="alcazar - the forgotten fortress (japan).rom" size="16384" crc="3ee454b0" sha1="807676038cbba043b8099eba9c5840a4811a7e59" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="alcazar - the forgotten fortress (japan).rom" size="0x4000" crc="3ee454b0" sha1="807676038cbba043b8099eba9c5840a4811a7e59" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -1399,9 +1471,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R48X5513" />
 		<info name="alt_title" value="アルカザール" />
+		<info name="gtin" value="04988013001091"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="alcazar - the forgotten fortress (japan) (alt 1).rom" size="16384" crc="baf2c03c" sha1="f3815211c6183b4f9c26b9e7d0a12c3b3870bdda" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="alcazar - the forgotten fortress (japan) (alt 1).rom" size="0x4000" crc="baf2c03c" sha1="f3815211c6183b4f9c26b9e7d0a12c3b3870bdda" />
 			</dataarea>
 		</part>
 	</software>
@@ -1413,8 +1487,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G009C" />
 		<info name="alt_title" value="アリババと４０人の盗賊" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="alibaba and 40 thieves (japan).rom" size="16384" crc="2f72b1e3" sha1="639cb280544b060a618af23daf234a44baaf88de" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="alibaba and 40 thieves (japan).rom" size="0x4000" crc="2f72b1e3" sha1="639cb280544b060a618af23daf234a44baaf88de" />
 			</dataarea>
 		</part>
 	</software>
@@ -1426,8 +1501,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G009C" />
 		<info name="alt_title" value="アリババと４０人の盗賊" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="alibaba and 40 thieves (japan) (alt 1).rom" size="16384" crc="f1b90309" sha1="acc14e9886a3281b658dc458c1ae93fa9f24db04" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="alibaba and 40 thieves (japan) (alt 1).rom" size="0x4000" crc="f1b90309" sha1="acc14e9886a3281b658dc458c1ae93fa9f24db04" />
 			</dataarea>
 		</part>
 	</software>
@@ -1439,33 +1515,37 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G009C" />
 		<info name="alt_title" value="アリババと４０人の盗賊" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="alibaba and 40 thieves (japan) (alt 2).rom" size="16384" crc="f1d176ff" sha1="41b3b1830084ef00b61339c46c96bd0ef62cd6d3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="alibaba and 40 thieves (japan) (alt 2).rom" size="0x4000" crc="f1d176ff" sha1="41b3b1830084ef00b61339c46c96bd0ef62cd6d3" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="alien8">
 		<description>Alien 8 (Japan)</description>
-		<year>1987</year>
+		<year>1986</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="JX-13" />
 		<info name="alt_title" value="エイリアン８" />
+		<info name="gtin" value="04907859102090"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="alien 8 (japan).rom" size="32768" crc="93a25be1" sha1="5fb90be078e432db92dd39e621d12f612dbea4a8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="alien 8 (japan).rom" size="0x8000" crc="93a25be1" sha1="5fb90be078e432db92dd39e621d12f612dbea4a8" />
 			</dataarea>
 		</part>
 	</software>
 
-<!-- is this the tape version converted to ROM? -->
+<!-- is this the tape version converted to ROM? Has 1985 copyright. -->
 	<software name="alien8h" cloneof="alien8">
 		<description>Alien 8 (Japan, hacked?)</description>
 		<year>1985</year>
 		<publisher>A.C.G.</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="alien 8 (japan) (alt 1).rom" size="32768" crc="3b4ed316" sha1="3de0cea6a4575e631fee0db985e0f0f584761980" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="alien 8 (japan) (alt 1).rom" size="0x8000" crc="3b4ed316" sha1="3de0cea6a4575e631fee0db985e0f0f584761980" />
 			</dataarea>
 		</part>
 	</software>
@@ -1478,8 +1558,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="aliens - alien 2 (japan).rom" size="131072" crc="c6fc7bd7" sha1="5380e913d8dac23470446844cab21f6921101af8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="aliens - alien 2 (japan).rom" size="0x20000" crc="c6fc7bd7" sha1="5380e913d8dac23470446844cab21f6921101af8" />
 			</dataarea>
 		</part>
 	</software>
@@ -1492,8 +1572,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="aliens - alien 2 (japan) (alt 1).rom" size="131072" crc="a6e924ab" sha1="2639792df6f7c7cfaffc2616b0e1849f18897ace" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="aliens - alien 2 (japan) (alt 1).rom" size="0x20000" crc="a6e924ab" sha1="2639792df6f7c7cfaffc2616b0e1849f18897ace" />
 			</dataarea>
 		</part>
 	</software>
@@ -1506,8 +1586,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="aliens - alien 2 (japan) (alt 2).rom" size="131072" crc="3ddcb524" sha1="0d9c472cf7687b86f3fe2e5af6545a26a0efd5fc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="aliens - alien 2 (japan) (alt 2).rom" size="0x20000" crc="3ddcb524" sha1="0d9c472cf7687b86f3fe2e5af6545a26a0efd5fc" />
 			</dataarea>
 		</part>
 	</software>
@@ -1518,9 +1598,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5103" />
 		<info name="alt_title" value="アルファロイド" />
+		<info name="gtin" value="04988013007192"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="alpha roid (japan).rom" size="32768" crc="4ef7c4e7" sha1="97e7d0ee40c7d6ce1a8edf7b06e5014e6745cfda" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="alpha roid (japan).rom" size="0x8000" crc="4ef7c4e7" sha1="97e7d0ee40c7d6ce1a8edf7b06e5014e6745cfda" />
 			</dataarea>
 		</part>
 	</software>
@@ -1531,9 +1613,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5103" />
 		<info name="alt_title" value="アルファロイド" />
+		<info name="gtin" value="04988013007192"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="alpha roid (japan) (alt 1).rom" size="32768" crc="716dc9af" sha1="627e4d311dfe8a43a629e63f444a6f41eebad835" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="alpha roid (japan) (alt 1).rom" size="0x8000" crc="716dc9af" sha1="627e4d311dfe8a43a629e63f444a6f41eebad835" />
 			</dataarea>
 		</part>
 	</software>
@@ -1543,8 +1627,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="alfaroid.rom" size="32768" crc="4a79851b" sha1="092ad12c308dfc6d940ba8b1369b4931a4fd45e1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="alfaroid.rom" size="0x8000" crc="4a79851b" sha1="092ad12c308dfc6d940ba8b1369b4931a4fd45e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -1556,21 +1641,23 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G029C" />
 		<info name="alt_title" value="アルファスクアドロン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="alpha squadron (japan).rom" size="16384" crc="055254e0" sha1="1d81e6cc165b3330b9b3c8b4f4da0417b1ab901e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="alpha squadron (japan).rom" size="0x4000" crc="055254e0" sha1="1d81e6cc165b3330b9b3c8b4f4da0417b1ab901e" />
 			</dataarea>
 		</part>
 	</software>
 
-<!-- Controller problem in this set with left dir? -->
 	<software name="amtruck">
 		<description>American Truck (Japan)</description>
 		<year>1985</year>
 		<publisher>Nihon Telenet</publisher>
 		<info name="alt_title" value="アメリカントラック" />
+		<info name="usage" value="Remap joystick buttons so they do not conflict with cursor keys, or remove player 1 joystick. Otherwise moving to the left will not work."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="american truck (japan).rom" size="32768" crc="ee8bc1b7" sha1="076abc988d51faef30143750dd41318a8a48c5c4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="american truck (japan).rom" size="0x8000" crc="ee8bc1b7" sha1="076abc988d51faef30143750dd41318a8a48c5c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -1581,21 +1668,23 @@ kept for now until finding out what those bytes affect...
 		<publisher>Nihon Telenet</publisher>
 		<info name="alt_title" value="アメリカントラック" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="american truck (japan) (alt 1).rom" size="32768" crc="1dd9b4d9" sha1="88fa967c420f7090a11e5de1d3674f4527f53d52" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="american truck (japan) (alt 1).rom" size="0x8000" crc="1dd9b4d9" sha1="88fa967c420f7090a11e5de1d3674f4527f53d52" />
 			</dataarea>
 		</part>
 	</software>
 
-<!-- Controller problem in this set with left dir? -->
 	<software name="amtruckb" cloneof="amtruck">
 		<description>American Truck (Japan, alt 2)</description>
 		<year>1985</year>
 		<publisher>Nihon Telenet</publisher>
 		<info name="alt_title" value="アメリカントラック" />
+		<info name="usage" value="Remap joystick buttons so they do not conflict with cursor keys, or remove player 1 joystick. Otherwise moving to the left will not work."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="american truck (japan) (alt 2).rom" size="32768" crc="d9f1354b" sha1="fd6cc08d4842a85a3c741cf9c30883ddfc378895" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="american truck (japan) (alt 2).rom" size="0x8000" crc="d9f1354b" sha1="fd6cc08d4842a85a3c741cf9c30883ddfc378895" />
 			</dataarea>
 		</part>
 	</software>
@@ -1605,8 +1694,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="amtruck.rom" size="32768" crc="4a8b6848" sha1="e1c0aaf53501aff407c49b5332c7b5e3977317c3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="amtruck.rom" size="0x8000" crc="4a8b6848" sha1="e1c0aaf53501aff407c49b5332c7b5e3977317c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -1616,9 +1706,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="アンジェロ" />
+		<info name="serial" value="20160"/>
+		<info name="isbn" value="4871488284"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="angelo (japan).rom" size="16384" crc="20143ec7" sha1="a1abfc53a36d387b9f0687e3f5897c1ebdf21517" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="angelo (japan).rom" size="0x4000" crc="20143ec7" sha1="a1abfc53a36d387b9f0687e3f5897c1ebdf21517" />
 			</dataarea>
 		</part>
 	</software>
@@ -1628,9 +1721,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="アンジェロ" />
+		<info name="serial" value="20160"/>
+		<info name="isbn" value="4871488284"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="angelo (japan) (alt 1).rom" size="16384" crc="3d8d0f4b" sha1="3a4a65dc6d540297a7aae0a9914897aacf740807" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="angelo (japan) (alt 1).rom" size="0x4000" crc="3d8d0f4b" sha1="3a4a65dc6d540297a7aae0a9914897aacf740807" />
 			</dataarea>
 		</part>
 	</software>
@@ -1639,9 +1735,12 @@ kept for now until finding out what those bytes affect...
 		<description>Antarctic Adventure (Europe)</description>
 		<year>1984</year>
 		<publisher>Konami</publisher>
+		<info name="serial" value="RC701-X05"/>
+		<info name="serial" value="5500142"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="antarctic adventure (europe).rom" size="16384" crc="6b739c93" sha1="2185be579cb51729f66bf02bdf3a7b6a3cbd7b40" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="antarctic adventure (europe).rom" size="0x4000" crc="6b739c93" sha1="2185be579cb51729f66bf02bdf3a7b6a3cbd7b40" />
 			</dataarea>
 		</part>
 	</software>
@@ -1650,9 +1749,11 @@ kept for now until finding out what those bytes affect...
 		<description>Antarctic Adventure (Europe, alt)</description>
 		<year>1984</year>
 		<publisher>Konami</publisher>
+		<info name="serial" value="RC701"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="antarctic adventure (europe) (alt 1).rom" size="16384" crc="e8bddedd" sha1="44deaef747c572a4550681fcccc1bbbdc46a1ffc" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="antarctic adventure (europe) (alt 1).rom" size="0x4000" crc="e8bddedd" sha1="44deaef747c572a4550681fcccc1bbbdc46a1ffc" />
 			</dataarea>
 		</part>
 	</software>
@@ -1662,10 +1763,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC701" />
+		<info name="serial" value="5500029"/>
 		<info name="alt_title" value="けっきょく南極大冒険" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="antarctic adventure (japan).rom" size="16384" crc="aae7028b" sha1="e894a38f3e2ad435cc5d17a66600e6016b5e47fb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="antarctic adventure (japan).rom" size="0x4000" crc="aae7028b" sha1="e894a38f3e2ad435cc5d17a66600e6016b5e47fb" />
 			</dataarea>
 		</part>
 	</software>
@@ -1675,7 +1778,8 @@ kept for now until finding out what those bytes affect...
 		<year>19??</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
 				<rom name="antarctic adventure - japanese version (1984)(konami)[cr prosoft][rc-701].rom" size="16385" crc="8ced0683" sha1="63d3755c81b2c294ff3bd96cfb9f5a2f3d83b86c" status="baddump" />
 			</dataarea>
 		</part>
@@ -1686,9 +1790,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="アンティ" />
+		<info name="serial" value="20119"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="anty (japan).rom" size="16384" crc="b1ace0a0" sha1="f236345f43828597739f4a326318b6a3876ff73f" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="anty (japan).rom" size="0x4000" crc="b1ace0a0" sha1="f236345f43828597739f4a326318b6a3876ff73f" />
 			</dataarea>
 		</part>
 	</software>
@@ -1698,9 +1804,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="アンティ" />
+		<info name="serial" value="20119"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="anty (japan) (alt 1).rom" size="16384" crc="5baacb31" sha1="1a00eef3df449d71abf4be5a4c8d01ba9dcd6b79" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="anty (japan) (alt 1).rom" size="0x4000" crc="5baacb31" sha1="1a00eef3df449d71abf4be5a4c8d01ba9dcd6b79" />
 			</dataarea>
 		</part>
 	</software>
@@ -1710,10 +1818,12 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>Paxon</publisher>
 		<info name="alt_title" value="アクアポリスＳＯＳ" />
+		<info name="serial" value="ES-2001"/>
 		<info name="usage" value="Requires a machine with RAM in a main slot" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="aqua polis sos (japan).rom" size="16384" crc="f115257a" sha1="633cb458eeab0fea59a70a9a620b7783a44eb0a6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="aqua polis sos (japan).rom" size="0x4000" crc="f115257a" sha1="633cb458eeab0fea59a70a9a620b7783a44eb0a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -1723,9 +1833,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Toshiba EMI</publisher>
 		<info name="alt_title" value="アクゥアタック" />
+		<info name="serial" value="PS-2006G"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="aquattack (japan).rom" size="16384" crc="f3297895" sha1="93462ac9a322c2e5e0d996fddbe9eba2f3436931" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="aquattack (japan).rom" size="0x4000" crc="f3297895" sha1="93462ac9a322c2e5e0d996fddbe9eba2f3436931" />
 			</dataarea>
 		</part>
 	</software>
@@ -1735,57 +1847,67 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Sein Soft</publisher>
 		<info name="alt_title" value="アラモ" />
+		<info name="serial" value="MXZS-11002"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="aramo (japan).rom" size="32768" crc="ab6b56ba" sha1="ec53d72e41e114574f4c116cab19e1633f3da207" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="aramo (japan).rom" size="0x8000" crc="ab6b56ba" sha1="ec53d72e41e114574f4c116cab19e1633f3da207" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="arkanoid">
-		<description>Arkanoid (Europe?)</description>
+		<description>Arkanoid (Europe)</description>
 		<year>1986</year>
-		<publisher>Taito ~ Imagine</publisher>
-		<info name="alt_title" value="アルカノイド" />
+		<publisher>Imagine</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="arkanoid (japan) (alt 1).rom" size="32768" crc="4fd4f778" sha1="45ce64a455a2b07f3c8a6d541cda3b0e058cc732" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="arkanoid (japan) (alt 1).rom" size="0x8000" crc="4fd4f778" sha1="45ce64a455a2b07f3c8a6d541cda3b0e058cc732" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="arkanoida" cloneof="arkanoid">
-		<description>Arkanoid (Europe?, alt)</description>
+		<description>Arkanoid (Europe, alt)</description>
 		<year>1986</year>
-		<publisher>Taito ~ Imagine</publisher>
-		<info name="alt_title" value="アルカノイド" />
+		<publisher>Imagine</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="arkanoid (japan) (alt 3).rom" size="32768" crc="140a5965" sha1="5002ba598469b34af25bff5011ccc70ed3723b0d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="arkanoid (japan) (alt 3).rom" size="0x8000" crc="140a5965" sha1="5002ba598469b34af25bff5011ccc70ed3723b0d" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Released with controller -->
 	<software name="arkanoidj" cloneof="arkanoid">
 		<description>Arkanoid (Japan)</description>
 		<year>1986</year>
-		<publisher>Taito</publisher>
+		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="アルカノイド" />
+		<info name="serial" value="MSX10"/>
+		<info name="gtin" value="04988611860076"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="arkanoid (japan).rom" size="32768" crc="c9a22dfc" sha1="2183f07fa3ba87360100b2fa21fda0f55c0f8814" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="arkanoid (japan).rom" size="0x8000" crc="c9a22dfc" sha1="2183f07fa3ba87360100b2fa21fda0f55c0f8814" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Released with controller -->
 	<software name="arkanoidja" cloneof="arkanoid">
 		<description>Arkanoid (Japan, alt)</description>
 		<year>1986</year>
-		<publisher>Taito</publisher>
+		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="アルカノイド" />
+		<info name="serial" value="MSX10"/>
+		<info name="gtin" value="04988611860076"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="arkanoid (japan) (alt 2).rom" size="32768" crc="38a00d1b" sha1="e1527ae16d33a09d9cf3d4ea52e63337d2273910" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="arkanoid (japan) (alt 2).rom" size="0x8000" crc="38a00d1b" sha1="e1527ae16d33a09d9cf3d4ea52e63337d2273910" />
 			</dataarea>
 		</part>
 	</software>
@@ -1795,12 +1917,14 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="arkanoid.rom" size="32768" crc="b62a0973" sha1="c30d7363fcfb38272ae927c684df1c52c7de1a72" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="arkanoid.rom" size="0x8000" crc="b62a0973" sha1="c30d7363fcfb38272ae927c684df1c52c7de1a72" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx only lists a cassette release for this title. -->
 	<software name="amc">
 		<description>Astro Marine Corps (Spain)</description>
 		<year>1989</year>
@@ -1808,8 +1932,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="astro marine corps (1989)(dinamic software)(es).rom" size="131072" crc="60f99d30" sha1="72815a7213f899a454bcf76733834ba499d35cd8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="astro marine corps (1989)(dinamic software)(es).rom" size="0x20000" crc="60f99d30" sha1="72815a7213f899a454bcf76733834ba499d35cd8" />
 			</dataarea>
 		</part>
 	</software>
@@ -1819,9 +1943,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="アスレチックボール" />
+		<info name="serial" value="20117"/>
+		<info name="isbn" value="4871489760"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="athletic ball (japan).rom" size="16384" crc="11bac0e6" sha1="fbe43d67a5bc0aedb2e194a4e5f9497b7488362b" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="athletic ball (japan).rom" size="0x4000" crc="11bac0e6" sha1="fbe43d67a5bc0aedb2e194a4e5f9497b7488362b" />
 			</dataarea>
 		</part>
 	</software>
@@ -1833,8 +1960,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC700" />
 		<info name="alt_title" value="わんぱくアスレチック (Wanpaku Athletic)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="athletic land (japan).rom" size="16384" crc="7b1acdea" sha1="90bdd12d632d2e909ac5d69235ad0366f430b734" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="athletic land (japan).rom" size="0x4000" crc="7b1acdea" sha1="90bdd12d632d2e909ac5d69235ad0366f430b734" />
 			</dataarea>
 		</part>
 	</software>
@@ -1846,8 +1974,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC700" />
 		<info name="alt_title" value="わんぱくアスレチック (Wanpaku Athletic)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="athletic land (japan) (alt 1).rom" size="16384" crc="d14361b2" sha1="866cb3ab10f17e4fb356fbd7277bbf17c4e27ebe" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="athletic land (japan) (alt 1).rom" size="0x4000" crc="d14361b2" sha1="866cb3ab10f17e4fb356fbd7277bbf17c4e27ebe" />
 			</dataarea>
 		</part>
 	</software>
@@ -1857,12 +1986,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Konami</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<!-- Mirroring not verified -->
-				<rom name="athletic land (japan) (beta).rom" size="16384" crc="e4a428b5" sha1="de9eb0e9ef183f49e9d9b631f8818f9cac5df409" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<!-- Mirroring not verified. ROM needs to be present at 0x0000-0xbfff for the software to work. -->
+				<rom name="athletic land (japan) (beta).rom" size="0x4000" crc="e4a428b5" sha1="de9eb0e9ef183f49e9d9b631f8818f9cac5df409" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -1872,9 +2001,11 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Pax Softonica</publisher>
 		<info name="alt_title" value="アタックフォー" />
+		<info name="serial" value="PS-8001?"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="attack four volley ball (japan).rom" size="32768" crc="7fdf81e9" sha1="c5f1897c416f62cd58cd6257282e3428155cd698" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="attack four volley ball (japan).rom" size="0x8000" crc="7fdf81e9" sha1="c5f1897c416f62cd58cd6257282e3428155cd698" />
 			</dataarea>
 		</part>
 	</software>
@@ -1886,8 +2017,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2015G" />
 		<info name="alt_title" value="B.C.'s Quest for Tires" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b.c.'s quest (japan).rom" size="32768" crc="9c9420d0" sha1="4c8a97669017296c2360ff9d53694a292197991e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b.c.'s quest (japan).rom" size="0x8000" crc="9c9420d0" sha1="4c8a97669017296c2360ff9d53694a292197991e" />
 			</dataarea>
 		</part>
 	</software>
@@ -1900,8 +2032,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2015G" />
 		<info name="alt_title" value="B.C.'s Quest for Tires" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b.c.'s quest (japan) (alt 1).rom" size="32768" crc="e2400f55" sha1="0d504c359661ac731de07a7319afd0e31f01a5d7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b.c.'s quest (japan) (alt 1).rom" size="0x8000" crc="e2400f55" sha1="0d504c359661ac731de07a7319afd0e31f01a5d7" />
 			</dataarea>
 		</part>
 	</software>
@@ -1912,9 +2045,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5090" />
 		<info name="alt_title" value="バックトゥザフューチャー" />
+		<info name="gtin" value="04988013001695"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="back to the future (japan).rom" size="32768" crc="dbdb64ac" sha1="469b07eef08348c9acc14e63ba0cd35aef236983" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="back to the future (japan).rom" size="0x8000" crc="dbdb64ac" sha1="469b07eef08348c9acc14e63ba0cd35aef236983" />
 			</dataarea>
 		</part>
 	</software>
@@ -1925,9 +2060,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5090" />
 		<info name="alt_title" value="バックトゥザフューチャー" />
+		<info name="gtin" value="04988013001695"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="back to the future (japan) (alt 1).rom" size="32768" crc="795c7aa1" sha1="1a6a751334c663fbfdf93f617a7d779f76f488ce" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="back to the future (japan) (alt 1).rom" size="0x8000" crc="795c7aa1" sha1="1a6a751334c663fbfdf93f617a7d779f76f488ce" />
 			</dataarea>
 		</part>
 	</software>
@@ -1939,8 +2076,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G023C" />
 		<info name="alt_title" value="バックギャモン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="back gammon (japan).rom" size="16384" crc="b632b6bb" sha1="2b8878609bcc0d1555ae250d621ba6e9df4afc52" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="back gammon (japan).rom" size="0x4000" crc="b632b6bb" sha1="2b8878609bcc0d1555ae250d621ba6e9df4afc52" />
 			</dataarea>
 		</part>
 	</software>
@@ -1952,8 +2090,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G023C" />
 		<info name="alt_title" value="バックギャモン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="back gammon (japan) (alt 1).rom" size="16384" crc="70c79a87" sha1="c345357e71d1b8f2c9663bf28abb5a3a2957d49f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="back gammon (japan) (alt 1).rom" size="0x4000" crc="70c79a87" sha1="c345357e71d1b8f2c9663bf28abb5a3a2957d49f" />
 			</dataarea>
 		</part>
 	</software>
@@ -1965,8 +2104,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-101" />
 		<info name="alt_title" value="バラン数" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="balance (japan).rom" size="8192" crc="cdabd75b" sha1="cd452442338366411f6b24739fe59e20f3ac24dc" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="balance (japan).rom" size="0x2000" crc="cdabd75b" sha1="cd452442338366411f6b24739fe59e20f3ac24dc" />
 			</dataarea>
 		</part>
 	</software>
@@ -1978,8 +2118,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-101" />
 		<info name="alt_title" value="バラン数" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="balance (japan) (alt 1).rom" size="8192" crc="336fdcd9" sha1="6d73ee99ac367a2558fd9366af75ad39ed0d4e69" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="balance (japan) (alt 1).rom" size="0x2000" crc="336fdcd9" sha1="6d73ee99ac367a2558fd9366af75ad39ed0d4e69" />
 			</dataarea>
 		</part>
 	</software>
@@ -1991,8 +2132,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-101" />
 		<info name="alt_title" value="バラン数" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="balance (japan) (alt 2).rom" size="16384" crc="86ea609d" sha1="134a6faf1592978608b55269aea101d5fad68760" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="balance (japan) (alt 2).rom" size="0x4000" crc="86ea609d" sha1="134a6faf1592978608b55269aea101d5fad68760" />
 			</dataarea>
 		</part>
 	</software>
@@ -2004,8 +2146,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-101" />
 		<info name="alt_title" value="バラン数" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="balance (japan) (alt 3).rom" size="16384" crc="d8349993" sha1="28323e06a402747a1e131dc30ce031a339f6c947" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="balance (japan) (alt 3).rom" size="0x4000" crc="d8349993" sha1="28323e06a402747a1e131dc30ce031a339f6c947" />
 			</dataarea>
 		</part>
 	</software>
@@ -2017,8 +2160,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-101" />
 		<info name="alt_title" value="バラン数" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="balance (japan) (alt 4).rom" size="8192" crc="6db125d7" sha1="b103d4248729aeda9ebf5766c1791b1950246968" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="balance (japan) (alt 4).rom" size="0x2000" crc="6db125d7" sha1="b103d4248729aeda9ebf5766c1791b1950246968" />
 			</dataarea>
 		</part>
 	</software>
@@ -2028,8 +2172,9 @@ kept for now until finding out what those bytes affect...
 		<year>19??</year>
 		<publisher>Studio GEN</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="banana (japan).rom" size="16384" crc="6aa7cbe0" sha1="7a40237867f62611d0e976666451648edb80753c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="banana (japan).rom" size="0x4000" crc="6aa7cbe0" sha1="7a40237867f62611d0e976666451648edb80753c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2040,9 +2185,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5807" />
 		<info name="alt_title" value="バンクパニック" />
+		<info name="gtin" value="04988013004399"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bank panic (japan).rom" size="32768" crc="d5e18df0" sha1="b0956b97c9087aabab333c271c7afd9754ae84cd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="bank panic (japan).rom" size="0x8000" crc="d5e18df0" sha1="b0956b97c9087aabab333c271c7afd9754ae84cd" />
 			</dataarea>
 		</part>
 	</software>
@@ -2053,9 +2200,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5807" />
 		<info name="alt_title" value="バンクパニック" />
+		<info name="gtin" value="04988013004399"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bank panic (japan) (alt 1).rom" size="32768" crc="a0a844ca" sha1="b337ea56278523f984d1b000cd00f339d82017a0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="bank panic (japan) (alt 1).rom" size="0x8000" crc="a0a844ca" sha1="b337ea56278523f984d1b000cd00f339d82017a0" />
 			</dataarea>
 		</part>
 	</software>
@@ -2065,36 +2214,39 @@ kept for now until finding out what those bytes affect...
 		<year>19??</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bank panic (1985)(pony canyon)[cr prosoft].rom" size="32768" crc="70160fe9" sha1="5ed42deb02556f93024b7911b4ac17c6469a8340" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="bank panic (1985)(pony canyon)[cr prosoft].rom" size="0x8000" crc="70160fe9" sha1="5ed42deb02556f93024b7911b4ac17c6469a8340" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="basicnyu">
 		<description>Basic Nyuumon (Japan)</description>
 		<year>1984</year>
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-502" />
 		<info name="alt_title" value="ＢＡＳＩＣ入門" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="basic lessons 1 (japan).rom" size="32768" crc="ee0a750e" sha1="9f0cbb1191235ecca4985de976a0993744b57930" offset="0x4000" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="basic lessons 1 (japan).rom" size="0x8000" crc="ee0a750e" sha1="9f0cbb1191235ecca4985de976a0993744b57930" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="basicny2">
 		<description>BASIC Nyuumon II - Programming-hen (Japan)</description>
 		<year>1985</year>
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-505" />
 		<info name="alt_title" value="ＢＡＳＩＣ入門 II" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="basic lessons 2 (japan).rom" size="32768" crc="13014324" sha1="01cf858888f5a0d3aee08f42a66c515ab0d06400" offset="0x4000" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="basic lessons 2 (japan).rom" size="0x8000" crc="13014324" sha1="01cf858888f5a0d3aee08f42a66c515ab0d06400" />
 			</dataarea>
 		</part>
 	</software>
@@ -2104,53 +2256,58 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Pack-In-Video</publisher>
 		<info name="alt_title" value="バットマン" />
+		<info name="serial" value="MS-13"/>
+		<info name="gtin" value="04988110800139"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="65536">
-				<rom name="batman (japan).rom" size="65536" crc="637f0494" sha1="709fb35338f21897e275237cc4c5615d0a5c2753" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="batman (japan).rom" size="0x10000" crc="637f0494" sha1="709fb35338f21897e275237cc4c5615d0a5c2753" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="btanuki">
 		<description>Batten Tanuki no Daibouken (Japan, v1.03)</description>
 		<year>1986</year>
 		<publisher>Tecno Soft</publisher>
 		<info name="serial" value="MXTJ-11002" />
 		<info name="alt_title" value="ばってんタヌキの大冒険" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="batten tanuki no daibouken (japan) (v1.03).rom" size="32768" crc="eba0738d" sha1="9b58c70b976ca1d841185de862e7d663ec9db56b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="batten tanuki no daibouken (japan) (v1.03).rom" size="0x8000" crc="eba0738d" sha1="9b58c70b976ca1d841185de862e7d663ec9db56b" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="btanukia" cloneof="btanuki">
 		<description>Batten Tanuki no Daibouken (Japan)</description>
 		<year>1986</year>
 		<publisher>Tecno Soft</publisher>
 		<info name="serial" value="MXTJ-11002" />
 		<info name="alt_title" value="ばってんタヌキの大冒険" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="batten tanuki no daibouken (japan) (alt 1).rom" size="32768" crc="e403ebea" sha1="f86a7945b34c97cc58d5ee27964968870bfcef93" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="batten tanuki no daibouken (japan) (alt 1).rom" size="0x8000" crc="e403ebea" sha1="f86a7945b34c97cc58d5ee27964968870bfcef93" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="btanukib" cloneof="btanuki">
 		<description>Batten Tanuki no Daibouken (Japan, alt)</description>
 		<year>1986</year>
 		<publisher>Tecno Soft</publisher>
 		<info name="serial" value="MXTJ-11002" />
 		<info name="alt_title" value="ばってんタヌキの大冒険" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="batten tanuki no daibouken (japan) (alt 2).rom" size="32768" crc="42262bd4" sha1="ee7dbd36a2b0bbae11c68ac4de75077f283bed05" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="batten tanuki no daibouken (japan) (alt 2).rom" size="0x8000" crc="42262bd4" sha1="ee7dbd36a2b0bbae11c68ac4de75077f283bed05" />
 			</dataarea>
 		</part>
 	</software>
@@ -2162,8 +2319,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G005C" />
 		<info name="alt_title" value="バトルクロス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="battle cross (japan).rom" size="16384" crc="25e675ea" sha1="8b63f36be31d7d021c19103ebe8c68b69aae699c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="battle cross (japan).rom" size="0x4000" crc="25e675ea" sha1="8b63f36be31d7d021c19103ebe8c68b69aae699c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2175,8 +2333,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="TEX-03" />
 		<info name="alt_title" value="バトルシップ・クラプトンII" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="battleship clapton ii (japan).rom" size="8192" crc="85f4767b" sha1="59bc608b1cb5bde2230bca0eb045cd6c58650774" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="battleship clapton ii (japan).rom" size="0x2000" crc="85f4767b" sha1="59bc608b1cb5bde2230bca0eb045cd6c58650774" />
 			</dataarea>
 		</part>
 	</software>
@@ -2188,19 +2347,22 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="TEX-03" />
 		<info name="alt_title" value="バトルシップ・クラプトンII" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="battleship clapton ii (japan) (alt 1).rom" size="16384" crc="2de725a3" sha1="0f214ea9e8d673ee0c66cb6615032e57920d588b" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="battleship clapton ii (japan) (alt 1).rom" size="0x4000" crc="2de725a3" sha1="0f214ea9e8d673ee0c66cb6615032e57920d588b" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx does not list a cartridge release? -->
 	<software name="beachead">
 		<description>Beach-Head (Europe)</description>
 		<year>19??</year>
 		<publisher>Access Software?</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="beach-head (europe).rom" size="32768" crc="785fa4cc" sha1="1bdb1898796e2b48b62a356035192b163113962c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="beach-head (europe).rom" size="0x8000" crc="785fa4cc" sha1="1bdb1898796e2b48b62a356035192b163113962c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2212,53 +2374,56 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5502" />
 		<info name="alt_title" value="ビームライダー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="beam rider (japan) (alt 1).rom" size="16384" crc="d6a6bee6" sha1="f51f936887498d21f6ee9fe8a7701633be67e79d" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="beam rider (japan) (alt 1).rom" size="0x4000" crc="d6a6bee6" sha1="f51f936887498d21f6ee9fe8a7701633be67e79d" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="becky">
 		<description>Becky (Japan)</description>
 		<year>1983</year>
 		<publisher>MIA</publisher>
 		<info name="serial" value="MM-3, MX-X3" />
 		<info name="alt_title" value="おてんばベッキーの大冒険 (Otenba Becky no Daibouken)" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="becky (japan).rom" size="16384" crc="a580b72a" sha1="d69d4a6f2834b20df3a2afbd7a927220e96e31e1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="becky (japan).rom" size="0x4000" crc="a580b72a" sha1="d69d4a6f2834b20df3a2afbd7a927220e96e31e1" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="beckya" cloneof="becky">
 		<description>Becky (Japan, alt)</description>
 		<year>1983</year>
 		<publisher>MIA</publisher>
 		<info name="serial" value="MM-3, MX-X3" />
 		<info name="alt_title" value="おてんばベッキーの大冒険 (Otenba Becky no Daibouken)" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="becky (japan) (alt 1).rom" size="16384" crc="d062ad02" sha1="702d8f1762d4efe994f520e21e8867adae13b817" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="becky (japan) (alt 1).rom" size="0x4000" crc="d062ad02" sha1="702d8f1762d4efe994f520e21e8867adae13b817" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="beckyb" cloneof="becky">
 		<description>Becky (Japan, alt 2)</description>
 		<year>1983</year>
 		<publisher>MIA</publisher>
 		<info name="serial" value="MM-3, MX-X3" />
 		<info name="alt_title" value="おてんばベッキーの大冒険 (Otenba Becky no Daibouken)" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="becky (japan) (alt 2).rom" size="16384" crc="14156258" sha1="01ebdd5981c4841abddf6f76eb1f73e237e7688f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="becky (japan) (alt 2).rom" size="0x4000" crc="14156258" sha1="01ebdd5981c4841abddf6f76eb1f73e237e7688f" />
 			</dataarea>
 		</part>
 	</software>
@@ -2266,11 +2431,13 @@ kept for now until finding out what those bytes affect...
 	<software name="beeflowr">
 		<description>Bee &amp; Flower (Japan)</description>
 		<year>1983</year>
-		<publisher>Reizon</publisher>
+		<publisher>National</publisher>
+		<info name="serial" value="CF-SS029"/>
 		<info name="usage" value="Requires a machine with RAM in a main slot" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="bee &amp; flower (japan).rom" size="16384" crc="0ad3707d" sha1="3197d73a5400a72420f91def6d3aa8bdcb392754" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="bee &amp; flower (japan).rom" size="0x4000" crc="0ad3707d" sha1="3197d73a5400a72420f91def6d3aa8bdcb392754" />
 			</dataarea>
 		</part>
 	</software>
@@ -2278,10 +2445,12 @@ kept for now until finding out what those bytes affect...
 	<software name="beeflowra" cloneof="beeflowr">
 		<description>Bee &amp; Flower (Japan, alt)</description>
 		<year>1983</year>
-		<publisher>Reizon</publisher>
+		<publisher>National</publisher>
+		<info name="serial" value="CF-SS029"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="bee &amp; flower (japan) (alt 1).rom" size="16384" crc="36fc4792" sha1="250d4c7c6565b0c4935f6301e8de2c182e659fd0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="bee &amp; flower (japan) (alt 1).rom" size="0x4000" crc="36fc4792" sha1="250d4c7c6565b0c4935f6301e8de2c182e659fd0" />
 			</dataarea>
 		</part>
 	</software>
@@ -2289,10 +2458,12 @@ kept for now until finding out what those bytes affect...
 	<software name="beeflowrb" cloneof="beeflowr">
 		<description>Bee &amp; Flower (Japan, alt 2)</description>
 		<year>1983</year>
-		<publisher>Reizon</publisher>
+		<publisher>National</publisher>
+		<info name="serial" value="CF-SS029"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="bee &amp; flower (japan) (alt 2).rom" size="16384" crc="cf2335c7" sha1="a2de457567e87c794fba8e35c992eac352da78be" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="bee &amp; flower (japan) (alt 2).rom" size="0x4000" crc="cf2335c7" sha1="a2de457567e87c794fba8e35c992eac352da78be" />
 			</dataarea>
 		</part>
 	</software>
@@ -2302,27 +2473,31 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Casio</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="casio_basic.rom" size="32768" crc="2181a21d" sha1="c48a68db822d9bded56ee1df55d18b81fbe135b7" offset="0x4000" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="casio_basic.rom" size="0x8000" crc="2181a21d" sha1="c48a68db822d9bded56ee1df55d18b81fbe135b7" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="blckonyx">
 		<description>The Black Onyx (Japan)</description>
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ブラックオニキス" />
+		<info name="serial" value="2016801"/>
+		<info name="isbn" value="4871488411"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="black onyx, the (japan).rom" size="32768" crc="e258c032" sha1="5400c0c929b31a70e76aac676b91d40445f1b427" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="black onyx, the (japan).rom" size="0x8000" crc="e258c032" sha1="5400c0c929b31a70e76aac676b91d40445f1b427" />
 			</dataarea>
 		</part>
 	</software>
 
 <!-- This was labeled as Europe Converted from Tape, but I haven't found any proof to support this -->
-<!-- It might be anyway, since the dump does not work properly on Jpn machines... -->
+<!-- It might be anyway, since the dump does not work properly on Japanese machines (keeps resetting) -->
 <!-- Investigate -->
 	<software name="blagger">
 		<description>Blagger MSX (Japan)</description>
@@ -2330,8 +2505,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>MicroCabin</publisher>
 		<info name="alt_title" value="ブラッガー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="blagger.rom" size="32768" crc="50475a7c" sha1="65af16d35b8d8454ec07718e9f8948335ca73bad" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="blagger.rom" size="0x8000" crc="50475a7c" sha1="65af16d35b8d8454ec07718e9f8948335ca73bad" />
 			</dataarea>
 		</part>
 	</software>
@@ -2342,8 +2518,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="serial" value="0226" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="block hole (korea) (unl).rom" size="32768" crc="824ae486" sha1="8e3e05e8928b5b77fa61f3b833e164bf5222a5fb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="block hole (korea) (unl).rom" size="0x8000" crc="824ae486" sha1="8e3e05e8928b5b77fa61f3b833e164bf5222a5fb" />
 			</dataarea>
 		</part>
 	</software>
@@ -2355,8 +2532,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2010G" />
 		<info name="alt_title" value="ブロッケードランナー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="blockade runner (japan).rom" size="16384" crc="8334b431" sha1="bd4b8c48f1d8107f11ae680a787d7b3825669b7c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="blockade runner (japan).rom" size="0x4000" crc="8334b431" sha1="bd4b8c48f1d8107f11ae680a787d7b3825669b7c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2364,11 +2542,13 @@ kept for now until finding out what those bytes affect...
 	<software name="boggy84">
 		<description>Boggy '84 (Japan)</description>
 		<year>1984</year>
-		<publisher>Nihon Columbia</publisher>
+		<publisher>Colpax</publisher>
 		<info name="alt_title" value="ボギー’８４" />
+		<info name="serial" value="48C99-1003"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="boggy '84 (japan).rom" size="8192" crc="ec089246" sha1="5c96169207e197237aa728d8ce4e24c0635d5904" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="boggy '84 (japan).rom" size="0x2000" crc="ec089246" sha1="5c96169207e197237aa728d8ce4e24c0635d5904" />
 			</dataarea>
 		</part>
 	</software>
@@ -2376,11 +2556,13 @@ kept for now until finding out what those bytes affect...
 	<software name="boggy84a" cloneof="boggy84">
 		<description>Boggy '84 (Japan, alt)</description>
 		<year>1984</year>
-		<publisher>Nihon Columbia</publisher>
+		<publisher>Colpax</publisher>
 		<info name="alt_title" value="ボギー’８４" />
+		<info name="serial" value="48C99-1003"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="boggy '84 (japan) (alt 1).rom" size="16384" crc="22e8b312" sha1="e2ef32f2fc312f96b8424569e9e85a6ea3b21ce4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="boggy '84 (japan) (alt 1).rom" size="0x4000" crc="22e8b312" sha1="e2ef32f2fc312f96b8424569e9e85a6ea3b21ce4" />
 			</dataarea>
 		</part>
 	</software>
@@ -2388,11 +2570,13 @@ kept for now until finding out what those bytes affect...
 	<software name="boggy84b" cloneof="boggy84">
 		<description>Boggy '84 (Japan, alt 2)</description>
 		<year>1984</year>
-		<publisher>Nihon Columbia</publisher>
+		<publisher>Colpax</publisher>
 		<info name="alt_title" value="ボギー’８４" />
+		<info name="serial" value="48C99-1003"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="boggy '84 (japan) (alt 2).rom" size="8192" crc="a4bf1253" sha1="04283ae02107917da6f54a0f38d3a28254f7ab69" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="boggy '84 (japan) (alt 2).rom" size="0x2000" crc="a4bf1253" sha1="04283ae02107917da6f54a0f38d3a28254f7ab69" />
 			</dataarea>
 		</part>
 	</software>
@@ -2403,8 +2587,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Sony Spain</publisher>
 		<info name="serial" value="HBS-IDE03" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="boing boing (spain).rom" size="8192" crc="f44e7fcd" sha1="d7e2a4f78b3e240309c6367ac9dd9c9aeb95e3ee" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="boing boing (spain).rom" size="0x2000" crc="f44e7fcd" sha1="d7e2a4f78b3e240309c6367ac9dd9c9aeb95e3ee" />
 			</dataarea>
 		</part>
 	</software>
@@ -2416,8 +2601,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="20116" />
 		<info name="alt_title" value="ボコスカウォーズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="bokosuka wars (japan).rom" size="16384" crc="dd6d9aad" sha1="e5171c368883de03fc8d75e61bf23d954ec1bba4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="bokosuka wars (japan).rom" size="0x4000" crc="dd6d9aad" sha1="e5171c368883de03fc8d75e61bf23d954ec1bba4" />
 			</dataarea>
 		</part>
 	</software>
@@ -2429,8 +2615,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="20116" />
 		<info name="alt_title" value="ボコスカウォーズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="bokosuka wars (japan) (alt 1).rom" size="16384" crc="93b8917a" sha1="5503d23faf94f076410d252f69f6bf5ece4da292" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="bokosuka wars (japan) (alt 1).rom" size="0x4000" crc="93b8917a" sha1="5503d23faf94f076410d252f69f6bf5ece4da292" />
 			</dataarea>
 		</part>
 	</software>
@@ -2441,11 +2628,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="XR-1043" />
 		<info name="alt_title" value="ボンバーキング" />
+		<info name="gtin" value="04988607102821"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="bomber king (japan).rom" size="131072" crc="8cf0e6c0" sha1="482cd650220e6931f85ee8532c61dac561365e30" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="bomber king (japan).rom" size="0x20000" crc="8cf0e6c0" sha1="482cd650220e6931f85ee8532c61dac561365e30" />
 			</dataarea>
 		</part>
 	</software>
@@ -2455,9 +2643,11 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="alt_title" value="ボンバーマン" />
+		<info name="serial" value="MXHI 11005"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="bomber man (japan).rom" size="8192" crc="9a5aef05" sha1="5324e053709ff8da6c18ae4afba6a2e0c3a722ba" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="bomber man (japan).rom" size="0x2000" crc="9a5aef05" sha1="5324e053709ff8da6c18ae4afba6a2e0c3a722ba" />
 			</dataarea>
 		</part>
 	</software>
@@ -2468,8 +2658,9 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Korea Soft Bank</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="bomber man (1986)(korea soft bank).rom" size="16384" crc="3df1f56f" sha1="64781236e70cf5dd530a420305533ff55db0e4ad" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="bomber man (1986)(korea soft bank).rom" size="0x4000" crc="3df1f56f" sha1="64781236e70cf5dd530a420305533ff55db0e4ad" />
 			</dataarea>
 		</part>
 	</software>
@@ -2479,8 +2670,9 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Korea Soft Bank</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="bomber man (1986)(korea soft bank)[a].rom" size="8192" crc="c9a2c37e" sha1="8976f8b8ab2a82f626a73c781d0a21899ae68dae" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="bomber man (1986)(korea soft bank)[a].rom" size="0x2000" crc="c9a2c37e" sha1="8976f8b8ab2a82f626a73c781d0a21899ae68dae" />
 			</dataarea>
 		</part>
 	</software>
@@ -2490,9 +2682,11 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>Ample Software</publisher>
 		<info name="alt_title" value="ブギウギジャングル" />
+		<info name="serial" value="AMX003"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="boogie woogi jungle (japan).rom" size="16384" crc="90ccea11" sha1="0b3241202f0e2be470e5f2e6139c01983a895bc8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="boogie woogi jungle (japan).rom" size="0x4000" crc="90ccea11" sha1="0b3241202f0e2be470e5f2e6139c01983a895bc8" />
 			</dataarea>
 		</part>
 	</software>
@@ -2502,9 +2696,11 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>Ample Software</publisher>
 		<info name="alt_title" value="ブギウギジャングル" />
+		<info name="serial" value="AMX003"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="boogie woogi jungle (japan) (alt 1).rom" size="16384" crc="374b63c9" sha1="05b7a1db1ff15f712e619fd1c79fd7710e93cb3b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="boogie woogi jungle (japan) (alt 1).rom" size="0x4000" crc="374b63c9" sha1="05b7a1db1ff15f712e619fd1c79fd7710e93cb3b" />
 			</dataarea>
 		</part>
 	</software>
@@ -2514,8 +2710,10 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>Ample Software</publisher>
 		<info name="alt_title" value="ブギウギジャングル" />
+		<info name="serial" value="AMX003"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
 				<rom name="boogie woogi jungle (japan) (alt 2).rom" size="16385" crc="464e7594" sha1="86f8e3250cdcbadccf131255a1ef59ed291be8e9" status="baddump" />
 			</dataarea>
 		</part>
@@ -2527,9 +2725,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="20114" />
 		<info name="alt_title" value="ブーメラン" />
+		<info name="isbn" value="4871489787"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="boomerang (japan).rom" size="16384" crc="0a140b27" sha1="ef535ab6013d9b6e38227272f2ebe6a0f0b33cb5" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="boomerang (japan).rom" size="0x4000" crc="0a140b27" sha1="ef535ab6013d9b6e38227272f2ebe6a0f0b33cb5" />
 			</dataarea>
 		</part>
 	</software>
@@ -2540,9 +2740,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="20114" />
 		<info name="alt_title" value="ブーメラン" />
+		<info name="isbn" value="4871489787"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="boomerang (japan) (alt 1).rom" size="16384" crc="5f1f9288" sha1="da7cfd16dd1a76ae6b551ceabfd7053ca8e3412f" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="boomerang (japan) (alt 1).rom" size="0x4000" crc="5f1f9288" sha1="da7cfd16dd1a76ae6b551ceabfd7053ca8e3412f" />
 			</dataarea>
 		</part>
 	</software>
@@ -2554,8 +2756,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="10" />
 		<info name="alt_title" value="ボスコニアン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bosconian (japan).rom" size="32768" crc="02f1997a" sha1="451cbb072011b26a7e0bc9931e67995a71f5fd6f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="bosconian (japan).rom" size="0x8000" crc="02f1997a" sha1="451cbb072011b26a7e0bc9931e67995a71f5fd6f" />
 			</dataarea>
 		</part>
 	</software>
@@ -2567,8 +2770,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="10" />
 		<info name="alt_title" value="ボスコニアン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bosconian (japan) (alt 1).rom" size="32768" crc="af3c5d48" sha1="33ad6d1bf1fb816b232ea706d149327e363c7b21" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="bosconian (japan) (alt 1).rom" size="0x8000" crc="af3c5d48" sha1="33ad6d1bf1fb816b232ea706d149327e363c7b21" />
 			</dataarea>
 		</part>
 	</software>
@@ -2580,8 +2784,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="10" />
 		<info name="alt_title" value="ボスコニアン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bosconian (japan) (alt 2).rom" size="32768" crc="626132ae" sha1="0bf7b432dc132f9a7bc74106261bca07d5f99690" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="bosconian (japan) (alt 2).rom" size="0x8000" crc="626132ae" sha1="0bf7b432dc132f9a7bc74106261bca07d5f99690" />
 			</dataarea>
 		</part>
 	</software>
@@ -2590,10 +2795,12 @@ kept for now until finding out what those bytes affect...
 		<description>Bouken Roman - Dota (Japan)</description>
 		<year>1986</year>
 		<publisher>System Soft</publisher>
-		<info name="alt_title" value="冒険浪漫" />
+		<info name="alt_title" value="冒険浪漫 (title screen)" />
+		<info name="alt_title" value="ぼうけんろまん (box)"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bouken roman - dota (japan).rom" size="32768" crc="57efca5a" sha1="b15e73a5ff1ae17ac67f2cebb5862d5e5bd80bc0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="bouken roman - dota (japan).rom" size="0x8000" crc="57efca5a" sha1="b15e73a5ff1ae17ac67f2cebb5862d5e5bd80bc0" />
 			</dataarea>
 		</part>
 	</software>
@@ -2602,10 +2809,12 @@ kept for now until finding out what those bytes affect...
 		<description>Bouken Roman - Dota (Japan, alt)</description>
 		<year>1986</year>
 		<publisher>System Soft</publisher>
-		<info name="alt_title" value="冒険浪漫" />
+		<info name="alt_title" value="冒険浪漫 (title screen)" />
+		<info name="alt_title" value="ぼうけんろまん (box)"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bouken roman - dota (japan) (alt 1).rom" size="32768" crc="c5ca7dff" sha1="1ffef57e6c06068b330027294aae173103c8f141" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="bouken roman - dota (japan) (alt 1).rom" size="0x8000" crc="c5ca7dff" sha1="1ffef57e6c06068b330027294aae173103c8f141" />
 			</dataarea>
 		</part>
 	</software>
@@ -2617,22 +2826,24 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="S149191-700" />
 		<info name="alt_title" value="チャンピオンバルダーダッシュ ~ Champion Boulder Dash (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="boulder dash (japan).rom" size="32768" crc="a3a56524" sha1="14fae375b81c86f71e872adca792c23aafac66a0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="boulder dash (japan).rom" size="0x8000" crc="a3a56524" sha1="14fae375b81c86f71e872adca792c23aafac66a0" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="brain">
 		<description>The Brain (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00010" />
 		<info name="alt_title" value="ザ・ブレイン" />
+		<info name="usage" value="Requires a Japanese system otherwise software will crash with a 'type mismatch' error."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="brain, the (japan).rom" size="16384" crc="bb402b47" sha1="208ce6cbff7402bfe52b1062e6b10ae09c0a3179" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="brain, the (japan).rom" size="0x4000" crc="bb402b47" sha1="208ce6cbff7402bfe52b1062e6b10ae09c0a3179" />
 			</dataarea>
 		</part>
 	</software>
@@ -2641,10 +2852,12 @@ kept for now until finding out what those bytes affect...
 		<description>Break In (Japan)</description>
 		<year>1987</year>
 		<publisher>Jaleco</publisher>
+		<info name="alt_title" value="ブレイクイン"/>
 		<info name="serial" value="JX-14" />
+		<info name="gtin" value="04907859102106"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="break in (japan).rom" size="65536" crc="8801b31e" sha1="bcfdb43b275c62a76856aab94fb1b53bd92b2db2" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="break in (japan).rom" size="0x10000" crc="8801b31e" sha1="bcfdb43b275c62a76856aab94fb1b53bd92b2db2" />
 			</dataarea>
 		</part>
 	</software>
@@ -2656,8 +2869,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="00070" />
 		<info name="alt_title" value="ブレークアウト" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="break out (japan).rom" size="16384" crc="70113f76" sha1="3d065377f11b23410282b6b76f26bd93b9d05184" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="break out (japan).rom" size="0x4000" crc="70113f76" sha1="3d065377f11b23410282b6b76f26bd93b9d05184" />
 			</dataarea>
 		</part>
 	</software>
@@ -2668,8 +2882,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="형제의 모험" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="brother adventure (korea) (unl).rom" size="32768" crc="3ca757d0" sha1="c64f2fad6417c64595bc204d843527e17a58776f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="brother adventure (korea) (unl).rom" size="0x8000" crc="3ca757d0" sha1="c64f2fad6417c64595bc204d843527e17a58776f" />
 			</dataarea>
 		</part>
 	</software>
@@ -2680,8 +2895,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="형제의 모험" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="brother adventure (korea) (alt 1) (unl).rom" size="32768" crc="fe0a902c" sha1="6f9b4d791f4a43d7182650f21a7bfe88d1c5c2b4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="brother adventure (korea) (alt 1) (unl).rom" size="0x8000" crc="fe0a902c" sha1="6f9b4d791f4a43d7182650f21a7bfe88d1c5c2b4" />
 			</dataarea>
 		</part>
 	</software>
@@ -2692,8 +2908,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Comptiq</publisher>
 		<info name="alt_title" value="ブルース・リー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bruce lee (japan).rom" size="32768" crc="a20b196d" sha1="621ea075a534584361c9e9d640e39007a79dfd78" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="bruce lee (japan).rom" size="0x8000" crc="a20b196d" sha1="621ea075a534584361c9e9d640e39007a79dfd78" />
 			</dataarea>
 		</part>
 	</software>
@@ -2703,9 +2920,11 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Dempa</publisher>
 		<info name="alt_title" value="バーガータイム" />
+		<info name="serial" value="DP-3912027"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="burgertime (japan).rom" size="32768" crc="e4a7c230" sha1="ce1376941359471cae41887fe11f10d3b696a926" offset="0x4000" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="burgertime (japan).rom" size="0x8000" crc="e4a7c230" sha1="ce1376941359471cae41887fe11f10d3b696a926" />
 			</dataarea>
 		</part>
 	</software>
@@ -2717,8 +2936,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-024" />
 		<info name="alt_title" value="ブルとマイティー危機一髪" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="buru to marty kikiippatsu - inspecteur z (japan).rom" size="32768" crc="9cf39bd6" sha1="613c741535c92dfb01afec4135ef8ebddb49f999" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="buru to marty kikiippatsu - inspecteur z (japan).rom" size="0x8000" crc="9cf39bd6" sha1="613c741535c92dfb01afec4135ef8ebddb49f999" />
 			</dataarea>
 		</part>
 	</software>
@@ -2730,8 +2950,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-007" />
 		<info name="alt_title" value="ぶた丸パンツ ~ Butamaru Pants (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="butam pants (japan).rom" size="8192" crc="4b2aa972" sha1="b755d7db109cd0a9392accd1c83e6d995a8a04d6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="butam pants (japan).rom" size="0x2000" crc="4b2aa972" sha1="b755d7db109cd0a9392accd1c83e6d995a8a04d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -2743,8 +2964,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-007" />
 		<info name="alt_title" value="ぶた丸パンツ ~ Butamaru Pants (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="butam pants (japan) (alt 1).rom" size="16384" crc="4474ca21" sha1="2f7ff0438f1a8d80292c9e1cb8d77a92c600b505" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="butam pants (japan) (alt 1).rom" size="0x4000" crc="4474ca21" sha1="2f7ff0438f1a8d80292c9e1cb8d77a92c600b505" />
 			</dataarea>
 		</part>
 	</software>
@@ -2756,8 +2978,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-007" />
 		<info name="alt_title" value="ぶた丸パンツ ~ Butamaru Pants (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="butam pants (japan) (alt 2).rom" size="16384" crc="a102f82d" sha1="e6a1d90a7a8b4e4b8a8e1afb3d971866931b986d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="butam pants (japan) (alt 2).rom" size="0x4000" crc="a102f82d" sha1="e6a1d90a7a8b4e4b8a8e1afb3d971866931b986d" />
 			</dataarea>
 		</part>
 	</software>
@@ -2769,8 +2992,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5082" />
 		<info name="alt_title" value="シーソー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="c-so (japan).rom" size="16384" crc="df8bfc89" sha1="cd69ce70747bc0deebba9fd307a07f5dfb926cc3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="c-so (japan).rom" size="0x4000" crc="df8bfc89" sha1="cd69ce70747bc0deebba9fd307a07f5dfb926cc3" />
 			</dataarea>
 		</part>
 	</software>
@@ -2780,8 +3004,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="c-so.rom" size="32768" crc="4f195441" sha1="22183520d99924a4185c5572a3cf948f4f0f04b5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="c-so.rom" size="0x8000" crc="4f195441" sha1="22183520d99924a4185c5572a3cf948f4f0f04b5" />
 			</dataarea>
 		</part>
 	</software>
@@ -2792,8 +3017,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Brother Kougyou</publisher>
 		<info name="alt_title" value="キャノンターボ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="cannon_turbo_(1987)_(brother).rom" size="32768" crc="1ff280e3" sha1="e997d8f02e413d2df5aed2bf7e79986c4c851d34" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="cannon_turbo_(1987)_(brother).rom" size="0x8000" crc="1ff280e3" sha1="e997d8f02e413d2df5aed2bf7e79986c4c851d34" />
 			</dataarea>
 		</part>
 	</software>
@@ -2805,8 +3031,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC716" />
 		<info name="alt_title" value="キャベッジパッチキッズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="cabbage patch kids (japan) (alt 1).rom" size="16384" crc="97a1b4b9" sha1="2a0f9899a4d8dba76db501d6e3435546cc7cd9aa" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="cabbage patch kids (japan) (alt 1).rom" size="0x4000" crc="97a1b4b9" sha1="2a0f9899a4d8dba76db501d6e3435546cc7cd9aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -2819,8 +3046,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC716" />
 		<info name="alt_title" value="キャベッジパッチキッズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="cabbage patch kids (japan).rom" size="16384" crc="057d2790" sha1="c06de0eda82e1daa3ea3cbc5eba5d884fd0ce8e8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="cabbage patch kids (japan).rom" size="0x4000" crc="057d2790" sha1="c06de0eda82e1daa3ea3cbc5eba5d884fd0ce8e8" />
 			</dataarea>
 		</part>
 	</software>
@@ -2830,8 +3058,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="cpkids.rom" size="32768" crc="2ab67576" sha1="ed547caf3e45f621b588cb1fa91008c9c1bc9ed7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="cpkids.rom" size="0x8000" crc="2ab67576" sha1="ed547caf3e45f621b588cb1fa91008c9c1bc9ed7" />
 			</dataarea>
 		</part>
 	</software>
@@ -2842,9 +3071,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00220" />
 		<info name="alt_title" value="キャンドゥーニンジャ" />
+		<info name="isbn" value="4871489469"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="candoo ninja (japan).rom" size="16384" crc="b6ab6786" sha1="69710f4b9cc3440e58c54bd4c562b3e90ff323e0" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="candoo ninja (japan).rom" size="0x4000" crc="b6ab6786" sha1="69710f4b9cc3440e58c54bd4c562b3e90ff323e0" />
 			</dataarea>
 		</part>
 	</software>
@@ -2855,9 +3086,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00220" />
 		<info name="alt_title" value="キャンドゥーニンジャ" />
+		<info name="isbn" value="4871489469"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="candoo ninja (japan) (alt 1).rom" size="16384" crc="037ba8b7" sha1="77f3f6758bd4cf5d2b44c51de958aa967c41a9d7" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="candoo ninja (japan) (alt 1).rom" size="0x4000" crc="037ba8b7" sha1="77f3f6758bd4cf5d2b44c51de958aa967c41a9d7" />
 			</dataarea>
 		</part>
 	</software>
@@ -2869,8 +3102,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MXHI 11003" />
 		<info name="alt_title" value="キャノンボール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="cannon ball (japan).rom" size="8192" crc="a667ad8a" sha1="b36c925005f1e530cab2b5f6e2a5ddfd182c0140" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="cannon ball (japan).rom" size="0x2000" crc="a667ad8a" sha1="b36c925005f1e530cab2b5f6e2a5ddfd182c0140" />
 			</dataarea>
 		</part>
 	</software>
@@ -2882,8 +3116,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MXHI 11003" />
 		<info name="alt_title" value="キャノンボール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="cannon ball (japan) (alt 1).rom" size="16384" crc="b64390e7" sha1="d32279e01fb5762778d696acc2053b9503d5a715" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="cannon ball (japan) (alt 1).rom" size="0x4000" crc="b64390e7" sha1="d32279e01fb5762778d696acc2053b9503d5a715" />
 			</dataarea>
 		</part>
 	</software>
@@ -2895,8 +3130,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="48C99-1005" />
 		<info name="alt_title" value="キャプテンシェフ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="captain chef (japan).rom" size="8192" crc="8e985857" sha1="f025c9c2db97dce608fcc1050426beff0dea43eb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="captain chef (japan).rom" size="0x2000" crc="8e985857" sha1="f025c9c2db97dce608fcc1050426beff0dea43eb" />
 			</dataarea>
 		</part>
 	</software>
@@ -2907,9 +3143,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-118" />
 		<info name="alt_title" value="カーファイター" />
+		<info name="gtin" value="04971850170464"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="car fighter (japan).rom" size="16384" crc="303187f5" sha1="e93c396649bf6328103e8da0247952ebef2a04e9" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="car fighter (japan).rom" size="0x4000" crc="303187f5" sha1="e93c396649bf6328103e8da0247952ebef2a04e9" />
 			</dataarea>
 		</part>
 	</software>
@@ -2919,10 +3157,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G004C" />
-		<info name="alt_title" value="カージャンボリー" />
+		<info name="alt_title" value="爆走スタントレーシング" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="car jamboree (japan).rom" size="16384" crc="94fc9169" sha1="11e2f95d1b58e1244efda761603a2ae6d0090d18" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="car jamboree (japan).rom" size="0x4000" crc="94fc9169" sha1="11e2f95d1b58e1244efda761603a2ae6d0090d18" />
 			</dataarea>
 		</part>
 	</software>
@@ -2932,10 +3171,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G004C" />
-		<info name="alt_title" value="カージャンボリー" />
+		<info name="alt_title" value="爆走スタントレーシング" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="car jamboree (japan) (alt 1).rom" size="32768" crc="a24195fa" sha1="8a158cdec0923b81ce13af2dffa5d1b7e096a469" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="car jamboree (japan) (alt 1).rom" size="0x8000" crc="a24195fa" sha1="8a158cdec0923b81ce13af2dffa5d1b7e096a469" />
 			</dataarea>
 		</part>
 	</software>
@@ -2944,9 +3184,11 @@ kept for now until finding out what those bytes affect...
 		<description>Car-Race (Japan)</description>
 		<year>1983</year>
 		<publisher>Ample Software</publisher>
+		<info name="serial" value="AMX002"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="car-race (japan).rom" size="8192" crc="3f0db564" sha1="97af4f422a283ac8ba387eb0b1b29395c2c966eb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="car-race (japan).rom" size="0x2000" crc="3f0db564" sha1="97af4f422a283ac8ba387eb0b1b29395c2c966eb" />
 			</dataarea>
 		</part>
 	</software>
@@ -2955,9 +3197,11 @@ kept for now until finding out what those bytes affect...
 		<description>Car-Race (Japan, alt)</description>
 		<year>1983</year>
 		<publisher>Ample Software</publisher>
+		<info name="serial" value="AMX002"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="car-race (japan) (alt 1).rom" size="16384" crc="9538d829" sha1="e7396ad700f7edf98cc2b0ec2e6127a68d3cd9ba" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="car-race (japan) (alt 1).rom" size="0x4000" crc="9538d829" sha1="e7396ad700f7edf98cc2b0ec2e6127a68d3cd9ba" />
 			</dataarea>
 		</part>
 	</software>
@@ -2966,8 +3210,10 @@ kept for now until finding out what those bytes affect...
 		<description>Car-Race (Japan, alt 2)</description>
 		<year>1983</year>
 		<publisher>Ample Software</publisher>
+		<info name="serial" value="AMX002"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
 				<rom name="car-race (japan) (alt 2).rom" size="16385" crc="51445292" sha1="ab7354c9ced9782d572c4dd69249b76a1244e5ce" status="baddump" />
 			</dataarea>
 		</part>
@@ -2980,8 +3226,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-114" />
 		<info name="alt_title" value="カシオワールドオープン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="casio worldopen (japan).rom" size="32768" crc="338491f5" sha1="0a2209e0a71684493998f6618af032ba580d4ff9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="casio worldopen (japan).rom" size="0x8000" crc="338491f5" sha1="0a2209e0a71684493998f6618af032ba580d4ff9" />
 			</dataarea>
 		</part>
 	</software>
@@ -2991,8 +3238,9 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Boram Soft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="casio world open (1985)(casio)[cr boram soft].rom" size="32768" crc="3508626f" sha1="5ec989d082566819d2a88664634084634f1a2c11" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="casio world open (1985)(casio)[cr boram soft].rom" size="0x8000" crc="3508626f" sha1="5ec989d082566819d2a88664634084634f1a2c11" />
 			</dataarea>
 		</part>
 	</software>
@@ -3003,9 +3251,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="2014409" />
 		<info name="alt_title" value="ザ・キャッスル" />
+		<info name="isbn" value="4871488748"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="castle, the (japan).rom" size="32768" crc="2149c32d" sha1="615c08820b926e28b143cd7812852e011d3eeffb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="castle, the (japan).rom" size="0x8000" crc="2149c32d" sha1="615c08820b926e28b143cd7812852e011d3eeffb" />
 			</dataarea>
 		</part>
 	</software>
@@ -3015,8 +3265,9 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Static Soft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="castle, the (1986)(ascii)[cr static soft].rom" size="32768" crc="48eccfaf" sha1="f53bdd847d0097fd4ca47dab031570366c882e65" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="castle, the (1986)(ascii)[cr static soft].rom" size="0x8000" crc="48eccfaf" sha1="f53bdd847d0097fd4ca47dab031570366c882e65" />
 			</dataarea>
 		</part>
 	</software>
@@ -3026,9 +3277,12 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="キャッスルエクセレント" />
+		<info name="serial" value="2018109"/>
+		<info name="isbn" value="4871488977"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="castle excellent (japan).rom" size="32768" crc="90f38029" sha1="811dca8fc14a2b00f503fbef74fdeae4f2873d4c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="castle excellent (japan).rom" size="0x8000" crc="90f38029" sha1="811dca8fc14a2b00f503fbef74fdeae4f2873d4c" />
 			</dataarea>
 		</part>
 	</software>
@@ -3038,9 +3292,12 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="キャッスルエクセレント" />
+		<info name="serial" value="2018109"/>
+		<info name="isbn" value="4871488977"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="castle excellent (japan) (alt 1).rom" size="32768" crc="3794a648" sha1="d55e9e237504bc6444c6b62894bf88292150042a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="castle excellent (japan) (alt 1).rom" size="0x8000" crc="3794a648" sha1="d55e9e237504bc6444c6b62894bf88292150042a" />
 			</dataarea>
 		</part>
 	</software>
@@ -3048,11 +3305,13 @@ kept for now until finding out what those bytes affect...
 	<software name="chackn">
 		<description>Chack'n Pop (Japan)</description>
 		<year>1984</year>
-		<publisher>Taito</publisher>
+		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="ちゃっくんぽっぷ" />
+		<info name="serial" value="NH-MSX02"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="chack'n pop (japan).rom" size="16384" crc="04f7e0b1" sha1="0b9a870d1e6cc712a3efce2349fb1c1cf6902d22" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="chack'n pop (japan).rom" size="0x4000" crc="04f7e0b1" sha1="0b9a870d1e6cc712a3efce2349fb1c1cf6902d22" />
 			</dataarea>
 		</part>
 	</software>
@@ -3060,11 +3319,13 @@ kept for now until finding out what those bytes affect...
 	<software name="chackna" cloneof="chackn">
 		<description>Chack'n Pop (Japan, alt)</description>
 		<year>1984</year>
-		<publisher>Taito</publisher>
+		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="ちゃっくんぽっぷ" />
+		<info name="serial" value="NH-MSX02"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="chack'n pop (japan) (alt 1).rom" size="16384" crc="0fff4d26" sha1="b6f10b6bedc26d9415335997493139ce7a2c7916" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="chack'n pop (japan) (alt 1).rom" size="0x4000" crc="0fff4d26" sha1="b6f10b6bedc26d9415335997493139ce7a2c7916" />
 			</dataarea>
 		</part>
 	</software>
@@ -3076,8 +3337,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5092" />
 		<info name="alt_title" value="チャレンジダービー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="challenge derby (japan).rom" size="32768" crc="a90daa22" sha1="3abae41cb742b76ff45dd178bd7db346137fe0fa" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="challenge derby (japan).rom" size="0x8000" crc="a90daa22" sha1="3abae41cb742b76ff45dd178bd7db346137fe0fa" />
 			</dataarea>
 		</part>
 	</software>
@@ -3089,8 +3351,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R55X5080" />
 		<info name="alt_title" value="チャンピオンボクシング" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="champion boxing (japan).rom" size="32768" crc="c4b7a5b9" sha1="39cb046a9b6b6ef4e769cdc6fdf36b274cd44039" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="champion boxing (japan).rom" size="0x8000" crc="c4b7a5b9" sha1="39cb046a9b6b6ef4e769cdc6fdf36b274cd44039" />
 			</dataarea>
 		</part>
 	</software>
@@ -3102,8 +3365,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5811" />
 		<info name="alt_title" value="チャンピオンアイスホッケー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="champion ice hockey (japan).rom" size="32768" crc="bf4b018f" sha1="ebb46dd4cf36407ad82d9f50d9bef3e938dc144e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="champion ice hockey (japan).rom" size="0x8000" crc="bf4b018f" sha1="ebb46dd4cf36407ad82d9f50d9bef3e938dc144e" />
 			</dataarea>
 		</part>
 	</software>
@@ -3115,8 +3379,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5809" />
 		<info name="alt_title" value="チャンピオン剣道" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="champion kendou (japan).rom" size="32768" crc="0103c767" sha1="f9e9a6e517ee0b9b3147abb6144b31ed2ca8dbda" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="champion kendou (japan).rom" size="0x8000" crc="0103c767" sha1="f9e9a6e517ee0b9b3147abb6144b31ed2ca8dbda" />
 			</dataarea>
 		</part>
 	</software>
@@ -3128,8 +3393,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5809" />
 		<info name="alt_title" value="チャンピオン剣道" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="champion kendou (japan) (alt 1).rom" size="32768" crc="6f05e6bf" sha1="a502e37f580bd287ed8338fcb1d809b8dc90bbe0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="champion kendou (japan) (alt 1).rom" size="0x8000" crc="6f05e6bf" sha1="a502e37f580bd287ed8338fcb1d809b8dc90bbe0" />
 			</dataarea>
 		</part>
 	</software>
@@ -3141,8 +3407,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R55X5801" />
 		<info name="alt_title" value="チャンピオンプロレス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="champion pro wrestling (japan).rom" size="32768" crc="6686c84e" sha1="af1a6f4dd12d726a7a4377753ce3db82bf24eba4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="champion pro wrestling (japan).rom" size="0x8000" crc="6686c84e" sha1="af1a6f4dd12d726a7a4377753ce3db82bf24eba4" />
 			</dataarea>
 		</part>
 	</software>
@@ -3154,8 +3421,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R55X5801" />
 		<info name="alt_title" value="チャンピオンプロレス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="champion pro wrestling (japan) (alt 1).rom" size="32768" crc="8d658f41" sha1="d1e3afecde1656099dadff99c6ed2aa8fa6dd834" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="champion pro wrestling (japan) (alt 1).rom" size="0x8000" crc="8d658f41" sha1="d1e3afecde1656099dadff99c6ed2aa8fa6dd834" />
 			</dataarea>
 		</part>
 	</software>
@@ -3167,8 +3435,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R55X5801" />
 		<info name="alt_title" value="チャンピオンプロレス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="champion pro wrestling (japan) (alt 2).rom" size="32768" crc="d4b0accd" sha1="0c364c3499df76f2e15d2aeb744a0de3730ff47b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="champion pro wrestling (japan) (alt 2).rom" size="0x8000" crc="d4b0accd" sha1="0c364c3499df76f2e15d2aeb744a0de3730ff47b" />
 			</dataarea>
 		</part>
 	</software>
@@ -3180,8 +3449,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5077" />
 		<info name="alt_title" value="チャンピオンサッカー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="champion soccer (japan).rom" size="16384" crc="67ab6f8f" sha1="821c611b851ddd4cf8cfb4e77cecbc882f12eb72" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="champion soccer (japan).rom" size="0x4000" crc="67ab6f8f" sha1="821c611b851ddd4cf8cfb4e77cecbc882f12eb72" />
 			</dataarea>
 		</part>
 	</software>
@@ -3192,31 +3462,37 @@ kept for now until finding out what those bytes affect...
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G047C" />
 		<info name="alt_title" value="チャンピオンシップロードランナー" />
+		<info name="gtin" value="04901780008216"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="championship lode runner (japan).rom" size="32768" crc="2f75e79c" sha1="650381b96f36e74a4eaf5ae3f924f6f8deac7100" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="championship lode runner (japan).rom" size="0x8000" crc="2f75e79c" sha1="650381b96f36e74a4eaf5ae3f924f6f8deac7100" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!--- Cannot play the game -->
 	<software name="cloderunk1" cloneof="cloderun" supported="no">
 		<description>Championship Lode Runner (Korea, bad?)</description>
 		<year>19??</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="championship lode runner (1985)(sony)[cr prosoft][b].rom" size="32768" crc="00114640" sha1="f5526481e64def129bd4109fa2074609ee2e92a0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="championship lode runner (1985)(sony)[cr prosoft][b].rom" size="0x8000" crc="00114640" sha1="f5526481e64def129bd4109fa2074609ee2e92a0" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!--- Cannot play the game -->
 	<software name="cloderunk2" cloneof="cloderun" supported="no">
 		<description>Championship Lode Runner (Korea, bad 2?)</description>
 		<year>19??</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="championship lode runner (1985)(sony)[cr prosoft][b2].rom" size="32770" crc="e81360fc" sha1="b5afee9c379017354fbefce797701efeeb30caea" status="baddump" offset="0x4000" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="32770">
+				<rom name="championship lode runner (1985)(sony)[cr prosoft][b2].rom" size="32770" crc="e81360fc" sha1="b5afee9c379017354fbefce797701efeeb30caea" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -3228,8 +3504,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5078" />
 		<info name="alt_title" value="チェッカーズインＴＡＮＴＡＮたぬき" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="checkers in tantan tanuki (japan).rom" size="16384" crc="d2b8c058" sha1="a4be5763cdf2dcd647b87e3aecbab28ecc69776e" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="checkers in tantan tanuki (japan).rom" size="0x4000" crc="d2b8c058" sha1="a4be5763cdf2dcd647b87e3aecbab28ecc69776e" />
 			</dataarea>
 		</part>
 	</software>
@@ -3241,8 +3518,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G015C" />
 		<info name="alt_title" value="コンピューターチェス ~ Computer Chess (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="chess (japan).rom" size="16384" crc="11eed1c7" sha1="2c0c71c549738d668518db317dd70aecefd4aa72" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="chess (japan).rom" size="0x4000" crc="11eed1c7" sha1="2c0c71c549738d668518db317dd70aecefd4aa72" />
 			</dataarea>
 		</part>
 	</software>
@@ -3254,8 +3532,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G019C" />
 		<info name="alt_title" value="チョップリフター" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="choplifter (japan).rom" size="32768" crc="1f5eafc8" sha1="a2a7c93c9c8b55a5cce4c9005f3c194e3b762e9c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="choplifter (japan).rom" size="0x8000" crc="1f5eafc8" sha1="a2a7c93c9c8b55a5cce4c9005f3c194e3b762e9c" />
 			</dataarea>
 		</part>
 	</software>
@@ -3267,8 +3546,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G019C" />
 		<info name="alt_title" value="チョップリフター" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="choplifter (japan) (alt 1).rom" size="32768" crc="c6f30d45" sha1="30673d173f96fe1830e579f18daf8ac9fc3366cb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="choplifter (japan) (alt 1).rom" size="0x8000" crc="c6f30d45" sha1="30673d173f96fe1830e579f18daf8ac9fc3366cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -3280,8 +3560,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G019C" />
 		<info name="alt_title" value="チョップリフター" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="choplifter (japan) (alt 2).rom" size="32768" crc="155768b0" sha1="b3ca70c8c8120f8261bb865baf5f57b6506ca02e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="choplifter (japan) (alt 2).rom" size="0x8000" crc="155768b0" sha1="b3ca70c8c8120f8261bb865baf5f57b6506ca02e" />
 			</dataarea>
 		</part>
 	</software>
@@ -3289,11 +3570,13 @@ kept for now until finding out what those bytes affect...
 	<software name="choroq">
 		<description>Choro Q (Japan)</description>
 		<year>1984</year>
-		<publisher>Taito</publisher>
+		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="チョロＱ" />
+		<info name="serial" value="NH-MSX05"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="choro q (japan).rom" size="16384" crc="5506bf9b" sha1="99f9e9753edbaee820e36a1a58f1cd7ae2b26265" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="choro q (japan).rom" size="0x4000" crc="5506bf9b" sha1="99f9e9753edbaee820e36a1a58f1cd7ae2b26265" />
 			</dataarea>
 		</part>
 	</software>
@@ -3301,11 +3584,13 @@ kept for now until finding out what those bytes affect...
 	<software name="choroqa" cloneof="choroq">
 		<description>Choro Q (Japan, alt)</description>
 		<year>1984</year>
-		<publisher>Taito</publisher>
+		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="チョロＱ" />
+		<info name="serial" value="NH-MSX05"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="choro q (japan) (alt 1).rom" size="16384" crc="65b34072" sha1="ee3ca231328534bba92f9a908c4faed865bcea68" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="choro q (japan) (alt 1).rom" size="0x4000" crc="65b34072" sha1="ee3ca231328534bba92f9a908c4faed865bcea68" />
 			</dataarea>
 		</part>
 	</software>
@@ -3315,21 +3600,24 @@ kept for now until finding out what those bytes affect...
 		<year>19??</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="choro q (1984)(taito)[cr prosoft].rom" size="32768" crc="ba580eb7" sha1="615d685fef332a7742324f9608eb69e6336faaa1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="choro q (1984)(taito)[cr prosoft].rom" size="0x8000" crc="ba580eb7" sha1="615d685fef332a7742324f9608eb69e6336faaa1" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="chuheib1">
 		<description>Chuugaku Hisshuu Eibunpou 1 (Japan)</description>
 		<year>1984</year>
 		<publisher>Stratford Computer Center</publisher>
-		<info name="alt_title" value="中学必修英文法" />
+		<info name="alt_title" value="中学必修英文法[中学1年]" />
+		<info name="serial" value="MXSU11047"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="chugaku hisshu eibunpo 1 (japan).rom" size="32768" crc="097e4a7e" sha1="20ce189d670c0fe5f2a945d73107df7d83070ff7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="chugaku hisshu eibunpo 1 (japan).rom" size="0x8000" crc="097e4a7e" sha1="20ce189d670c0fe5f2a945d73107df7d83070ff7" />
 			</dataarea>
 		</part>
 	</software>
@@ -3341,8 +3629,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC712" />
 		<info name="alt_title" value="サーカスチャーリー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="circus charlie (japan).rom" size="16384" crc="83b8d8f3" sha1="ae6d0efd55def94274f4cec459df8927d132675a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="circus charlie (japan).rom" size="0x4000" crc="83b8d8f3" sha1="ae6d0efd55def94274f4cec459df8927d132675a" />
 			</dataarea>
 		</part>
 	</software>
@@ -3350,11 +3639,13 @@ kept for now until finding out what those bytes affect...
 	<software name="citycon">
 		<description>City Connection (Japan)</description>
 		<year>1986</year>
-		<publisher>Nihon Dexter</publisher>
+		<publisher>Jaleco</publisher>
 		<info name="alt_title" value="シティコネクション" />
+		<info name="serial" value="JX-10"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="city connection (japan).rom" size="32768" crc="6031a583" sha1="0071b2eb214ff002dbbb7532653585b35b56f243" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="city connection (japan).rom" size="0x8000" crc="6031a583" sha1="0071b2eb214ff002dbbb7532653585b35b56f243" />
 			</dataarea>
 		</part>
 	</software>
@@ -3362,11 +3653,13 @@ kept for now until finding out what those bytes affect...
 	<software name="citycona" cloneof="citycon">
 		<description>City Connection (Japan, alt)</description>
 		<year>1986</year>
-		<publisher>Nihon Dexter</publisher>
+		<publisher>Jaleco</publisher>
 		<info name="alt_title" value="シティコネクション" />
+		<info name="serial" value="JX-10"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="city connection (japan) (alt 1).rom" size="32768" crc="625c3689" sha1="07af8b1ec0786c44778f68ef3bb0b3d4793f42e3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="city connection (japan) (alt 1).rom" size="0x8000" crc="625c3689" sha1="07af8b1ec0786c44778f68ef3bb0b3d4793f42e3" />
 			</dataarea>
 		</part>
 	</software>
@@ -3378,8 +3671,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G050C" />
 		<info name="alt_title" value="コースターレース" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="coaster race (japan).rom" size="32768" crc="399fd445" sha1="17f24b9339291dea40d2ed36517f223b9e4f49e1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="coaster race (japan).rom" size="0x8000" crc="399fd445" sha1="17f24b9339291dea40d2ed36517f223b9e4f49e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -3391,8 +3685,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G050C" />
 		<info name="alt_title" value="コースターレース" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="coaster race (japan) (alt 1).rom" size="32768" crc="a48acff7" sha1="308c73fc04c3b390b72ea8d4980c94c74ba38a5c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="coaster race (japan) (alt 1).rom" size="0x8000" crc="a48acff7" sha1="308c73fc04c3b390b72ea8d4980c94c74ba38a5c" />
 			</dataarea>
 		</part>
 	</software>
@@ -3404,8 +3699,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G050C" />
 		<info name="alt_title" value="コースターレース" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="coaster race (japan) (alt 2).rom" size="32768" crc="00d996ff" sha1="47ea8d512d9fec15df8770f3b5017aea9bbba9fd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="coaster race (japan) (alt 2).rom" size="0x8000" crc="00d996ff" sha1="47ea8d512d9fec15df8770f3b5017aea9bbba9fd" />
 			</dataarea>
 		</part>
 	</software>
@@ -3415,9 +3711,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="alt_title" value="カラーボール" />
+		<info name="serial" value="MX-1002"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="color ball (japan).rom" size="8192" crc="12552a1f" sha1="ac391fe51f69e0a55fe3ab66c8ec3f2792dd5d08" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="color ball (japan).rom" size="0x2000" crc="12552a1f" sha1="ac391fe51f69e0a55fe3ab66c8ec3f2792dd5d08" />
 			</dataarea>
 		</part>
 	</software>
@@ -3427,9 +3725,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="alt_title" value="カラーボール" />
+		<info name="serial" value="MX-1002"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="color ball (japan) (alt 1).rom" size="16384" crc="73f1e939" sha1="83fdaa429ad8b155ab2328a72fcb8de642ff5615" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="color ball (japan) (alt 1).rom" size="0x4000" crc="73f1e939" sha1="83fdaa429ad8b155ab2328a72fcb8de642ff5615" />
 			</dataarea>
 		</part>
 	</software>
@@ -3439,9 +3739,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="alt_title" value="カラーボール" />
+		<info name="serial" value="MX-1002"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="color ball (japan) (alt 2).rom" size="16384" crc="f4f6e561" sha1="95d8a590bad595f9441aea4bf68667de05b1b34b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="color ball (japan) (alt 2).rom" size="0x4000" crc="f4f6e561" sha1="95d8a590bad595f9441aea4bf68667de05b1b34b" />
 			</dataarea>
 		</part>
 	</software>
@@ -3453,32 +3755,38 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5100" />
 		<info name="alt_title" value="カモン！ピコ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="come on picot (japan).rom" size="32768" crc="98b1cc99" sha1="1cf39e12313ff3064353c136262f176a56ab20a6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="come on picot (japan).rom" size="0x8000" crc="98b1cc99" sha1="1cf39e12313ff3064353c136262f176a56ab20a6" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx only lists a cassette release for this software. -->
 	<software name="comecoco">
 		<description>Comecocos (Spain)</description>
 		<year>198?</year>
 		<publisher>Idealogic</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="comecocos (spain).rom" size="16384" crc="5cfc6700" sha1="546aaf36ee78717fe06125185f0d420fdff0d34c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="comecocos (spain).rom" size="0x4000" crc="5cfc6700" sha1="546aaf36ee78717fe06125185f0d420fdff0d34c" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="cometail">
 		<description>Comet Tail (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="コメットテイル" />
+		<info name="serial" value="00110"/>
+		<info name="isbn" value="4871489221"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="comet tail (japan).rom" size="16384" crc="74af0726" sha1="a054ddeaf471212764cc596bcbd30e94b10e6c28" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="comet tail (japan).rom" size="0x4000" crc="74af0726" sha1="a054ddeaf471212764cc596bcbd30e94b10e6c28" />
 			</dataarea>
 		</part>
 	</software>
@@ -3490,8 +3798,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC714" />
 		<info name="alt_title" value="ぽんぽこパン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="comic bakery (japan).rom" size="16384" crc="a4097e41" sha1="fc327d3946366ca75de0d0619eb0917a27e1bd61" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="comic bakery (japan).rom" size="0x4000" crc="a4097e41" sha1="fc327d3946366ca75de0d0619eb0917a27e1bd61" />
 			</dataarea>
 		</part>
 	</software>
@@ -3503,8 +3812,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC714" />
 		<info name="alt_title" value="ぽんぽこパン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="comic bakery (japan) (alt 1).rom" size="16384" crc="9a70d9c9" sha1="d2604a1f76cadd36ede570e23ad49b0885187e25" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="comic bakery (japan) (alt 1).rom" size="0x4000" crc="9a70d9c9" sha1="d2604a1f76cadd36ede570e23ad49b0885187e25" />
 			</dataarea>
 		</part>
 	</software>
@@ -3516,8 +3826,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC714" />
 		<info name="alt_title" value="ぽんぽこパン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="comic bakery (japan) (alt 2).rom" size="16384" crc="03dae53c" sha1="8cf06f93d4e8bcf7be04ae8532f72e6eec8ba2f1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="comic bakery (japan) (alt 2).rom" size="0x4000" crc="03dae53c" sha1="8cf06f93d4e8bcf7be04ae8532f72e6eec8ba2f1" />
 			</dataarea>
 		</part>
 	</software>
@@ -3529,22 +3840,24 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G008C" />
 		<info name="alt_title" value="コンピュータービリヤード" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="computer billiards (japan).rom" size="8192" crc="9098682d" sha1="630aec6f93df8d1ef83c52a0bb6ec571b9c6eed4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="computer billiards (japan).rom" size="0x2000" crc="9098682d" sha1="630aec6f93df8d1ef83c52a0bb6ec571b9c6eed4" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="cnyumon">
 		<description>Computer Nyuumon (Japan)</description>
 		<year>1985</year>
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-506" />
 		<info name="alt_title" value="コンピュータ入門" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="computer nyuumon - computer lessons (japan).rom" size="32768" crc="50bb1930" sha1="1fc9d3b54a617e57fd6ed10f2ce3c01456710e37" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="computer nyuumon - computer lessons (japan).rom" size="0x8000" crc="50bb1930" sha1="1fc9d3b54a617e57fd6ed10f2ce3c01456710e37" />
 			</dataarea>
 		</part>
 	</software>
@@ -3556,8 +3869,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G003C" />
 		<info name="alt_title" value="コンピューターオセロ ~ Computer Othello (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="computer othello (japan).rom" size="16384" crc="6936c965" sha1="bd8f335fc45e9920f0691a525a0fc853b2e4b595" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="computer othello (japan).rom" size="0x4000" crc="6936c965" sha1="bd8f335fc45e9920f0691a525a0fc853b2e4b595" />
 			</dataarea>
 		</part>
 	</software>
@@ -3569,19 +3883,22 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G003C" />
 		<info name="alt_title" value="コンピューターオセロ ~ Computer Othello (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="computer othello (japan) (alt 1).rom" size="16384" crc="6a8ed770" sha1="81c50af8ef09e0b7a8a69fd4715592b5e803cdb5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="computer othello (japan) (alt 1).rom" size="0x4000" crc="6a8ed770" sha1="81c50af8ef09e0b7a8a69fd4715592b5e803cdb5" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- According to generation-msx only released on floppy as part of 'Super Game Collection'. -->
 	<software name="cpachi">
 		<description>Computer Pachinko (Japan)</description>
 		<year>1984</year>
 		<publisher>Sony</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="computer pachinko (japan).rom" size="16384" crc="1bd2c6b3" sha1="99d3ef107f2ac4d452b05eb96b922924ef4c5434" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="computer pachinko (japan).rom" size="0x4000" crc="1bd2c6b3" sha1="99d3ef107f2ac4d452b05eb96b922924ef4c5434" />
 			</dataarea>
 		</part>
 	</software>
@@ -3592,8 +3909,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Cross Talk</publisher>
 		<info name="alt_title" value="コンドリ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="con-dori (japan).rom" size="8192" crc="d9006ebe" sha1="09cc29b413dc7b8747420615bf798169ae68ad14" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="con-dori (japan).rom" size="0x2000" crc="d9006ebe" sha1="09cc29b413dc7b8747420615bf798169ae68ad14" />
 			</dataarea>
 		</part>
 	</software>
@@ -3604,8 +3922,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Cross Talk</publisher>
 		<info name="alt_title" value="コンドリ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="con-dori (japan) (alt 1).rom" size="16384" crc="ce71bb57" sha1="868d84f8a6ae0434bf86adfbb86996ceddefba84" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="con-dori (japan) (alt 1).rom" size="0x4000" crc="ce71bb57" sha1="868d84f8a6ae0434bf86adfbb86996ceddefba84" />
 			</dataarea>
 		</part>
 	</software>
@@ -3616,8 +3935,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Cross Talk</publisher>
 		<info name="alt_title" value="コンドリ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="con-dori (japan) (alt 2).rom" size="16384" crc="69405f96" sha1="8592b14ee701eaaf433113a26b199084c124992f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="con-dori (japan) (alt 2).rom" size="0x4000" crc="69405f96" sha1="8592b14ee701eaaf433113a26b199084c124992f" />
 			</dataarea>
 		</part>
 	</software>
@@ -3625,11 +3945,13 @@ kept for now until finding out what those bytes affect...
 <!-- only tape released? tap2crt hack??
      There is a cartridge version released by Al Alamiah, but it is likely not this one. Marked as bad dump.
  -->
+	<!-- cannot start a game. -->
 	<software name="confused" supported="no">
 		<description>Confused? (Europe)</description>
 		<year>198?</year>
 		<publisher>Eaglesoft</publisher>
 		<part name="cart" interface="msx_cart">
+			<feature name="start_page" value="1"/>
 			<dataarea name="rom" size="49152">
 				<rom name="confused (europe).rom" size="49152" crc="63084e71" sha1="9865f0bc4d54137809f0d8b48d5461ddf0c5bf4c" status="baddump" />
 			</dataarea>
@@ -3641,9 +3963,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="キャプテン・コスモ ~ Captain Cosmo (Box, Cart)" />
+		<info name="serial" value="20122"/>
+		<info name="isbn" value="4871489833"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="cosmo (japan).rom" size="16384" crc="5780acfd" sha1="5ad0ba434407a7eeecb597b3d20bcfc6fe05c319" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="cosmo (japan).rom" size="0x4000" crc="5780acfd" sha1="5ad0ba434407a7eeecb597b3d20bcfc6fe05c319" />
 			</dataarea>
 		</part>
 	</software>
@@ -3653,9 +3978,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="キャプテン・コスモ ~ Captain Cosmo (Box, Cart)" />
+		<info name="serial" value="20122"/>
+		<info name="isbn" value="4871489833"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="cosmo (japan) (alt 1).rom" size="16384" crc="ff3c8091" sha1="bb7468dd32a160851b39121d24713b0b4e065c19" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="cosmo (japan) (alt 1).rom" size="0x4000" crc="ff3c8091" sha1="bb7468dd32a160851b39121d24713b0b4e065c19" />
 			</dataarea>
 		</part>
 	</software>
@@ -3667,8 +3995,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G037C" />
 		<info name="alt_title" value="コスモエクスプローラ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="cosmo-explorer (japan).rom" size="32768" crc="3f534824" sha1="0ac6c061c3897a3989dcd75b4878c850c71e4bb8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="cosmo-explorer (japan).rom" size="0x8000" crc="3f534824" sha1="0ac6c061c3897a3989dcd75b4878c850c71e4bb8" />
 			</dataarea>
 		</part>
 	</software>
@@ -3680,8 +4009,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G037C" />
 		<info name="alt_title" value="コスモエクスプローラ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="cosmo-explorer (japan) (alt 1).rom" size="32768" crc="d21f6b76" sha1="b6f8e1431bda1296c2959b10b021b80e0ff2a8a2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="cosmo-explorer (japan) (alt 1).rom" size="0x8000" crc="d21f6b76" sha1="b6f8e1431bda1296c2959b10b021b80e0ff2a8a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -3691,9 +4021,11 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Cosmos Computer</publisher>
 		<info name="alt_title" value="カレイジアスペルセウス" />
+		<info name="serial" value="P-033"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="courageous perseus (japan).rom" size="32768" crc="b6d707c7" sha1="613cc52fbd5822ade47daa3ec21479641a009c2c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="courageous perseus (japan).rom" size="0x8000" crc="b6d707c7" sha1="613cc52fbd5822ade47daa3ec21479641a009c2c" />
 			</dataarea>
 		</part>
 	</software>
@@ -3703,9 +4035,11 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Cosmos Computer</publisher>
 		<info name="alt_title" value="カレイジアスペルセウス" />
+		<info name="serial" value="P-033"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="courageous perseus (japan) (alt 1).rom" size="32768" crc="0fad4984" sha1="6cf3f098d592d7dcb767a0e24b5caf327b5f22db" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="courageous perseus (japan) (alt 1).rom" size="0x8000" crc="0fad4984" sha1="6cf3f098d592d7dcb767a0e24b5caf327b5f22db" />
 			</dataarea>
 		</part>
 	</software>
@@ -3716,11 +4050,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Heart Soft</publisher>
 		<info name="serial" value="HRK-22" />
 		<info name="alt_title" value="クレイズ" />
+		<info name="gtin" value="04988641002187"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="craze (japan).rom" size="131072" crc="d83966d0" sha1="9e0312e72f30a20f556b64fe37dbbfe0d4471823" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="craze (japan).rom" size="0x20000" crc="d83966d0" sha1="9e0312e72f30a20f556b64fe37dbbfe0d4471823" />
 			</dataarea>
 		</part>
 	</software>
@@ -3730,9 +4065,12 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="クレージーブレット" />
+		<info name="serial" value="000A0"/>
+		<info name="isbn" value="4871489159"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="crazy bullet (japan).rom" size="16384" crc="d0e8f418" sha1="5d5dfe6cec605de421c3aed3a743d6840fec1457" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="crazy bullet (japan).rom" size="0x4000" crc="d0e8f418" sha1="5d5dfe6cec605de421c3aed3a743d6840fec1457" />
 			</dataarea>
 		</part>
 	</software>
@@ -3742,8 +4080,9 @@ kept for now until finding out what those bytes affect...
 		<year>1988</year>
 		<publisher>Titus</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="crazy cars (europe).rom" size="32768" crc="de18372d" sha1="76c191bf7dcc0888d65e543c47f615ae45b75b92" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="crazy cars (europe).rom" size="0x8000" crc="de18372d" sha1="76c191bf7dcc0888d65e543c47f615ae45b75b92" />
 			</dataarea>
 		</part>
 	</software>
@@ -3755,16 +4094,13 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G006C" />
 		<info name="alt_title" value="クレイジートレイン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
+			<feature name="start_page" value="0"/>
+			<dataarea name="rom" size="0x8000">
 				<!-- Mirroring not verified -->
-				<rom name="crazy train (japan).rom" size="8192" crc="39e6ff25" sha1="8aca0ee5845b0b39af624e8a998bb04f02d0fda4" />
-				<rom size="8192" offset="0x2000" loadflag="reload" />
-				<rom size="8192" offset="0x4000" loadflag="reload" />
-				<rom size="8192" offset="0x6000" loadflag="reload" />
-				<rom size="8192" offset="0x8000" loadflag="reload" />
-				<rom size="8192" offset="0xa000" loadflag="reload" />
-				<rom size="8192" offset="0xc000" loadflag="reload" />
-				<rom size="8192" offset="0xe000" loadflag="reload" />
+				<rom name="crazy train (japan).rom" size="0x2000" crc="39e6ff25" sha1="8aca0ee5845b0b39af624e8a998bb04f02d0fda4" />
+				<rom size="0x2000" offset="0x2000" loadflag="reload" />
+				<rom size="0x2000" offset="0x4000" loadflag="reload" />
+				<rom size="0x2000" offset="0x6000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -3776,16 +4112,13 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G006C" />
 		<info name="alt_title" value="クレイジートレイン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
+			<feature name="start_page" value="0"/>
+			<dataarea name="rom" size="0x8000">
 				<!-- Mirroring not verified -->
-				<rom name="crazy train (japan) (alt 1).rom" size="8192" crc="b8764cd3" sha1="31b452ff42624c6ac1e0141d65869df1eabe5bb3" />
-				<rom size="8192" offset="0x2000" loadflag="reload" />
-				<rom size="8192" offset="0x4000" loadflag="reload" />
-				<rom size="8192" offset="0x6000" loadflag="reload" />
-				<rom size="8192" offset="0x8000" loadflag="reload" />
-				<rom size="8192" offset="0xa000" loadflag="reload" />
-				<rom size="8192" offset="0xc000" loadflag="reload" />
-				<rom size="8192" offset="0xe000" loadflag="reload" />
+				<rom name="crazy train (japan) (alt 1).rom" size="0x2000" crc="b8764cd3" sha1="31b452ff42624c6ac1e0141d65869df1eabe5bb3" />
+				<rom size="0x2000" offset="0x2000" loadflag="reload" />
+				<rom size="0x2000" offset="0x4000" loadflag="reload" />
+				<rom size="0x2000" offset="0x6000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -3799,8 +4132,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="cross_blaim" />
 			<feature name="mapper" value="CROSS-BLAIM" />
-			<dataarea name="rom" size="65536">
-				<rom name="cross blaim (japan).rom" size="65536" crc="47273220" sha1="bb902e82a2bdda61101a9b3646462adecdd18c8d" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="cross blaim (japan).rom" size="0x10000" crc="47273220" sha1="bb902e82a2bdda61101a9b3646462adecdd18c8d" />
 			</dataarea>
 		</part>
 	</software>
@@ -3812,8 +4145,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5083" />
 		<info name="alt_title" value="クルゼーダー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="crusader (japan).rom" size="32768" crc="0b69dd50" sha1="d0e8bc3f5fd93dcd07cbb945b00018a491842242" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="crusader (japan).rom" size="0x8000" crc="0b69dd50" sha1="d0e8bc3f5fd93dcd07cbb945b00018a491842242" />
 			</dataarea>
 		</part>
 	</software>
@@ -3825,8 +4159,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5083" />
 		<info name="alt_title" value="クルゼーダー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="crusader (japan) (alt 1).rom" size="32768" crc="e167fede" sha1="3d2d0a2eb3d12fa67ecbbb90b7ac1bdc76ad8412" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="crusader (japan) (alt 1).rom" size="0x8000" crc="e167fede" sha1="3d2d0a2eb3d12fa67ecbbb90b7ac1bdc76ad8412" />
 			</dataarea>
 		</part>
 	</software>
@@ -3838,8 +4173,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5083" />
 		<info name="alt_title" value="クルゼーダー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="crusader (japan) (alt 2).rom" size="32768" crc="40afef74" sha1="c6f090882886dcf783e5b65bff75c5e034fbb2eb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="crusader (japan) (alt 2).rom" size="0x8000" crc="40afef74" sha1="c6f090882886dcf783e5b65bff75c5e034fbb2eb" />
 			</dataarea>
 		</part>
 	</software>
@@ -3849,8 +4185,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Clover</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="crusader.rom" size="32768" crc="73f3c7e2" sha1="a0b6f2ce1428d21dfb81606d517890bf8f7cec03" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="crusader.rom" size="0x8000" crc="73f3c7e2" sha1="a0b6f2ce1428d21dfb81606d517890bf8f7cec03" />
 			</dataarea>
 		</part>
 	</software>
@@ -3862,8 +4199,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="cyborg z (zemina, 1991).rom" size="131072" crc="77efe84a" sha1="c2e661e9b68a78e5a5fae5ae297b5d964d82491e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="cyborg z (zemina, 1991).rom" size="0x20000" crc="77efe84a" sha1="c2e661e9b68a78e5a5fae5ae297b5d964d82491e" />
 			</dataarea>
 		</part>
 	</software>
@@ -3874,8 +4211,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Toshiba</publisher>
 		<info name="serial" value="HX-S117" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="d-day (japan).rom" size="16384" crc="5d284ea6" sha1="18e87e15b09ec2fddc52fad10edc57918fadec34" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="d-day (japan).rom" size="0x4000" crc="5d284ea6" sha1="18e87e15b09ec2fddc52fad10edc57918fadec34" />
 			</dataarea>
 		</part>
 	</software>
@@ -3886,8 +4224,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Toshiba</publisher>
 		<info name="serial" value="HX-S117" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="d-day (japan) (alt 1).rom" size="16384" crc="6641c97a" sha1="ba325451fb5a80c2872742c5bd61e7bb75c5763b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="d-day (japan) (alt 1).rom" size="0x4000" crc="6641c97a" sha1="ba325451fb5a80c2872742c5bd61e7bb75c5763b" />
 			</dataarea>
 		</part>
 	</software>
@@ -3898,8 +4237,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Toshiba</publisher>
 		<info name="serial" value="HX-S117" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="d-day (japan) (alt 2).rom" size="16384" crc="a7f0dd41" sha1="c62e058c2a54f3c9adba2e6a3006b8e749c43bd7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="d-day (japan) (alt 2).rom" size="0x4000" crc="a7f0dd41" sha1="c62e058c2a54f3c9adba2e6a3006b8e749c43bd7" />
 			</dataarea>
 		</part>
 	</software>
@@ -3910,8 +4250,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Toshiba</publisher>
 		<info name="serial" value="HX-S117" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="d-day (japan) (alt 3).rom" size="16384" crc="a89b0f57" sha1="0ba8ae697f3045b3b3175b27d00ac0e522288ff1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="d-day (japan) (alt 3).rom" size="0x4000" crc="a89b0f57" sha1="0ba8ae697f3045b3b3175b27d00ac0e522288ff1" />
 			</dataarea>
 		</part>
 	</software>
@@ -3921,8 +4262,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>San Ho</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="d-day.rom" size="16384" crc="8a79ee57" sha1="0f5e4590d526f5a15d0442fd9194f76bce9bc081" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="d-day.rom" size="0x4000" crc="8a79ee57" sha1="0f5e4590d526f5a15d0442fd9194f76bce9bc081" />
 			</dataarea>
 		</part>
 	</software>
@@ -3934,8 +4276,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-101" />
 		<info name="alt_title" value="大障害競馬, Exciting Jockey (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="casio daishogai keiba (japan).rom" size="16384" crc="5312db08" sha1="5b17cb69697cf55dff1f0b8777e19d5abc1771fc" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="casio daishogai keiba (japan).rom" size="0x4000" crc="5312db08" sha1="5b17cb69697cf55dff1f0b8777e19d5abc1771fc" />
 			</dataarea>
 		</part>
 	</software>
@@ -3947,8 +4290,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GA-117" />
 		<info name="alt_title" value="大脱走" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="daidasso (japan).rom" size="32768" crc="fc17c9bc" sha1="27a487e56721e947c1f46644f2f8a50156dda82d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="daidasso (japan).rom" size="0x8000" crc="fc17c9bc" sha1="27a487e56721e947c1f46644f2f8a50156dda82d" />
 			</dataarea>
 		</part>
 	</software>
@@ -3958,21 +4302,24 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Comptiq</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="dam busters, the (japan) (alt 1).rom" size="32768" crc="711a7a6e" sha1="0738fefa62be2acbd0f324f28538bba9551406ac" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="dam busters, the (japan) (alt 1).rom" size="0x8000" crc="711a7a6e" sha1="0738fefa62be2acbd0f324f28538bba9551406ac" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="dambustra" cloneof="dambustr">
+	<!-- Cannot get past first copyright screen -->
+	<software name="dambustra" cloneof="dambustr" supported="no">
 		<description>The Dam Busters (Japan)</description>
 		<year>1985</year>
 		<publisher>Comptiq</publisher>
 		<info name="serial" value="C259191-701" />
 		<info name="alt_title" value="ダムバスター ~ Dam Busters (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="dam busters, the (japan).rom" size="32768" crc="6fde5bca" sha1="d8c074267e0b2ec225d5acba688ea7304233da13" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="dam busters, the (japan).rom" size="0x8000" crc="6fde5bca" sha1="d8c074267e0b2ec225d5acba688ea7304233da13" />
 			</dataarea>
 		</part>
 	</software>
@@ -3982,9 +4329,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="デインジャーＸ４" />
+		<info name="serial" value="20115"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="danger x4 (japan).rom" size="16384" crc="571f12fb" sha1="6a4e8325d2174747d56cbe4c6803cbf40eb40a62" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="danger x4 (japan).rom" size="0x4000" crc="571f12fb" sha1="6a4e8325d2174747d56cbe4c6803cbf40eb40a62" />
 			</dataarea>
 		</part>
 	</software>
@@ -3994,9 +4343,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="デインジャーＸ４" />
+		<info name="serial" value="20115"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="danger x4 (japan) (alt 1).rom" size="16384" crc="3cf16a16" sha1="7c618058809302bc3553d6189bcf310f2e5b0e08" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="danger x4 (japan) (alt 1).rom" size="0x4000" crc="3cf16a16" sha1="7c618058809302bc3553d6189bcf310f2e5b0e08" />
 			</dataarea>
 		</part>
 	</software>
@@ -4006,9 +4357,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="デインジャーＸ４" />
+		<info name="serial" value="20115"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="danger x4 (japan) (alt 2).rom" size="16384" crc="22f5e82a" sha1="50eafa5d735af5b34d14f9f6b8c2d9cd2f0441db" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="danger x4 (japan) (alt 2).rom" size="0x4000" crc="22f5e82a" sha1="50eafa5d735af5b34d14f9f6b8c2d9cd2f0441db" />
 			</dataarea>
 		</part>
 	</software>
@@ -4018,9 +4371,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ダビデII" />
+		<info name="serial" value="AMX005"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="david ii (japan).rom" size="16384" crc="e04bffe5" sha1="4b19979e01bab2289abb6034cb3c2d02c2e890d1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="david ii (japan).rom" size="0x4000" crc="e04bffe5" sha1="4b19979e01bab2289abb6034cb3c2d02c2e890d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -4030,21 +4385,23 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="david2.rom" size="16384" crc="4fd42edb" sha1="c5cd97eebe8ac90e57197f0df847f24e14779e2f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="david2.rom" size="0x4000" crc="4fd42edb" sha1="c5cd97eebe8ac90e57197f0df847f24e14779e2f" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="dawnpatr" supported="no">
+	<software name="dawnpatr">
 		<description>Dawn Patrol (Japan)</description>
 		<year>1986</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5403" />
 		<info name="alt_title" value="ドーンパトロール" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="dawn patrol (japan).rom" size="65536" crc="1fc65e80" sha1="6856a13b67750d36c4c466d30472dc5465879bbf" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="dawn patrol (japan).rom" size="0x10000" crc="1fc65e80" sha1="6856a13b67750d36c4c466d30472dc5465879bbf" />
 			</dataarea>
 		</part>
 	</software>
@@ -4055,16 +4412,15 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R48X5506" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="decathlon (japan).rom" size="16384" crc="f99b1c22" sha1="5d43cb6ca89f31d5f543e4dcd3fa9987b9769602" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<feature name="start_page" value="0"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="decathlon (japan).rom" size="0x4000" crc="f99b1c22" sha1="5d43cb6ca89f31d5f543e4dcd3fa9987b9769602" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="deepdng" supported="partial">
+	<software name="deepdng">
 		<description>Deep Dungeon (Japan)</description>
 		<year>1988</year>
 		<publisher>ScapTrust</publisher>
@@ -4072,10 +4428,10 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8_sram" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="deep dungeon (japan).rom" size="131072" crc="27fd8f9a" sha1="e6419519c2d3247ea395e4feaa494a2e23e469ce" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="deep dungeon (japan).rom" size="0x20000" crc="27fd8f9a" sha1="e6419519c2d3247ea395e4feaa494a2e23e469ce" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -4088,10 +4444,10 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="deep dungeon ii (japan).rom" size="131072" crc="101db19c" sha1="d82135a5e28b750c44995af116db890a15f6428a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="deep dungeon ii (japan).rom" size="0x20000" crc="101db19c" sha1="d82135a5e28b750c44995af116db890a15f6428a" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -4101,9 +4457,11 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Dempa</publisher>
 		<info name="alt_title" value="デーモンクリスタル" />
+		<info name="serial" value="DP-3912028"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="demon crystal, the (japan).rom" size="32768" crc="11de4dfd" sha1="6bad9af91907c2a97fa2f4b9dd2a699ce0d70fba" offset="0x4000" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="demon crystal, the (japan).rom" size="0x8000" crc="11de4dfd" sha1="6bad9af91907c2a97fa2f4b9dd2a699ce0d70fba" />
 			</dataarea>
 		</part>
 	</software>
@@ -4113,10 +4471,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>General</publisher>
 		<info name="alt_title" value="デビルズ・ヘブン" />
+		<info name="serial" value="ES-2003"/>
 		<info name="usage" value="Requires a machine with RAM in a main slot" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="devil's heaven (japan).rom" size="16384" crc="ce08f27d" sha1="91ba5c063d0ed383165b26e4609d7abda02a5242" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="devil's heaven (japan).rom" size="0x4000" crc="ce08f27d" sha1="91ba5c063d0ed383165b26e4609d7abda02a5242" />
 			</dataarea>
 		</part>
 	</software>
@@ -4128,8 +4488,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="07" />
 		<info name="alt_title" value="ディグダグ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="dig dug (japan).rom" size="32768" crc="3c749758" sha1="6e2e5cff4ee4dd935fbe6684f2c54b39eca06092" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="dig dug (japan).rom" size="0x8000" crc="3c749758" sha1="6e2e5cff4ee4dd935fbe6684f2c54b39eca06092" />
 			</dataarea>
 		</part>
 	</software>
@@ -4141,8 +4502,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="07" />
 		<info name="alt_title" value="ディグダグ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="dig dug (japan) (alt 1).rom" size="32768" crc="7c3d7dea" sha1="e3391daab17710b3f34c70f60ac6c8bfea15b6cc" />
+			<feature name="start_page" value="1"/>
+ß			<dataarea name="rom" size="0x8000">
+				<rom name="dig dug (japan) (alt 1).rom" size="0x8000" crc="7c3d7dea" sha1="e3391daab17710b3f34c70f60ac6c8bfea15b6cc" />
 			</dataarea>
 		</part>
 	</software>
@@ -4156,8 +4518,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="digital devil monogatari megami tensei (japan) (alt 1).rom" size="131072" crc="367d385e" sha1="03b42b77b1a7412f1d7bd0998cf8f2f003f77d0a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="digital devil monogatari megami tensei (japan) (alt 1).rom" size="0x20000" crc="367d385e" sha1="03b42b77b1a7412f1d7bd0998cf8f2f003f77d0a" />
 			</dataarea>
 		</part>
 	</software>
@@ -4168,9 +4530,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5805" />
 		<info name="alt_title" value="どきどきペンギンランド" />
+		<info name="gtin" value="04988013000896"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="doki doki penguin land (japan).rom" size="32768" crc="652d0e39" sha1="6b12bb291e1a98a43ccff8ceb94d23585848febc" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="doki doki penguin land (japan).rom" size="0x8000" crc="652d0e39" sha1="6b12bb291e1a98a43ccff8ceb94d23585848febc" />
 			</dataarea>
 		</part>
 	</software>
@@ -4181,9 +4545,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5805" />
 		<info name="alt_title" value="どきどきペンギンランド" />
+		<info name="gtin" value="04988013000896"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="doki doki penguin land (japan) (alt 1).rom" size="32768" crc="de4af7f6" sha1="23531b4e8a2b3e975483318846cf89e65f32f7d1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="doki doki penguin land (japan) (alt 1).rom" size="0x8000" crc="de4af7f6" sha1="23531b4e8a2b3e975483318846cf89e65f32f7d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -4195,8 +4561,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="E-M004" />
 		<info name="alt_title" value="ドアドアｍｋII ~ Door Door mkII (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="doordoor (japan).rom" size="16384" crc="f8ad9717" sha1="f8feeac4384bc4f109c70f962e15ce925bf70c13" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="doordoor (japan).rom" size="0x4000" crc="f8ad9717" sha1="f8feeac4384bc4f109c70f962e15ce925bf70c13" />
 			</dataarea>
 		</part>
 	</software>
@@ -4208,8 +4575,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G014C" />
 		<info name="alt_title" value="ドロドン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="dorodon (japan).rom" size="16384" crc="5aa63a76" sha1="19c610339c0480c3d2d0d1c21e3ccbf2179bb191" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="dorodon (japan).rom" size="0x4000" crc="5aa63a76" sha1="19c610339c0480c3d2d0d1c21e3ccbf2179bb191" />
 			</dataarea>
 		</part>
 	</software>
@@ -4220,8 +4588,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="더블 드라곤" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="double dragon (korea) (unl).rom" size="32768" crc="c70e3a34" sha1="6724b2abce8145609333c8b2964de0f1a90d9cd5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="double dragon (korea) (unl).rom" size="0x8000" crc="c70e3a34" sha1="6724b2abce8145609333c8b2964de0f1a90d9cd5" />
 			</dataarea>
 		</part>
 	</software>
@@ -4233,8 +4602,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-003" />
 		<info name="alt_title" value="ドラゴン・アタック" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="dragon attack (japan).rom" size="8192" crc="a0ff8771" sha1="761ab0aa7f528bf0f51ea9de75c847ea949478d7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="dragon attack (japan).rom" size="0x2000" crc="a0ff8771" sha1="761ab0aa7f528bf0f51ea9de75c847ea949478d7" />
 			</dataarea>
 		</part>
 	</software>
@@ -4246,8 +4616,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-003" />
 		<info name="alt_title" value="ドラゴン・アタック" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="dragon attack (japan) (alt 1).rom" size="16384" crc="981facd3" sha1="533dc6d28ca60c090740879dcb3cfa386544ee45" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="dragon attack (japan) (alt 1).rom" size="0x4000" crc="981facd3" sha1="533dc6d28ca60c090740879dcb3cfa386544ee45" />
 			</dataarea>
 		</part>
 	</software>
@@ -4261,8 +4632,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="262144">
-				<rom name="dragon quest ii (japan) (alt 1).rom" size="262144" crc="d44165a3" sha1="d7b46aece68c924e09f07e3df45711f337d35d6a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dragon quest ii (japan) (alt 1).rom" size="0x40000" crc="d44165a3" sha1="d7b46aece68c924e09f07e3df45711f337d35d6a" />
 			</dataarea>
 		</part>
 	</software>
@@ -4274,8 +4645,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="4" />
 		<info name="alt_title" value="ドラゴンスレイヤー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="dragon slayer (japan).rom" size="32768" crc="6a515349" sha1="397716d26a075c6d731f0b04f3fa24aa39521798" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="dragon slayer (japan).rom" size="0x8000" crc="6a515349" sha1="397716d26a075c6d731f0b04f3fa24aa39521798" />
 			</dataarea>
 		</part>
 	</software>
@@ -4285,9 +4657,12 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Victor</publisher>
 		<info name="alt_title" value="ドレイナー" />
+		<info name="serial" value="M-2009"/>
+		<info name="gtin" value="04988002126309"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="drainer (japan).rom" size="32768" crc="db803e8a" sha1="e34161034364ef03df907d62976c2ac8f551404f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="drainer (japan).rom" size="0x8000" crc="db803e8a" sha1="e34161034364ef03df907d62976c2ac8f551404f" />
 			</dataarea>
 		</part>
 	</software>
@@ -4297,9 +4672,12 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ダンジョンマスター" />
+		<info name="serial" value="2019201"/>
+		<info name="isbn" value="4871488969"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="dungeon master (japan).rom" size="32768" crc="33700744" sha1="353e2bd901e5502375dc92a04e1686c1192fcf42" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="dungeon master (japan).rom" size="0x8000" crc="33700744" sha1="353e2bd901e5502375dc92a04e1686c1192fcf42" />
 			</dataarea>
 		</part>
 	</software>
@@ -4310,9 +4688,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>HAL Kenkyuujo</publisher>
 		<info name="serial" value="HM-021" />
 		<info name="alt_title" value="ダンクショット" />
+		<info name="gtin" value="04988610115214"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="dunk shot (japan).rom" size="32768" crc="6c366b32" sha1="f63d274a8a7ad8e285dd8800264ab9c14aa9f870" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="dunk shot (japan).rom" size="0x8000" crc="6c366b32" sha1="f63d274a8a7ad8e285dd8800264ab9c14aa9f870" />
 			</dataarea>
 		</part>
 	</software>
@@ -4323,9 +4703,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>HAL Kenkyuujo</publisher>
 		<info name="serial" value="HM-021" />
 		<info name="alt_title" value="ダンクショット" />
+		<info name="gtin" value="04988610115214"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="dunk shot (japan) (alt 1).rom" size="32768" crc="99b7eab1" sha1="e7d9d1e4dcf48779dab41eb6c15478f934bd8bc1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="dunk shot (japan) (alt 1).rom" size="0x8000" crc="99b7eab1" sha1="e7d9d1e4dcf48779dab41eb6c15478f934bd8bc1" />
 			</dataarea>
 		</part>
 	</software>
@@ -4335,11 +4717,12 @@ kept for now until finding out what those bytes affect...
 		<year>1988</year>
 		<publisher>Toshiba EMI</publisher>
 		<info name="serial" value="PS-2023G" />
+		<info name="gtin" value="04988006022621"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="dynamite bowl (japan).rom" size="131072" crc="47ec57da" sha1="d7109cf20a22558f923c833ff0b4e2311340acb1" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="dynamite bowl (japan).rom" size="0x20000" crc="47ec57da" sha1="d7109cf20a22558f923c833ff0b4e2311340acb1" />
 			</dataarea>
 		</part>
 	</software>
@@ -4350,8 +4733,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G017C" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="exa innova (japan).rom" size="16384" crc="4ff88059" sha1="7f6906ff7017a558952197198ac7a1c1e222ed9d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="exa innova (japan).rom" size="0x4000" crc="4ff88059" sha1="7f6906ff7017a558952197198ac7a1c1e222ed9d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4362,19 +4746,23 @@ kept for now until finding out what those bytes affect...
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G017C" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="exa innova (japan) (alt 1).rom" size="16384" crc="d5b51149" sha1="a14b357a1b16163f5ffa96b0b617d352713ac047" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="exa innova (japan) (alt 1).rom" size="0x4000" crc="d5b51149" sha1="a14b357a1b16163f5ffa96b0b617d352713ac047" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Screen stays black -->
 	<software name="eagle5" supported="no">
 		<description>Eagles 5 (Korea)</description>
 		<year>1990</year>
 		<publisher>Zemina</publisher>
+		<info name="alt_title" value="독수리5형제"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="eagles 5 (zemina, 1990).rom" size="32768" crc="b9df4c42" sha1="6365ee1bfd4764546681d860c90b59f27b25f213" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="eagles 5 (zemina, 1990).rom" size="0x8000" crc="b9df4c42" sha1="6365ee1bfd4764546681d860c90b59f27b25f213" />
 			</dataarea>
 		</part>
 	</software>
@@ -4386,8 +4774,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-113" />
 		<info name="alt_title" value="イーグルファイター" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="eagle fighter (japan).rom" size="32768" crc="5c808e73" sha1="d916f0e4bd3c829a0472c6ec18d08907a5c991f3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="eagle fighter (japan).rom" size="0x8000" crc="5c808e73" sha1="d916f0e4bd3c829a0472c6ec18d08907a5c991f3" />
 			</dataarea>
 		</part>
 	</software>
@@ -4399,8 +4788,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-113" />
 		<info name="alt_title" value="イーグルファイター" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="eagle fighter (japan) (alt 1).rom" size="32768" crc="cf7edaeb" sha1="83fed4090d0942c8e0054437745c1c0ebefc6222" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="eagle fighter (japan) (alt 1).rom" size="0x8000" crc="cf7edaeb" sha1="83fed4090d0942c8e0054437745c1c0ebefc6222" />
 			</dataarea>
 		</part>
 	</software>
@@ -4412,8 +4802,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-018" />
 		<info name="alt_title" value="エッガーランドミステリー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="eggerland mystery (japan).rom" size="32768" crc="232b1050" sha1="e49f66e8ba45d0647c93a57bbc1fb7aba4665a6e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="eggerland mystery (japan).rom" size="0x8000" crc="232b1050" sha1="e49f66e8ba45d0647c93a57bbc1fb7aba4665a6e" />
 			</dataarea>
 		</part>
 	</software>
@@ -4425,22 +4816,24 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MSX-7" />
 		<info name="alt_title" value="エレベーターアクション" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="elevator action (japan).rom" size="32768" crc="39886593" sha1="6cbddd118afe63e79cb8a40f8aa879df1c7590e1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="elevator action (japan).rom" size="0x8000" crc="39886593" sha1="6cbddd118afe63e79cb8a40f8aa879df1c7590e1" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="erika">
 		<description>Erika (Japan)</description>
 		<year>1987</year>
 		<publisher>Jast</publisher>
 		<info name="serial" value="MXJA02R" />
 		<info name="alt_title" value="ＳＦアダルトアドベンチャーエリカ ~ SF Adult Adventure Erika (Box?)" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="erika (japan).rom" size="32768" crc="85ac5626" sha1="7de755f98b6a68886e61473d524d0aa6ab6577d7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="erika (japan).rom" size="0x8000" crc="85ac5626" sha1="7de755f98b6a68886e61473d524d0aa6ab6577d7" />
 			</dataarea>
 		</part>
 	</software>
@@ -4452,8 +4845,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="00160" />
 		<info name="alt_title" value="エクスチェンジャー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="exchanger (japan).rom" size="16384" crc="2c2b8a0e" sha1="ded8d969542b7be02524037fa244e6648c3f4e03" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="exchanger (japan).rom" size="0x4000" crc="2c2b8a0e" sha1="ded8d969542b7be02524037fa244e6648c3f4e03" />
 			</dataarea>
 		</part>
 	</software>
@@ -4465,8 +4859,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="00160" />
 		<info name="alt_title" value="エクスチェンジャー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="exchanger (japan) (alt 1).rom" size="16384" crc="691c0503" sha1="b5b28f53b16d43742d9d7daf5ee7dcf74b80e6c8" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="exchanger (japan) (alt 1).rom" size="0x4000" crc="691c0503" sha1="b5b28f53b16d43742d9d7daf5ee7dcf74b80e6c8" />
 			</dataarea>
 		</part>
 	</software>
@@ -4478,8 +4873,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="DP3912010" />
 		<info name="alt_title" value="エクセリオン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="exerion (japan).rom" size="16384" crc="7abefd3d" sha1="975fdf521c08030896eb50af4f39a23500eaf7ac" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="exerion (japan).rom" size="0x4000" crc="7abefd3d" sha1="975fdf521c08030896eb50af4f39a23500eaf7ac" />
 			</dataarea>
 		</part>
 	</software>
@@ -4491,8 +4887,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="DP3912010" />
 		<info name="alt_title" value="エクセリオン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="exerion (japan) (alt 1).rom" size="16384" crc="24b3b811" sha1="09b0ea7c5595f4e9c9a15219f30e3423bbc25f66" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="exerion (japan) (alt 1).rom" size="0x4000" crc="24b3b811" sha1="09b0ea7c5595f4e9c9a15219f30e3423bbc25f66" />
 			</dataarea>
 		</part>
 	</software>
@@ -4504,7 +4901,8 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="DP3912010" />
 		<info name="alt_title" value="エクセリオン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
 				<rom name="exerion (japan) (alt 2).rom" size="16417" crc="369cb84e" sha1="8ecc34ebff9d37c0fe9560cfdc53a052cff3d1ab" status="baddump" />
 			</dataarea>
 		</part>
@@ -4515,8 +4913,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="exerion.rom" size="32768" crc="55b25506" sha1="c221c5d90c3c6eabf1a651072cd9841ad1b25d7d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="exerion.rom" size="0x8000" crc="55b25506" sha1="c221c5d90c3c6eabf1a651072cd9841ad1b25d7d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4528,8 +4927,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HX-S118" />
 		<info name="alt_title" value="エクセリオン II -ゾルニ-" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="exerion ii - zorni (japan).rom" size="16384" crc="0b6c146f" sha1="2b36fe2b0d98d65ab31f13fcb858db6858a51d46" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="exerion ii - zorni (japan).rom" size="0x4000" crc="0b6c146f" sha1="2b36fe2b0d98d65ab31f13fcb858db6858a51d46" />
 			</dataarea>
 		</part>
 	</software>
@@ -4541,8 +4941,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HX-S118" />
 		<info name="alt_title" value="エクセリオン II -ゾルニ-" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="exerion ii - zorni (japan) (alt 1).rom" size="16384" crc="f3144243" sha1="aa1621a6b61f7cfb2df8dd2cf8647a943e13dfa7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="exerion ii - zorni (japan) (alt 1).rom" size="0x4000" crc="f3144243" sha1="aa1621a6b61f7cfb2df8dd2cf8647a943e13dfa7" />
 			</dataarea>
 		</part>
 	</software>
@@ -4554,8 +4955,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-120" />
 		<info name="alt_title" value="エクゾイドＺ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="exoide-z (japan).rom" size="16384" crc="6e19c254" sha1="3137e676c37195d46fe6acc4395d0dc4d711d919" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="exoide-z (japan).rom" size="0x4000" crc="6e19c254" sha1="3137e676c37195d46fe6acc4395d0dc4d711d919" />
 			</dataarea>
 		</part>
 	</software>
@@ -4567,8 +4969,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-120" />
 		<info name="alt_title" value="エクゾイドＺ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="exoide-z (japan) (alt 1).rom" size="16384" crc="0c7fb621" sha1="06bfdd6d0f0d84b1d534c81b27150193969168b3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="exoide-z (japan) (alt 1).rom" size="0x4000" crc="0c7fb621" sha1="06bfdd6d0f0d84b1d534c81b27150193969168b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -4580,8 +4983,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-120" />
 		<info name="alt_title" value="エクゾイドＺ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="exoide-z (japan) (alt 2).rom" size="16384" crc="2d97d2bd" sha1="91bee8af612f69c5413a1d23102cc5ea896c2caa" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="exoide-z (japan) (alt 2).rom" size="0x4000" crc="2d97d2bd" sha1="91bee8af612f69c5413a1d23102cc5ea896c2caa" />
 			</dataarea>
 		</part>
 	</software>
@@ -4592,9 +4996,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-129" />
 		<info name="alt_title" value="エクゾイドＺエリア５" />
+		<info name="gtin" valu="04971850104971"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="exoide-z area 5 (japan).rom" size="32768" crc="ad529df0" sha1="22c7abe6c8f4b7897ecb583d4913d35b5f62c5e1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="exoide-z area 5 (japan).rom" size="0x8000" crc="ad529df0" sha1="22c7abe6c8f4b7897ecb583d4913d35b5f62c5e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -4604,8 +5010,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="exoidez.rom" size="32768" crc="b0d63c50" sha1="3987c45a35e5c3fe494a00ef0690a329790ae34d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="exoidez.rom" size="0x8000" crc="b0d63c50" sha1="3987c45a35e5c3fe494a00ef0690a329790ae34d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4619,8 +5026,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="f-1 spirit - the way to formula-1 (japan).rom" size="131072" crc="12bfd3a9" sha1="ff72a1788d47f9876d9fabd720f6a289fb409090" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="f-1 spirit - the way to formula-1 (japan).rom" size="0x20000" crc="12bfd3a9" sha1="ff72a1788d47f9876d9fabd720f6a289fb409090" />
 			</dataarea>
 		</part>
 	</software>
@@ -4634,8 +5041,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="f-1 spirit - the way to formula-1 (japan) (alt 1).rom" size="131072" crc="64d2df7c" sha1="42fbb18722df3e34e5b0f935a2dc0ce0d85099e9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="f-1 spirit - the way to formula-1 (japan) (alt 1).rom" size="0x20000" crc="64d2df7c" sha1="42fbb18722df3e34e5b0f935a2dc0ce0d85099e9" />
 			</dataarea>
 		</part>
 	</software>
@@ -4647,8 +5054,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="f-1 spirit - the way to formula 1 (1987)(zemina)[rc-752].rom" size="131072" crc="f5a3b765" sha1="6e5acdfb1c1610257a7aabf3d5aa858866dbcf2e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="f-1 spirit - the way to formula 1 (1987)(zemina)[rc-752].rom" size="0x20000" crc="f5a3b765" sha1="6e5acdfb1c1610257a7aabf3d5aa858866dbcf2e" />
 			</dataarea>
 		</part>
 	</software>
@@ -4658,21 +5065,25 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="Ｆ１６ファイティングファルコン" />
+		<info name="serial" value="20145"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="f16 fighting falcon (japan).rom" size="16384" crc="70a0cb2c" sha1="5c7a13b64b48065231f05c35b4c8b209534f3a8b" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="f16 fighting falcon (japan).rom" size="0x4000" crc="70a0cb2c" sha1="5c7a13b64b48065231f05c35b4c8b209534f3a8b" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Different first screen, older? newer? -->
 	<software name="fatetris">
 		<description>FA Tetris (Korea)</description>
 		<year>1989</year>
 		<publisher>FA Soft</publisher>
 		<info name="alt_title" value="에프에이 테트리스" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="fa tetris (korea) (unl).rom" size="32768" crc="1ec87e3a" sha1="a469935dd39a856c06676817f51b403a3678ac1a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="fa tetris (korea) (unl).rom" size="0x8000" crc="1ec87e3a" sha1="a469935dd39a856c06676817f51b403a3678ac1a" />
 			</dataarea>
 		</part>
 	</software>
@@ -4683,8 +5094,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>FA Soft</publisher>
 		<info name="alt_title" value="에프에이 테트리스" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tetrisb.rom" size="32768" crc="4c6df534" sha1="e8d4acdc4141fb9edaaa5c6aeb4fcf19594e3512" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="tetrisb.rom" size="0x8000" crc="4c6df534" sha1="e8d4acdc4141fb9edaaa5c6aeb4fcf19594e3512" />
 			</dataarea>
 		</part>
 	</software>
@@ -4695,8 +5107,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>FA Soft</publisher>
 		<info name="alt_title" value="에프에이 테트리스" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tetris_n.rom" size="32768" crc="30151594" sha1="32b9ae8409abcca5e8536e890b21cc310cf45822" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="tetris_n.rom" size="0x8000" crc="30151594" sha1="32b9ae8409abcca5e8536e890b21cc310cf45822" />
 			</dataarea>
 		</part>
 	</software>
@@ -4706,9 +5119,12 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="フェアリー" />
+		<info name="serial" value="20140"/>
+		<info name="isbn" value="4871488179"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="fairy (japan).rom" size="16384" crc="314728c3" sha1="edd61208e11149e226cd2eddf5c9eca8ee1ba33e" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="fairy (japan).rom" size="0x4000" crc="314728c3" sha1="edd61208e11149e226cd2eddf5c9eca8ee1ba33e" />
 			</dataarea>
 		</part>
 	</software>
@@ -4718,11 +5134,12 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Hot-B</publisher>
 		<info name="alt_title" value="フェアリーランドストーリー" />
+		<info name="gtin" value="04967948000041"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="fairy land story, the (japan).rom" size="131072" crc="26e34f05" sha1="e11afc03db4e1d03976d02796b29da9c65d4ff3d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="fairy land story, the (japan).rom" size="0x20000" crc="26e34f05" sha1="e11afc03db4e1d03976d02796b29da9c65d4ff3d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4732,11 +5149,12 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Hot-B</publisher>
 		<info name="alt_title" value="フェアリーランドストーリー" />
+		<info name="gtin" value="04967948000041"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="fairy land story, the (japan) (alt 1).rom" size="131072" crc="c032376b" sha1="2bb837a9051277ba574d8351a9f91f9e57033074" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="fairy land story, the (japan) (alt 1).rom" size="0x20000" crc="c032376b" sha1="2bb837a9051277ba574d8351a9f91f9e57033074" />
 			</dataarea>
 		</part>
 	</software>
@@ -4748,8 +5166,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="fantasy zone (1987)(zemina).rom" size="131072" crc="c73d4d25" sha1="442a39b196f19a22fc7fb8f14bf17386a292b60e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="fantasy zone (1987)(zemina).rom" size="0x20000" crc="c73d4d25" sha1="442a39b196f19a22fc7fb8f14bf17386a292b60e" />
 			</dataarea>
 		</part>
 	</software>
@@ -4761,8 +5179,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2013G" />
 		<info name="alt_title" value="人魚伝説 ~ Ningyu Densetsu (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="fathom (japan).rom" size="32768" crc="f06a58da" sha1="ae52922a197a2f47c7fc4adf9dbfde13c136ed14" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="fathom (japan).rom" size="0x8000" crc="f06a58da" sha1="ae52922a197a2f47c7fc4adf9dbfde13c136ed14" />
 			</dataarea>
 		</part>
 	</software>
@@ -4774,8 +5193,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5084" />
 		<info name="alt_title" value="ファイナルジャスティス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="final justice (japan).rom" size="16384" crc="851ba4bb" sha1="9bca89c71c033bb9a85ee30cf75960ec839c0462" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="final justice (japan).rom" size="0x4000" crc="851ba4bb" sha1="9bca89c71c033bb9a85ee30cf75960ec839c0462" />
 			</dataarea>
 		</part>
 	</software>
@@ -4787,8 +5207,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5084" />
 		<info name="alt_title" value="ファイナルジャスティス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="final justice (japan) (alt 1).rom" size="16384" crc="41a86301" sha1="1e70296a07a5ff62d01e5115b8c8b87f891585c9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="final justice (japan) (alt 1).rom" size="0x4000" crc="41a86301" sha1="1e70296a07a5ff62d01e5115b8c8b87f891585c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -4800,22 +5221,23 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5084" />
 		<info name="alt_title" value="ファイナルジャスティス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="final justice (japan) (alt 2).rom" size="16384" crc="b1663de8" sha1="d833c66dd541239908555762e04bcbb22bca748a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="final justice (japan) (alt 2).rom" size="0x4000" crc="b1663de8" sha1="d833c66dd541239908555762e04bcbb22bca748a" />
 			</dataarea>
 		</part>
 	</software>
 
-<!-- Title screen is not displayed -->
-	<software name="finalmj" supported="partial">
+	<software name="finalmj">
 		<description>Final Mahjong (Japan)</description>
 		<year>1983</year>
 		<publisher>MIA</publisher>
 		<info name="serial" value="MM-4, MX-X4" />
 		<info name="alt_title" value="ファイナル麻雀" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="final mahjong (japan).rom" size="16384" crc="b120b314" sha1="d086280dea7fb10fabaae26ed9d404bbe69c70c4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="final mahjong (japan).rom" size="0x4000" crc="b120b314" sha1="d086280dea7fb10fabaae26ed9d404bbe69c70c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -4827,8 +5249,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="final zone wolf (1986)(zemina).rom" size="131072" crc="06310fb1" sha1="90ea059c57f011a4fb33a558e868ee639882fe5e" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="final zone wolf (1986)(zemina).rom" size="0x20000" crc="06310fb1" sha1="90ea059c57f011a4fb33a558e868ee639882fe5e" />
 			</dataarea>
 		</part>
 	</software>
@@ -4840,8 +5262,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MX-1008" />
 		<info name="alt_title" value="ファイヤーレスキュー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="fire rescue (japan).rom" size="16384" crc="8005a9ba" sha1="0889ca383bcf24198db1fb2dd23dea1bf8c18be8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="fire rescue (japan).rom" size="0x4000" crc="8005a9ba" sha1="0889ca383bcf24198db1fb2dd23dea1bf8c18be8" />
 			</dataarea>
 		</part>
 	</software>
@@ -4853,34 +5276,37 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MX-1008" />
 		<info name="alt_title" value="ファイヤーレスキュー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="fire rescue (japan) (alt 1).rom" size="16384" crc="7b2ef621" sha1="ec0320eda10bf6bbee8081f6672a7bf9d858c1bb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="fire rescue (japan) (alt 1).rom" size="0x4000" crc="7b2ef621" sha1="ec0320eda10bf6bbee8081f6672a7bf9d858c1bb" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="flappy">
-		<description>Flappy (Japan)</description>
+		<description>Flappy Limited (Japan)</description>
 		<year>1985</year>
 		<publisher>dB-Soft</publisher>
 		<info name="serial" value="MS1-G2101-L1" />
 		<info name="alt_title" value="フラッピーリミテッド ~ Flappy Limited (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="flappy (japan).rom" size="16384" crc="b6285a0b" sha1="40c626d8c53e2e2d4e7e25d55aa2c11c2645780f" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="flappy (japan).rom" size="0x4000" crc="b6285a0b" sha1="40c626d8c53e2e2d4e7e25d55aa2c11c2645780f" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="flappya" cloneof="flappy">
-		<description>Flappy (Japan, alt)</description>
+		<description>Flappy Limited (Japan, alt)</description>
 		<year>1985</year>
 		<publisher>dB-Soft</publisher>
 		<info name="serial" value="MS1-G2101-L1" />
 		<info name="alt_title" value="フラッピーリミテッド ~ Flappy Limited (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="flappy (japan) (alt 1).rom" size="16384" crc="56ec7bbf" sha1="6f391d0408223138b7927ed719d7ac1b6c38ca0d" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="flappy (japan) (alt 1).rom" size="0x4000" crc="56ec7bbf" sha1="6f391d0408223138b7927ed719d7ac1b6c38ca0d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4891,8 +5317,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>dB-Soft</publisher>
 		<info name="serial" value="MS1-G2108-L1" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="flappy - limited 85 (japan).rom" size="16384" crc="4a4f3084" sha1="46f3954d7f92f5d00f45b82fdde543c28a4b53c9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="flappy - limited 85 (japan).rom" size="0x4000" crc="4a4f3084" sha1="46f3954d7f92f5d00f45b82fdde543c28a4b53c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -4902,8 +5329,9 @@ kept for now until finding out what those bytes affect...
 		<year>1991</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="flash point (korea) (unl).rom" size="32768" crc="c4a33da7" sha1="de95b99dffeab5c2b453778dbdc8723dc15cbfd7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="flash point (korea) (unl).rom" size="0x8000" crc="c4a33da7" sha1="de95b99dffeab5c2b453778dbdc8723dc15cbfd7" />
 			</dataarea>
 		</part>
 	</software>
@@ -4913,8 +5341,9 @@ kept for now until finding out what those bytes affect...
 		<year>1991</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="flash point (korea) (alt 1) (unl).rom" size="32768" crc="25708cfa" sha1="a3fc0a55a91ed0041221f8da788d824d9d795913" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="flash point (korea) (alt 1) (unl).rom" size="0x8000" crc="25708cfa" sha1="a3fc0a55a91ed0041221f8da788d824d9d795913" />
 			</dataarea>
 		</part>
 	</software>
@@ -4926,8 +5355,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2004G" />
 		<info name="alt_title" value="フラッシュスプラッシュ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="flash splash (japan).rom" size="8192" crc="5c187cf7" sha1="60f685670de6d2d8ed5f1b1ddd40fac851ff1982" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="flash splash (japan).rom" size="0x2000" crc="5c187cf7" sha1="60f685670de6d2d8ed5f1b1ddd40fac851ff1982" />
 			</dataarea>
 		</part>
 	</software>
@@ -4939,32 +5369,37 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MR-400005" />
 		<info name="alt_title" value="フリッキー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="flicky (japan).rom" size="32768" crc="88250e5d" sha1="5999cc1407afe5ba8a760f16178c4cac9c3fa192" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="flicky (japan).rom" size="0x8000" crc="88250e5d" sha1="5999cc1407afe5ba8a760f16178c4cac9c3fa192" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="flideck">
-		<description>Flight Deck (Japan)</description>
+		<description>Flight Deck II (Japan)</description>
 		<year>1986</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="alt_title" value="フライトデッキ" />
+		<info name="serial" value="R49X5105"/>
+		<info name="gtin" value="04988013008298"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="flight deck (japan).rom" size="65536" crc="a00526d0" sha1="3eee7c72362522c27866d4367a8cf1e22932db32" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="flight deck (japan).rom" size="0x10000" crc="a00526d0" sha1="3eee7c72362522c27866d4367a8cf1e22932db32" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="flidecka" cloneof="flideck">
-		<description>Flight Deck (Japan, alt)</description>
+		<description>Flight Deck II (Japan, alt)</description>
 		<year>1986</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="alt_title" value="フライトデッキ" />
+		<info name="serial" value="R49X5105"/>
+		<info name="gtin" value="04988013008298"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="flight deck (japan) (alt 1).rom" size="65536" crc="4b162065" sha1="488f01314da5644fbf2ca938c6f9720ef2b0d0f9" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="flight deck (japan) (alt 1).rom" size="0x10000" crc="4b162065" sha1="488f01314da5644fbf2ca938c6f9720ef2b0d0f9" />
 			</dataarea>
 		</part>
 	</software>
@@ -4974,9 +5409,12 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="フリッパースリッパー" />
+		<info name="serial" value="20096"/>
+		<info name="isbn" value="4871489647"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="flipper slipper (japan).rom" size="16384" crc="fd7de91e" sha1="3377d2017cc8433fa20b432c9d2328c53bbc10e6" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="flipper slipper (japan).rom" size="0x4000" crc="fd7de91e" sha1="3377d2017cc8433fa20b432c9d2328c53bbc10e6" />
 			</dataarea>
 		</part>
 	</software>
@@ -4986,9 +5424,12 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="フリッパースリッパー" />
+		<info name="serial" value="20096"/>
+		<info name="isbn" value="4871489647"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="flipper slipper (japan) (alt 1).rom" size="16384" crc="f0b5fe8d" sha1="49bfa9871bb0ad3b47a7c63b14a10e0e8ae48a52" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="flipper slipper (japan) (alt 1).rom" size="0x4000" crc="f0b5fe8d" sha1="49bfa9871bb0ad3b47a7c63b14a10e0e8ae48a52" />
 			</dataarea>
 		</part>
 	</software>
@@ -5000,8 +5441,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="ND-02MR" />
 		<info name="alt_title" value="フォーメーションＺ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="formation z (japan).rom" size="32768" crc="37b55d09" sha1="c0d33b513704adc56718b1f56c1062718683c77c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="formation z (japan).rom" size="0x8000" crc="37b55d09" sha1="c0d33b513704adc56718b1f56c1062718683c77c" />
 			</dataarea>
 		</part>
 	</software>
@@ -5013,8 +5455,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="ND-02MR" />
 		<info name="alt_title" value="フォーメーションＺ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="formation z (japan) (alt 1).rom" size="32768" crc="74560bbd" sha1="ce01afe30da38dc58994c8264070195e1cd921b8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="formation z (japan) (alt 1).rom" size="0x8000" crc="74560bbd" sha1="ce01afe30da38dc58994c8264070195e1cd921b8" />
 			</dataarea>
 		</part>
 	</software>
@@ -5023,10 +5466,12 @@ kept for now until finding out what those bytes affect...
 		<description>Frogger (Japan)</description>
 		<year>1983</year>
 		<publisher>Konami</publisher>
+		<info name="alt_title" value="フロッガー"/>
 		<info name="serial" value="RC704" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="frogger (japan).rom" size="8192" crc="97e2fcb4" sha1="a194b845857c8b33ef4fd5e53d7f38150b4fa4cf" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="frogger (japan).rom" size="0x2000" crc="97e2fcb4" sha1="a194b845857c8b33ef4fd5e53d7f38150b4fa4cf" />
 			</dataarea>
 		</part>
 	</software>
@@ -5035,10 +5480,12 @@ kept for now until finding out what those bytes affect...
 		<description>Frogger (Japan, alt)</description>
 		<year>1983</year>
 		<publisher>Konami</publisher>
+		<info name="alt_title" value="フロッガー"/>
 		<info name="serial" value="RC704" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="frogger (japan) (alt 1).rom" size="16384" crc="71edc580" sha1="d8e9fd3e9420bcbb1dd530fda1e9c718aa08d8e4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="frogger (japan) (alt 1).rom" size="0x4000" crc="71edc580" sha1="d8e9fd3e9420bcbb1dd530fda1e9c718aa08d8e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -5046,11 +5493,13 @@ kept for now until finding out what those bytes affect...
 	<software name="frontlin">
 		<description>Front Line (Japan)</description>
 		<year>1984</year>
-		<publisher>Taito</publisher>
+		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="フロントライン" />
+		<info name="serial" value="NH-MSX01"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="front line (japan).rom" size="16384" crc="b9d03f7b" sha1="ec54e05a6f784f9c616c94ab8d57e5d2647abc66" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="front line (japan).rom" size="0x4000" crc="b9d03f7b" sha1="ec54e05a6f784f9c616c94ab8d57e5d2647abc66" />
 			</dataarea>
 		</part>
 	</software>
@@ -5058,11 +5507,13 @@ kept for now until finding out what those bytes affect...
 	<software name="frontlina" cloneof="frontlin">
 		<description>Front Line (Japan, alt)</description>
 		<year>1984</year>
-		<publisher>Taito</publisher>
+		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="フロントライン" />
+		<info name="serial" value="NH-MSX01"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="front line (japan) (alt 1).rom" size="16384" crc="8d632577" sha1="883537f12814ee63c48a0ab744383f8d8e6a5ca2" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="front line (japan) (alt 1).rom" size="0x4000" crc="8d632577" sha1="883537f12814ee63c48a0ab744383f8d8e6a5ca2" />
 			</dataarea>
 		</part>
 	</software>
@@ -5070,11 +5521,13 @@ kept for now until finding out what those bytes affect...
 	<software name="frontlinb" cloneof="frontlin">
 		<description>Front Line (Japan, alt 2)</description>
 		<year>1984</year>
-		<publisher>Taito</publisher>
+		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="フロントライン" />
+		<info name="serial" value="NH-MSX01"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="front line (japan) (alt 2).rom" size="16384" crc="5958f98c" sha1="64ae3acdce06d1b41e23ee2730797fd7e472bddf" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="front line (japan) (alt 2).rom" size="0x4000" crc="5958f98c" sha1="64ae3acdce06d1b41e23ee2730797fd7e472bddf" />
 			</dataarea>
 		</part>
 	</software>
@@ -5086,8 +5539,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-002" />
 		<info name="alt_title" value="フルーツサーチ ~ Fruits Search (Box, Cart)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="fruit search (japan).rom" size="8192" crc="eba95a38" sha1="a27eb9cd77837c1e443e275d0e10888e0fd248f4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="fruit search (japan).rom" size="0x2000" crc="eba95a38" sha1="a27eb9cd77837c1e443e275d0e10888e0fd248f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -5099,8 +5553,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-002" />
 		<info name="alt_title" value="フルーツサーチ ~ Fruits Search (Box, Cart)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="fruit search (japan) (alt 1).rom" size="16384" crc="b1160421" sha1="a41e43fa3c64d776831451c35fe8bdee58625041" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="fruit search (japan) (alt 1).rom" size="0x4000" crc="b1160421" sha1="a41e43fa3c64d776831451c35fe8bdee58625041" />
 			</dataarea>
 		</part>
 	</software>
@@ -5112,19 +5567,22 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="Z-00203" />
 		<info name="alt_title" value="ファンキー・マウス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="funky mouse (japan).rom" size="16384" crc="b5c0dace" sha1="e7657d8070399d8e4d65308b356e110d83d23151" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="funky mouse (japan).rom" size="0x4000" crc="b5c0dace" sha1="e7657d8070399d8e4d65308b356e110d83d23151" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx only lists a cassette release for this software. -->
 	<software name="futbol">
 		<description>Futbol (Spain)</description>
 		<year>1985</year>
 		<publisher>Indescomp</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="futbol (spain).rom" size="16384" crc="1de36299" sha1="138a2d56237aea915baaef85e69425a658506cfb" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="futbol (spain).rom" size="0x4000" crc="1de36299" sha1="138a2d56237aea915baaef85e69425a658506cfb" />
 			</dataarea>
 		</part>
 	</software>
@@ -5136,8 +5594,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="08" />
 		<info name="alt_title" value="ギャラガ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="galaga (japan).rom" size="32768" crc="8856961d" sha1="faa5aef23febc61a875e28eebe3aadf83e1f5ba7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="galaga (japan).rom" size="0x8000" crc="8856961d" sha1="faa5aef23febc61a875e28eebe3aadf83e1f5ba7" />
 			</dataarea>
 		</part>
 	</software>
@@ -5149,8 +5608,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="08" />
 		<info name="alt_title" value="ギャラガ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="galaga (japan) (alt 1).rom" size="16384" crc="89f7fb19" sha1="2a34f0221193712c43f336f08d2a6e58a1a8974a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="galaga (japan) (alt 1).rom" size="0x4000" crc="89f7fb19" sha1="2a34f0221193712c43f336f08d2a6e58a1a8974a" />
 			</dataarea>
 		</part>
 	</software>
@@ -5162,8 +5622,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="08" />
 		<info name="alt_title" value="ギャラガ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="galaga (japan) (alt 2).rom" size="32768" crc="6ed06ee5" sha1="25308ebb33fd87a7f6a8e61868d3dcde3bd622c5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="galaga (japan) (alt 2).rom" size="0x8000" crc="6ed06ee5" sha1="25308ebb33fd87a7f6a8e61868d3dcde3bd622c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -5175,8 +5636,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="08" />
 		<info name="alt_title" value="ギャラガ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="galaga (japan) (alt 3).rom" size="32768" crc="a7f6f597" sha1="95f36cf00cee3db55940eb60cd39412226a99e94" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="galaga (japan) (alt 3).rom" size="0x8000" crc="a7f6f597" sha1="95f36cf00cee3db55940eb60cd39412226a99e94" />
 			</dataarea>
 		</part>
 	</software>
@@ -5186,8 +5648,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>San Ho</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="galaga.rom" size="32768" crc="87c9f574" sha1="c81a30eca8cc5226855ea752a9d83181247329ea" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="galaga.rom" size="0x8000" crc="87c9f574" sha1="c81a30eca8cc5226855ea752a9d83181247329ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -5199,8 +5662,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="03" />
 		<info name="alt_title" value="ギャラクシアン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="galaxian (japan).rom" size="8192" crc="e223ffd1" sha1="e2abb08abacce57703fc008881279890328f6277" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="galaxian (japan).rom" size="0x2000" crc="e223ffd1" sha1="e2abb08abacce57703fc008881279890328f6277" />
 			</dataarea>
 		</part>
 	</software>
@@ -5212,8 +5676,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="03" />
 		<info name="alt_title" value="ギャラクシアン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="galaxian (japan) (alt 1).rom" size="8192" crc="4980ffac" sha1="aa2ba89e0b1c91a4405f516ef003ad14a401096c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="galaxian (japan) (alt 1).rom" size="0x2000" crc="4980ffac" sha1="aa2ba89e0b1c91a4405f516ef003ad14a401096c" />
 			</dataarea>
 		</part>
 	</software>
@@ -5225,8 +5690,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="03" />
 		<info name="alt_title" value="ギャラクシアン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="galaxian (japan) (alt 2).rom" size="8192" crc="e6f9d8a7" sha1="692fd8a85978adafbb530510fff71848f39d4fbd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="galaxian (japan) (alt 2).rom" size="0x2000" crc="e6f9d8a7" sha1="692fd8a85978adafbb530510fff71848f39d4fbd" />
 			</dataarea>
 		</part>
 	</software>
@@ -5240,8 +5706,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="gall force - defense of chaos (japan) (alt 1).rom" size="131072" crc="f65b5271" sha1="3425eea336140da03d7d7f09a94fd928d70e2212" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="gall force - defense of chaos (japan) (alt 1).rom" size="0x20000" crc="f65b5271" sha1="3425eea336140da03d7d7f09a94fd928d70e2212" />
 			</dataarea>
 		</part>
 	</software>
@@ -5255,22 +5721,23 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="gall force - defense of chaos (japan) (alt 2).rom" size="131072" crc="ec036e37" sha1="abe52920e895c148851649ecb9c029fdc41a275f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="gall force - defense of chaos (japan) (alt 2).rom" size="0x20000" crc="ec036e37" sha1="abe52920e895c148851649ecb9c029fdc41a275f" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="gameland">
 		<description>Game Land (Japan)</description>
 		<year>1984</year>
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-501" />
 		<info name="alt_title" value="ゲームランド" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="game land (japan).rom" size="32768" crc="004976d3" sha1="39ffaacd0c2875018e7673a887a921fe9d31d6dc" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="game land (japan).rom" size="0x8000" crc="004976d3" sha1="39ffaacd0c2875018e7673a887a921fe9d31d6dc" />
 			</dataarea>
 		</part>
 	</software>
@@ -5308,8 +5775,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="korean_80in1" />
 			<feature name="mapper" value="80IN1" />
-			<dataarea name="rom" size="524288">
-				<rom name="30games.rom" size="524288" crc="8d452fa1" sha1="2de7891988a868f89f0c02fc84f762597d542d6f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="30games.rom" size="0x80000" crc="8d452fa1" sha1="2de7891988a868f89f0c02fc84f762597d542d6f" />
 			</dataarea>
 		</part>
 	</software>
@@ -5334,8 +5801,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="korean_80in1" />
 			<feature name="mapper" value="80IN1" />
-			<dataarea name="rom" size="524288">
-				<rom name="80games.rom" size="524288" crc="d9aa0055" sha1="a4a75ed32c2af3c5f009661bb76be4f65e2e9a1f" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="80games.rom" size="0x80000" crc="d9aa0055" sha1="a4a75ed32c2af3c5f009661bb76be4f65e2e9a1f" />
 			</dataarea>
 		</part>
 	</software>
@@ -5347,8 +5814,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="524288">
-				<rom name="games_80_game_collection_pack.rom" size="524288" crc="0808be76" sha1="922eccd546f7a7074bd5741eac2bde4a0075b8c0" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="games_80_game_collection_pack.rom" size="0x80000" crc="0808be76" sha1="922eccd546f7a7074bd5741eac2bde4a0075b8c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -5387,8 +5854,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="000D0" />
 		<info name="alt_title" value="ギャング・マスター" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="gang master (japan).rom" size="16384" crc="c3ee7e15" sha1="1ce1ebbb0f62224aa776c4523e2ef708154e7b52" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="gang master (japan).rom" size="0x4000" crc="c3ee7e15" sha1="1ce1ebbb0f62224aa776c4523e2ef708154e7b52" />
 			</dataarea>
 		</part>
 	</software>
@@ -5400,8 +5868,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R55X5509" />
 		<info name="alt_title" value="ゴーストバスターズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ghostbusters (europe).rom" size="32768" crc="c9bcbe5a" sha1="ba30ad98a8488bec6d0c661f7b859beb2fe219d1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ghostbusters (europe).rom" size="0x8000" crc="c9bcbe5a" sha1="ba30ad98a8488bec6d0c661f7b859beb2fe219d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -5412,9 +5881,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ZAP</publisher>
 		<info name="serial" value="20141" />
 		<info name="alt_title" value="グライダー" />
+		<info name="isbn" value="4871488195"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="glider (japan).rom" size="16384" crc="ae35e4ad" sha1="3a46902d265d98b27bff3a34160de1c7ef4f116c" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="glider (japan).rom" size="0x4000" crc="ae35e4ad" sha1="3a46902d265d98b27bff3a34160de1c7ef4f116c" />
 			</dataarea>
 		</part>
 	</software>
@@ -5425,9 +5896,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ZAP</publisher>
 		<info name="serial" value="20141" />
 		<info name="alt_title" value="グライダー" />
+		<info name="isbn" value="4871488195"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="glider (japan) (alt 1).rom" size="16384" crc="5a23f1ee" sha1="310ab424edf15d5399e31fdbc1230ddcde307d1a" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="glider (japan) (alt 1).rom" size="0x4000" crc="5a23f1ee" sha1="310ab424edf15d5399e31fdbc1230ddcde307d1a" />
 			</dataarea>
 		</part>
 	</software>
@@ -5439,8 +5912,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="BMX-002" />
 		<info name="alt_title" value="ゴジラＶＳ３大怪獣 ~ Godzilla VS 3 Dai Kaiju (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="godzilla (japan).rom" size="16384" crc="be071826" sha1="2dacf7a08857cbdc706d24b4a46665113d16ff99" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="godzilla (japan).rom" size="0x4000" crc="be071826" sha1="2dacf7a08857cbdc706d24b4a46665113d16ff99" />
 			</dataarea>
 		</part>
 	</software>
@@ -5452,8 +5926,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="BMX-002" />
 		<info name="alt_title" value="ゴジラＶＳ３大怪獣 ~ Godzilla VS 3 Dai Kaiju (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="godzilla (japan) (alt 1).rom" size="16384" crc="83d44b03" sha1="83fba43371d8d3c50a97c96923e52b40df2a7816" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="godzilla (japan) (alt 1).rom" size="0x4000" crc="83d44b03" sha1="83fba43371d8d3c50a97c96923e52b40df2a7816" />
 			</dataarea>
 		</part>
 	</software>
@@ -5463,9 +5938,11 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Toho</publisher>
 		<info name="alt_title" value="ゴジラくん" />
+		<info name="serial" value="CS11-005R"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="godzilla-kun (japan).rom" size="32768" crc="ed4a211d" sha1="d6b6cb3d85b991f8adf2e07a0e8e74b586741d12" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="godzilla-kun (japan).rom" size="0x8000" crc="ed4a211d" sha1="d6b6cb3d85b991f8adf2e07a0e8e74b586741d12" />
 			</dataarea>
 		</part>
 	</software>
@@ -5475,9 +5952,11 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Toho</publisher>
 		<info name="alt_title" value="ゴジラくん" />
+		<info name="serial" value="CS11-005R"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="godzilla-kun (japan) (alt 1).rom" size="32768" crc="6498865f" sha1="8bd874aa854cc26d7fc48e7d2de60dbbee681721" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="godzilla-kun (japan) (alt 1).rom" size="0x8000" crc="6498865f" sha1="8bd874aa854cc26d7fc48e7d2de60dbbee681721" />
 			</dataarea>
 		</part>
 	</software>
@@ -5485,12 +5964,13 @@ kept for now until finding out what those bytes affect...
 	<software name="gokiburi">
 		<description>Gokiburi Daisakusen (Japan)</description>
 		<year>1983</year>
-		<publisher>Magicsoft</publisher>
-		<info name="serial" value="MXMD 21001" />
+		<publisher>National</publisher>
+		<info name="serial" value="MXMD 21001 / CF-SS018" />
 		<info name="alt_title" value="ゴキブリ大作戦" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="gokiburi daisakusen - bug bomb (japan).rom" size="16384" crc="69ecb2ed" sha1="30e3681be376a76cf9e0f89e54555a7631759e15" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="gokiburi daisakusen - bug bomb (japan).rom" size="0x4000" crc="69ecb2ed" sha1="30e3681be376a76cf9e0f89e54555a7631759e15" />
 			</dataarea>
 		</part>
 	</software>
@@ -5500,9 +5980,12 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ゴルフゲーム" />
+		<info name="serial" value="00040"/>
+		<info name="4871489086"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="golf game (japan).rom" size="16384" crc="5d88275f" sha1="69bda8b4a96187597b95cd5c43e58da0716d0fc8" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="golf game (japan).rom" size="0x4000" crc="5d88275f" sha1="69bda8b4a96187597b95cd5c43e58da0716d0fc8" />
 			</dataarea>
 		</part>
 	</software>
@@ -5514,8 +5997,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2002G" />
 		<info name="alt_title" value="五目ならべ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="gomok narabe - omo go (japan).rom" size="16384" crc="269f079f" sha1="aacaf2e694a1c05f2ef20a8ce6892242c0f88919" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="gomok narabe - omo go (japan).rom" size="0x4000" crc="269f079f" sha1="aacaf2e694a1c05f2ef20a8ce6892242c0f88919" />
 			</dataarea>
 		</part>
 	</software>
@@ -5527,8 +6011,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2002G" />
 		<info name="alt_title" value="五目ならべ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="gomok narabe - omo go (japan) (alt 1).rom" size="16384" crc="c3816d36" sha1="6f0f61285be1158ecf2e5393619187f26a7395be" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="gomok narabe - omo go (japan) (alt 1).rom" size="0x4000" crc="c3816d36" sha1="6f0f61285be1158ecf2e5393619187f26a7395be" />
 			</dataarea>
 		</part>
 	</software>
@@ -5539,9 +6024,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC734" />
 		<info name="alt_title" value="グーニーズ" />
+		<info name="gtin" value="04988602502619"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="goonies, the (japan).rom" size="32768" crc="db327847" sha1="b1248f7b9d4e16a894555c51c533d3fd9a90802e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="goonies, the (japan).rom" size="0x8000" crc="db327847" sha1="b1248f7b9d4e16a894555c51c533d3fd9a90802e" />
 			</dataarea>
 		</part>
 	</software>
@@ -5552,9 +6039,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC734" />
 		<info name="alt_title" value="グーニーズ" />
+		<info name="gtin" value="04988602502619"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="goonies, the (japan) (alt 1).rom" size="32768" crc="c6445f82" sha1="250d0d6e646eae4817802c49e367ad8c1c35a462" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="goonies, the (japan) (alt 1).rom" size="0x8000" crc="c6445f82" sha1="250d0d6e646eae4817802c49e367ad8c1c35a462" />
 			</dataarea>
 		</part>
 	</software>
@@ -5565,9 +6054,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC734" />
 		<info name="alt_title" value="グーニーズ" />
+		<info name="gtin" value="04988602502619"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="goonies, the (japan) (alt 2).rom" size="32768" crc="38f04741" sha1="b7b4d5c83d8c336dbfe32833bba974cea7f0cb8d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="goonies, the (japan) (alt 2).rom" size="0x8000" crc="38f04741" sha1="b7b4d5c83d8c336dbfe32833bba974cea7f0cb8d" />
 			</dataarea>
 		</part>
 	</software>
@@ -5579,8 +6070,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R55X5802" />
 		<info name="alt_title" value="Ｇ．Ｐ．ワールド ~ G.P. World (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="gp world (japan).rom" size="32768" crc="9dbdd4bc" sha1="eadf124b91b996b890b1ae84b75b21ee6568d1f3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="gp world (japan).rom" size="0x8000" crc="9dbdd4bc" sha1="eadf124b91b996b890b1ae84b75b21ee6568d1f3" />
 			</dataarea>
 		</part>
 	</software>
@@ -5590,9 +6082,11 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="KN327" />
+		<info name="gtin" value="05015173100438"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="green beret (europe).rom" size="32768" crc="61f41bcd" sha1="3ea788262557f578b25e4e36e61c1cf9fb1155d1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="green beret (europe).rom" size="0x8000" crc="61f41bcd" sha1="3ea788262557f578b25e4e36e61c1cf9fb1155d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -5602,9 +6096,11 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="KN327" />
+		<info name="gtin" value="05015173100438"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="green beret (europe) (alt 1).rom" size="32768" crc="46f5e571" sha1="acd46021a228b2b612c82d04c124b78e7d4c25e3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="green beret (europe) (alt 1).rom" size="0x8000" crc="46f5e571" sha1="acd46021a228b2b612c82d04c124b78e7d4c25e3" />
 			</dataarea>
 		</part>
 	</software>
@@ -5614,8 +6110,9 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="green beret (1987)(zemina).rom" size="32768" crc="3caec828" sha1="a6b77c5873f220c00578339761552e5ee82fab62" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="green beret (1987)(zemina).rom" size="0x8000" crc="3caec828" sha1="a6b77c5873f220c00578339761552e5ee82fab62" />
 			</dataarea>
 		</part>
 	</software>
@@ -5627,8 +6124,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="C279191-703 / C279191-702" />
 		<info name="alt_title" value="B.C.'s Quest for Tires II - Grog's Revenge" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="grog's revenge (japan).rom" size="32768" crc="5f74ae0e" sha1="32615267e8497db3f5e6f5348ee309e73c80a1a7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="grog's revenge (japan).rom" size="0x8000" crc="5f74ae0e" sha1="32615267e8497db3f5e6f5348ee309e73c80a1a7" />
 			</dataarea>
 		</part>
 	</software>
@@ -5640,8 +6138,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="C279191-703 / C279191-702" />
 		<info name="alt_title" value="B.C.'s Quest for Tires II - Grog's Revenge" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="grog's revenge (japan) (alt 1).rom" size="32768" crc="eba19b7e" sha1="04325bfe5bc20a8f6d086933d138fb92ca200111" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="grog's revenge (japan) (alt 1).rom" size="0x8000" crc="eba19b7e" sha1="04325bfe5bc20a8f6d086933d138fb92ca200111" />
 			</dataarea>
 		</part>
 	</software>
@@ -5653,8 +6152,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="I.A-861" />
 		<info name="alt_title" value="ガーディック" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="guardic (japan).rom" size="32768" crc="6aebb9d3" sha1="67baaaa870ad4a08f55ec1c67dbeabc97b6f18a0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="guardic (japan).rom" size="0x8000" crc="6aebb9d3" sha1="67baaaa870ad4a08f55ec1c67dbeabc97b6f18a0" />
 			</dataarea>
 		</part>
 	</software>
@@ -5666,8 +6166,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="I.A-861" />
 		<info name="alt_title" value="ガーディック" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="guardic (japan) (alt 1).rom" size="32768" crc="106230b8" sha1="5e28fa0cd90bcfb7995acb025a22f6f556ccac08" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="guardic (japan) (alt 1).rom" size="0x8000" crc="106230b8" sha1="5e28fa0cd90bcfb7995acb025a22f6f556ccac08" />
 			</dataarea>
 		</part>
 	</software>
@@ -5677,9 +6178,12 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="alt_title" value="ガルケイブ" />
+		<info name="serial" value="R49X5810"/>
+		<info name="gtin" value="04988013006591"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="gulkave (japan).rom" size="32768" crc="a02029d0" sha1="ca5f14925a7d33d83dc581bbe2ff5258389bfba7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="gulkave (japan).rom" size="0x8000" crc="a02029d0" sha1="ca5f14925a7d33d83dc581bbe2ff5258389bfba7" />
 			</dataarea>
 		</part>
 	</software>
@@ -5689,9 +6193,12 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="alt_title" value="ガルケイブ" />
+		<info name="serial" value="R49X5810"/>
+		<info name="gtin" value="04988013006591"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="gulkave (japan) (alt 1).rom" size="32768" crc="fdb3bc27" sha1="e90b579ac64798343abb635fcbf929e83714312a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="gulkave (japan) (alt 1).rom" size="0x8000" crc="fdb3bc27" sha1="e90b579ac64798343abb635fcbf929e83714312a" />
 			</dataarea>
 		</part>
 	</software>
@@ -5700,9 +6207,11 @@ kept for now until finding out what those bytes affect...
 		<description>Gulkave (Korea)</description>
 		<year>198?</year>
 		<publisher>ProSoft</publisher>
+		<info name="alt_title" value="간케이브"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="gulkave.rom" size="32768" crc="0bee5a87" sha1="ed798b8ee852611a0e4d054bf31652ef3f73e67f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="gulkave.rom" size="0x8000" crc="0bee5a87" sha1="ed798b8ee852611a0e4d054bf31652ef3f73e67f" />
 			</dataarea>
 		</part>
 	</software>
@@ -5712,8 +6221,9 @@ kept for now until finding out what those bytes affect...
 		<year>1990</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="prosoft_gunsmoke_(1990)(prosoft).rom" size="32768" crc="1318dba7" sha1="b27aef37ab7327e12a8d4460b89af391d3789961" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="prosoft_gunsmoke_(1990)(prosoft).rom" size="0x8000" crc="1318dba7" sha1="b27aef37ab7327e12a8d4460b89af391d3789961" />
 			</dataarea>
 		</part>
 	</software>
@@ -5725,8 +6235,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="JX-12" />
 		<info name="alt_title" value="ガンフライト" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="gun fright (japan).rom" size="32768" crc="f877b3d6" sha1="445963fddfbd0487addaf4b0ad620520e426a1d2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="gun fright (japan).rom" size="0x8000" crc="f877b3d6" sha1="445963fddfbd0487addaf4b0ad620520e426a1d2" />
 			</dataarea>
 		</part>
 	</software>
@@ -5737,8 +6248,9 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>A.C.G.</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="gunfright (1986)(ultimate play the game).rom" size="32768" crc="31fe5c5b" sha1="c4bd9f0d34061b4025f8d5c5866d51c763612e92" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="gunfright (1986)(ultimate play the game).rom" size="0x8000" crc="31fe5c5b" sha1="c4bd9f0d34061b4025f8d5c5866d51c763612e92" />
 			</dataarea>
 		</part>
 	</software>
@@ -5750,8 +6262,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2016G" />
 		<info name="alt_title" value="軍人将棋軍神マース" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="gunjin shogi mars (japan).rom" size="32768" crc="174f409d" sha1="f2ec3714138175212b6b6e28b5da4361cc4b5471" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="gunjin shogi mars (japan).rom" size="0x8000" crc="174f409d" sha1="f2ec3714138175212b6b6e28b5da4361cc4b5471" />
 			</dataarea>
 		</part>
 	</software>
@@ -5762,9 +6275,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Nidecom</publisher>
 		<info name="serial" value="MSX-8" />
 		<info name="alt_title" value="ジャイロダイン" />
+		<info name="gtin" value="04988611860038"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="gyrodine (japan).rom" size="32768" crc="0e89433b" sha1="99a8631cdc37f0dd9d8793ea8eadd3f34e0bba51" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="gyrodine (japan).rom" size="0x8000" crc="0e89433b" sha1="99a8631cdc37f0dd9d8793ea8eadd3f34e0bba51" />
 			</dataarea>
 		</part>
 	</software>
@@ -5774,8 +6289,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="gyrodine.rom" size="32768" crc="1f10db79" sha1="6e17ee44d62f57be20177a692319e4da14be572f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="gyrodine.rom" size="0x8000" crc="1f10db79" sha1="6e17ee44d62f57be20177a692319e4da14be572f" />
 			</dataarea>
 		</part>
 	</software>
@@ -5787,11 +6303,10 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5505" />
 		<info name="alt_title" value="ヒーロー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="h.e.r.o. (japan).rom" size="16384" crc="97ab0d70" sha1="6fbb385147a939a7e6b47f5945d8e3b671a8c065" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<feature name="start_page" value="0"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="h.e.r.o. (japan).rom" size="0x4000" crc="97ab0d70" sha1="6fbb385147a939a7e6b47f5945d8e3b671a8c065" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -5803,21 +6318,23 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2003G" />
 		<info name="alt_title" value="花札" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hanafuta (japan).rom" size="32768" crc="5d6655c5" sha1="5370b7746112621169d503bbec2e7fc526279f53" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hanafuta (japan).rom" size="0x8000" crc="5d6655c5" sha1="5370b7746112621169d503bbec2e7fc526279f53" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="hanakoi">
 		<description>MSX Hanafuda Koi Koi (Japan)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="花札コイコイ" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hafanuda koi koi - gostop godori (japan).rom" size="16384" crc="17b160cb" sha1="301ef3c728041eb1dfd89227a901c32eb000d348" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hafanuda koi koi - gostop godori (japan).rom" size="0x4000" crc="17b160cb" sha1="301ef3c728041eb1dfd89227a901c32eb000d348" />
 			</dataarea>
 		</part>
 	</software>
@@ -5828,9 +6345,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5806" />
 		<info name="alt_title" value="ハングオン" />
+		<info name="gtin" value="04988013003590"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hang-on (japan).rom" size="32768" crc="48e7212c" sha1="26fc48ddaca0fedc90fc151d4ecd5ca6d1ccc77b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hang-on (japan).rom" size="0x8000" crc="48e7212c" sha1="26fc48ddaca0fedc90fc151d4ecd5ca6d1ccc77b" />
 			</dataarea>
 		</part>
 	</software>
@@ -5841,9 +6360,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5806" />
 		<info name="alt_title" value="ハングオン" />
+		<info name="gtin" value="04988013003590"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hang-on (japan) (alt 1).rom" size="32768" crc="1f9bbd9a" sha1="a67e699edb471c35a217a5c3e6831c6cdb0eabe5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hang-on (japan) (alt 1).rom" size="0x8000" crc="1f9bbd9a" sha1="a67e699edb471c35a217a5c3e6831c6cdb0eabe5" />
 			</dataarea>
 		</part>
 	</software>
@@ -5854,22 +6375,26 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5806" />
 		<info name="alt_title" value="ハングオン" />
+		<info name="gtin" value="04988013003590"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hang-on (japan) (alt 2).rom" size="32768" crc="69dc9f85" sha1="7f086cc2ca0c35bf599f48c2d5e901e89411239f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hang-on (japan) (alt 2).rom" size="0x8000" crc="69dc9f85" sha1="7f086cc2ca0c35bf599f48c2d5e901e89411239f" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="harapeko">
 		<description>Harapeko Pakkun (Japan)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="はらぺこパックン" />
+		<info name="isbn" value="4871489485"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="harapeko pakkun (japan).rom" size="8192" crc="145bb27b" sha1="8f35c41a5235dec22c3b99cd6dd63cfda0a7a821" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="harapeko pakkun (japan).rom" size="0x2000" crc="145bb27b" sha1="8f35c41a5235dec22c3b99cd6dd63cfda0a7a821" />
 			</dataarea>
 		</part>
 	</software>
@@ -5881,8 +6406,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-008" />
 		<info name="alt_title" value="ヘビーボクシング" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="heavy boxing (japan).rom" size="8192" crc="11e46700" sha1="69bc7cb436ea2ea3a6b49c3b050bae24271a2f9c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="heavy boxing (japan).rom" size="0x2000" crc="11e46700" sha1="69bc7cb436ea2ea3a6b49c3b050bae24271a2f9c" />
 			</dataarea>
 		</part>
 	</software>
@@ -5894,8 +6420,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-008" />
 		<info name="alt_title" value="ヘビーボクシング" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="heavy boxing (japan) (alt 1).rom" size="16384" crc="911185e1" sha1="0fa2bb1effefde0861fe53a38ff5b56a6a320c80" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="heavy boxing (japan) (alt 1).rom" size="0x4000" crc="911185e1" sha1="0fa2bb1effefde0861fe53a38ff5b56a6a320c80" />
 			</dataarea>
 		</part>
 	</software>
@@ -5905,8 +6432,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hboxing.rom" size="32768" crc="693706f9" sha1="3b697fd0424848e23d9d21ef97d47d2716bb08f6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hboxing.rom" size="0x8000" crc="693706f9" sha1="3b697fd0424848e23d9d21ef97d47d2716bb08f6" />
 			</dataarea>
 		</part>
 	</software>
@@ -5916,9 +6444,11 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Comptiq</publisher>
 		<info name="alt_title" value="ハイスト" />
+		<info name="serial" value="S069191-707"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="heist, the (japan).rom" size="32768" crc="04e454c5" sha1="20191b437958e990d14660f476c340e140236c70" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="heist, the (japan).rom" size="0x8000" crc="04e454c5" sha1="20191b437958e990d14660f476c340e140236c70" />
 			</dataarea>
 		</part>
 	</software>
@@ -5930,8 +6460,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="001F0" />
 		<info name="alt_title" value="ヘリタンク" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="helitank (japan).rom" size="16384" crc="cd63cd50" sha1="6844ddf610e1a98b55e77fcc364b38a037751a2b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="helitank (japan).rom" size="0x4000" crc="cd63cd50" sha1="6844ddf610e1a98b55e77fcc364b38a037751a2b" />
 			</dataarea>
 		</part>
 	</software>
@@ -5939,11 +6470,13 @@ kept for now until finding out what those bytes affect...
 	<software name="highway">
 		<description>High Way Star (Japan)</description>
 		<year>1983</year>
-		<publisher>ASCII</publisher>
+		<publisher>National</publisher>
 		<info name="alt_title" value="ハイウェイスター" />
+		<info name="serial" value="CF-SS037"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="high way star (japan).rom" size="16384" crc="24851440" sha1="f72681f09b52d530ec905e8df21c4a15e30201ab" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="high way star (japan).rom" size="0x4000" crc="24851440" sha1="f72681f09b52d530ec905e8df21c4a15e30201ab" />
 			</dataarea>
 		</part>
 	</software>
@@ -5953,8 +6486,9 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>Qnix</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="high way star (korea).rom" size="16384" crc="ed1625d8" sha1="c0fa7d53b3e66bd1e1680bb135db8f74abbac52e" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="high way star (korea).rom" size="0x4000" crc="ed1625d8" sha1="c0fa7d53b3e66bd1e1680bb135db8f74abbac52e" />
 			</dataarea>
 		</part>
 	</software>
@@ -5964,9 +6498,11 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>MicroCabin</publisher>
 		<info name="alt_title" value="飛車" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hisya (japan).rom" size="16384" crc="136bba04" sha1="3c2295fb9fc9f1b6a607a74f4538e24d170522e5" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hisya (japan).rom" size="0x4000" crc="136bba04" sha1="3c2295fb9fc9f1b6a607a74f4538e24d170522e5" />
 			</dataarea>
 		</part>
 	</software>
@@ -5978,8 +6514,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MX-1001" />
 		<info name="alt_title" value="ひつじやーい" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="hitsuji yai - preety sheep (japan).rom" size="8192" crc="11502a96" sha1="bbca0b00374ba5366ba53b380285d38857450a7d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="hitsuji yai - preety sheep (japan).rom" size="0x2000" crc="11502a96" sha1="bbca0b00374ba5366ba53b380285d38857450a7d" />
 			</dataarea>
 		</part>
 	</software>
@@ -5991,8 +6528,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-016" />
 		<info name="alt_title" value="ホールインワン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hole in one (japan).rom" size="16384" crc="98e7b01b" sha1="2f8416d9cce6587aba4b71b1d3e3b626609ce7ed" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hole in one (japan).rom" size="0x4000" crc="98e7b01b" sha1="2f8416d9cce6587aba4b71b1d3e3b626609ce7ed" />
 			</dataarea>
 		</part>
 	</software>
@@ -6004,8 +6542,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-016" />
 		<info name="alt_title" value="ホールインワン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hole in one (japan) (alt 1).rom" size="16384" crc="86731751" sha1="4f73d4b731b8309145b2a9bf9c37620e4f4a391c" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hole in one (japan) (alt 1).rom" size="0x4000" crc="86731751" sha1="4f73d4b731b8309145b2a9bf9c37620e4f4a391c" />
 			</dataarea>
 		</part>
 	</software>
@@ -6017,8 +6556,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-016" />
 		<info name="alt_title" value="ホールインワン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hole in one (japan) (alt 2).rom" size="16384" crc="ff063cdb" sha1="c344ed78465203e12143bd9889281ba981a195e4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hole in one (japan) (alt 2).rom" size="0x4000" crc="ff063cdb" sha1="c344ed78465203e12143bd9889281ba981a195e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -6030,8 +6570,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-016" />
 		<info name="alt_title" value="ホールインワン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hole in one (japan) (alt 3).rom" size="16384" crc="5bd60572" sha1="f3952b790ae2a8a1434b52bf816c56c9e680f73e" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hole in one (japan) (alt 3).rom" size="0x4000" crc="5bd60572" sha1="f3952b790ae2a8a1434b52bf816c56c9e680f73e" />
 			</dataarea>
 		</part>
 	</software>
@@ -6043,8 +6584,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-019" />
 		<info name="alt_title" value="ホールインワンプロフェッショナル" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hole in one professional (japan).rom" size="32768" crc="350ae107" sha1="a55617157c5d89db5900654b641e757a37fecd1a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hole in one professional (japan).rom" size="0x8000" crc="350ae107" sha1="a55617157c5d89db5900654b641e757a37fecd1a" />
 			</dataarea>
 		</part>
 	</software>
@@ -6056,8 +6598,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-019" />
 		<info name="alt_title" value="ホールインワンプロフェッショナル" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hole in one professional (japan) (alt 1).rom" size="32768" crc="acfcbba6" sha1="bb75492c6ebbbf1827b3695f70e481d65487da44" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hole in one professional (japan) (alt 1).rom" size="0x8000" crc="acfcbba6" sha1="bb75492c6ebbbf1827b3695f70e481d65487da44" />
 			</dataarea>
 		</part>
 	</software>
@@ -6070,8 +6613,9 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Eaglesoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hopper (europe).rom" size="16384" crc="d3032ad7" sha1="dd9a41e4c8802cd4bbb87e30281711f4e7ae017f" status="baddump" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hopper (europe).rom" size="0x4000" crc="d3032ad7" sha1="dd9a41e4c8802cd4bbb87e30281711f4e7ae017f" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -6083,8 +6627,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MXHI 11032" />
 		<info name="alt_title" value="ゴルフ狂 ~ Golf Kyo (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hudson 3d golf (japan).rom" size="16384" crc="d83a6a3f" sha1="e904efabc5a75840c50ea7edb07052683468a64a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hudson 3d golf (japan).rom" size="0x4000" crc="d83a6a3f" sha1="e904efabc5a75840c50ea7edb07052683468a64a" />
 			</dataarea>
 		</part>
 	</software>
@@ -6096,41 +6641,44 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MXHI 11032" />
 		<info name="alt_title" value="ゴルフ狂 ~ Golf Kyo (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hudson 3d golf (japan) (alt 1).rom" size="32768" crc="c4260c47" sha1="27847b02d2acbebab61f2f05bd2fff0c2291a09d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hudson 3d golf (japan) (alt 1).rom" size="0x8000" crc="c4260c47" sha1="27847b02d2acbebab61f2f05bd2fff0c2291a09d" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="hfox">
 		<description>Hurry Fox MSX Special (Japan)</description>
 		<year>1986</year>
 		<publisher>MicroCabin</publisher>
 		<info name="serial" value="44780" />
 		<info name="alt_title" value="は～りぃふぉっくすＭＳＸスペシャル" />
+		<info name="gtin" value="04988608447808"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16_sram" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="262144">
-				<rom name="hurryfox msx special (japan).rom" size="131072" crc="96b7faca" sha1="a3de07612da7986387a4f5c41bbbc7e3b244e077" />
-				<rom size="131072" offset="0x20000" loadflag="reload" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="hurryfox msx special (japan).rom" size="0x20000" crc="96b7faca" sha1="a3de07612da7986387a4f5c41bbbc7e3b244e077" />
+				<rom size="0x20000" offset="0x20000" loadflag="reload" />
 			</dataarea>
 			<dataarea name="sram" size="2048">
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="hfox2" cloneof="hfox">
+	<software name="hfox2">
 		<description>Hurry Fox - Yuki no Maou hen (Japan)</description>
 		<year>1985</year>
 		<publisher>MicroCabin</publisher>
 		<info name="alt_title" value="は～りぃふぉっくす雪の魔王編" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="hfox" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="65536">
-				<rom name="hurryfox yuki no maoh (japan).rom" size="65536" crc="c7fe3ee1" sha1="3626b5dd3188ec2a16e102d05c79f8f242fbd892" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="hurryfox yuki no maoh (japan).rom" size="0x10000" crc="c7fe3ee1" sha1="3626b5dd3188ec2a16e102d05c79f8f242fbd892" />
 			</dataarea>
 		</part>
 	</software>
@@ -6140,10 +6688,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>General</publisher>
 		<info name="alt_title" value="ハッスルチュミー" />
+		<info name="serial" value="ES-2004"/>
 		<info name="usage" value="Requires a machine with RAM in a main slot" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hustle chumy (japan).rom" size="16384" crc="99518a12" sha1="e06ed9b0b3e1fbb9f27be65c37b4d9b548889b4f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hustle chumy (japan).rom" size="0x4000" crc="99518a12" sha1="e06ed9b0b3e1fbb9f27be65c37b4d9b548889b4f" />
 			</dataarea>
 		</part>
 	</software>
@@ -6153,9 +6703,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>General</publisher>
 		<info name="alt_title" value="ハッスルチュミー" />
+		<info name="serial" value="ES-2004"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hustle chumy (japan) (alt 1).rom" size="16384" crc="22fd4780" sha1="86e688cea0f0c8bcd31b6bcd19fd72ac108646bb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hustle chumy (japan) (alt 1).rom" size="0x4000" crc="22fd4780" sha1="86e688cea0f0c8bcd31b6bcd19fd72ac108646bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -6166,9 +6718,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TEX-62" />
 		<info name="alt_title" value="ハイドライド" />
+		<info name="gtin" value="04988604030622"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hydlide (japan).rom" size="32768" crc="0f9d6f56" sha1="9dcb43b654a08de2c52147f4a2e628b5fe3761c8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hydlide (japan).rom" size="0x8000" crc="0f9d6f56" sha1="9dcb43b654a08de2c52147f4a2e628b5fe3761c8" />
 			</dataarea>
 		</part>
 	</software>
@@ -6182,10 +6736,10 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8_sram" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="hydlide ii - shine of darkness (japan) (alt 1).rom" size="131072" crc="b886d7f5" sha1="a3537934a4d9dfbf27aca5aaf42e0f18e4975366" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="hydlide ii - shine of darkness (japan) (alt 1).rom" size="0x20000" crc="b886d7f5" sha1="a3537934a4d9dfbf27aca5aaf42e0f18e4975366" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -6197,8 +6751,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="524288">
-				<rom name="hydlide iii - the space memories (1987)(zemina).rom" size="524288" crc="41c82156" sha1="5d2062ecc7176ca2b100724c2a17f877878d721d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="hydlide iii - the space memories (1987)(zemina).rom" size="0x80000" crc="41c82156" sha1="5d2062ecc7176ca2b100724c2a17f877878d721d" />
 			</dataarea>
 		</part>
 	</software>
@@ -6210,8 +6764,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC710" />
 		<info name="alt_title" value="ハイパーオリンピックI" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hyper olympic 1 (japan).rom" size="16384" crc="fef1d8fa" sha1="56c4813ac549af8711b2e2e42d7db1b960c4c040" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hyper olympic 1 (japan).rom" size="0x4000" crc="fef1d8fa" sha1="56c4813ac549af8711b2e2e42d7db1b960c4c040" />
 			</dataarea>
 		</part>
 	</software>
@@ -6221,8 +6776,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="holympic.rom" size="32768" crc="f36447c5" sha1="82a15beb8b31d250c12666e5e773a539ad5e47c5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="holympic.rom" size="0x8000" crc="f36447c5" sha1="82a15beb8b31d250c12666e5e773a539ad5e47c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -6234,8 +6790,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC711" />
 		<info name="alt_title" value="ハイパーオリンピックII" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hyper olympic 2 (japan).rom" size="16384" crc="38cb690b" sha1="cc9a82898da39e5cfeb0400006d093d3b869f28c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hyper olympic 2 (japan).rom" size="0x4000" crc="38cb690b" sha1="cc9a82898da39e5cfeb0400006d093d3b869f28c" />
 			</dataarea>
 		</part>
 	</software>
@@ -6247,8 +6804,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC718" />
 		<info name="alt_title" value="ハイパーラリー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hyper rally (japan).rom" size="16384" crc="f94d452e" sha1="7dfe091e02f6c1b21bd65e44eb5052d564d0ef92" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hyper rally (japan).rom" size="0x4000" crc="f94d452e" sha1="7dfe091e02f6c1b21bd65e44eb5052d564d0ef92" />
 			</dataarea>
 		</part>
 	</software>
@@ -6260,8 +6818,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC718" />
 		<info name="alt_title" value="ハイパーラリー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hyper rally (japan) (alt 1).rom" size="16384" crc="c575cec6" sha1="3b13e164130cab9b36c1a95e06f8d9fd707fc97f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hyper rally (japan) (alt 1).rom" size="0x4000" crc="c575cec6" sha1="3b13e164130cab9b36c1a95e06f8d9fd707fc97f" />
 			</dataarea>
 		</part>
 	</software>
@@ -6273,8 +6832,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC718" />
 		<info name="alt_title" value="ハイパーラリー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hyper rally (japan) (alt 2).rom" size="16384" crc="75cbb75d" sha1="d1a7cbaff354b59003f0e297723b912cb6ad0b36" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hyper rally (japan) (alt 2).rom" size="0x4000" crc="75cbb75d" sha1="d1a7cbaff354b59003f0e297723b912cb6ad0b36" />
 			</dataarea>
 		</part>
 	</software>
@@ -6286,8 +6846,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC718" />
 		<info name="alt_title" value="ハイパーラリー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hyper rally (japan) (alt 3).rom" size="16384" crc="0c5957aa" sha1="14393568469c74bd6f8be7770149db19f0553ab6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hyper rally (japan) (alt 3).rom" size="0x4000" crc="0c5957aa" sha1="14393568469c74bd6f8be7770149db19f0553ab6" />
 			</dataarea>
 		</part>
 	</software>
@@ -6299,8 +6860,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC715" />
 		<info name="alt_title" value="ハイパースポーツ1" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hyper sports 1 (japan).rom" size="16384" crc="18db4ff2" sha1="2c85b993671de612e9338d094565a4eb32a97ea0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hyper sports 1 (japan).rom" size="0x4000" crc="18db4ff2" sha1="2c85b993671de612e9338d094565a4eb32a97ea0" />
 			</dataarea>
 		</part>
 	</software>
@@ -6312,8 +6874,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC715" />
 		<info name="alt_title" value="ハイパースポーツ1" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hyper sports 1 (japan) (alt 1).rom" size="16384" crc="0b5296f7" sha1="9cab6a793e39076e3f598aa54bffd5585ddc7e3e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hyper sports 1 (japan) (alt 1).rom" size="0x4000" crc="0b5296f7" sha1="9cab6a793e39076e3f598aa54bffd5585ddc7e3e" />
 			</dataarea>
 		</part>
 	</software>
@@ -6325,19 +6888,21 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC717" />
 		<info name="alt_title" value="ハイパースポーツ2" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="hyper sports 2 (japan).rom" size="16384" crc="968fa8d6" sha1="9002aa0b2d49a9fc323180487ff591781867a99c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="hyper sports 2 (japan).rom" size="0x4000" crc="968fa8d6" sha1="9002aa0b2d49a9fc323180487ff591781867a99c" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="hypersp2k" cloneof="hypersp2">
 		<description>Hyper Sports 2 (Korea)</description>
-		<year>198?</year>
+		<year>1986</year>
 		<publisher>Topia</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hsports2.rom" size="32768" crc="fc932c9f" sha1="d74463824c3c15cb391ef7a13054472b5e7abe73" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hsports2.rom" size="0x8000" crc="fc932c9f" sha1="d74463824c3c15cb391ef7a13054472b5e7abe73" />
 			</dataarea>
 		</part>
 	</software>
@@ -6349,8 +6914,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC733" />
 		<info name="alt_title" value="ハイパースポーツ3" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hyper sports 3 (japan).rom" size="32768" crc="80a831e1" sha1="af4e0490c178a18a47b34831fb5e3cf8b61d34d9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hyper sports 3 (japan).rom" size="0x8000" crc="80a831e1" sha1="af4e0490c178a18a47b34831fb5e3cf8b61d34d9" />
 			</dataarea>
 		</part>
 	</software>
@@ -6362,8 +6928,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC733" />
 		<info name="alt_title" value="ハイパースポーツ3" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hyper sports 3 (japan) (alt 1).rom" size="32768" crc="9f47e445" sha1="ec76d4d9b61bdbde9a4b5be082dbdae96321a591" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hyper sports 3 (japan) (alt 1).rom" size="0x8000" crc="9f47e445" sha1="ec76d4d9b61bdbde9a4b5be082dbdae96321a591" />
 			</dataarea>
 		</part>
 	</software>
@@ -6375,8 +6942,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC733" />
 		<info name="alt_title" value="ハイパースポーツ3" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hyper sports 3 (japan) (alt 2).rom" size="32768" crc="b615c709" sha1="6842fb21abb2531c17fe0687d77e012348d3dc2c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hyper sports 3 (japan) (alt 2).rom" size="0x8000" crc="b615c709" sha1="6842fb21abb2531c17fe0687d77e012348d3dc2c" />
 			</dataarea>
 		</part>
 	</software>
@@ -6388,8 +6956,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-112" />
 		<info name="alt_title" value="アイスワールド" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="ice world (japan).rom" size="16384" crc="16e7b4be" sha1="167b226b54cc5b681a69d2c1509116ffaba868e4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="ice world (japan).rom" size="0x4000" crc="16e7b4be" sha1="167b226b54cc5b681a69d2c1509116ffaba868e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -6401,8 +6970,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-117" />
 		<info name="alt_title" value="伊賀忍法帖" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="iga ninpouten - small ninja (japan).rom" size="16384" crc="51727e48" sha1="f629b8f7133c3442d0371a4d84275fb2e0974854" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="iga ninpouten - small ninja (japan).rom" size="0x4000" crc="51727e48" sha1="f629b8f7133c3442d0371a4d84275fb2e0974854" />
 			</dataarea>
 		</part>
 	</software>
@@ -6414,8 +6984,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-128" />
 		<info name="alt_title" value="伊賀忍法帖満月城の戦い" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="iga ninpouten 2 - small ninja 2 (japan).rom" size="32768" crc="4aa97644" sha1="f52113b45062adc75cf7a0ed0538b3a07696cc24" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="iga ninpouten 2 - small ninja 2 (japan).rom" size="0x8000" crc="4aa97644" sha1="f52113b45062adc75cf7a0ed0538b3a07696cc24" />
 			</dataarea>
 		</part>
 	</software>
@@ -6427,8 +6998,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MX-1009" />
 		<info name="alt_title" value="インディアンの冒険" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="indian no bouken (japan).rom" size="16384" crc="3a550788" sha1="aa68633ff1afd385535b2abd7c8756b6cf79256a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="indian no bouken (japan).rom" size="0x4000" crc="3a550788" sha1="aa68633ff1afd385535b2abd7c8756b6cf79256a" />
 			</dataarea>
 		</part>
 	</software>
@@ -6437,10 +7009,12 @@ kept for now until finding out what those bytes affect...
 		<description>Iligks (Japan)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
-		<info name="alt_title" value="イリーガスエピソードIV ~ Iligks Episode IV (Box?)" />
+		<info name="alt_title" value="イリーガスエピソードIV ~ Iligks Episode IV (Box)" />
+		<info name="isbn" value="4871489248"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="iriegas (japan).rom" size="16384" crc="36a08e0b" sha1="95ae5b3e24ad0bea21902cb7dfd3fd9581166a76" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="iriegas (japan).rom" size="0x4000" crc="36a08e0b" sha1="95ae5b3e24ad0bea21902cb7dfd3fd9581166a76" />
 			</dataarea>
 		</part>
 	</software>
@@ -6449,11 +7023,12 @@ kept for now until finding out what those bytes affect...
 		<description>Ink - Exxon Surfing</description>
 		<year>2006</year>
 		<publisher>Matra</publisher>
+		<info name="gtin" value="00737875698505"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ink" />
-			<dataarea name="rom" size="524288">
+			<dataarea name="rom" size="0x80000">
 				<!-- Am29F040B flashrom dump -->
-				<rom name="ink.bin" size="524288" crc="23049642" sha1="4d74d3bad55a9b1deb88b81bd4ad5165383508d5" />
+				<rom name="ink.bin" size="0x80000" crc="23049642" sha1="4d74d3bad55a9b1deb88b81bd4ad5165383508d5" />
 			</dataarea>
 		</part>
 	</software>
@@ -6464,9 +7039,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="20213" />
 		<info name="alt_title" value="テセウス" />
+		<info name="isbn" value="4871489639"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="iriegas - theseus (japan).rom" size="16384" crc="80495007" sha1="8aa6d0aadf00de9112696da5b7dc6e3b62f2d9be" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="iriegas - theseus (japan).rom" size="0x4000" crc="80495007" sha1="8aa6d0aadf00de9112696da5b7dc6e3b62f2d9be" />
 			</dataarea>
 		</part>
 	</software>
@@ -6477,9 +7054,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="20213" />
 		<info name="alt_title" value="テセウス" />
+		<info name="isbn" value="4871489639"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="iriegas - theseus (japan) (alt 1).rom" size="16384" crc="53236741" sha1="ed1f7342b9b26ec02ca2d584570d75f925167ea1" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="iriegas - theseus (japan) (alt 1).rom" size="0x4000" crc="53236741" sha1="ed1f7342b9b26ec02ca2d584570d75f925167ea1" />
 			</dataarea>
 		</part>
 	</software>
@@ -6489,8 +7068,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="theseus.rom" size="16384" crc="6235de29" sha1="f9201b7b99a6cb4d8c847e30dc2617d4243be8e7" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="theseus.rom" size="0x4000" crc="6235de29" sha1="f9201b7b99a6cb4d8c847e30dc2617d4243be8e7" />
 			</dataarea>
 		</part>
 	</software>
@@ -6501,9 +7081,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-132" />
 		<info name="alt_title" value="一寸法師のどんなもんだい" />
+		<info name="gtin" value="04971850105008"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="issunhoushi no donnamondai (japan).rom" size="32768" crc="a7c43855" sha1="02a2fafc7b9249db76803ece347ba73be25f71b5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="issunhoushi no donnamondai (japan).rom" size="0x8000" crc="a7c43855" sha1="02a2fafc7b9249db76803ece347ba73be25f71b5" />
 			</dataarea>
 		</part>
 	</software>
@@ -6514,9 +7096,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-132" />
 		<info name="alt_title" value="一寸法師のどんなもんだい" />
+		<info name="gtin" value="04971850105008"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="issunhoushi no donnamondai (japan) (alt 1).rom" size="32768" crc="2a285706" sha1="14451b2931a014e949a4b3d2973d424d910e0d9d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="issunhoushi no donnamondai (japan) (alt 1).rom" size="0x8000" crc="2a285706" sha1="14451b2931a014e949a4b3d2973d424d910e0d9d" />
 			</dataarea>
 		</part>
 	</software>
@@ -6527,8 +7111,9 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Angel?</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="issunhoushi no donnamondai. little samurai (1987)(casio)[cr angel].rom" size="32768" crc="5b66062b" sha1="88533246b479840de98c824484dceeb5f2f99366" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="issunhoushi no donnamondai. little samurai (1987)(casio)[cr angel].rom" size="0x8000" crc="5b66062b" sha1="88533246b479840de98c824484dceeb5f2f99366" />
 			</dataarea>
 		</part>
 	</software>
@@ -6538,9 +7123,12 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>ASCII ~ MSX Magazine</publisher>
 		<info name="alt_title" value="Ｊ．Ｐ．ウインクル" />
+		<info name="serial" value="2507601"/>
+		<info name="isbn" value="4871480569"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="j.p. winkle (japan).rom" size="32768" crc="57e1221c" sha1="2391ae8c961b4a38b3beaee9ed3362fb2c71851f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="j.p. winkle (japan).rom" size="0x8000" crc="57e1221c" sha1="2391ae8c961b4a38b3beaee9ed3362fb2c71851f" />
 			</dataarea>
 		</part>
 	</software>
@@ -6550,24 +7138,25 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="jpwinkle.rom" size="32768" crc="1bc4132b" sha1="4e4989c8f6336663690217f32aca22a319b90091" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="jpwinkle.rom" size="0x8000" crc="1bc4132b" sha1="4e4989c8f6336663690217f32aca22a319b90091" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="jagura" cloneof="jagur">
 		<description>Jagur (Japan, alt)</description>
 		<year>1987</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="XR-1040" />
 		<info name="alt_title" value="ジャガー5 ~ Jagur 5 (Box?)" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="jagur (japan) (alt 1).rom" size="131072" crc="dbf2f244" sha1="1aeae1180471e9a6e8e866993031b881a341f921" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="jagur (japan) (alt 1).rom" size="0x20000" crc="dbf2f244" sha1="1aeae1180471e9a6e8e866993031b881a341f921" />
 			</dataarea>
 		</part>
 	</software>
@@ -6578,35 +7167,37 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="雀華" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="janka (japan).rom" size="16384" crc="61ea6742" sha1="ecc68b4a042794424df771a3336361fdb50d0875" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="janka (japan).rom" size="0x4000" crc="61ea6742" sha1="ecc68b4a042794424df771a3336361fdb50d0875" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="janyuu">
 		<description>Janyuu (Japan)</description>
 		<year>1987</year>
 		<publisher>Technosoft</publisher>
 		<info name="alt_title" value="雀友" />
-		<info name="usage" value="Requires a Japanese system" />
+		<info name="serial" value="MXTJ-11003"/>
+		<info name="usage" value="Requires a Japanese system." />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="janyuu (japan).rom" size="32768" crc="c8ff3829" sha1="c6227431bfbc3aa921120ec3da7f6429a1a799a0" status="baddump" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="janyuu (japan).rom" size="0x8000" crc="c8ff3829" sha1="c6227431bfbc3aa921120ec3da7f6429a1a799a0" />
 			</dataarea>
 		</part>
 	</software>
 
-<!-- Title screen differs from the one depicted at http://www.generation-msx.nl/msxdb/softwareinfo/497 -->
 	<software name="jetsetw">
 		<description>Jet Set Willy (Japan)</description>
 		<year>1985</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="alt_title" value="ジェットセットウィリー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="jet set willy (japan).rom" size="16384" crc="9191c890" sha1="45b5b0e9dd8d11d034e09803f92ec9720cda1e3c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="jet set willy (japan).rom" size="0x4000" crc="9191c890" sha1="45b5b0e9dd8d11d034e09803f92ec9720cda1e3c" />
 			</dataarea>
 		</part>
 	</software>
@@ -6617,21 +7208,24 @@ kept for now until finding out what those bytes affect...
 		<publisher>Hudson Soft</publisher>
 		<info name="alt_title" value="ジェットセットウィリー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="jet set willy (japan) (alt 1).rom" size="16384" crc="6e57f290" sha1="cb352e97e9416f4c3032118758fc77d6d0f3ad73" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="jet set willy (japan) (alt 1).rom" size="0x4000" crc="6e57f290" sha1="cb352e97e9416f4c3032118758fc77d6d0f3ad73" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="jigsaw">
 		<description>Jigsaw Set (Japan)</description>
 		<year>1983</year>
 		<publisher>MIA</publisher>
 		<info name="alt_title" value="ジグソーセット" />
+		<info name="serial" value="MX-X5"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="jigsaw set (japan).rom" size="16384" crc="f278c6f3" sha1="f99919c8f42addb7f65ab4fb21b603ee7e716c90" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="jigsaw set (japan).rom" size="0x4000" crc="f278c6f3" sha1="f99919c8f42addb7f65ab4fb21b603ee7e716c90" />
 			</dataarea>
 		</part>
 	</software>
@@ -6643,8 +7237,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G024C" />
 		<info name="alt_title" value="実戦四人麻雀" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="jissen - 4-nin mahjong (japan).rom" size="16384" crc="e8df4aa8" sha1="ebde4d61184438175db424fdf25cec238d91a15f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="jissen - 4-nin mahjong (japan).rom" size="0x4000" crc="e8df4aa8" sha1="ebde4d61184438175db424fdf25cec238d91a15f" />
 			</dataarea>
 		</part>
 	</software>
@@ -6654,9 +7249,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="雀フレンド" />
+		<info name="serial" value="NH-MSX03"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="jyan friend (japan).rom" size="16384" crc="6567f14d" sha1="4991dc097e248436506ed5c8bc3f367a65267ee7" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="jyan friend (japan).rom" size="0x4000" crc="6567f14d" sha1="4991dc097e248436506ed5c8bc3f367a65267ee7" />
 			</dataarea>
 		</part>
 	</software>
@@ -6668,8 +7265,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MXHI 11033" />
 		<info name="alt_title" value="ジャン狂" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="jyankyo (japan).rom" size="16384" crc="7382f3ac" sha1="17e1111b1d6aa80e8bc525be345c25e3b00ed504" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="jyankyo (japan).rom" size="0x4000" crc="7382f3ac" sha1="17e1111b1d6aa80e8bc525be345c25e3b00ed504" />
 			</dataarea>
 		</part>
 	</software>
@@ -6679,9 +7277,11 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="20162" />
+		<info name="isbn" value="4871488314"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="jump (japan).rom" size="16384" crc="0599617b" sha1="39ef139d8d66fb18b04dff8b9a5386011f497479" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="jump (japan).rom" size="0x4000" crc="0599617b" sha1="39ef139d8d66fb18b04dff8b9a5386011f497479" />
 			</dataarea>
 		</part>
 	</software>
@@ -6689,11 +7289,13 @@ kept for now until finding out what those bytes affect...
 	<software name="jumpcstr">
 		<description>Jump Coaster (Japan)</description>
 		<year>1984</year>
-		<publisher>Nihon Columbia</publisher>
+		<publisher>Colpax</publisher>
 		<info name="alt_title" value="ジャンプコースター" />
+		<info name="serial" value="48C99-1001"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="jump coaster (japan).rom" size="8192" crc="c15a25da" sha1="a53d1ea775a6c90a84f1f36349540b16cf8307e4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="jump coaster (japan).rom" size="0x2000" crc="c15a25da" sha1="a53d1ea775a6c90a84f1f36349540b16cf8307e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -6705,16 +7307,11 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G002C" />
 		<info name="alt_title" value="ジュノファースト" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
+			<feature name="start_page" value="0"/>
+			<dataarea name="rom" size="0x8000">
 				<!-- Mirroring not verified -->
-				<rom name="juno first (japan).rom" size="8192" crc="ea67df20" sha1="a70c6b0e90e7b8ba3e5bc06c9ae7d6af344e491f" />
-				<rom size="8192" offset="0x2000" loadflag="reload" />
-				<rom size="8192" offset="0x4000" loadflag="reload" />
-				<rom size="8192" offset="0x6000" loadflag="reload" />
-				<rom size="8192" offset="0x8000" loadflag="reload" />
-				<rom size="8192" offset="0xa000" loadflag="reload" />
-				<rom size="8192" offset="0xc000" loadflag="reload" />
-				<rom size="8192" offset="0xe000" loadflag="reload" />
+				<rom name="juno first (japan).rom" size="0x2000" crc="ea67df20" sha1="a70c6b0e90e7b8ba3e5bc06c9ae7d6af344e491f"/>
+				<rom size="0x2000" offset="0x4000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -6726,11 +7323,11 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC-719" />
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="keyboard_master" />
-			<dataarea name="rom" size="16384">
-				<rom name="keyboard_master_prototype.rom" size="16384" crc="a076a5ab" sha1="2308dd0f15fb5395a1d8a08489daff65ead8e0f2" />
+			<dataarea name="rom" size="0x4000">
+				<rom name="keyboard_master_prototype.rom" size="0x4000" crc="a076a5ab" sha1="2308dd0f15fb5395a1d8a08489daff65ead8e0f2" />
 			</dataarea>
-			<dataarea name="vlm5030" size="16384">
-				<rom name="keyboard_master_vlm5030.rom" size="16384" crc="3ae325dc" sha1="4f36d139ee4baa7d5980f765de9895570ee05f40" />
+			<dataarea name="vlm5030" size="0x4000">
+				<rom name="keyboard_master_vlm5030.rom" size="0x4000" crc="3ae325dc" sha1="4f36d139ee4baa7d5980f765de9895570ee05f40" />
 			</dataarea>
 		</part>
 	</software>
@@ -6738,12 +7335,13 @@ kept for now until finding out what those bytes affect...
 	<software name="legkage">
 		<description>Kage no Densetsu - The Legend of Kage (Japan)</description>
 		<year>1986</year>
-		<publisher>Taito</publisher>
+		<publisher>Nidecom</publisher>
 		<info name="serial" value="MSX-9" />
 		<info name="alt_title" value="影の伝説" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="kage no densetsu - legend of kage, the (japan).rom" size="32768" crc="69367e10" sha1="ffc8c57b26f2f495bd77efac5b815efe9c25336c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="kage no densetsu - legend of kage, the (japan).rom" size="0x8000" crc="69367e10" sha1="ffc8c57b26f2f495bd77efac5b815efe9c25336c" />
 			</dataarea>
 		</part>
 	</software>
@@ -6755,8 +7353,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-103" />
 		<info name="alt_title" value="カラ丸珍道中" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="karamaru (japan).rom" size="16384" crc="12be29fc" sha1="223337db25c942ece732214aba5dd624b574e9c4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="karamaru (japan).rom" size="0x4000" crc="12be29fc" sha1="223337db25c942ece732214aba5dd624b574e9c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -6768,11 +7367,11 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5503" />
 		<info name="alt_title" value="キーストンケーパーズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="keystone kapers (japan).rom" size="16384" crc="b1cf2097" sha1="3d5160331beb1c5cc54ba6ecef6b3ce2ff4660b6" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="keystone kapers (japan).rom" size="0x4000" crc="b1cf2097" sha1="3d5160331beb1c5cc54ba6ecef6b3ce2ff4660b6" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -6780,12 +7379,13 @@ kept for now until finding out what those bytes affect...
 	<software name="kickit">
 		<description>Kick It (Japan)</description>
 		<year>1986</year>
-		<publisher>HAL Kenkyuujo</publisher>
+		<publisher>Seika Romox</publisher>
 		<info name="serial" value="SR-002" />
 		<info name="alt_title" value="キックイット" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="kick it (japan).rom" size="32768" crc="e4f63cb7" sha1="65334123c7d00ca623bf5f7a55756cc75958debb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="kick it (japan).rom" size="0x8000" crc="e4f63cb7" sha1="65334123c7d00ca623bf5f7a55756cc75958debb" />
 			</dataarea>
 		</part>
 	</software>
@@ -6793,24 +7393,25 @@ kept for now until finding out what those bytes affect...
 	<software name="kickita" cloneof="kickit">
 		<description>Kick It (Japan, alt)</description>
 		<year>1986</year>
-		<publisher>HAL Kenkyuujo</publisher>
+		<publisher>Seika Romox</publisher>
 		<info name="serial" value="SR-002" />
 		<info name="alt_title" value="キックイット" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="kick it (japan) (alt 1).rom" size="32768" crc="3424a220" sha1="f033ab8a33e2d7a8ac1313b862bc138138b4346e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="kick it (japan) (alt 1).rom" size="0x8000" crc="3424a220" sha1="f033ab8a33e2d7a8ac1313b862bc138138b4346e" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="kinasai">
 		<description>Kinasai (Japan)</description>
 		<year>1984</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="kinasai (japan) (unl).rom" size="16384" crc="18866b57" sha1="f772396becdbd15ba0648bf1aef8ccb155e1adad" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="kinasai (japan) (unl).rom" size="0x4000" crc="18866b57" sha1="f772396becdbd15ba0648bf1aef8ccb155e1adad" />
 			</dataarea>
 		</part>
 	</software>
@@ -6822,8 +7423,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="05" />
 		<info name="alt_title" value="キング&amp;バルーン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="king &amp; balloon (japan).rom" size="32768" crc="2aba2253" sha1="ed15174dec31a29f9d41a06de3008db04af11a25" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="king &amp; balloon (japan).rom" size="0x8000" crc="2aba2253" sha1="ed15174dec31a29f9d41a06de3008db04af11a25" />
 			</dataarea>
 		</part>
 	</software>
@@ -6835,8 +7437,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="05" />
 		<info name="alt_title" value="キング&amp;バルーン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="king &amp; balloon (japan) (alt 1).rom" size="16384" crc="1eeba987" sha1="bec70fbf9b1384b6a8adc45226689f02d996b6a7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="king &amp; balloon (japan) (alt 1).rom" size="0x4000" crc="1eeba987" sha1="bec70fbf9b1384b6a8adc45226689f02d996b6a7" />
 			</dataarea>
 		</part>
 	</software>
@@ -6849,8 +7452,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="king knight (japan) (alt 1).rom" size="131072" crc="4d884352" sha1="a2ca7e6e216f8b450eb8db10a4120f0353275b6b" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="king knight (japan) (alt 1).rom" size="0x20000" crc="4d884352" sha1="a2ca7e6e216f8b450eb8db10a4120f0353275b6b" />
 			</dataarea>
 		</part>
 	</software>
@@ -6863,8 +7466,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="king knight (japan) (alt 2).rom" size="131072" crc="ab6cd62c" sha1="46062d3393c49884f84c2dc437ff27854e9d2e49" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="king knight (japan) (alt 2).rom" size="0x20000" crc="ab6cd62c" sha1="46062d3393c49884f84c2dc437ff27854e9d2e49" />
 			</dataarea>
 		</part>
 	</software>
@@ -6876,8 +7479,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC727" />
 		<info name="alt_title" value="王家の谷 ~ Ouke no Tani (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="king's valley (japan, europe).rom" size="16384" crc="dfac2125" sha1="07448ffb20f260df159a19df2cae1ee5545a0aef" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="king's valley (japan, europe).rom" size="0x4000" crc="dfac2125" sha1="07448ffb20f260df159a19df2cae1ee5545a0aef" />
 			</dataarea>
 		</part>
 	</software>
@@ -6889,8 +7493,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC727" />
 		<info name="alt_title" value="王家の谷 ~ Ouke no Tani (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="king's valley (japan, europe) (alt 1).rom" size="16384" crc="5a141c44" sha1="0cf26bf02c5b94df118129a681a7f14add708177" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="king's valley (japan, europe) (alt 1).rom" size="0x4000" crc="5a141c44" sha1="0cf26bf02c5b94df118129a681a7f14add708177" />
 			</dataarea>
 		</part>
 	</software>
@@ -6902,8 +7507,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC727" />
 		<info name="alt_title" value="王家の谷 ~ Ouke no Tani (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="king's valley (japan, europe) (alt 2).rom" size="16384" crc="e7c3e1b7" sha1="43dc3911b9a336bb7b17bdbe6e48464e01f2c425" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="king's valley (japan, europe) (alt 2).rom" size="0x4000" crc="e7c3e1b7" sha1="43dc3911b9a336bb7b17bdbe6e48464e01f2c425" />
 			</dataarea>
 		</part>
 	</software>
@@ -6915,8 +7521,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC727" />
 		<info name="alt_title" value="王家の谷 ~ Ouke no Tani (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="king's valley (japan, europe) (alt 3).rom" size="16384" crc="201d7691" sha1="a4383f789482a9e868a9f136aa722129673c2a81" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="king's valley (japan, europe) (alt 3).rom" size="0x4000" crc="201d7691" sha1="a4383f789482a9e868a9f136aa722129673c2a81" />
 			</dataarea>
 		</part>
 	</software>
@@ -6928,8 +7535,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC727" />
 		<info name="alt_title" value="王家の谷 ~ Ouke no Tani (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="king's valley (japan, europe) (alt 4).rom" size="16384" crc="627bdcd6" sha1="8c9a9a9afe13a58e4cfb72489af2d6b080dffaf6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="king's valley (japan, europe) (alt 4).rom" size="0x4000" crc="627bdcd6" sha1="8c9a9a9afe13a58e4cfb72489af2d6b080dffaf6" />
 			</dataarea>
 		</part>
 	</software>
@@ -6943,36 +7551,38 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="king's valley ii (japan, europe).rom" size="131072" crc="e82a8e8e" sha1="cfd872d005b7bd4cdd6e06c4c0162191f0b0415d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="king's valley ii (japan, europe).rom" size="0x20000" crc="e82a8e8e" sha1="cfd872d005b7bd4cdd6e06c4c0162191f0b0415d" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="kinnikum">
 		<description>Kinnikuman - Colosseum Deathmatch (Japan)</description>
 		<year>1985</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="BMX-005" />
+		<info name="serial" value="BMX-005 / 0204702" />
 		<info name="alt_title" value="キン肉マン コロシアムデスマッチ" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="kinnikuman - muscle man (japan).rom" size="32768" crc="166781b7" sha1="bf7e27b3456f1a96d94a8dbf06688c8f833bd818" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="kinnikuman - muscle man (japan).rom" size="0x8000" crc="166781b7" sha1="bf7e27b3456f1a96d94a8dbf06688c8f833bd818" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="kinnikuma" cloneof="kinnikum">
 		<description>Kinnikuman - Colosseum Deathmatch (Japan, alt)</description>
 		<year>1985</year>
 		<publisher>Bandai</publisher>
 		<info name="serial" value="BMX-005" />
 		<info name="alt_title" value="キン肉マン コロシアムデスマッチ" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="kinnikuman - muscle man (japan) (alt 1).rom" size="32768" crc="500d112d" sha1="dd76ee1071e427cbfedeeedcb3a4b8bcad56ba71" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="kinnikuman - muscle man (japan) (alt 1).rom" size="0x8000" crc="500d112d" sha1="dd76ee1071e427cbfedeeedcb3a4b8bcad56ba71" />
 			</dataarea>
 		</part>
 	</software>
@@ -6981,9 +7591,11 @@ kept for now until finding out what those bytes affect...
 		<description>Kinnikuman - Colosseum Deathmatch (Korea)</description>
 		<year>198?</year>
 		<publisher>San Ho</publisher>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="wrestling.rom" size="32768" crc="36ed61af" sha1="9da5878205d58fbcc641c5f10da1aa2dc450ec97" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="wrestling.rom" size="0x8000" crc="36ed61af" sha1="9da5878205d58fbcc641c5f10da1aa2dc450ec97" />
 			</dataarea>
 		</part>
 	</software>
@@ -6995,8 +7607,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="ND-04MR" />
 		<info name="alt_title" value="ナイトロアー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="knight lore (japan).rom" size="32768" crc="b575c44a" sha1="e98e4351119d78b6402c4499ed16faeb3364f6c3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="knight lore (japan).rom" size="0x8000" crc="b575c44a" sha1="e98e4351119d78b6402c4499ed16faeb3364f6c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -7007,9 +7620,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC739" />
 		<info name="alt_title" value="魔城伝説" />
+		<info name="gtin" value="04988602505832"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="knightmare - majou densetsu (japan).rom" size="32768" crc="0db84205" sha1="c8ff858d239c62a859f15c2f1bf44e1d657cec13" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="knightmare - majou densetsu (japan).rom" size="0x8000" crc="0db84205" sha1="c8ff858d239c62a859f15c2f1bf44e1d657cec13" />
 			</dataarea>
 		</part>
 	</software>
@@ -7020,9 +7635,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC739" />
 		<info name="alt_title" value="魔城伝説" />
+		<info name="gtin" value="04988602505832"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="knightmare - majou densetsu (japan) (alt 1).rom" size="32768" crc="ca9f791b" sha1="da8249452da86c0ba44f0ae279ccff82a1ddd756" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="knightmare - majou densetsu (japan) (alt 1).rom" size="0x8000" crc="ca9f791b" sha1="da8249452da86c0ba44f0ae279ccff82a1ddd756" />
 			</dataarea>
 		</part>
 	</software>
@@ -7033,9 +7650,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC739" />
 		<info name="alt_title" value="魔城伝説" />
+		<info name="gtin" value="04988602505832"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="knightmare - majou densetsu (japan) (alt 2).rom" size="32768" crc="5876a372" sha1="1d6a355a9ce84c78e3bafc27a4f1151e240f68f0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="knightmare - majou densetsu (japan) (alt 2).rom" size="0x8000" crc="5876a372" sha1="1d6a355a9ce84c78e3bafc27a4f1151e240f68f0" />
 			</dataarea>
 		</part>
 	</software>
@@ -7045,8 +7664,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="knightma.rom" size="32768" crc="b9819ea6" sha1="7435a9caec4cdefe398299ba9b6adf89c302fda5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="knightma.rom" size="0x8000" crc="b9819ea6" sha1="7435a9caec4cdefe398299ba9b6adf89c302fda5" />
 			</dataarea>
 		</part>
 	</software>
@@ -7057,11 +7677,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC749" />
 		<info name="alt_title" value="ガリウスの迷宮 ~ Galious no Meikyuu (Box?)" />
+		<info name="gtin" value="04988602526226"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="knightmare ii - the maze of galious (japan).rom" size="131072" crc="fe23d253" sha1="4d51d3c5036311392b173a576bc7d91dc9fed6cb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="knightmare ii - the maze of galious (japan).rom" size="0x20000" crc="fe23d253" sha1="4d51d3c5036311392b173a576bc7d91dc9fed6cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -7070,11 +7691,12 @@ kept for now until finding out what those bytes affect...
 		<description>Knightmare II - The Maze of Galious (Korea)</description>
 		<year>1987</year>
 		<publisher>Zemina</publisher>
+		<info name="alt_title" value="마성전설 II"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="knightmare ii - the maze of galious (1987)(zemina)[rc-749].rom" size="131072" crc="d7f35938" sha1="7a786959d8fc0b518b35341422f096dd6019468d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="knightmare ii - the maze of galious (1987)(zemina)[rc-749].rom" size="0x20000" crc="d7f35938" sha1="7a786959d8fc0b518b35341422f096dd6019468d" />
 			</dataarea>
 		</part>
 	</software>
@@ -7085,11 +7707,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC754" />
 		<info name="alt_title" value="シャロム" />
+		<info name="gtin" value="04988602532265"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="262144">
-				<rom name="knightmare iii - shalom (japan).rom" size="262144" crc="cf60fa7d" sha1="25f5adeca8a2ddb754d25eb18cff0d84e5b003bc" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="knightmare iii - shalom (japan).rom" size="0x40000" crc="cf60fa7d" sha1="25f5adeca8a2ddb754d25eb18cff0d84e5b003bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -7099,11 +7722,12 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Dempa</publisher>
 		<info name="alt_title" value="ナイザースペシャル" />
+		<info name="serial" value="DP-3912034"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="knither special (japan).rom" size="131072" crc="a3b2fe71" sha1="63d4e39c59f24f880809caa534d7a46ae83f4c9f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="knither special (japan).rom" size="0x20000" crc="a3b2fe71" sha1="63d4e39c59f24f880809caa534d7a46ae83f4c9f" />
 			</dataarea>
 		</part>
 	</software>
@@ -7112,9 +7736,11 @@ kept for now until finding out what those bytes affect...
 		<description>Knuckle Joe (Korea)</description>
 		<year>1989</year>
 		<publisher>Prosoft</publisher>
+		<info name="alt_title" value="너클죠"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="knuckle joe.rom" size="32768" crc="33be6192" sha1="6147f63a319b44b60259b35a75b1c083280b92ea" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="knuckle joe.rom" size="0x8000" crc="33be6192" sha1="6147f63a319b44b60259b35a75b1c083280b92ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -7123,9 +7749,11 @@ kept for now until finding out what those bytes affect...
 		<description>Koedoli (Korea)</description>
 		<year>1988</year>
 		<publisher>Aproman</publisher>
+		<info name="alt_title" value="꾀돌이"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="koedoli (mickey soft, 1988).rom" size="32768" crc="cb345bcc" sha1="6895a062e10b790e19a55952e634662f3135fa55" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="koedoli (mickey soft, 1988).rom" size="0x8000" crc="cb345bcc" sha1="6895a062e10b790e19a55952e634662f3135fa55" />
 			</dataarea>
 		</part>
 	</software>
@@ -7137,8 +7765,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC724" />
 		<info name="alt_title" value="コナミのベースボール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="konami's baseball (japan).rom" size="16384" crc="b660494b" sha1="076d6f5b9f8427f6959f7a255abb4acac0dd9d0c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="konami's baseball (japan).rom" size="0x4000" crc="b660494b" sha1="076d6f5b9f8427f6959f7a255abb4acac0dd9d0c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7150,8 +7779,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC724" />
 		<info name="alt_title" value="コナミのベースボール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="konami's baseball (japan) (alt 1).rom" size="16384" crc="6a8e56e1" sha1="9bdfe44a7a0d5151346ff14ece3216b5108cc775" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="konami's baseball (japan) (alt 1).rom" size="0x4000" crc="6a8e56e1" sha1="9bdfe44a7a0d5151346ff14ece3216b5108cc775" />
 			</dataarea>
 		</part>
 	</software>
@@ -7162,8 +7792,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC706" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="konami's billiards (europe).rom" size="8192" crc="0b65fe4d" sha1="fc6660a202dbd228c9e0d7c404340d1dcc1e2844" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="konami's billiards (europe).rom" size="0x2000" crc="0b65fe4d" sha1="fc6660a202dbd228c9e0d7c404340d1dcc1e2844" />
 			</dataarea>
 		</part>
 	</software>
@@ -7175,8 +7806,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC736" />
 		<info name="alt_title" value="コナミのボクシング" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="konami's boxing (japan).rom" size="32768" crc="3a442408" sha1="7adb6812f3702b93aa2b2a872722bbd40915670d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's boxing (japan).rom" size="0x8000" crc="3a442408" sha1="7adb6812f3702b93aa2b2a872722bbd40915670d" />
 			</dataarea>
 		</part>
 	</software>
@@ -7188,8 +7820,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC736" />
 		<info name="alt_title" value="コナミのボクシング" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="konami's boxing (japan) (alt 1).rom" size="32768" crc="19ccbce1" sha1="5e349166fce12d45f3ce3f69ecd6b2a70ef4d68b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's boxing (japan) (alt 1).rom" size="0x8000" crc="19ccbce1" sha1="5e349166fce12d45f3ce3f69ecd6b2a70ef4d68b" />
 			</dataarea>
 		</part>
 	</software>
@@ -7201,8 +7834,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC736" />
 		<info name="alt_title" value="コナミのボクシング" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="konami's boxing (japan) (alt 2).rom" size="32768" crc="0d94e7b2" sha1="9e190cf3ca52d85fd34eb5df2c0dd8490448b9a2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's boxing (japan) (alt 2).rom" size="0x8000" crc="0d94e7b2" sha1="9e190cf3ca52d85fd34eb5df2c0dd8490448b9a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -7213,8 +7847,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC732" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="konami's football (europe).rom" size="32768" crc="ba1b16fc" sha1="8e9fb34b356b02a839dce5139c12030593be13a2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's football (europe).rom" size="0x8000" crc="ba1b16fc" sha1="8e9fb34b356b02a839dce5139c12030593be13a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -7225,8 +7860,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC732" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="konami's football (europe) (alt 1).rom" size="32768" crc="93604c07" sha1="eaa6b787784bae1c7f648b57daa1c88cf2b1b095" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's football (europe) (alt 1).rom" size="0x8000" crc="93604c07" sha1="eaa6b787784bae1c7f648b57daa1c88cf2b1b095" />
 			</dataarea>
 		</part>
 	</software>
@@ -7237,8 +7873,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC732" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="konami's football (europe) (alt 2).rom" size="32768" crc="c700fc49" sha1="10698ea6b0423f2e858a4c28c10f39646ca5495f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's football (europe) (alt 2).rom" size="0x8000" crc="c700fc49" sha1="10698ea6b0423f2e858a4c28c10f39646ca5495f" />
 			</dataarea>
 		</part>
 	</software>
@@ -7250,8 +7887,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC723" />
 		<info name="alt_title" value="コナミのゴルフ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="konami's golf (japan).rom" size="16384" crc="08c7e406" sha1="6a3a68836a468cc761a268175c64d53c4c1c48bd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="konami's golf (japan).rom" size="0x4000" crc="08c7e406" sha1="6a3a68836a468cc761a268175c64d53c4c1c48bd" />
 			</dataarea>
 		</part>
 	</software>
@@ -7263,8 +7901,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC723" />
 		<info name="alt_title" value="コナミのゴルフ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="konami's golf (japan) (alt 1).rom" size="16384" crc="0e3380fe" sha1="bcf72a4673c7982361db4efaf8ebc776b6539938" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="konami's golf (japan) (alt 1).rom" size="0x4000" crc="0e3380fe" sha1="bcf72a4673c7982361db4efaf8ebc776b6539938" />
 			</dataarea>
 		</part>
 	</software>
@@ -7276,8 +7915,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC723" />
 		<info name="alt_title" value="コナミのゴルフ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="konami's golf (japan) (alt 2).rom" size="16384" crc="f06befd3" sha1="5c7971aa8688ffc429a3e315dd3d45c38f72ddeb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="konami's golf (japan) (alt 2).rom" size="0x4000" crc="f06befd3" sha1="5c7971aa8688ffc429a3e315dd3d45c38f72ddeb" />
 			</dataarea>
 		</part>
 	</software>
@@ -7289,8 +7929,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC707" />
 		<info name="alt_title" value="コナミの麻雀道場 ~ Konami no Mahjong Dojo (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="konami's mahjong (japan).rom" size="32768" crc="114198e5" sha1="f415e4096ff3f6a9f17bfbf02f146e44f0d5fb66" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's mahjong (japan).rom" size="0x8000" crc="114198e5" sha1="f415e4096ff3f6a9f17bfbf02f146e44f0d5fb66" />
 			</dataarea>
 		</part>
 	</software>
@@ -7302,8 +7943,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC731" />
 		<info name="alt_title" value="コナミのピンポン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="konami's ping-pong (japan).rom" size="16384" crc="3f200491" sha1="ae5b8e69732a23aee102bcd996ad06225f1b3eba" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="konami's ping-pong (japan).rom" size="0x4000" crc="3f200491" sha1="ae5b8e69732a23aee102bcd996ad06225f1b3eba" />
 			</dataarea>
 		</part>
 	</software>
@@ -7315,8 +7957,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC731" />
 		<info name="alt_title" value="コナミのピンポン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="konami's ping-pong (japan) (alt 1).rom" size="16384" crc="bbcdd731" sha1="9f4ac1287b8caa286a847c86ac8601a711be2d82" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="konami's ping-pong (japan) (alt 1).rom" size="0x4000" crc="bbcdd731" sha1="9f4ac1287b8caa286a847c86ac8601a711be2d82" />
 			</dataarea>
 		</part>
 	</software>
@@ -7328,8 +7971,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC731" />
 		<info name="alt_title" value="コナミのピンポン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="konami's ping-pong (japan) (alt 2).rom" size="16384" crc="a4d465a4" sha1="5e1a50affe1fa973f69e423a8827751b93fc53ee" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="konami's ping-pong (japan) (alt 2).rom" size="0x4000" crc="a4d465a4" sha1="5e1a50affe1fa973f69e423a8827751b93fc53ee" />
 			</dataarea>
 		</part>
 	</software>
@@ -7341,8 +7985,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC731" />
 		<info name="alt_title" value="コナミのピンポン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="konami's ping-pong (japan) (alt 3).rom" size="16384" crc="2829a061" sha1="6c68f7be1eb46cca6dcdbb9192cbff9d59604357" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="konami's ping-pong (japan) (alt 3).rom" size="0x4000" crc="2829a061" sha1="6c68f7be1eb46cca6dcdbb9192cbff9d59604357" />
 			</dataarea>
 		</part>
 	</software>
@@ -7352,8 +7997,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pingpong.rom" size="32768" crc="67a1ba79" sha1="90592a09228b3e3300eed51ebd7358b5ed2afa09" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="pingpong.rom" size="0x8000" crc="67a1ba79" sha1="90592a09228b3e3300eed51ebd7358b5ed2afa09" />
 			</dataarea>
 		</part>
 	</software>
@@ -7365,8 +8011,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC732" />
 		<info name="alt_title" value="コナミのサッカー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="konami's soccer (japan).rom" size="32768" crc="74bc8295" sha1="fd7518a6aedb51630364082c27bdfe4411adfd4c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's soccer (japan).rom" size="0x8000" crc="74bc8295" sha1="fd7518a6aedb51630364082c27bdfe4411adfd4c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7378,8 +8025,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC732" />
 		<info name="alt_title" value="コナミのサッカー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="konami's soccer (japan) (alt 1).rom" size="32768" crc="58ea53b9" sha1="89ccb1a7ffaaa75cee9bdc9b4a9ec9b063af7199" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's soccer (japan) (alt 1).rom" size="0x8000" crc="58ea53b9" sha1="89ccb1a7ffaaa75cee9bdc9b4a9ec9b063af7199" />
 			</dataarea>
 		</part>
 	</software>
@@ -7391,8 +8039,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC732" />
 		<info name="alt_title" value="コナミのサッカー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="konami's soccer (japan) (alt 2).rom" size="32768" crc="e861d2bd" sha1="a0ed2c50e55241d23bb5d12cb6528a2a0c3bc156" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's soccer (japan) (alt 2).rom" size="0x8000" crc="e861d2bd" sha1="a0ed2c50e55241d23bb5d12cb6528a2a0c3bc156" />
 			</dataarea>
 		</part>
 	</software>
@@ -7404,8 +8053,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC732" />
 		<info name="alt_title" value="コナミのサッカー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="konami's soccer (japan) (alt 3).rom" size="32768" crc="ccfb0ca2" sha1="79c1bf77c08b733ae04e069deaf25fd24b28beb7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's soccer (japan) (alt 3).rom" size="0x8000" crc="ccfb0ca2" sha1="79c1bf77c08b733ae04e069deaf25fd24b28beb7" />
 			</dataarea>
 		</part>
 	</software>
@@ -7417,8 +8067,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC720" />
 		<info name="alt_title" value="コナミのテニス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="konami's tennis (japan).rom" size="16384" crc="61726be4" sha1="5f6972e9e374753faf092409f1ee10bba5231b66" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="konami's tennis (japan).rom" size="0x4000" crc="61726be4" sha1="5f6972e9e374753faf092409f1ee10bba5231b66" />
 			</dataarea>
 		</part>
 	</software>
@@ -7430,8 +8081,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC720" />
 		<info name="alt_title" value="コナミのテニス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="konami's tennis (japan) (alt 1).rom" size="16384" crc="cfce0a28" sha1="d5f5d2850b0bfda45ba4dfff70d3fd9986399a94" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="konami's tennis (japan) (alt 1).rom" size="0x4000" crc="cfce0a28" sha1="d5f5d2850b0bfda45ba4dfff70d3fd9986399a94" />
 			</dataarea>
 		</part>
 	</software>
@@ -7441,7 +8093,8 @@ kept for now until finding out what those bytes affect...
 		<year>19??</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
 				<rom name="konami's tennis (1984)(konami)[cr prosoft][rc-720].rom" size="16385" crc="a5427ecd" sha1="54008fe7cd7f1a47fca70462a0a7b5682146099b" status="baddump" />
 			</dataarea>
 		</part>
@@ -7453,9 +8106,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-124" />
 		<info name="alt_title" value="仔猫の大冒険 チビちゃんがいく" />
+		<info name="gtin" value="04971850104186"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="koneko no daibouken - catboy (japan).rom" size="32768" crc="5a0b8739" sha1="0039cff292fe740d8c87cc2131a473cbb4f8c4f4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="koneko no daibouken - catboy (japan).rom" size="0x8000" crc="5a0b8739" sha1="0039cff292fe740d8c87cc2131a473cbb4f8c4f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -7465,9 +8120,12 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="クンフーマスター" />
+		<info name="serial" value="20099"/>
+		<info name="isbn" value="4871489655"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="kung fu master (japan).rom" size="16384" crc="08f23b3e" sha1="c1dfc86c441e1128194f3ab490c94e29275b5df9" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="kung fu master (japan).rom" size="0x4000" crc="08f23b3e" sha1="c1dfc86c441e1128194f3ab490c94e29275b5df9" />
 			</dataarea>
 		</part>
 	</software>
@@ -7477,9 +8135,12 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="クンフーマスター" />
+		<info name="serial" value="20099"/>
+		<info name="isbn" value="4871489655"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="kung fu master (japan) (alt 1).rom" size="16384" crc="10fc1118" sha1="602c4d0d12fd59725c0c4e40f51d6bdeb679ea36" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="kung fu master (japan) (alt 1).rom" size="0x4000" crc="10fc1118" sha1="602c4d0d12fd59725c0c4e40f51d6bdeb679ea36" />
 			</dataarea>
 		</part>
 	</software>
@@ -7489,9 +8150,12 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="クンフーマスター" />
+		<info name="serial" value="20099"/>
+		<info name="isbn" value="4871489655"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="kung fu master (japan) (alt 2).rom" size="16384" crc="103724ad" sha1="05da84093d973d3bfbd3143ffd155a16a9ec5f82" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="kung fu master (japan) (alt 2).rom" size="0x4000" crc="103724ad" sha1="05da84093d973d3bfbd3143ffd155a16a9ec5f82" />
 			</dataarea>
 		</part>
 	</software>
@@ -7503,8 +8167,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2011G" />
 		<info name="alt_title" value="功夫大君" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="kung fu taigun (japan).rom" size="16384" crc="c1aaf8cb" sha1="e817ab7b50674c414b1c1b72530024eb03396a41" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="kung fu taigun (japan).rom" size="0x4000" crc="c1aaf8cb" sha1="e817ab7b50674c414b1c1b72530024eb03396a41" />
 			</dataarea>
 		</part>
 	</software>
@@ -7516,7 +8181,8 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2011G" />
 		<info name="alt_title" value="功夫大君" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
 				<rom name="kung fu taigun (japan) (alt 1).rom" size="16385" crc="8c30be94" sha1="304ea29469461f1cfa801f62af0bf5045a6882fc" status="baddump" />
 			</dataarea>
 		</part>
@@ -7526,24 +8192,27 @@ kept for now until finding out what those bytes affect...
 		<description>Kung-Fu Taikun (Korea)</description>
 		<year>198?</year>
 		<publisher>Zemina</publisher>
-		<info name="alt_title" value="??? ~ Son Son (Box)"/>
+		<info name="alt_title" value="손오공 ~ Son Son (Box)"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="kimpo.rom" size="16384" crc="cb43bfba" sha1="8d5fe498a25420de9f428265ebbb1fc2a6c0f2ca" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="kimpo.rom" size="0x4000" crc="cb43bfba" sha1="8d5fe498a25420de9f428265ebbb1fc2a6c0f2ca" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="laddrbld">
 		<description>Ladder Building (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00100" />
 		<info name="alt_title" value="ラダービルディング" />
+		<info name="isbn" value="4871489213"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="ladder building (japan).rom" size="16384" crc="c6064ce0" sha1="15ca962994fd25a56bee2f543a83f133f9d2265f" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="ladder building (japan).rom" size="0x4000" crc="c6064ce0" sha1="15ca962994fd25a56bee2f543a83f133f9d2265f" />
 			</dataarea>
 		</part>
 	</software>
@@ -7552,11 +8221,12 @@ kept for now until finding out what those bytes affect...
 		<description>Laptick 2 (Japan)</description>
 		<year>1986</year>
 		<publisher>dB-Soft</publisher>
-		<info name="serial" value="MS-G2115-L1" />
+		<info name="serial" value="MS-G2115-L1 / MXDF-11007" />
 		<info name="alt_title" value="らぷてっく２" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="laptick 2 (japan).rom" size="32768" crc="091fe438" sha1="c4f952258020de9e23a718a78c18d22e2cccfe3c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="laptick 2 (japan).rom" size="0x8000" crc="091fe438" sha1="c4f952258020de9e23a718a78c18d22e2cccfe3c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7570,8 +8240,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="legendly knight (korea).rom" size="131072" crc="8e0f0638" sha1="6a98d5787dd0e76f04283ce0aec55d45ba81565d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="legendly knight (korea).rom" size="0x20000" crc="8e0f0638" sha1="6a98d5787dd0e76f04283ce0aec55d45ba81565d" />
 			</dataarea>
 		</part>
 	</software>
@@ -7584,12 +8254,13 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="legendly knight (korea) (alt 1).rom" size="131072" crc="d6635d68" sha1="2cea9cdd501d77f2b6bd78ae2ae9a63aba64cfed" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="legendly knight (korea) (alt 1).rom" size="0x20000" crc="d6635d68" sha1="2cea9cdd501d77f2b6bd78ae2ae9a63aba64cfed" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx does not list a cartridge release of this software. -->
 	<software name="lightcor">
 		<description>The Light Corridor (Europe)</description>
 		<year>1990</year>
@@ -7597,8 +8268,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="65536">
-				<rom name="light corridor, the (europe).rom" size="65536" crc="a330b549" sha1="0442dd29ea0f7b78c9cd5849ec7ef5bb21ec0bf5" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="light corridor, the (europe).rom" size="0x10000" crc="a330b549" sha1="0442dd29ea0f7b78c9cd5849ec7ef5bb21ec0bf5" />
 			</dataarea>
 		</part>
 	</software>
@@ -7610,8 +8281,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G020C" />
 		<info name="alt_title" value="ロードランナー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="lode runner (japan).rom" size="32768" crc="adc58732" sha1="818a6cedbfdf3a5af0c844f32a18e3930178c798" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="lode runner (japan).rom" size="0x8000" crc="adc58732" sha1="818a6cedbfdf3a5af0c844f32a18e3930178c798" />
 			</dataarea>
 		</part>
 	</software>
@@ -7623,8 +8295,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G020C" />
 		<info name="alt_title" value="ロードランナー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="lode runner (japan) (alt 1).rom" size="32768" crc="25b70773" sha1="0421a25aff3ae300b2a4536dd0aa5fa924e7dd72" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="lode runner (japan) (alt 1).rom" size="0x8000" crc="25b70773" sha1="0421a25aff3ae300b2a4536dd0aa5fa924e7dd72" />
 			</dataarea>
 		</part>
 	</software>
@@ -7636,8 +8309,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G039C" />
 		<info name="alt_title" value="ロードランナーII" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="lode runner ii (japan).rom" size="32768" crc="32ab8b20" sha1="4b04574b3b71958664ac730987c4c8ebedeba890" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="lode runner ii (japan).rom" size="0x8000" crc="32ab8b20" sha1="4b04574b3b71958664ac730987c4c8ebedeba890" />
 			</dataarea>
 		</part>
 	</software>
@@ -7648,9 +8322,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="20121" />
 		<info name="alt_title" value="ロードオーバー" />
+		<info name="isbn" value="4871489817"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="lord over (japan).rom" size="16384" crc="ab5e42fe" sha1="4025045e93f51afd58545104cc2c897226febaf7" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="lord over (japan).rom" size="0x4000" crc="ab5e42fe" sha1="4025045e93f51afd58545104cc2c897226febaf7" />
 			</dataarea>
 		</part>
 	</software>
@@ -7659,11 +8336,12 @@ kept for now until finding out what those bytes affect...
 		<description>Lot Lot (Japan)</description>
 		<year>1985</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="TSX-2" />
+		<info name="serial" value="48TSX-2" />
 		<info name="alt_title" value="ロットロット" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="lot lot (japan).rom" size="32768" crc="c1679aeb" sha1="3c2db6321ee84e3690757c08ade9dc096bd209b3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="lot lot (japan).rom" size="0x8000" crc="c1679aeb" sha1="3c2db6321ee84e3690757c08ade9dc096bd209b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -7674,21 +8352,25 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5079" />
 		<info name="alt_title" value="ルナーボール" />
+		<info name="gtin" value="04988013001398"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="lunar ball (japan).rom" size="32768" crc="d8a116d8" sha1="95f75fae9b3e961149e352cef3d7e478e9887d5a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="lunar ball (japan).rom" size="0x8000" crc="d8a116d8" sha1="95f75fae9b3e961149e352cef3d7e478e9887d5a" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx only has images of a cassette release. Was it really released on cartrtidge? -->
 	<software name="mgunjoe">
 		<description>Machinegun Joe vs The Mafia (Japan)</description>
 		<year>1984</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="alt_title" value="銀行強盗 ~ Ginkou Goutou (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="machinegun joe vs the mafia (japan).rom" size="16384" crc="628f033d" sha1="97dd31b2f0dd056abd808062e306b0c2536975bc" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="machinegun joe vs the mafia (japan).rom" size="0x4000" crc="628f033d" sha1="97dd31b2f0dd056abd808062e306b0c2536975bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -7700,8 +8382,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MK-5511" />
 		<info name="alt_title" value="超時空要塞マクロス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="macross (japan).rom" size="32768" crc="6e742024" sha1="09af3b68be4eea5f5594d5d2d124d92b127dd390" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="macross (japan).rom" size="0x8000" crc="6e742024" sha1="09af3b68be4eea5f5594d5d2d124d92b127dd390" />
 			</dataarea>
 		</part>
 	</software>
@@ -7713,8 +8396,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MK-5511" />
 		<info name="alt_title" value="超時空要塞マクロス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="macross (japan) (alt 1).rom" size="32768" crc="86ccf417" sha1="81ddaf3a42c1e1a3d3722e0cd046316a202acd33" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="macross (japan) (alt 1).rom" size="0x8000" crc="86ccf417" sha1="81ddaf3a42c1e1a3d3722e0cd046316a202acd33" />
 			</dataarea>
 		</part>
 	</software>
@@ -7726,8 +8410,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G048C" />
 		<info name="alt_title" value="魔法使いウィズ ~ Mahou Tsukai Wiz (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="magical kid wiz (japan).rom" size="32768" crc="8c2f2c59" sha1="087afebb16bfd96f465fb0d004326d55452bdd81" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="magical kid wiz (japan).rom" size="0x8000" crc="8c2f2c59" sha1="087afebb16bfd96f465fb0d004326d55452bdd81" />
 			</dataarea>
 		</part>
 	</software>
@@ -7739,8 +8424,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G048C" />
 		<info name="alt_title" value="魔法使いウィズ ~ Mahou Tsukai Wiz" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="magical kid wiz (japan) (alt 1).rom" size="32768" crc="2c2f5b6c" sha1="a3d1212eb4c58958f063aa8577ddfa07903b28b3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="magical kid wiz (japan) (alt 1).rom" size="0x8000" crc="2c2f5b6c" sha1="a3d1212eb4c58958f063aa8577ddfa07903b28b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -7752,8 +8438,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G048C" />
 		<info name="alt_title" value="魔法使いウィズ ~ Mahou Tsukai Wiz" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="magical kid wiz (japan) (alt 2).rom" size="32768" crc="74d6a1b1" sha1="3e2ef016f255168e2df1906e678ca22f880917b8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="magical kid wiz (japan) (alt 2).rom" size="0x8000" crc="74d6a1b1" sha1="3e2ef016f255168e2df1906e678ca22f880917b8" />
 			</dataarea>
 		</part>
 	</software>
@@ -7765,8 +8452,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC713" />
 		<info name="alt_title" value="マジカルツリー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="magical tree (japan).rom" size="16384" crc="827038a2" sha1="b82dc590aadc930b43db303bb3e3458e7695e3b5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="magical tree (japan).rom" size="0x4000" crc="827038a2" sha1="b82dc590aadc930b43db303bb3e3458e7695e3b5" />
 			</dataarea>
 		</part>
 	</software>
@@ -7778,8 +8466,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC713" />
 		<info name="alt_title" value="マジカルツリー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="magical tree (japan) (alt 1).rom" size="16384" crc="f3606c66" sha1="bf5678f3c065a4507f71ed6206a63ac922ad93dd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="magical tree (japan) (alt 1).rom" size="0x4000" crc="f3606c66" sha1="bf5678f3c065a4507f71ed6206a63ac922ad93dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -7793,8 +8482,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="magnum prohibition 1931 (japan).rom" size="131072" crc="d446ba1e" sha1="3243a5cc562451de527917e9ca85657286b2852f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="magnum prohibition 1931 (japan).rom" size="0x20000" crc="d446ba1e" sha1="3243a5cc562451de527917e9ca85657286b2852f" />
 			</dataarea>
 		</part>
 	</software>
@@ -7808,8 +8497,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="magnum prohibition 1931 (japan) (alt 1).rom" size="131072" crc="2a8bbb4d" sha1="9c5c1c40ec30c34b1b436cf8cc494c0b509e81fc" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="magnum prohibition 1931 (japan) (alt 1).rom" size="0x20000" crc="2a8bbb4d" sha1="9c5c1c40ec30c34b1b436cf8cc494c0b509e81fc" />
 			</dataarea>
 		</part>
 	</software>
@@ -7818,11 +8507,12 @@ kept for now until finding out what those bytes affect...
 		<description>Manes (Japan)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="Z-00303" />
+		<info name="serial" value="Z-00303 / 20118" />
 		<info name="alt_title" value="メーニーズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="manes (japan).rom" size="16384" crc="b7002f08" sha1="2729bb0e68a64af525df4c5d9687bae07245980a" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="manes (japan).rom" size="0x4000" crc="b7002f08" sha1="2729bb0e68a64af525df4c5d9687bae07245980a" />
 			</dataarea>
 		</part>
 	</software>
@@ -7831,11 +8521,12 @@ kept for now until finding out what those bytes affect...
 		<description>Manes (Japan, alt)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="Z-00303" />
+		<info name="serial" value="Z-00303 / 20118" />
 		<info name="alt_title" value="メーニーズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="manes (japan) (alt 1).rom" size="16384" crc="a97a19ec" sha1="47129fe3791a7171f8fa792f953d7b5d58ba5c24" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="manes (japan) (alt 1).rom" size="0x4000" crc="a97a19ec" sha1="47129fe3791a7171f8fa792f953d7b5d58ba5c24" />
 			</dataarea>
 		</part>
 	</software>
@@ -7844,11 +8535,12 @@ kept for now until finding out what those bytes affect...
 		<description>Manes (Japan, alt 2)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="Z-00303" />
+		<info name="serial" value="Z-00303 / 20118" />
 		<info name="alt_title" value="メーニーズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="manes (japan) (alt 2).rom" size="16384" crc="af275ca8" sha1="820174b4dd3f3df87e5e32fb6f7ed457542d96c1" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="manes (japan) (alt 2).rom" size="0x4000" crc="af275ca8" sha1="820174b4dd3f3df87e5e32fb6f7ed457542d96c1" />
 			</dataarea>
 		</part>
 	</software>
@@ -7860,8 +8552,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="02" />
 		<info name="alt_title" value="マッピー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mappy (japan).rom" size="16384" crc="3b702e9a" sha1="e7d06c0a5c7f256c061e5b8173fdcc145d2fc4d6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mappy (japan).rom" size="0x4000" crc="3b702e9a" sha1="e7d06c0a5c7f256c061e5b8173fdcc145d2fc4d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -7873,12 +8566,14 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="02" />
 		<info name="alt_title" value="マッピー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mappy (japan) (alt 1).rom" size="32768" crc="a0358870" sha1="a8313b0dce35faa80b399a220f19b04333fdec1d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mappy (japan) (alt 1).rom" size="0x8000" crc="a0358870" sha1="a8313b0dce35faa80b399a220f19b04333fdec1d" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Has a glitch in the name on the title screen. Bad dump? -->
 	<software name="mappyb" cloneof="mappy">
 		<description>Mappy (Japan, alt 2)</description>
 		<year>1984</year>
@@ -7886,8 +8581,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="02" />
 		<info name="alt_title" value="マッピー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mappy (japan) (alt 2).rom" size="32768" crc="a006ad6b" sha1="20ce82112ba0c50063667d61e43979ac464a3bb4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mappy (japan) (alt 2).rom" size="0x8000" crc="a006ad6b" sha1="20ce82112ba0c50063667d61e43979ac464a3bb4" />
 			</dataarea>
 		</part>
 	</software>
@@ -7899,8 +8595,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="000B0" />
 		<info name="alt_title" value="マリンバトル" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="marine battle (japan).rom" size="16384" crc="24923bdb" sha1="a66e19e58ac5b4da7db071ca7ead40c28a332198" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="marine battle (japan).rom" size="0x4000" crc="24923bdb" sha1="a66e19e58ac5b4da7db071ca7ead40c28a332198" />
 			</dataarea>
 		</part>
 	</software>
@@ -7912,8 +8609,8 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5108" />
 		<info name="alt_title" value="魔性の館ガバリン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="mashou no tachi goblin (japan).rom" size="65536" crc="d34d74f7" sha1="e4d61ee74867066b04b0f6aba35d98d72665e6e0" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="mashou no tachi goblin (japan).rom" size="0x10000" crc="d34d74f7" sha1="e4d61ee74867066b04b0f6aba35d98d72665e6e0" />
 			</dataarea>
 		</part>
 	</software>
@@ -7925,8 +8622,8 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5108" />
 		<info name="alt_title" value="魔性の館ガバリン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="mashou no tachi goblin (japan) (alt 1).rom" size="65536" crc="6ef086eb" sha1="8f92ea214a7a11394c512080d3b65a7afa9a92ed" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="mashou no tachi goblin (japan) (alt 1).rom" size="0x10000" crc="6ef086eb" sha1="8f92ea214a7a11394c512080d3b65a7afa9a92ed" />
 			</dataarea>
 		</part>
 	</software>
@@ -7938,32 +8635,35 @@ kept for now until finding out what those bytes affect...
 		<info name="alt_title" value="メガロポリスＳＯＳ" />
 		<info name="usage" value="Requires a machine with RAM in a main slot" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="megalopolis sos (japan).rom" size="16384" crc="cf744d2e" sha1="8c6e1e21cc45b2ca72ceea93df48eda9cef1dbad" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="megalopolis sos (japan).rom" size="0x4000" crc="cf744d2e" sha1="8c6e1e21cc45b2ca72ceea93df48eda9cef1dbad" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="megalsosa" cloneof="megalsos">
-		<description>Megalopolis SOS (Japan, alt)</description>
-		<year>1983</year>
-		<publisher>Paxon</publisher>
+		<description>Megalopolis SOS (Japan, Compile)</description>
+		<year>1984</year>
+		<publisher>Compile</publisher>
 		<info name="alt_title" value="メガロポリスＳＯＳ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="megalopolis sos (japan) (alt 1).rom" size="16384" crc="02b17e2a" sha1="3167ffc2f2411138e4545cbdf4466c3237a04874" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="megalopolis sos (japan) (alt 1).rom" size="0x4000" crc="02b17e2a" sha1="3167ffc2f2411138e4545cbdf4466c3237a04874" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="megalsosb" cloneof="megalsos">
-		<description>Megalopolis SOS (Japan, alt 2)</description>
-		<year>1983</year>
-		<publisher>Paxon</publisher>
+		<description>Megalopolis SOS (Japan, Compile, alt)</description>
+		<year>1984</year>
+		<publisher>Compile</publisher>
 		<info name="alt_title" value="メガロポリスＳＯＳ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="megalopolis sos (japan) (alt 2).rom" size="16384" crc="07e85697" sha1="2af58d6b3a8c77270fa5bb82f129fc97f999b7ec" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="megalopolis sos (japan) (alt 2).rom" size="0x4000" crc="07e85697" sha1="2af58d6b3a8c77270fa5bb82f129fc97f999b7ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -7974,11 +8674,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>HAL Kenkyuujo</publisher>
 		<info name="serial" value="HM-023" />
 		<info name="alt_title" value="迷宮神話" />
+		<info name="gtin" value="04988610115238"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="meikyuu shinwa (japan).rom" size="131072" crc="2f8065eb" sha1="98b7a6ac44b82ccfc45eb51595e2905adabac1c7" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="meikyuu shinwa (japan).rom" size="0x20000" crc="2f8065eb" sha1="98b7a6ac44b82ccfc45eb51595e2905adabac1c7" />
 			</dataarea>
 		</part>
 	</software>
@@ -7989,11 +8690,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>HAL Kenkyuujo</publisher>
 		<info name="serial" value="HM-023" />
 		<info name="alt_title" value="迷宮神話" />
+		<info name="gtin" value="04988610115238"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="meikyuu shinwa (japan) (alt 1).rom" size="131072" crc="1d1ec602" sha1="e92baa5fdfb2715e68700024d964098ef35704d9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="meikyuu shinwa (japan) (alt 1).rom" size="0x20000" crc="1d1ec602" sha1="e92baa5fdfb2715e68700024d964098ef35704d9" />
 			</dataarea>
 		</part>
 	</software>
@@ -8004,9 +8706,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G049C" />
 		<info name="alt_title" value="ミッドナイトブラザーズずっこけ探偵 ~ Midnight Brothers Zukkoke Tantei (Box?)" />
+		<info name="gtin" value="04901780008223"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="midnight brothers (japan).rom" size="32768" crc="ce2882f6" sha1="97adcb652bc4baf02d29a9abe5e6547065dec298" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="midnight brothers (japan).rom" size="0x8000" crc="ce2882f6" sha1="97adcb652bc4baf02d29a9abe5e6547065dec298" />
 			</dataarea>
 		</part>
 	</software>
@@ -8017,9 +8721,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G049C" />
 		<info name="alt_title" value="ミッドナイトブラザーズずっこけ探偵 ~ Midnight Brothers Zukkoke Tantei (Box?)" />
+		<info name="gtin" value="04901780008223"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="midnight brothers (japan) (alt 1).rom" size="32768" crc="7bc61bd5" sha1="f1d68b477f3f54c0b6080985954208b0d95c5973" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="midnight brothers (japan) (alt 1).rom" size="0x8000" crc="7bc61bd5" sha1="f1d68b477f3f54c0b6080985954208b0d95c5973" />
 			</dataarea>
 		</part>
 	</software>
@@ -8030,8 +8736,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ミッドナイトビルディング" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="midnight building (japan).rom" size="16384" crc="7b5282e4" sha1="5460aa3be896ad949bea75444bc6e7e072a859b8" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="midnight building (japan).rom" size="0x4000" crc="7b5282e4" sha1="5460aa3be896ad949bea75444bc6e7e072a859b8" />
 			</dataarea>
 		</part>
 	</software>
@@ -8039,11 +8746,13 @@ kept for now until finding out what those bytes affect...
 	<software name="midway">
 		<description>Midway (Japan)</description>
 		<year>1983</year>
-		<publisher>Magicsoft</publisher>
-		<info name="alt_title" value="カラー・ミッドウエイ ~ Color Midway (Box?)" />
+		<publisher>National</publisher>
+		<info name="alt_title" value="カラー・ミッドウエイ ~ Color Midway" />
+		<info name="serial" value="CF-SS012"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="midway (japan).rom" size="16384" crc="40e2f32a" sha1="3a8c815f9f97c067828e22f50386a9383f8e1a3d" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="midway (japan).rom" size="0x4000" crc="40e2f32a" sha1="3a8c815f9f97c067828e22f50386a9383f8e1a3d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8054,8 +8763,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Sony Spain</publisher>
 		<info name="serial" value="HBS-IDE05" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="mil caras (spain).rom" size="8192" crc="0deacd48" sha1="7c50d00a0d7b8c3474ed492465a92622ca160151" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="mil caras (spain).rom" size="0x2000" crc="0deacd48" sha1="7c50d00a0d7b8c3474ed492465a92622ca160151" />
 			</dataarea>
 		</part>
 	</software>
@@ -8067,8 +8777,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="11" />
 		<info name="alt_title" value="ミニゴルフ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mini golf (japan).rom" size="16384" crc="855ca028" sha1="d2bf27695023a3e7daaeab1cb76572f2c412de1e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mini golf (japan).rom" size="0x4000" crc="855ca028" sha1="d2bf27695023a3e7daaeab1cb76572f2c412de1e" />
 			</dataarea>
 		</part>
 	</software>
@@ -8080,8 +8791,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="11" />
 		<info name="alt_title" value="ミニゴルフ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mini golf (japan) (alt 1).rom" size="32768" crc="187964d3" sha1="5a709255f73eb8b601bf9d81210260488f8ac511" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mini golf (japan) (alt 1).rom" size="0x8000" crc="187964d3" sha1="5a709255f73eb8b601bf9d81210260488f8ac511" />
 			</dataarea>
 		</part>
 	</software>
@@ -8092,11 +8804,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Natsume</publisher>
 		<info name="serial" value="NP-003" />
 		<info name="alt_title" value="三つ目がとおる" />
+		<info name="gtin" value="04988635100059"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="mitsumega toohru - three-eyed one comes here, the (japan).rom" size="131072" crc="4faccae0" sha1="176ec8e65a9fdbf59edc245b9e8388cc94195db9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="mitsumega toohru - three-eyed one comes here, the (japan).rom" size="0x20000" crc="4faccae0" sha1="176ec8e65a9fdbf59edc245b9e8388cc94195db9" />
 			</dataarea>
 		</part>
 	</software>
@@ -8108,8 +8821,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-130" />
 		<info name="alt_title" value="モアイの秘宝" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="moai no hibou (japan).rom" size="32768" crc="0427df83" sha1="f924d89a28966a1d08c10d5ddbc9e0e182be4669" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="moai no hibou (japan).rom" size="0x8000" crc="0427df83" sha1="f924d89a28966a1d08c10d5ddbc9e0e182be4669" />
 			</dataarea>
 		</part>
 	</software>
@@ -8118,9 +8832,11 @@ kept for now until finding out what those bytes affect...
 		<description>Moai no Hihou (Korea)</description>
 		<year>1986?</year>
 		<publisher>Static Soft</publisher>
+		<info name="alt_title" value="모아의보물"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="moai no hibou (japan) (alt 1).rom" size="32768" crc="0b3061fc" sha1="428b5bdd5cbb3e4ff637cfa5db8c41d8d0070813" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="moai no hibou (japan) (alt 1).rom" size="0x8000" crc="0b3061fc" sha1="428b5bdd5cbb3e4ff637cfa5db8c41d8d0070813" />
 			</dataarea>
 		</part>
 	</software>
@@ -8132,8 +8848,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-025" />
 		<info name="alt_title" value="機動惑星スティルス ~ Kidou Wakusei Suthirus" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mobile planet suthirus - approach from the westgate (japan).rom" size="32768" crc="eba19259" sha1="336d714e3bc2dfe3626e55d01ee4ef74a48cf652" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mobile planet suthirus - approach from the westgate (japan).rom" size="0x8000" crc="eba19259" sha1="336d714e3bc2dfe3626e55d01ee4ef74a48cf652" />
 			</dataarea>
 		</part>
 	</software>
@@ -8142,11 +8859,12 @@ kept for now until finding out what those bytes affect...
 		<description>Mobile-Suit Gundam - Last Shooting (Japan)</description>
 		<year>1984</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="0201250" />
+		<info name="serial" value="0201250 / BMX-001" />
 		<info name="alt_title" value="機動戦士ガンダム ~ Kidou Senshi Gundam" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mobile-suit gundam - last shooting (japan).rom" size="16384" crc="1d27d31f" sha1="917270dd44c63dc883289b4e0902fe6c812f5ea3" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mobile-suit gundam - last shooting (japan).rom" size="0x4000" crc="1d27d31f" sha1="917270dd44c63dc883289b4e0902fe6c812f5ea3" />
 			</dataarea>
 		</part>
 	</software>
@@ -8155,11 +8873,12 @@ kept for now until finding out what those bytes affect...
 		<description>Mobile-Suit Gundam - Last Shooting (Japan, alt)</description>
 		<year>1984</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="0201250" />
+		<info name="serial" value="0201250 / BMX-001" />
 		<info name="alt_title" value="機動戦士ガンダム ~ Kidou Senshi Gundam" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mobile-suit gundam - last shooting (japan) (alt 1).rom" size="32768" crc="4725206f" sha1="c0717a9831d66e29eb907be598ba6606e17ea044" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mobile-suit gundam - last shooting (japan) (alt 1).rom" size="0x8000" crc="4725206f" sha1="c0717a9831d66e29eb907be598ba6606e17ea044" />
 			</dataarea>
 		</part>
 	</software>
@@ -8169,8 +8888,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="gundam.rom" size="32768" crc="5cef14d1" sha1="4b565ee44647923b349e6abb150a9c52f00722e4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="gundam.rom" size="0x8000" crc="5cef14d1" sha1="4b565ee44647923b349e6abb150a9c52f00722e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -8181,21 +8901,23 @@ kept for now until finding out what those bytes affect...
 		<publisher>Leben Pro</publisher>
 		<info name="alt_title" value="もうかりまっか？ぼちぼちでんな!" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mokarimakka (japan).rom" size="32768" crc="d40f481d" sha1="17ac538dd63bc93ec0b88b6dd92079e807c22908" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mokarimakka (japan).rom" size="0x8000" crc="d40f481d" sha1="17ac538dd63bc93ec0b88b6dd92079e807c22908" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="mole">
 		<description>Mole (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00050" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mole (japan).rom" size="16384" crc="d0e39c9b" sha1="7d0bb1dac966ceee2e4c53f77e6e057d65f15d4d" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mole (japan).rom" size="0x4000" crc="d0e39c9b" sha1="7d0bb1dac966ceee2e4c53f77e6e057d65f15d4d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8206,8 +8928,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mole mole (1985)(victor)[tr pt].rom" size="32768" crc="7092ca0c" sha1="5720bf88ea080ac58e73ad11ffa116cf29733d76" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mole mole (1985)(victor)[tr pt].rom" size="0x8000" crc="7092ca0c" sha1="5720bf88ea080ac58e73ad11ffa116cf29733d76" />
 			</dataarea>
 		</part>
 	</software>
@@ -8217,9 +8940,12 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Victor</publisher>
 		<info name="alt_title" value="モールモール2" />
+		<info name="serial" value="M-2003"/>
+		<info name="gtin" value="04988002015023"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mole mole 2 (japan).rom" size="32768" crc="309f886b" sha1="f364a44d0b4ceaaa8706830237c0b824dcf9ce0c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mole mole 2 (japan).rom" size="0x8000" crc="309f886b" sha1="f364a44d0b4ceaaa8706830237c0b824dcf9ce0c" />
 			</dataarea>
 		</part>
 	</software>
@@ -8231,8 +8957,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC702" />
 		<info name="alt_title" value="モン太君のいち・に・さんすう ~ Monta-kun no Ichi-Ni-San Suu (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="monkey academy (japan).rom" size="16384" crc="98cd6912" sha1="8b2626f8dbbb3e97a5087b340a3f3d56c8ee84d1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="monkey academy (japan).rom" size="0x4000" crc="98cd6912" sha1="8b2626f8dbbb3e97a5087b340a3f3d56c8ee84d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -8244,8 +8971,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC702" />
 		<info name="alt_title" value="モン太君のいち・に・さんすう ~ Monta-kun no Ichi-Ni-San Suu (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="monkey academy (japan) (alt 1).rom" size="16384" crc="e73c12e6" sha1="e61f407e51ea4411145e236272842bdb3e0743e6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="monkey academy (japan) (alt 1).rom" size="0x4000" crc="e73c12e6" sha1="e61f407e51ea4411145e236272842bdb3e0743e6" />
 			</dataarea>
 		</part>
 	</software>
@@ -8257,8 +8985,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC702" />
 		<info name="alt_title" value="モン太君のいち・に・さんすう ~ Monta-kun no Ichi-Ni-San Suu (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="monkey academy (japan) (alt 2).rom" size="16384" crc="3ddcac18" sha1="6fefe304cc8cd099456bbbbbcb23ff776cb113c9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="monkey academy (japan) (alt 2).rom" size="0x4000" crc="3ddcac18" sha1="6fefe304cc8cd099456bbbbbcb23ff776cb113c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -8270,8 +8999,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC702" />
 		<info name="alt_title" value="モン太君のいち・に・さんすう ~ Monta-kun no Ichi-Ni-San Suu (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="monkey academy (japan) (alt 3).rom" size="16384" crc="d1896f6e" sha1="e0d84b3b2ac7675c3ed104797840d43bc2347a5b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="monkey academy (japan) (alt 3).rom" size="0x4000" crc="d1896f6e" sha1="e0d84b3b2ac7675c3ed104797840d43bc2347a5b" />
 			</dataarea>
 		</part>
 	</software>
@@ -8281,48 +9011,54 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Toho</publisher>
 		<info name="alt_title" value="モンスターズフェア" />
+		<info name="serial" value="CS11-006R"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="monster's fair (japan).rom" size="32768" crc="1ba6e461" sha1="b6d39bbaedb89f8c908cc2f44a0ab17e4b80ca4f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="monster's fair (japan).rom" size="0x8000" crc="1ba6e461" sha1="b6d39bbaedb89f8c908cc2f44a0ab17e4b80ca4f" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="moonland">
 		<description>Moon Landing (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ムーンランディング" />
+		<info name="serial" value="00060"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="moon landing (japan).rom" size="16384" crc="8a2c11da" sha1="b2d9dcee787ace26f8f4d2d18e24a3d645a6f853" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="moon landing (japan).rom" size="0x4000" crc="8a2c11da" sha1="b2d9dcee787ace26f8f4d2d18e24a3d645a6f853" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
-	<software name="mpatrol">
+	<!-- In the copyright message on the title screen several characters are doubled. -->
+	<software name="mpatrol" supported="partial">
 		<description>Moon Patrol (Japan)</description>
 		<year>1984</year>
 		<publisher>Dempa</publisher>
 		<info name="serial" value="DP-3912011" />
 		<info name="alt_title" value="ムーンパトロール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="moon patrol (japan).rom" size="16384" crc="febb1155" sha1="d1cf5410ed71f77670f65eb08ee944436bc0eb10" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="moon patrol (japan).rom" size="0x4000" crc="febb1155" sha1="d1cf5410ed71f77670f65eb08ee944436bc0eb10" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
+	<!-- In the copyright message on the title screen several characters are doubled. -->
 	<software name="mpatrolk" cloneof="mpatrol">
 		<description>Moon Patrol (Korea)</description>
 		<year>19??</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="moon patrol (1984)(irem)[cr prosoft].rom" size="16384" crc="d4151ce7" sha1="4a7dc53f122dbe0cc6a299902b0642c96141e071" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="moon patrol (1984)(irem)[cr prosoft].rom" size="0x4000" crc="d4151ce7" sha1="4a7dc53f122dbe0cc6a299902b0642c96141e071" />
 			</dataarea>
 		</part>
 	</software>
@@ -8334,12 +9070,14 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2012G" />
 		<info name="alt_title" value="宇宙戦士「隼」 ~ Uchuu Senshi Hayabusa (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="moonsweeper (japan).rom" size="32768" crc="f1637c31" sha1="f93e23d958d2075bf476cb05a3c4f48d0c41aabb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="moonsweeper (japan).rom" size="0x8000" crc="f1637c31" sha1="f93e23d958d2075bf476cb05a3c4f48d0c41aabb" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Konami logo on blue screen. -->
 	<software name="mopirang">
 		<description>Mopiranger (Japan)</description>
 		<year>1985</year>
@@ -8347,12 +9085,14 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC728" />
 		<info name="alt_title" value="モピレンジャー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mopiranger (japan).rom" size="16384" crc="9d73e4c5" sha1="33ec3136dfb6fd44014c8bbffc8ac79c3cafe75c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mopiranger (japan).rom" size="0x4000" crc="9d73e4c5" sha1="33ec3136dfb6fd44014c8bbffc8ac79c3cafe75c" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Konami logo on blue screen. -->
 	<software name="mopiranga" cloneof="mopirang">
 		<description>Mopiranger (Japan, alt)</description>
 		<year>1985</year>
@@ -8360,12 +9100,14 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC728" />
 		<info name="alt_title" value="モピレンジャー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mopiranger (japan) (alt 1).rom" size="16384" crc="097f4e4a" sha1="4a185a3db81c2ce20d176d13fa5f619c6b7a170c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mopiranger (japan) (alt 1).rom" size="0x4000" crc="097f4e4a" sha1="4a185a3db81c2ce20d176d13fa5f619c6b7a170c" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Konami logo on black screen. -->
 	<software name="mopirangb" cloneof="mopirang">
 		<description>Mopiranger (Japan, alt 2)</description>
 		<year>1985</year>
@@ -8373,12 +9115,14 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC728" />
 		<info name="alt_title" value="モピレンジャー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mopiranger (japan) (alt 2).rom" size="16384" crc="213e623b" sha1="1b3059c7873765a476fb7791a4d6fc846ab05ade" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mopiranger (japan) (alt 2).rom" size="0x4000" crc="213e623b" sha1="1b3059c7873765a476fb7791a4d6fc846ab05ade" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Konami logo on blue screen. -->
 	<software name="mopirangc" cloneof="mopirang">
 		<description>Mopiranger (Japan, alt 3)</description>
 		<year>1985</year>
@@ -8386,12 +9130,14 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC728" />
 		<info name="alt_title" value="モピレンジャー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mopiranger (japan) (alt 3).rom" size="16384" crc="73d0ce5a" sha1="ddc458bb3c70e0708841e516d9b89220c0e098a1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mopiranger (japan) (alt 3).rom" size="0x4000" crc="73d0ce5a" sha1="ddc458bb3c70e0708841e516d9b89220c0e098a1" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Konami logo on blue screen. -->
 	<software name="mopirangd" cloneof="mopirang">
 		<description>Mopiranger (Japan, alt 4)</description>
 		<year>1985</year>
@@ -8399,8 +9145,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC728" />
 		<info name="alt_title" value="モピレンジャー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mopiranger (japan) (alt 4).rom" size="16384" crc="6135bd9a" sha1="14e7ef125cc902001995bbd8acca0eae2f213dc1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mopiranger (japan) (alt 4).rom" size="0x4000" crc="6135bd9a" sha1="14e7ef125cc902001995bbd8acca0eae2f213dc1" />
 			</dataarea>
 		</part>
 	</software>
@@ -8410,22 +9157,24 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mopirang.rom" size="32768" crc="46bfe597" sha1="dd9d6ed442122d142987fd691001efcc2bc18c7c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mopirang.rom" size="0x8000" crc="46bfe597" sha1="dd9d6ed442122d142987fd691001efcc2bc18c7c" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="moritaot">
 		<description>Morita Kazuo no Othello (Japan)</description>
 		<year>1986</year>
 		<publisher>Toshiba EMI</publisher>
 		<info name="serial" value="PS-2017G" />
 		<info name="alt_title" value="森田和郎のオセロ" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="morita kazuo no othello (japan).rom" size="32768" crc="a94d7d08" sha1="4dd934902907db50ba76053f59ae7737d55824f4" offset="0x4000" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="morita kazuo no othello (japan).rom" size="0x8000" crc="a94d7d08" sha1="4dd934902907db50ba76053f59ae7737d55824f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -8437,8 +9186,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G007C" />
 		<info name="alt_title" value="マウザー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mouser (japan).rom" size="16384" crc="06a64527" sha1="1fb861152a9f3f9c2b2dace26d5f1d93ab9b4ad8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mouser (japan).rom" size="0x4000" crc="06a64527" sha1="1fb861152a9f3f9c2b2dace26d5f1d93ab9b4ad8" />
 			</dataarea>
 		</part>
 	</software>
@@ -8449,8 +9199,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>HAL Kenkyuujo</publisher>
 		<info name="serial" value="HM-012" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="mr. chin (japan).rom" size="8192" crc="414d29bc" sha1="b5d130a50f6939028702c1645426a29ec8ead6e5" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="mr. chin (japan).rom" size="0x2000" crc="414d29bc" sha1="b5d130a50f6939028702c1645426a29ec8ead6e5" />
 			</dataarea>
 		</part>
 	</software>
@@ -8460,8 +9211,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mrchin.rom" size="32768" crc="68c2426a" sha1="bd8227af9833b7c02fa8ecff6416b7cb9e3e1de4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mrchin.rom" size="0x8000" crc="68c2426a" sha1="bd8227af9833b7c02fa8ecff6416b7cb9e3e1de4" />
 			</dataarea>
 		</part>
 	</software>
@@ -8472,8 +9224,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Nihon Columbia</publisher>
 		<info name="serial" value="48C99-1004" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="mr. do (japan).rom" size="8192" crc="4098d71d" sha1="dc69c7a9ea93cbb0093300955935ef156af5c194" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="mr. do (japan).rom" size="0x2000" crc="4098d71d" sha1="dc69c7a9ea93cbb0093300955935ef156af5c194" />
 			</dataarea>
 		</part>
 	</software>
@@ -8483,8 +9236,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="extra.rom" size="32768" crc="121c7d23" sha1="4ab3c16e32a3a0f4373e24cd47cd2805013f2f65" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="extra.rom" size="0x8000" crc="121c7d23" sha1="4ab3c16e32a3a0f4373e24cd47cd2805013f2f65" />
 			</dataarea>
 		</part>
 	</software>
@@ -8496,8 +9250,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G018C" />
 		<info name="alt_title" value="ミスタードゥｖｓユニコーンズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mr. do vs unicorns (japan).rom" size="16384" crc="09090135" sha1="01544042b810c0b401fce5d180adb6fea9b5ed20" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mr. do vs unicorns (japan).rom" size="0x4000" crc="09090135" sha1="01544042b810c0b401fce5d180adb6fea9b5ed20" />
 			</dataarea>
 		</part>
 	</software>
@@ -8508,8 +9263,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Nihon Columbia</publisher>
 		<info name="alt_title" value="ミスタードゥワイルドライド" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mr. do's wild ride (japan).rom" size="16384" crc="6786a7ee" sha1="e9b3652482a5b09ae662203f8758a30aa23af62f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mr. do's wild ride (japan).rom" size="0x4000" crc="6786a7ee" sha1="e9b3652482a5b09ae662203f8758a30aa23af62f" />
 			</dataarea>
 		</part>
 	</software>
@@ -8521,8 +9277,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Angel?</publisher>
 		<info name="alt_title" value="ミスタードゥワイルドライド" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mr. do's wildride (1985)(nippon columbia - colpax - universal)[cr angel].rom" size="16384" crc="01ea3a27" sha1="4b168d751cedf73f09ad6b7a7e4ce809880b10dd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mr. do's wildride (1985)(nippon columbia - colpax - universal)[cr angel].rom" size="0x4000" crc="01ea3a27" sha1="4b168d751cedf73f09ad6b7a7e4ce809880b10dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -8531,9 +9288,12 @@ kept for now until finding out what those bytes affect...
 		<description>MSX 21 (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
+		<info name="serial" value="00070"/>
+		<info name="isbn" value="4871489175"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="msx 21 (japan).rom" size="16384" crc="13b8243c" sha1="ca05a183f4e7e56102706d1b9b852ad4350264ba" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="msx 21 (japan).rom" size="0x4000" crc="13b8243c" sha1="ca05a183f4e7e56102706d1b9b852ad4350264ba" />
 			</dataarea>
 		</part>
 	</software>
@@ -8541,12 +9301,13 @@ kept for now until finding out what those bytes affect...
 	<software name="msxbball">
 		<description>MSX Baseball (Japan)</description>
 		<year>1984</year>
-		<publisher>Panasoft</publisher>
+		<publisher>National</publisher>
 		<info name="serial" value="CF-SM002" />
 		<info name="alt_title" value="パナソフトのベースボール ~ Panasoft no Baseball (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="msx baseball (japan).rom" size="16384" crc="f79d3088" sha1="85a3842eabac50c4e1332666c161541be3508249" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="msx baseball (japan).rom" size="0x4000" crc="f79d3088" sha1="85a3842eabac50c4e1332666c161541be3508249" />
 			</dataarea>
 		</part>
 	</software>
@@ -8554,12 +9315,13 @@ kept for now until finding out what those bytes affect...
 	<software name="msxbballa" cloneof="msxbball">
 		<description>MSX Baseball (Japan, alt)</description>
 		<year>1984</year>
-		<publisher>Panasoft</publisher>
+		<publisher>National</publisher>
 		<info name="serial" value="CF-SM002" />
 		<info name="alt_title" value="パナソフトのベースボール ~ Panasoft no Baseball (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="msx baseball (japan) (alt 1).rom" size="16384" crc="f928f075" sha1="76d488497d9ba54b302a4326f45909f643bdcd7a" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="msx baseball (japan) (alt 1).rom" size="0x4000" crc="f928f075" sha1="76d488497d9ba54b302a4326f45909f643bdcd7a" />
 			</dataarea>
 		</part>
 	</software>
@@ -8569,23 +9331,27 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Panasoft</publisher>
 		<info name="alt_title" value="パナソフトのベースボール II ~ Panasoft no Baseball II (Box?)" />
+		<info name="serial" value="PANA-3"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="msx baseball ii national (japan).rom" size="16384" crc="0cb78f0e" sha1="ac150939558ec4e56446be9502177f28a29881eb" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="msx baseball ii national (japan).rom" size="0x4000" crc="0cb78f0e" sha1="ac150939558ec4e56446be9502177f28a29881eb" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="msxderby">
 		<description>MSX Derby (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00090" />
 		<info name="alt_title" value="ＭＳＸダービー" />
+		<info name="isbn" value="4871489167"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="msx derby (japan).rom" size="16384" crc="268cc301" sha1="c1c350c719236af5eef8798c4532351befcfd348" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="msx derby (japan).rom" size="0x4000" crc="268cc301" sha1="c1c350c719236af5eef8798c4532351befcfd348" />
 			</dataarea>
 		</part>
 	</software>
@@ -8597,22 +9363,24 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PANA-1" />
 		<info name="alt_title" value="パナソフトのラグビー ~ Panasoft no Rugby (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="msx rugby (japan).rom" size="16384" crc="61b33748" sha1="35abd4a14033710730da72edf278aad42d641621" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="msx rugby (japan).rom" size="0x4000" crc="61b33748" sha1="35abd4a14033710730da72edf278aad42d641621" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="shogigam">
 		<description>MSX Shogi Game (Japan)</description>
 		<year>1984</year>
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G034C" />
 		<info name="alt_title" value="ＭＳＸ将棋 ~ MSX Shougi" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="shogi game (japan).rom" size="32768" crc="18ad3380" sha1="299e52dfbbb94ace4fd1ef59ece45364ce0bb450" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="shogi game (japan).rom" size="0x8000" crc="18ad3380" sha1="299e52dfbbb94ace4fd1ef59ece45364ce0bb450" />
 			</dataarea>
 		</part>
 	</software>
@@ -8622,9 +9390,11 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Panasoft</publisher>
 		<info name="alt_title" value="パナソフトのサッカー ~ Panasoft no Rugby (Box?)" />
+		<info name="serial" value="PANA-2"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="msx soccer (japan).rom" size="16384" crc="6824e45d" sha1="d2aa1605a6b56c118e18b385ab879536d74cc355" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="msx soccer (japan).rom" size="0x4000" crc="6824e45d" sha1="d2aa1605a6b56c118e18b385ab879536d74cc355" />
 			</dataarea>
 		</part>
 	</software>
@@ -8634,9 +9404,11 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Panasoft</publisher>
 		<info name="alt_title" value="パナソフトのサッカー ~ Panasoft no Rugby (Box?)" />
+		<info name="serial" value="PANA-2"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="msx soccer (japan) (alt 1).rom" size="16384" crc="f31d13b9" sha1="c76ca96ed23621a6267d9906cc4a1ee428677f98" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="msx soccer (japan) (alt 1).rom" size="0x4000" crc="f31d13b9" sha1="c76ca96ed23621a6267d9906cc4a1ee428677f98" />
 			</dataarea>
 		</part>
 	</software>
@@ -8646,50 +9418,54 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="msxsocce.rom" size="32768" crc="80d26722" sha1="556071f03bfddef1bc84ae311ba286ad849868ad" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="msxsocce.rom" size="0x8000" crc="80d26722" sha1="556071f03bfddef1bc84ae311ba286ad849868ad" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="sokoban">
 		<description>MSX Soukoban (Japan)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00240" />
 		<info name="alt_title" value="倉庫番" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="soukoban (japan).rom" size="16384" crc="030ddf11" sha1="04bd78730b100dd879e2fbd3fe646d2bc9bbc46b" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="soukoban (japan).rom" size="0x4000" crc="030ddf11" sha1="04bd78730b100dd879e2fbd3fe646d2bc9bbc46b" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="sokobana" cloneof="sokoban">
 		<description>MSX Soukoban (Japan, alt)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00240" />
 		<info name="alt_title" value="倉庫番" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="soukoban (japan) (alt 1).rom" size="32768" crc="bc815cfa" sha1="cf55b0d12e550f71cef709358bc7e799eced0083" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="soukoban (japan) (alt 1).rom" size="0x8000" crc="bc815cfa" sha1="cf55b0d12e550f71cef709358bc7e799eced0083" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="sokobanb" cloneof="sokoban">
 		<description>MSX Soukoban (Japan, alt 2)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00240" />
 		<info name="alt_title" value="倉庫番" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="soukoban (japan) (alt 2).rom" size="16384" crc="e683af8a" sha1="2338946a671d31d12360ace4eeb33f7bc7db56f1" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="soukoban (japan) (alt 2).rom" size="0x4000" crc="e683af8a" sha1="2338946a671d31d12360ace4eeb33f7bc7db56f1" />
 			</dataarea>
 		</part>
 	</software>
@@ -8700,8 +9476,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Qnix</publisher>
 		<info name="alt_title" value="아이-큐" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="soukoban (1984)(qnix).rom" size="16384" crc="ebb55d7f" sha1="6ec24f574a8e40d8785b3e721b1605e1984c5834" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="soukoban (1984)(qnix).rom" size="0x4000" crc="ebb55d7f" sha1="6ec24f574a8e40d8785b3e721b1605e1984c5834" />
 			</dataarea>
 		</part>
 	</software>
@@ -8712,8 +9489,8 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
-			<dataarea name="rom" size="131072">
-				<rom name="valis - the fantasm soldier (1987)(zemina).rom" size="131072" crc="87361b76" sha1="dccdb2d18c70a94e48b3ec5e0cb986c5d708bbc9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="valis - the fantasm soldier (1987)(zemina).rom" size="0x20000" crc="87361b76" sha1="dccdb2d18c70a94e48b3ec5e0cb986c5d708bbc9" />
 			</dataarea>
 		</part>
 	</software>
@@ -8723,9 +9500,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Technopolis Soft</publisher>
 		<info name="alt_title" value="ナウシカ・ゲーム" />
+		<info name="serial" value="58TSX-1"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="nausicaa (japan).rom" size="16384" crc="e84994f7" sha1="fb968a2407eee00c683af3ac19e88015341564ad" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="nausicaa (japan).rom" size="0x4000" crc="e84994f7" sha1="fb968a2407eee00c683af3ac19e88015341564ad" />
 			</dataarea>
 		</part>
 	</software>
@@ -8736,11 +9515,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC742" />
 		<info name="alt_title" value="グラディウス" />
+		<info name="gtin" value="04988602510744"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="nemesis (japan, europe).rom" size="131072" crc="4d44255f" sha1="e31ac6520e912c27ce96431a1dfb112bf71cb7b9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nemesis (japan, europe).rom" size="0x20000" crc="4d44255f" sha1="e31ac6520e912c27ce96431a1dfb112bf71cb7b9" />
 			</dataarea>
 		</part>
 	</software>
@@ -8751,11 +9531,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC742" />
 		<info name="alt_title" value="グラディウス" />
+		<info name="gtin" value="04988602510744"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="nemesis (japan, europe) (alt 1).rom" size="131072" crc="4dfcc009" sha1="f0e4168ea18188fca2581526c2503223b9a28581" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nemesis (japan, europe) (alt 1).rom" size="0x20000" crc="4dfcc009" sha1="f0e4168ea18188fca2581526c2503223b9a28581" />
 			</dataarea>
 		</part>
 	</software>
@@ -8766,11 +9547,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC751" />
 		<info name="alt_title" value="グラディウス2" />
+		<info name="gtin" value="04988602528701"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="nemesis 2 (japan, europe).rom" size="131072" crc="db847b2b" sha1="d63e20369f98487767810a0c57603bef6a2a07e5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nemesis 2 (japan, europe).rom" size="0x20000" crc="db847b2b" sha1="d63e20369f98487767810a0c57603bef6a2a07e5" />
 			</dataarea>
 		</part>
 	</software>
@@ -8781,11 +9563,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC751" />
 		<info name="alt_title" value="グラディウス2" />
+		<info name="gtin" value="04988602528701"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="nemesis 2 (japan, europe) (alt 1).rom" size="131072" crc="32aba4e3" sha1="ab30cdeaacbdf14e6366d43d881338178fc665cb" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nemesis 2 (japan, europe) (alt 1).rom" size="0x20000" crc="32aba4e3" sha1="ab30cdeaacbdf14e6366d43d881338178fc665cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -8798,8 +9581,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="nemesis 2 (japan, europe) (beta).rom" size="131072" crc="dfa8c827" sha1="4c2f015685a17db7a8c3893e868e0a84a8dbf1e5" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nemesis 2 (japan, europe) (beta).rom" size="0x20000" crc="dfa8c827" sha1="4c2f015685a17db7a8c3893e868e0a84a8dbf1e5" />
 			</dataarea>
 		</part>
 	</software>
@@ -8812,8 +9595,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="nemesis 2 (japan) (demo).rom" size="131072" crc="c8fac21a" sha1="6844758ff5c2c410115d4d7cf12498c42e931732" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="nemesis 2 (japan) (demo).rom" size="0x20000" crc="c8fac21a" sha1="6844758ff5c2c410115d4d7cf12498c42e931732" />
 			</dataarea>
 		</part>
 	</software>
@@ -8824,11 +9607,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC764" />
 		<info name="alt_title" value="ゴーファーの野望 EPISODE II" />
+		<info name="gtin" value="04988602546415"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="262144">
-				<rom name="nemesis 3 - the eve of destruction (japan, europe).rom" size="262144" crc="4b61ae91" sha1="7393f677e0fae5fc83071c6b74756117b7d75e2d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nemesis 3 - the eve of destruction (japan, europe).rom" size="0x40000" crc="4b61ae91" sha1="7393f677e0fae5fc83071c6b74756117b7d75e2d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8839,11 +9623,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC764" />
 		<info name="alt_title" value="ゴーファーの野望 EPISODE II" />
+		<info name="gtin" value="04988602546415"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="262144">
-				<rom name="nemesis 3 - the eve of destruction (japan, europe) (alt 1).rom" size="262144" crc="0db7132f" sha1="0413bb3aeacb0c28429b8c85b42796dbe48bef6d" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nemesis 3 - the eve of destruction (japan, europe) (alt 1).rom" size="0x40000" crc="0db7132f" sha1="0413bb3aeacb0c28429b8c85b42796dbe48bef6d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8854,11 +9639,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC764" />
 		<info name="alt_title" value="ゴーファーの野望 EPISODE II" />
+		<info name="gtin" value="04988602546415"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="262144">
-				<rom name="nemesis 3 - the eve of destruction (japan, europe) (alt 2).rom" size="262144" crc="329987bc" sha1="5692e41b3a4c5e767cf290fd6c24942d0fd7b2e3" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="nemesis 3 - the eve of destruction (japan, europe) (alt 2).rom" size="0x40000" crc="329987bc" sha1="5692e41b3a4c5e767cf290fd6c24942d0fd7b2e3" />
 			</dataarea>
 		</part>
 	</software>
@@ -8870,8 +9656,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-102" />
 		<info name="alt_title" value="熱戦甲子園" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="nessen koushiyen (japan).rom" size="16384" crc="2afbf7d1" sha1="b7fd07b7825c6beeb19b1f38631d2869f60939fb" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="nessen koushiyen (japan).rom" size="0x4000" crc="2afbf7d1" sha1="b7fd07b7825c6beeb19b1f38631d2869f60939fb" />
 			</dataarea>
 		</part>
 	</software>
@@ -8882,8 +9669,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="뉴 보글보글" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="new_bubble_bobble_(zemmina).rom" size="32768" crc="0e989532" sha1="223c1f5d38b54d4d5a58988223bb95df1998a620" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="new_bubble_bobble_(zemmina).rom" size="0x8000" crc="0e989532" sha1="223c1f5d38b54d4d5a58988223bb95df1998a620" />
 			</dataarea>
 		</part>
 	</software>
@@ -8895,8 +9683,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="뉴 보글보글" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bubble bobble (korea) (unl).rom" size="32768" crc="6d1b1ee1" sha1="d1ece8b5ffeb9b99230e640af32cb488fee51e35" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="bubble bobble (korea) (unl).rom" size="0x8000" crc="6d1b1ee1" sha1="d1ece8b5ffeb9b99230e640af32cb488fee51e35" />
 			</dataarea>
 		</part>
 	</software>
@@ -8908,8 +9697,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="뉴 보글보글" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="bubble bobble (korea) (alt 1) (unl).rom" size="32768" crc="0bc2c4ac" sha1="58551545e73c838a2e995e6951ab644ed2590786" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="bubble bobble (korea) (alt 1) (unl).rom" size="0x8000" crc="0bc2c4ac" sha1="58551545e73c838a2e995e6951ab644ed2590786" />
 			</dataarea>
 		</part>
 	</software>
@@ -8921,8 +9711,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="ND-05MR" />
 		<info name="alt_title" value="ナイトシェード" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="night shade (japan).rom" size="32768" crc="72ddb449" sha1="50e27c5b83c8afe00b077406081d063263e98b62" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="night shade (japan).rom" size="0x8000" crc="72ddb449" sha1="50e27c5b83c8afe00b077406081d063263e98b62" />
 			</dataarea>
 		</part>
 	</software>
@@ -8932,8 +9723,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ninja.rom" size="32768" crc="18510ca7" sha1="1f8b9ac28dbadaf5316770cd6a421c998e33a8cb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ninja.rom" size="0x8000" crc="18510ca7" sha1="1f8b9ac28dbadaf5316770cd6a421c998e33a8cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -8945,8 +9737,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="JX-11" />
 		<info name="alt_title" value="忍者じゃじゃ丸くん" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ninja jajamaru-kun (japan).rom" size="32768" crc="2a28ff97" sha1="371de6f12d834da07c8e67b13e75fc22618ba5e9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ninja jajamaru-kun (japan).rom" size="0x8000" crc="2a28ff97" sha1="371de6f12d834da07c8e67b13e75fc22618ba5e9" />
 			</dataarea>
 		</part>
 	</software>
@@ -8956,8 +9749,9 @@ kept for now until finding out what those bytes affect...
 		<year>19??</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ninja jaja maru kun (1986)(nippon dexter)[cr prosoft].rom" size="32768" crc="9cc8c883" sha1="ac5639b8ca66600e61452697ed44b48607256065" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ninja jaja maru kun (1986)(nippon dexter)[cr prosoft].rom" size="0x8000" crc="9cc8c883" sha1="ac5639b8ca66600e61452697ed44b48607256065" />
 			</dataarea>
 		</part>
 	</software>
@@ -8968,9 +9762,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5808" />
 		<info name="alt_title" value="忍者プリンセス" />
+		<info name="gtin" value="04988013004795"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ninja princess (japan).rom" size="32768" crc="203ef741" sha1="9dfc71887ffc6d94b8780b5d6f207e24c1f58b54" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ninja princess (japan).rom" size="0x8000" crc="203ef741" sha1="9dfc71887ffc6d94b8780b5d6f207e24c1f58b54" />
 			</dataarea>
 		</part>
 	</software>
@@ -8981,9 +9777,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5808" />
 		<info name="alt_title" value="忍者プリンセス" />
+		<info name="gtin" value="04988013004795"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ninja princess (japan) (alt 1).rom" size="32768" crc="99260557" sha1="62bfff23e2beae00db14b6c3e933043218b33ded" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ninja princess (japan) (alt 1).rom" size="0x8000" crc="99260557" sha1="62bfff23e2beae00db14b6c3e933043218b33ded" />
 			</dataarea>
 		</part>
 	</software>
@@ -8995,8 +9793,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HX-S107" />
 		<info name="alt_title" value="忍者くん" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="ninjakun (japan).rom" size="16384" crc="d388cfd1" sha1="ec2f1e747756ba1fdae606658aeeafa07e6e7fd4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="ninjakun (japan).rom" size="0x4000" crc="d388cfd1" sha1="ec2f1e747756ba1fdae606658aeeafa07e6e7fd4" />
 			</dataarea>
 		</part>
 	</software>
@@ -9008,8 +9807,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="ND-01MR" />
 		<info name="alt_title" value="忍者くん魔城の冒険" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ninjakun majou (japan).rom" size="32768" crc="ef339b82" sha1="c9d10b1df3bcadb3d917cf2a6877ae6e71ca3a57" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ninjakun majou (japan).rom" size="0x8000" crc="ef339b82" sha1="c9d10b1df3bcadb3d917cf2a6877ae6e71ca3a57" />
 			</dataarea>
 		</part>
 	</software>
@@ -9021,8 +9821,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MX-1010" />
 		<info name="alt_title" value="忍者影" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="ninjya kage (japan).rom" size="16384" crc="b202f481" sha1="0125bce373c95ee78df074d19ad032158edc74a2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="ninjya kage (japan).rom" size="0x4000" crc="b202f481" sha1="0125bce373c95ee78df074d19ad032158edc74a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -9034,8 +9835,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MX-1010" />
 		<info name="alt_title" value="忍者影" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="ninjya kage (japan) (alt 1).rom" size="16384" crc="56bd8018" sha1="049892d1633bcb3f1d5067ba710adeb89b38fcac" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="ninjya kage (japan) (alt 1).rom" size="0x4000" crc="56bd8018" sha1="049892d1633bcb3f1d5067ba710adeb89b38fcac" />
 			</dataarea>
 		</part>
 	</software>
@@ -9044,9 +9846,11 @@ kept for now until finding out what those bytes affect...
 		<description>Nuts &amp; Milk (Japan)</description>
 		<year>1983</year>
 		<publisher>Hudson Soft</publisher>
+		<info name="serial" value="MXHI 11028"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="nuts_milk_(1984)_(hudson).rom" size="32768" crc="8bff4901" sha1="aab3416aa54fa9b49e98c8286ba6a8f5093545d9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="nuts_milk_(1984)_(hudson).rom" size="0x8000" crc="8bff4901" sha1="aab3416aa54fa9b49e98c8286ba6a8f5093545d9" />
 			</dataarea>
 		</part>
 	</software>
@@ -9057,22 +9861,25 @@ kept for now until finding out what those bytes affect...
 		<publisher>Victor</publisher>
 		<info name="serial" value="M-2004" />
 		<info name="alt_title" value="ミクとしおりのニャンニャンプロレス" />
+		<info name="gtin" value="04988002023141"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="nyannyan pro wrestling (japan).rom" size="32768" crc="02ae3eda" sha1="aeecb99ed7bfe2ff39a5f42637b6b33ecc79c443" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="nyannyan pro wrestling (japan).rom" size="0x8000" crc="02ae3eda" sha1="aeecb99ed7bfe2ff39a5f42637b6b33ecc79c443" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="nyorols">
 		<description>Nyorols (Japan)</description>
 		<year>1983</year>
-		<publisher>MIA</publisher>
-		<info name="alt_title" value="MX-X6" />
+		<publisher>National</publisher>
+		<info name="alt_title" value="MX-X6 / CF-SS028" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="nyorols (japan).rom" size="16384" crc="6d81d863" sha1="98e33dca445850cdf24f09050756c3b75202ac13" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="nyorols (japan).rom" size="0x4000" crc="6d81d863" sha1="98e33dca445850cdf24f09050756c3b75202ac13" />
 			</dataarea>
 		</part>
 	</software>
@@ -9083,8 +9890,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ファーマー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="o'mac farmer (japan).rom" size="16384" crc="b05ffed2" sha1="5dcecc7c790e398a1c652db568c1e66c6f25e5e4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="o'mac farmer (japan).rom" size="0x4000" crc="b05ffed2" sha1="5dcecc7c790e398a1c652db568c1e66c6f25e5e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -9094,9 +9902,11 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Comptiq</publisher>
 		<info name="alt_title" value="オイルズ・ウェル" />
+		<info name="serial" value="S209191-703"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="oil's well (japan).rom" size="32768" crc="3c7f3767" sha1="5b53794d3d73df29cbcec411c0f65e9e9898977f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="oil's well (japan).rom" size="0x8000" crc="3c7f3767" sha1="5b53794d3d73df29cbcec411c0f65e9e9898977f" />
 			</dataarea>
 		</part>
 	</software>
@@ -9106,23 +9916,27 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Comptiq</publisher>
 		<info name="alt_title" value="オイルズ・ウェル" />
+		<info name="serial" value="S209191-703"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="oil's well (japan) (alt 1).rom" size="32768" crc="aa2154fb" sha1="244eae705df950f60b7d4b523d57b9cfded96b8e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="oil's well (japan) (alt 1).rom" size="0x8000" crc="aa2154fb" sha1="244eae705df950f60b7d4b523d57b9cfded96b8e" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="golgo13">
 		<description>Okami no Su - Golgo 13 Adventure Game (Japan)</description>
 		<year>1984</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5066" />
 		<info name="alt_title" value="ゴルゴ１３狼の巣 ~ Golgo 13 Okami no Su (Box)" />
+		<info name="gtin" value="04988013001299"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="okami no su (japan).rom" size="32768" crc="40d3889f" sha1="031a611ba1f75b7d5fe3ed088a61c24598b4b314" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="okami no su (japan).rom" size="0x8000" crc="40d3889f" sha1="031a611ba1f75b7d5fe3ed088a61c24598b4b314" />
 			</dataarea>
 		</part>
 	</software>
@@ -9131,24 +9945,28 @@ kept for now until finding out what those bytes affect...
 		<description>Othello (Japan, Pony Canyon)</description>
 		<year>1985</year>
 		<publisher>Pony Canyon</publisher>
+		<info name="alt_title" value="オセロ"/>
 		<info name="serial" value="R49X5089" />
+		<info name="gtin" value="04988013002494"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="othello (japan).rom" size="32768" crc="fd3921cd" sha1="6238f9c5f4c0012b3425be203c23092f6b624fe8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="othello (japan).rom" size="0x8000" crc="fd3921cd" sha1="6238f9c5f4c0012b3425be203c23092f6b624fe8" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="oyotango">
 		<description>Oyoide Tango (Japan)</description>
 		<year>1985</year>
 		<publisher>HAL Kenkyuujo</publisher>
 		<info name="serial" value="HM-102" />
 		<info name="alt_title" value="泳いでタンゴ" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="oyoide tango (japan).rom" size="8192" crc="01a24ca7" sha1="41ba54c945104915ccc8d465930445c905d839e4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="oyoide tango (japan).rom" size="0x2000" crc="01a24ca7" sha1="41ba54c945104915ccc8d465930445c905d839e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -9160,8 +9978,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="01" />
 		<info name="alt_title" value="パックマン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pac-man (japan).rom" size="16384" crc="d74dffa2" sha1="61695eb1dc6242d8a70c7ef2172cf86a26e3c2dd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pac-man (japan).rom" size="0x4000" crc="d74dffa2" sha1="61695eb1dc6242d8a70c7ef2172cf86a26e3c2dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -9173,8 +9992,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="01" />
 		<info name="alt_title" value="パックマン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pac-man (japan) (alt 1).rom" size="32768" crc="505acae7" sha1="a72724a79c2c50ec66046c0828934b5cad11b7c9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="pac-man (japan) (alt 1).rom" size="0x8000" crc="505acae7" sha1="a72724a79c2c50ec66046c0828934b5cad11b7c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -9186,8 +10006,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="01" />
 		<info name="alt_title" value="パックマン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pac-man (japan) (alt 2).rom" size="16384" crc="926bc903" sha1="56febd50be4accb3eb8c73ff4ff641ea767108b3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pac-man (japan) (alt 2).rom" size="0x4000" crc="926bc903" sha1="56febd50be4accb3eb8c73ff4ff641ea767108b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -9198,8 +10019,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Clover</publisher>
 		<info name="usage" value="Requires a machine with RAM in a main slot" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pacman.rom" size="32768" crc="52e694ab" sha1="8435d825a47afabcd50e5295c36eefd5d5a421cb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="pacman.rom" size="0x8000" crc="52e694ab" sha1="8435d825a47afabcd50e5295c36eefd5d5a421cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -9211,8 +10033,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2014G" />
 		<info name="alt_title" value="パチコン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pachi com (japan).rom" size="32768" crc="ce7f6c91" sha1="a2e144546a191da8829b9ca9fa019884fe95156c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="pachi com (japan).rom" size="0x8000" crc="ce7f6c91" sha1="a2e144546a191da8829b9ca9fa019884fe95156c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9222,8 +10045,9 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Boram Soft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pachicom (1985)(toshiba-emi)[cr boram soft].rom" size="32768" crc="bc1b4322" sha1="22e8e217e96cd8229462c58ca7ead1ae33088fc4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="pachicom (1985)(toshiba-emi)[cr boram soft].rom" size="0x8000" crc="bc1b4322" sha1="22e8e217e96cd8229462c58ca7ead1ae33088fc4" />
 			</dataarea>
 		</part>
 	</software>
@@ -9235,8 +10059,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-104" />
 		<info name="alt_title" value="パチンコＵＦＯ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="casio pachinko-u.f.o. (japan).rom" size="16384" crc="4088efaa" sha1="cad653766b597a4aa130a9a1956ece77ba4d52bc" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="casio pachinko-u.f.o. (japan).rom" size="0x4000" crc="4088efaa" sha1="cad653766b597a4aa130a9a1956ece77ba4d52bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -9247,9 +10072,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00180" />
 		<info name="alt_title" value="パイパニック" />
+		<info name="isbn" value="4871489337"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pai panic (japan).rom" size="16384" crc="6fd70773" sha1="5558ba634018b22dcc687a01f9422fe60ea57adc" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pai panic (japan).rom" size="0x4000" crc="6fd70773" sha1="5558ba634018b22dcc687a01f9422fe60ea57adc" />
 			</dataarea>
 		</part>
 	</software>
@@ -9261,8 +10088,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="00120" />
 		<info name="alt_title" value="ペアーズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pairs (japan).rom" size="16384" crc="9c1c10ca" sha1="27bc809518fbb6c0d52c949e7cbe81980a801d32" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pairs (japan).rom" size="0x4000" crc="9c1c10ca" sha1="27bc809518fbb6c0d52c949e7cbe81980a801d32" />
 			</dataarea>
 		</part>
 	</software>
@@ -9274,19 +10102,22 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="00120" />
 		<info name="alt_title" value="ペアーズ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pairs (japan) (alt 1).rom" size="16384" crc="3f042540" sha1="df13ed647ed4f5a6b04f1710fc1140ea65dc966f" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pairs (japan) (alt 1).rom" size="0x4000" crc="3f042540" sha1="df13ed647ed4f5a6b04f1710fc1140ea65dc966f" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx only lists this software as Links Network download. -->
 	<software name="panther">
 		<description>Panther (Japan)</description>
 		<year>1986</year>
 		<publisher>Irem</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="panther (japan).rom" size="32768" crc="33b9968c" sha1="479608b5a86d7c77bd6c4dd00605b8efb2e5b43e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="panther (japan).rom" size="0x8000" crc="33b9968c" sha1="479608b5a86d7c77bd6c4dd00605b8efb2e5b43e" />
 			</dataarea>
 		</part>
 	</software>
@@ -9297,11 +10128,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC759" />
 		<info name="alt_title" value="パロディウス～タコは地球を救う～" />
+		<info name="gtin" value="04988602537079"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="parodius (japan).rom" size="131072" crc="9bb308f5" sha1="2220363ae56ef707ab2471fcdb36f4816ad1d32c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="parodius (japan).rom" size="0x20000" crc="9bb308f5" sha1="2220363ae56ef707ab2471fcdb36f4816ad1d32c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9312,25 +10144,27 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC759" />
 		<info name="alt_title" value="パロディウス～タコは地球を救う～" />
+		<info name="gtin" value="04988602537079"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="parodius (japan) (alt 1).rom" size="131072" crc="ca21cde4" sha1="75d3b72d9ceeaa55c76223d935629a30ae4124d6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="parodius (japan) (alt 1).rom" size="0x20000" crc="ca21cde4" sha1="75d3b72d9ceeaa55c76223d935629a30ae4124d6" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="passball">
 		<description>Pass Ball (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00000" />
 		<info name="alt_title" value="パスボール" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pass ball (japan).rom" size="16384" crc="82b8f501" sha1="aeb705ac42f8d9d62ecdb25899535d1f14f1c49c" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pass ball (japan).rom" size="0x4000" crc="82b8f501" sha1="aeb705ac42f8d9d62ecdb25899535d1f14f1c49c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9340,40 +10174,43 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="alt_title" value="パストファインダー" />
+		<info name="serial" value="R48X5510"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="pastfinder (japan).rom" size="16384" crc="d6d8d1d7" sha1="8117ec66c0645a54422841a632cfd6602f35c4f9" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pastfinder (japan).rom" size="0x4000" crc="d6d8d1d7" sha1="8117ec66c0645a54422841a632cfd6602f35c4f9" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="payload">
 		<description>Pay Load (Japan)</description>
 		<year>1985</year>
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G042C" />
 		<info name="alt_title" value="頑張れトラックボーイ ペイロード ~ Ganbare Truck Boy - Payload (Box)" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pay load (japan).rom" size="32768" crc="d15b0b1a" sha1="5f965bbba026134818759d25119d4114599132a8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="pay load (japan).rom" size="0x8000" crc="d15b0b1a" sha1="5f965bbba026134818759d25119d4114599132a8" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="payloada" cloneof="payload">
 		<description>Pay Load (Japan, alt)</description>
 		<year>1985</year>
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G042C" />
 		<info name="alt_title" value="頑張れトラックボーイ ペイロード ~ Ganbare Truck Boy - Payload (Box)" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pay load (japan) (alt 1).rom" size="32768" crc="165eae6d" sha1="0486938b52fbcf30a4fa206e07960a5b866fca61" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="pay load (japan) (alt 1).rom" size="0x8000" crc="165eae6d" sha1="0486938b52fbcf30a4fa206e07960a5b866fca61" />
 			</dataarea>
 		</part>
 	</software>
@@ -9381,11 +10218,13 @@ kept for now until finding out what those bytes affect...
 	<software name="peetan">
 		<description>Peetan (Japan)</description>
 		<year>1984</year>
-		<publisher>Nihon Columbia</publisher>
+		<publisher>Colpax</publisher>
 		<info name="alt_title" value="ピータン" />
+		<info name="serial" value="48C99-1002"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="peetan (japan).rom" size="8192" crc="941069ae" sha1="190bcab0325ded99f42f32976bf965f0164ad2a4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="peetan (japan).rom" size="0x2000" crc="941069ae" sha1="190bcab0325ded99f42f32976bf965f0164ad2a4" />
 			</dataarea>
 		</part>
 	</software>
@@ -9396,9 +10235,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Victor</publisher>
 		<info name="serial" value="M-2002" />
 		<info name="alt_title" value="ペガサス" />
+		<info name="gtin" value="04988002018291"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pegasus (japan).rom" size="32768" crc="c23fa0d5" sha1="37e6fe7d07b3f8b2c585c77b231207ac8baa1ea3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="pegasus (japan).rom" size="0x8000" crc="c23fa0d5" sha1="37e6fe7d07b3f8b2c585c77b231207ac8baa1ea3" />
 			</dataarea>
 		</part>
 	</software>
@@ -9409,11 +10250,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC743" />
 		<info name="alt_title" value="夢大陸アドベンチャー" />
+		<info name="gtin" value="04988602511550"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="penguin adventure (japan, europe).rom" size="131072" crc="0f6418d3" sha1="d53e0c8bcd98820afe820f756af35cc97911bfe4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="penguin adventure (japan, europe).rom" size="0x20000" crc="0f6418d3" sha1="d53e0c8bcd98820afe820f756af35cc97911bfe4" />
 			</dataarea>
 		</part>
 	</software>
@@ -9422,11 +10264,12 @@ kept for now until finding out what those bytes affect...
 		<description>Yume Tairiku Adventure (Korea, Zemina)</description>
 		<year>1987</year>
 		<publisher>Zemina</publisher>
+		<info name="alt_title" value="꿈의 대륙"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="yume tairiku adventure. penguin adventure (1987)(zemina)[rc-743].rom" size="131072" crc="80814e55" sha1="d3d411c8b7891aef9c59cbc20bb4fa3ff0ca03ea" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="yume tairiku adventure. penguin adventure (1987)(zemina)[rc-743].rom" size="0x20000" crc="80814e55" sha1="d3d411c8b7891aef9c59cbc20bb4fa3ff0ca03ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -9438,8 +10281,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="yume tairiku adventure. penguin adventure (1986)(konami)[cr screen][rc-743].rom" size="131072" crc="38c35d99" sha1="898bda19f882c6d1dffdb2173db84a97dc21f7d6" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="yume tairiku adventure. penguin adventure (1986)(konami)[cr screen][rc-743].rom" size="0x20000" crc="38c35d99" sha1="898bda19f882c6d1dffdb2173db84a97dc21f7d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -9450,9 +10293,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="2016701" />
 		<info name="alt_title" value="ぺんぎんくんウォーズ" />
+		<info name="isbn" value="4871488381"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="penguin-kun wars (japan).rom" size="32768" crc="6d2b3e0c" sha1="5aab681334f9e97fe8d7e0eb008b2afd5e0fc3ac" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="penguin-kun wars (japan).rom" size="0x8000" crc="6d2b3e0c" sha1="5aab681334f9e97fe8d7e0eb008b2afd5e0fc3ac" />
 			</dataarea>
 		</part>
 	</software>
@@ -9462,21 +10307,24 @@ kept for now until finding out what those bytes affect...
 		<year>19??</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="penguin wars (1985)(ascii)[cr prosoft].rom" size="32768" crc="9827fad6" sha1="86231b604338a9b4c63be995adb2fd9860bab20b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="penguin wars (1985)(ascii)[cr prosoft].rom" size="0x8000" crc="9827fad6" sha1="86231b604338a9b4c63be995adb2fd9860bab20b" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
+	<!-- Generation-msx does not list a cartridge release for this software but a Links Network download. -->
 	<software name="picopico">
 		<description>Pico Pico (Japan)</description>
 		<year>1983</year>
 		<publisher>Microcabin</publisher>
 		<info name="alt_title" value="ピコピコ" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="pico pico (japan).rom" size="8192" crc="ba3e62d3" sha1="683478868f6c6423cc3e9c6aabe1868b30b1e47d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="pico pico (japan).rom" size="0x2000" crc="ba3e62d3" sha1="683478868f6c6423cc3e9c6aabe1868b30b1e47d" />
 			</dataarea>
 		</part>
 	</software>
@@ -9488,8 +10336,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-004" />
 		<info name="alt_title" value="ピクチャーパズル" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="picture puzzle (japan).rom" size="8192" crc="9e51ae0a" sha1="336a7c451a03c9a55726d171603b54628ad832c8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="picture puzzle (japan).rom" size="0x2000" crc="9e51ae0a" sha1="336a7c451a03c9a55726d171603b54628ad832c8" />
 			</dataarea>
 		</part>
 	</software>
@@ -9501,8 +10350,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-004" />
 		<info name="alt_title" value="ピクチャーパズル" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="picture puzzle (japan) (alt 1).rom" size="16384" crc="d7eacc0a" sha1="663d12f6fed3ce5017b783db3032eb69d8554fed" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="picture puzzle (japan) (alt 1).rom" size="0x4000" crc="d7eacc0a" sha1="663d12f6fed3ce5017b783db3032eb69d8554fed" />
 			</dataarea>
 		</part>
 	</software>
@@ -9510,11 +10360,13 @@ kept for now until finding out what those bytes affect...
 	<software name="pillbox">
 		<description>Pillbox (Japan)</description>
 		<year>1983</year>
-		<publisher>Magicsoft</publisher>
+		<publisher>National</publisher>
 		<info name="alt_title" value="カラー・トーチカ ~ Color Touchika (Box?)" />
+		<info name="serial" value="CF-SS001"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pillbox (japan).rom" size="16384" crc="436c3f29" sha1="76a79dd0554b8f7e84468fcd3bf73459ce4aeb2b" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pillbox (japan).rom" size="0x4000" crc="436c3f29" sha1="76a79dd0554b8f7e84468fcd3bf73459ce4aeb2b" />
 			</dataarea>
 		</part>
 	</software>
@@ -9522,15 +10374,18 @@ kept for now until finding out what those bytes affect...
 	<software name="pillboxa" cloneof="pillbox">
 		<description>Pillbox (Japan, alt)</description>
 		<year>1983</year>
-		<publisher>Magicsoft</publisher>
+		<publisher>National</publisher>
 		<info name="alt_title" value="カラー・トーチカ ~ Color Touchika (Box?)" />
+		<info name="serial" value="CF-SS001"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pillbox (japan) (alt 1).rom" size="16384" crc="3345caef" sha1="3450f93fc2b08a052a709930c97edead0099e447" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pillbox (japan) (alt 1).rom" size="0x4000" crc="3345caef" sha1="3450f93fc2b08a052a709930c97edead0099e447" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx does not list a cartridge release for this software. -->
 	<software name="pinblast">
 		<description>Pinball Blaster (Europe)</description>
 		<year>1988</year>
@@ -9538,8 +10393,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="65536">
-				<rom name="pinball blaster (europe).rom" size="65536" crc="68fe9580" sha1="c95f8edb24edca9f5d38c26d0e8a34c6b61efb0c" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pinball blaster (europe).rom" size="0x10000" crc="68fe9580" sha1="c95f8edb24edca9f5d38c26d0e8a34c6b61efb0c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9551,8 +10406,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="Z-00103" />
 		<info name="alt_title" value="パイナップリン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pine applin (japan).rom" size="16384" crc="7411c6f2" sha1="878554d3b579e72b2d3c22e6330208ee0d1ee8a6" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pine applin (japan).rom" size="0x4000" crc="7411c6f2" sha1="878554d3b579e72b2d3c22e6330208ee0d1ee8a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -9564,8 +10420,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="Z-00103" />
 		<info name="alt_title" value="パイナップリン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pine applin (japan) (alt 1).rom" size="16384" crc="bdcb6199" sha1="211e1f7e86495178fb2b05e163b04ed4b7455034" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pine applin (japan) (alt 1).rom" size="0x4000" crc="bdcb6199" sha1="211e1f7e86495178fb2b05e163b04ed4b7455034" />
 			</dataarea>
 		</part>
 	</software>
@@ -9573,11 +10430,13 @@ kept for now until finding out what those bytes affect...
 	<software name="pingball">
 		<description>Pingball Maker (Japan)</description>
 		<year>1985</year>
-		<publisher>Nihon Columbia</publisher>
+		<publisher>Colpax</publisher>
 		<info name="alt_title" value="ピンボールメーカー" />
+		<info name="serial" value="48C99-1012"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pingball maker (japan).rom" size="16384" crc="2eff15e7" sha1="91bd6c21530654fab12cd8a797044d494834c223" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pingball maker (japan).rom" size="0x4000" crc="2eff15e7" sha1="91bd6c21530654fab12cd8a797044d494834c223" />
 			</dataarea>
 		</part>
 	</software>
@@ -9585,11 +10444,12 @@ kept for now until finding out what those bytes affect...
 	<software name="pinkychs">
 		<description>Pinky Chase (Japan)</description>
 		<year>1984</year>
-		<publisher>Nihon Columbia</publisher>
+		<publisher>Colpax</publisher>
 		<info name="alt_title" value="ピンキーチェイス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pinky chase (japan).rom" size="16384" crc="b5b40df0" sha1="1fbd7af23177ab1de799764d8a26bc2bbf85b042" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pinky chase (japan).rom" size="0x4000" crc="b5b40df0" sha1="1fbd7af23177ab1de799764d8a26bc2bbf85b042" />
 			</dataarea>
 		</part>
 	</software>
@@ -9601,8 +10461,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="ND-03MR" />
 		<info name="alt_title" value="ピピ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="pipi (japan).rom" size="32768" crc="6f172cd8" sha1="be8bb7f5e812cd31a65aec3782a2d526bef9b3d6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="pipi (japan).rom" size="0x8000" crc="6f172cd8" sha1="be8bb7f5e812cd31a65aec3782a2d526bef9b3d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -9614,8 +10475,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC729" />
 		<info name="alt_title" value="ピポルス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pippols (japan).rom" size="16384" crc="be6a5e19" sha1="10e63eba7d2b10d946822f21e7fd106f5dfab632" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pippols (japan).rom" size="0x4000" crc="be6a5e19" sha1="10e63eba7d2b10d946822f21e7fd106f5dfab632" />
 			</dataarea>
 		</part>
 	</software>
@@ -9627,8 +10489,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC729" />
 		<info name="alt_title" value="ピポルス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pippols (japan) (alt 1).rom" size="16384" crc="f4e97ad5" sha1="0a9c576eabaf2651ddca35bf17f96e509d6c6ba0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pippols (japan) (alt 1).rom" size="0x4000" crc="f4e97ad5" sha1="0a9c576eabaf2651ddca35bf17f96e509d6c6ba0" />
 			</dataarea>
 		</part>
 	</software>
@@ -9640,8 +10503,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC729" />
 		<info name="alt_title" value="ピポルス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pippols (japan) (alt 2).rom" size="16384" crc="d5fe3564" sha1="d621e2a2f0f924a17673f5d47f2182095074acf4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pippols (japan) (alt 2).rom" size="0x4000" crc="d5fe3564" sha1="d621e2a2f0f924a17673f5d47f2182095074acf4" />
 			</dataarea>
 		</part>
 	</software>
@@ -9653,8 +10517,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC729" />
 		<info name="alt_title" value="ピポルス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pippols (japan) (alt 3).rom" size="16384" crc="eab63f24" sha1="cf8e40315f34e30e1be4776bbebc08c0a8403523" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pippols (japan) (alt 3).rom" size="0x4000" crc="eab63f24" sha1="cf8e40315f34e30e1be4776bbebc08c0a8403523" />
 			</dataarea>
 		</part>
 	</software>
@@ -9666,11 +10531,11 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5508" />
 		<info name="alt_title" value="ピットフォールII" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="pitfall ii - lost caverns (japan).rom" size="16384" crc="d307a7b8" sha1="78079266711e60420480e4d95a39f0d7d974ad32" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pitfall ii - lost caverns (japan).rom" size="0x4000" crc="d307a7b8" sha1="78079266711e60420480e4d95a39f0d7d974ad32" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -9682,11 +10547,11 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5508" />
 		<info name="alt_title" value="ピットフォールII" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="pitfall ii - lost caverns (japan) (alt 1).rom" size="16384" crc="71c59868" sha1="ae8c7355c829248305384243f78a870453367e77" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pitfall ii - lost caverns (japan) (alt 1).rom" size="0x4000" crc="71c59868" sha1="ae8c7355c829248305384243f78a870453367e77" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -9698,11 +10563,11 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5501" />
 		<info name="alt_title" value="ピットフォール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="pitfall (japan).rom" size="16384" crc="5a009c55" sha1="b88e9c548873dcfd190e0e38f7b279344eea41ec" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pitfall (japan).rom" size="0x4000" crc="5a009c55" sha1="b88e9c548873dcfd190e0e38f7b279344eea41ec" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -9714,11 +10579,11 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5501" />
 		<info name="alt_title" value="ピットフォール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="pitfall (japan) (alt 1).rom" size="16384" crc="930aeb2c" sha1="5fb4b6c3735e4d9415565a856bb69f9fb4857161" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pitfall (japan) (alt 1).rom" size="0x4000" crc="930aeb2c" sha1="5fb4b6c3735e4d9415565a856bb69f9fb4857161" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -9730,11 +10595,11 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5501" />
 		<info name="alt_title" value="ピットフォール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="pitfall (japan) (alt 2).rom" size="16384" crc="2cb24473" sha1="2fa9c0f016efc2d1752a272c632393f5063ea06c" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="pitfall (japan) (alt 2).rom" size="0x4000" crc="2cb24473" sha1="2fa9c0f016efc2d1752a272c632393f5063ea06c" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -9746,12 +10611,14 @@ kept for now until finding out what those bytes affect...
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-G054C" />
 		<info name="alt_title" value="プレイボール" />
+		<info name="gtin" value="04901780055531"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="play ball (japan).rom" size="32768" crc="d178833b" sha1="e6fbfb4b10dc393953211dda4b114080a08302a1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="play ball (japan).rom" size="0x8000" crc="d178833b" sha1="e6fbfb4b10dc393953211dda4b114080a08302a1" />
 			</dataarea>
-			<dataarea name="upd7756" size="32768">
-				<rom name="upd7756.bin" size="32768" status="nodump" />
+			<dataarea name="upd7756" size="0x8000">
+				<rom name="upd7756.bin" size="0x8000" status="nodump" />
 			</dataarea>
 		</part>
 	</software>
@@ -9762,9 +10629,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Victor</publisher>
 		<info name="serial" value="M-2005" />
 		<info name="alt_title" value="ポイントX占領作戦" />
+		<info name="gtin" value="04988002025503"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="poiny x senryosakusen - operation thanksgiving (japan).rom" size="32768" crc="9d59f2d1" sha1="6f247c8af6fc1881242281f19912068b03ca4126" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="poiny x senryosakusen - operation thanksgiving (japan).rom" size="0x8000" crc="9d59f2d1" sha1="6f247c8af6fc1881242281f19912068b03ca4126" />
 			</dataarea>
 		</part>
 	</software>
@@ -9775,9 +10644,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5091" />
 		<info name="alt_title" value="ポリスストーリー" />
+		<info name="gtin" value="04988013001794"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="police story, the (japan).rom" size="32768" crc="7867d044" sha1="cdaf507dba4a48b5c98850a96f61f6d2e8464e00" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="police story, the (japan).rom" size="0x8000" crc="7867d044" sha1="cdaf507dba4a48b5c98850a96f61f6d2e8464e00" />
 			</dataarea>
 		</part>
 	</software>
@@ -9788,21 +10659,24 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5091" />
 		<info name="alt_title" value="ポリスストーリー" />
+		<info name="gtin" value="04988013001794"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="police story, the (japan) (alt 1).rom" size="32768" crc="e4554b51" sha1="835b3e2bae1d680d7050ce188c617fbcfb326eb3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="police story, the (japan) (alt 1).rom" size="0x8000" crc="e4554b51" sha1="835b3e2bae1d680d7050ce188c617fbcfb326eb3" />
 			</dataarea>
 		</part>
 	</software>
 
-<software name="poppaq">
+	<software name="poppaq">
 		<description>Poppaq the Fish (Japan)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ポパック・ザ・フィッシュ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="poppaq the fish (japan).rom" size="16384" crc="bd387377" sha1="c713ecd0e2ef89b2443e516d5ffa53d3a3422e22" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="poppaq the fish (japan).rom" size="0x4000" crc="bd387377" sha1="c713ecd0e2ef89b2443e516d5ffa53d3a3422e22" />
 			</dataarea>
 		</part>
 	</software>
@@ -9812,12 +10686,14 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Boram Soft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="poppaq the fish (1986)(ascii)[cr boram soft].rom" size="16384" crc="cc36e779" sha1="b8f9248a6f2bc02ed2dcae3f21d6fe0e572e23fe" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="poppaq the fish (1986)(ascii)[cr boram soft].rom" size="0x4000" crc="cc36e779" sha1="b8f9248a6f2bc02ed2dcae3f21d6fe0e572e23fe" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx does not list a cartridge release for this software. -->
 	<software name="pricemag">
 		<description>The Price of Magik (Europe)</description>
 		<year>1986</year>
@@ -9825,33 +10701,37 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="65536">
-				<rom name="price of magik, the (europe).rom" size="65536" crc="b43e7881" sha1="ac109dac24df4dae813ca5d9f0938cc48a162bb1" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="price of magik, the (europe).rom" size="0x10000" crc="b43e7881" sha1="ac109dac24df4dae813ca5d9f0938cc48a162bb1" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="profbb">
 		<description>Professional Baseball (Japan)</description>
 		<year>1986</year>
 		<publisher>Technopolis Soft</publisher>
+		<info name="alt_title" value="プロフェッショナルベースボール"/>
+		<info name="serial" value="48TSX-3"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="professional baseball (japan).rom" size="32768" crc="8ca4cd58" sha1="24c5cbf1ee4caa6d83a5aa7a5f3818692542fda8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="professional baseball (japan).rom" size="0x8000" crc="8ca4cd58" sha1="24c5cbf1ee4caa6d83a5aa7a5f3818692542fda8" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="profmj">
 		<description>Professional Mahjong (Japan)</description>
 		<year>1985</year>
 		<publisher>Chat Noir</publisher>
 		<info name="alt_title" value="プロフェッショナル麻雀" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="professional mahjong (japan).rom" size="32768" crc="f1ec5e18" sha1="da5fd6ce2f92a40b1ccaf6e3c425d720febc3543" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="professional mahjong (japan).rom" size="0x8000" crc="f1ec5e18" sha1="da5fd6ce2f92a40b1ccaf6e3c425d720febc3543" />
 			</dataarea>
 		</part>
 	</software>
@@ -9862,26 +10742,28 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R48X5086" />
 		<info name="alt_title" value="プロテクター" />
+		<info name="gtin" value="04988013000995"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="protector, the (japan).rom" size="16384" crc="5747e69d" sha1="d03fdca57b55bdb7e6b5481615b8ad0c8a71f77d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="protector, the (japan).rom" size="0x4000" crc="5747e69d" sha1="d03fdca57b55bdb7e6b5481615b8ad0c8a71f77d" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="psychwar">
 		<description>Psychic War - Cosmic Soldier 2 (Japan)</description>
 		<year>1987</year>
 		<publisher>Kogado</publisher>
 		<info name="alt_title" value="サイキックウォー" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8_sram" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="262144">
-				<rom name="psychic war - cosmic soldier 2 (japan).rom" size="262144" crc="b8fc19a4" sha1="16c692a2c9babfdadd8408d2f0f8fae3a8d96fd5" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="psychic war - cosmic soldier 2 (japan).rom" size="0x40000" crc="b8fc19a4" sha1="16c692a2c9babfdadd8408d2f0f8fae3a8d96fd5" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -9891,8 +10773,9 @@ kept for now until finding out what those bytes affect...
 		<year>1990</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="puznic.rom" size="32768" crc="ac28fa71" sha1="3b9df9bf57ac9d8f155c623c8ed6057a79491738" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="puznic.rom" size="0x8000" crc="ac28fa71" sha1="3b9df9bf57ac9d8f155c623c8ed6057a79491738" />
 			</dataarea>
 		</part>
 	</software>
@@ -9904,8 +10787,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="220426" />
 		<info name="alt_title" value="パズルパニック" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="puzzle panic (japan).rom" size="32768" crc="1313c0c7" sha1="a36c00f32cad6b603bc5525a741cb09064670f34" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="puzzle panic (japan).rom" size="0x8000" crc="1313c0c7" sha1="a36c00f32cad6b603bc5525a741cb09064670f34" />
 			</dataarea>
 		</part>
 	</software>
@@ -9917,8 +10801,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="TEX-02" />
 		<info name="alt_title" value="ピラミッド・ワープ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="pyramid warp (japan).rom" size="8192" crc="0aec8ddb" sha1="1ad2178c27874704b395ab250200d9acb7d3de9c" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="pyramid warp (japan).rom" size="0x2000" crc="0aec8ddb" sha1="1ad2178c27874704b395ab250200d9acb7d3de9c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9929,9 +10814,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC746" />
 		<info name="alt_title" value="Ｑバート" />
+		<info name="gtin" value="04988602512755"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="q-bert (japan).rom" size="32768" crc="0e988f0e" sha1="531a7f736d86095d791d6d0f267be66eef07949c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="q-bert (japan).rom" size="0x8000" crc="0e988f0e" sha1="531a7f736d86095d791d6d0f267be66eef07949c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9942,9 +10829,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC746" />
 		<info name="alt_title" value="Ｑバート" />
+		<info name="gtin" value="04988602512755"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="q-bert (japan) (alt 1).rom" size="32768" crc="a112532b" sha1="2e16a588246743c9b901afdbf1ba094a0b1c8b5d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="q-bert (japan) (alt 1).rom" size="0x8000" crc="a112532b" sha1="2e16a588246743c9b901afdbf1ba094a0b1c8b5d" />
 			</dataarea>
 		</part>
 	</software>
@@ -9955,8 +10844,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="クィーンズゴルフ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="queen's golf (japan).rom" size="16384" crc="40eef5cd" sha1="1f72e0cd58afe22075a129ac854bbdce0704b0c8" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="queen's golf (japan).rom" size="0x4000" crc="40eef5cd" sha1="1f72e0cd58afe22075a129ac854bbdce0704b0c8" />
 			</dataarea>
 		</part>
 	</software>
@@ -9967,8 +10857,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="クィーンズゴルフ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="queen's golf (japan) (alt 2).rom" size="16384" crc="9c4787d7" sha1="be9d337dd412056f5fe78fd19467a63e80e3864c" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="queen's golf (japan) (alt 2).rom" size="0x4000" crc="9c4787d7" sha1="be9d337dd412056f5fe78fd19467a63e80e3864c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9980,8 +10871,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="クィーンズゴルフ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="queen's golf (japan) (alt 1).rom" size="16384" crc="27b78cb3" sha1="97c39dad3e065f9083fefae157f278844b208058" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="queen's golf (japan) (alt 1).rom" size="0x4000" crc="27b78cb3" sha1="97c39dad3e065f9083fefae157f278844b208058" />
 			</dataarea>
 		</part>
 	</software>
@@ -9993,8 +10885,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G036C" />
 		<info name="alt_title" value="バンゲリングベイ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="raid on bungeling bay (japan).rom" size="32768" crc="a87a666d" sha1="636eb837c5d80fb6b0692a72954ca91291ba831b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="raid on bungeling bay (japan).rom" size="0x8000" crc="a87a666d" sha1="636eb837c5d80fb6b0692a72954ca91291ba831b" />
 			</dataarea>
 		</part>
 	</software>
@@ -10006,8 +10899,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="06" />
 		<info name="alt_title" value="ラリーＸ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="rally-x (japan).rom" size="16384" crc="63413493" sha1="fc7212c6813574224114c3bb5bfa99206c0816a5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="rally-x (japan).rom" size="0x4000" crc="63413493" sha1="fc7212c6813574224114c3bb5bfa99206c0816a5" />
 			</dataarea>
 		</part>
 	</software>
@@ -10019,8 +10913,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="06" />
 		<info name="alt_title" value="ラリーＸ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="rally-x (japan) (alt 1).rom" size="16384" crc="9fd2f1dc" sha1="3dcecd610e832e7769547d3b6ce2b767f65f3563" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="rally-x (japan) (alt 1).rom" size="0x4000" crc="9fd2f1dc" sha1="3dcecd610e832e7769547d3b6ce2b767f65f3563" />
 			</dataarea>
 		</part>
 	</software>
@@ -10032,8 +10927,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="06" />
 		<info name="alt_title" value="ラリーＸ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="rally-x (japan) (alt 2).rom" size="32768" crc="2b5cb04e" sha1="c5af6c4255bab55d68e82fa016cb35e3213ba244" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="rally-x (japan) (alt 2).rom" size="0x8000" crc="2b5cb04e" sha1="c5af6c4255bab55d68e82fa016cb35e3213ba244" />
 			</dataarea>
 		</part>
 	</software>
@@ -10043,8 +10939,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="rally-x.rom" size="32768" crc="cf49b8f5" sha1="e5de6e75ab06822aa10263e971b2473a3b573124" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="rally-x.rom" size="0x8000" crc="cf49b8f5" sha1="e5de6e75ab06822aa10263e971b2473a3b573124" />
 			</dataarea>
 		</part>
 	</software>
@@ -10056,8 +10953,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MS-1" />
 		<info name="alt_title" value="ランボー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="rambo (japan).rom" size="32768" crc="6a2e3726" sha1="770805bd0be8b09a3be10030060d6ad8dc07d1c3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="rambo (japan).rom" size="0x8000" crc="6a2e3726" sha1="770805bd0be8b09a3be10030060d6ad8dc07d1c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -10069,8 +10967,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MS-1" />
 		<info name="alt_title" value="ランボー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="rambo (japan) (alt 1).rom" size="32768" crc="dba4377b" sha1="4334acc2bd5c921bc4dcb6de9a1fcc79d843ee15" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="rambo (japan) (alt 1).rom" size="0x8000" crc="dba4377b" sha1="4334acc2bd5c921bc4dcb6de9a1fcc79d843ee15" />
 			</dataarea>
 		</part>
 	</software>
@@ -10082,8 +10981,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MS-1" />
 		<info name="alt_title" value="ランボー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="rambo (japan) (alt 2).rom" size="32768" crc="0859f662" sha1="ac381dfb4d0b52dedb18a8df7a4651ed2978d12f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="rambo (japan) (alt 2).rom" size="0x8000" crc="0859f662" sha1="ac381dfb4d0b52dedb18a8df7a4651ed2978d12f" />
 			</dataarea>
 		</part>
 	</software>
@@ -10095,8 +10995,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MS-1" />
 		<info name="alt_title" value="ランボー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="rambo (japan) (alt 3).rom" size="32768" crc="2236ddf6" sha1="fe1d02284b0b051308e3c796e8e9eee2f86521b8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="rambo (japan) (alt 3).rom" size="0x8000" crc="2236ddf6" sha1="fe1d02284b0b051308e3c796e8e9eee2f86521b8" />
 			</dataarea>
 		</part>
 	</software>
@@ -10106,9 +11007,11 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>Takara</publisher>
 		<info name="alt_title" value="リアルテニス" />
+		<info name="serial" value="TA-503"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="real tennis (japan).rom" size="8192" crc="25fe441c" sha1="54a49a3c8b42b8b246e62ed45346cf52836ddcac" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="real tennis (japan).rom" size="0x2000" crc="25fe441c" sha1="54a49a3c8b42b8b246e62ed45346cf52836ddcac" />
 			</dataarea>
 		</part>
 	</software>
@@ -10119,8 +11022,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="レッドゾーン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="red zone (japan).rom" size="16384" crc="e9b5b6ff" sha1="61e26157f0701cce2ddb860a12f187912398b1b4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="red zone (japan).rom" size="0x4000" crc="e9b5b6ff" sha1="61e26157f0701cce2ddb860a12f187912398b1b4" />
 			</dataarea>
 		</part>
 	</software>
@@ -10131,22 +11035,24 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="レッドゾーン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="red zone (japan) (alt 1).rom" size="16384" crc="0c2da50f" sha1="91e17aba249925c7e0e5c280469bef09d5534da8" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="red zone (japan) (alt 1).rom" size="0x4000" crc="0c2da50f" sha1="91e17aba249925c7e0e5c280469bef09d5534da8" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="renjuod">
 		<description>Renju &amp; Ojama Dogs (Japan)</description>
 		<year>1985</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R48X5074" />
 		<info name="alt_title" value="連珠 ~ Renju (Box)" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="renju &amp; ojama dogs (japan).rom" size="16384" crc="40df2723" sha1="c72af5118835e49ac6d181cc832336ab22ec5dcb" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="renju &amp; ojama dogs (japan).rom" size="0x4000" crc="40df2723" sha1="c72af5118835e49ac6d181cc832336ab22ec5dcb" />
 			</dataarea>
 		</part>
 	</software>
@@ -10156,9 +11062,11 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ライズアウト" />
+		<info name="serial" value="000E0"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="rise out from dungeons (japan).rom" size="16384" crc="6a6d37cf" sha1="5fbc5d6a01e66a1c456b82ac1190ccde61bc7832" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="rise out from dungeons (japan).rom" size="0x4000" crc="6a6d37cf" sha1="5fbc5d6a01e66a1c456b82ac1190ccde61bc7832" />
 			</dataarea>
 		</part>
 	</software>
@@ -10168,9 +11076,11 @@ kept for now until finding out what those bytes affect...
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ライズアウト" />
+		<info name="serial" value="000E0"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="rise out from dungeons (japan) (alt 1).rom" size="16384" crc="01043328" sha1="f02ca47be665e83d812979d8074a985e5637b979" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="rise out from dungeons (japan) (alt 1).rom" size="0x4000" crc="01043328" sha1="f02ca47be665e83d812979d8074a985e5637b979" />
 			</dataarea>
 		</part>
 	</software>
@@ -10182,11 +11092,11 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5504" />
 		<info name="alt_title" value="リバーレイド" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="river raid (japan).rom" size="16384" crc="2fc1d75b" sha1="33be9017faf173eae04d0c91ca8d42d1c20596c0" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="river raid (japan).rom" size="0x4000" crc="2fc1d75b" sha1="33be9017faf173eae04d0c91ca8d42d1c20596c0" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -10198,8 +11108,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC730" />
 		<info name="alt_title" value="ロードファイター" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="road fighter (japan).rom" size="16384" crc="01ddb68f" sha1="bf4a0bab1e8eaa70a8b12cd9a81d7a90a74c9e26" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="road fighter (japan).rom" size="0x4000" crc="01ddb68f" sha1="bf4a0bab1e8eaa70a8b12cd9a81d7a90a74c9e26" />
 			</dataarea>
 		</part>
 	</software>
@@ -10211,8 +11122,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC730" />
 		<info name="alt_title" value="ロードファイター" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="road fighter (japan) (alt 1).rom" size="16384" crc="cb82d8c9" sha1="7abdf08e9c0a511b8182c502ed8c5f42778437e9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="road fighter (japan) (alt 1).rom" size="0x4000" crc="cb82d8c9" sha1="7abdf08e9c0a511b8182c502ed8c5f42778437e9" />
 			</dataarea>
 		</part>
 	</software>
@@ -10222,11 +11134,12 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Micronet</publisher>
 		<info name="alt_title" value="ロボレス２００１年 ~ Robo Wres 2001 (Box?)" />
+		<info name="serial" value="MR-400007"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii16" />
 			<feature name="mapper" value="M60002-0125SP-16" />
-			<dataarea name="rom" size="131072">
-				<rom name="robo wres 2001 (japan).rom" size="131072" crc="788637d5" sha1="46c98a3143f5a80b2090311a770f9b73000881c0" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="robo wres 2001 (japan).rom" size="0x20000" crc="788637d5" sha1="46c98a3143f5a80b2090311a770f9b73000881c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -10235,10 +11148,12 @@ kept for now until finding out what those bytes affect...
 		<description>RoboCop</description>
 		<year>1992</year>
 		<publisher>Sieco</publisher>
+		<info name="alt_title" value="강철 로보캅"/>
+		<info name="serial" value="SI-3131Z"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
-			<dataarea name="rom" size="131072">
-				<rom name="sieco_robocop_(1992)(sieco).rom" size="131072" crc="4628ef05" sha1="9d7dfb01f3bed10a708a8a496798599693decf21" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sieco_robocop_(1992)(sieco).rom" size="0x20000" crc="4628ef05" sha1="9d7dfb01f3bed10a708a8a496798599693decf21" />
 			</dataarea>
 		</part>
 	</software>
@@ -10248,8 +11163,9 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="robofrog (japan).rom" size="16384" crc="99ddb974" sha1="acce81bf851fa5869cd75181df4fcf7d4489a9db" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="robofrog (japan).rom" size="0x4000" crc="99ddb974" sha1="acce81bf851fa5869cd75181df4fcf7d4489a9db" />
 			</dataarea>
 		</part>
 	</software>
@@ -10259,24 +11175,25 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="robofrog (japan) (alt 1).rom" size="16384" crc="82e47a43" sha1="a2f9e1250c67d2e98be70900d4370545321cdbfe" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="robofrog (japan) (alt 1).rom" size="0x4000" crc="82e47a43" sha1="a2f9e1250c67d2e98be70900d4370545321cdbfe" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="rockbolt">
-		<description>Rock'n Bolt (Japan)</description>
+		<description>Rockn' Bolt (Japan)</description>
 		<year>1985</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R48X5511" />
 		<info name="alt_title" value="ロックンボルト" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="rock'n bolt (japan).rom" size="16384" crc="430e5789" sha1="1edabc3226648b54ae98d524b31f37ca47c8c88b" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="rock'n bolt (japan).rom" size="0x4000" crc="430e5789" sha1="1edabc3226648b54ae98d524b31f37ca47c8c88b" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -10285,13 +11202,14 @@ kept for now until finding out what those bytes affect...
 		<description>Roc'n Rope</description>
 		<year>2008</year>
 		<publisher>Icon Games</publisher>
+		<info name="gtin" value="07399111110528"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="32768">
+			<dataarea name="rom" size="0x8000">
 				<!-- Original Dump from an 39SF010 flashrom - 128kb Image.  32KB Rom file cropped out of image after discarding unused area (FF)
-				<rom name="roc'n rope.bin" size="131072" crc="a71c2009" sha1="4429fe7090953dd509feccafd87ea4e8deb6360f" /> -->
-				<rom name="roc'n rope.rom" size="32768" crc="c0c32c3e" sha1="74b2dbb51437b531ca78c314d666aabe0fd2e177" />
+				<rom name="roc'n rope.bin" size="0x20000" crc="a71c2009" sha1="4429fe7090953dd509feccafd87ea4e8deb6360f" /> -->
+				<rom name="roc'n rope.rom" size="0x8000" crc="c0c32c3e" sha1="74b2dbb51437b531ca78c314d666aabe0fd2e177" />
 			</dataarea>
 		</part>
 	</software>
@@ -10300,9 +11218,11 @@ kept for now until finding out what those bytes affect...
 		<description>Roger Rubbish (Europe)</description>
 		<year>1985</year>
 		<publisher>Spectravideo</publisher>
+		<info name="serial" value="003"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="roger rubbish (europe).rom" size="16384" crc="452556ce" sha1="8607b92458584d5aa770369d94d50361b1d64bd3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="roger rubbish (europe).rom" size="0x4000" crc="452556ce" sha1="8607b92458584d5aa770369d94d50361b1d64bd3" />
 			</dataarea>
 		</part>
 	</software>
@@ -10311,9 +11231,11 @@ kept for now until finding out what those bytes affect...
 		<description>Roger Rubbish (Europe, alt)</description>
 		<year>1985</year>
 		<publisher>Spectravideo</publisher>
+		<info name="serial" value="003"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="roger rubbish (europe) (alt 1).rom" size="8192" crc="33056633" sha1="1500a07693a7c06189f4cd6764d5ee62f0edd85d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="roger rubbish (europe) (alt 1).rom" size="0x2000" crc="33056633" sha1="1500a07693a7c06189f4cd6764d5ee62f0edd85d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10325,8 +11247,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-015" />
 		<info name="alt_title" value="ローラーボール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="roller ball (japan).rom" size="16384" crc="56200fef" sha1="44baa180f6c9e0f140ac1f0afae75c412cb06b9e" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="roller ball (japan).rom" size="0x4000" crc="56200fef" sha1="44baa180f6c9e0f140ac1f0afae75c412cb06b9e" />
 			</dataarea>
 		</part>
 	</software>
@@ -10338,8 +11261,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-015" />
 		<info name="alt_title" value="ローラーボール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="roller ball (japan) (alt 1).rom" size="16384" crc="798fa044" sha1="ff9877666d983759d41398c5e3e29801ad95a589" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="roller ball (japan) (alt 1).rom" size="0x4000" crc="798fa044" sha1="ff9877666d983759d41398c5e3e29801ad95a589" />
 			</dataarea>
 		</part>
 	</software>
@@ -10349,9 +11273,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ローターズ" />
+		<info name="serial" value="20102"/>
+		<info name="isbn" value="4871489671"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="rotors (japan).rom" size="16384" crc="1cdb462e" sha1="34544106fbd29b2a72e1e8c2e0f260b79a0b0883" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="rotors (japan).rom" size="0x4000" crc="1cdb462e" sha1="34544106fbd29b2a72e1e8c2e0f260b79a0b0883" />
 			</dataarea>
 		</part>
 	</software>
@@ -10362,11 +11289,12 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC758" />
 		<info name="alt_title" value="沙羅曼蛇" />
+		<info name="gtin" value="04988602532425"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="salamander (japan).rom" size="131072" crc="c36f559d" sha1="0d459788b6c464b50cbc2436e67a2cef248e0c4a" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="salamander (japan).rom" size="0x20000" crc="c36f559d" sha1="0d459788b6c464b50cbc2436e67a2cef248e0c4a" />
 			</dataarea>
 		</part>
 	</software>
@@ -10378,24 +11306,24 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami_scc" />
 			<feature name="mapper" value="KONAMI-SCC" />
-			<dataarea name="rom" size="131072">
-				<rom name="salamander - operation x (1988)(zemina)[rc-758].rom" size="131072" crc="40d19bf6" sha1="d30c17109fa1c4a81e39dca57b79464b0aa0b7c2" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="salamander - operation x (1988)(zemina)[rc-758].rom" size="0x20000" crc="40d19bf6" sha1="d30c17109fa1c4a81e39dca57b79464b0aa0b7c2" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="sangokub" cloneof="sangoku">
 		<description>Sangokushi (Japan, alt 2)</description>
 		<year>1986</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="MXKN11008" />
 		<info name="alt_title" value="三國志" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="262144">
-				<rom name="sangokushi (japan) (alt 1).rom" size="262144" crc="803cc690" sha1="3f741ba2ab08c5e9fb658882b36b8e3d01682f58" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="sangokushi (japan) (alt 1).rom" size="0x40000" crc="803cc690" sha1="3f741ba2ab08c5e9fb658882b36b8e3d01682f58" />
 			</dataarea>
 		</part>
 	</software>
@@ -10405,9 +11333,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00190" />
+		<info name="isbn" value="4871489345"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="sasa (japan).rom" size="16384" crc="7faf00c0" sha1="e767c0239b79821463fa42f2c1989d3fd1b4b868" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="sasa (japan).rom" size="0x4000" crc="7faf00c0" sha1="e767c0239b79821463fa42f2c1989d3fd1b4b868" />
 			</dataarea>
 		</part>
 	</software>
@@ -10417,21 +11347,24 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00190" />
+		<info name="isbn" value="4871489345"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="sasa (japan) (alt 1).rom" size="16384" crc="ae6f517d" sha1="395c5f40692c45b891abe07c89d1e87829665fc7" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="sasa (japan) (alt 1).rom" size="0x4000" crc="ae6f517d" sha1="395c5f40692c45b891abe07c89d1e87829665fc7" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx only has details on a cassette release. -->
 	<software name="saurus">
 		<description>Saurusland (Japan)</description>
 		<year>1983</year>
 		<publisher>Nihon Columbia</publisher>
 		<info name="alt_title" value="ザウルスランド" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="saurus land (japan).rom" size="16384" crc="5f2fe556" sha1="1a6de1cff831429394dc2b9528993a1dfcae14c6" />
+			<dataarea name="rom" size="0x4000">
+				<rom name="saurus land (japan).rom" size="0x4000" crc="5f2fe556" sha1="1a6de1cff831429394dc2b9528993a1dfcae14c6" />
 			</dataarea>
 		</part>
 	</software>
@@ -10442,9 +11375,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Toshiba EMI</publisher>
 		<info name="serial" value="PS-2019G" />
 		<info name="alt_title" value="スカーレット７" />
+		<info name="gtin" value="04988006004900"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="scarlet 7 - the mightiest women (japan).rom" size="32768" crc="c2ed4c08" sha1="bc3be8f829211dd8a8eb854f86ff014c47ed9254" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="scarlet 7 - the mightiest women (japan).rom" size="0x8000" crc="c2ed4c08" sha1="bc3be8f829211dd8a8eb854f86ff014c47ed9254" />
 			</dataarea>
 		</part>
 	</software>
@@ -10456,8 +11391,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G030C" />
 		<info name="alt_title" value="サイオン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="scion (japan).rom" size="16384" crc="ba3a8ea1" sha1="09fbbd923e0deb82f5e20fa8ce2d842adbf4a646" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="scion (japan).rom" size="0x4000" crc="ba3a8ea1" sha1="09fbbd923e0deb82f5e20fa8ce2d842adbf4a646" />
 			</dataarea>
 		</part>
 	</software>
@@ -10468,9 +11404,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="001C1" />
 		<info name="alt_title" value="スコープオン" />
+		<info name="isbn" value="487148937X"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="scope on - fight in space (japan).rom" size="16384" crc="5b33e583" sha1="c73d4c27aa2b0fb946e398323bd67d9e53c4f9ef" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="scope on - fight in space (japan).rom" size="0x4000" crc="5b33e583" sha1="c73d4c27aa2b0fb946e398323bd67d9e53c4f9ef" />
 			</dataarea>
 		</part>
 	</software>
@@ -10482,8 +11420,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="AMX001" />
 		<info name="alt_title" value="スクランブルエッグ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="scramble eggs (japan).rom" size="8192" crc="02dc77e8" sha1="05182561e05fa8e7c8a8184eda885dc4fd12cc5b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="scramble eggs (japan).rom" size="0x2000" crc="02dc77e8" sha1="05182561e05fa8e7c8a8184eda885dc4fd12cc5b" />
 			</dataarea>
 		</part>
 	</software>
@@ -10491,10 +11430,12 @@ kept for now until finding out what those bytes affect...
 	<software name="seahuntr">
 		<description>Sea Hunter (Europe)</description>
 		<year>1984</year>
-		<publisher>DynaData?</publisher>
+		<publisher>Spectravideo</publisher>
+		<info name="serial" value="001"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="sea hunter (europe).rom" size="16384" crc="1fd18174" sha1="c1d272645a249757b8be5bd913ba2d3447892387" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="sea hunter (europe).rom" size="0x4000" crc="1fd18174" sha1="c1d272645a249757b8be5bd913ba2d3447892387" />
 			</dataarea>
 		</part>
 	</software>
@@ -10504,9 +11445,12 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="聖拳アチョー" />
+		<info name="serial" value="2018201"/>
+		<info name="isbn" value="4871488721"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="kung fu acho (japan).rom" size="32768" crc="999dd794" sha1="530ecff542a537c320b17bd5d64c86d5d65619f3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="kung fu acho (japan).rom" size="0x8000" crc="999dd794" sha1="530ecff542a537c320b17bd5d64c86d5d65619f3" />
 			</dataarea>
 		</part>
 	</software>
@@ -10516,20 +11460,24 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="聖拳アチョー" />
+		<info name="serial" value="2018201"/>
+		<info name="isbn" value="4871488721"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="kung fu acho (japan) (alt 1).rom" size="32768" crc="0da11df8" sha1="fc22cec076c0a0a1ee7e410772af3d7d31de3149" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="kung fu acho (japan) (alt 1).rom" size="0x8000" crc="0da11df8" sha1="fc22cec076c0a0a1ee7e410772af3d7d31de3149" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="seikachok" cloneof="seikacho">
 		<description>Seiken Achou (Korea)</description>
-		<year>198?</year>
+		<year>1987</year>
 		<publisher>Clover</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="karateka.rom" size="32768" crc="6adeadf5" sha1="da95bcd1f0c28683cfb4a7a2c10599261dca3622" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="karateka.rom" size="0x8000" crc="6adeadf5" sha1="da95bcd1f0c28683cfb4a7a2c10599261dca3622" />
 			</dataarea>
 		</part>
 	</software>
@@ -10541,8 +11489,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G016C" />
 		<info name="alt_title" value="センジョー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="senjyo (japan).rom" size="16384" crc="126bc4cd" sha1="e373e3e9be4f6d30d5db84b699082c00b2021ba3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="senjyo (japan).rom" size="0x4000" crc="126bc4cd" sha1="e373e3e9be4f6d30d5db84b699082c00b2021ba3" />
 			</dataarea>
 		</part>
 	</software>
@@ -10554,8 +11503,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G016C" />
 		<info name="alt_title" value="センジョー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="senjyo (japan) (alt 1).rom" size="16384" crc="7d558b04" sha1="4936916bf914d99c5b9e3f4c7385f44b6b97d4c5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="senjyo (japan) (alt 1).rom" size="0x4000" crc="7d558b04" sha1="4936916bf914d99c5b9e3f4c7385f44b6b97d4c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -10567,8 +11517,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2005G" />
 		<info name="alt_title" value="スゥーワーサム" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="sewer sam (japan).rom" size="32768" crc="925c0aee" sha1="db0ed31c779fffd2084946e3ba69512b372d845f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="sewer sam (japan).rom" size="0x8000" crc="925c0aee" sha1="db0ed31c779fffd2084946e3ba69512b372d845f" />
 			</dataarea>
 		</part>
 	</software>
@@ -10580,8 +11531,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5094" />
 		<info name="alt_title" value="将棋" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="shougi (japan).rom" size="32768" crc="ece16709" sha1="83df4081529fe5b8bb0a3601614d36c8384c9202" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="shougi (japan).rom" size="0x8000" crc="ece16709" sha1="83df4081529fe5b8bb0a3601614d36c8384c9202" />
 			</dataarea>
 		</part>
 	</software>
@@ -10590,9 +11542,12 @@ kept for now until finding out what those bytes affect...
 		<description>Shougi (Japan, MicroCabin)</description>
 		<year>1985</year>
 		<publisher>MicroCabin</publisher>
+		<info name="alt_title" value="将棋" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="shougi 2 (japan).rom" size="16384" crc="a44495d5" sha1="0e06519e68c78a8f018152511f4f13374c5856aa" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="shougi 2 (japan).rom" size="0x4000" crc="a44495d5" sha1="0e06519e68c78a8f018152511f4f13374c5856aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -10604,20 +11559,23 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2008G" />
 		<info name="alt_title" value="将棋名人" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="shougi meijin (japan).rom" size="32768" crc="b90dee1d" sha1="f9ad0cdb227c588b1a5c75220ed53d0314550d7f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="shougi meijin (japan).rom" size="0x8000" crc="b90dee1d" sha1="f9ad0cdb227c588b1a5c75220ed53d0314550d7f" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="shoutmat">
+	<!-- Came with a microphone that connected to the joystick port. -->
+	<software name="shoutmat" supported="partial">
 		<description>Shout Match (Japan)</description>
 		<year>1987</year>
 		<publisher>Victor</publisher>
 		<info name="alt_title" value="シャウトマッチ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="shout match (japan).rom" size="32768" crc="729d2540" sha1="d844c4c5ae9c7ac671c4be71ac1190a1e5db4d36" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="shout match (japan).rom" size="0x8000" crc="729d2540" sha1="d844c4c5ae9c7ac671c4be71ac1190a1e5db4d36" />
 			</dataarea>
 		</part>
 	</software>
@@ -10629,8 +11587,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-119" />
 		<info name="alt_title" value="シンドバッド７つの冒険" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="sinbad (japan).rom" size="16384" crc="8273fd0e" sha1="d120ca303c3e1dd56adee68f10e9e1ab51f50ab3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="sinbad (japan).rom" size="0x4000" crc="8273fd0e" sha1="d120ca303c3e1dd56adee68f10e9e1ab51f50ab3" />
 			</dataarea>
 		</part>
 	</software>
@@ -10642,8 +11601,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-103" />
 		<info name="alt_title" value="スキーコマンド" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="casio ski command (japan).rom" size="16384" crc="d8750242" sha1="17d6db13d7d76fbd110f53b168ab0001c7e65817" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="casio ski command (japan).rom" size="0x4000" crc="d8750242" sha1="17d6db13d7d76fbd110f53b168ab0001c7e65817" />
 			</dataarea>
 		</part>
 	</software>
@@ -10655,8 +11615,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="GPM-103" />
 		<info name="alt_title" value="スキーコマンド" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="casio ski command (japan) (alt 1).rom" size="16384" crc="edb91850" sha1="fe53d85adb758103097fd56132e71c7f4cb32313" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="casio ski command (japan) (alt 1).rom" size="0x4000" crc="edb91850" sha1="fe53d85adb758103097fd56132e71c7f4cb32313" />
 			</dataarea>
 		</part>
 	</software>
@@ -10666,8 +11627,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Aproman</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="skicomma.rom" size="32768" crc="06980ea1" sha1="8c317e50e0aa75dfaa374412ce9866d16c0214fd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="skicomma.rom" size="0x8000" crc="06980ea1" sha1="8c317e50e0aa75dfaa374412ce9866d16c0214fd" />
 			</dataarea>
 		</part>
 	</software>
@@ -10677,8 +11639,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>ProSoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="skicommb.rom" size="32768" crc="a0276799" sha1="18419523962b57f1ff49d62182f50882d6c42228" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="skicommb.rom" size="0x8000" crc="a0276799" sha1="18419523962b57f1ff49d62182f50882d6c42228" />
 			</dataarea>
 		</part>
 	</software>
@@ -10688,9 +11651,11 @@ kept for now until finding out what those bytes affect...
 		<year>1988</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="alt_title" value="スクーター" />
+		<info name="serial" value="R49X5402"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="skooter (japan) (alt 1).rom" size="32768" crc="f9e0fb4c" sha1="d264152d4974b78959465acfe0d5678e72930073" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="skooter (japan) (alt 1).rom" size="0x8000" crc="f9e0fb4c" sha1="d264152d4974b78959465acfe0d5678e72930073" />
 			</dataarea>
 		</part>
 	</software>
@@ -10700,9 +11665,11 @@ kept for now until finding out what those bytes affect...
 		<year>1988</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="alt_title" value="スクーター" />
+		<info name="serial" value="R49X5402"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="skooter (japan).rom" size="32768" crc="53b87deb" sha1="64f1ce4691056047f404460031acb0b82a76968d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="skooter (japan).rom" size="0x8000" crc="53b87deb" sha1="64f1ce4691056047f404460031acb0b82a76968d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10713,9 +11680,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Magical Zoo</publisher>
 		<info name="serial" value="MXMH21052" />
 		<info name="alt_title" value="スカイギャルド" />
+		<info name="gtin" value="04988614000011"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="sky galdo (japan).rom" size="32768" crc="54f84047" sha1="136d838cc1297940d96cd8e27aea9f9e3c7088a6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="sky galdo (japan).rom" size="0x8000" crc="54f84047" sha1="136d838cc1297940d96cd8e27aea9f9e3c7088a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -10727,8 +11696,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC721" />
 		<info name="alt_title" value="スカイジャガー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="sky jaguar (japan).rom" size="16384" crc="e4f725fd" sha1="1f8334dc7459cfcf2ad132e94976015c02e51390" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="sky jaguar (japan).rom" size="0x4000" crc="e4f725fd" sha1="1f8334dc7459cfcf2ad132e94976015c02e51390" />
 			</dataarea>
 		</part>
 	</software>
@@ -10738,8 +11708,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="skyjagua.rom" size="32768" crc="7e7fa3a0" sha1="e8d2f130b0937d1baced5a3996b78f163d4fa70a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="skyjagua.rom" size="0x8000" crc="7e7fa3a0" sha1="e8d2f130b0937d1baced5a3996b78f163d4fa70a" />
 			</dataarea>
 		</part>
 	</software>
@@ -10748,22 +11719,27 @@ kept for now until finding out what those bytes affect...
 		<description>Slapshot (Spain)</description>
 		<year>1985</year>
 		<publisher>Sony Spain</publisher>
+		<info name="alt_title" value="Hockey Sobre Hielo (box)"/>
 		<info name="serial" value="HBS-I034" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="slapshot (spain).rom" size="16384" crc="7e558b9e" sha1="e3a52d448e69d6d14f67d35f24d9924158b1cce1" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="slapshot (spain).rom" size="0x4000" crc="7e558b9e" sha1="e3a52d448e69d6d14f67d35f24d9924158b1cce1" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="snakeit">
-		<description>Snake It (Europe)</description>
-		<year>1986?</year>
-		<publisher>Eaglesoft</publisher>
+		<description>Snake It (Japan)</description>
+		<year>1987</year>
+		<publisher>Seika Romox</publisher>
 		<info name="alt_title" value="スネイクイット" />
+		<info name="serial" value="SR-003"/>
+		<info name="gtin" value="04988625000031"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="snake it (europe).rom" size="32768" crc="4a44bf23" sha1="7300d44a753dacf582d3079ed09eafc9dd629530" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="snake it (europe).rom" size="0x8000" crc="4a44bf23" sha1="7300d44a753dacf582d3079ed09eafc9dd629530" />
 			</dataarea>
 		</part>
 	</software>
@@ -10773,11 +11749,12 @@ kept for now until finding out what those bytes affect...
 		<year>1988</year>
 		<publisher>Dempa</publisher>
 		<info name="alt_title" value="ソフィア" />
+		<info name="serial" value="DP-3912043"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="65536">
-				<rom name="sofia (japan).rom" size="65536" crc="14811951" sha1="5a12439f74ca5d1c2664f01ff6a8302d3ce907a8" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="sofia (japan).rom" size="0x10000" crc="14811951" sha1="5a12439f74ca5d1c2664f01ff6a8302d3ce907a8" />
 			</dataarea>
 		</part>
 	</software>
@@ -10788,9 +11765,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pack-In-Video</publisher>
 		<info name="serial" value="MS-6" />
 		<info name="alt_title" value="スペースキャンプ" />
+		<info name="gtin" value="04988110800061"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="space camp (japan).rom" size="32768" crc="eb197b9d" sha1="de10aa2a2abfdcafe0064e1e76b676f54c7aafc6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="space camp (japan).rom" size="0x8000" crc="eb197b9d" sha1="de10aa2a2abfdcafe0064e1e76b676f54c7aafc6" />
 			</dataarea>
 		</part>
 	</software>
@@ -10801,9 +11780,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pack-In-Video</publisher>
 		<info name="serial" value="MS-6" />
 		<info name="alt_title" value="スペースキャンプ" />
+		<info name="gtin" value="04988110800061"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="space camp (japan) (alt 1).rom" size="32768" crc="cdd43807" sha1="d1ad3beb29aecaa7c3bc1fd8a4be3b10d38cc47a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="space camp (japan) (alt 1).rom" size="0x8000" crc="cdd43807" sha1="d1ad3beb29aecaa7c3bc1fd8a4be3b10d38cc47a" />
 			</dataarea>
 		</part>
 	</software>
@@ -10815,8 +11796,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="NH-MSX06" />
 		<info name="alt_title" value="スペースインベーダー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="space invaders (japan).rom" size="16384" crc="de02932d" sha1="4971bdd3db63d394fbc2186182c901ca4b32535b" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="space invaders (japan).rom" size="0x4000" crc="de02932d" sha1="4971bdd3db63d394fbc2186182c901ca4b32535b" />
 			</dataarea>
 		</part>
 	</software>
@@ -10829,8 +11811,9 @@ kept for now until finding out what those bytes affect...
 		<info name="alt_title" value="スペースメイズアタック" />
 		<info name="usage" value="Requires a machine with RAM in a main slot" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="space maze attack (japan).rom" size="8192" crc="4a45cbc0" sha1="93bf6725a3c1b7071064a01884e1b6e8c6f8b579" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="space maze attack (japan).rom" size="0x2000" crc="4a45cbc0" sha1="93bf6725a3c1b7071064a01884e1b6e8c6f8b579" />
 			</dataarea>
 		</part>
 	</software>
@@ -10843,8 +11826,9 @@ kept for now until finding out what those bytes affect...
 		<info name="alt_title" value="スペースメイズアタック" />
 		<info name="usage" value="Requires a machine with RAM in a main slot" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="space maze attack (japan) (alt 1).rom" size="8192" crc="d6eadaa2" sha1="a00f9e66f1fa3de15b028e0fbfed636e194bb967" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="space maze attack (japan) (alt 1).rom" size="0x2000" crc="d6eadaa2" sha1="a00f9e66f1fa3de15b028e0fbfed636e194bb967" />
 			</dataarea>
 		</part>
 	</software>
@@ -10856,8 +11840,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-006" />
 		<info name="alt_title" value="スペースメイズアタック" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="space maze attack (japan) (alt 2).rom" size="16384" crc="1932baf6" sha1="fbbd9a77004f9bdbcfc292f85c32106faa18cfa6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="space maze attack (japan) (alt 2).rom" size="0x4000" crc="1932baf6" sha1="fbbd9a77004f9bdbcfc292f85c32106faa18cfa6" />
 			</dataarea>
 		</part>
 	</software>
@@ -10869,8 +11854,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-013" />
 		<info name="alt_title" value="スペーストラブル" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="space trouble (japan).rom" size="8192" crc="26119f0a" sha1="7c0f720c7601ca6dc86c81ab6a76e0587a052f75" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="space trouble (japan).rom" size="0x2000" crc="26119f0a" sha1="7c0f720c7601ca6dc86c81ab6a76e0587a052f75" />
 			</dataarea>
 		</part>
 	</software>
@@ -10882,16 +11868,11 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G001C" />
 		<info name="alt_title" value="スパーキー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
+			<feature name="start_page" value="0"/>
+			<dataarea name="rom" size="0x8000">
 				<!-- Mirroring not verified -->
-				<rom name="sparkie (japan).rom" size="8192" crc="f03ed7d5" sha1="4b996bddf88605c432f73564922106a63d31f62c" />
-				<rom size="8192" offset="0x2000" loadflag="reload" />
-				<rom size="8192" offset="0x4000" loadflag="reload" />
-				<rom size="8192" offset="0x6000" loadflag="reload" />
-				<rom size="8192" offset="0x8000" loadflag="reload" />
-				<rom size="8192" offset="0xa000" loadflag="reload" />
-				<rom size="8192" offset="0xc000" loadflag="reload" />
-				<rom size="8192" offset="0xe000" loadflag="reload" />
+				<rom name="sparkie (japan).rom" size="0x2000" crc="f03ed7d5" sha1="4b996bddf88605c432f73564922106a63d31f62c" />
+				<rom size="0x2000" offset="0x4000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -10902,9 +11883,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Irem</publisher>
 		<info name="serial" value="IM-01" />
 		<info name="alt_title" value="スペランカー" />
+		<info name="gtin" value="04962891300019"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="spelunker (japan).rom" size="32768" crc="dc948a3a" sha1="49e14b0248c649e7b5754357597695abef70c17d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="spelunker (japan).rom" size="0x8000" crc="dc948a3a" sha1="49e14b0248c649e7b5754357597695abef70c17d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10915,9 +11898,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Irem</publisher>
 		<info name="serial" value="IM-01" />
 		<info name="alt_title" value="スペランカー" />
+		<info name="gtin" value="04962891300019"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="spelunker (japan) (alt 1).rom" size="32768" crc="4c738b64" sha1="4d80fae5133d55503968ee246c1346cddb020ffc" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="spelunker (japan) (alt 1).rom" size="0x8000" crc="4c738b64" sha1="4d80fae5133d55503968ee246c1346cddb020ffc" />
 			</dataarea>
 		</part>
 	</software>
@@ -10928,8 +11913,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Hudson Soft</publisher>
 		<info name="alt_title" value="ザ・スパイダー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="spider, the (japan).rom" size="16384" crc="a156ac02" sha1="97f1790146116198133c083de113ed1e5ca6ff21" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="spider, the (japan).rom" size="0x4000" crc="a156ac02" sha1="97f1790146116198133c083de113ed1e5ca6ff21" />
 			</dataarea>
 		</part>
 	</software>
@@ -10939,9 +11925,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Toshiba EMI</publisher>
 		<info name="alt_title" value="スクエアダンサー" />
+		<info name="serial" value="PS-2007G"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="square dancer (japan).rom" size="16384" crc="dd5cf5c8" sha1="18b90aaa2284eb46233e9203af1e8cf1922c417c" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="square dancer (japan).rom" size="0x4000" crc="dd5cf5c8" sha1="18b90aaa2284eb46233e9203af1e8cf1922c417c" />
 			</dataarea>
 		</part>
 	</software>
@@ -10950,9 +11938,13 @@ kept for now until finding out what those bytes affect...
 		<description>Squish'em (Japan)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
+		<info name="alt_title" value="スクィッシュゼム"/>
+		<info name="serial" value="001B0"/>
+		<info name="isbn" value="4871489361"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="squish'em (japan).rom" size="16384" crc="f3b22c91" sha1="7bf7bd134ddf9ed5b489f7f2eb0aa26bb2428fc9" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="squish'em (japan).rom" size="0x4000" crc="f3b22c91" sha1="7bf7bd134ddf9ed5b489f7f2eb0aa26bb2428fc9" />
 			</dataarea>
 		</part>
 	</software>
@@ -10961,9 +11953,13 @@ kept for now until finding out what those bytes affect...
 		<description>Squish'em (Japan, alt)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
+		<info name="alt_title" value="スクィッシュゼム"/>
+		<info name="serial" value="001B0"/>
+		<info name="isbn" value="4871489361"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="squish'em (japan) (alt 1).rom" size="16384" crc="da50254f" sha1="364ae6695509f5cf16985cc2946a45af5ca4cf56" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="squish'em (japan) (alt 1).rom" size="0x4000" crc="da50254f" sha1="364ae6695509f5cf16985cc2946a45af5ca4cf56" />
 			</dataarea>
 		</part>
 	</software>
@@ -10975,8 +11971,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G033C" />
 		<info name="alt_title" value="スターブレーザー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="star blazer (japan).rom" size="16384" crc="fd902e5d" sha1="eda9580a1ac75707f621c251a7424df3846e4ec0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="star blazer (japan).rom" size="0x4000" crc="fd902e5d" sha1="eda9580a1ac75707f621c251a7424df3846e4ec0" />
 			</dataarea>
 		</part>
 	</software>
@@ -10988,8 +11985,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G033C" />
 		<info name="alt_title" value="スターブレーザー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="star blazer (japan) (alt 1).rom" size="16384" crc="1c952691" sha1="b07a6ae619fcc6291838959dc1a899de832f8d97" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="star blazer (japan) (alt 1).rom" size="0x4000" crc="1c952691" sha1="b07a6ae619fcc6291838959dc1a899de832f8d97" />
 			</dataarea>
 		</part>
 	</software>
@@ -11001,22 +11999,24 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G033C" />
 		<info name="alt_title" value="スターブレーザー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="star blazer (japan) (alt 2).rom" size="16384" crc="a242fe0d" sha1="a1e1bffe4b4ea6d67c973fa483c4d6273f68de3c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="star blazer (japan) (alt 2).rom" size="0x4000" crc="a242fe0d" sha1="a1e1bffe4b4ea6d67c973fa483c4d6273f68de3c" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="starcomm">
 		<description>Star Command (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="00031" />
+		<info name="serial" value="00030 / 00031" />
 		<info name="alt_title" value="スターコマンド" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="star command (japan).rom" size="16384" crc="4579ce12" sha1="225894da7e3afabf33abf05e519e1f6bcac77a21" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="star command (japan).rom" size="0x4000" crc="4579ce12" sha1="225894da7e3afabf33abf05e519e1f6bcac77a21" />
 			</dataarea>
 		</part>
 	</software>
@@ -11026,9 +12026,11 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Jast</publisher>
 		<info name="alt_title" value="スタートラップくりいむレモン" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="star trap (japan).rom" size="32768" crc="dcde05dd" sha1="b2bcc1c0d64b6ee9f0e9bbbcf0ef7b64d80d3b90" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="star trap (japan).rom" size="0x8000" crc="dcde05dd" sha1="b2bcc1c0d64b6ee9f0e9bbbcf0ef7b64d80d3b90" />
 			</dataarea>
 		</part>
 	</software>
@@ -11038,9 +12040,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="スターシップシミュレータ" />
+		<info name="serial" value = "00200"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="starship simulator (japan).rom" size="16384" crc="236d2ab1" sha1="0e5062bb18b4a6fb93a89318772928874dd4d6ea" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="starship simulator (japan).rom" size="0x4000" crc="236d2ab1" sha1="0e5062bb18b4a6fb93a89318772928874dd4d6ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -11050,9 +12054,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="スターシップシミュレータ" />
+		<info name="serial" value="00200"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="starship simulator (japan) (alt 1).rom" size="16384" crc="87824af6" sha1="e3ce88e95115765e31193777e57fcb9b40e10d3a" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="starship simulator (japan) (alt 1).rom" size="0x4000" crc="87824af6" sha1="e3ce88e95115765e31193777e57fcb9b40e10d3a" />
 			</dataarea>
 		</part>
 	</software>
@@ -11064,8 +12070,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-001" />
 		<info name="alt_title" value="ステップアップ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="step up (japan).rom" size="8192" crc="cabcddf1" sha1="27ce427eb1c86ba22707a6ee9086db9d39962dc6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="step up (japan).rom" size="0x2000" crc="cabcddf1" sha1="27ce427eb1c86ba22707a6ee9086db9d39962dc6" />
 			</dataarea>
 		</part>
 	</software>
@@ -11077,8 +12084,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-001" />
 		<info name="alt_title" value="ステップアップ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="step up (japan) (alt 1).rom" size="8192" crc="60a8927b" sha1="fc5d252a26c93dc4cc30984b954a6a5124dee653" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="step up (japan) (alt 1).rom" size="0x2000" crc="60a8927b" sha1="fc5d252a26c93dc4cc30984b954a6a5124dee653" />
 			</dataarea>
 		</part>
 	</software>
@@ -11088,8 +12096,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="stepup.rom" size="32768" crc="5bce3fec" sha1="b3370cdf4707d9c38afc0f42c11cba5e745ead6a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="stepup.rom" size="0x8000" crc="5bce3fec" sha1="b3370cdf4707d9c38afc0f42c11cba5e745ead6a" />
 			</dataarea>
 		</part>
 	</software>
@@ -11099,23 +12108,28 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ステッパー" />
+		<info name="serial" value="20163"/>
+		<info name="isbn" value="4871488330"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="stepper (japan).rom" size="16384" crc="0fb7df8f" sha1="1fa7398005fb0bd7075141035e8d888197162030" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="stepper (japan).rom" size="0x4000" crc="0fb7df8f" sha1="1fa7398005fb0bd7075141035e8d888197162030" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="stonewis">
 		<description>Kenja no Ishi - The Stone of Wisdom (Japan)</description>
 		<year>1986</year>
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-125" />
 		<info name="alt_title" value="賢者の石" />
+		<info name="gtin" value="04971850104193"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="stone of wisdom, the (japan).rom" size="32768" crc="8c7a7435" sha1="3950f22265139a84cf57f3c0936e7927173f3d7a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="stone of wisdom, the (japan).rom" size="0x8000" crc="8c7a7435" sha1="3950f22265139a84cf57f3c0936e7927173f3d7a" />
 			</dataarea>
 		</part>
 	</software>
@@ -11127,8 +12141,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="ND-06MR" />
 		<info name="alt_title" value="ストレンジループ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="strange loop (japan).rom" size="32768" crc="6554c0c5" sha1="3063bc3ac5af6d990d8d002acbc9c3a18bab71f6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="strange loop (japan).rom" size="0x8000" crc="6554c0c5" sha1="3063bc3ac5af6d990d8d002acbc9c3a18bab71f6" />
 			</dataarea>
 		</part>
 	</software>
@@ -11140,19 +12155,21 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="street master.rom" size="131072" crc="7269c520" sha1="65da0e5c5de057a1ed836ec19b1f07e10f4b738f" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="street master.rom" size="0x20000" crc="7269c520" sha1="65da0e5c5de057a1ed836ec19b1f07e10f4b738f" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx does not list a cartridge relase for this software. -->
 	<software name="suparobo">
 		<description>Suparobo (Japan)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="suparobo (japan).rom" size="16384" crc="483eddcc" sha1="ccf6e244d27ec61195280d0915a3b43d291e3fad" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="suparobo (japan).rom" size="0x4000" crc="483eddcc" sha1="ccf6e244d27ec61195280d0915a3b43d291e3fad" />
 			</dataarea>
 		</part>
 	</software>
@@ -11164,8 +12181,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-010" />
 		<info name="alt_title" value="スーパービリヤード" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="super billiards (japan).rom" size="8192" crc="79bc12b2" sha1="05d7016f39e94bf9fc33d0e8482ff3038d6e01bd" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="super billiards (japan).rom" size="0x2000" crc="79bc12b2" sha1="05d7016f39e94bf9fc33d0e8482ff3038d6e01bd" />
 			</dataarea>
 		</part>
 	</software>
@@ -11174,11 +12192,12 @@ kept for now until finding out what those bytes affect...
 		<description>Super Bioman 4 (Korea)</description>
 		<year>199?</year>
 		<publisher>Zemina</publisher>
+		<info name="alt_title" value="바이오맨4"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="65536">
-				<rom name="super bioman 4 (korea) (unl).rom" size="65536" crc="112abf34" sha1="dacc9ed6a80fb15c3e82c4081c07211e033ba820" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="super bioman 4 (korea) (unl).rom" size="0x10000" crc="112abf34" sha1="dacc9ed6a80fb15c3e82c4081c07211e033ba820" />
 			</dataarea>
 		</part>
 	</software>
@@ -11191,8 +12210,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="super boy 3 (korea) (unl).rom" size="131072" crc="9195c34c" sha1="5d65a308bb9ec8c4b4ce334b18d699b1f53227ef" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super boy 3 (korea) (unl).rom" size="0x20000" crc="9195c34c" sha1="5d65a308bb9ec8c4b4ce334b18d699b1f53227ef" />
 			</dataarea>
 		</part>
 	</software>
@@ -11205,8 +12224,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="super boy iii (1991)(zemina).rom" size="131072" crc="f422ad79" sha1="9bafce699964f4aabc6b60c71a71c9ff5b0cc82d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="super boy iii (1991)(zemina).rom" size="0x20000" crc="f422ad79" sha1="9bafce699964f4aabc6b60c71a71c9ff5b0cc82d" />
 			</dataarea>
 		</part>
 	</software>
@@ -11217,8 +12236,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="슈퍼보이 I" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="super boy i (korea) (unl).rom" size="32768" crc="13b34548" sha1="8b65d999ba187c98ba97a038ea46655fd9d62deb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="super boy i (korea) (unl).rom" size="0x8000" crc="13b34548" sha1="8b65d999ba187c98ba97a038ea46655fd9d62deb" />
 			</dataarea>
 		</part>
 	</software>
@@ -11229,8 +12249,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="슈퍼보이 II" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="super boy ii (korea) (unl).rom" size="32768" crc="09206bfd" sha1="85153a8f25882cadde8295d040ddb7586c93cefe" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="super boy ii (korea) (unl).rom" size="0x8000" crc="09206bfd" sha1="85153a8f25882cadde8295d040ddb7586c93cefe" />
 			</dataarea>
 		</part>
 	</software>
@@ -11241,8 +12262,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="슈퍼보이 II" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="super boy ii (1989)(zemina).rom" size="32768" crc="7de493ab" sha1="cd466c04209a8815a95d3723653e263a868de9e0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="super boy ii (1989)(zemina).rom" size="0x8000" crc="7de493ab" sha1="cd466c04209a8815a95d3723653e263a868de9e0" />
 			</dataarea>
 		</part>
 	</software>
@@ -11253,12 +12275,14 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="슈퍼버블버블" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="super bubble bobble (korea) (unl).rom" size="32768" crc="37b5d39b" sha1="03f112b38fb1d05a9b0b50d3c6a54aa2ce9dd2b0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="super bubble bobble (korea) (unl).rom" size="0x8000" crc="37b5d39b" sha1="03f112b38fb1d05a9b0b50d3c6a54aa2ce9dd2b0" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Konami logo on black background. -->
 	<software name="scobra">
 		<description>Super Cobra (Japan)</description>
 		<year>1983</year>
@@ -11266,12 +12290,14 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC705" />
 		<info name="alt_title" value="スーパーコブラ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="super cobra (japan).rom" size="8192" crc="97425d70" sha1="a84608f1c2fe1aea1a8a586f2e335cb64bb951fc" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="super cobra (japan).rom" size="0x2000" crc="97425d70" sha1="a84608f1c2fe1aea1a8a586f2e335cb64bb951fc" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Konami logo on blue background. -->
 	<software name="scobraa" cloneof="scobra">
 		<description>Super Cobra (Japan, alt)</description>
 		<year>1983</year>
@@ -11279,8 +12305,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC705" />
 		<info name="alt_title" value="スーパーコブラ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="super cobra (japan) (alt 1).rom" size="8192" crc="bfcc181d" sha1="7ad00597ceb5a02379055230d907c4421982329a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="super cobra (japan) (alt 1).rom" size="0x2000" crc="bfcc181d" sha1="7ad00597ceb5a02379055230d907c4421982329a" />
 			</dataarea>
 		</part>
 	</software>
@@ -11292,19 +12319,22 @@ kept for now until finding out what those bytes affect...
 		<year>1990</year>
 		<publisher>Hi-Com</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="super columns (japan).rom" size="32768" crc="f0a030ec" sha1="16553c30fcdd0e1d00a48fe1cb2def537c4a7c3f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="super columns (japan).rom" size="0x8000" crc="f0a030ec" sha1="16553c30fcdd0e1d00a48fe1cb2def537c4a7c3f" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx lists cartridge releases by Indescomp, ASCII, and Microbyte, not by Spectravideo. -->
 	<software name="superxf">
 		<description>Super Cross Force (Europe)</description>
 		<year>1983</year>
 		<publisher>Spectravideo</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="super cross force (europe).rom" size="16384" crc="f05a7f4e" sha1="54f288590f0c882f6e3a9b7c3f7d15b407190975" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="super cross force (europe).rom" size="0x4000" crc="f05a7f4e" sha1="54f288590f0c882f6e3a9b7c3f7d15b407190975" />
 			</dataarea>
 		</part>
 	</software>
@@ -11315,12 +12345,14 @@ kept for now until finding out what those bytes affect...
 		<publisher>Ample Software</publisher>
 		<info name="serial" value="AMX004" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="super drinker (japan).rom" size="16384" crc="3254017e" sha1="82c68a93d01f103af4fe9f9205184ffd1a36a90f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="super drinker (japan).rom" size="0x4000" crc="3254017e" sha1="82c68a93d01f103af4fe9f9205184ffd1a36a90f" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- The Japanese release contains a cartridge and a cassette tape. -->
 	<software name="superglf">
 		<description>Super Golf (Japan)</description>
 		<year>1984</year>
@@ -11328,8 +12360,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G028C" />
 		<info name="alt_title" value="スーパーゴルフ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="super golf (japan).rom" size="32768" crc="66aadfa8" sha1="27c2cdee4be0ca166c2ebd2dac61115a56bb9856" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="super golf (japan).rom" size="0x8000" crc="66aadfa8" sha1="27c2cdee4be0ca166c2ebd2dac61115a56bb9856" />
 			</dataarea>
 		</part>
 	</software>
@@ -11340,8 +12373,8 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
-			<dataarea name="rom" size="262144">
-				<rom name="super laydock - mission striker (1988)(zemina).rom" size="262144" crc="b885a464" sha1="244399d67d7851f3daa9bb87a14f5b8ef6d8c160" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="super laydock - mission striker (1988)(zemina).rom" size="0x40000" crc="b885a464" sha1="244399d67d7851f3daa9bb87a14f5b8ef6d8c160" />
 			</dataarea>
 		</part>
 	</software>
@@ -11349,11 +12382,13 @@ kept for now until finding out what those bytes affect...
 	<software name="suppachi">
 		<description>Super Pachinko (Japan)</description>
 		<year>1985</year>
-		<publisher>Nihon Columbia</publisher>
+		<publisher>Colpax</publisher>
 		<info name="alt_title" value="スーパーパチンコ" />
+		<info name="serial" value="48C99-1010"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="super pachinko (japan).rom" size="16384" crc="8aebddd2" sha1="991ef9890dc3e0c0d29d6d249675eae182aca30c" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="super pachinko (japan).rom" size="0x4000" crc="8aebddd2" sha1="991ef9890dc3e0c0d29d6d249675eae182aca30c" />
 			</dataarea>
 		</part>
 	</software>
@@ -11363,9 +12398,11 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Sieco</publisher>
 		<info name="alt_title" value="슈퍼 펭귄" />
+		<info name="serial" value="SI-3131Z"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="sieco_superpenguin_(sieco).rom" size="32768" crc="0555a6e9" sha1="c3b7eec94774183ec120d6b4b816cd9f69e1f0c5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="sieco_superpenguin_(sieco).rom" size="0x8000" crc="0555a6e9" sha1="c3b7eec94774183ec120d6b4b816cd9f69e1f0c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -11377,8 +12414,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-005" />
 		<info name="alt_title" value="スーパースネーク" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="super snake (japan).rom" size="8192" crc="491c6af0" sha1="58b3b3a678364d0649c1af0c27da144cfee85146" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="super snake (japan).rom" size="0x2000" crc="491c6af0" sha1="58b3b3a678364d0649c1af0c27da144cfee85146" />
 			</dataarea>
 		</part>
 	</software>
@@ -11390,8 +12428,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-005" />
 		<info name="alt_title" value="スーパースネーク" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="super snake (japan) (alt 1).rom" size="16384" crc="f192f67e" sha1="0348f1758daa118ebaf2bc593ff9a0a622fc89e8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="super snake (japan) (alt 1).rom" size="0x4000" crc="f192f67e" sha1="0348f1758daa118ebaf2bc593ff9a0a622fc89e8" />
 			</dataarea>
 		</part>
 	</software>
@@ -11403,8 +12442,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-005" />
 		<info name="alt_title" value="スーパースネーク" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="super snake (japan) (alt 2).rom" size="16384" crc="e31a0336" sha1="8dcd9618f92fb014d16e8f4ec9a813e65424ad7d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="super snake (japan) (alt 2).rom" size="0x4000" crc="e31a0336" sha1="8dcd9618f92fb014d16e8f4ec9a813e65424ad7d" />
 			</dataarea>
 		</part>
 	</software>
@@ -11416,8 +12456,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G021C" />
 		<info name="alt_title" value="スーパーサッカー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="super soccer (japan).rom" size="32768" crc="6408ed24" sha1="996a1c0d92400287c15545116b952f84c7dc03b1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="super soccer (japan).rom" size="0x8000" crc="6408ed24" sha1="996a1c0d92400287c15545116b952f84c7dc03b1" />
 			</dataarea>
 		</part>
 	</software>
@@ -11429,8 +12470,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G022C" />
 		<info name="alt_title" value="スーパーテニス ~ Super Tennis (Box)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="super tennis (japan).rom" size="16384" crc="d560d9c0" sha1="4a1282901221207da79432fb0bcb4f1e722c8278" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="super tennis (japan).rom" size="0x4000" crc="d560d9c0" sha1="4a1282901221207da79432fb0bcb4f1e722c8278" />
 			</dataarea>
 		</part>
 	</software>
@@ -11441,8 +12483,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Sony Spain</publisher>
 		<info name="serial" value="HBS-I030" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="super tripper (spain).rom" size="32768" crc="0c36f5bd" sha1="1a5295a337e5b969c939644cb5ad55b84a6ad31d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="super tripper (spain).rom" size="0x8000" crc="0c36f5bd" sha1="1a5295a337e5b969c939644cb5ad55b84a6ad31d" />
 			</dataarea>
 		</part>
 	</software>
@@ -11453,8 +12496,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Taito</publisher>
 		<info name="alt_title" value="スイートアーコン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="sweet acorn (japan).rom" size="16384" crc="58670a22" sha1="221c76d6ac483fb1f11c87d37b9617f1e1d7bc6d" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="sweet acorn (japan).rom" size="0x4000" crc="58670a22" sha1="221c76d6ac483fb1f11c87d37b9617f1e1d7bc6d" />
 			</dataarea>
 		</part>
 	</software>
@@ -11465,8 +12509,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Taito</publisher>
 		<info name="alt_title" value="スイートアーコン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="sweet acorn (japan) (alt 1).rom" size="16384" crc="54a8bf3c" sha1="c8015d4453efb9f78005f6c8481cbce9d99f6cc5" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="sweet acorn (japan) (alt 1).rom" size="0x4000" crc="54a8bf3c" sha1="c8015d4453efb9f78005f6c8481cbce9d99f6cc5" />
 			</dataarea>
 		</part>
 	</software>
@@ -11478,8 +12523,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5076" />
 		<info name="alt_title" value="窓ふき会社のスイングくん ~ Madofukigaisha no Swing-kun (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="swing (japan).rom" size="16384" crc="c93fadf4" sha1="2d8e39f210da6d633f773cda03e9970712ea84cf" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="swing (japan).rom" size="0x4000" crc="c93fadf4" sha1="2d8e39f210da6d633f773cda03e9970712ea84cf" />
 			</dataarea>
 		</part>
 	</software>
@@ -11491,12 +12537,14 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5076" />
 		<info name="alt_title" value="窓ふき会社のスイングくん ~ Madofukigaisha no Swing-kun (Box?)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="swing (japan) (alt 1).rom" size="16384" crc="60355c9e" sha1="719f457d8fcbf6c21a88e88f34fcd54f5e96ad68" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="swing (japan) (alt 1).rom" size="0x4000" crc="60355c9e" sha1="719f457d8fcbf6c21a88e88f34fcd54f5e96ad68" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Takeru version? -->
 	<software name="takameij">
 		<description>Takahashi Meijin no Boukenjima (Japan)</description>
 		<year>1986</year>
@@ -11504,12 +12552,14 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="BC-M9" />
 		<info name="alt_title" value="高橋名人の冒険島" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="wonder boy (japan).rom" size="32768" crc="892266ca" sha1="d74c381ea17acb94527ef3abaa280793a824d322" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="wonder boy (japan).rom" size="0x8000" crc="892266ca" sha1="d74c381ea17acb94527ef3abaa280793a824d322" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Takeru version? -->
 	<software name="takameija" cloneof="takameij">
 		<description>Takahashi Meijin no Boukenjima (Japan, alt)</description>
 		<year>1986</year>
@@ -11517,8 +12567,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="BC-M9" />
 		<info name="alt_title" value="高橋名人の冒険島" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="wonder boy (japan) (alt 1).rom" size="32768" crc="5130c27b" sha1="1672af5bc1740480e8302f7690589ea5b5391bcb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="wonder boy (japan) (alt 1).rom" size="0x8000" crc="5130c27b" sha1="1672af5bc1740480e8302f7690589ea5b5391bcb" />
 			</dataarea>
 		</part>
 	</software>
@@ -11528,8 +12579,9 @@ kept for now until finding out what those bytes affect...
 		<year>1988</year>
 		<publisher>Star Frontiers</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="takahasi meijin no boukenjima. wonder boy (1986)(hudson soft)[cr star frontiers].rom" size="32768" crc="78ab8fd7" sha1="b5cf03684c03dd74a9d5def34a4c2fc621c8b20d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="takahasi meijin no boukenjima. wonder boy (1986)(hudson soft)[cr star frontiers].rom" size="0x8000" crc="78ab8fd7" sha1="b5cf03684c03dd74a9d5def34a4c2fc621c8b20d" />
 			</dataarea>
 		</part>
 	</software>
@@ -11539,8 +12591,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="wonderboy.rom" size="32768" crc="9b4fb6c9" sha1="352d69066885fc2c7c75f0e3acd885f953916d1c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="wonderboy.rom" size="0x8000" crc="9b4fb6c9" sha1="352d69066885fc2c7c75f0e3acd885f953916d1c" />
 			</dataarea>
 		</part>
 	</software>
@@ -11551,8 +12604,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Brother Kougyou</publisher>
 		<info name="alt_title" value="タケル伝説" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="fuun takeshijyou (japan).rom" size="32768" crc="c57272c3" sha1="53337b61d7b86e6d18501967fcfc0908a00cc55c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="fuun takeshijyou (japan).rom" size="0x8000" crc="c57272c3" sha1="53337b61d7b86e6d18501967fcfc0908a00cc55c" />
 			</dataarea>
 		</part>
 	</software>
@@ -11564,8 +12618,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R49X5104" />
 		<info name="alt_title" value="谷川浩司の将棋指南" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="shougi sinan 1 (japan).rom" size="32768" crc="ead8e29c" sha1="1c4de8d4a1cbf5aa2bcf7816a1e55ee4584f59fb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="shougi sinan 1 (japan).rom" size="0x8000" crc="ead8e29c" sha1="1c4de8d4a1cbf5aa2bcf7816a1e55ee4584f59fb" />
 			</dataarea>
 		</part>
 	</software>
@@ -11577,8 +12632,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="09" />
 		<info name="alt_title" value="タンクバタリアン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="tank battalion (japan).rom" size="8192" crc="f48a0c3b" sha1="5bbcbd47f05a2742cfb0cad88856eb2df6e469fe" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="tank battalion (japan).rom" size="0x2000" crc="f48a0c3b" sha1="5bbcbd47f05a2742cfb0cad88856eb2df6e469fe" />
 			</dataarea>
 		</part>
 	</software>
@@ -11588,9 +12644,12 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="タティカ" />
+		<info name="serial" value="20130"/>
+		<info name="isbn" value="4871488128"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="tatica (japan).rom" size="16384" crc="7914f7a6" sha1="7fef9411858b1ff3ff019646e9e7aa0c61c7e87d" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="tatica (japan).rom" size="0x4000" crc="7914f7a6" sha1="7fef9411858b1ff3ff019646e9e7aa0c61c7e87d" />
 			</dataarea>
 		</part>
 	</software>
@@ -11600,9 +12659,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="たわらくん ~ Tawara-kun" />
+		<info name="serial" value="20082"/>
+		<info name="isbn" value="4871489612"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="tawara-kun (japan).rom" size="16384" crc="589ce03e" sha1="14f2d64d05e2e53e876e3d6af0a5711e557e3c96" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="tawara-kun (japan).rom" size="0x4000" crc="589ce03e" sha1="14f2d64d05e2e53e876e3d6af0a5711e557e3c96" />
 			</dataarea>
 		</part>
 	</software>
@@ -11612,9 +12674,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="たわらくん ~ Tawara-kun" />
+		<info name="serial" value="20082"/>
+		<info name="isbn" value="4871489612"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="tawara-kun (japan) (alt 1).rom" size="16384" crc="d69e9ea6" sha1="8dd49e12677443aede319f41bf3f82a08d0e5b5d" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="tawara-kun (japan) (alt 1).rom" size="0x4000" crc="d69e9ea6" sha1="8dd49e12677443aede319f41bf3f82a08d0e5b5d" />
 			</dataarea>
 		</part>
 	</software>
@@ -11624,9 +12689,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="たわらくん ~ Tawara-kun" />
+		<info name="serial" value="20082"/>
+		<info name="isbn" value="4871489612"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="tawara-kun (japan) (alt 2).rom" size="16384" crc="895cb183" sha1="8f74c91e6598d8de188ae1b506c44229c768b11f" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="tawara-kun (japan) (alt 2).rom" size="0x4000" crc="895cb183" sha1="8f74c91e6598d8de188ae1b506c44229c768b11f" />
 			</dataarea>
 		</part>
 	</software>
@@ -11636,9 +12704,12 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Victor</publisher>
 		<info name="alt_title" value="ナイルの涙 ~ Nile no Namida (Box?)" />
+		<info name="serial" value="M-2006"/>
+		<info name="gtin" value="04988002102358"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tear of nile (japan).rom" size="32768" crc="867ba302" sha1="a8eff8c532da894c86198b04b0a5d7707feb28c5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="tear of nile (japan).rom" size="0x8000" crc="867ba302" sha1="a8eff8c532da894c86198b04b0a5d7707feb28c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -11648,9 +12719,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="テレバニー" />
+		<info name="serial" value="00210"/>
+		<info name="isbn" value="4871489450"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="telebunnie (japan).rom" size="16384" crc="377fefef" sha1="4e17efbe87adc232c055d0dc26eb4476c661aafe" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="telebunnie (japan).rom" size="0x4000" crc="377fefef" sha1="4e17efbe87adc232c055d0dc26eb4476c661aafe" />
 			</dataarea>
 		</part>
 	</software>
@@ -11660,9 +12734,12 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="テレバニー" />
+		<info name="serial" value="00210"/>
+		<info name="isbn" value="4871489450"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="telebunnie (japan) (alt 1).rom" size="16384" crc="29314400" sha1="50439f12ddff3ed449da3cc1442385aaba609e7d" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="telebunnie (japan) (alt 1).rom" size="0x4000" crc="29314400" sha1="50439f12ddff3ed449da3cc1442385aaba609e7d" />
 			</dataarea>
 		</part>
 	</software>
@@ -11674,45 +12751,53 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="PS-2018G" />
 		<info name="alt_title" value="天才ラビアン大奮戦" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tensai rabbian daifunsen (japan).rom" size="32768" crc="b7322600" sha1="249da12e2711c643c5e18cf96184d33dbf7e2305" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="tensai rabbian daifunsen (japan).rom" size="0x8000" crc="b7322600" sha1="249da12e2711c643c5e18cf96184d33dbf7e2305" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="tenshit">
 		<description>Tenshi-tachi no Gogo (Japan)</description>
 		<year>1987</year>
 		<publisher>Jast</publisher>
 		<info name="alt_title" value="天使たちの午後" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tensidachino gogo (japan).rom" size="32768" crc="c58fbb99" sha1="010d5f325fc38c5b590841d15ce4f07d59f2a4cb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="tensidachino gogo (japan).rom" size="0x8000" crc="c58fbb99" sha1="010d5f325fc38c5b590841d15ce4f07d59f2a4cb" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Copyright message does not mention ASCII. -->
 	<software name="tetrahor">
 		<description>Tetra Horror (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="テトラホラー" />
+		<info name="serial" value="00290"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="tetra horror (japan).rom" size="16384" crc="e2d3377c" sha1="53814fdfeacce237bb68fb9056d005eb614b708a" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="tetra horror (japan).rom" size="0x4000" crc="e2d3377c" sha1="53814fdfeacce237bb68fb9056d005eb614b708a" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Copyright message mentions ASCII. -->
 	<software name="tetrahora" cloneof="tetrahor">
 		<description>Tetra Horror (Japan, alt)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="テトラホラー" />
+		<info name="serial" value="00290"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="tetra horror (japan) (alt 1).rom" size="16384" crc="2e1be8b6" sha1="4ff12fc3adf389a1f76a7a9bab6b2fd20044f5b4" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="tetra horror (japan) (alt 1).rom" size="0x4000" crc="2e1be8b6" sha1="4ff12fc3adf389a1f76a7a9bab6b2fd20044f5b4" />
 			</dataarea>
 		</part>
 	</software>
@@ -11721,9 +12806,11 @@ kept for now until finding out what those bytes affect...
 		<description>Tetris (Korea)</description>
 		<year>19??</year>
 		<publisher>Zemina</publisher>
+		<info name="serial" value="002"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tetris (korea) (unl).rom" size="32768" crc="adcb026d" sha1="e9398aceb9f8a648e4bcebe02e5d7b14a3744c7d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="tetris (korea) (unl).rom" size="0x8000" crc="adcb026d" sha1="e9398aceb9f8a648e4bcebe02e5d7b14a3744c7d" />
 			</dataarea>
 		</part>
 	</software>
@@ -11732,9 +12819,11 @@ kept for now until finding out what those bytes affect...
 		<description>Tetris (Korea, alt)</description>
 		<year>198?</year>
 		<publisher>Zemina</publisher>
+		<info name="serial" value="002"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tetrisa.rom" size="32768" crc="b358d5a7" sha1="90df63292fc2f210b88cc8ec284391423d21c917" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="tetrisa.rom" size="0x8000" crc="b358d5a7" sha1="90df63292fc2f210b88cc8ec284391423d21c917" />
 			</dataarea>
 		</part>
 	</software>
@@ -11744,36 +12833,39 @@ kept for now until finding out what those bytes affect...
 		<year>1989</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tetris2.rom" size="32768" crc="d1e2f414" sha1="93b9420a4b0590b43163c02b43d7fbfd51fe9a92" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="tetris2.rom" size="0x8000" crc="d1e2f414" sha1="93b9420a4b0590b43163c02b43d7fbfd51fe9a92" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="tetsuman">
 		<description>Tetsuman (Japan)</description>
 		<year>1985</year>
 		<publisher>HAL Kenkyuujo</publisher>
 		<info name="serial" value="HM-017" />
 		<info name="alt_title" value="てつまん" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="tetsuman (japan).rom" size="16384" crc="929d6786" sha1="3c29eef381d77f8c1f425a3e29919013c72f875c" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="tetsuman (japan).rom" size="0x4000" crc="929d6786" sha1="3c29eef381d77f8c1f425a3e29919013c72f875c" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="tetsumana" cloneof="tetsuman">
 		<description>Tetsuman (Japan, alt)</description>
 		<year>1985</year>
 		<publisher>HAL Kenkyuujo</publisher>
 		<info name="serial" value="HM-017" />
 		<info name="alt_title" value="てつまん" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="tetsuman (japan) (alt 1).rom" size="16384" crc="b6c02ae7" sha1="f6711e1e2bac04d45b8988f1d03529ad777abf4e" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="tetsuman (japan) (alt 1).rom" size="0x4000" crc="b6c02ae7" sha1="f6711e1e2bac04d45b8988f1d03529ad777abf4e" />
 			</dataarea>
 		</part>
 	</software>
@@ -11781,11 +12873,12 @@ kept for now until finding out what those bytes affect...
 	<software name="thexder">
 		<description>Thexder (Japan)</description>
 		<year>1986</year>
-		<publisher>Game Arts?</publisher>
+		<publisher>Game Arts</publisher>
 		<info name="alt_title" value="テクザー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="thexder (japan).rom" size="32768" crc="599aa9ac" sha1="a2109da08b1921c4b3b47c6847598d424581b508" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="thexder (japan).rom" size="0x8000" crc="599aa9ac" sha1="a2109da08b1921c4b3b47c6847598d424581b508" />
 			</dataarea>
 		</part>
 	</software>
@@ -11793,11 +12886,12 @@ kept for now until finding out what those bytes affect...
 	<software name="thexdera" cloneof="thexder">
 		<description>Thexder (Japan, alt)</description>
 		<year>1986</year>
-		<publisher>Game Arts?</publisher>
+		<publisher>Game Arts</publisher>
 		<info name="alt_title" value="テクザー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="thexder (japan) (alt 1).rom" size="32768" crc="da428d4b" sha1="6420473ec647e4d750bc2247020b6722435b5211" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="thexder (japan) (alt 1).rom" size="0x8000" crc="da428d4b" sha1="6420473ec647e4d750bc2247020b6722435b5211" />
 			</dataarea>
 		</part>
 	</software>
@@ -11805,11 +12899,12 @@ kept for now until finding out what those bytes affect...
 	<software name="thexderb" cloneof="thexder">
 		<description>Thexder (Japan, alt 2)</description>
 		<year>1986</year>
-		<publisher>Game Arts?</publisher>
+		<publisher>Game Arts</publisher>
 		<info name="alt_title" value="テクザー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="thexder (japan) (alt 2).rom" size="32768" crc="61704513" sha1="049e7dccd3977049b5f68aad7754105b014ba771" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="thexder (japan) (alt 2).rom" size="0x8000" crc="61704513" sha1="049e7dccd3977049b5f68aad7754105b014ba771" />
 			</dataarea>
 		</part>
 	</software>
@@ -11820,8 +12915,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="용의 전설" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="thrdrsto.rom" size="32768" crc="f052e5fb" sha1="6a7ab69c47cc168dd872d32f395541be4939255e" offset="000000" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="thrdrsto.rom" size="0x8000" crc="f052e5fb" sha1="6a7ab69c47cc168dd872d32f395541be4939255e" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -11833,8 +12929,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="2013603" />
 		<info name="alt_title" value="サンダーボール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="thunder ball (japan).rom" size="32768" crc="86f902a9" sha1="4f73ba24163946f6247523fc3f2aa5de00c3d7a6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="thunder ball (japan).rom" size="0x8000" crc="86f902a9" sha1="4f73ba24163946f6247523fc3f2aa5de00c3d7a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -11846,8 +12943,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="2013603" />
 		<info name="alt_title" value="サンダーボール" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="thunder ball (japan) (alt 1).rom" size="32768" crc="b06b8920" sha1="de5da311941056a90cab28fd91522c054871513f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="thunder ball (japan) (alt 1).rom" size="0x8000" crc="b06b8920" sha1="de5da311941056a90cab28fd91522c054871513f" />
 			</dataarea>
 		</part>
 	</software>
@@ -11859,8 +12957,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="AR-8601" />
 		<info name="alt_title" value="サンダーボルト" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="thunderbolt (japan).rom" size="32768" crc="d8739501" sha1="136f2dedd45f4419837eb1e4e623cb1dc317ef39" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="thunderbolt (japan).rom" size="0x8000" crc="d8739501" sha1="136f2dedd45f4419837eb1e4e623cb1dc317ef39" />
 			</dataarea>
 		</part>
 	</software>
@@ -11872,8 +12971,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="AR-8601" />
 		<info name="alt_title" value="サンダーボルト" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="thunderbolt (japan) (alt 1).rom" size="32768" crc="6b63047c" sha1="b3d57f968fdfebe77f78c05f4a075d139f219ae0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="thunderbolt (japan) (alt 1).rom" size="0x8000" crc="6b63047c" sha1="b3d57f968fdfebe77f78c05f4a075d139f219ae0" />
 			</dataarea>
 		</part>
 	</software>
@@ -11885,8 +12985,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="AR-8601" />
 		<info name="alt_title" value="サンダーボルト" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="thunderbolt (japan) (alt 2).rom" size="32768" crc="de3a82f5" sha1="d1fcd47f6b68fcee9914b32fd48b2634cf60c994" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="thunderbolt (japan) (alt 2).rom" size="0x8000" crc="de3a82f5" sha1="d1fcd47f6b68fcee9914b32fd48b2634cf60c994" />
 			</dataarea>
 		</part>
 	</software>
@@ -11895,10 +12996,12 @@ kept for now until finding out what those bytes affect...
 		<description>Time Pilot (Japan)</description>
 		<year>1983</year>
 		<publisher>Konami</publisher>
+		<info name="alt_title" value="タイムパイロット"/>
 		<info name="serial" value="RC703" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="time pilot (japan).rom" size="16384" crc="e4abe008" sha1="c1c5ec4042760880216f781ebd5e7174a3b0f9ca" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="time pilot (japan).rom" size="0x4000" crc="e4abe008" sha1="c1c5ec4042760880216f781ebd5e7174a3b0f9ca" />
 			</dataarea>
 		</part>
 	</software>
@@ -11907,10 +13010,12 @@ kept for now until finding out what those bytes affect...
 		<description>Time Pilot (Japan, alt)</description>
 		<year>1983</year>
 		<publisher>Konami</publisher>
+		<info name="alt_title" value="タイムパイロット"/>
 		<info name="serial" value="RC703" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="time pilot (japan) (alt 1).rom" size="16384" crc="23152fc3" sha1="b3c2dc4d1c940ddb4b9e742b8f5a47ab1e2d385f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="time pilot (japan) (alt 1).rom" size="0x4000" crc="23152fc3" sha1="b3c2dc4d1c940ddb4b9e742b8f5a47ab1e2d385f" />
 			</dataarea>
 		</part>
 	</software>
@@ -11921,8 +13026,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Aproman</publisher>
 		<info name="alt_title" value="띠띠!빵빵!" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ti ti pang pang.rom" size="32768" crc="2808a3bc" sha1="00ffd7adfc0a7a342912344ad64902e226b3ad41" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ti ti pang pang.rom" size="0x8000" crc="2808a3bc" sha1="00ffd7adfc0a7a342912344ad64902e226b3ad41" />
 			</dataarea>
 		</part>
 	</software>
@@ -11930,10 +13036,13 @@ kept for now until finding out what those bytes affect...
 	<software name="toprollr">
 		<description>Top Roller! (Japan)</description>
 		<year>1984</year>
-		<publisher>Jaleco</publisher>
+		<publisher>Toshiba</publisher>
+		<info name="alt_title" value="トップローラー"/>
+		<info name="serial" value="HX-S119"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="top roller (japan).rom" size="16384" crc="fc609730" sha1="37c85041128ee21300327726b7300a20ef6b84dd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="top roller (japan).rom" size="0x4000" crc="fc609730" sha1="37c85041128ee21300327726b7300a20ef6b84dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -11945,8 +13054,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MK-8618" />
 		<info name="alt_title" value="トップルジップ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="topple zip (japan).rom" size="32768" crc="190f4ce5" sha1="ea8d86ac74dcdca1c72daae517722431767c5ad2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="topple zip (japan).rom" size="0x8000" crc="190f4ce5" sha1="ea8d86ac74dcdca1c72daae517722431767c5ad2" />
 			</dataarea>
 		</part>
 	</software>
@@ -11958,8 +13068,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="12" />
 		<info name="alt_title" value="ドルアーガの塔 ~ Druaga no Tou" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tower of druaga, the (japan).rom" size="32768" crc="47bef309" sha1="9b815efaa927c11827acfdb0f9b9197b5ac97572" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="tower of druaga, the (japan).rom" size="0x8000" crc="47bef309" sha1="9b815efaa927c11827acfdb0f9b9197b5ac97572" />
 			</dataarea>
 		</part>
 	</software>
@@ -11970,8 +13081,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC710" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="track &amp; field 1 (europe).rom" size="16384" crc="e96b861d" sha1="9b55970341aaab59a73ae921c6ccf29009c1a8f0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="track &amp; field 1 (europe).rom" size="0x4000" crc="e96b861d" sha1="9b55970341aaab59a73ae921c6ccf29009c1a8f0" />
 			</dataarea>
 		</part>
 	</software>
@@ -11982,8 +13094,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC711" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="track &amp; field 2 (europe).rom" size="16384" crc="b1ff5899" sha1="be16501255617bade264dbf63dc59008e1d84ac8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="track &amp; field 2 (europe).rom" size="0x4000" crc="b1ff5899" sha1="be16501255617bade264dbf63dc59008e1d84ac8" />
 			</dataarea>
 		</part>
 	</software>
@@ -11995,8 +13108,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G046C" />
 		<info name="alt_title" value="渋滞パニックトラフィック ~ Juutai Panic Traffic" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="traffic (japan).rom" size="32768" crc="b80ebeb4" sha1="7dbeaf25e3a1a66f9c6b331332dc36e73b511d4a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="traffic (japan).rom" size="0x8000" crc="b80ebeb4" sha1="7dbeaf25e3a1a66f9c6b331332dc36e73b511d4a" />
 			</dataarea>
 		</part>
 	</software>
@@ -12008,8 +13122,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-G046C" />
 		<info name="alt_title" value="渋滞パニックトラフィック ~ Juutai Panic Traffic" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="traffic (japan) (alt 1).rom" size="32768" crc="f6b87d85" sha1="503cbad7516c6fde89761388ab32845f35284cc6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="traffic (japan) (alt 1).rom" size="0x8000" crc="f6b87d85" sha1="503cbad7516c6fde89761388ab32845f35284cc6" />
 			</dataarea>
 		</part>
 	</software>
@@ -12019,21 +13134,26 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="トライアルスキー" />
+		<info name="serial" value="20097"/>
+		<info name="isbn" value="4871489620"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="trial ski (japan).rom" size="16384" crc="152bebc2" sha1="dfd7ef6fd86efd5c8019b59d8fa5c5a47cf90cd0" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="trial ski (japan).rom" size="0x4000" crc="152bebc2" sha1="dfd7ef6fd86efd5c8019b59d8fa5c5a47cf90cd0" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx does not list a cartridge release for this software. -->
 	<software name="trickboy">
 		<description>Trick Boy (Japan)</description>
 		<year>1984</year>
 		<publisher>T&amp;E Soft</publisher>
 		<info name="alt_title" value="トリックボーイ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="trick boy (japan).rom" size="16384" crc="e05798fa" sha1="e93da3d1910d513dbb78ad599adbb05eb92b5930" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="trick boy (japan).rom" size="0x4000" crc="e05798fa" sha1="e93da3d1910d513dbb78ad599adbb05eb92b5930" />
 			</dataarea>
 		</part>
 	</software>
@@ -12045,8 +13165,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MXZS-11003" />
 		<info name="alt_title" value="トリトーン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tritorn (japan).rom" size="32768" crc="c0a81a48" sha1="4a35065d97d81a94a7649d19b3f9abd34f834eab" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="tritorn (japan).rom" size="0x8000" crc="c0a81a48" sha1="4a35065d97d81a94a7649d19b3f9abd34f834eab" />
 			</dataarea>
 		</part>
 	</software>
@@ -12057,9 +13178,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Toshiba EMI</publisher>
 		<info name="serial" value="PS-2020G" />
 		<info name="alt_title" value="トランプエイド" />
+		<info name="gtin" value="04988006006836"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="trumpaid (japan).rom" size="32768" crc="dfada43c" sha1="8547ae0fa25b9f3e26b90d4f3e1a4325b9248549" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="trumpaid (japan).rom" size="0x8000" crc="dfada43c" sha1="8547ae0fa25b9f3e26b90d4f3e1a4325b9248549" />
 			</dataarea>
 		</part>
 	</software>
@@ -12070,9 +13193,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00230" />
 		<info name="alt_title" value="ターボート" />
+		<info name="isbn" value="4871489434"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="turboat (japan).rom" size="16384" crc="c7abc409" sha1="08be92145a99dd6e0539ff79dca62b2f4cc59b0b" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="turboat (japan).rom" size="0x4000" crc="c7abc409" sha1="08be92145a99dd6e0539ff79dca62b2f4cc59b0b" />
 			</dataarea>
 		</part>
 	</software>
@@ -12081,9 +13206,11 @@ kept for now until finding out what those bytes affect...
 		<description>Turmoil (Japan)</description>
 		<year>1984</year>
 		<publisher>ASCII</publisher>
+		<info name="serial" value="001A0"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="turmoil (japan).rom" size="16384" crc="17683f42" sha1="6b496a50626c3e67dfe49c15a3847448dbeb05a8" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="turmoil (japan).rom" size="0x4000" crc="17683f42" sha1="6b496a50626c3e67dfe49c15a3847448dbeb05a8" />
 			</dataarea>
 		</part>
 	</software>
@@ -12093,8 +13220,9 @@ kept for now until finding out what those bytes affect...
 		<year>1984?</year>
 		<publisher>Qnix</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="turmoil (1984)(qnix).rom" size="16384" crc="2cf9d4ab" sha1="8e413a3be17e3f0e4304219a413a5eb04f2b3a04" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="turmoil (1984)(qnix).rom" size="0x4000" crc="2cf9d4ab" sha1="8e413a3be17e3f0e4304219a413a5eb04f2b3a04" />
 			</dataarea>
 		</part>
 	</software>
@@ -12105,9 +13233,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC740" />
 		<info name="alt_title" value="ツインビー" />
+		<info name="gtin" value="04988602510034"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="twin bee (japan).rom" size="32768" crc="c730d4a4" sha1="d33fe18ede20da4dd3d6991a9c2995e149c8fc3f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="twin bee (japan).rom" size="0x8000" crc="c730d4a4" sha1="d33fe18ede20da4dd3d6991a9c2995e149c8fc3f" />
 			</dataarea>
 		</part>
 	</software>
@@ -12118,9 +13248,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC740" />
 		<info name="alt_title" value="ツインビー" />
+		<info name="gtin" value="04988602510034"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="twin bee (japan) (alt 1).rom" size="32768" crc="71309c8f" sha1="751d722a4f36a03e88ac62118ae8d880e40c1c84" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="twin bee (japan) (alt 1).rom" size="0x8000" crc="71309c8f" sha1="751d722a4f36a03e88ac62118ae8d880e40c1c84" />
 			</dataarea>
 		</part>
 	</software>
@@ -12131,9 +13263,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC740" />
 		<info name="alt_title" value="ツインビー" />
+		<info name="gtin" value="04988602510034"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="twin bee (japan) (alt 2).rom" size="32768" crc="3827a473" sha1="adb3977309d373ad1dc995ae7d2f8280f1673d66" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="twin bee (japan) (alt 2).rom" size="0x8000" crc="3827a473" sha1="adb3977309d373ad1dc995ae7d2f8280f1673d66" />
 			</dataarea>
 		</part>
 	</software>
@@ -12144,9 +13278,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC740" />
 		<info name="alt_title" value="ツインビー" />
+		<info name="gtin" value="04988602510034"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="twin bee (japan) (alt 3).rom" size="32768" crc="23260108" sha1="8b828d33dcdfd324df1827ef79f5ca9635968c6e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="twin bee (japan) (alt 3).rom" size="0x8000" crc="23260108" sha1="8b828d33dcdfd324df1827ef79f5ca9635968c6e" />
 			</dataarea>
 		</part>
 	</software>
@@ -12156,8 +13292,9 @@ kept for now until finding out what those bytes affect...
 		<year>1989</year>
 		<publisher>Best</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="twin hammer (europe).rom" size="32768" crc="28a7cebc" sha1="4fa5382df5a8ff7d631be22bb8445e7bc8018a11" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="twin hammer (europe).rom" size="0x8000" crc="28a7cebc" sha1="4fa5382df5a8ff7d631be22bb8445e7bc8018a11" />
 			</dataarea>
 		</part>
 	</software>
@@ -12168,9 +13305,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>ASCII</publisher>
 		<info name="serial" value="2018801" />
 		<info name="alt_title" value="ＴＺＲグランプリライダー" />
+		<info name="isbn" value="4871488934"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="tzr - grand prix rider (japan).rom" size="32768" crc="d792c827" sha1="f3c0c1f0ec3e10cd4a5eaae26d593198b1a5ab9a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="tzr - grand prix rider (japan).rom" size="0x8000" crc="d792c827" sha1="f3c0c1f0ec3e10cd4a5eaae26d593198b1a5ab9a" />
 			</dataarea>
 		</part>
 	</software>
@@ -12179,11 +13318,12 @@ kept for now until finding out what those bytes affect...
 		<description>Ultraman (Japan)</description>
 		<year>1984</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="BMX-003" />
+		<info name="serial" value="BMX-003 / 0201252" />
 		<info name="alt_title" value="ウルトラマン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="ultraman (japan).rom" size="16384" crc="973d816d" sha1="e73a449e34652c18af0a72ab5c3637afa57d5842" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="ultraman (japan).rom" size="0x4000" crc="973d816d" sha1="e73a449e34652c18af0a72ab5c3637afa57d5842" />
 			</dataarea>
 		</part>
 	</software>
@@ -12193,13 +13333,17 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Victor</publisher>
 		<info name="alt_title" value="ヴィーナスファイヤー" />
+		<info name="serial" value="M-2007"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="venus fire (japan).rom" size="32768" crc="ee0b8452" sha1="df797593395346e94aa1cf13a9524e30d631888d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="venus fire (japan).rom" size="0x8000" crc="ee0b8452" sha1="df797593395346e94aa1cf13a9524e30d631888d" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Konami logo on black background. -->
 	<software name="hustler" cloneof="konbill">
 		<description>Video Hustler (Japan)</description>
 		<year>1984</year>
@@ -12207,12 +13351,14 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC706" />
 		<info name="alt_title" value="ビデオハスラー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="video hustler (japan).rom" size="8192" crc="64853262" sha1="82868a81d805fb391fce588623fc888296cbf62a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="video hustler (japan).rom" size="0x2000" crc="64853262" sha1="82868a81d805fb391fce588623fc888296cbf62a" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Konami logo on blue background. -->
 	<software name="hustlera" cloneof="konbill">
 		<description>Video Hustler (Japan, alt)</description>
 		<year>1984</year>
@@ -12220,8 +13366,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC706" />
 		<info name="alt_title" value="ビデオハスラー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="video hustler (japan) (alt 1).rom" size="8192" crc="8d99c3b0" sha1="eed68d254a17d76c36e094dd8a50a362a964e1b7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="video hustler (japan) (alt 1).rom" size="0x2000" crc="8d99c3b0" sha1="eed68d254a17d76c36e094dd8a50a362a964e1b7" />
 			</dataarea>
 		</part>
 	</software>
@@ -12230,11 +13377,12 @@ kept for now until finding out what those bytes affect...
 		<description>Vifam (Japan)</description>
 		<year>1984</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="0201253" />
+		<info name="serial" value="0201253 / BMX-004" />
 		<info name="alt_title" value="銀河漂流バイファム (Ginga Hyoryuu Vifam)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="bifamu (japan).rom" size="16384" crc="f3c1119a" sha1="ebff5d2b4253f62d3a00f1a6d6b4d81053c7b8a6" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="bifamu (japan).rom" size="0x4000" crc="f3c1119a" sha1="ebff5d2b4253f62d3a00f1a6d6b4d81053c7b8a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -12243,11 +13391,12 @@ kept for now until finding out what those bytes affect...
 		<description>Vifam (Japan, alt)</description>
 		<year>1984</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="0201253" />
+		<info name="serial" value="0201253 / BMX-004" />
 		<info name="alt_title" value="銀河漂流バイファム (Ginga Hyoryuu Vifam)" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="bifamu (japan) (alt 1).rom" size="16384" crc="fdaa85f0" sha1="4806e6bc1fd24d5a62c6df57ea8fd1b51d6e4b80" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="bifamu (japan) (alt 1).rom" size="0x4000" crc="fdaa85f0" sha1="4806e6bc1fd24d5a62c6df57ea8fd1b51d6e4b80" />
 			</dataarea>
 		</part>
 	</software>
@@ -12256,9 +13405,11 @@ kept for now until finding out what those bytes affect...
 		<description>Vigilante (Korea)</description>
 		<year>1990</year>
 		<publisher>Clover</publisher>
+		<info name="serial" value="G-M12"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="vigilante_(clover).rom" size="32768" crc="2619f221" sha1="eafd8cf86facdeb038e87900de4f1233dd69347c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="vigilante_(clover).rom" size="0x8000" crc="2619f221" sha1="eafd8cf86facdeb038e87900de4f1233dd69347c" />
 			</dataarea>
 		</part>
 	</software>
@@ -12270,8 +13421,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MSI-G2105-LI" />
 		<info name="alt_title" value="ヴォルガード" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="volguard (japan).rom" size="32768" crc="874e59fb" sha1="6dfc622e350d29859f05fddb3fa1f974cd4c8bf2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="volguard (japan).rom" size="0x8000" crc="874e59fb" sha1="6dfc622e350d29859f05fddb3fa1f974cd4c8bf2" />
 			</dataarea>
 		</part>
 	</software>
@@ -12283,8 +13435,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="04" />
 		<info name="alt_title" value="ワープ&amp;ワープ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="warp &amp; warp (japan).rom" size="8192" crc="90f5f414" sha1="52f95f6f4261be00ae1b9caf88a05c021c229e28" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="warp &amp; warp (japan).rom" size="0x2000" crc="90f5f414" sha1="52f95f6f4261be00ae1b9caf88a05c021c229e28" />
 			</dataarea>
 		</part>
 	</software>
@@ -12294,22 +13447,25 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Zemina</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="warpwarp.rom" size="32768" crc="e66eaed9" sha1="1f47ccfd979e653b96c9d7a36f62daf3a186e186" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="warpwarp.rom" size="0x8000" crc="e66eaed9" sha1="1f47ccfd979e653b96c9d7a36f62daf3a186e186" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="warrior">
 		<description>Warrior (Japan)</description>
 		<year>1983</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="00140" />
 		<info name="alt_title" value="ウォーリア" />
+		<info name="isbn" value="4871489256"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="columns (japan).rom" size="16384" crc="21a0b009" sha1="9b4da7636809d5690d6bd5d782ffa3cf9f4c63ec" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="columns (japan).rom" size="0x4000" crc="21a0b009" sha1="9b4da7636809d5690d6bd5d782ffa3cf9f4c63ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -12319,9 +13475,12 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ウォーロイド" />
+		<info name="serial" value="2013302"/>
+		<info name="isbn" value="487148839X"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="warroid (japan).rom" size="32768" crc="a0a19fd5" sha1="de6db54cef2cc4cbcc09c57c8ed0a1ff01347b6e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="warroid (japan).rom" size="0x8000" crc="a0a19fd5" sha1="de6db54cef2cc4cbcc09c57c8ed0a1ff01347b6e" />
 			</dataarea>
 		</part>
 	</software>
@@ -12331,45 +13490,51 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>ASCII</publisher>
 		<info name="alt_title" value="ウォーロイド" />
+		<info name="serial" value="2013302"/>
+		<info name="isbn" value="487148839X"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="warroid (japan) (alt 1).rom" size="32768" crc="e621ebc9" sha1="6ce0632acc2351ae968d7d3ce9c9a0af05c713cf" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="warroid (japan) (alt 1).rom" size="0x8000" crc="e621ebc9" sha1="6ce0632acc2351ae968d7d3ce9c9a0af05c713cf" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="waterdrv">
-		<description>Water Driver (Japan)</description>
+		<description>Water Driver (Spain)</description>
 		<year>1984</year>
-		<publisher>Colpax?</publisher>
-		<info name="alt_title" value="３Ｄウォータードライバー" />
+		<publisher>Sony Spain</publisher>
+		<info name="serial" value="HBS-I025"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="water driver (japan).rom" size="16384" crc="d5af9e82" sha1="28aaf59dadb425c1ef6fca860439f4e42e1737b8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="water driver (japan).rom" size="0x4000" crc="d5af9e82" sha1="28aaf59dadb425c1ef6fca860439f4e42e1737b8" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="wbells">
-		<description>Wedding Bells (Japan)</description>
+		<description>Wedding Bells (Spain)</description>
 		<year>1984</year>
-		<publisher>Nihon Columbia</publisher>
-		<info name="alt_title" value="ウェディングベル" />
+		<publisher>Sony Spain</publisher>
+		<info name="serial" value="HBS-I027"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="wedding bells (1984)(nippon columbia - colpax - universal).rom" size="16384" crc="00585f00" sha1="9dddbce94fb98776ad01870b98f44687b8b068c9" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="wedding bells (1984)(nippon columbia - colpax - universal).rom" size="0x4000" crc="00585f00" sha1="9dddbce94fb98776ad01870b98f44687b8b068c9" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="wbellsa" cloneof="wbells">
-		<description>Wedding Bells (Japan, alt)</description>
+		<description>Wedding Bells (Spain, alt)</description>
 		<year>1984</year>
-		<publisher>Nihon Columbia</publisher>
-		<info name="alt_title" value="ウェディングベル" />
+		<publisher>Sony Spain</publisher>
+		<info name="serial" value="HBS-I027"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="wedding bells (1984)(nippon columbia - colpax - universal)[a].rom" size="16384" crc="c41c55cb" sha1="aa2aaa193cddd15c230684499d68bf73f715ed9c" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="wedding bells (1984)(nippon columbia - colpax - universal)[a].rom" size="0x4000" crc="c41c55cb" sha1="aa2aaa193cddd15c230684499d68bf73f715ed9c" />
 			</dataarea>
 		</part>
 	</software>
@@ -12382,8 +13547,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="131072">
-				<rom name="wonsiin (kr).rom" size="131072" crc="a05258f5" sha1="f98f9c0fd32b2392b57b14105a9b730c8957d9b9" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="wonsiin (kr).rom" size="0x20000" crc="a05258f5" sha1="f98f9c0fd32b2392b57b14105a9b730c8957d9b9" />
 			</dataarea>
 		</part>
 	</software>
@@ -12394,8 +13559,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Sony Spain</publisher>
 		<info name="serial" value="HBS-I041" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="wrangler (spain).rom" size="16384" crc="7185f5e8" sha1="76209c36bec7ca971c6db2e3bbce267147e4a361" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="wrangler (spain).rom" size="0x4000" crc="7185f5e8" sha1="76209c36bec7ca971c6db2e3bbce267147e4a361" />
 			</dataarea>
 		</part>
 	</software>
@@ -12406,8 +13572,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Electric Software</publisher>
 		<info name="serial" value="5206/1" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="wreck, the (europe).rom" size="32768" crc="7efde800" sha1="58e335c943d2647c3ff1e689069d9fa5e1c7ff6e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="wreck, the (europe).rom" size="0x8000" crc="7efde800" sha1="58e335c943d2647c3ff1e689069d9fa5e1c7ff6e" />
 			</dataarea>
 		</part>
 	</software>
@@ -12419,8 +13586,8 @@ kept for now until finding out what those bytes affect...
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
 			<feature name="mapper" value="KONAMI" />
-			<dataarea name="rom" size="262144">
-				<rom name="dragon slayer 2 - xanadu (1987)(zemina).rom" size="262144" crc="119b7ba8" sha1="fcdbc5e15dd6b973e0f1112f4599dad985f48042" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="dragon slayer 2 - xanadu (1987)(zemina).rom" size="0x40000" crc="119b7ba8" sha1="fcdbc5e15dd6b973e0f1112f4599dad985f48042" />
 			</dataarea>
 		</part>
 	</software>
@@ -12431,8 +13598,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Zemina</publisher>
 		<info name="alt_title" value="마이크로 제비우스 ~ Micro Xevious (Box)"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="micro xevious.rom" size="32768" crc="58568aa5" sha1="1c4e9d38a8f57212dbf12f7aaba6549683b93ed4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="micro xevious.rom" size="0x8000" crc="58568aa5" sha1="1c4e9d38a8f57212dbf12f7aaba6549683b93ed4" />
 			</dataarea>
 		</part>
 	</software>
@@ -12442,9 +13610,11 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="ザイゾログ" />
+		<info name="serial" value="NH-MSX04"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="xyxolog (japan).rom" size="16384" crc="c7303910" sha1="15cc2f7412373253e908689a778738d52656ad74" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="xyxolog (japan).rom" size="0x4000" crc="c7303910" sha1="15cc2f7412373253e908689a778738d52656ad74" />
 			</dataarea>
 		</part>
 	</software>
@@ -12454,20 +13624,23 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Nidecom</publisher>
 		<info name="alt_title" value="ザイゾログ" />
+		<info name="serial" value="NH-MSX04"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="xyxolog (japan) (alt 1).rom" size="16384" crc="c9074b91" sha1="1e2abac01eb37e43a7a61da25dc147bbdc30ad32" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="xyxolog (japan) (alt 1).rom" size="0x4000" crc="c9074b91" sha1="1e2abac01eb37e43a7a61da25dc147bbdc30ad32" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="yabyum">
 		<description>Yab Yum (Netherlands)</description>
-		<year>19??</year>
+		<year>1985</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="yab yum (netherlands).rom" size="8192" crc="2836cd86" sha1="1a6c5ba03e0cc76f7e001784e1a205375f5602b8" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="yab yum (netherlands).rom" size="0x2000" crc="2836cd86" sha1="1a6c5ba03e0cc76f7e001784e1a205375f5602b8" />
 			</dataarea>
 		</part>
 	</software>
@@ -12479,8 +13652,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Hudson Soft</publisher>
 		<info name="alt_title" value="野球狂" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="honkball (japan).rom" size="32768" crc="24b94274" sha1="f27721cf9ec316ea3b18233f699febf739b25678" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="honkball (japan).rom" size="0x8000" crc="24b94274" sha1="f27721cf9ec316ea3b18233f699febf739b25678" />
 			</dataarea>
 		</part>
 	</software>
@@ -12491,9 +13665,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-131" />
 		<info name="alt_title" value="闇の竜王ハデスの紋章" />
+		<info name="gtin" value="04971850104995"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hades no monsho (japan).rom" size="32768" crc="4d105f57" sha1="fcc6b6b9f05de409492a1fb988fa671e46d54196" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hades no monsho (japan).rom" size="0x8000" crc="4d105f57" sha1="fcc6b6b9f05de409492a1fb988fa671e46d54196" />
 			</dataarea>
 		</part>
 	</software>
@@ -12504,9 +13680,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-131" />
 		<info name="alt_title" value="闇の竜王ハデスの紋章" />
+		<info name="gtin" value="04971850104995"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hades no monsho (japan) (alt 1).rom" size="32768" crc="f42f4a15" sha1="1804cfbc4f175136b7b934b575d49cbc0e726ffe" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hades no monsho (japan) (alt 1).rom" size="0x8000" crc="f42f4a15" sha1="1804cfbc4f175136b7b934b575d49cbc0e726ffe" />
 			</dataarea>
 		</part>
 	</software>
@@ -12517,8 +13695,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Brother Kougyou</publisher>
 		<info name="alt_title" value="イエローサブマリン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="yellow submarine (japan).rom" size="16384" crc="71e6605f" sha1="939ed6053363112c34766335b93d0ddf25059468" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="yellow submarine (japan).rom" size="0x4000" crc="71e6605f" sha1="939ed6053363112c34766335b93d0ddf25059468" />
 			</dataarea>
 		</part>
 	</software>
@@ -12530,8 +13709,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC725" />
 		<info name="alt_title" value="イーアルカンフー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="yie ar kung-fu (japan).rom" size="16384" crc="8a12ec4f" sha1="a3090a15c95334da3e0f94030eadee02b5032c0c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="yie ar kung-fu (japan).rom" size="0x4000" crc="8a12ec4f" sha1="a3090a15c95334da3e0f94030eadee02b5032c0c" />
 			</dataarea>
 		</part>
 	</software>
@@ -12543,8 +13723,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC725" />
 		<info name="alt_title" value="イーアルカンフー" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="yie ar kung-fu (japan) (alt 1).rom" size="16384" crc="0e197b49" sha1="8b3994ab39768f15617fb2cd9199000226b935bd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="yie ar kung-fu (japan) (alt 1).rom" size="0x4000" crc="0e197b49" sha1="8b3994ab39768f15617fb2cd9199000226b935bd" />
 			</dataarea>
 		</part>
 	</software>
@@ -12552,10 +13733,12 @@ kept for now until finding out what those bytes affect...
 	<software name="yieark" cloneof="yiear">
 		<description>Yie Ar Kung-Fu (Korea)</description>
 		<year>198?</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<publisher>Clover</publisher>
+		<info name="alt_title" value="쿵후"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="yakungfu.rom" size="32768" crc="372086b5" sha1="b0406a38453c3bffcc990576bb725bbf7acaf132" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="yakungfu.rom" size="0x8000" crc="372086b5" sha1="b0406a38453c3bffcc990576bb725bbf7acaf132" />
 			</dataarea>
 		</part>
 	</software>
@@ -12567,8 +13750,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC737" />
 		<info name="alt_title" value="イーガー皇帝の逆襲 ~ Yie-Gah Koutei no Gyakushuu" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="yie ar kung-fu ii - the emperor yie-gah (japan).rom" size="32768" crc="d66034a9" sha1="57827f8d49369e4dbf20a968e535374d35ff1648" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="yie ar kung-fu ii - the emperor yie-gah (japan).rom" size="0x8000" crc="d66034a9" sha1="57827f8d49369e4dbf20a968e535374d35ff1648" />
 			</dataarea>
 		</part>
 	</software>
@@ -12580,8 +13764,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC737" />
 		<info name="alt_title" value="イーガー皇帝の逆襲 ~ Yie-Gah Koutei no Gyakushuu" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="yie ar kung-fu ii - the emperor yie-gah (japan) (alt 1).rom" size="32768" crc="8099f5c7" sha1="609d0bac4933d1bcc877746a3e14d82c204f40e7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="yie ar kung-fu ii - the emperor yie-gah (japan) (alt 1).rom" size="0x8000" crc="8099f5c7" sha1="609d0bac4933d1bcc877746a3e14d82c204f40e7" />
 			</dataarea>
 		</part>
 	</software>
@@ -12593,8 +13778,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="RC737" />
 		<info name="alt_title" value="イーガー皇帝の逆襲 ~ Yie-Gah Koutei no Gyakushuu" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="yie ar kung-fu ii - the emperor yie-gah (japan) (alt 2).rom" size="32768" crc="70e679c3" sha1="5017abeca8fbed43ff2fd1a936843acdc7192dcc" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="yie ar kung-fu ii - the emperor yie-gah (japan) (alt 2).rom" size="0x8000" crc="70e679c3" sha1="5017abeca8fbed43ff2fd1a936843acdc7192dcc" />
 			</dataarea>
 		</part>
 	</software>
@@ -12606,8 +13792,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MK-7401" />
 		<info name="alt_title" value="妖怪探偵ちまちま" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="yokai tanken chimachima (japan).rom" size="32768" crc="8d636963" sha1="c60a28a4048710ad3c63ef5bcf4ce03db54c00bb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="yokai tanken chimachima (japan).rom" size="0x8000" crc="8d636963" sha1="c60a28a4048710ad3c63ef5bcf4ce03db54c00bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -12618,9 +13805,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-123" />
 		<info name="alt_title" value="妖怪屋敷" />
+		<info name="gtin" value="04971850104179"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="haunted boynight (japan).rom" size="32768" crc="2faf6e26" sha1="15345c8745028c96fc79036b2e3e180ad2f62dab" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="haunted boynight (japan).rom" size="0x8000" crc="2faf6e26" sha1="15345c8745028c96fc79036b2e3e180ad2f62dab" />
 			</dataarea>
 		</part>
 	</software>
@@ -12631,73 +13820,74 @@ kept for now until finding out what those bytes affect...
 		<publisher>Cosmos Computer</publisher>
 		<info name="alt_title" value="超戦士ザイダーバトルオブペガス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zaider - battle of peguss (japan).rom" size="32768" crc="beccf133" sha1="de765e699af4d76d8fa80fb10d1e41581bec11bf" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zaider - battle of peguss (japan).rom" size="0x8000" crc="beccf133" sha1="de765e699af4d76d8fa80fb10d1e41581bec11bf" />
 			</dataarea>
 		</part>
 	</software>
 
-<!-- is this bad? title screen is broken... -->
 	<software name="zaidera" cloneof="zaider">
 		<description>Chou Senshi Zaider - Battle of Peguss (Japan, alt)</description>
 		<year>1986</year>
 		<publisher>Cosmos Computer</publisher>
 		<info name="alt_title" value="超戦士ザイダーバトルオブペガス" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zaider - battle of peguss (japan) (alt 1).rom" size="32768" crc="453bcd36" sha1="f784350af0c5c7407d83da2bb499c59a08496aac" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zaider - battle of peguss (japan) (alt 1).rom" size="0x8000" crc="453bcd36" sha1="f784350af0c5c7407d83da2bb499c59a08496aac" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="zanac2">
-		<description>Zanac 2nd Version (Japan)</description>
+		<description>Zanac A.I. - 2nd Version (Japan)</description>
 		<year>1987</year>
-		<publisher>Pony Canyon</publisher>
-		<info name="serial" value="R49X5093" />
-		<info name="alt_title" value="ザナック" />
+		<publisher>Takeru</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zanac (japan) (v2).rom" size="32768" crc="8f1917d4" sha1="b030b3c22baadd0d419657dcfa4b974ae1cd7508" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zanac (japan) (v2).rom" size="0x8000" crc="8f1917d4" sha1="b030b3c22baadd0d419657dcfa4b974ae1cd7508" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="zanac2a" cloneof="zanac2">
-		<description>Zanac 2nd Version (Japan, alt)</description>
+		<description>Zanac A.I. - 2nd Version (Japan, alt)</description>
 		<year>1987</year>
-		<publisher>Pony Canyon</publisher>
-		<info name="serial" value="R49X5093" />
-		<info name="alt_title" value="ザナック" />
+		<publisher>Takeru</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zanac (japan) (v2) (alt 1).rom" size="32768" crc="8414ea0e" sha1="ffa8fc5756f7e1d1ef168618f5606aca10f8b2c7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zanac (japan) (v2) (alt 1).rom" size="0x8000" crc="8414ea0e" sha1="ffa8fc5756f7e1d1ef168618f5606aca10f8b2c7" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="zanac">
-		<description>Zanac (Japan)</description>
+		<description>Zanac A.I. (Japan)</description>
 		<year>1986</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5093" />
 		<info name="alt_title" value="ザナック" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zanac (japan).rom" size="32768" crc="425e0d34" sha1="46e9ed7b7f6dfda8eee266476c9ebc4dd9d8fcc2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zanac (japan).rom" size="0x8000" crc="425e0d34" sha1="46e9ed7b7f6dfda8eee266476c9ebc4dd9d8fcc2" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="zanaca" cloneof="zanac">
-		<description>Zanac (Japan, alt)</description>
+		<description>Zanac A.I. (Japan, alt)</description>
 		<year>1986</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5093" />
 		<info name="alt_title" value="ザナック" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zanac (japan) (alt 1).rom" size="32768" crc="7f95533c" sha1="372623401599c57968daac0312dd9a0abbc6bd2f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zanac (japan) (alt 1).rom" size="0x8000" crc="7f95533c" sha1="372623401599c57968daac0312dd9a0abbc6bd2f" />
 			</dataarea>
 		</part>
 	</software>
@@ -12709,8 +13899,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5803" />
 		<info name="alt_title" value="ザクソン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zaxxon (japan).rom" size="32768" crc="0b3ba595" sha1="d88f33ee40839f87cdce6cc4820e1dd192a01776" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zaxxon (japan).rom" size="0x8000" crc="0b3ba595" sha1="d88f33ee40839f87cdce6cc4820e1dd192a01776" />
 			</dataarea>
 		</part>
 	</software>
@@ -12722,20 +13913,23 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="R48X5803" />
 		<info name="alt_title" value="ザクソン" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zaxxon (japan) (alt 1).rom" size="32768" crc="353dd532" sha1="3da301b1082c158e505523fa22c19f1b3f4d851c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zaxxon (japan) (alt 1).rom" size="0x8000" crc="353dd532" sha1="3da301b1082c158e505523fa22c19f1b3f4d851c" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Generation-msx does not list a seperate cartridge release for this software. -->
 	<software name="baduk">
 		<description>Zemmix Baduk Gyosil (Korea)</description>
 		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<publisher>Zemina</publisher>
 		<info name="alt_title" value="재믹스바둑교실" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="baduk.rom" size="16384" crc="5ad4442d" sha1="8301e32565cc81023c71da10f2f3e2f8befb7e3f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="baduk.rom" size="0x4000" crc="5ad4442d" sha1="8301e32565cc81023c71da10f2f3e2f8befb7e3f" />
 			</dataarea>
 		</part>
 	</software>
@@ -12745,12 +13939,13 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="alt_title" value="ゼンジー" />
+		<info name="serial" value="R48X5507"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="zenji (japan).rom" size="16384" crc="77b3b0b9" sha1="c9440172802818cc5b9ae559fbd3f346a263605c" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="zenji (japan).rom" size="0x4000" crc="77b3b0b9" sha1="c9440172802818cc5b9ae559fbd3f346a263605c" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -12762,8 +13957,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MS1-G2109-L1" />
 		<info name="alt_title" value="ゼクサスリミテッド" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zexas limited (japan).rom" size="32768" crc="efefa02a" sha1="a87971b9df0de44644c2188f5f475aef7ae85304" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zexas limited (japan).rom" size="0x8000" crc="efefa02a" sha1="a87971b9df0de44644c2188f5f475aef7ae85304" />
 			</dataarea>
 		</part>
 	</software>
@@ -12775,8 +13971,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MS1-G2109-L1" />
 		<info name="alt_title" value="ゼクサスリミテッド" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zexas limited (japan) (alt 1).rom" size="32768" crc="01a73292" sha1="9d5f6098b71712e9d9e386739b82fc484380f114" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zexas limited (japan) (alt 1).rom" size="0x8000" crc="01a73292" sha1="9d5f6098b71712e9d9e386739b82fc484380f114" />
 			</dataarea>
 		</part>
 	</software>
@@ -12788,8 +13985,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MS1-G2109-L1" />
 		<info name="alt_title" value="ゼクサスリミテッド" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zexas limited (japan) (alt 2).rom" size="32768" crc="1e48edca" sha1="71442ac703c2966142b04071fedf180e81daab9a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zexas limited (japan) (alt 2).rom" size="0x8000" crc="1e48edca" sha1="71442ac703c2966142b04071fedf180e81daab9a" />
 			</dataarea>
 		</part>
 	</software>
@@ -12800,9 +13998,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="R49X5804" />
 		<info name="alt_title" value="ズーム９０９" />
+		<info name="gtin" value="04988013000797"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zoom 909 (japan).rom" size="32768" crc="64283863" sha1="07db3e3ffb16c138f9da12cacde48bf7522a188c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zoom 909 (japan).rom" size="0x8000" crc="64283863" sha1="07db3e3ffb16c138f9da12cacde48bf7522a188c" />
 			</dataarea>
 		</part>
 	</software>
@@ -12812,8 +14012,9 @@ kept for now until finding out what those bytes affect...
 		<year>19??</year>
 		<publisher>Prosoft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="zoom 909 (1985)(sega)[cr prosoft].rom" size="32768" crc="34b186ad" sha1="626e4fc5f12f6f354baf6d607beadacbbafd74ce" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="zoom 909 (1985)(sega)[cr prosoft].rom" size="0x8000" crc="34b186ad" sha1="626e4fc5f12f6f354baf6d607beadacbbafd74ce" />
 			</dataarea>
 		</part>
 	</software>
@@ -12825,8 +14026,9 @@ kept for now until finding out what those bytes affect...
 		<year>1990</year>
 		<publisher>Nagi-P Soft</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="mars ii (japan).rom" size="8192" crc="48e9d13b" sha1="a3772599cdb84df71ef2bb38b1e2cb2f66593969" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="mars ii (japan).rom" size="0x2000" crc="48e9d13b" sha1="a3772599cdb84df71ef2bb38b1e2cb2f66593969" />
 			</dataarea>
 		</part>
 	</software>
@@ -12839,13 +14041,17 @@ kept for now until finding out what those bytes affect...
 
 <!-- Unconfirmed dumps (from misc collections) -->
 
-	<software name="cheese" supported="partial">
+	<!-- Sold with Neos MS-10 mouse. -->
+	<software name="cheese">
 		<description>Cheese (Japan)</description>
 		<year>1984</year>
 		<publisher>Nihon Electronics</publisher>
+		<info name="serial" value="MS-10R"/>
+		<info name="usage" value="Requires a mouse in general purpose port 1."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="cheese (japan) (program).rom" size="16384" crc="325bb241" sha1="dd5c2d2d5f0947159b7615f647fb8121f3b037a2" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="cheese (japan) (program).rom" size="0x4000" crc="325bb241" sha1="dd5c2d2d5f0947159b7615f647fb8121f3b037a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -12853,13 +14059,13 @@ kept for now until finding out what those bytes affect...
 	<software name="designer">
 		<description>The Designer's Pencil (Europe)</description>
 		<year>1984</year>
-		<publisher>Activision?</publisher>
+		<publisher>Activision</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="designer's pencil, the (europe) (program).rom" size="16384" crc="ce588c20" sha1="4b4a58a310a1138b95192d7fe0881bbdc45601d4" />
-				<rom size="16384" offset="0x4000" loadflag="reload" />
-				<rom size="16384" offset="0x8000" loadflag="reload" />
-				<rom size="16384" offset="0xc000" loadflag="reload" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="designer's pencil, the (europe) (program).rom" size="0x4000" crc="ce588c20" sha1="4b4a58a310a1138b95192d7fe0881bbdc45601d4" />
+				<rom size="0x4000" offset="0x4000" loadflag="reload" />
+				<rom size="0x4000" offset="0x8000" loadflag="reload" />
+				<rom size="0x4000" offset="0xc000" loadflag="reload" />
 			</dataarea>
 		</part>
 	</software>
@@ -12868,9 +14074,11 @@ kept for now until finding out what those bytes affect...
 		<description>Dr. Copy (Japan)</description>
 		<year>1987</year>
 		<publisher>Emiiru?</publisher>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="dr. copy (japan).rom" size="16384" crc="f7848700" sha1="6e6b8cdc55713eabc724f3ec9624e9884254ab33" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="dr. copy (japan).rom" size="0x4000" crc="f7848700" sha1="6e6b8cdc55713eabc724f3ec9624e9884254ab33" />
 			</dataarea>
 		</part>
 	</software>
@@ -12882,8 +14090,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-014" />
 		<info name="usage" value="Application can be entered from Basic by typing CALL EDDY2" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="eddy 2 (japan) (program).rom" size="16384" crc="2de03477" sha1="28bf2354cdd70e30b682f40b734029ece44d70bd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="eddy 2 (japan) (program).rom" size="0x4000" crc="2de03477" sha1="28bf2354cdd70e30b682f40b734029ece44d70bd" />
 			</dataarea>
 		</part>
 	</software>
@@ -12895,8 +14104,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-014" />
 		<info name="usage" value="Application can be entered from Basic by typing CALL EDDY2" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="eddy 2 (japan) (program) (alt 1).rom" size="16384" crc="141a6300" sha1="20f1883c45fc3c39ddf48a7de69b6ef588fac8fb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="eddy 2 (japan) (program) (alt 1).rom" size="0x4000" crc="141a6300" sha1="20f1883c45fc3c39ddf48a7de69b6ef588fac8fb" />
 			</dataarea>
 		</part>
 	</software>
@@ -12907,12 +14117,13 @@ kept for now until finding out what those bytes affect...
 		<publisher>R.Amy</publisher>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="easispeech" />
-			<dataarea name="rom" size="8192">
-				<rom name="easi-speech.rom" size="8192" crc="7b00670c" sha1="5a1a91cbba1790461def230d22503ec2c4719cc1" />
+			<dataarea name="rom" size="0x2000">
+				<rom name="easi-speech.rom" size="0x2000" crc="7b00670c" sha1="5a1a91cbba1790461def230d22503ec2c4719cc1" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Release includes a cartridge and a cassette. -->
 	<software name="falc">
 		<description>Family Automation Language Community (Japan)</description>
 		<year>1984</year>
@@ -12920,8 +14131,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-S002C" />
 		<info name="alt_title" value="ファルク" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="family automation language community (japan) (program).rom" size="32768" crc="fd8a5c1d" sha1="216243b4bcb9070f9e86c3f04edaaa493e4b459c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="family automation language community (japan) (program).rom" size="0x8000" crc="fd8a5c1d" sha1="216243b4bcb9070f9e86c3f04edaaa493e4b459c" />
 			</dataarea>
 		</part>
 	</software>
@@ -12932,8 +14144,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Sony</publisher>
 		<info name="serial" value="HBS-H019C" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="farm kit (europe) (program).rom" size="32768" crc="83e1aa1a" sha1="e6b71484d5ab578fd3695917fce3c1e805a5b536" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="farm kit (europe) (program).rom" size="0x8000" crc="83e1aa1a" sha1="e6b71484d5ab578fd3695917fce3c1e805a5b536" />
 			</dataarea>
 		</part>
 	</software>
@@ -12942,13 +14155,16 @@ kept for now until finding out what those bytes affect...
 		<description>FM Pana Amusement Cartridge</description>
 		<year>19??</year>
 		<publisher>Panasoft</publisher>
+		<info name="serial" value="SW-M004"/>
+		<info name="gtin" value="04902704840035"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="rom1" interface="msx_cart">
 			<feature name="slot" value="fmpac" />
 			<feature name="mapper" value="FM-PAC" />
-			<dataarea name="rom" size="65536">
-				<rom name="fmpac.rom" size="65536" crc="0e84505d" sha1="9d789166e3caf28e4742fe933d962e99618c633d" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="fmpac.rom" size="0x10000" crc="0e84505d" sha1="9d789166e3caf28e4742fe933d962e99618c633d" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -12957,9 +14173,12 @@ kept for now until finding out what those bytes affect...
 		<description>Game Master (Europe)</description>
 		<year>1985</year>
 		<publisher>Konami</publisher>
+		<info name="serial" value="RC735"/>
+		<info name="gtin" value="04988602502633"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="game master (europe).rom" size="16384" crc="160cfbd2" sha1="4fe90868376704336fbf45619a47ce18736ff1b2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="game master (europe).rom" size="0x4000" crc="160cfbd2" sha1="4fe90868376704336fbf45619a47ce18736ff1b2" />
 			</dataarea>
 		</part>
 	</software>
@@ -12968,9 +14187,12 @@ kept for now until finding out what those bytes affect...
 		<description>Game Master (Europe, alt)</description>
 		<year>1985</year>
 		<publisher>Konami</publisher>
+		<info name="serial" value="RC735"/>
+		<info name="gtin" value="04988602502633"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="game master (europe) (alt 1).rom" size="16384" crc="5bb30e2b" sha1="70ba2331844bd5c14906e9f2284eba119b3e41bf" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="game master (europe) (alt 1).rom" size="0x4000" crc="5bb30e2b" sha1="70ba2331844bd5c14906e9f2284eba119b3e41bf" />
 			</dataarea>
 		</part>
 	</software>
@@ -12979,26 +14201,31 @@ kept for now until finding out what those bytes affect...
 		<description>Hit-Bit Demo</description>
 		<year>1984</year>
 		<publisher>Sony</publisher>
+		<info name="serial" value="UR-843-2"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="sonydemo.rom" size="32768" crc="91e476f0" sha1="fc2a86cd2c24e2acce77a6d3e491821a03dccdfa" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="sonydemo.rom" size="0x8000" crc="91e476f0" sha1="fc2a86cd2c24e2acce77a6d3e491821a03dccdfa" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="homecalc">
 		<description>Home Calc (Japan)</description>
 		<year>1984</year>
-		<publisher>Matsushita</publisher>
+		<publisher>National</publisher>
 		<info name="alt_title" value="ホームカルク" />
+		<info name="serial" value="CF-SM001"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="home calc (japan) (program).rom" size="16384" crc="906c24ae" sha1="f29cac37c5001ddc752ff4a0b9cc51a965906da8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="home calc (japan) (program).rom" size="0x4000" crc="906c24ae" sha1="f29cac37c5001ddc752ff4a0b9cc51a965906da8" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Software is completely in English. -->
 	<software name="homewrtr">
 		<description>Home Writer (Japan)</description>
 		<year>1984</year>
@@ -13006,8 +14233,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-H003C" />
 		<info name="alt_title" value="パソコンタイプライター" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="home writer (japan) (program).rom" size="16384" crc="228e4ed2" sha1="cc06d65a9aba634e3ad75675b960140932506ffe" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="home writer (japan) (program).rom" size="0x4000" crc="228e4ed2" sha1="cc06d65a9aba634e3ad75675b960140932506ffe" />
 			</dataarea>
 		</part>
 	</software>
@@ -13018,9 +14246,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Victor</publisher>
 		<info name="serial" value="HS-R7501" />
 		<info name="alt_title" value="ジョイテロップ" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="joytelop (japan) (program).rom" size="32768" crc="6f9deb1b" sha1="5ceedd2ae401febb79c1f6a64ddef4b2e1790674" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="joytelop (japan) (program).rom" size="0x8000" crc="6f9deb1b" sha1="5ceedd2ae401febb79c1f6a64ddef4b2e1790674" />
 			</dataarea>
 		</part>
 	</software>
@@ -13033,35 +14263,40 @@ kept for now until finding out what those bytes affect...
 		<info name="alt_title" value="描きくけコン" />
 		<info name="usage" value="Application can be started from Basic by typing _GRATOOL or pressing F1" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="kakikukekon (japan) (program).rom" size="16384" crc="4a4a6148" sha1="632ef250c76b222158ba90dfc68b9e004dbafe3a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="kakikukekon (japan) (program).rom" size="0x4000" crc="4a4a6148" sha1="632ef250c76b222158ba90dfc68b9e004dbafe3a" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="keiba">
 		<description>The Keiba (Japan)</description>
 		<year>1986</year>
 		<publisher>Champion Soft</publisher>
 		<info name="alt_title" value="ザ・競馬" />
+		<info nmae="serial" value="MXCP-11005"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="keiba, the (japan) (program).rom" size="32768" crc="df958ed5" sha1="09779f0e9ec0c36ee3700690e2b6e282a4b40a0b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="keiba, the (japan) (program).rom" size="0x8000" crc="df958ed5" sha1="09779f0e9ec0c36ee3700690e2b6e282a4b40a0b" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Release contains a cartridge and a cassette. -->
 	<software name="konsynth">
 		<description>ShinyoSizer - Konami's Synthesizer (Japan)</description>
 		<year>1986</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC741" />
 		<info name="alt_title" value="新世ＳＩＺＥＲ" />
+		<info name="gtin" value="04988602510072"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="synthesizer" />
-			<dataarea name="rom" size="32768">
-				<rom name="konami's synthesizer (japan) (program).rom" size="32768" crc="b9b0999a" sha1="2feff37d593683ce1c7dfac33ed3207895e01a03" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="konami's synthesizer (japan) (program).rom" size="0x8000" crc="b9b0999a" sha1="2feff37d593683ce1c7dfac33ed3207895e01a03" />
 			</dataarea>
 		</part>
 	</software>
@@ -13072,9 +14307,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC735" />
 		<info name="alt_title" value="コナミのゲームを１０倍楽しむカートリッジ" />
+		<info name="gtin" value="04988602502633"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="game master (japan).rom" size="16384" crc="8f1a102e" sha1="9648d43f3c25d67b9e4972f777d7b02470080d1c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="game master (japan).rom" size="0x4000" crc="8f1a102e" sha1="9648d43f3c25d67b9e4972f777d7b02470080d1c" />
 			</dataarea>
 		</part>
 	</software>
@@ -13085,9 +14322,11 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC735" />
 		<info name="alt_title" value="コナミのゲームを１０倍楽しむカートリッジ" />
+		<info name="gtin" value="04988602502633"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="game master (japan) (alt 1).rom" size="16384" crc="bd1c5a59" sha1="abce0b855d67ac10bc667e0f23ceab4a12ffeee6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="game master (japan) (alt 1).rom" size="0x4000" crc="bd1c5a59" sha1="abce0b855d67ac10bc667e0f23ceab4a12ffeee6" />
 			</dataarea>
 		</part>
 	</software>
@@ -13098,13 +14337,14 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC755" />
 		<info name="alt_title" value="コナミの新１０倍カートリッジ" />
+		<info name="gtin" value="04988602532326"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="gamemaster2" />
 			<feature name="mapper" value="GMASTER2" />
-			<dataarea name="rom" size="131072">
-				<rom name="game master ii (japan).rom" size="131072" crc="084c5803" sha1="5c00f9e3a48411e08fac89b1dfdd2a6e95853919" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="game master ii (japan).rom" size="0x20000" crc="084c5803" sha1="5c00f9e3a48411e08fac89b1dfdd2a6e95853919" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
@@ -13115,58 +14355,67 @@ kept for now until finding out what those bytes affect...
 		<publisher>Konami</publisher>
 		<info name="serial" value="RC755" />
 		<info name="alt_title" value="コナミの新１０倍カートリッジ" />
+		<info name="gtin" value="04988602532326"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="gamemaster2" />
 			<feature name="mapper" value="GMASTER2" />
-			<dataarea name="rom" size="131072">
-				<rom name="game master ii (japan) (alt 1).rom" size="131072" crc="2d93f9cc" sha1="fe74b4df9698a61dffd3ac88f47619675514ba1c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="game master ii (japan) (alt 1).rom" size="0x20000" crc="2d93f9cc" sha1="fe74b4df9698a61dffd3ac88f47619675514ba1c" />
 			</dataarea>
-			<dataarea name="sram" size="8192">
+			<dataarea name="sram" size="0x2000">
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="nga2" supported="partial">
-		<description>The Links - NGA II - Network Game Adapter II (Japan)</description>
+	<!-- Modem hardware not emulated -->
+	<software name="nga2" supported="no">
+		<description>The Links - NGA II - NT-300 - Network Game Adapter II (Japan)</description>
 		<year>198?</year>
 		<publisher>Nihon Telenet</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="links, the (japan) (nga ii) (program).rom" size="16384" crc="351b6deb" sha1="88f3a72513b04459212289797942c4d76f495a05" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="links, the (japan) (nga ii) (program).rom" size="0x4000" crc="351b6deb" sha1="88f3a72513b04459212289797942c4d76f495a05" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="nga2a" cloneof="nga2" supported="partial">
-		<description>The Links - NGA II - Network Game Adapter II (Japan, alt)</description>
+	<!-- Modem hardware not emulated -->
+	<software name="nga2a" cloneof="nga2" supported="no">
+		<description>The Links - NGA II - NT-300 - Network Game Adapter II (Japan, alt)</description>
 		<year>198?</year>
 		<publisher>Nihon Telenet</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="links, the (japan) (nga ii) (program) (alt 1).rom" size="32768" crc="38908590" sha1="5dd2ac08fd05a1e091c7c6ecb6c10b49992bdd46" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="links, the (japan) (nga ii) (program) (alt 1).rom" size="0x8000" crc="38908590" sha1="5dd2ac08fd05a1e091c7c6ecb6c10b49992bdd46" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="nga" supported="partial">
-		<description>The Links - NGA - Network Game Adapter (Japan)</description>
+	<!-- Modem hardware not emulated -->
+	<software name="nga" supported="no">
+		<description>The Links - NGA - NT-190 - Network Game Adapter (Japan)</description>
 		<year>198?</year>
 		<publisher>Nihon Telenet</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="links, the (japan) (program).rom" size="16384" crc="87b72f40" sha1="bc76a04970c547b7c080e747d393d13c87e82e7d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="links, the (japan) (program).rom" size="0x4000" crc="87b72f40" sha1="bc76a04970c547b7c080e747d393d13c87e82e7d" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="msxaid" supported="no">
+	<software name="msxaid">
 		<description>MSX-Aid (Japan)</description>
 		<year>1986</year>
 		<publisher>ASCII</publisher>
-		<info name="usage" value="From Basic type CALL HELP for more information" />
+		<info name="isbn" value="4871488942"/>
+		<info name="usage" value="Requires a Japanese system. From Basic type CALL HELP for more information. Add commands CALL MON, CALL MESSAGE, CALL VARLIST, CALL TRACE, CALL XREF, CALL FIND, CALL CFILES." />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="msx-aid (japan) (program).rom" size="16384" crc="a7c4ac70" sha1="d4edb2af4170fd4069960ad61d3f664462bef568" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="msx-aid (japan) (program).rom" size="0x4000" crc="a7c4ac70" sha1="d4edb2af4170fd4069960ad61d3f664462bef568" />
 			</dataarea>
 		</part>
 	</software>
@@ -13177,8 +14426,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Philips UK</publisher>
 		<info name="serial" value="VG 8103/20" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="msxlogo_uk.rom" size="32768" crc="ca258fd7" sha1="c07f47c59f83038c16d6d5052aaf6c271bff4334" offset="0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="msxlogo_uk.rom" size="0x8000" crc="ca258fd7" sha1="c07f47c59f83038c16d6d5052aaf6c271bff4334" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13188,8 +14438,9 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Telemática/Talent</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="msxlogo_ar.rom" size="32768" crc="0e6ecb9f" sha1="e45ddc5bf1a1e63756d11fb43fc50276ca35cab0" offset="0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="msxlogo_ar.rom" size="0x8000" crc="0e6ecb9f" sha1="e45ddc5bf1a1e63756d11fb43fc50276ca35cab0" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13199,8 +14450,9 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Epcom</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="msxlogo_br_11.rom" size="32768" crc="1ed6cd48" sha1="abb5cd4c8bdde234cadb0e10b794be3249dc51a5" offset="0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="msxlogo_br_11.rom" size="0x8000" crc="1ed6cd48" sha1="abb5cd4c8bdde234cadb0e10b794be3249dc51a5" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13210,8 +14462,9 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Epcom</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="msxlogo_br_12.rom" size="32768" crc="9b841c1c" sha1="a99796b45c92ca6b18e685130ae3eea43946cf2b" offset="0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="msxlogo_br_12.rom" size="0x8000" crc="9b841c1c" sha1="a99796b45c92ca6b18e685130ae3eea43946cf2b" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13222,8 +14475,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Philips Spain</publisher>
 		<info name="serial" value="VG 8103/28" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="msxlogo_es.rom" size="32768" crc="83dd2424" sha1="4141eb7540003f4abd31dee14fa1ee8be1b01a97" offset="0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="msxlogo_es.rom" size="0x8000" crc="83dd2424" sha1="4141eb7540003f4abd31dee14fa1ee8be1b01a97" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13234,8 +14488,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Philips</publisher>
 		<info name="serial" value="VG 8103/23" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="msxlogo_nl.rom" size="32768" crc="7af0aa39" sha1="47663f883f98ab9ddaa0bf0c2831c567919f56f1" offset="0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="msxlogo_nl.rom" size="0x8000" crc="7af0aa39" sha1="47663f883f98ab9ddaa0bf0c2831c567919f56f1" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13246,8 +14501,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>COMtech</publisher>
 		<info name="alt_title" value="COMTECH-LOGO" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="msxlogo_pl.rom" size="32768" crc="98d394eb" sha1="4354b46484c07c43eec80a92e405e13c2a8fcb73" offset="0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="msxlogo_pl.rom" size="0x8000" crc="98d394eb" sha1="4354b46484c07c43eec80a92e405e13c2a8fcb73" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13257,8 +14513,9 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Micro Technology</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="mt-base (1987)(micro technology)(nl)[cr speedy-hacking no].rom" size="16384" crc="64889eb2" sha1="4c921e31137d167976fb654e03d36ef133701936" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="mt-base (1987)(micro technology)(nl)[cr speedy-hacking no].rom" size="0x4000" crc="64889eb2" sha1="4c921e31137d167976fb654e03d36ef133701936" />
 			</dataarea>
 		</part>
 	</software>
@@ -13270,8 +14527,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HM-011" />
 		<info name="alt_title" value="ミュージックエディタ ＭＵＥ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="music editor (japan) (program).rom" size="16384" crc="74cf041b" sha1="20a2e3d7966916f46eb26cc1aa226ec2d11646f9" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="music editor (japan) (program).rom" size="0x4000" crc="74cf041b" sha1="20a2e3d7966916f46eb26cc1aa226ec2d11646f9" />
 			</dataarea>
 		</part>
 	</software>
@@ -13281,13 +14539,17 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>MCS</publisher>
 		<info name="alt_title" value="ミュージック・ハーモナイザー3" />
+		<info name="serial" value="0301"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="music harmonizer 3 (japan) (program).rom" size="16384" crc="4583548c" sha1="85e3386d30dd9a64f4cc1bca03cff35b440f70b5" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="music harmonizer 3 (japan) (program).rom" size="0x4000" crc="4583548c" sha1="85e3386d30dd9a64f4cc1bca03cff35b440f70b5" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Release contains a cartridge and a cassette. -->
 	<software name="musicg7">
 		<description>Music Studio G7 (Japan)</description>
 		<year>1985</year>
@@ -13295,8 +14557,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="HBS-H010C" />
 		<info name="alt_title" value="ミュージックスタジオG7" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="music studio g7 (japan) (program).rom" size="32768" crc="ba215cfe" sha1="8c06d9e1e188431c13721af965faa7391140af2e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="music studio g7 (japan) (program).rom" size="0x8000" crc="ba215cfe" sha1="8c06d9e1e188431c13721af965faa7391140af2e" />
 			</dataarea>
 		</part>
 	</software>
@@ -13308,8 +14571,9 @@ kept for now until finding out what those bytes affect...
 		<info name="serial" value="MW-002" />
 		<info name="alt_title" value="ＰＳＧミュージライター" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="musiwriter (japan) (program).rom" size="16384" crc="77c3424c" sha1="fc4c05ca47c94df877bed2e02307bd6307f738a6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="musiwriter (japan) (program).rom" size="0x4000" crc="77c3424c" sha1="fc4c05ca47c94df877bed2e02307bd6307f738a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -13319,72 +14583,84 @@ kept for now until finding out what those bytes affect...
 		<year>1987</year>
 		<publisher>Tokyo Shoseki</publisher>
 		<info name="alt_title" value="ニューキャルシリーズニューホライズン 1" />
+		<info name="serial" value="NHG-01"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="new horizon - english course 1 (japan) (program).rom" size="131072" crc="85d47f39" sha1="ec1bb5c36952b12e6c0805e9a8d5bf31c20a68c4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="new horizon - english course 1 (japan) (program).rom" size="0x20000" crc="85d47f39" sha1="ec1bb5c36952b12e6c0805e9a8d5bf31c20a68c4" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="nihonshi">
 		<description>Nihon-Shi Nenpyou (Japan)</description>
 		<year>1987</year>
 		<publisher>Stratford Computer Center</publisher>
 		<info name="alt_title" value="日本史年表" />
+		<info name="serial" value="MXSU11104"/>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="nihon-shi nenpyou (japan) (program).rom" size="32768" crc="c903a4ec" sha1="7013fcf8c76bc610cec9f55fbb99374182641251" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="nihon-shi nenpyou (japan) (program).rom" size="0x8000" crc="c903a4ec" sha1="7013fcf8c76bc610cec9f55fbb99374182641251" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="pcsakkyo">
 		<description>Pasokon Sakkyokka (Japan)</description>
 		<year>1983</year>
-		<publisher>ASCII</publisher>
-		<info name="serial" value="CF-SS009" />
+		<publisher>MCS</publisher>
+		<info name="serial" value="0321" />
 		<info name="alt_title" value="パソコン作曲家" />
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="pasokon sakkyokuka (japan) (program).rom" size="16384" crc="e74b7943" sha1="a6b2fdae9551ef3633926f6177c771d794d1e91b" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="pasokon sakkyokuka (japan) (program).rom" size="0x4000" crc="e74b7943" sha1="a6b2fdae9551ef3633926f6177c771d794d1e91b" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="psyched" supported="no">
-		<description>Psychedelia (Europe)</description>
+		<description>Psychedelia (Europe, cas2crt hack)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="psychedelia (europe) (program).rom" size="16384" crc="9d89337a" sha1="fae437072234c65bca174db9aefd2107a53c358a" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="psychedelia (europe) (program).rom" size="0x4000" crc="9d89337a" sha1="fae437072234c65bca174db9aefd2107a53c358a" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="rtseq">
-		<description>Real Time Sequencer DMS1 (Europe?)</description>
-		<year>19??</year>
+	<!-- Software does not start. -->
+	<software name="rtseq" supported="no">
+		<description>Real Time Sequencer DMS1 (Europe)</description>
+		<year>1985</year>
 		<publisher>Digital Music Systems</publisher>
+		<info name="alt_title" value="Real Time Sequence/Recorder (SFG-01/5) (cartridge)"/>
+		<info name="usage" value="For use with Yamaha CX5 Music Computer."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="dms1.rom" size="16384" crc="5b99ac67" sha1="5e67916f671ba197066048630e3b9117e8534432" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="dms1.rom" size="0x4000" crc="5b99ac67" sha1="5e67916f671ba197066048630e3b9117e8534432" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="simplasm">
-		<description>Simple ASM 1.0 (Japan)</description>
+		<description>Simple ASM v1.0 (Japan)</description>
 		<year>1984</year>
 		<publisher>Coral</publisher>
+		<info name="serial" value="CS-013"/>
 		<info name="usage" value="Type CALL EDT or CALL START" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="simple asm 1.0 (japan) (program).rom" size="16384" crc="2d46778a" sha1="4937a8e35072012a980f85ecfc60604d9d900244" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="simple asm 1.0 (japan) (program).rom" size="0x4000" crc="2d46778a" sha1="4937a8e35072012a980f85ecfc60604d9d900244" />
 			</dataarea>
 		</part>
 	</software>
@@ -13394,8 +14670,9 @@ kept for now until finding out what those bytes affect...
 		<year>19??</year>
 		<publisher>Philips</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="fddtest.rom" size="32768" crc="c8fb5375" sha1="47f24d1ab9349632d0a2122cd9a7a77a1331d586" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="fddtest.rom" size="0x8000" crc="c8fb5375" sha1="47f24d1ab9349632d0a2122cd9a7a77a1331d586" />
 			</dataarea>
 		</part>
 	</software>
@@ -13405,9 +14682,10 @@ kept for now until finding out what those bytes affect...
 		<year>19??</year>
 		<publisher>Philips</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
 				<!-- It does not seem like a real dump of the service test cartridge. It only contains some RS232 setup code, but those components are not even on the pcb. -->
-				<rom name="stcmsx1p.rom" size="16384" crc="941647ed" sha1="d24682996ab2291199d49ba77a60e1888398e967" status="baddump" />
+				<rom name="stcmsx1p.rom" size="0x4000" crc="941647ed" sha1="d24682996ab2291199d49ba77a60e1888398e967" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -13417,58 +14695,65 @@ kept for now until finding out what those bytes affect...
 		<year>1984</year>
 		<publisher>Computermates</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="spread sheet (europe) (program).rom" size="16384" crc="f24066b7" sha1="33c62e6f7478be369580a2d985ff57667f13cf84" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="spread sheet (europe) (program).rom" size="0x4000" crc="f24066b7" sha1="33c62e6f7478be369580a2d985ff57667f13cf84" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="supermon">
 		<description>Super Monitor (Japan, v1.2)</description>
 		<year>1985</year>
 		<publisher>Emiiru?</publisher>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="super monitor (japan) (v1.2) (program).rom" size="8192" crc="0dd5ea7d" sha1="35f13b5a32c64b21517f0c4009f264067338912e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="super monitor (japan) (v1.2) (program).rom" size="0x2000" crc="0dd5ea7d" sha1="35f13b5a32c64b21517f0c4009f264067338912e" />
 			</dataarea>
 		</part>
 	</software>
 
-	<!-- Glitches in msx driver, works fine in some Japanese machines, like cf1200 -->
 	<software name="supermona" cloneof="supermon">
 		<description>Super Monitor (Japan, v1.1)</description>
 		<year>1985</year>
 		<publisher>Emiiru?</publisher>
+		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="super monitor (japan) (v1.1) (program).rom" size="8192" crc="c7b2e638" sha1="55f30c8b7118870802d00db860bc1945f18a42c0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="super monitor (japan) (v1.1) (program).rom" size="0x2000" crc="c7b2e638" sha1="55f30c8b7118870802d00db860bc1945f18a42c0" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Released as cartridge + cassette -->
 	<software name="supersyn">
 		<description>Super Synth (Japan)</description>
 		<year>1984</year>
 		<publisher>Victor</publisher>
-		<info name="serial" value="M-20001" />
+		<info name="serial" value="M-20001 (cartridge) / M-20002 (cassette)" />
 		<info name="alt_title" value="スーパーシンセ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="super synth (japan) (program).rom" size="16384" crc="168832a2" sha1="830efa0b25e1cf34d5f55d08cb80709d0a2c82ec" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="super synth (japan) (program).rom" size="0x4000" crc="168832a2" sha1="830efa0b25e1cf34d5f55d08cb80709d0a2c82ec" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Released as cartridge + cassette -->
 	<software name="supersyna" cloneof="supersyn">
 		<description>Super Synth (Japan, alt)</description>
 		<year>1984</year>
 		<publisher>Victor</publisher>
-		<info name="serial" value="M-20001" />
+		<info name="serial" value="M-20001 (cartridge) / M-20002 (cassette)" />
 		<info name="alt_title" value="スーパーシンセ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="super synth (japan) (program) (alt 1).rom" size="16384" crc="31729cd0" sha1="a2f8f8f9f46262342eee0a1df7c6871008a3a189" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="super synth (japan) (program) (alt 1).rom" size="0x4000" crc="31729cd0" sha1="a2f8f8f9f46262342eee0a1df7c6871008a3a189" />
 			</dataarea>
 		</part>
 	</software>
@@ -13478,19 +14763,21 @@ kept for now until finding out what those bytes affect...
 		<year>19??</year>
 		<publisher>Gradiente</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="toque.rom" size="16384" crc="28c5dbfa" sha1="b1a154ed8f52c2a74457e1c03c99608181dfb8ee" />
+			<feature name="start_page" value="2"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="toque.rom" size="0x4000" crc="28c5dbfa" sha1="b1a154ed8f52c2a74457e1c03c99608181dfb8ee" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="zen">
-		<description>Zen Assembler (Europe)</description>
+		<description>Zen Assembler (Europe, cas2crt hack)</description>
 		<year>1986</year>
 		<publisher>Kuma Computers?</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="zen (europe) (program).rom" size="16384" crc="95e3c098" sha1="59679b1ed40416f4c8d65085e5473c621bea6ac4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="zen (europe) (program).rom" size="0x4000" crc="95e3c098" sha1="59679b1ed40416f4c8d65085e5473c621bea6ac4" />
 			</dataarea>
 		</part>
 	</software>
@@ -13503,8 +14790,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Yamaha</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="dx7 voicing program (japan) (program).rom" size="16384" crc="3755ca3d" sha1="c20def84efe71efdf91df3100919d151b2e7bdc1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="dx7 voicing program (japan) (program).rom" size="0x4000" crc="3755ca3d" sha1="c20def84efe71efdf91df3100919d151b2e7bdc1" />
 			</dataarea>
 		</part>
 	</software>
@@ -13514,8 +14802,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Yamaha</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="yrm103.rom" size="16384" crc="3dfa2059" sha1="20c24130b7a9d50b5cede80f1638b686c2778800" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="yrm103.rom" size="0x4000" crc="3dfa2059" sha1="20c24130b7a9d50b5cede80f1638b686c2778800" />
 			</dataarea>
 		</part>
 	</software>
@@ -13525,8 +14814,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Yamaha</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="yrm304.rom" size="32768" crc="170afead" sha1="c79626eddf8bc390d64ada99ad6da32dfd52d086" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="yrm304.rom" size="0x8000" crc="170afead" sha1="c79626eddf8bc390d64ada99ad6da32dfd52d086" />
 			</dataarea>
 		</part>
 	</software>
@@ -13536,8 +14826,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Yamaha</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="yrm105.rom" size="16384" crc="61125c14" sha1="70b5bcd6c3fb0eab8b500d93a16dfa3f7e6694e8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="yrm105.rom" size="0x4000" crc="61125c14" sha1="70b5bcd6c3fb0eab8b500d93a16dfa3f7e6694e8" />
 			</dataarea>
 		</part>
 	</software>
@@ -13547,8 +14838,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Yamaha</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="yrm305.rom" size="32768" crc="f9bb212c" sha1="ffbb462cb42c7f497ec82746da0cba032fede613" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="yrm305.rom" size="0x8000" crc="f9bb212c" sha1="ffbb462cb42c7f497ec82746da0cba032fede613" />
 			</dataarea>
 		</part>
 	</software>
@@ -13558,8 +14850,9 @@ kept for now until finding out what those bytes affect...
 		<year>1985</year>
 		<publisher>Yamaha</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="fb-01 voicing program (japan) (program).rom" size="32768" crc="6f2e48ab" sha1="43dbcc9536fe61c8172eceeec1481778f7a2b9bd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="fb-01 voicing program (japan) (program).rom" size="0x8000" crc="6f2e48ab" sha1="43dbcc9536fe61c8172eceeec1481778f7a2b9bd" />
 			</dataarea>
 		</part>
 	</software>
@@ -13569,8 +14862,8 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Yamaha</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="cmp01.rom" size="65536" crc="0c6b46da" sha1="971da55e92167674628a12c443efc43bafcfb6b4" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="cmp01.rom" size="0x10000" crc="0c6b46da" sha1="971da55e92167674628a12c443efc43bafcfb6b4" />
 			</dataarea>
 		</part>
 	</software>
@@ -13581,8 +14874,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Yamaha</publisher>
 		<info name="alt_title" value="ＦＭミュージックコンポーザ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="fm music composer (japan) (program).rom" size="16384" crc="8c13ccea" sha1="39c12004adb3442f2c43aade8a0be420d59eefb1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="fm music composer (japan) (program).rom" size="0x4000" crc="8c13ccea" sha1="39c12004adb3442f2c43aade8a0be420d59eefb1" />
 			</dataarea>
 		</part>
 	</software>
@@ -13593,8 +14887,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Yamaha</publisher>
 		<info name="alt_title" value="ＦＭミュージックコンポーザ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="yrm101.rom" size="16384" crc="22812981" sha1="337087199d58666029f00e08ca82b1917ab58c80" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="yrm101.rom" size="0x4000" crc="22812981" sha1="337087199d58666029f00e08ca82b1917ab58c80" />
 			</dataarea>
 		</part>
 	</software>
@@ -13605,8 +14900,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Yamaha</publisher>
 		<info name="alt_title" value="ＦＭミュージックコンポーザII" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="fm music composer ii (japan) (program).rom" size="32768" crc="2cbfe03e" sha1="e60e2abf907b66f5b275c7b7b710439adae58d37" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="fm music composer ii (japan) (program).rom" size="0x8000" crc="2cbfe03e" sha1="e60e2abf907b66f5b275c7b7b710439adae58d37" />
 			</dataarea>
 		</part>
 	</software>
@@ -13617,8 +14913,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Yamaha</publisher>
 		<info name="alt_title" value="ＦＭミュージックマクロ" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="fm music macro (japan) (program).rom" size="32768" crc="fad0860b" sha1="7c2743df543c0d8a4ba7e42bf7db580b996d102e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="fm music macro (japan) (program).rom" size="0x8000" crc="fad0860b" sha1="7c2743df543c0d8a4ba7e42bf7db580b996d102e" />
 			</dataarea>
 		</part>
 	</software>
@@ -13628,8 +14925,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Yamaha</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="yrm504.rom" size="32768" crc="44f5f606" sha1="f5e2e4aacd44739d3a0c1ea4ecb87da385ce89dc" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="yrm504.rom" size="0x8000" crc="44f5f606" sha1="f5e2e4aacd44739d3a0c1ea4ecb87da385ce89dc" />
 			</dataarea>
 		</part>
 	</software>
@@ -13640,8 +14938,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Yamaha</publisher>
 		<info name="alt_title" value="ＦＭ音色プログラム" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="fm voicing program (japan) (program).rom" size="16384" crc="70b36f17" sha1="e4c8f3b87d755c21572040c51cec1431ae59a0be" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="fm voicing program (japan) (program).rom" size="0x4000" crc="70b36f17" sha1="e4c8f3b87d755c21572040c51cec1431ae59a0be" />
 			</dataarea>
 		</part>
 	</software>
@@ -13652,8 +14951,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Yamaha</publisher>
 		<info name="usage" value="Type CALL FMV" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="yrm102.rom" size="16384" crc="570c1150" sha1="057238307d93a8c2cbb2a296b9dc2f4585315af1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="yrm102.rom" size="0x4000" crc="570c1150" sha1="057238307d93a8c2cbb2a296b9dc2f4585315af1" />
 			</dataarea>
 		</part>
 	</software>
@@ -13664,8 +14964,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Yamaha</publisher>
 		<info name="usage" value="Type CALL FMV" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="yrm502.rom" size="16384" crc="51f7ddd1" sha1="2a4b4a4657e3077df8a88f98210b76883d3702b1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="yrm502.rom" size="0x4000" crc="51f7ddd1" sha1="2a4b4a4657e3077df8a88f98210b76883d3702b1" />
 			</dataarea>
 		</part>
 	</software>
@@ -13675,8 +14976,9 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Yamaha</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="midi macro (japan) (program).rom" size="32768" crc="91daf424" sha1="e7c800fa576b3a9554836aa9c5eaa3ae893805d4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="midi macro (japan) (program).rom" size="0x8000" crc="91daf424" sha1="e7c800fa576b3a9554836aa9c5eaa3ae893805d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -13686,6 +14988,7 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Yamaha</publisher>
 		<part name="cart" interface="msx_cart">
+			<feature name="start_page" value="0"/>
 			<dataarea name="rom" size="49152">
 				<rom name="yrm303.rom" size="49152" crc="29877db7" sha1="4a5cf6fffaa793eca8583ac8b2ba71bf993cccb4" />
 			</dataarea>
@@ -13697,8 +15000,9 @@ kept for now until finding out what those bytes affect...
 		<year>198?</year>
 		<publisher>Yamaha</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="yrm301.rom" size="32768" crc="ecee5307" sha1="0e24c5c4f16d5f9564d1bcbf29e4187cb6ad9701" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="yrm301.rom" size="0x8000" crc="ecee5307" sha1="0e24c5c4f16d5f9564d1bcbf29e4187cb6ad9701" />
 			</dataarea>
 		</part>
 	</software>
@@ -13709,8 +15013,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Yamaha</publisher>
 		<info name="alt_title" value="プレイカードセット" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="yamaha play card system (japan) (program).rom" size="16384" crc="309ba37a" sha1="8161d9b325c708af463c5622bd89ca94754cfdef" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="yamaha play card system (japan) (program).rom" size="0x4000" crc="309ba37a" sha1="8161d9b325c708af463c5622bd89ca94754cfdef" />
 			</dataarea>
 		</part>
 	</software>
@@ -13721,8 +15026,9 @@ kept for now until finding out what those bytes affect...
 		<publisher>Yamaha</publisher>
 		<info name="usage" value="Type CALL RX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="yrm302.rom" size="32768" crc="c9ef7b59" sha1="e03ec3a6bb6d8b1bc6eab349c7675cb72aa47d57" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="yrm302.rom" size="0x8000" crc="c9ef7b59" sha1="e03ec3a6bb6d8b1bc6eab349c7675cb72aa47d57" />
 			</dataarea>
 		</part>
 	</software>
@@ -13730,13 +15036,15 @@ kept for now until finding out what those bytes affect...
 
 <!-- SYSTEM ROMS? -->
 
+	<!-- Release contains cartridge and a 2DD floppy. -->
 	<software name="msxbasic" supported="no">
 		<description>MSX Basic-kun Plus 2.0 (Japan)</description>
 		<year>1988</year>
 		<publisher>ASCII</publisher>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="msx basic-kun plus (japan) (program).rom" size="16384" crc="a13615d2" sha1="c279c3f41d5368761f9088157b80214d835a548c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="msx basic-kun plus (japan) (program).rom" size="0x4000" crc="a13615d2" sha1="c279c3f41d5368761f9088157b80214d835a548c" />
 			</dataarea>
 		</part>
 	</software>
@@ -13747,7 +15055,7 @@ kept for now until finding out what those bytes affect...
 		<publisher>Panasonic</publisher>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="msxaud_fsca1" />
-			<dataarea name="rom" size="131072">
+			<dataarea name="rom" size="0x20000">
 				<!--
 				    20140725:
 				    There are 3 versions of this rom floating around:
@@ -13756,7 +15064,7 @@ kept for now until finding out what those bytes affect...
 				    36d47cf70618fdb460f97a8ceb75013ec4529063 - A dump made using an eeprom reader. This dump differs one bit with the dump above (offset 8a49, bit 3)
 				    By looking the code it is not yet possible to say which one is 100% correct, so marking it as baddump for the moment.
 				-->
-				<rom name="msx audio (japan) (fs-ca1) (program).rom" size="131072" crc="78584d2e" sha1="a45692849acf29ddb653707a62747985439f6d4f" status="baddump" />
+				<rom name="msx audio (japan) (fs-ca1) (program).rom" size="0x20000" crc="78584d2e" sha1="a45692849acf29ddb653707a62747985439f6d4f" status="baddump" />
 			</dataarea>
 			<!-- uPD4364C - is actually an 8KB SRAM chip, but only 4KB is used -->
 			<dataarea name="sram" size="4096">
@@ -13771,8 +15079,8 @@ kept for now until finding out what those bytes affect...
 		<publisher>Toshiba</publisher>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="msxaud_hxmu900" />
-			<dataarea name="rom" size="32768">
-				<rom name="msx audio (japan) (hx-mu900) (program).rom" size="32768" crc="dc405f8c" sha1="0d246b0e3edc63803fcce861ea07eadf29dc488c" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="msx audio (japan) (hx-mu900) (program).rom" size="0x8000" crc="dc405f8c" sha1="0d246b0e3edc63803fcce861ea07eadf29dc488c" />
 			</dataarea>
 		</part>
 	</software>
@@ -13783,14 +15091,14 @@ kept for now until finding out what those bytes affect...
 		<publisher>Philips</publisher>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="msxaud_nms1205" />
-			<dataarea name="rom" size="32768">
+			<dataarea name="rom" size="0x8000">
 				<!-- SUM16 should be DE54, not verified -->
-				<rom name="nms1205.bin" size="32768" crc="5ecaeef0" sha1="c7463e1fd0433c5d41b70670d6c10fd781b66426" />
+				<rom name="nms1205.bin" size="0x8000" crc="5ecaeef0" sha1="c7463e1fd0433c5d41b70670d6c10fd781b66426" />
 			</dataarea>
 <!--
 This memory is currently declared as a memory region inside the nms1205 implementation otherwise the
 legacy FM implementations cannot find it.
-            <dataarea name="ram" size="32768">
+            <dataarea name="ram" size="0x8000">
             </dataarea>
 -->
 		</part>
@@ -13803,14 +15111,14 @@ legacy FM implementations cannot find it.
         <publisher>Philips</publisher>
         <part name="cart" interface="msx_cart">
             <feature name="slot" value="msxaud_nms1205" />
-            <dataarea name="rom" size="32768">
+            <dataarea name="rom" size="0x8000">
                 <!- - SUM16: 53BF - ->
-                <rom name="nms1205_53bf.bin" size="32768" crc="6e68bd44" sha1="146d9738b6d534277dab9b41a07556ffec9065b9" status="baddump" />
+                <rom name="nms1205_53bf.bin" size="0x8000" crc="6e68bd44" sha1="146d9738b6d534277dab9b41a07556ffec9065b9" status="baddump" />
             </dataarea>
 <!- -
 This memory is currently declared as a memory region inside the nms1205 implementation otherwise the
 legacy FM implementations cannot find it.
-            <dataarea name="ram" size="32768">
+            <dataarea name="ram" size="0x8000">
             </dataarea>
 - ->
         </part>
@@ -13826,15 +15134,15 @@ legacy FM implementations cannot find it.
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="fs_sr022" />
 			<feature name="pcb" value="DFUP0058ZAJ" />
-			<dataarea name="rom" size="262144">
-				<rom name="PRO ROM V1.0 DASR022A1.ic16" size="32768" crc="381b3431" sha1="8c7ae1a1720b1dae9af9904e638b868f56d905c2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="PRO ROM V1.0 DASR022A1.ic16" size="0x8000" crc="381b3431" sha1="8c7ae1a1720b1dae9af9904e638b868f56d905c2" />
 				<!-- The dictionary is in 4 32KB EEPROMs instead of one 128KB rom:
 				     - DIC1 ROM V1.0 DASR022B1.ic15
 				     - DIC2 ROM V1.0 DASR022C1.ic14
 				     - DIC3 ROM V1.0 DASR022D1.ic13
 				     - DIC4 ROM V1.0 DASR022E1.ic12
 				-->
-				<rom name="jisyo data (japan) (program).rom" size="131072" crc="46e90b77" sha1="765413bb6b03bc3bb888ee8fe00b99ef69c1317a" status="baddump" offset="0x20000" />
+				<rom name="jisyo data (japan) (program).rom" size="0x20000" crc="46e90b77" sha1="765413bb6b03bc3bb888ee8fe00b99ef69c1317a" status="baddump" offset="0x20000" />
 			</dataarea>
 		</part>
 	</software>
@@ -13847,79 +15155,89 @@ legacy FM implementations cannot find it.
 <!-- AL ALAMIAH -->
 
 	<software name="123">
-		<description>123 (Arab)</description>
+		<description>123 (Arab, v1.17)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
 		<info name="serial" value="P081" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="123.rom" size="32768" crc="cb1a7f99" sha1="a7c116e987f561aaa6199c3018433c431268ca86" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="123.rom" size="0x8000" crc="cb1a7f99" sha1="a7c116e987f561aaa6199c3018433c431268ca86" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="123a">
-		<description>123 (Arab, alt)</description>
+		<description>123 (Arab, v1.16)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
 		<info name="serial" value="P081" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="123alt.rom" size="32768" crc="3ce4eaf5" sha1="150b249b6402ed89ed03cc7125f9472c931dcb2a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="123alt.rom" size="0x8000" crc="3ce4eaf5" sha1="150b249b6402ed89ed03cc7125f9472c931dcb2a" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="addsub">
-		<description>Add &amp; Subtract (Arab)</description>
+		<description>Add &amp; Subtract (Arab, v1.13)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اجمع و اطرح"/>
 		<info name="serial" value="M054" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="add &amp; subtract (al-alamiah, 1986).rom" size="32768" crc="2f06ba46" sha1="8f5e7717a506e3314d48ae9ff5e6c6c8a3df72eb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="add &amp; subtract (al-alamiah, 1986).rom" size="0x8000" crc="2f06ba46" sha1="8f5e7717a506e3314d48ae9ff5e6c6c8a3df72eb" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="abcar">
-		<description>Aleph Ba Ta (Arab)</description>
+		<description>Aleph Ba Ta (Arab, v1.11)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الحروف العربية"/>
 		<info name="serial" value="P078" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="alphabets in arabic (al alamiah, 1986).rom" size="32768" crc="c61fe4a4" sha1="148c9a4f316ff73c4e802baadc34bf852492821d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="alphabets in arabic (al alamiah, 1986).rom" size="0x8000" crc="c61fe4a4" sha1="148c9a4f316ff73c4e802baadc34bf852492821d" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="abcar1" cloneof="abcar">
-		<description>Aleph Ba Ta (Arab, alt)</description>
+		<description>Aleph Ba Ta (Arab, v1.13)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الحروف العربية"/>
 		<info name="serial" value="P078" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="abc-a.rom" size="32768" crc="5414b1d1" sha1="6898910ed409daee48c8f9f5b20505330d46f714" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="abc-a.rom" size="0x8000" crc="5414b1d1" sha1="6898910ed409daee48c8f9f5b20505330d46f714" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="abcen">
-		<description>ABC (Arab)</description>
+		<description>ABC (Arab, v1.06)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
-		<info name="serial" value="P078" />
+		<info name="alt_title" value="الحروف الإنجليزية"/>
+		<info name="serial" value="P092" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="abc.rom" size="32768" crc="915f13d1" sha1="5bd09e5a9669c58365c87f32a0e9a8e59680d5c9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="abc.rom" size="0x8000" crc="915f13d1" sha1="5bd09e5a9669c58365c87f32a0e9a8e59680d5c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -13928,24 +15246,28 @@ legacy FM implementations cannot find it.
 		<description>Arab History (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="تاريخ العرب"/>
 		<info name="serial" value="H018" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="arab history (al alamiah, 1985).rom" size="32768" crc="4b113079" sha1="3ce544aaefdb8a916a1639afea774eb75ec4702f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="arab history (al alamiah, 1985).rom" size="0x8000" crc="4b113079" sha1="3ce544aaefdb8a916a1639afea774eb75ec4702f" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="arabhista" cloneof="arabhist">
-		<description>Arab History (Arab, alt)</description>
+		<description>Arab History (Arab, v1.23)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="تاريخ العرب"/>
 		<info name="serial" value="H018" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a-history.rom" size="32768" crc="c8895419" sha1="80a2c10a28307efc765260ff4d422c58b65921fe" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a-history.rom" size="0x8000" crc="c8895419" sha1="80a2c10a28307efc765260ff4d422c58b65921fe" />
 			</dataarea>
 		</part>
 	</software>
@@ -13954,11 +15276,13 @@ legacy FM implementations cannot find it.
 		<description>Arab Homeland (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الوطن العربي"/>
 		<info name="serial" value="H017" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="arab homeland (al alamiah, 1985).rom" size="32768" crc="378daca3" sha1="374c44e0e045e1167c1891b6400a75c4fa4ddae7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="arab homeland (al alamiah, 1985).rom" size="0x8000" crc="378daca3" sha1="374c44e0e045e1167c1891b6400a75c4fa4ddae7" />
 			</dataarea>
 		</part>
 	</software>
@@ -13967,11 +15291,13 @@ legacy FM implementations cannot find it.
 		<description>Arab Homeland (Arab, alt)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الوطن العربي"/>
 		<info name="serial" value="H017" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a-homeland.rom" size="32768" crc="a5bc40ec" sha1="6b4b099fa7a87c5059ebb40da3089d0d61967644" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a-homeland.rom" size="0x8000" crc="a5bc40ec" sha1="6b4b099fa7a87c5059ebb40da3089d0d61967644" />
 			</dataarea>
 		</part>
 	</software>
@@ -13980,11 +15306,13 @@ legacy FM implementations cannot find it.
 		<description>Arabic Learn BASIC (Arab, v1.10)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="تعلم بيسيك"/>
 		<info name="serial" value="C047" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_basic.rom" size="32768" crc="ce684d05" sha1="0cc58a60e35303442abf82f28b7030ac1ae4e538" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_basic.rom" size="0x8000" crc="ce684d05" sha1="0cc58a60e35303442abf82f28b7030ac1ae4e538" />
 			</dataarea>
 		</part>
 	</software>
@@ -13993,11 +15321,13 @@ legacy FM implementations cannot find it.
 		<description>Arabic Learn BASIC (Arab, v1.09)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="تعلم بيسيك"/>
 		<info name="serial" value="C047" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="learn sakhr basic.rom" size="32768" crc="fd691ad1" sha1="bf3d9433bf32d3af7a7adc0ba77b9690ac754daa" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="learn sakhr basic.rom" size="0x8000" crc="fd691ad1" sha1="bf3d9433bf32d3af7a7adc0ba77b9690ac754daa" />
 			</dataarea>
 		</part>
 	</software>
@@ -14006,11 +15336,13 @@ legacy FM implementations cannot find it.
 		<description>Around the Clock (Arab)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="حول الساعة"/>
 		<info name="serial" value="F048" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="aroundtheclock.rom" size="32768" crc="39505e12" sha1="b49a41e57ddde304c9706e9b65bbf63733c14c88" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="aroundtheclock.rom" size="0x8000" crc="39505e12" sha1="b49a41e57ddde304c9706e9b65bbf63733c14c88" />
 			</dataarea>
 		</part>
 	</software>
@@ -14019,23 +15351,27 @@ legacy FM implementations cannot find it.
 		<description>Around the Clock (Arab, alt)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="حول الساعة"/>
 		<info name="serial" value="F048" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="aroundtheclock-b.rom" size="32768" crc="81995044" sha1="fd9eef4ea54e31e9ffb121c079e4b76c990d755c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="aroundtheclock-b.rom" size="0x8000" crc="81995044" sha1="fd9eef4ea54e31e9ffb121c079e4b76c990d755c" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="belnot">
-		<description>Believe It or Not (Arab)</description>
+		<description>Believe It or Not (Arab, v1.03)</description>
 		<year>1990</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="صدق أو لا تصدق"/>
+		<info name="serial" value="E095"/>
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="believe it or not (al-alamiah, 1990).rom" size="65536" crc="fc9aeb19" sha1="1071420c786d882187ec277a47d486a92071231f" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="believe it or not (al-alamiah, 1990).rom" size="0x10000" crc="fc9aeb19" sha1="1071420c786d882187ec277a47d486a92071231f" />
 			</dataarea>
 		</part>
 	</software>
@@ -14044,11 +15380,13 @@ legacy FM implementations cannot find it.
 		<description>Boullata (Arab)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="بولاتا"/>
 		<info name="serial" value="G002" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="boullata (al alamiah, 1984).rom" size="32768" crc="dcd67501" sha1="254208d7ea2f7cc1035cfe7685238ac3ad17e438" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="boullata (al alamiah, 1984).rom" size="0x8000" crc="dcd67501" sha1="254208d7ea2f7cc1035cfe7685238ac3ad17e438" />
 			</dataarea>
 		</part>
 	</software>
@@ -14057,24 +15395,28 @@ legacy FM implementations cannot find it.
 		<description>Cross Word (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الكلمات المتقاطعة"/>
 		<info name="serial" value="F034" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="cross word (al-alamiah, 1985).rom" size="32768" crc="8bd9d246" sha1="7538fe6f0dfbf72ba7a89d349258afdff547b4c1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="cross word (al-alamiah, 1985).rom" size="0x8000" crc="8bd9d246" sha1="7538fe6f0dfbf72ba7a89d349258afdff547b4c1" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="discomp">
-		<description>Discover the Computer (Arab)</description>
+		<description>Discover the Computer (Arab, v1.13)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="إستكشف الكمبيوتر"/>
 		<info name="serial" value="C045" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="discover the computer (al-alamiah, 1986).rom" size="32768" crc="edd6de7f" sha1="39a40c1265cc663eef0d21dea01a9bf52c8c140e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="discover the computer (al-alamiah, 1986).rom" size="0x8000" crc="edd6de7f" sha1="39a40c1265cc663eef0d21dea01a9bf52c8c140e" />
 			</dataarea>
 		</part>
 	</software>
@@ -14083,11 +15425,13 @@ legacy FM implementations cannot find it.
 		<description>Double Face (Arab, v1.1)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ذو الوجهين"/>
 		<info name="serial" value="F007" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="doubleface1-.rom" size="32768" crc="301ba28a" sha1="a66fe495cfd443cac9cfd434d95a537e6984dbc6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="doubleface1-.rom" size="0x8000" crc="301ba28a" sha1="a66fe495cfd443cac9cfd434d95a537e6984dbc6" />
 			</dataarea>
 		</part>
 	</software>
@@ -14096,11 +15440,13 @@ legacy FM implementations cannot find it.
 		<description>Double Face (Arab)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ذو الوجهين"/>
 		<info name="serial" value="F007" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="double face (al-alamiah, 1987).rom" size="32768" crc="9314cd65" sha1="ac2475e955e98c5d5816ec60118b424b46c30670" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="double face (al-alamiah, 1987).rom" size="0x8000" crc="9314cd65" sha1="ac2475e955e98c5d5816ec60118b424b46c30670" />
 			</dataarea>
 		</part>
 	</software>
@@ -14109,11 +15455,13 @@ legacy FM implementations cannot find it.
 		<description>Double Face 2 (Arab, v1.8)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ذو الوجهين ٢"/>
 		<info name="serial" value="F064" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="double face 2 (al alamiah, 1987) (v2.18).rom" size="32768" crc="82114c93" sha1="3627431db990b6913606328ae2fb3340452b2797" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="double face 2 (al alamiah, 1987) (v2.18).rom" size="0x8000" crc="82114c93" sha1="3627431db990b6913606328ae2fb3340452b2797" />
 			</dataarea>
 		</part>
 	</software>
@@ -14122,11 +15470,13 @@ legacy FM implementations cannot find it.
 		<description>Double Face 2 (Arab, v1.7)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ذو الوجهين ٢"/>
 		<info name="serial" value="F064" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="double face 2 (al alamiah, 1987) (v2.17).rom" size="32768" crc="a7c4509f" sha1="08cb8d0a42e1c2a0961aff3ab70262525964b434" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="double face 2 (al alamiah, 1987) (v2.17).rom" size="0x8000" crc="a7c4509f" sha1="08cb8d0a42e1c2a0961aff3ab70262525964b434" />
 			</dataarea>
 		</part>
 	</software>
@@ -14135,11 +15485,13 @@ legacy FM implementations cannot find it.
 		<description>Double Jaw (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ذو الفكين"/>
 		<info name="serial" value="L014" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="double jaw (al alamiah, 1985).rom" size="32768" crc="c4179415" sha1="afcc2f649e4001a2a8bb701874ef4a26e224f689" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="double jaw (al alamiah, 1985).rom" size="0x8000" crc="c4179415" sha1="afcc2f649e4001a2a8bb701874ef4a26e224f689" />
 			</dataarea>
 		</part>
 	</software>
@@ -14148,11 +15500,13 @@ legacy FM implementations cannot find it.
 		<description>Double Jaw (Arab, alt)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ذو الفكين"/>
 		<info name="serial" value="L014" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="double jaw (al alamiah, 1985) (another dump).rom" size="32768" crc="b1ca767b" sha1="7b89c2d62c3106a87c3375bbc0284d2b5a364cc9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="double jaw (al alamiah, 1985) (another dump).rom" size="0x8000" crc="b1ca767b" sha1="7b89c2d62c3106a87c3375bbc0284d2b5a364cc9" />
 			</dataarea>
 		</part>
 	</software>
@@ -14161,11 +15515,13 @@ legacy FM implementations cannot find it.
 		<description>Electromatic (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="كهروماتيك"/>
 		<info name="serial" value="S020" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="electromatic (al-alamiah, 1985).rom" size="32768" crc="d41730fd" sha1="94584ca2e89ab0b249cd52f3a356176a03f9e35f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="electromatic (al-alamiah, 1985).rom" size="0x8000" crc="d41730fd" sha1="94584ca2e89ab0b249cd52f3a356176a03f9e35f" />
 			</dataarea>
 		</part>
 	</software>
@@ -14174,76 +15530,88 @@ legacy FM implementations cannot find it.
 		<description>Electromatic (Arab, alt)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="كهروماتيك"/>
 		<info name="serial" value="S020" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_kh.rom" size="32768" crc="165a24e7" sha1="1dbe5a8e05fd8ed6a2181271e7423610a259b5b7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_kh.rom" size="0x8000" crc="165a24e7" sha1="1dbe5a8e05fd8ed6a2181271e7423610a259b5b7" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="energy">
-		<description>The Energy (Arab)</description>
+		<description>The Energy (Arab, v1.14)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الطاقة"/>
 		<info name="serial" value="S065" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_energy.rom" size="32768" crc="13c7458b" sha1="b153dc92b9ff967cb8829182dfe2ae40c210aefb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_energy.rom" size="0x8000" crc="13c7458b" sha1="b153dc92b9ff967cb8829182dfe2ae40c210aefb" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="energya" cloneof="energy">
-		<description>The Energy (Arab, alt)</description>
+		<description>The Energy (Arab, v1.14, alt)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الطاقة"/>
 		<info name="serial" value="S065" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="energy.rom" size="32768" crc="6e1120ff" sha1="ad2e1e957ee469d51faa07a99a20dbf00003dacf" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="energy.rom" size="0x8000" crc="6e1120ff" sha1="ad2e1e957ee469d51faa07a99a20dbf00003dacf" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="equation">
-		<description>Equations (Arab)</description>
+		<description>Equations (Arab, v1.04)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="معادلات"/>
 		<info name="serial" value="M029" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="equations (al-alamiah, 1985).rom" size="32768" crc="09a020f3" sha1="f2ac1ce7584297bb646caec3fe4f0384ed5b072f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="equations (al-alamiah, 1985).rom" size="0x8000" crc="09a020f3" sha1="f2ac1ce7584297bb646caec3fe4f0384ed5b072f" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="exinfo1">
-		<description>Examine Your Information 1 (Arab)</description>
+		<description>Examine Your Information 1 (Arab, v1.02)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اختبر معلوماتك"/>
 		<info name="serial" value="E035" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="examine your information 1 (al alamiah, 1985).rom" size="32768" crc="add14057" sha1="e9d7957a45ef0ac4cb2b206af424332081d3d3cb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="examine your information 1 (al alamiah, 1985).rom" size="0x8000" crc="add14057" sha1="e9d7957a45ef0ac4cb2b206af424332081d3d3cb" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="exinfo1a" cloneof="exinfo1">
-		<description>Examine Your Information 1 (Arab, alt)</description>
+		<description>Examine Your Information 1 (Arab, v1.02, alt)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اختبر معلوماتك"/>
 		<info name="serial" value="E035" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="test knowledge 1.rom" size="32768" crc="2771df26" sha1="33352b5e33057bebe0c9b989afe90f178aba7243" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="test knowledge 1.rom" size="0x8000" crc="2771df26" sha1="33352b5e33057bebe0c9b989afe90f178aba7243" />
 			</dataarea>
 		</part>
 	</software>
@@ -14252,11 +15620,13 @@ legacy FM implementations cannot find it.
 		<description>Examine Your Information 2 (Arab, v2.07)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اختبر معلوماتك ٢"/>
 		<info name="serial" value="E077" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_test2.rom" size="32768" crc="5a3ec5fe" sha1="4a7827c5f6b73a0f607381dd85353ed3a69d8694" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_test2.rom" size="0x8000" crc="5a3ec5fe" sha1="4a7827c5f6b73a0f607381dd85353ed3a69d8694" />
 			</dataarea>
 		</part>
 	</software>
@@ -14265,11 +15635,13 @@ legacy FM implementations cannot find it.
 		<description>Examine Your Information 2 (Arab, v2.05)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اختبر معلوماتك ٢"/>
 		<info name="serial" value="E077" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="test knowledge 2.rom" size="32768" crc="893ef583" sha1="82bf80166e77f99a6f1e091f97f8ab167373dc60" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="test knowledge 2.rom" size="0x8000" crc="893ef583" sha1="82bf80166e77f99a6f1e091f97f8ab167373dc60" />
 			</dataarea>
 		</part>
 	</software>
@@ -14278,11 +15650,14 @@ legacy FM implementations cannot find it.
 		<description>Examine Your Information 3 (Arab, v1.12)</description>
 		<year>1988</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اختبر معلوماتت ٣"/>
 		<info name="serial" value="E086" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="131072">
-				<rom name="test knowledge 3.rom" size="131072" crc="34eba5d3" sha1="16f06109c57de5a39fbe150de9c25754483ee9fb" />
+			<feature name="slot" value="ascii8" />
+			<feature name="mapper" value="M60002-0125SP" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="test knowledge 3.rom" size="0x20000" crc="34eba5d3" sha1="16f06109c57de5a39fbe150de9c25754483ee9fb" />
 			</dataarea>
 		</part>
 	</software>
@@ -14291,65 +15666,75 @@ legacy FM implementations cannot find it.
 		<description>Examine Your Information 3 (Arab, v1.10)</description>
 		<year>1988</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اختبر معلوماتت ٣"/>
 		<info name="serial" value="E086" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="examine your information 3 (al alamiah, 1988).rom" size="131072" crc="4bba7482" sha1="1257d2004e625e1ca60ef78a43cd59c7fa2df29c" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="examine your information 3 (al alamiah, 1988).rom" size="0x20000" crc="4bba7482" sha1="1257d2004e625e1ca60ef78a43cd59c7fa2df29c" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="express">
-		<description>Express (Arab)</description>
+		<description>Express (Arab, v1.21)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="إكسبريس"/>
 		<info name="serial" value="F036" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="express (al-alamiah, 1985).rom" size="32768" crc="9c8e8ef6" sha1="a5dc0aa283072f772ee4b9eb93b0966500dd306b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="express (al-alamiah, 1985).rom" size="0x8000" crc="9c8e8ef6" sha1="a5dc0aa283072f772ee4b9eb93b0966500dd306b" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="expressa" cloneof="express">
-		<description>Express (Arab, alt)</description>
+		<description>Express (Arab, v1.21, alt)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="إكسبريس"/>
 		<info name="serial" value="F036" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="express (al-alamiah, 1985) (another dump).rom" size="32768" crc="f07afcb1" sha1="7758f57e91dd62ddb5c88cdd73dc0fb5ccd4de7f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="express (al-alamiah, 1985) (another dump).rom" size="0x8000" crc="f07afcb1" sha1="7758f57e91dd62ddb5c88cdd73dc0fb5ccd4de7f" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="faces">
-		<description>Faces (Arab)</description>
+		<description>Faces (Arab, v1.23)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="وجوه"/>
 		<info name="serial" value="P096" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="faces (al-alamiah, 1987).rom" size="32768" crc="3548afb7" sha1="a420f8d7d3631b1c795d182162221b21aaf48f1b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="faces (al-alamiah, 1987).rom" size="0x8000" crc="3548afb7" sha1="a420f8d7d3631b1c795d182162221b21aaf48f1b" />
 			</dataarea>
 		</part>
 	</software>
 
+	<!-- Software does not go past al alamiah copyright screen. -->
 	<software name="fract1" supported="no">
 		<description>Fractions 1 (Arab)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="كسور ١"/>
 		<info name="serial" value="M028" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="fractions 1 (al-alamiah, 1987).rom" size="32768" crc="ec312e56" sha1="e930f53bf480aba5d50d97ee7c60aad96c000d33" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="fractions 1 (al-alamiah, 1987).rom" size="0x8000" crc="ec312e56" sha1="e930f53bf480aba5d50d97ee7c60aad96c000d33" />
 			</dataarea>
 		</part>
 	</software>
@@ -14358,11 +15743,13 @@ legacy FM implementations cannot find it.
 		<description>Fractions 2 (Arab, v2.04)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="كسور ٢"/>
 		<info name="serial" value="M043" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_ksoor2.rom" size="32768" crc="874d4a36" sha1="b8b277064fe2427f586a6ad32504ec5ce756a574" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_ksoor2.rom" size="0x8000" crc="874d4a36" sha1="b8b277064fe2427f586a6ad32504ec5ce756a574" />
 			</dataarea>
 		</part>
 	</software>
@@ -14371,11 +15758,13 @@ legacy FM implementations cannot find it.
 		<description>Fractions 2 (Arab, v2.03)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="كسور ٢"/>
 		<info name="serial" value="M043" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="fractions 2 (al-alamiah, 1987).rom" size="32768" crc="0805af68" sha1="bb3df0a7656249e486accc60f583d3dd41db590b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="fractions 2 (al-alamiah, 1987).rom" size="0x8000" crc="0805af68" sha1="bb3df0a7656249e486accc60f583d3dd41db590b" />
 			</dataarea>
 		</part>
 	</software>
@@ -14385,43 +15774,50 @@ legacy FM implementations cannot find it.
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
 		<info name="usage" value="Requires an Arabic MSX" />
+		<info name="serial" value="GM020"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="hype-arabic.rom" size="32768" crc="24783377" sha1="6ad2f111227d6d4659f0089b9397896d16f867a0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="hype-arabic.rom" size="0x8000" crc="24783377" sha1="6ad2f111227d6d4659f0089b9397896d16f867a0" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="headtail">
-		<description>Head &amp; Tail (Arab)</description>
+		<description>Head &amp; Tail (Arab, v1.19)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="رأس و ذيل"/>
 		<info name="serial" value="F053" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="head &amp; tail (al alamiah, 1987).rom" size="32768" crc="cb06d33f" sha1="46c01cb08daca99a987799ae2b2a6a168d9f9d52" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="head &amp; tail (al alamiah, 1987).rom" size="0x8000" crc="cb06d33f" sha1="46c01cb08daca99a987799ae2b2a6a168d9f9d52" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="headtaila" cloneof="headtail">
-		<description>Head &amp; Tail (Arab, alt)</description>
+		<description>Head &amp; Tail (Arab, v1.19, alt)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="رأس و ذيل"/>
 		<info name="serial" value="F053" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="headtail.rom" size="32768" crc="b755250e" sha1="f4d4d132866707e7f8a97408b093acabb67ef5aa" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="headtail.rom" size="0x8000" crc="b755250e" sha1="f4d4d132866707e7f8a97408b093acabb67ef5aa" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="quran">
-		<description>The Holy Quran</description>
+		<description>The Holy Quran (v1.00)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="القرآن الكريم"/>
 		<info name="serial" value="R052" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
@@ -14437,11 +15833,13 @@ legacy FM implementations cannot find it.
 		<description>Ibn Maleck (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ابن مالك"/>
 		<info name="serial" value="A006" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ibn maleck (al alamiah, 1985).rom" size="32768" crc="7def468e" sha1="2d174a58c81eda0490e4606afa167bbe4082d845" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ibn maleck (al alamiah, 1985).rom" size="0x8000" crc="7def468e" sha1="2d174a58c81eda0490e4606afa167bbe4082d845" />
 			</dataarea>
 		</part>
 	</software>
@@ -14450,11 +15848,13 @@ legacy FM implementations cannot find it.
 		<description>Ibn Maleck (Arab, alt)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ابن مالك"/>
 		<info name="serial" value="A006" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ibnmalik-.rom" size="32768" crc="858ec773" sha1="c5248a712d9e58ea5f9b34f398419cbecef8a1fe" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ibnmalik-.rom" size="0x8000" crc="858ec773" sha1="c5248a712d9e58ea5f9b34f398419cbecef8a1fe" />
 			</dataarea>
 		</part>
 	</software>
@@ -14463,11 +15863,13 @@ legacy FM implementations cannot find it.
 		<description>Ibn Sina 1 (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ابن سينا ١"/>
 		<info name="serial" value="S010" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ibn sina 1 (al-alamiah, 1985).rom" size="32768" crc="ace7c69f" sha1="f332df804849c7a12f50dbbdbbb37949716b3671" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ibn sina 1 (al-alamiah, 1985).rom" size="0x8000" crc="ace7c69f" sha1="f332df804849c7a12f50dbbdbbb37949716b3671" />
 			</dataarea>
 		</part>
 	</software>
@@ -14476,11 +15878,13 @@ legacy FM implementations cannot find it.
 		<description>Ibn Sina 1 (Arab, alt)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ابن سينا ١"/>
 		<info name="serial" value="S010" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ibn sina 1 (al-alamiah, 1985) (another dump).rom" size="32768" crc="d69f1e94" sha1="c17b78ae95a17a3d3eb4cd00546f15cbbf4c846e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ibn sina 1 (al-alamiah, 1985) (another dump).rom" size="0x8000" crc="d69f1e94" sha1="c17b78ae95a17a3d3eb4cd00546f15cbbf4c846e" />
 			</dataarea>
 		</part>
 	</software>
@@ -14489,11 +15893,13 @@ legacy FM implementations cannot find it.
 		<description>Ibn Sina 2 (Arab, v1.01)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ابن سينا ٢"/>
 		<info name="serial" value="S012" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ibn sina 2 (al-alamiah, 1985) (another dump).rom" size="32768" crc="212ae5dc" sha1="136506ec295af5b3aa0012cf9cf2405be1cbd712" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ibn sina 2 (al-alamiah, 1985) (another dump).rom" size="0x8000" crc="212ae5dc" sha1="136506ec295af5b3aa0012cf9cf2405be1cbd712" />
 			</dataarea>
 		</part>
 	</software>
@@ -14502,63 +15908,73 @@ legacy FM implementations cannot find it.
 		<description>Ibn Sina 2 (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ابن سينا ٢"/>
 		<info name="serial" value="S012" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="ibn sina 2 (al-alamiah, 1985).rom" size="32768" crc="af44335a" sha1="630db2516b6f6da16882f507e74fb35455552ea4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ibn sina 2 (al-alamiah, 1985).rom" size="0x8000" crc="af44335a" sha1="630db2516b6f6da16882f507e74fb35455552ea4" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="inforace">
-		<description>Info Race (Arab)</description>
+		<description>Info Race (Arab, v1.02)</description>
 		<year>1990</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="سباق المعلومات"/>
 		<info name="serial" value="P079" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="131072">
-				<rom name="info race.rom" size="131072" crc="97330c37" sha1="217b21d10d80fe2d5d04636ee8c2f97f6edfe34a" />
+			<feature name="slot" value="ascii8" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="info race.rom" size="0x20000" crc="97330c37" sha1="217b21d10d80fe2d5d04636ee8c2f97f6edfe34a" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="islam5">
-		<description>Islam Built on Five (Arab)</description>
+		<description>Islam Built on Five (Arab, v1.21)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="بني الإسلام على خمس"/>
 		<info name="serial" value="R059" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="islam built on five (al-alamiah, 1986).rom" size="32768" crc="891b558b" sha1="60d1de0c217be896902c7d80e1d216715a2be562" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="islam built on five (al-alamiah, 1986).rom" size="0x8000" crc="891b558b" sha1="60d1de0c217be896902c7d80e1d216715a2be562" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="islam5a" cloneof="islam5">
-		<description>Islam Built on Five (Arab, alt)</description>
+		<description>Islam Built on Five (Arab, v1.21, alt)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="بني الإسلام على خمس"/>
 		<info name="serial" value="R059" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_islam.rom" size="32768" crc="8e3ce8d5" sha1="eb164a0a65077687c6e71f3ba2f3956f3aea6bb3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_islam.rom" size="0x8000" crc="8e3ce8d5" sha1="eb164a0a65077687c6e71f3ba2f3956f3aea6bb3" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="islam5b" cloneof="islam5">
-		<description>Islam Built on Five (Arab, alt 2)</description>
+		<description>Islam Built on Five (Arab, v1.21, alt 2)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="بني الإسلام على خمس"/>
 		<info name="serial" value="R059" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="islam pillars.rom" size="32768" crc="b7aba96d" sha1="4a28e8bc5ff7b57c63ce810972c3ffc2683ee3d4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="islam pillars.rom" size="0x8000" crc="b7aba96d" sha1="4a28e8bc5ff7b57c63ce810972c3ffc2683ee3d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -14569,8 +15985,9 @@ legacy FM implementations cannot find it.
 		<publisher>Al Alamiah</publisher>
 		<info name="serial" value="GA013" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="jet bomber (1985)(al alamiah).rom" size="32768" crc="41d93536" sha1="53c6655b0ea7c07101018879f3bf60de071c247b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="jet bomber (1985)(al alamiah).rom" size="0x8000" crc="41d93536" sha1="53c6655b0ea7c07101018879f3bf60de071c247b" />
 			</dataarea>
 		</part>
 	</software>
@@ -14579,11 +15996,13 @@ legacy FM implementations cannot find it.
 		<description>Koufi (Arab)</description>
 		<year>1984</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="كوفي"/>
 		<info name="serial" value="A001" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="koufi (al alamiah, 1984).rom" size="32768" crc="1e556011" sha1="175ff6dc3a71eba25aee1d111f8777ee4089696e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="koufi (al alamiah, 1984).rom" size="0x8000" crc="1e556011" sha1="175ff6dc3a71eba25aee1d111f8777ee4089696e" />
 			</dataarea>
 		</part>
 	</software>
@@ -14592,63 +16011,70 @@ legacy FM implementations cannot find it.
 		<description>Koufi (Arab, alt)</description>
 		<year>1984</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="كوفي"/>
 		<info name="serial" value="A001" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_kofi.rom" size="32768" crc="d9f61384" sha1="7a0ddc5f086a6bc7e8e7f7b1840988623a2cc1b5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_kofi.rom" size="0x8000" crc="d9f61384" sha1="7a0ddc5f086a6bc7e8e7f7b1840988623a2cc1b5" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="alnrom">
-		<description>Language of Numbers (Arab)</description>
+		<description>Language of Numbers (Arab, v1.01)</description>
 		<year>1989</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="لغة الأرقام"/>
 		<info name="serial" value="L101" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="a_ln.rom" size="65536" crc="fd8cd298" sha1="fea0a6406b22aa67dfbf6985e18dd7a0a6f071a6" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="a_ln.rom" size="0x10000" crc="fd8cd298" sha1="fea0a6406b22aa67dfbf6985e18dd7a0a6f071a6" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="count1">
-		<description>Let's Count 1 (Arab)</description>
+		<description>Let's Count 1 (Arab, v1.06)</description>
 		<year>1989</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="هيا نحسب ١"/>
 		<info name="serial" value="P058" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="a_lets1.rom" size="65536" crc="76e5363a" sha1="08eb5001bd95ffb7232cdbdffbec7634eb110ad8" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="a_lets1.rom" size="0x10000" crc="76e5363a" sha1="08eb5001bd95ffb7232cdbdffbec7634eb110ad8" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="count3">
-		<description>Let's Count 3 (Arab)</description>
+		<description>Let's Count 3 (Arab, v1.01)</description>
 		<year>1990</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="هيا نحسب ٣"/>
 		<info name="serial" value="P088" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="let's count 3 (al alamiah, 1990).rom" size="65536" crc="e57e3f59" sha1="73938f51fcb26349aa17e1ae1f1bd43b20ef227b" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="let's count 3 (al alamiah, 1990).rom" size="0x10000" crc="e57e3f59" sha1="73938f51fcb26349aa17e1ae1f1bd43b20ef227b" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="think">
-		<description>Let's Think (Arab)</description>
+		<description>Let's Think (Arab, v1.05)</description>
 		<year>1989</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="هيا نفكر"/>
 		<info name="serial" value="P041" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_lt.rom" size="32768" crc="e38a3528" sha1="99107515d4985c101ed73cf45e27e3405fd62ca4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_lt.rom" size="0x8000" crc="e38a3528" sha1="99107515d4985c101ed73cf45e27e3405fd62ca4" />
 			</dataarea>
 		</part>
 	</software>
@@ -14657,11 +16083,13 @@ legacy FM implementations cannot find it.
 		<description>Magic Touch (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اللمسة السحرية"/>
 		<info name="serial" value="C016" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="magic touch.rom" size="32768" crc="db4c54b6" sha1="951a5310534c16a6923eedf28278c13102b6a19f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="magic touch.rom" size="0x8000" crc="db4c54b6" sha1="951a5310534c16a6923eedf28278c13102b6a19f" />
 			</dataarea>
 		</part>
 	</software>
@@ -14670,11 +16098,13 @@ legacy FM implementations cannot find it.
 		<description>Magic Touch (Arab, alt)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اللمسة السحرية"/>
 		<info name="serial" value="C016" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="magic touch (a).rom" size="32768" crc="381bcb71" sha1="b9d5ec448d5de19c62dc09ffe3b257e0cef610d2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="magic touch (a).rom" size="0x8000" crc="381bcb71" sha1="b9d5ec448d5de19c62dc09ffe3b257e0cef610d2" />
 			</dataarea>
 		</part>
 	</software>
@@ -14683,11 +16113,13 @@ legacy FM implementations cannot find it.
 		<description>Magic Tune (Arab, v1.02)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="النغمة السحرية"/>
 		<info name="serial" value="U019" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="magic tune (al alamiah, 1985).rom" size="32768" crc="1ce01799" sha1="44ece0064495f7c90344e42fc14e29341d4e08bb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="magic tune (al alamiah, 1985).rom" size="0x8000" crc="1ce01799" sha1="44ece0064495f7c90344e42fc14e29341d4e08bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -14696,50 +16128,58 @@ legacy FM implementations cannot find it.
 		<description>Magic Tune (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="النغمة السحرية"/>
 		<info name="serial" value="U019" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_tune.rom" size="32768" crc="a405e5bf" sha1="abf5521759369518dd66390491ac0601c28e25bc" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_tune.rom" size="0x8000" crc="a405e5bf" sha1="abf5521759369518dd66390491ac0601c28e25bc" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="magwrite">
-		<description>Magic Writer (Arab)</description>
+		<description>Magic Writer (Arab, v1.08)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الكاتب السحري"/>
 		<info name="serial" value="C042" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_writer.rom" size="32768" crc="c7020ba3" sha1="48518d95d06a7761c4afe5235ef995bdc53c1952" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_writer.rom" size="0x8000" crc="c7020ba3" sha1="48518d95d06a7761c4afe5235ef995bdc53c1952" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="magnetic">
-		<description>Magnetics (Arab)</description>
+		<description>Magnetics (Arab, v1.05)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="المغناطيس"/>
 		<info name="serial" value="S056" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_mg.rom" size="32768" crc="fcb812a0" sha1="eb374a5e1d3209fa5da24a8fbbe9c4839dd02679" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_mg.rom" size="0x8000" crc="fcb812a0" sha1="eb374a5e1d3209fa5da24a8fbbe9c4839dd02679" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="magnetica" cloneof="magnetic">
-		<description>Magnetics (Arab, alt)</description>
+		<description>Magnetics (Arab, v1.05, alt)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="المغناطيس"/>
 		<info name="serial" value="S056" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="magnetics.rom" size="32768" crc="166d5599" sha1="4998d34b559f4a531843cebd2302212658d953f7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="magnetics.rom" size="0x8000" crc="166d5599" sha1="4998d34b559f4a531843cebd2302212658d953f7" />
 			</dataarea>
 		</part>
 	</software>
@@ -14748,11 +16188,13 @@ legacy FM implementations cannot find it.
 		<description>Memory (Arab)</description>
 		<year>1984</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الذاكرة"/>
 		<info name="serial" value="K004" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_memory.rom" size="32768" crc="e913cb77" sha1="7f0037069d75a36f1a73b8f7dd286d33f80be6dd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_memory.rom" size="0x8000" crc="e913cb77" sha1="7f0037069d75a36f1a73b8f7dd286d33f80be6dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -14761,249 +16203,286 @@ legacy FM implementations cannot find it.
 		<description>Memory (Arab, alt)</description>
 		<year>1984</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الذاكرة"/>
 		<info name="serial" value="K004" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="memory.rom" size="32768" crc="9f40b15e" sha1="6523381fa5012b45a69af0e351f239c97afd4be7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="memory.rom" size="0x8000" crc="9f40b15e" sha1="6523381fa5012b45a69af0e351f239c97afd4be7" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="multdiv">
-		<description>Multiply &amp; Divide (Arab)</description>
+		<description>Multiply &amp; Divide (Arab, v1.06)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اضرب و اقسم"/>
 		<info name="serial" value="M055" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_m&amp;d.rom" size="32768" crc="241623f9" sha1="860f5180c9028cbf675d9b1e59b7e7487c59ea0c" />
+		<info name="alt_title" value="الذاكرة"/>
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_m&amp;d.rom" size="0x8000" crc="241623f9" sha1="860f5180c9028cbf675d9b1e59b7e7487c59ea0c" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="multdiva" cloneof="multdiv">
-		<description>Multiply &amp; Divide (Arab, alt)</description>
+		<description>Multiply &amp; Divide (Arab, v1.06, alt)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اضرب و اقسم"/>
 		<info name="serial" value="M055" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mult &amp; div.rom" size="32768" crc="f7c40d1f" sha1="20effe093026e9209bd3327114e9ad51676cf807" />
+		<info name="alt_title" value="الذاكرة"/>
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mult &amp; div.rom" size="0x8000" crc="f7c40d1f" sha1="20effe093026e9209bd3327114e9ad51676cf807" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="museuman">
-		<description>Museum &amp; Ancient (Arab)</description>
+		<description>Museum &amp; Ancient (Arab, v1.05)</description>
 		<year>1990</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="متاحف وآثار"/>
 		<info name="serial" value="E071" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="a_athar.rom" size="131072" crc="c3b051e6" sha1="0a7bed652592ed6325acd037f1f5bbbd1d31b239" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="a_athar.rom" size="0x20000" crc="c3b051e6" sha1="0a7bed652592ed6325acd037f1f5bbbd1d31b239" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="myclock">
-		<description>My Clock (Arab)</description>
+		<description>My Clock (Arab, v1.15)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ساعتي"/>
 		<info name="serial" value="P025" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="my clock (al alamiah, 1987).rom" size="32768" crc="938fc4a2" sha1="11927d62332a3310ad462f2f532ac30533c1fc17" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="my clock (al alamiah, 1987).rom" size="0x8000" crc="938fc4a2" sha1="11927d62332a3310ad462f2f532ac30533c1fc17" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="myclocka" cloneof="myclock">
-		<description>My Clock (Arab, alt)</description>
+		<description>My Clock (Arab, v1.15, alt)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ساعتي"/>
 		<info name="serial" value="P025" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="my watch.rom" size="32768" crc="3a336af1" sha1="d9195b9a24f6e7c5b99eca046908915bfe369d46" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="my watch.rom" size="0x8000" crc="3a336af1" sha1="d9195b9a24f6e7c5b99eca046908915bfe369d46" />
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="mydict" supported="no">
-		<description>My Small Dictionary (Arab)</description>
+	<software name="mydict">
+		<description>My Small Dictionary (Arab, v1.10)</description>
 		<year>1989</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="قاموسي الصغير"/>
 		<info name="serial" value="P032" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="my small dictionary (al alamiah, 1989).rom" size="65536" crc="23b12582" sha1="acc93f818a9f2925bfcc61df7d9fe2e0cbc0a9ae" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="my small dictionary (al alamiah, 1989).rom" size="0x10000" crc="23b12582" sha1="acc93f818a9f2925bfcc61df7d9fe2e0cbc0a9ae" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="numbtarg">
-		<description>Number &amp; Target (Arab)</description>
+		<description>Number &amp; Target (Arab, v1.13)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="رقم وهدف"/>
 		<info name="serial" value="E082" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="number &amp; target (al alamiah, 1986).rom" size="32768" crc="424bf9d6" sha1="ddfb953e6c6d9c1be15362b9a0299259a66a2c98" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="number &amp; target (al alamiah, 1986).rom" size="0x8000" crc="424bf9d6" sha1="ddfb953e6c6d9c1be15362b9a0299259a66a2c98" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="numbtarga" cloneof="numbtarg">
-		<description>Number &amp; Target (Arab, alt)</description>
+		<description>Number &amp; Target (Arab, v1.13, alt)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="رقم وهدف"/>
 		<info name="serial" value="E082" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="num &amp; target.rom" size="16384" crc="fa7543bb" sha1="ce493944b6b57ffa56e7eb09df76e73b65dcb800" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="num &amp; target.rom" size="0x4000" crc="fa7543bb" sha1="ce493944b6b57ffa56e7eb09df76e73b65dcb800" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="optics">
-		<description>Optics (Arab)</description>
+		<description>Optics (Arabm, v1.11)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="بصريات"/>
 		<info name="serial" value="S027" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_basari.rom" size="32768" crc="3beed275" sha1="3c9301eea142857ee5e9e04d0caebbc5a4245715" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_basari.rom" size="0x8000" crc="3beed275" sha1="3c9301eea142857ee5e9e04d0caebbc5a4245715" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="arabwrld">
-		<description>Our Arabic World (Arab)</description>
+		<description>Our Arabic World (Arab, v1.24)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="عالمنا العربي"/>
 		<info name="serial" value="H060" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="our arabic world (al alamiah, 1987).rom" size="32768" crc="758c890c" sha1="6c684481c42106c1e8e5bfa5261a9d8cfde3323f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="our arabic world (al alamiah, 1987).rom" size="0x8000" crc="758c890c" sha1="6c684481c42106c1e8e5bfa5261a9d8cfde3323f" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="arabwrlda" cloneof="arabwrld">
-		<description>Our Arabic World (Arab, alt)</description>
+		<description>Our Arabic World (Arab, v1.24, alt)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="عالمنا العربي"/>
 		<info name="serial" value="H060" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="our arab world.rom" size="32768" crc="8207ee57" sha1="6918679b2be2d014b60b4025a3877dee9ad5f407" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="our arab world.rom" size="0x8000" crc="8207ee57" sha1="6918679b2be2d014b60b4025a3877dee9ad5f407" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="pertabla">
-		<description>Periodic Table (Arab, Al Alamiah)</description>
+		<description>Periodic Table (Arab, Al Alamiah, v1.04)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الجدول الدوري"/>
 		<info name="serial" value="S030" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_table.rom" size="32768" crc="d43fa7c2" sha1="823b638419dc81767a8511db190212607908cece" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_table.rom" size="0x8000" crc="d43fa7c2" sha1="823b638419dc81767a8511db190212607908cece" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="pertablaa" cloneof="pertabla">
-		<description>Periodic Table (Arab, Al Alamiah, alt)</description>
+		<description>Periodic Table (Arab, Al Alamiah, v1.04, alt)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الجدول الدوري"/>
 		<info name="serial" value="S030" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="periodic table.rom" size="32768" crc="a4901bbf" sha1="7033c47a3b20fd04054ef37d209e1545ac053865" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="periodic table.rom" size="0x8000" crc="a4901bbf" sha1="7033c47a3b20fd04054ef37d209e1545ac053865" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="picword">
-		<description>Pictures &amp; Words (Arab)</description>
+		<description>Pictures &amp; Words (Arab, v1.03)</description>
 		<year>1989</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="صور و كلمات"/>
 		<info name="serial" value="L042" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="pictures &amp; words (al alamiah, 1989).rom" size="131072" crc="ea5c9f48" sha1="5b25d93259a358f2064adc44f6382c91c9394861" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="pictures &amp; words (al alamiah, 1989).rom" size="0x20000" crc="ea5c9f48" sha1="5b25d93259a358f2064adc44f6382c91c9394861" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="project">
-		<description>Projectiles (Arab)</description>
+		<description>Projectiles (Arab, v1.12)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="المقذوفات"/>
 		<info name="serial" value="S031" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_mkzofat.rom" size="32768" crc="81506031" sha1="17bbed846045f3325b1d34c686d35889f9efe157" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_mkzofat.rom" size="0x8000" crc="81506031" sha1="17bbed846045f3325b1d34c686d35889f9efe157" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="proverbs">
-		<description>Proverbs (Arab)</description>
+		<description>Proverbs (Arab, v1.11)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="أمثال و أقوال"/>
 		<info name="serial" value="A057" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="proverbs (al-alamiah, 1985).rom" size="32768" crc="ca876e39" sha1="b186d547c0b79612bffb63dd49c3230f156c2bbe" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="proverbs (al-alamiah, 1985).rom" size="0x8000" crc="ca876e39" sha1="b186d547c0b79612bffb63dd49c3230f156c2bbe" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="puzzle">
-		<description>Puzzle (Arab)</description>
+		<description>Puzzle (Arab, v1.11)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الأحاجي"/>
 		<info name="serial" value="K075" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_puzle.rom" size="32768" crc="c9d0ac79" sha1="0dfe92b48e99bed4cd879e4026d036f94c826ce8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_puzle.rom" size="0x8000" crc="c9d0ac79" sha1="0dfe92b48e99bed4cd879e4026d036f94c826ce8" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="rainbows">
-		<description>Rainbow Stories (Arab)</description>
+		<description>Rainbow Stories (Arab, v1.20)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="حكايات قوس قزح"/>
 		<info name="serial" value="P066" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="rainbow stories (al alamiah, 1986).rom" size="32768" crc="749488c7" sha1="108abde71e59839fb4d1e59c3a0cb2366220030c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="rainbow stories (al alamiah, 1986).rom" size="0x8000" crc="749488c7" sha1="108abde71e59839fb4d1e59c3a0cb2366220030c" />
 			</dataarea>
 		</part>
 	</software>
@@ -15012,11 +16491,13 @@ legacy FM implementations cannot find it.
 		<description>Sea Horse (Arab)</description>
 		<year>1984</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="حصان البحر"/>
 		<info name="serial" value="L003" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="sea horse (al alamiah, 1984).rom" size="32768" crc="59b2178f" sha1="1b5b269bc0c905aff94ebea598a936e34a74fb07" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="sea horse (al alamiah, 1984).rom" size="0x8000" crc="59b2178f" sha1="1b5b269bc0c905aff94ebea598a936e34a74fb07" />
 			</dataarea>
 		</part>
 	</software>
@@ -15025,43 +16506,46 @@ legacy FM implementations cannot find it.
 		<description>Arabic Sakhr BASIC (Arab)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="صخر بيسيك"/>
 		<info name="serial" value="C026" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="a_sakhr.rom" size="131072" crc="6488cc19" sha1="9ee1559df309a5d833808908a0aac3b811c45312" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="a_sakhr.rom" size="0x20000" crc="6488cc19" sha1="9ee1559df309a5d833808908a0aac3b811c45312" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="sakhrdic">
-		<description>Sakhr Dictionary (Arab)</description>
+		<description>Sakhr Dictionary (Arab, v1.19)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="قاموس صخر"/>
 		<info name="serial" value="F063" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="a_qs.rom" size="131072" crc="22528d5c" sha1="64c49fdabbdd5e13c4310b03a183ea1a018154a4" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="a_qs.rom" size="0x20000" crc="22528d5c" sha1="64c49fdabbdd5e13c4310b03a183ea1a018154a4" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="sakhrfil">
-		<description>Sakhr Files (Arab)</description>
+		<description>Sakhr Files (Arab, v1.17)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="ملفات صخر"/>
 		<info name="serial" value="B051" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="sahkr files (al alamiah, 19xx).rom" size="131072" crc="b872ec39" sha1="09b100f109c03e60ab7f777c508bf240f6acd79d" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="sahkr files (al alamiah, 19xx).rom" size="0x20000" crc="b872ec39" sha1="09b100f109c03e60ab7f777c508bf240f6acd79d" />
 			</dataarea>
 		</part>
 	</software>
@@ -15070,11 +16554,12 @@ legacy FM implementations cannot find it.
 		<description>Sakhr Logo (Arab)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="صخر لوغو"/>
 		<info name="serial" value="C050" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="a_logo-a.rom" size="65536" crc="25bd7869" sha1="a2901318f8216ccd2f4d08b0f272e1bf90ab197a" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="a_logo-a.rom" size="0x10000" crc="25bd7869" sha1="a2901318f8216ccd2f4d08b0f272e1bf90ab197a" />
 			</dataarea>
 		</part>
 	</software>
@@ -15083,11 +16568,13 @@ legacy FM implementations cannot find it.
 		<description>Sebaweh I (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="سيبويه ١"/>
 		<info name="serial" value="A009" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="sebaweh 1 (al alamiah, 1985).rom" size="32768" crc="703aa998" sha1="d0cd48404eec5975d0f284c46b3cd710236b87a5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="sebaweh 1 (al alamiah, 1985).rom" size="0x8000" crc="703aa998" sha1="d0cd48404eec5975d0f284c46b3cd710236b87a5" />
 			</dataarea>
 		</part>
 	</software>
@@ -15096,11 +16583,13 @@ legacy FM implementations cannot find it.
 		<description>Sebaweh II (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="سيبويه ٢"/>
 		<info name="serial" value="A023" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="sebaweh 2 (al alamiah, 19985).rom" size="32768" crc="522006ea" sha1="bbabc8ce1e39d4405dee587737e4dea24477c24d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="sebaweh 2 (al alamiah, 19985).rom" size="0x8000" crc="522006ea" sha1="bbabc8ce1e39d4405dee587737e4dea24477c24d" />
 			</dataarea>
 		</part>
 	</software>
@@ -15109,11 +16598,13 @@ legacy FM implementations cannot find it.
 		<description>Secret Word (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="العالم السري"/>
 		<info name="serial" value="F044" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_secretword.rom" size="32768" crc="3106a35d" sha1="fdc3cc10b4821ea5169c817fcbd6e99fac464feb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_secretword.rom" size="0x8000" crc="3106a35d" sha1="fdc3cc10b4821ea5169c817fcbd6e99fac464feb" />
 			</dataarea>
 		</part>
 	</software>
@@ -15122,11 +16613,13 @@ legacy FM implementations cannot find it.
 		<description>Sets (Arab, v1.23)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="المجموعات"/>
 		<info name="serial" value="M011" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="sets (al alamiah, 1985).rom" size="32768" crc="654ba5bf" sha1="7c811f87fc2c61b5622b75ffa37fa43b9f2a1503" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="sets (al alamiah, 1985).rom" size="0x8000" crc="654ba5bf" sha1="7c811f87fc2c61b5622b75ffa37fa43b9f2a1503" />
 			</dataarea>
 		</part>
 	</software>
@@ -15135,24 +16628,28 @@ legacy FM implementations cannot find it.
 		<description>Sets (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="المجموعات"/>
 		<info name="serial" value="M011" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="sets.rom" size="32768" crc="9a21c20a" sha1="98f3eec607cae92e01c1310f25d980f2859b88cd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="sets.rom" size="0x8000" crc="9a21c20a" sha1="98f3eec607cae92e01c1310f25d980f2859b88cd" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="shathera">
-		<description>Shater Hassan (Arab, Al Alamiah)</description>
+		<description>Shater Hassan (Arab, Al Alamiah, v1.07)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الشاطر حسن"/>
 		<info name="serial" value="P046" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="shater hassan (al alamiah, 1987).rom" size="32768" crc="6d32e0e9" sha1="a4d4a6fc06739c543ff0767a1006ae2860d9b635" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="shater hassan (al alamiah, 1987).rom" size="0x8000" crc="6d32e0e9" sha1="a4d4a6fc06739c543ff0767a1006ae2860d9b635" />
 			</dataarea>
 		</part>
 	</software>
@@ -15161,11 +16658,13 @@ legacy FM implementations cannot find it.
 		<description>Smartness Examine 1 (Arab, v1.02)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اختبر ذكائك"/>
 		<info name="serial" value="K015" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="smartness examine 1 (al alamiah, 1985).rom" size="32768" crc="8add2cbf" sha1="113b8547944e2325245553c18a4a4c3d1f864bf1" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="smartness examine 1 (al alamiah, 1985).rom" size="0x8000" crc="8add2cbf" sha1="113b8547944e2325245553c18a4a4c3d1f864bf1" />
 			</dataarea>
 		</part>
 	</software>
@@ -15174,24 +16673,28 @@ legacy FM implementations cannot find it.
 		<description>Smartness Examine 1 (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اختبر ذكائك"/>
 		<info name="serial" value="K015" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_zaka1.rom" size="32768" crc="6a0f3daa" sha1="2f1aacc5d18973e59f9eafa20d7ffddca34d0ef9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_zaka1.rom" size="0x8000" crc="6a0f3daa" sha1="2f1aacc5d18973e59f9eafa20d7ffddca34d0ef9" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="smartex2">
-		<description>Smartness Examine 2 (Arab)</description>
+		<description>Smartness Examine 2 (Arab, v1.06)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="اختبر ذكائك ٢"/>
 		<info name="serial" value="K073" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="smartness examine 2 (al alamiah, 1985).rom" size="32768" crc="4f57624d" sha1="c3680636efd8d2f3a7c1c6774dd36399c754b71d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="smartness examine 2 (al alamiah, 1985).rom" size="0x8000" crc="4f57624d" sha1="c3680636efd8d2f3a7c1c6774dd36399c754b71d" />
 			</dataarea>
 		</part>
 	</software>
@@ -15200,11 +16703,13 @@ legacy FM implementations cannot find it.
 		<description>Space Arithmetic (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="حساب الفضاء"/>
 		<info name="serial" value="M013" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="space arithmetic (al alamiah, 1985).rom" size="32768" crc="987b7c33" sha1="a25f9b813c4488c73c5f54055748b4dbb057c2e9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="space arithmetic (al alamiah, 1985).rom" size="0x8000" crc="987b7c33" sha1="a25f9b813c4488c73c5f54055748b4dbb057c2e9" />
 			</dataarea>
 		</part>
 	</software>
@@ -15213,50 +16718,57 @@ legacy FM implementations cannot find it.
 		<description>Star Wars (Arab)</description>
 		<year>1986</year>
 		<publisher>Al Alamiah</publisher>
-		<info name="serial" value="" />
+		<info name="serial" value="GA015" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_sw.rom" size="32768" crc="5f332c62" sha1="f74e7e90961c7fd5978ff6301f6491e58819f199" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_sw.rom" size="0x8000" crc="5f332c62" sha1="f74e7e90961c7fd5978ff6301f6491e58819f199" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="arablogo">
-		<description>Sulhof Arab Logo (Arab)</description>
+		<description>Sulhof Arab Logo (Arab, v1.25)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="سلحوف اللوغو العربي"/>
 		<info name="serial" value="C061" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_b.rom" size="32768" crc="088f0df9" sha1="f2b5b9029575b85f0730914a44e57f94c9313df5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_b.rom" size="0x8000" crc="088f0df9" sha1="f2b5b9029575b85f0730914a44e57f94c9313df5" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="who">
-		<description>Who? (Arab)</description>
+		<description>Who? (Arab, v1.14)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="من ؟"/>
 		<info name="serial" value="E083" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_mn.rom" size="32768" crc="da3ca043" sha1="d2c5c19ad327149f029a72e1834b97761e570f02" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_mn.rom" size="0x8000" crc="da3ca043" sha1="d2c5c19ad327149f029a72e1834b97761e570f02" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="whoa" cloneof="who">
-		<description>Who? (Arab, alt)</description>
+		<description>Who? (Arab, v1.14, alt)</description>
 		<year>1987</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="من ؟"/>
 		<info name="serial" value="E083" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="who.rom" size="32768" crc="9cbc0c03" sha1="b815cb222a6314c1adad0945af7be759a14c200a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="who.rom" size="0x8000" crc="9cbc0c03" sha1="b815cb222a6314c1adad0945af7be759a14c200a" />
 			</dataarea>
 		</part>
 	</software>
@@ -15265,11 +16777,13 @@ legacy FM implementations cannot find it.
 		<description>Window on the World (Arab, v1.02)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="نافذة على العالم"/>
 		<info name="serial" value="H005" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="window on the world (al alamiah, 1985).rom" size="32768" crc="1a920ee0" sha1="a81155d9d12eb9272cbb9281de99b96d5d16fe09" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="window on the world (al alamiah, 1985).rom" size="0x8000" crc="1a920ee0" sha1="a81155d9d12eb9272cbb9281de99b96d5d16fe09" />
 			</dataarea>
 		</part>
 	</software>
@@ -15278,11 +16792,13 @@ legacy FM implementations cannot find it.
 		<description>Window on the World (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="نافذة على العالم"/>
 		<info name="serial" value="H005" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_world.rom" size="32768" crc="2b3a714a" sha1="e7324782c7bec087105312275043984907cbfe1f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_world.rom" size="0x8000" crc="2b3a714a" sha1="e7324782c7bec087105312275043984907cbfe1f" />
 			</dataarea>
 		</part>
 	</software>
@@ -15291,11 +16807,13 @@ legacy FM implementations cannot find it.
 		<description>Voyage to Mecca (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="رحلة إلى مكة"/>
 		<info name="serial" value="R008" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="voyage to mecca (al-alamiah, 1985).rom" size="32768" crc="a50b65ce" sha1="e2287d736cc4ad7951a965ac058d2e16ac7c36c6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="voyage to mecca (al-alamiah, 1985).rom" size="0x8000" crc="a50b65ce" sha1="e2287d736cc4ad7951a965ac058d2e16ac7c36c6" />
 			</dataarea>
 		</part>
 	</software>
@@ -15304,11 +16822,13 @@ legacy FM implementations cannot find it.
 		<description>Voyage to Mecca (Arab, alt)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="رحلة إلى مكة"/>
 		<info name="serial" value="R008" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_makka.rom" size="32768" crc="4702de34" sha1="01e58fa57a8590595cb3cf5370e60ed53302e93d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_makka.rom" size="0x8000" crc="4702de34" sha1="01e58fa57a8590595cb3cf5370e60ed53302e93d" />
 			</dataarea>
 		</part>
 	</software>
@@ -15317,11 +16837,13 @@ legacy FM implementations cannot find it.
 		<description>Voyage to Mecca (Arab, alt 2)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="رحلة إلى مكة"/>
 		<info name="serial" value="R008" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="mecca trip.rom" size="32768" crc="5c18eabd" sha1="09d2563fd5d9df095aa48be5ead7771c23c50ad2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="mecca trip.rom" size="0x8000" crc="5c18eabd" sha1="09d2563fd5d9df095aa48be5ead7771c23c50ad2" />
 			</dataarea>
 		</part>
 	</software>
@@ -15330,11 +16852,13 @@ legacy FM implementations cannot find it.
 		<description>Wonderful Child (Arab, v1.02)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الطفل العجيب"/>
 		<info name="serial" value="P021" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a_child.rom" size="32768" crc="581947d7" sha1="e5a347daa39098a38918b1fceb756d93bbcf1dd0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a_child.rom" size="0x8000" crc="581947d7" sha1="e5a347daa39098a38918b1fceb756d93bbcf1dd0" />
 			</dataarea>
 		</part>
 	</software>
@@ -15343,11 +16867,13 @@ legacy FM implementations cannot find it.
 		<description>Wonderful Child (Arab)</description>
 		<year>1985</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الطفل العجيب"/>
 		<info name="serial" value="P021" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="wonderful child (al-alamiah, 1985).rom" size="32768" crc="2e3ebe4f" sha1="b9f88876b5caba3758a968c9f652de832e412aba" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="wonderful child (al-alamiah, 1985).rom" size="0x8000" crc="2e3ebe4f" sha1="b9f88876b5caba3758a968c9f652de832e412aba" />
 			</dataarea>
 		</part>
 	</software>
@@ -15358,51 +16884,55 @@ legacy FM implementations cannot find it.
 		<publisher>Husnisoft</publisher>
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="amazingkid.rom" size="32768" crc="43690da6" sha1="55cc50740d68d2558351cd8d125821dd1be70a1c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="amazingkid.rom" size="0x8000" crc="43690da6" sha1="55cc50740d68d2558351cd8d125821dd1be70a1c" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="youngart">
-		<description>Young Artist (Arab)</description>
+		<description>Young Artist (Arab, v1.17)</description>
 		<year>1988</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الفنان الصغير"/>
 		<info name="serial" value="P076" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="a_artist.rom" size="131072" crc="25013264" sha1="e19cfcbe92ec3682bee869dfad5f6b4058b1f2ce" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="a_artist.rom" size="0x20000" crc="25013264" sha1="e19cfcbe92ec3682bee869dfad5f6b4058b1f2ce" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="youngres">
-		<description>Young Researcher (Arab)</description>
+		<description>Young Researcher (Arab, v1.03)</description>
 		<year>1989</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="الباحث الصغير"/>
 		<info name="serial" value="P098" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="65536">
-				<rom name="a_smallserch.rom" size="65536" crc="e5479952" sha1="e4f7a94d0cb43f56f73d54c22364e91434363945" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="a_smallserch.rom" size="0x10000" crc="e5479952" sha1="e4f7a94d0cb43f56f73d54c22364e91434363945" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="zoo">
-		<description>The Zoo (Arab)</description>
+		<description>The Zoo (Arab, v1.05)</description>
 		<year>1989</year>
 		<publisher>Al Alamiah</publisher>
+		<info name="alt_title" value="حديقة الحيوان"/>
 		<info name="serial" value="F062" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="ascii8" />
 			<feature name="mapper" value="M60002-0125SP" />
-			<dataarea name="rom" size="131072">
-				<rom name="the zoo (al alamiah, 1989).rom" size="131072" crc="eb40e36f" sha1="ad3d8fc2201a245e352875918e421b42764e4148" />
+			<dataarea name="rom" size="0x20000">
+				<rom name="the zoo (al alamiah, 1989).rom" size="0x20000" crc="eb40e36f" sha1="ad3d8fc2201a245e352875918e421b42764e4148" />
 			</dataarea>
 		</part>
 	</software>
@@ -15414,10 +16944,12 @@ legacy FM implementations cannot find it.
 		<description>A'lamona (Arab)</description>
 		<year>1985</year>
 		<publisher>Barq</publisher>
+		<!-- generaton-msx has AQ004 but no photographic proof for either -->
 		<info name="serial" value="AQ001" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="a'lamona (barq, 1985).rom" size="32768" crc="4913bdd0" sha1="bf5f571c88c9100ac7fccd92ae89e7780787683a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="a'lamona (barq, 1985).rom" size="0x8000" crc="4913bdd0" sha1="bf5f571c88c9100ac7fccd92ae89e7780787683a" />
 			</dataarea>
 		</part>
 	</software>
@@ -15426,10 +16958,12 @@ legacy FM implementations cannot find it.
 		<description>A'lamona (Arab, alt)</description>
 		<year>1985</year>
 		<publisher>Barq</publisher>
+		<!-- generaton-msx has AQ004 but no photographic proof for either -->
 		<info name="serial" value="AQ001" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_aalamna.rom" size="32768" crc="04f74be6" sha1="a27a19d784aa8e3e121ec28d70479e4825db5b5d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_aalamna.rom" size="0x8000" crc="04f74be6" sha1="a27a19d784aa8e3e121ec28d70479e4825db5b5d" />
 			</dataarea>
 		</part>
 	</software>
@@ -15438,9 +16972,12 @@ legacy FM implementations cannot find it.
 		<description>Aladdin (Arab)</description>
 		<year>1986</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="علاء الدين"/>
+		<info name="seriall" value="AQ008"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="aladdin (barq, 1986).rom" size="32768" crc="895199cb" sha1="b50f5feacdfbdabed9cad6963c801d71263d48a2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="aladdin (barq, 1986).rom" size="0x8000" crc="895199cb" sha1="b50f5feacdfbdabed9cad6963c801d71263d48a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -15449,9 +16986,12 @@ legacy FM implementations cannot find it.
 		<description>Aladdin (Arab, alt)</description>
 		<year>1986</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="علاء الدين"/>
+		<info name="seriall" value="AQ008"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_alaalden.rom" size="32768" crc="d81b6187" sha1="917cec78a48fb4a2f9a01713592b4d7a118bddf3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_alaalden.rom" size="0x8000" crc="d81b6187" sha1="917cec78a48fb4a2f9a01713592b4d7a118bddf3" />
 			</dataarea>
 		</part>
 	</software>
@@ -15460,9 +17000,12 @@ legacy FM implementations cannot find it.
 		<description>Assistant (Arab)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="المساعد"/>
+		<info name="serial" value="AQ21"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="assistant (barq, 1987).rom" size="32768" crc="36607198" sha1="e98dd601ef1773b6f23a4b1f77a7dd55820b196f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="assistant (barq, 1987).rom" size="0x8000" crc="36607198" sha1="e98dd601ef1773b6f23a4b1f77a7dd55820b196f" />
 			</dataarea>
 		</part>
 	</software>
@@ -15471,9 +17014,11 @@ legacy FM implementations cannot find it.
 		<description>Baba Sanfour (Arab)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="بابا سنفور"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="baba sanfour (barq, 1987).rom" size="32768" crc="88996641" sha1="fef7350500c9168b7fc46f96f5d79150fff423c9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="baba sanfour (barq, 1987).rom" size="0x8000" crc="88996641" sha1="fef7350500c9168b7fc46f96f5d79150fff423c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -15482,9 +17027,11 @@ legacy FM implementations cannot find it.
 		<description>Baba Sanfour (Arab, alt)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="بابا سنفور"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_sanfor.rom" size="32768" crc="14c36e7d" sha1="7eba01b7a509597e9a82e1d315c45fb1633d3e1e" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_sanfor.rom" size="0x8000" crc="14c36e7d" sha1="7eba01b7a509597e9a82e1d315c45fb1633d3e1e" />
 			</dataarea>
 		</part>
 	</software>
@@ -15493,9 +17040,12 @@ legacy FM implementations cannot find it.
 		<description>Arabic Barq BASIC (Arab)</description>
 		<year>1986</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="برق - بيسيك"/>
+		<info name="serial" value="AQ010"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_basic.rom" size="32768" crc="bdc18f43" sha1="f9f3e2e6222e1cdb0784bf041e4a01146aab736a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_basic.rom" size="0x8000" crc="bdc18f43" sha1="f9f3e2e6222e1cdb0784bf041e4a01146aab736a" />
 			</dataarea>
 		</part>
 	</software>
@@ -15504,9 +17054,11 @@ legacy FM implementations cannot find it.
 		<description>Barq Games</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="العاب برق"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_game.rom" size="32768" crc="bffe1ecb" sha1="9fd29a3a70d4092d52af90b2680c943a22796773" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_game.rom" size="0x8000" crc="bffe1ecb" sha1="9fd29a3a70d4092d52af90b2680c943a22796773" />
 			</dataarea>
 		</part>
 	</software>
@@ -15515,10 +17067,12 @@ legacy FM implementations cannot find it.
 		<description>Barq Writer (Arab)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="الكاتب"/>
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="barq writer (barq, 1987).rom" size="32768" crc="bf2e13a4" sha1="b13b8a747e8bb1ba875724d1a3fbdcbfcff6594c" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="barq writer (barq, 1987).rom" size="0x8000" crc="bf2e13a4" sha1="b13b8a747e8bb1ba875724d1a3fbdcbfcff6594c" />
 			</dataarea>
 		</part>
 	</software>
@@ -15527,9 +17081,12 @@ legacy FM implementations cannot find it.
 		<description>Fraction (Arab)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="الكسور"/>
+		<info name="serial" value="AQ015"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="fraction (barq, 1987).rom" size="32768" crc="d3137a35" sha1="66fbc5c4e51b10e1b7ed6f5863dbf8b7a4438fda" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="fraction (barq, 1987).rom" size="0x8000" crc="d3137a35" sha1="66fbc5c4e51b10e1b7ed6f5863dbf8b7a4438fda" />
 			</dataarea>
 		</part>
 	</software>
@@ -15538,9 +17095,12 @@ legacy FM implementations cannot find it.
 		<description>Fraction (Arab, alt)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="الكسور"/>
+		<info name="serial" value="AQ015"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_ksoor.rom" size="32768" crc="316e74f9" sha1="d1bf83a8c0763a0229e7f96a1204c2344dd76db2" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_ksoor.rom" size="0x8000" crc="316e74f9" sha1="d1bf83a8c0763a0229e7f96a1204c2344dd76db2" />
 			</dataarea>
 		</part>
 	</software>
@@ -15549,9 +17109,11 @@ legacy FM implementations cannot find it.
 		<description>Game Box (Arab)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="صندوق الألعاب"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_box.rom" size="32768" crc="212be193" sha1="bf355b7de4af6367323dd10a159091a233519e26" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_box.rom" size="0x8000" crc="212be193" sha1="bf355b7de4af6367323dd10a159091a233519e26" />
 			</dataarea>
 		</part>
 	</software>
@@ -15560,9 +17122,12 @@ legacy FM implementations cannot find it.
 		<description>Glory (Arab)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="أمجادنا"/>
+		<info name="serial" value="AQ007"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="glory (barq, 1987).rom" size="32768" crc="e0079b95" sha1="9d65b7ba150c5d65af21191531a2f5cdbf05a7b5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="glory (barq, 1987).rom" size="0x8000" crc="e0079b95" sha1="9d65b7ba150c5d65af21191531a2f5cdbf05a7b5" />
 			</dataarea>
 		</part>
 	</software>
@@ -15571,9 +17136,11 @@ legacy FM implementations cannot find it.
 		<description>Great Language (Arab)</description>
 		<year>1988</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="أحلى الكلام"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="[unknown] (barq, 19xx) (arabic).rom" size="32768" crc="07def65a" sha1="a86ac07631e27d64cbc5309b8a82e2961f3cece9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="[unknown] (barq, 19xx) (arabic).rom" size="0x8000" crc="07def65a" sha1="a86ac07631e27d64cbc5309b8a82e2961f3cece9" />
 			</dataarea>
 		</part>
 	</software>
@@ -15582,10 +17149,12 @@ legacy FM implementations cannot find it.
 		<description>Instructor (Arab)</description>
 		<year>1985</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="المرشد"/>
 		<info name="serial" value="AQ004" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="instructor (barq, 1985).rom" size="32768" crc="e4983680" sha1="90161111906b3efa51089b0c79f6d365f70b2ebb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="instructor (barq, 1985).rom" size="0x8000" crc="e4983680" sha1="90161111906b3efa51089b0c79f6d365f70b2ebb" />
 			</dataarea>
 		</part>
 	</software>
@@ -15594,10 +17163,12 @@ legacy FM implementations cannot find it.
 		<description>Instructor (Arab, alt)</description>
 		<year>1985</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="المرشد"/>
 		<info name="serial" value="AQ004" />
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_morshd.rom" size="32768" crc="45c697ce" sha1="cb09942ae3b81089fa0ea7a1150596d63bf9a682" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_morshd.rom" size="0x8000" crc="45c697ce" sha1="cb09942ae3b81089fa0ea7a1150596d63bf9a682" />
 			</dataarea>
 		</part>
 	</software>
@@ -15606,9 +17177,11 @@ legacy FM implementations cannot find it.
 		<description>Knowledge (Arab)</description>
 		<year>1988</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="عالم المعرفة"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="[unknown 2] (barq, 19xx) (arabic).rom" size="32768" crc="a592e659" sha1="a1c69bae93eb063a01ef5de71036065576e64335" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="[unknown 2] (barq, 19xx) (arabic).rom" size="0x8000" crc="a592e659" sha1="a1c69bae93eb063a01ef5de71036065576e64335" />
 			</dataarea>
 		</part>
 	</software>
@@ -15617,9 +17190,12 @@ legacy FM implementations cannot find it.
 		<description>Meaning (Arab)</description>
 		<year>1986</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="المعاني"/>
+		<info name="serial" value="AQ005"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="meaning (barq, 1986).rom" size="32768" crc="4c2ba393" sha1="fcacf044fb5d704b2cc14554f35c5a4dca464cd8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="meaning (barq, 1986).rom" size="0x8000" crc="4c2ba393" sha1="fcacf044fb5d704b2cc14554f35c5a4dca464cd8" />
 			</dataarea>
 		</part>
 	</software>
@@ -15628,9 +17204,12 @@ legacy FM implementations cannot find it.
 		<description>Meaning (Arab, alt)</description>
 		<year>1986</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="المعاني"/>
+		<info name="serial" value="AQ005"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_meaning.rom" size="32768" crc="232362d6" sha1="34abc343f2d678df9d9ea1268ef9132547a526da" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_meaning.rom" size="0x8000" crc="232362d6" sha1="34abc343f2d678df9d9ea1268ef9132547a526da" />
 			</dataarea>
 		</part>
 	</software>
@@ -15639,9 +17218,12 @@ legacy FM implementations cannot find it.
 		<description>My Lady (Arab)</description>
 		<year>1986</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="سيدتي"/>
+		<info name="serial" value="AQ006"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="my lady (barq, 1986).rom" size="32768" crc="d398f47b" sha1="8bdf4bca4b3cc792ee9a5acc50e8595accd90345" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="my lady (barq, 1986).rom" size="0x8000" crc="d398f47b" sha1="8bdf4bca4b3cc792ee9a5acc50e8595accd90345" />
 			</dataarea>
 		</part>
 	</software>
@@ -15650,9 +17232,11 @@ legacy FM implementations cannot find it.
 		<description>Numbers' World (Arab)</description>
 		<year>1985</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="عالم الأرقام"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="numbers world (barq, 1985).rom" size="32768" crc="5ec11635" sha1="0b7f1c39e4b375954fbc470064f0829a050fe1c3" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="numbers world (barq, 1985).rom" size="0x8000" crc="5ec11635" sha1="0b7f1c39e4b375954fbc470064f0829a050fe1c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -15661,9 +17245,12 @@ legacy FM implementations cannot find it.
 		<description>Our Homeland (Arab)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="بلادنا"/>
+		<info name="serial" value="AQ012"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="our homeland (barq, 1987).rom" size="32768" crc="32192dcb" sha1="735b365c61b1610c1c4746fef086b35b73ef6561" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="our homeland (barq, 1987).rom" size="0x8000" crc="32192dcb" sha1="735b365c61b1610c1c4746fef086b35b73ef6561" />
 			</dataarea>
 		</part>
 	</software>
@@ -15672,9 +17259,12 @@ legacy FM implementations cannot find it.
 		<description>Our Homeland (Arab, alt)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="بلادنا"/>
+		<info name="serial" value="AQ012"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_country.rom" size="32768" crc="9dc4e2b9" sha1="1831c3dc9476929d94a89ce0c7994eca64c0fb6d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_country.rom" size="0x8000" crc="9dc4e2b9" sha1="1831c3dc9476929d94a89ce0c7994eca64c0fb6d" />
 			</dataarea>
 		</part>
 	</software>
@@ -15683,9 +17273,12 @@ legacy FM implementations cannot find it.
 		<description>Organizer (Arab)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="المفكرة"/>
+		<info name="serial" value="AQ019"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="organizer (barq, 1987).rom" size="32768" crc="d3c10572" sha1="2844ff2d4cdee59a42e85c869c367354eb2da651" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="organizer (barq, 1987).rom" size="0x8000" crc="d3c10572" sha1="2844ff2d4cdee59a42e85c869c367354eb2da651" />
 			</dataarea>
 		</part>
 	</software>
@@ -15694,9 +17287,11 @@ legacy FM implementations cannot find it.
 		<description>Physics (Arab)</description>
 		<year>1988</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="الفيزياء"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="physics (barq, 1988).rom" size="32768" crc="45a1b1d1" sha1="4013470a0fe6183ac4e967fade73d9fae71ffdbc" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="physics (barq, 1988).rom" size="0x8000" crc="45a1b1d1" sha1="4013470a0fe6183ac4e967fade73d9fae71ffdbc" />
 			</dataarea>
 		</part>
 	</software>
@@ -15705,9 +17300,11 @@ legacy FM implementations cannot find it.
 		<description>Rhetoric (Arab)</description>
 		<year>1988</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="البيان"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_albayan.rom" size="32768" crc="6d5b9da6" sha1="d616e0b55d4dddf16bd686e6353acf9947b47f42" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_albayan.rom" size="0x8000" crc="6d5b9da6" sha1="d616e0b55d4dddf16bd686e6353acf9947b47f42" />
 			</dataarea>
 		</part>
 	</software>
@@ -15716,9 +17313,12 @@ legacy FM implementations cannot find it.
 		<description>Shater Hassan (Arab, Barq)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="الشاطر حسن"/>
+		<info name="serial" value="AQ017"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="shater hassan (barq, 1987).rom" size="32768" crc="fdff48a9" sha1="ef051be25daf7339d46d6ad643a04cfce80460c4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="shater hassan (barq, 1987).rom" size="0x8000" crc="fdff48a9" sha1="ef051be25daf7339d46d6ad643a04cfce80460c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -15727,9 +17327,12 @@ legacy FM implementations cannot find it.
 		<description>Shater Hassan (Arab, Barq, alt)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="الشاطر حسن"/>
+		<info name="serial" value="AQ017"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_hasan.rom" size="32768" crc="f10e4f15" sha1="6be1ee2b07dbb3e08fccfe6f1b37adfeb742bd23" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_hasan.rom" size="0x8000" crc="f10e4f15" sha1="6be1ee2b07dbb3e08fccfe6f1b37adfeb742bd23" />
 			</dataarea>
 		</part>
 	</software>
@@ -15738,9 +17341,11 @@ legacy FM implementations cannot find it.
 		<description>Sidbad (Arab)</description>
 		<year>1985</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="سندباد"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="sidbad (barq, 1985).rom" size="32768" crc="d5f7ff95" sha1="2200e15dcb7d56f97a5a308dc75fef53fae25e29" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="sidbad (barq, 1985).rom" size="0x8000" crc="d5f7ff95" sha1="2200e15dcb7d56f97a5a308dc75fef53fae25e29" />
 			</dataarea>
 		</part>
 	</software>
@@ -15749,9 +17354,11 @@ legacy FM implementations cannot find it.
 		<description>Sky Wolf (Arab)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="ذئب الجو"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="sky wolf (barq, 1987).rom" size="32768" crc="b77badb6" sha1="edd02daa045ac0ecec333ad8fbb2c69eff1888c7" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="sky wolf (barq, 1987).rom" size="0x8000" crc="b77badb6" sha1="edd02daa045ac0ecec333ad8fbb2c69eff1888c7" />
 			</dataarea>
 		</part>
 	</software>
@@ -15760,9 +17367,11 @@ legacy FM implementations cannot find it.
 		<description>Sky Wolf (Arab, alt)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="ذئب الجو"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_wolf.rom" size="32768" crc="0fc6208a" sha1="43ae7320aa08cb2bbdf03d56bc77dcd2bfbe3628" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_wolf.rom" size="0x8000" crc="0fc6208a" sha1="43ae7320aa08cb2bbdf03d56bc77dcd2bfbe3628" />
 			</dataarea>
 		</part>
 	</software>
@@ -15771,9 +17380,11 @@ legacy FM implementations cannot find it.
 		<description>Space Trip (Arab)</description>
 		<year>1986</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="رحلة إلى الفضاء"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="b_space.rom" size="32768" crc="e25319a2" sha1="ee138a69d7bc2bcb2cb386b837464f8985a0942b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="b_space.rom" size="0x8000" crc="e25319a2" sha1="ee138a69d7bc2bcb2cb386b837464f8985a0942b" />
 			</dataarea>
 		</part>
 	</software>
@@ -15782,9 +17393,11 @@ legacy FM implementations cannot find it.
 		<description>Think with Me (Arab)</description>
 		<year>1988</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="فكر معي"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="[unknown 3] (barq, 19xx) (arabic).rom" size="32768" crc="edb5220c" sha1="30f468f02e43c8fcad8d3c9b90f51f98f33329ea" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="[unknown 3] (barq, 19xx) (arabic).rom" size="0x8000" crc="edb5220c" sha1="30f468f02e43c8fcad8d3c9b90f51f98f33329ea" />
 			</dataarea>
 		</part>
 	</software>
@@ -15793,9 +17406,12 @@ legacy FM implementations cannot find it.
 		<description>Traffic (Arab)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="المرور"/>
+		<info nmae="serial" value="AQ018"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="traffic (barq, 1987).rom" size="32768" crc="ababe79c" sha1="b7b63a9b333a0cb1ca0453bffac358fde5430578" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="traffic (barq, 1987).rom" size="0x8000" crc="ababe79c" sha1="b7b63a9b333a0cb1ca0453bffac358fde5430578" />
 			</dataarea>
 		</part>
 	</software>
@@ -15804,9 +17420,11 @@ legacy FM implementations cannot find it.
 		<description>Treasure (Arab)</description>
 		<year>1987</year>
 		<publisher>Barq</publisher>
+		<info name="alt_title" value="الكنز"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="treasure (barq, 1987).rom" size="32768" crc="4aa4f14f" sha1="fd4def0c4c352d97d576cac3be03ab6139d1d1dd" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="treasure (barq, 1987).rom" size="0x8000" crc="4aa4f14f" sha1="fd4def0c4c352d97d576cac3be03ab6139d1d1dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -15820,8 +17438,8 @@ legacy FM implementations cannot find it.
 		<publisher>Clover</publisher>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="super_swangi" />
-			<dataarea name="rom" size="65536">
-				<rom name="super_swangi.rom" size="65536" crc="c59b86a1" sha1="3d330e3c97ee3e2e362c8a0fc2cfac69af5ace81" offset="0x0" />
+			<dataarea name="rom" size="0x10000">
+				<rom name="super_swangi.rom" size="0x10000" crc="c59b86a1" sha1="3d330e3c97ee3e2e362c8a0fc2cfac69af5ace81" offset="0x0" />
 			</dataarea>
 		</part>
 	</software>
@@ -15833,9 +17451,11 @@ legacy FM implementations cannot find it.
 		<description>Back (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="عودة"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="m_game.rom" size="16384" crc="652128da" sha1="62a4853598e663046a926ddeb269cbf520ab75ab" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="m_game.rom" size="0x4000" crc="652128da" sha1="62a4853598e663046a926ddeb269cbf520ab75ab" />
 			</dataarea>
 		</part>
 	</software>
@@ -15844,9 +17464,11 @@ legacy FM implementations cannot find it.
 		<description>Computation (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الحساب"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_count.rom" size="32768" crc="416dc78e" sha1="017d0dac6646331ff4692f2f6b9a513c7a021ce9" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_count.rom" size="0x8000" crc="416dc78e" sha1="017d0dac6646331ff4692f2f6b9a513c7a021ce9" />
 			</dataarea>
 		</part>
 	</software>
@@ -15855,9 +17477,11 @@ legacy FM implementations cannot find it.
 		<description>The Computer (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكمبيوتر"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_computer.rom" size="32768" crc="6c3c9998" sha1="f6ddb513448d10fdb19a921ffb8bc43e7388491d" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_computer.rom" size="0x8000" crc="6c3c9998" sha1="f6ddb513448d10fdb19a921ffb8bc43e7388491d" />
 			</dataarea>
 		</part>
 	</software>
@@ -15866,20 +17490,24 @@ legacy FM implementations cannot find it.
 		<description>Electricity (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكهرباء"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_electric.rom" size="32768" crc="ad649fac" sha1="bfb79527fc1229fd6eafbec797109f22650acd6b" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_electric.rom" size="0x8000" crc="ad649fac" sha1="bfb79527fc1229fd6eafbec797109f22650acd6b" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="english">
-		<description>English (Arab)</description>
+		<description>Tom &amp; Jerry English (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="توم و جيري (انجليزي)"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_english.rom" size="32768" crc="acad4847" sha1="d2cd548bed4aadd2cacd486481e18fb3568d74b6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_english.rom" size="0x8000" crc="acad4847" sha1="d2cd548bed4aadd2cacd486481e18fb3568d74b6" />
 			</dataarea>
 		</part>
 	</software>
@@ -15888,9 +17516,11 @@ legacy FM implementations cannot find it.
 		<description>Geometry (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="المساحة"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_geometry.rom" size="32768" crc="4ae638fe" sha1="dcfb1e044bf3cfac22077848c0756ea30b5468bc" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_geometry.rom" size="0x8000" crc="4ae638fe" sha1="dcfb1e044bf3cfac22077848c0756ea30b5468bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -15899,9 +17529,11 @@ legacy FM implementations cannot find it.
 		<description>Information Bank (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="بنك المعلومات"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_exercise.rom" size="32768" crc="25694778" sha1="00a926746e9d656642d1eebdfaf517acf7c00d2f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_exercise.rom" size="0x8000" crc="25694778" sha1="00a926746e9d656642d1eebdfaf517acf7c00d2f" />
 			</dataarea>
 		</part>
 	</software>
@@ -15910,9 +17542,11 @@ legacy FM implementations cannot find it.
 		<description>Master in English - Intermediate Second Grade - Pt. 1-2 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="اللغة الإنجليزية للثانوية العامة ج1"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_english2-1.rom" size="32768" crc="201994e9" sha1="299936bc4014e949186e513b05b1cf5c99487a6f" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_english2-1.rom" size="0x8000" crc="201994e9" sha1="299936bc4014e949186e513b05b1cf5c99487a6f" />
 			</dataarea>
 		</part>
 	</software>
@@ -15921,9 +17555,11 @@ legacy FM implementations cannot find it.
 		<description>Master in English - Intermediate Second Grade - Pt. 2-2 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="اللغة الإنجليزية للثانوية العامة ج2"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="magic writer (al alamiah, 1985).rom" size="32768" crc="ebfddc8a" sha1="c44f8728ce96429bf28ffe20fc2c1ec794592604" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="magic writer (al alamiah, 1985).rom" size="0x8000" crc="ebfddc8a" sha1="c44f8728ce96429bf28ffe20fc2c1ec794592604" />
 			</dataarea>
 		</part>
 	</software>
@@ -15932,9 +17568,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Arabic Grammar for First Preparatory Class - Part 1-1 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في اللغة العربية - النحو أول متوسط ج1"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_grammar1-1.rom" size="32768" crc="91258ec9" sha1="058ecd437a1d633972646f883604cca57e79f0a5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_grammar1-1.rom" size="0x8000" crc="91258ec9" sha1="058ecd437a1d633972646f883604cca57e79f0a5" />
 			</dataarea>
 		</part>
 	</software>
@@ -15943,9 +17581,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Arabic Grammar for First Preparatory Class - Part 1-2 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info  name="alt_title" value="الكامل في اللغة العربية - النحو أول متوسط ج2"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_grammar1-2.rom" size="32768" crc="d9dac75d" sha1="dfd09b46fc5716b5b2c96c07c03e9df06dc6d635" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_grammar1-2.rom" size="0x8000" crc="d9dac75d" sha1="dfd09b46fc5716b5b2c96c07c03e9df06dc6d635" />
 			</dataarea>
 		</part>
 	</software>
@@ -15954,9 +17594,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Arabic Grammar for Second Preparatory Class - Part 1-1 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في اللغة العربية - النحو الثاني متوسط ج 1"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_grammar2-1.rom" size="32768" crc="bd52f5e7" sha1="4269b4e9e6cd863bb233ae82999b13b940ed88df" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_grammar2-1.rom" size="0x8000" crc="bd52f5e7" sha1="4269b4e9e6cd863bb233ae82999b13b940ed88df" />
 			</dataarea>
 		</part>
 	</software>
@@ -15965,9 +17607,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Math for First Preparatory Class - Part 1-2 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في الرياضيات للأول متوسط ج2"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_math1-2.rom" size="32768" crc="8bea242c" sha1="6ddd87bbaee7b22d1715e6a09cdd91e06e2ad2dc" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_math1-2.rom" size="0x8000" crc="8bea242c" sha1="6ddd87bbaee7b22d1715e6a09cdd91e06e2ad2dc" />
 			</dataarea>
 		</part>
 	</software>
@@ -15976,9 +17620,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Math for Second Preparatory Class - Part 1-1 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في الرياضيات للثاني المتوسط ج1"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_math2-1.rom" size="32768" crc="2ee1888b" sha1="8b816f328958ba87388aa5a9abbd895f9c48e7ca" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_math2-1.rom" size="0x8000" crc="2ee1888b" sha1="8b816f328958ba87388aa5a9abbd895f9c48e7ca" />
 			</dataarea>
 		</part>
 	</software>
@@ -15987,9 +17633,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Math for Second Preparatory Class - Part 1-2 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في الرياضيات للثاني المتوسط ج2"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_math2-2.rom" size="32768" crc="2b591d20" sha1="d5028fedcc9f990357e222b62c5c0fccc22698a6" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_math2-2.rom" size="0x8000" crc="2b591d20" sha1="d5028fedcc9f990357e222b62c5c0fccc22698a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -15998,9 +17646,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Math for Third Preparatory Class - Part 1-1 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في الرياضيات للثالث المتوسط ج1"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_math3-1.rom" size="32768" crc="1c755e71" sha1="190a24223d1544f61fa627f4d6e27cde48d64196" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_math3-1.rom" size="0x8000" crc="1c755e71" sha1="190a24223d1544f61fa627f4d6e27cde48d64196" />
 			</dataarea>
 		</part>
 	</software>
@@ -16009,9 +17659,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Math for Third Preparatory Class - Part 1-2 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في الرياضيات للثالث المتوسط ج2"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_math3-2.rom" size="32768" crc="aaf1c8d4" sha1="36f3efea2f462ef890b4d0c4758092d9fd0d36f5" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_math3-2.rom" size="0x8000" crc="aaf1c8d4" sha1="36f3efea2f462ef890b4d0c4758092d9fd0d36f5" />
 			</dataarea>
 		</part>
 	</software>
@@ -16020,9 +17672,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Science for First Preparatory Class - Part 1-1 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في العلوم للأول المتوسط ج1"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_olom1-1.rom" size="32768" crc="52864334" sha1="18b50a5dc9bba07a7bcc9982a21b799289e72859" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_olom1-1.rom" size="0x8000" crc="52864334" sha1="18b50a5dc9bba07a7bcc9982a21b799289e72859" />
 			</dataarea>
 		</part>
 	</software>
@@ -16031,9 +17685,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Science for Second Preparatory Class - Part 1-1 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في العلوم للثاني المتوسط ج1"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_olom2-1.rom" size="32768" crc="e0618969" sha1="000a04fceebba105b6fab2ffe9e09d7b521a63af" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_olom2-1.rom" size="0x8000" crc="e0618969" sha1="000a04fceebba105b6fab2ffe9e09d7b521a63af" />
 			</dataarea>
 		</part>
 	</software>
@@ -16042,9 +17698,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Science for Second Preparatory Class - Part 1-2 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في العلوم للثاني المتوسط ج2"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_olom2-2.rom" size="32768" crc="0c22c832" sha1="610c043c147bca0ca1a4bebc6f3cf88ec9def9c8" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_olom2-2.rom" size="0x8000" crc="0c22c832" sha1="610c043c147bca0ca1a4bebc6f3cf88ec9def9c8" />
 			</dataarea>
 		</part>
 	</software>
@@ -16053,9 +17711,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Science for Second Preparatory Class - Part 1-3 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في العلوم للثاني المتوسط ج3"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_olom2-3.rom" size="32768" crc="4739f9c1" sha1="11adeff026e7223a67709d0bb4264e340e18c920" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_olom2-3.rom" size="0x8000" crc="4739f9c1" sha1="11adeff026e7223a67709d0bb4264e340e18c920" />
 			</dataarea>
 		</part>
 	</software>
@@ -16064,9 +17724,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Science for Third Preparatory Class - Part 1-1 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في العلوم للثالث المتوسط ج1"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_olom3-1.rom" size="32768" crc="fb91817e" sha1="ac42d6a4891109690bcd0235decfc701eef754cb" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_olom3-1.rom" size="0x8000" crc="fb91817e" sha1="ac42d6a4891109690bcd0235decfc701eef754cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -16075,9 +17737,11 @@ legacy FM implementations cannot find it.
 		<description>Perfect Science for Third Preparatory Class - Part 2-2 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الكامل في العلوم للثالث المتوسط ج2"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_olom3-2.rom" size="32768" crc="0da9ccb9" sha1="ad72beb1ad8841accbbc91d04caec3f325828231" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_olom3-2.rom" size="0x8000" crc="0da9ccb9" sha1="ad72beb1ad8841accbbc91d04caec3f325828231" />
 			</dataarea>
 		</part>
 	</software>
@@ -16086,9 +17750,11 @@ legacy FM implementations cannot find it.
 		<description>Periodic Table (Arab, Methali)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الجدول الدوري"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_table.rom" size="32768" crc="0d9de7a2" sha1="3c3707ba58fd287bc7ac4b485ea65cd7132f2464" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_table.rom" size="0x8000" crc="0d9de7a2" sha1="3c3707ba58fd287bc7ac4b485ea65cd7132f2464" />
 			</dataarea>
 		</part>
 	</software>
@@ -16097,9 +17763,11 @@ legacy FM implementations cannot find it.
 		<description>Physics Hasan ibn al-Haytham (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="الفيزياء حسن بن الهيثم"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_basari.rom" size="32768" crc="cfdcad63" sha1="e8ce88ccc904d535a8d7ec3cb48bc684364c1855" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_basari.rom" size="0x8000" crc="cfdcad63" sha1="e8ce88ccc904d535a8d7ec3cb48bc684364c1855" />
 			</dataarea>
 		</part>
 	</software>
@@ -16108,9 +17776,11 @@ legacy FM implementations cannot find it.
 		<description>Tom &amp; Jerry Math 1 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="توم وجيري -رياضيات 1"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_tom&amp;jery1.rom" size="32768" crc="abfb4973" sha1="83f35ae22f72544edc345302621563d101a4715a" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_tom&amp;jery1.rom" size="0x8000" crc="abfb4973" sha1="83f35ae22f72544edc345302621563d101a4715a" />
 			</dataarea>
 		</part>
 	</software>
@@ -16119,9 +17789,11 @@ legacy FM implementations cannot find it.
 		<description>Tom &amp; Jerry Math 2 (Arab)</description>
 		<year>1988</year>
 		<publisher>Methali</publisher>
+		<info name="alt_title" value="توم وجيري -رياضيات 2"/>
 		<part name="cart" interface="msx_cart">
-			<dataarea name="rom" size="32768">
-				<rom name="m_tom&amp;jery2.rom" size="32768" crc="95f23cf1" sha1="00d758adee7a07ded4381c823da72ced0eae98c4" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="m_tom&amp;jery2.rom" size="0x8000" crc="95f23cf1" sha1="00d758adee7a07ded4381c823da72ced0eae98c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -16136,8 +17808,8 @@ legacy FM implementations cannot find it.
 		<info name="alt_title" value="東芝漢字ROMカートリッジ" />
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="kanji" />
-			<dataarea name="kanji" size="131072">
-				<rom name="kanjifont.rom" size="131072" crc="d23d4d2d" sha1="db03211b7db46899df41db2b1dfbec972109a967" />
+			<dataarea name="kanji" size="0x20000">
+				<rom name="kanjifont.rom" size="0x20000" crc="d23d4d2d" sha1="db03211b7db46899df41db2b1dfbec972109a967" />
 			</dataarea>
 		</part>
 	</software>
@@ -16150,8 +17822,8 @@ legacy FM implementations cannot find it.
 		<!-- Word processor -->
 		<part name="ec701" interface="msx_cart">
 			<feature name="slot" value="ec701" />
-			<dataarea name="rom" size="524288">
-				<rom name="ec701_program.ic1" size="32768" crc="1caec27b" sha1="4cc5be7536c11a89b5ec736a62a2b832361cd23d" />
+			<dataarea name="rom" size="0x80000">
+				<rom name="ec701_program.ic1" size="0x8000" crc="1caec27b" sha1="4cc5be7536c11a89b5ec736a62a2b832361cd23d" />
 				<!-- should be 3 roms at ic2, ic3, and ic4 -->
 				<rom name="ec701_dictionary.rom" size="393216" crc="b3582eb0" sha1="661c7261dc261e9ef2106755946f95d8b9b699b4" status="baddump" offset="0x20000" />
 			</dataarea>
@@ -16159,8 +17831,8 @@ legacy FM implementations cannot find it.
 		<!-- Kanji ROM -->
 		<part name="ec702" interface="msx_cart">
 			<feature name="slot" value="kanji" />
-			<dataarea name="kanji" size="131072">
-				<rom name="kanjifont.rom" size="131072" crc="3b8fdf44" sha1="fc71561a64f73da0e0043d256f67fd18d7fc3a7f" />
+			<dataarea name="kanji" size="0x20000">
+				<rom name="kanjifont.rom" size="0x20000" crc="3b8fdf44" sha1="fc71561a64f73da0e0043d256f67fd18d7fc3a7f" />
 			</dataarea>
 		</part>
 	</software>
@@ -16461,8 +18133,8 @@ legacy FM implementations cannot find it.
 		<publisher>Daou</publisher>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="dooly" />
-			<dataarea name="rom" size="32768">
-				<rom name="dooly.rom" size="32768" crc="71a1b1ec" sha1="dbac346f03950fbef81a003b4a42b2898a4e54c1" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="dooly.rom" size="0x8000" crc="71a1b1ec" sha1="dbac346f03950fbef81a003b4a42b2898a4e54c1" />
 			</dataarea>
 		</part>
 	</software>
@@ -16475,8 +18147,8 @@ legacy FM implementations cannot find it.
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
-			<dataarea name="rom" size="32768">
-				<rom name="bioman4.rom" size="32768" crc="7306e61d" sha1="9aba571fbdedcdcd0c20dcae8fdde31328d51b1c" status="baddump" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="bioman4.rom" size="0x8000" crc="7306e61d" sha1="9aba571fbdedcdcd0c20dcae8fdde31328d51b1c" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -16489,8 +18161,8 @@ legacy FM implementations cannot find it.
 		<info name="alt_title" value="슈퍼 브로스 월드 1" />
 		<part name="cart" interface="msx_cart">
 			<feature name="slot" value="konami" />
-			<dataarea name="rom" size="32768">
-				<rom name="sbrosw_n.rom" size="32768" crc="62256991" sha1="a3e8e076b9c8d4060082233a2f16184cf4911a85" status="baddump" />
+			<dataarea name="rom" size="0x8000">
+				<rom name="sbrosw_n.rom" size="0x8000" crc="62256991" sha1="a3e8e076b9c8d4060082233a2f16184cf4911a85" status="baddump" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/msx1_cart.xml
+++ b/hash/msx1_cart.xml
@@ -4503,7 +4503,7 @@ kept for now until finding out what those bytes affect...
 		<info name="alt_title" value="ディグダグ" />
 		<part name="cart" interface="msx_cart">
 			<feature name="start_page" value="1"/>
-ß			<dataarea name="rom" size="0x8000">
+			<dataarea name="rom" size="0x8000">
 				<rom name="dig dug (japan) (alt 1).rom" size="0x8000" crc="7c3d7dea" sha1="e3391daab17710b3f34c70f60ac6c8bfea15b6cc" />
 			</dataarea>
 		</part>
@@ -4996,7 +4996,7 @@ kept for now until finding out what those bytes affect...
 		<publisher>Casio</publisher>
 		<info name="serial" value="GPM-129" />
 		<info name="alt_title" value="エクゾイドＺエリア５" />
-		<info name="gtin" valu="04971850104971"/>
+		<info name="gtin" value="04971850104971"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="start_page" value="1"/>
 			<dataarea name="rom" size="0x8000">
@@ -14275,7 +14275,7 @@ kept for now until finding out what those bytes affect...
 		<year>1986</year>
 		<publisher>Champion Soft</publisher>
 		<info name="alt_title" value="ザ・競馬" />
-		<info nmae="serial" value="MXCP-11005"/>
+		<info name="serial" value="MXCP-11005"/>
 		<info name="usage" value="Requires a Japanese system."/>
 		<part name="cart" interface="msx_cart">
 			<feature name="start_page" value="1"/>
@@ -16222,7 +16222,6 @@ legacy FM implementations cannot find it.
 		<info name="serial" value="M055" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-		<info name="alt_title" value="الذاكرة"/>
 			<feature name="start_page" value="1"/>
 			<dataarea name="rom" size="0x8000">
 				<rom name="a_m&amp;d.rom" size="0x8000" crc="241623f9" sha1="860f5180c9028cbf675d9b1e59b7e7487c59ea0c" />
@@ -17407,7 +17406,7 @@ legacy FM implementations cannot find it.
 		<year>1987</year>
 		<publisher>Barq</publisher>
 		<info name="alt_title" value="المرور"/>
-		<info nmae="serial" value="AQ018"/>
+		<info name="serial" value="AQ018"/>
 		<part name="cart" interface="msx_cart">
 			<feature name="start_page" value="1"/>
 			<dataarea name="rom" size="0x8000">

--- a/hash/msx1_cart.xml
+++ b/hash/msx1_cart.xml
@@ -16237,7 +16237,6 @@ legacy FM implementations cannot find it.
 		<info name="serial" value="M055" />
 		<info name="usage" value="Requires an Arabic MSX" />
 		<part name="cart" interface="msx_cart">
-		<info name="alt_title" value="الذاكرة"/>
 			<feature name="start_page" value="1"/>
 			<dataarea name="rom" size="0x8000">
 				<rom name="mult &amp; div.rom" size="0x8000" crc="f7c40d1f" sha1="20effe093026e9209bd3327114e9ad51676cf807" />

--- a/hash/msx2_cart.xml
+++ b/hash/msx2_cart.xml
@@ -184,6 +184,7 @@ LZ93A13 (32 pin) - 8KB banks
 		<year>1987</year>
 		<publisher>Taito</publisher>
 		<info name="alt_title" value="バブルボブル" />
+		<info name="serial" value="TMS-02" />
 		<info name="usage" value="Requires a Japanese system" />
 		<part name="cart" interface="msx_cart">
 			<feature name="pcb" value="TA-1M" />
@@ -3104,9 +3105,9 @@ LZ93A13 (32 pin) - 8KB banks
 		<year>19??</year>
 		<publisher>Philips</publisher>
 		<part name="cart" interface="msx_cart">
-			<feature name="mapper" value="NOMAPPER" />
-			<dataarea name="rom" size="16384">
-				<rom name="stcmsx2p.bin" size="16384" crc="4e4fbe2a" sha1="f29cef9d13d50d9e3158064c6bb381def6ff384d" offset="0x0000" />
+			<feature name="start_page" value="0"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="stcmsx2p.bin" size="0x4000" crc="4e4fbe2a" sha1="f29cef9d13d50d9e3158064c6bb381def6ff384d" />
 			</dataarea>
 		</part>
 	</software>
@@ -3115,10 +3116,11 @@ LZ93A13 (32 pin) - 8KB banks
 		<description>Cheese 2 (Japan)</description>
 		<year>1985</year>
 		<publisher>Neos</publisher>
+		<info name="usage" value="Requires a mouse in general purpose port 1."/>
 		<part name="cart" interface="msx_cart">
-			<feature name="mapper" value="NOMAPPER" />
-			<dataarea name="rom" size="32768">
-				<rom name="cheese 2 (japan) (program).rom" size="32768" crc="2ffb49c3" sha1="930b4896c1590ebbb74d330447ec36e3feb5cab6" status="baddump" offset="0" />
+			<feature name="start_page" value="1"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="cheese 2 (japan) (program).rom" size="0x8000" crc="2ffb49c3" sha1="930b4896c1590ebbb74d330447ec36e3feb5cab6" status="baddump" />
 			</dataarea>
 		</part>
 	</software>

--- a/src/devices/bus/msx/cart/nomapper.cpp
+++ b/src/devices/bus/msx/cart/nomapper.cpp
@@ -50,60 +50,81 @@ image_init_result msx_cart_nomapper_device::initialize_cartridge(std::string &me
 	const u32 size = cart_rom_region()->bytes();
 	u8 *rom = cart_rom_region()->base();
 
-	// determine start address, default to 0x4000
-	m_start_address = 0x4000;
-
-	switch (size)
+	// 64KB images fill all pages.
+	if (size == 0x10000)
 	{
-		// 8KB/16KB
-		case 0x2000: case 0x4000:
+		m_start_address = 0;
+	}
+	else if (is_loaded_through_softlist())
+	{
+		const char *start_page_str = get_feature("start_page");
+		if (!start_page_str)
 		{
-			uint16_t start = rom[3] << 8 | rom[2];
-
-			// start address of $0000: call address in the $4000 region: $4000, else $8000
-			if (start == 0)
-			{
-				if ((rom[5] & 0xc0) == 0x40)
-					m_start_address = 0x4000;
-				else
-					m_start_address = 0x8000;
-			}
-
-			// start address in the $8000 region: $8000, else default
-			else if ((start & 0xc000) == 0x8000)
-				m_start_address = 0x8000;
-
-			break;
+			message = "msx_cart_nomapper_device: Feature 'start_page' was not found.";
+			return image_init_result::FAIL;
+		}
+		u32 start_page = strtol(start_page_str, nullptr, 0);
+		if (start_page > 2)
+		{
+			message = "msx_cart_nomapper_device: Invalid value for 'start_page', allowed values are 0, 1, and 2";
+			return image_init_result::FAIL;
 		}
 
-		// 32KB
-		case 0x8000:
-			// take default, check when no "AB" at $0000, but "AB" at $4000
-			if (rom[0] != 'A' && rom[1] != 'B' && rom[0x4000] == 'A' && rom[0x4001] == 'B')
-			{
-				uint16_t start = rom[0x4003] << 8 | rom[0x4002];
+		m_start_address = start_page * 0x4000;
+	}
+	else
+	{
+		// Try to guess the start address from the rom contents.
+		// determine start address, default to 0x4000
+		m_start_address = 0x4000;
 
-				// start address of $0000 and call address in the $4000 region, or start address outside the $8000 region: $0000, else default
-				if ((start == 0 && (rom[0x4005] & 0xc0) == 0x40) || start < 0x8000 || start >= 0xc000)
-					m_start_address = 0;
+		switch (size)
+		{
+			// 8KB/16KB
+			case 0x2000: case 0x4000:
+			{
+				uint16_t start = rom[3] << 8 | rom[2];
+
+				// start address of $0000: call address in the $4000 region: $4000, else $8000
+				if (start == 0)
+				{
+					if ((rom[5] & 0xc0) == 0x40)
+						m_start_address = 0x4000;
+					else
+						m_start_address = 0x8000;
+				}
+
+				// start address in the $8000 region: $8000, else default
+				else if ((start & 0xc000) == 0x8000)
+					m_start_address = 0x8000;
+
+				break;
 			}
 
-			break;
+			// 32KB
+			case 0x8000:
+				// take default, check when no "AB" at $0000, but "AB" at $4000
+				if (rom[0] != 'A' && rom[1] != 'B' && rom[0x4000] == 'A' && rom[0x4001] == 'B')
+				{
+					uint16_t start = rom[0x4003] << 8 | rom[0x4002];
 
-		// 48KB
-		case 0xc000:
-			// "AB" at $0000, but no "AB" at $4000, not "AB": $0000
-			if (rom[0] == 'A' && rom[1] == 'B' && rom[0x4000] != 'A' && rom[0x4001] != 'B')
-				m_start_address = 0x4000;
-			else
-				m_start_address = 0;
+					// start address of $0000 and call address in the $4000 region, or start address outside the $8000 region: $0000, else default
+					if ((start == 0 && (rom[0x4005] & 0xc0) == 0x40) || start < 0x8000 || start >= 0xc000)
+						m_start_address = 0;
+				}
 
-			break;
+				break;
 
-		// 64KB
-		default:
-			m_start_address = 0;
-			break;
+			// 48KB
+			case 0xc000:
+				// "AB" at $0000, but no "AB" at $4000, not "AB": $0000
+				if (rom[0] == 'A' && rom[1] == 'B' && rom[0x4000] != 'A' && rom[0x4001] != 'B')
+					m_start_address = 0x4000;
+				else
+					m_start_address = 0;
+
+				break;
+		}
 	}
 
 	m_end_address = std::min<u32>(m_start_address + size, 0x10000);

--- a/src/devices/bus/msx/slot/cartridge.h
+++ b/src/devices/bus/msx/slot/cartridge.h
@@ -92,6 +92,8 @@ protected:
 	memory_region *cart_kanji_region() { return m_exp ? m_exp->memregion("kanji") : nullptr; }
 	memory_region *cart_ram_region() { return m_exp ? m_exp->memregion("ram") : nullptr; }
 	memory_region *cart_sram_region() { return m_exp ? m_exp->memregion("sram") : nullptr; }
+	const char *get_feature(std::string_view feature_name) { return m_exp ? m_exp->get_feature(feature_name) : nullptr; }
+	bool is_loaded_through_softlist() { return m_exp ? m_exp->loaded_through_softlist() : false; }
 	DECLARE_WRITE_LINE_MEMBER(irq_out);
 	address_space &memory_space() const;
 	address_space &io_space() const;


### PR DESCRIPTION
- Use hexadecimal sizes.
- Add a feature to explicitly indicate where in memory cartridges without mappers should be loaded.
- Updated serial, isbn, gtin, and usage notes.
- Updated versions for Arabic releases and added Arabic alt_titles.