### PR TITLE
misc/gfamily.cpp: Re-encoded the CHD from the GHO the right way [Recreativas.org]

### DIFF
--- a/src/mame/misc/gfamily.cpp
+++ b/src/mame/misc/gfamily.cpp
@@ -97,7 +97,7 @@ ROM_START( gmfamily )
 	ROM_LOAD("pic12f508.u6", 0x8000, 0x2000, NO_DUMP) // 1 Kbytes internal ROM
 
 	DISK_REGION( "ide:0:hdd:image" ) // From a Norton Ghost recovery image
-	DISK_IMAGE( "gamesfamily_1.1", 0, SHA1(cd6b8d19f430c510a95a838d7b8c578f89ccf834) )
+	DISK_IMAGE( "gamesfamily_1.1", 0, SHA1(0410c24cea2a5dc816f4972df65cb1cb0bf1d730) )
 ROM_END
 
 } // Anonymous namespace


### PR DESCRIPTION
The HDD CHD boots fine. The procedure used to create the CHD from the Norton Ghost image was: 
1.- Use Norton Ghost to convert from GHO to VHD using the 'ntexact' option. 
2.- Use QEmu to convert from VHD to raw.
3.- Use chdman to convert from raw to CHD.