### PR TITLE
hng64_3d.ipp : use 16-bit framebuffer rather than 32-bit for the 3D, so it can be passed as index values into the mixer

### DIFF
--- a/src/devices/cpu/tlcs870/tlcs870.cpp
+++ b/src/devices/cpu/tlcs870/tlcs870.cpp
@@ -1251,6 +1251,50 @@ void tlcs870_device::device_start()
 	m_tcx_timer[1] = timer_alloc(FUNC(tlcs870_device::tc2_cb), this);
 	m_tcx_timer[2] = timer_alloc(FUNC(tlcs870_device::tc3_cb), this);
 	m_tcx_timer[3] = timer_alloc(FUNC(tlcs870_device::tc4_cb), this);
+
+	save_item(NAME(m_prvpc));
+	save_item(NAME(m_pc));
+	save_item(NAME(m_sp));
+	save_item(NAME(m_port_out_latch));
+	save_item(NAME(m_read_input_port));
+	save_item(NAME(m_port0_cr));
+	save_item(NAME(m_port1_cr));
+	save_item(NAME(m_port6_cr));
+	save_item(NAME(m_port7_cr));
+	save_item(NAME(m_cycles));
+	save_item(NAME(m_tmppc));
+	save_item(NAME(m_addr));
+	save_item(NAME(m_F));
+	save_item(NAME(m_RBS));
+	save_item(NAME(m_IL));
+	save_item(NAME(m_EIR));
+	save_item(NAME(m_EINTCR));
+	save_item(NAME(m_ADCCR));
+	save_item(NAME(m_ADCDR));
+	save_item(NAME(m_SYSCR1));
+	save_item(NAME(m_SYSCR2));
+	save_item(NAME(m_TBTCR));
+	save_item(NAME(m_TREG1A));
+	save_item(NAME(m_TREG1B));
+	save_item(NAME(m_TC1CR));
+	save_item(NAME(m_TREG2));
+	save_item(NAME(m_TC2CR));
+	save_item(NAME(m_TREG3A));
+	save_item(NAME(m_TREG3B));
+	save_item(NAME(m_TC3CR));
+	save_item(NAME(m_TREG4));
+	save_item(NAME(m_TC4CR));
+	save_item(NAME(m_SIOCR1));
+	save_item(NAME(m_SIOCR2));
+	save_item(NAME(m_WDTCR1));
+	save_item(NAME(m_irqstate));
+	save_item(NAME(m_transfer_numbytes));
+	save_item(NAME(m_transfer_pos));
+	save_item(NAME(m_transfer_shiftreg));
+	save_item(NAME(m_transfer_shiftpos));
+	save_item(NAME(m_transfer_mode));
+	save_item(NAME(m_transmit_bits));
+	save_item(NAME(m_receive_bits));
 }
 
 

--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -1800,13 +1800,6 @@ void hng64_state::init_hng64_reorder_gfx()
 
 void hng64_state::init_hng64()
 {
-	/* 1 meg of virtual address space for the com cpu */
-	m_com_virtual_mem = std::make_unique<uint8_t[]>(0x100000);
-	m_com_op_base     = std::make_unique<uint8_t[]>(0x10000);
-
-	m_soundram = std::make_unique<uint16_t[]>(0x200000/2);
-	m_soundram2 = std::make_unique<uint16_t[]>(0x200000/2);
-
 	init_hng64_reorder_gfx();
 }
 
@@ -2113,13 +2106,20 @@ TIMER_DEVICE_CALLBACK_MEMBER(hng64_state::hng64_irq)
 
 void hng64_state::machine_start()
 {
+	/* 1 meg of virtual address space for the com cpu */
+	m_com_virtual_mem = std::make_unique<uint8_t[]>(0x100000);
+	m_com_op_base = std::make_unique<uint8_t[]>(0x10000);
+
+	m_soundram = std::make_unique<uint16_t[]>(0x200000 / 2);
+	m_soundram2 = std::make_unique<uint16_t[]>(0x200000 / 2);
+
 	/* set the fastest DRC options */
 	m_maincpu->mips3drc_set_options(MIPS3DRC_FASTEST_OPTIONS + MIPS3DRC_STRICT_VERIFY);
 
 	/* configure fast RAM regions */
 	m_maincpu->add_fastram(0x00000000, 0x00ffffff, false, m_mainram);
-	m_maincpu->add_fastram(0x04000000, 0x05ffffff, true,  m_cart);
-	m_maincpu->add_fastram(0x1fc00000, 0x1fc7ffff, true,  m_rombase);
+	m_maincpu->add_fastram(0x04000000, 0x05ffffff, true, m_cart);
+	m_maincpu->add_fastram(0x1fc00000, 0x1fc7ffff, true, m_rombase);
 
 	for (int i = 0; i < 0x38 / 4; i++)
 	{
@@ -2132,6 +2132,43 @@ void hng64_state::machine_start()
 	m_comhack_timer = timer_alloc(FUNC(hng64_state::comhack_callback), this);
 
 	init_io();
+
+	save_pointer(NAME(m_com_virtual_mem), 0x100000);
+	save_pointer(NAME(m_com_op_base), 0x10000);
+	save_pointer(NAME(m_soundram), 0x200000 / 2);
+	save_pointer(NAME(m_soundram2), 0x200000 / 2);
+
+	save_item(NAME(m_fbcontrol));
+
+	save_item(NAME(m_dma_start));
+	save_item(NAME(m_dma_dst));
+	save_item(NAME(m_dma_len));
+
+	save_item(NAME(m_mcu_en));
+
+	save_item(NAME(m_activeDisplayList));
+	save_item(NAME(m_no_machine_error_code));
+
+	save_item(NAME(m_unk_vreg_toggle));
+	save_item(NAME(m_p1_trig));
+
+	save_item(NAME(m_screen_dis));
+
+	save_item(NAME(m_old_animmask));
+	save_item(NAME(m_old_animbits));
+	save_item(NAME(m_old_tileflags));
+
+	save_item(NAME(m_port7));
+	save_item(NAME(m_port1));
+	save_item(NAME(m_ex_ramaddr));
+	save_item(NAME(m_ex_ramaddr_upper));
+
+	save_item(NAME(m_irq_pending));
+
+	save_item(NAME(m_irq_level));
+
+	save_item(NAME(main_latch));
+	save_item(NAME(sound_latch));
 }
 
 TIMER_CALLBACK_MEMBER(hng64_state::comhack_callback)

--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -2472,6 +2472,7 @@ void hng64_state::hng64(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(hng64_state::screen_vblank_hng64));
 
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_888, 0x1000);
+	PALETTE(config, m_palette_3d).set_format(palette_device::xRGB_888, 0x1000 * 0x10);
 
 	hng64_audio(config);
 	hng64_network(config);

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -18,6 +18,24 @@
 #include "screen.h"
 #include "tilemap.h"
 
+/* Having a 32 bit buffer with RGB values in it doesn't make
+   logical sense for the mixing stage, nor do the RAM tests
+   indicate that there would be enough framebuffer RAM for
+   one if even a single alpha bit is to be included.
+
+   However, it is unclear how the 'lighting' and non-textured
+   polygons work without storing RGB in the framebuffer at present.
+
+   Each framebuffer has enough RAM for 24 bits of data for a 512x256
+   layer (screen is interlaced, so it doesn't really have 448 pixels
+   in height)
+   
+   theory: 11 bit palette index (can use either half of palette)
+            1 bit 'blend'
+            4 bit 'light'
+            8 bit depth?
+*/
+//#define USE_32BIT_3DBUFFER
 
 /////////////////
 /// 3d Engine ///
@@ -102,14 +120,22 @@ public:
 	void render_flat_scanline(int32_t scanline, const extent_t& extent, const hng64_poly_data& renderData, int threadid);
 
 	hng64_state& state() { return m_state; }
+#ifdef USE_32BIT_3DBUFFER
 	bitmap_rgb32& colorBuffer3d() { return m_colorBuffer3d; }
+#else
+	bitmap_ind16& colorBuffer3d() { return m_colorBuffer3d; }
+#endif
 	float* depthBuffer3d() { return m_depthBuffer3d.get(); }
 
 private:
 	hng64_state& m_state;
 
 	// (Temporarily class members - someday they will live in the memory map)
+#ifdef USE_32BIT_3DBUFFER
 	bitmap_rgb32 m_colorBuffer3d;
+#else
+	bitmap_ind16 m_colorBuffer3d;
+#endif
 	std::unique_ptr<float[]> m_depthBuffer3d;
 };
 

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -50,7 +50,7 @@ struct polyVert
 	float normal[4]{};        // Normal (X Y Z 1.0)
 	float clipCoords[4]{};    // Homogeneous screen space coordinates (X Y Z W)
 
-	float light[3]{};         // The intensity of the illumination at this point
+	float light;         // The intensity of the illumination at this point
 
 	uint16_t colorIndex = 0;    // Flat shaded polygons, no texture, no lighting
 };

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -137,6 +137,7 @@ public:
 		driver_device(mconfig, type, tag),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
+		m_palette_3d(*this, "palette3d"),
 		m_paletteram(*this, "paletteram"),
 		m_vblank(*this, "VBLANK"),
 		m_maincpu(*this, "maincpu"),
@@ -184,6 +185,7 @@ public:
 	uint8_t *m_texturerom = nullptr;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
+	required_device<palette_device> m_palette_3d;
 	required_shared_ptr<u32> m_paletteram;
 	required_ioport m_vblank;
 
@@ -342,6 +344,7 @@ private:
 	void dl_unk_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	uint32_t dl_vreg_r();
 
+	void set_single_palette_entry(int entry, uint8_t r, uint8_t g, uint8_t b);
 	void update_palette_entry(int entry);
 	void pal_w(offs_t offset, uint32_t data, uint32_t mem_mask);
 	void tcram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -455,6 +455,7 @@ private:
 	void setLighting(const uint16_t* packet);
 	void set3dFlags(const uint16_t* packet);
 	void setCameraProjectionMatrix(const uint16_t* packet);
+	void recoverStandardVerts(polygon& currentPoly, int m, uint16_t* chunkOffset_verts, int& counter);
 	void recoverPolygonBlock(const uint16_t* packet, int& numPolys);
 	void printPacket(const uint16_t* packet, int hex);
 	float uToF(uint16_t input);

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -33,7 +33,7 @@ struct polyVert
 
 	float light;         // The intensity of the illumination at this point
 
-	uint16_t colorIndex = 0;    // Flat shaded polygons, no texture, no lighting
+	//uint16_t colorIndex = 0;    // Flat shaded polygons, no texture, no lighting
 };
 
 struct polygon
@@ -52,8 +52,7 @@ struct polygon
 	uint8_t texPageVertOffset = 0;    // If it does use small texture pages, how far is this page vertically offset?
 
 	uint32_t palOffset = 0;           // The base offset where this object's palette starts.
-
-	uint32_t debugColor = 0;          // Will go away someday.  Used to explicitly color polygons for debugging.
+	uint16_t colorIndex = 0;
 };
 
 
@@ -85,8 +84,8 @@ struct hng64_poly_data
 	uint8_t texPageSmall = 0;
 	uint8_t texPageHorizOffset = 0;
 	uint8_t texPageVertOffset = 0;
-	int palOffset = 0;
-	int debugColor = 0;
+	uint32_t palOffset = 0;
+	uint16_t colorIndex = 0;
 };
 
 class hng64_state;

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -18,25 +18,6 @@
 #include "screen.h"
 #include "tilemap.h"
 
-/* Having a 32 bit buffer with RGB values in it doesn't make
-   logical sense for the mixing stage, nor do the RAM tests
-   indicate that there would be enough framebuffer RAM for
-   one if even a single alpha bit is to be included.
-
-   However, it is unclear how the 'lighting' and non-textured
-   polygons work without storing RGB in the framebuffer at present.
-
-   Each framebuffer has enough RAM for 24 bits of data for a 512x256
-   layer (screen is interlaced, so it doesn't really have 448 pixels
-   in height)
-   
-   theory: 11 bit palette index (can use either half of palette)
-            1 bit 'blend'
-            4 bit 'light'
-            8 bit depth?
-*/
-//#define USE_32BIT_3DBUFFER
-
 /////////////////
 /// 3d Engine ///
 /////////////////
@@ -120,22 +101,14 @@ public:
 	void render_flat_scanline(int32_t scanline, const extent_t& extent, const hng64_poly_data& renderData, int threadid);
 
 	hng64_state& state() { return m_state; }
-#ifdef USE_32BIT_3DBUFFER
-	bitmap_rgb32& colorBuffer3d() { return m_colorBuffer3d; }
-#else
 	bitmap_ind16& colorBuffer3d() { return m_colorBuffer3d; }
-#endif
 	float* depthBuffer3d() { return m_depthBuffer3d.get(); }
 
 private:
 	hng64_state& m_state;
 
 	// (Temporarily class members - someday they will live in the memory map)
-#ifdef USE_32BIT_3DBUFFER
-	bitmap_rgb32 m_colorBuffer3d;
-#else
 	bitmap_ind16 m_colorBuffer3d;
-#endif
 	std::unique_ptr<float[]> m_depthBuffer3d;
 };
 

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -1274,8 +1274,8 @@ void hng64_poly_renderer::render_texture_scanline(int32_t scanline, const extent
 				// Naive Alpha Implementation (?) - don't draw if you're at texture index 0...
 				if (paletteEntry != 0)
 				{
-					float rIntensity = rCorrect / 255.0f;
-					uint8_t lightval = (uint8_t)(rIntensity / 16.0f);
+					float rIntensity = rCorrect / 16.0f;
+					uint8_t lightval = (uint8_t)rIntensity;
 					uint16_t color = ((renderData.palOffset + paletteEntry) & 0xfff) | (lightval << 12);
 					*colorBuffer = color;
 					*depthBuffer = z;

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -333,7 +333,7 @@ void hng64_state::recoverStandardVerts(polygon& currentPoly, int m, uint16_t* ch
 	currentPoly.vert[m].worldCoords[3] = 1.0f;
 	currentPoly.n = 3;
 
-	uint16_t unused = chunkOffset_verts[counter++]; (void)unused; // chunkOffset_verts[ xxxx+3 ] is set to 0x70 on some 'blended' objects (fatfurwa translucent globe, buriki shadows, but not on fatfurwa shadows)
+	[[maybe_unused]] uint16_t unused = chunkOffset_verts[counter++]; // chunkOffset_verts[ xxxx+3 ] is set to 0x70 on some 'blended' objects (fatfurwa translucent globe, buriki shadows, but not on fatfurwa shadows)
 
 	currentPoly.vert[m].texCoords[0] = uToF(chunkOffset_verts[counter]);
 	if (currentPoly.flatShade)
@@ -712,11 +712,10 @@ void hng64_state::recoverPolygonBlock(const uint16_t* packet, int& numPolys)
 				currentPoly.faceNormal[3] = lastPoly.faceNormal[3];
 
 				// TODO: I'm not reading 3 necessary words here (maybe face normal)
-				uint16_t unused;
+				[[maybe_unused]] uint16_t unused;
 				unused = chunkOffset[counter++];
 				unused = chunkOffset[counter++];
 				unused = chunkOffset[counter++];
-				(void)unused;
 
 				chunkLength = counter;
 				break;

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -613,7 +613,7 @@ void hng64_state::recoverPolygonBlock(const uint16_t* packet, int& numPolys)
 					currentPoly.vert[m].normal[3] = 0.0f;
 
 					if (currentPoly.flatShade)
-						currentPoly.colorIndex = chunkOffset[7 + (9*m)] >> 5;
+						currentPoly.colorIndex = chunkOffset[7] >> 5;
 				}
 
 				// Redundantly called, but it works...
@@ -644,7 +644,7 @@ void hng64_state::recoverPolygonBlock(const uint16_t* packet, int& numPolys)
 					currentPoly.vert[m].texCoords[1] = uToF(chunkOffset[8 + (6*m)]);
 
 					if (currentPoly.flatShade)
-						currentPoly.colorIndex = chunkOffset[7 + (6*m)] >> 5;
+						currentPoly.colorIndex = chunkOffset[7] >> 5;
 
 					currentPoly.vert[m].normal[0] = uToF(chunkOffset[21]);
 					currentPoly.vert[m].normal[1] = uToF(chunkOffset[22]);

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -1209,12 +1209,7 @@ void hng64_poly_renderer::render_texture_scanline(int32_t scanline, const extent
 	const float dt = extent.param[6].dpdx;
 
 	// Pointers to the pixel buffers
-#ifdef USE_32BIT_3DBUFFER
-	uint32_t* colorBuffer = &m_colorBuffer3d.pix(scanline, extent.startx);
-#else
 	uint16_t* colorBuffer = &m_colorBuffer3d.pix(scanline, extent.startx);
-#endif
-
 	float*  depthBuffer = &m_depthBuffer3d[(scanline * m_state.m_screen->visible_area().width()) + extent.startx];
 
 	const uint8_t *textureOffset = &m_state.m_texturerom[renderData.texIndex * 1024 * 1024];
@@ -1280,23 +1275,8 @@ void hng64_poly_renderer::render_texture_scanline(int32_t scanline, const extent
 				if (paletteEntry != 0)
 				{
 					float rIntensity = rCorrect / 255.0f;
-#ifdef USE_32BIT_3DBUFFER
-					// The color out of the texture
-					rgb_t color = m_state.m_palette->pen((renderData.palOffset + paletteEntry) & 0xfff);
-
-					// Apply the lighting
-					float red   = color.r() * rIntensity;
-
-					// Clamp and finalize
-					red = color.r() + red;
-
-					if (red >= 255) red = 255;
-
-					color = rgb_t(255, (uint8_t)red, (uint8_t)red, (uint8_t)red);
-#else
 					uint8_t lightval = (uint8_t)(rIntensity / 16.0f);
 					uint16_t color = ((renderData.palOffset + paletteEntry) & 0xfff) | (lightval << 12);
-#endif
 					*colorBuffer = color;
 					*depthBuffer = z;
 				}
@@ -1328,11 +1308,7 @@ void hng64_poly_renderer::render_flat_scanline(int32_t scanline, const extent_t&
 	const float db = extent.param[3].dpdx;
 
 	// Pointers to the pixel buffers
-#ifdef USE_32BIT_3DBUFFER
-	uint32_t* colorBuffer = &m_colorBuffer3d.pix(scanline, extent.startx);
-#else
 	uint16_t* colorBuffer = &m_colorBuffer3d.pix(scanline, extent.startx);
-#endif
 	float*  depthBuffer = &m_depthBuffer3d[(scanline * m_state.m_screen->visible_area().width()) + extent.startx];
 
 	// Step over each pixel in the horizontal span
@@ -1340,17 +1316,7 @@ void hng64_poly_renderer::render_flat_scanline(int32_t scanline, const extent_t&
 	{
 		if (z < *depthBuffer)
 		{
-#ifdef USE_32BIT_3DBUFFER
-			// Clamp and finalize
-			if (r >= 255) r = 255;
-			if (g >= 255) g = 255;
-			if (b >= 255) b = 255;
-
-			rgb_t color = rgb_t(255, (uint8_t)r, (uint8_t)g, (uint8_t)b);
-			*colorBuffer = color;
-#else
 			*colorBuffer = rand() & 0xfff;
-#endif
 			*depthBuffer = z;
 		}
 

--- a/src/mame/snk/hng64_sprite.ipp
+++ b/src/mame/snk/hng64_sprite.ipp
@@ -45,7 +45,7 @@
 do \
 { \
 	uint32_t srcdata = (SOURCE); \
-	if (xdrawpos <= cliprect.right() && xdrawpos >= cliprect.left() && ypos <= cliprect.bottom() && ypos >= cliprect.top()) \
+	if (xdrawpos <= cliprect.right() && xdrawpos >= cliprect.left()) \
 	{ \
 		if (zval < (DESTZ)) \
 		{ \
@@ -64,7 +64,7 @@ while (0)
 do \
 { \
 	uint32_t srcdata = (SOURCE); \
-	if (xdrawpos <= cliprect.right() && xdrawpos >= cliprect.left() && ypos <= cliprect.bottom() && ypos >= cliprect.top()) \
+	if (xdrawpos <= cliprect.right() && xdrawpos >= cliprect.left()) \
 	{ \
 		if (zval > (DESTZ)) \
 		{ \
@@ -357,11 +357,14 @@ void hng64_state::draw_sprites_buffer(screen_device& screen, const rectangle& cl
 				}
 			}
 
-			uint32_t full_srcpix_y2 = realline * dy;
-			int used_ysource_pos = full_srcpix_y2 >> 16;
-			int ytilebbb = used_ysource_pos / 0x10;
-			int use_tile_line = used_ysource_pos & 0xf;
-			draw_sprite_line(screen, cliprect, use_tile_line, ypos, xpos, chainx, dx, dy, ytilebbb, chaini, currentsprite, chainy, xflip, yflip, zval, zsort, blend, checkerboard, mosaic);
+			if (ypos <= cliprect.bottom() && ypos >= cliprect.top())
+			{
+				uint32_t full_srcpix_y2 = realline * dy;
+				int used_ysource_pos = full_srcpix_y2 >> 16;
+				int ytilebbb = used_ysource_pos / 0x10;
+				int use_tile_line = used_ysource_pos & 0xf;
+				draw_sprite_line(screen, cliprect, use_tile_line, ypos, xpos, chainx, dx, dy, ytilebbb, chaini, currentsprite, chainy, xflip, yflip, zval, zsort, blend, checkerboard, mosaic);
+			}
 			ypos++;
 		}
 

--- a/src/mame/snk/hng64_sprite.ipp
+++ b/src/mame/snk/hng64_sprite.ipp
@@ -112,7 +112,7 @@ do \
 } \
 while (0)
 
-void hng64_state::drawline(bitmap_ind16 & dest, bitmap_ind16 & destz, const rectangle & cliprect,
+inline void hng64_state::drawline(bitmap_ind16 & dest, bitmap_ind16 & destz, const rectangle & cliprect,
 	gfx_element * gfx, uint32_t code, uint32_t color, int flipy, int32_t xpos,
 	int32_t dx, int32_t dy, uint32_t trans_pen, uint32_t zval, bool zrev, bool blend, bool checkerboard, uint8_t mosaic, uint8_t &mosaic_count_x, int32_t ypos, const u8 *srcdata, int32_t srcx, uint32_t leftovers, int curyy, uint16_t &srcpix)
 {
@@ -146,7 +146,7 @@ void hng64_state::drawline(bitmap_ind16 & dest, bitmap_ind16 & destz, const rect
 	}
 }
 
-void hng64_state::zoom_transpen(bitmap_ind16 &dest, bitmap_ind16 &destz, const rectangle &cliprect,
+inline void hng64_state::zoom_transpen(bitmap_ind16 &dest, bitmap_ind16 &destz, const rectangle &cliprect,
 		gfx_element *gfx, uint32_t code, uint32_t color, int flipx, int flipy, int32_t xpos, int32_t ypos,
 		int32_t dx, int32_t dy, uint32_t dstwidth, uint32_t trans_pen, uint32_t zval, bool zrev, bool blend, bool checkerboard, uint8_t mosaic, uint8_t &mosaic_count_x, int curyy, uint16_t &srcpix)
 {
@@ -196,7 +196,7 @@ void hng64_state::zoom_transpen(bitmap_ind16 &dest, bitmap_ind16 &destz, const r
 
 }
 
-void hng64_state::get_tile_details(bool chain, uint16_t spritenum, uint8_t xtile, uint8_t ytile, uint8_t xsize, uint8_t ysize, bool xflip, bool yflip, uint32_t& tileno, uint16_t& pal, uint8_t &gfxregion)
+inline void hng64_state::get_tile_details(bool chain, uint16_t spritenum, uint8_t xtile, uint8_t ytile, uint8_t xsize, uint8_t ysize, bool xflip, bool yflip, uint32_t& tileno, uint16_t& pal, uint8_t &gfxregion)
 {
 	int offset;
 	if (!xflip)
@@ -373,7 +373,7 @@ void hng64_state::draw_sprites_buffer(screen_device& screen, const rectangle& cl
 }
 
 
-void hng64_state::draw_sprite_line(screen_device& screen, const rectangle& cliprect, int32_t curyy, int16_t ypos, int16_t xpos, int chainx, int32_t dx, int32_t dy, int ytileblock, int chaini, int currentsprite, int chainy, int xflip, int yflip, uint16_t zval, bool zsort, bool blend, bool checkerboard, uint8_t mosaic)
+inline void hng64_state::draw_sprite_line(screen_device& screen, const rectangle& cliprect, int32_t curyy, int16_t ypos, int16_t xpos, int chainx, int32_t dx, int32_t dy, int ytileblock, int chaini, int currentsprite, int chainy, int xflip, int yflip, uint16_t zval, bool zsort, bool blend, bool checkerboard, uint8_t mosaic)
 {
 	uint32_t srcpix_x = 0;
 	uint16_t srcpix = 0;

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -847,8 +847,15 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 
 	// this correctly allows buriki intro sprites to use regular alpha, not additive
 	// while also being correct for sams64, which wants additive, but appears to be
-	// incorrect for Fatal Fury's "hit effects which want additive
-	uint8_t spriteblendtype = (m_tcram[0x10 / 4] >> 16) & 0x10;
+	// incorrect for Fatal Fury's hit effects which want additive
+	// 
+	// the 6 regs around here have the same values in fatfur and buriki, so are unlikely
+	// to control the blend type.
+	//uint8_t spriteblendtype = (m_tcram[0x10 / 4] >> 16) & 0x10;
+
+	// would be an odd place for it, after the 'vblank' flag but...
+	uint8_t spriteblendtype = (m_tcram[0x4c / 4] >> 16) & 0x01;
+
 
 	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
@@ -957,7 +964,7 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 
 
 			m_tcram[0x48 / 4], // this is where the 'vblank' thing lives
-			m_tcram[0x4c / 4],
+			m_tcram[0x4c / 4], // 0001 0000 or 0000 0000 - works(?) as blend type selection for sprite mixing?
 			m_tcram[0x50 / 4],
 			m_tcram[0x54 / 4],
 			m_tcram[0x58 / 4],

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -829,7 +829,7 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 				if (srcpix & 0x0fff)
 				{
 					rgb_t col = clut[srcpix & 0x0fff];
-					uint8_t intensity = (srcpix & 0xf000) >> 8;
+					uint8_t intensity = (srcpix & 0xf000) >> 10;
 					uint16_t r = col.r();
 					uint16_t g = col.g();
 					uint16_t b = col.b();

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -931,12 +931,12 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 
 			// is this 2 groups of 3 regS?
 			(m_tcram[0x0c / 4] >> 24) & 0xff, // 04 = 'blend' on tm1  
-			(m_tcram[0x0c / 4] >> 16) & 0xff, // 04 = blend all sprites? (buriki intro, text fades?)
-			(m_tcram[0x0c / 4] >> 8) & 0xff,  // 10 gets set here in some cases when blended sprites are used too (blend type against a different input layer?)
+			(m_tcram[0x0c / 4] >> 16) & 0xff, // 04 = set when fades are going on with blended sprites in buriki intro? otherwise usually 00
+			(m_tcram[0x0c / 4] >> 8) & 0xff,  // upper bit not used? value usually 2x, 4x, 5x or 6x
 			// 2nd group?
 			(m_tcram[0x0c / 4] >> 0) & 0xff, //  04 = 'blend' on tm3  (used in transitions?)
-			(m_tcram[0x10 / 4] >> 24) & 0xff,
-			(m_tcram[0x10 / 4] >> 16) & 0xff, // 10 being set seems to change sprite blend mode (maybe blend type against one input layer)
+			(m_tcram[0x10 / 4] >> 24) & 0xff, // usually (always?) 00
+			(m_tcram[0x10 / 4] >> 16) & 0xff, // upper bit not used? value usually 2x, 4x, 5x or 6x
 
 			m_tcram[0x10 / 4] & 0xffff, // unused?
 

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -828,9 +828,9 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 			for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
 			{
 				uint16_t srcpix = *src;
-				if (srcpix & 0x7fff)
+				if (srcpix & 0x0fff)
 				{
-					*dst = clut[srcpix & 0x7fff];
+					*dst = clut[srcpix & 0x0fff];
 				}
 
 				dst++;

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -828,7 +828,24 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 				uint16_t srcpix = *src;
 				if (srcpix & 0x0fff)
 				{
-					*dst = clut[srcpix & 0x0fff];
+					rgb_t col = clut[srcpix & 0x0fff];
+					uint8_t intensity = (srcpix & 0xf000) >> 8;
+					uint16_t r = col.r();
+					uint16_t g = col.g();
+					uint16_t b = col.b();
+
+					r = r + intensity;
+					g = g + intensity;
+					b = b + intensity;
+
+					if (r > 255)
+						r = 255;
+					if (g > 255)
+						g = 255;
+					if (b > 255)
+						b = 255;
+
+					*dst = rgb_t(r, g, b);
 				}
 
 				dst++;

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -803,25 +803,23 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 
 	pen_t const *const clut = &m_palette->pen(0);
 
+	/*
+	   Each framebuffer has enough RAM for 24 bits of data for a 512x256
+	   layer (screen is interlaced, so it doesn't really have 448 pixels
+	   in height)
+   
+	   theory: 11 bit palette index (can use either half of palette)
+				1 bit 'blend'
+				4 bit 'light'
+				8 bit depth?
+	*/
+
 	// 3d gets drawn next
 	if (!(m_fbcontrol[0] & 0x01))
 	{
 		// Blit the color buffer into the primary bitmap
 		for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 		{
-#ifdef USE_32BIT_3DBUFFER
-			const uint32_t *src = &m_poly_renderer->colorBuffer3d().pix(y, cliprect.min_x);
-			uint32_t *dst = &bitmap.pix(y, cliprect.min_x);
-
-			for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
-			{
-				if (*src & 0xff000000)
-					*dst = *src;
-
-				dst++;
-				src++;
-			}
-#else
 			const uint16_t *src = &m_poly_renderer->colorBuffer3d().pix(y, cliprect.min_x);
 			uint32_t *dst = &bitmap.pix(y, cliprect.min_x);
 
@@ -836,7 +834,6 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 				dst++;
 				src++;
 			}
-#endif
 		}
 	}
 


### PR DESCRIPTION
- use 16-bit framebuffer rather than 32-bit for the 3D, so it can be passed as index values into the mixer
note, looks a bit worse for now in terms of lighting, but I think this is going to be closer to how the hardware works, just our lighting calculations are wrong anyway.