### PR TITLE
taito/taito_f3_v.cpp: line clip fixes, landmakr/quizhuhu palette fix

### DIFF
--- a/src/mame/taito/taito_f3.h
+++ b/src/mame/taito/taito_f3.h
@@ -200,6 +200,10 @@ protected:
 		s16 clip0_r[256]{};
 		s16 clip1_l[256]{};
 		s16 clip1_r[256]{};
+		s16 clip2_l[256]{};
+		s16 clip2_r[256]{};
+		s16 clip3_l[256]{};
+		s16 clip3_r[256]{};
 	};
 
 	int m_game = 0;

--- a/src/mame/taito/taito_f3.h
+++ b/src/mame/taito/taito_f3.h
@@ -184,8 +184,8 @@ protected:
 		u8 *tsrc[256]{}, *tsrc_s[256]{};
 		int x_count[256]{};
 		u32 x_zoom[256]{};
-		u32 clip0[256]{};
-		u32 clip1[256]{};
+		u32 clip_in[256]{};
+		u32 clip_ex[256]{};
 		u16 pal_add[256]{};
 	};
 
@@ -194,16 +194,10 @@ protected:
 		u16 alpha_level[256]{};
 		u16 spri[256]{};
 		u16 sprite_alpha[256]{};
-		u32 sprite_clip0[256]{};
-		u32 sprite_clip1[256]{};
-		s16 clip0_l[256]{};
-		s16 clip0_r[256]{};
-		s16 clip1_l[256]{};
-		s16 clip1_r[256]{};
-		s16 clip2_l[256]{};
-		s16 clip2_r[256]{};
-		s16 clip3_l[256]{};
-		s16 clip3_r[256]{};
+		u32 sprite_clip_in[256]{};
+		u32 sprite_clip_ex[256]{};
+		s16 clip_l[4][256]{};
+		s16 clip_r[4][256]{};
 	};
 
 	int m_game = 0;

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -77,6 +77,9 @@ Line ram memory map:
                 Where bit 2 of x enables effect on playfield 3
                 Where bit 3 of x enables effect on playfield 4
 
+    0x1000: Unknown control word?
+        (usually 0x00f0; gseeker, spcinvdj, twinqix, puchicar set 0x0000)
+
     0x4000: Column scroll & clipping info
 
     0x5000: Clip plane 0 (low bits (high in 4400))
@@ -159,7 +162,7 @@ Line ram memory map:
         0x0400 = If set enable clip plane 2
         0x0800 = If set enable clip plane 3
         0x1000 = Affects interpretation of inverse mode bits. If on, 1 = invert. if off, 0 = invert.
-        0xe000 = Blend mode, 0x2000 = Normal, 0x6000 = Alpha A, 0xa000 = Alpha B, others disable line
+        0xe000 = Blend mode, 0x3000 = Normal, 0x7000 = Alpha A, 0xb000 = Alpha B, others disable line
 
     0xc000 - 0xffff: Unused.
 

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -1579,6 +1579,8 @@ void taito_f3_state::calculate_clip(int y, u16 pri, u32 *clip0, u32 *clip1, int 
 	else
 		*clip1 = clipl | (clipr << 16);
 }
+#undef CALC_CLIP_INV
+#undef CALC_CLIP
 
 void taito_f3_state::get_spritealphaclip_info()
 {

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -384,10 +384,20 @@ TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info)
 	// This fixes (at least) the rain in round 6 of Arabian Magic.
 	const u8 extra_planes = ((tile >> (16 + 10)) & 3); // 0 = 4bpp, 1 = 5bpp, 2 = unused?, 3 = 6bpp
 
-	tileinfo.set(3,
-			tile & 0xffff,
-			(tile >> 16) & 0x1ff & (~extra_planes),
-			TILE_FLIPYX(tile >> 30));
+    if (m_game == LANDMAKR || m_game == QUIZHUHU)
+	{
+		tileinfo.set(3,
+				tile & 0xffff,
+				(tile >> 16) & 0x1ff,
+				TILE_FLIPYX(tile >> 30));
+	}
+	else
+	{
+		tileinfo.set(3,tile & 0xffff,
+				(tile >> 16) & 0x1ff & (~extra_planes),
+				TILE_FLIPYX(tile >> 30));
+	}
+
 	tileinfo.category =  abtype & 1;      /* alpha blending type */
 	tileinfo.pen_mask = (extra_planes << 4) | 0x0f;
 }
@@ -1757,15 +1767,10 @@ void taito_f3_state::get_spritealphaclip_info()
 		if (line_t->clip3_r[y] < 0) line_t->clip3_r[y] = 0;
 
 		/* Evaluate sprite clipping */
-		if (sprite_clip & 0x080) // TODO: is this correct for sprites, at least?
-		{
-			line_t->sprite_clip0[y] = 0x7fff7fff;
-			line_t->sprite_clip1[y] = 0;
-		}
-		else if (sprite_clip & 0x33)
+		if (sprite_clip & 0xff)
 		{
 			int line_enable = 1;
-			calculate_clip(y, ((sprite_clip & 0x33) << 4), &line_t->sprite_clip0[y], &line_t->sprite_clip1[y], &line_enable);
+			calculate_clip(y, ((sprite_clip & 0xff) << 4), &line_t->sprite_clip0[y], &line_t->sprite_clip1[y], &line_enable);
 			if (line_enable == 0)
 				line_t->sprite_clip0[y] = 0x7fff7fff;
 		}

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -381,12 +381,13 @@ TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info)
 	const u32 tile = (m_pf_data[Layer][tile_index * 2 + 0] << 16) | (m_pf_data[Layer][tile_index * 2 + 1] & 0xffff);
 	const u8 abtype = (tile >> (16 + 9)) & 1;
 	// tiles can be configured to use 4, 5, or 6 bpp data.
-	// if tiles use more than 4bpp, the bottom bits of the color code must be masked out.
-	// This fixes (at least) the rain in round 6 of Arabian Magic.
 	const u8 extra_planes = ((tile >> (16 + 10)) & 3); // 0 = 4bpp, 1 = 5bpp, 2 = unused?, 3 = 6bpp
 
-	// some games don't want this. maybe not bpp-based truncation?
-	// (landmakr win mes load to palette 0xBE, quizhuhu fade effects)
+	// FIXME: some (5bpp?) games need the bottom bits of the color code to be masked out.
+	// (mt00895 arabian magic stage 6 rain (color 0x105->104), mt01925 rayforce explosion, mt01917 rayforce ships, mt00900 kaiser knuckle azteca throw)
+	// however, there are (6bpp) cases which *don't* want any adjustment that this breaks:
+	// (quizhuhu fade palette 0x7, landmakrj win message palette 0xBE)
+	// special case until better understood.
 	if (m_game == LANDMAKR || m_game == QUIZHUHU)
 	{
 		tileinfo.set(3,
@@ -396,7 +397,8 @@ TILE_GET_INFO_MEMBER(taito_f3_state::get_tile_info)
 	}
 	else
 	{
-		tileinfo.set(3,tile & 0xffff,
+		tileinfo.set(3,
+				tile & 0xffff,
 				(tile >> 16) & 0x1ff & (~extra_planes),
 				TILE_FLIPYX(tile >> 30));
 	}

--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -1566,7 +1566,7 @@ void taito_f3_state::calculate_clip(int y, u16 pri, u32 *clip0, u32 *clip1, int 
 	}
 	else
 	{
-		pri_reduced = 0x0300 | (pri & (1 << (5 + line_t->c0))) >> line_t->c0 \
+		pri_reduced = 0x0300 | (pri & (1 << (4 + line_t->c0))) >> line_t->c0 \
 			| (pri & (1 << (4 + line_t->c1))) >> (line_t->c1 - 1);
 	}
 
@@ -1720,7 +1720,7 @@ void taito_f3_state::get_spritealphaclip_info()
 
 			if (m_line_ram[0x100 + y] & 4) // 5000 control playfield 3
 				clip2_low = (m_line_ram[(clip_base_low + 0x400) / 2] >> 0) & 0xffff;
-			if (m_line_ram[0x000 + y] & 4) // ? 4000 control for combined clip high pf 3/4
+			if (m_line_ram[0x000 + y] & 8) // ? 4000 control for combined clip high pf 3/4
 				clip2_high = (m_line_ram[(clip_base_high + 0x200) / 2] >> 0) & 0xffff;
 			if (m_line_ram[0x100 + y] & 8) // 5000 control playfield 4
 				clip3_low = (m_line_ram[(clip_base_low + 0x600) / 2] >> 0) & 0xffff;


### PR DESCRIPTION
 - respect all 4 clip planes (needed by landmakrj, quizhuhu)
 - remove some incorrect assumptions about clip plane 3 enable bit being a clip disable
 - found a 'invert clip inverse mode' flag. most games set it, caused problems with unset pbobble4, commandw
 - don't truncate landmakr/quizhuhu palette offsets: caused green fades in quizhuhu, incorrect win message colors in landmakrj. apparently the truncation fixed symptoms in a number of games, deserves more research.

fixes mt00950: landmakr: Winning message is missing.
fixes mt01014: quizhuhu: The question text is not displayed.
fixes mt02819: pbobble4 and clones: Victory screen not shown at end of match
fixes commandw map display
fixes quizhuhu pre-taito logo intro not visible
fixes landmakr ending slide display