### PR TITLE
c64_flop_misc.xml, c64_flop_orig.xml: Metadata cleaning

### DIFF
--- a/hash/c64_flop_misc.xml
+++ b/hash/c64_flop_misc.xml
@@ -137,7 +137,7 @@ license:CC0-1.0
 	<!-- Educational -->
 
 	<software name="kats1">
-		<description>KÄTS-opetuslevy 1 (Fin)</description>
+		<description>KÄTS-opetuslevy 1 (Finland)</description>
 		<year>1989</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -150,7 +150,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="kats2">
-		<description>KÄTS-opetuslevy 2 (Fin)</description>
+		<description>KÄTS-opetuslevy 2 (Finland)</description>
 		<year>1989</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -163,7 +163,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="kertolas">
-		<description>Kertolasku (Fin)</description>
+		<description>Kertolasku (Finland)</description>
 		<year>1986</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -176,7 +176,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="lrsharj">
-		<description>LRS-harjoitus (Fin)</description>
+		<description>LRS-harjoitus (Finland)</description>
 		<year>1988</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -189,7 +189,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="opinkirj">
-		<description>Opin kirjoittamaan (Fin)</description>
+		<description>Opin kirjoittamaan (Finland)</description>
 		<year>1985</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -202,7 +202,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="opinluk1">
-		<description>Opin lukemaan 1 (Fin)</description>
+		<description>Opin lukemaan 1 (Finland)</description>
 		<year>1985</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -215,7 +215,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="opinluk2">
-		<description>Opin lukemaan 2 (Fin)</description>
+		<description>Opin lukemaan 2 (Finland)</description>
 		<year>1985</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -228,7 +228,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="psenglsh">
-		<description>PS-English (Fin)</description>
+		<description>PS-English (Finland)</description>
 		<year>1986</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -241,7 +241,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="psmemory">
-		<description>PS-Memory (Fin)</description>
+		<description>PS-Memory (Finland)</description>
 		<year>1989</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -254,7 +254,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="puventti">
-		<description>Puhuva venttipeli (Fin)</description>
+		<description>Puhuva venttipeli (Finland)</description>
 		<year>1986</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -267,7 +267,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="vahennys">
-		<description>Vähennyslasku (Fin)</description>
+		<description>Vähennyslasku (Finland)</description>
 		<year>1986</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -280,7 +280,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="valmhrj1">
-		<description>Valmiusharjoituksia 1 (Fin)</description>
+		<description>Valmiusharjoituksia 1 (Finland)</description>
 		<year>198?</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>
@@ -293,7 +293,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="yhteenla">
-		<description>Yhteenlasku (Fin)</description>
+		<description>Yhteenlasku (Finland)</description>
 		<year>198?</year>
 		<publisher>Koulun erityispalvelu</publisher>
 		<sharedfeat name="requirement" value="c64_cart:ps64"/>

--- a/hash/c64_flop_orig.xml
+++ b/hash/c64_flop_orig.xml
@@ -682,7 +682,7 @@ license:CC0-1.0
 	<!-- Applications -->
 
 	<software name="basickaa">
-		<description>BASIC-kääntäjä (Fin)</description>
+		<description>BASIC-kääntäjä (Finland)</description>
 		<year>1984</year>
 		<publisher>Amersoft</publisher>
 
@@ -694,7 +694,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="sprbas64">
-		<description>SuperBase 64 (Fin)</description>
+		<description>SuperBase 64 (Finland)</description>
 		<year>1983</year>
 		<publisher>Precision</publisher>
 


### PR DESCRIPTION
Replaced countries' abbreviation by the full name