### PR TITLE
hng64.cpp - further video improvements

### DIFF
--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -1202,8 +1202,8 @@ void hng64_state::hng_map(address_map &map)
 
 	// 3D framebuffer
 	map(0x30000000, 0x30000003).rw(FUNC(hng64_state::hng64_fbcontrol_r), FUNC(hng64_state::hng64_fbcontrol_w)).umask32(0xffffffff);
-	map(0x30000004, 0x30000007).w(FUNC(hng64_state::hng64_fbunkpair_w)).umask32(0xffff);
-	map(0x30000008, 0x3000000b).w(FUNC(hng64_state::hng64_fbscroll_w)).umask32(0xffff);
+	map(0x30000004, 0x30000007).w(FUNC(hng64_state::hng64_fbscale_w));
+	map(0x30000008, 0x3000000b).w(FUNC(hng64_state::hng64_fbscroll_w));
 	map(0x3000000c, 0x3000000f).w(FUNC(hng64_state::hng64_fbunkbyte_w)).umask32(0xffffffff);
 	map(0x30000010, 0x3000002f).rw(FUNC(hng64_state::hng64_fbtable_r), FUNC(hng64_state::hng64_fbtable_w)).share("fbtable");
 

--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -1204,7 +1204,7 @@ void hng64_state::hng_map(address_map &map)
 	map(0x30000000, 0x30000003).rw(FUNC(hng64_state::hng64_fbcontrol_r), FUNC(hng64_state::hng64_fbcontrol_w)).umask32(0xffffffff);
 	map(0x30000004, 0x30000007).w(FUNC(hng64_state::hng64_fbscale_w)).share("fbscale");
 	map(0x30000008, 0x3000000b).w(FUNC(hng64_state::hng64_fbscroll_w)).share("fbscroll");
-	map(0x3000000c, 0x3000000f).w(FUNC(hng64_state::hng64_fbunkbyte_w)).umask32(0xffffffff);
+	map(0x3000000c, 0x3000000f).w(FUNC(hng64_state::hng64_fbunkbyte_w)).share("fbunk");
 	map(0x30000010, 0x3000002f).rw(FUNC(hng64_state::hng64_fbtable_r), FUNC(hng64_state::hng64_fbtable_w)).share("fbtable");
 
 	map(0x30100000, 0x3015ffff).rw(FUNC(hng64_state::hng64_fbram1_r), FUNC(hng64_state::hng64_fbram1_w)).share("fbram1");  // 3D Display Buffer A

--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -1202,8 +1202,8 @@ void hng64_state::hng_map(address_map &map)
 
 	// 3D framebuffer
 	map(0x30000000, 0x30000003).rw(FUNC(hng64_state::hng64_fbcontrol_r), FUNC(hng64_state::hng64_fbcontrol_w)).umask32(0xffffffff);
-	map(0x30000004, 0x30000007).w(FUNC(hng64_state::hng64_fbscale_w));
-	map(0x30000008, 0x3000000b).w(FUNC(hng64_state::hng64_fbscroll_w));
+	map(0x30000004, 0x30000007).w(FUNC(hng64_state::hng64_fbscale_w)).share("fbscale");
+	map(0x30000008, 0x3000000b).w(FUNC(hng64_state::hng64_fbscroll_w)).share("fbscroll");
 	map(0x3000000c, 0x3000000f).w(FUNC(hng64_state::hng64_fbunkbyte_w)).umask32(0xffffffff);
 	map(0x30000010, 0x3000002f).rw(FUNC(hng64_state::hng64_fbtable_r), FUNC(hng64_state::hng64_fbtable_w)).share("fbtable");
 

--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -1061,12 +1061,15 @@ void hng64_state::hng64_dualport_w(offs_t offset, uint8_t data)
 /************************************************************************************************************/
 
 /* The following is guesswork, needs confirmation with a test on the real board. */
+// every sprite is 0x20 bytes
+// 
 void hng64_state::hng64_sprite_clear_even_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	auto &mspace = m_maincpu->space(AS_PROGRAM);
 	uint32_t spr_offs;
 
-	spr_offs = (offset) * 0x10 * 4;
+	spr_offs = (offset) * 0x40;
+	// for one sprite
 	if(ACCESSING_BITS_16_31)
 	{
 		mspace.write_dword(0x20000000+0x00+0x00+spr_offs, 0x00000000);
@@ -1074,6 +1077,7 @@ void hng64_state::hng64_sprite_clear_even_w(offs_t offset, uint32_t data, uint32
 		mspace.write_dword(0x20000000+0x10+0x00+spr_offs, 0x00000000);
 		mspace.write_dword(0x20000000+0x18+0x00+spr_offs, 0x00000000);
 	}
+	// for another sprite
 	if(ACCESSING_BITS_8_15)
 	{
 		mspace.write_dword(0x20000000+0x00+0x20+spr_offs, 0x00000000);
@@ -1088,7 +1092,8 @@ void hng64_state::hng64_sprite_clear_odd_w(offs_t offset, uint32_t data, uint32_
 	auto &mspace = m_maincpu->space(AS_PROGRAM);
 	uint32_t spr_offs;
 
-	spr_offs = (offset) * 0x10 * 4;
+	spr_offs = (offset) * 0x40;
+	// for one sprite
 	if(ACCESSING_BITS_16_31)
 	{
 		mspace.write_dword(0x20000000+0x04+0x00+spr_offs, 0x00000000);
@@ -1096,6 +1101,7 @@ void hng64_state::hng64_sprite_clear_odd_w(offs_t offset, uint32_t data, uint32_
 		mspace.write_dword(0x20000000+0x14+0x00+spr_offs, 0x00000000);
 		mspace.write_dword(0x20000000+0x1c+0x00+spr_offs, 0x00000000);
 	}
+	// for another sprite
 	if(ACCESSING_BITS_0_15)
 	{
 		mspace.write_dword(0x20000000+0x04+0x20+spr_offs, 0x00000000);
@@ -2206,6 +2212,7 @@ void hng64_state::machine_reset()
 	m_fbcontrol[2] = 0x00;
 	m_fbcontrol[3] = 0x00;
 
+	clear3d();
 }
 
 /***********************************************

--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -1067,7 +1067,6 @@ void hng64_state::hng64_sprite_clear_even_w(offs_t offset, uint32_t data, uint32
 	uint32_t spr_offs;
 
 	spr_offs = (offset) * 0x10 * 4;
-
 	if(ACCESSING_BITS_16_31)
 	{
 		mspace.write_dword(0x20000000+0x00+0x00+spr_offs, 0x00000000);
@@ -1090,18 +1089,17 @@ void hng64_state::hng64_sprite_clear_odd_w(offs_t offset, uint32_t data, uint32_
 	uint32_t spr_offs;
 
 	spr_offs = (offset) * 0x10 * 4;
-
 	if(ACCESSING_BITS_16_31)
 	{
 		mspace.write_dword(0x20000000+0x04+0x00+spr_offs, 0x00000000);
-		mspace.write_dword(0x20000000+0x0c+0x00+spr_offs, 0x00000000);
+	//	mspace.write_dword(0x20000000+0x0c+0x00+spr_offs, 0x00000000); // erases part of the slash palette in the sams64 2nd intro when we don't want it to! (2nd slash)
 		mspace.write_dword(0x20000000+0x14+0x00+spr_offs, 0x00000000);
 		mspace.write_dword(0x20000000+0x1c+0x00+spr_offs, 0x00000000);
 	}
 	if(ACCESSING_BITS_0_15)
 	{
 		mspace.write_dword(0x20000000+0x04+0x20+spr_offs, 0x00000000);
-		mspace.write_dword(0x20000000+0x0c+0x20+spr_offs, 0x00000000);
+	//	mspace.write_dword(0x20000000+0x0c+0x20+spr_offs, 0x00000000); // erases part of the slash palette in the sams64 2nd intro when we don't want it to! (1st slash)
 		mspace.write_dword(0x20000000+0x14+0x20+spr_offs, 0x00000000);
 		mspace.write_dword(0x20000000+0x1c+0x20+spr_offs, 0x00000000);
 	}

--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -2126,6 +2126,8 @@ void hng64_state::machine_start()
 		m_videoregs[i] = 0xdeadbeef;
 	}
 
+	m_videoregs[0] = 0x00000000;
+
 	m_irq_pending = 0;
 
 	m_3dfifo_timer = timer_alloc(FUNC(hng64_state::hng64_3dfifo_processed), this);

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -303,6 +303,10 @@ private:
 	uint16_t m_texturescrollx = 0;
 	uint16_t m_texturescrolly = 0;
 	uint16_t m_paletteState3d = 0;
+	uint16_t m_modelscalex = 0;
+	uint16_t m_modelscaley = 0;
+	uint16_t m_modelscalez = 0;
+
 	float m_projectionMatrix[16]{};
 	float m_modelViewMatrix[16]{};
 	float m_cameraMatrix[16]{};
@@ -467,7 +471,7 @@ private:
 	void setLighting(const uint16_t* packet);
 	void set3dFlags(const uint16_t* packet);
 	void setCameraProjectionMatrix(const uint16_t* packet);
-	void recoverStandardVerts(polygon& currentPoly, int m, uint16_t* chunkOffset_verts, int& counter);
+	void recoverStandardVerts(polygon& currentPoly, int m, uint16_t* chunkOffset_verts, int& counter, const uint16_t *packet);
 	void recoverPolygonBlock(const uint16_t* packet, int& numPolys);
 	void printPacket(const uint16_t* packet, int hex);
 	float uToF(uint16_t input);

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -336,8 +336,8 @@ private:
 	uint8_t hng64_fbcontrol_r(offs_t offset);
 	void hng64_fbcontrol_w(offs_t offset, uint8_t data);
 
-	void hng64_fbunkpair_w(offs_t offset, uint16_t data);
-	void hng64_fbscroll_w(offs_t offset, uint16_t data);
+	void hng64_fbscale_w(offs_t offset, uint32_t data, uint32_t mem_mask);
+	void hng64_fbscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask);
 
 	void hng64_fbunkbyte_w(offs_t offset, uint8_t data);
 

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -170,6 +170,7 @@ public:
 		m_fbram2(*this, "fbram2"),
 		m_fbscale(*this, "fbscale"),
 		m_fbscroll(*this, "fbscroll"),
+		m_fbunk(*this, "fbunk"),
 		m_idt7133_dpram(*this, "com_ram"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_in(*this, "IN%u", 0U),
@@ -238,6 +239,7 @@ private:
 	required_shared_ptr<uint32_t> m_fbram2;
 	required_shared_ptr<uint32_t> m_fbscale;
 	required_shared_ptr<uint32_t> m_fbscroll;
+	required_shared_ptr<uint32_t> m_fbunk;
 
 	required_shared_ptr<uint32_t> m_idt7133_dpram;
 	//required_shared_ptr<uint8_t> m_com_mmu_mem;
@@ -343,7 +345,7 @@ private:
 	void hng64_fbscale_w(offs_t offset, uint32_t data, uint32_t mem_mask);
 	void hng64_fbscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask);
 
-	void hng64_fbunkbyte_w(offs_t offset, uint8_t data);
+	void hng64_fbunkbyte_w(offs_t offset, uint32_t data, uint32_t mem_mask);
 
 	uint32_t hng64_fbtable_r(offs_t offset, uint32_t mem_mask = ~0);
 	void hng64_fbtable_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -92,7 +92,7 @@ struct hng64_poly_data
 	uint16_t colorIndex = 0;
 	bool blend = false;
 	uint16_t texscrollx = 0;
-	uint16_t texscrolly = 0;;
+	uint16_t texscrolly = 0;
 };
 
 class hng64_state;
@@ -107,15 +107,15 @@ public:
 	void render_flat_scanline(int32_t scanline, const extent_t& extent, const hng64_poly_data& renderData, int threadid);
 
 	hng64_state& state() { return m_state; }
-	bitmap_ind16& colorBuffer3d() { return m_colorBuffer3d; }
 	float* depthBuffer3d() { return m_depthBuffer3d.get(); }
+	uint16_t* colorBuffer3d() { return m_colorBuffer3d.get(); }
 
 private:
 	hng64_state& m_state;
 
 	// (Temporarily class members - someday they will live in the memory map)
-	bitmap_ind16 m_colorBuffer3d;
 	std::unique_ptr<float[]> m_depthBuffer3d;
+	std::unique_ptr<uint16_t[]> m_colorBuffer3d;
 };
 
 

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -44,6 +44,7 @@ struct polygon
 	float faceNormal[4]{};        // Normal of the face overall - for calculating visibility and flat-shading...
 	bool visible = false;                // Polygon visibility in scene
 	bool flatShade = false;              // Flat shaded polygon, no texture, no lighting
+	bool blend = false;
 
 	uint8_t texIndex = 0;             // Which texture to draw from (0x00-0x0f)
 	uint8_t tex4bpp = 0;              // How to index into the texture
@@ -86,6 +87,7 @@ struct hng64_poly_data
 	uint8_t texPageVertOffset = 0;
 	uint32_t palOffset = 0;
 	uint16_t colorIndex = 0;
+	bool blend = false;
 };
 
 class hng64_state;

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -168,6 +168,8 @@ public:
 		m_comhack(*this, "comhack"),
 		m_fbram1(*this, "fbram1"),
 		m_fbram2(*this, "fbram2"),
+		m_fbscale(*this, "fbscale"),
+		m_fbscroll(*this, "fbscroll"),
 		m_idt7133_dpram(*this, "com_ram"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_in(*this, "IN%u", 0U),
@@ -234,6 +236,8 @@ private:
 	required_shared_ptr<uint32_t> m_comhack;
 	required_shared_ptr<uint32_t> m_fbram1;
 	required_shared_ptr<uint32_t> m_fbram2;
+	required_shared_ptr<uint32_t> m_fbscale;
+	required_shared_ptr<uint32_t> m_fbscroll;
 
 	required_shared_ptr<uint32_t> m_idt7133_dpram;
 	//required_shared_ptr<uint8_t> m_com_mmu_mem;

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -54,6 +54,9 @@ struct polygon
 
 	uint32_t palOffset = 0;           // The base offset where this object's palette starts.
 	uint16_t colorIndex = 0;
+
+	uint16_t texscrollx = 0;
+	uint16_t texscrolly = 0;
 };
 
 
@@ -88,6 +91,8 @@ struct hng64_poly_data
 	uint32_t palOffset = 0;
 	uint16_t colorIndex = 0;
 	bool blend = false;
+	uint16_t texscrollx = 0;
+	uint16_t texscrolly = 0;;
 };
 
 class hng64_state;
@@ -295,7 +300,9 @@ private:
 	uint16_t m_old_tileflags[4]{};
 
 	// 3d State
-	int m_paletteState3d = 0;
+	uint16_t m_texturescrollx = 0;
+	uint16_t m_texturescrolly = 0;
+	uint16_t m_paletteState3d = 0;
 	float m_projectionMatrix[16]{};
 	float m_modelViewMatrix[16]{};
 	float m_cameraMatrix[16]{};

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -437,7 +437,7 @@ private:
 	void hng64_drawtilemap(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int tm, int flags, int line);
 
 	void hng64_tilemap_draw_roz_core_line(screen_device &screen, bitmap_rgb32 &dest, const rectangle &cliprect, tilemap_t *tmap,
-		int wraparound, uint8_t drawformat, uint8_t alpha, uint8_t mosaic, uint8_t tm);
+		int wraparound, uint8_t drawformat, uint8_t alpha, uint8_t mosaic, uint8_t tm, int splitside);
 
 	std::unique_ptr<hng64_poly_renderer> m_poly_renderer;
 

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -360,7 +360,7 @@ void hng64_state::recoverPolygonBlock(const uint16_t* packet, int& numPolys)
 	/*//////////////
 	// PACKET FORMAT
 	// [0]  - 0100 ... ID
-	// [1]  - --c- ---p ---b lo--
+	// [1]  - --c- ---p o--b l---
 	//      l = use lighting
 	//      p = use dynamic palette (maybe not just this, wrong for roadedge car select where it isn't set but needs to be)
 	//      o = use dynamic texture offset (sky reflection in xrally/roadedge windows, also waterfalls?)

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -225,7 +225,7 @@ void hng64_state::setLighting(const uint16_t* packet)
 	// [7]  - ???? ... ? Seems to be another light vector ?
 	// [8]  - ???? ... ? Seems to be another light vector ?
 	// [9]  - xxxx ... Strength according to sams64_2 (in combination with vector length) [0,512]
-	// folowing could just be leftover data
+	// following could just be leftover data
 	// [10] - ???? ... ? Used in fatfurwa
 	// [11] - ???? ... ? Used in fatfurwa
 	// [12] - ???? ... ? Used in fatfurwa
@@ -257,7 +257,7 @@ void hng64_state::set3dFlags(const uint16_t* packet)
 	// [6]  - ???? ... scale?
 	// [7]  - ???? ... scale?
 	// [8]  - xx?? ... Palette offset & ??
-	// folowing could just be leftover data
+	// following could just be leftover data
 	// [9]  - ???? ... ? Very much used - seem to bounce around when characters are on screen
 	// [10] - ???? ... ? ''  ''
 	// [11] - ???? ... ? ''  ''
@@ -298,7 +298,7 @@ void hng64_state::setCameraProjectionMatrix(const uint16_t* packet)
 	// [11] - xxxx ... Camera projection left   - confirmed by sams64_2
 	// [12] - xxxx ... Camera projection top    - confirmed by sams64_2
 	// [13] - xxxx ... Camera projection bottom - confirmed by sams64_2
-	// folowing could just be leftover data
+	// following could just be leftover data
 	// [14] - ???? ... ? Gets data during buriki door-run
 	// [15] - ???? ... ? Gets data during buriki door-run
 	////////////*/

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -182,6 +182,7 @@ void hng64_state::setCameraTransformation(const uint16_t* packet)
 	// [10] - xxxx ... Extrinsic camera matrix
 	// [11] - xxxx ... Extrinsic camera matrix
 	// [12] - xxxx ... Extrinsic camera matrix
+	// following might be unused leftover data
 	// [13] - ???? ... ? Flips per-frame during fatfurwa 'HNG64'
 	// [14] - ???? ... ? Could be some floating-point values during buriki 'door run'
 	// [15] - ???? ... ? Same as 13 & 14
@@ -224,6 +225,7 @@ void hng64_state::setLighting(const uint16_t* packet)
 	// [7]  - ???? ... ? Seems to be another light vector ?
 	// [8]  - ???? ... ? Seems to be another light vector ?
 	// [9]  - xxxx ... Strength according to sams64_2 (in combination with vector length) [0,512]
+	// folowing could just be leftover data
 	// [10] - ???? ... ? Used in fatfurwa
 	// [11] - ???? ... ? Used in fatfurwa
 	// [12] - ???? ... ? Used in fatfurwa
@@ -255,7 +257,7 @@ void hng64_state::set3dFlags(const uint16_t* packet)
 	// [6]  - ???? ... scale?
 	// [7]  - ???? ... scale?
 	// [8]  - xx?? ... Palette offset & ??
-	// ***** below are probably NOT used, but instead just contain old data that isn't cleared from the list when this packet is used *****
+	// folowing could just be leftover data
 	// [9]  - ???? ... ? Very much used - seem to bounce around when characters are on screen
 	// [10] - ???? ... ? ''  ''
 	// [11] - ???? ... ? ''  ''
@@ -289,6 +291,7 @@ void hng64_state::setCameraProjectionMatrix(const uint16_t* packet)
 	// [11] - xxxx ... Camera projection left   - confirmed by sams64_2
 	// [12] - xxxx ... Camera projection top    - confirmed by sams64_2
 	// [13] - xxxx ... Camera projection bottom - confirmed by sams64_2
+	// folowing could just be leftover data
 	// [14] - ???? ... ? Gets data during buriki door-run
 	// [15] - ???? ... ? Gets data during buriki door-run
 	////////////*/
@@ -608,6 +611,7 @@ void hng64_state::recoverPolygonBlock(const uint16_t* packet, int& numPolys)
 			// Must be a conditional enable?
 			// 0x0100 is set on the cars, but not the waterfall
 			// 0x0080 is set on the cars, and the waterfall - maybe correct?
+			// 0x0001 is set on the cars, but not the waterfall
 			if ((packet[1] & 0x0080))
 			{
 				currentPoly.texscrollx = m_texturescrollx;

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -1129,12 +1129,14 @@ void hng64_state::hng64_fbcontrol_w(offs_t offset, uint8_t data)
 // they are NOT used for buriki 'how to play' scren, which uses unhandled values in the 3d packets to reposition the fighters instead
 void hng64_state::hng64_fbscale_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
+	COMBINE_DATA(&m_fbscale[offset]);
+
 	if (mem_mask & 0xffff0000)
 	{
-		// NORMAL value is 3fe0
+		// NORMAL value is 3fe0 (0x400 / 2 = 0x200 = 512)
 		// ':maincpu' (8006E46C): hng64_fb_scale_x 3fe00000 ffff0000
 
-		// on xrally course select this is 39e0
+		// on xrally course select this is 39e0 (0x3a0 / 2 = 0x1d0 = 464)
 		// hng64_fb_scale_x 39e00000 ffff0000
 
 		//logerror("%s: hng64_fb_scale_x %08x %08x\n", machine().describe_context(), data, mem_mask);
@@ -1142,13 +1144,14 @@ void hng64_state::hng64_fbscale_w(offs_t offset, uint32_t data, uint32_t mem_mas
 
 	if (mem_mask & 0x0000ffff)
 	{
-		// NORMAL value is 37e0
+		// NORMAL value is 37e0  (0x380 / 2 = 0x1c0 = 448)
 		// hng64_fb_scale_y 000037e0 0000ffff
 
-		// on xrally course select this is 32e0
+		// on xrally course select this is 32e0 (0x330 / 2 = 408)
 		// hng64_fb_scale_y 000032e0 0000ffff
 
 		// during fatfurwa scaled intro it uses 2de0, although writes 37e0 in the same frame; presumably rendering takes place while it is 2de0 though
+		// 0x2e0 / 2 = 0x170 = 368    (needs to be ~287 pixels though)
 		// ':maincpu' (800667A0): hng64_fb_scale_y 00002de0 0000ffff
 		//logerror("%s: hng64_fb_scale_y %08x %08x\n", machine().describe_context(), data, mem_mask);
 	}
@@ -1156,31 +1159,34 @@ void hng64_state::hng64_fbscale_w(offs_t offset, uint32_t data, uint32_t mem_mas
 
 void hng64_state::hng64_fbscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
+	COMBINE_DATA(&m_fbscroll[offset]);
+
 	// this is used ingame on the samsho games, and on the car select screen in xrally (youtube video confirms position of car needs to change)
 	if (mem_mask & 0xffff0000)
 	{
-		// NORMAL value is e000
+		// NORMAL value is e000 (e0 = 224)
 		// hng64_fbscroll x e0000000 ffff0000
 
-		// on xrally course select this is e600
+		// on xrally course select this is e600  (+0600 from normal)
 		// ':maincpu' (8002327C): hng64_fbscroll x e6000000 ffff0000
 
 		// on xrally car select this is e680
 		// hng64_fbscroll x e6800000 ffff0000
-		//logerror("%s: hng64_fbscroll x %08x %08x\n", machine().describe_context(), data, mem_mask);
+		//logerror("%s: hng64_fbscroll x %08x (%d) %08x\n", machine().describe_context(), data, ((data&0x7fff0000) >> 21), mem_mask);
 	}
 
 	if (mem_mask & 0x0000ffff)
 	{
-		// NORMAL value is 1c00
+		// NORMAL value is 1c00  (1c0 = 448) /2 = 224 (midpoint y?)
 		// ':maincpu' (8006FA18): hng64_fbscroll y 00001c00 0000ffff
 
-		// on xrally course select this is 1700
-		// ':maincpu' (8002327C): hng64_fbscroll y 00001700 0000ffff
+		// on xrally course select this is 1700  (0x170 = 368)
+		// ':maincpu' (8002327C): hng64_fbscroll y 00001700 0000ffff (-0500 from normal)
 
-		// on xrally car select this is 1260
+		// on xrally car select this is 1260 (and needs to be higher up)
 		// ':maincpu' (80012820): hng64_fbscroll y 00001260 0000ffff
-		//logerror("%s: hng64_fbscroll y %08x %08x\n", machine().describe_context(), data, mem_mask);
+		// 00001a60 on screen after, not quite as high up, but higher than 1c00
+		//logerror("%s: hng64_fbscroll y %08x (%d) %08x\n", machine().describe_context(), data, (data >> 5), mem_mask);
 	}
 }
 

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -360,9 +360,10 @@ void hng64_state::recoverPolygonBlock(const uint16_t* packet, int& numPolys)
 	/*//////////////
 	// PACKET FORMAT
 	// [0]  - 0100 ... ID
-	// [1]  - --c- ---p ---b l---
+	// [1]  - --c- ---p ---b lo--
 	//      l = use lighting
 	//      p = use dynamic palette (maybe not just this, wrong for roadedge car select where it isn't set but needs to be)
+	//      o = use dynamic texture offset (sky reflection in xrally/roadedge windows, also waterfalls?)
 	//      b = backface culling?
 	//      c = set on objects a certain distance away (maybe optimization to disable clipping against camera?)
 	// none of these bits appear to be connected to texture size to solve the road/banner problem in xrally/roadedge
@@ -605,10 +606,17 @@ void hng64_state::recoverPolygonBlock(const uint16_t* packet, int& numPolys)
 			// but if we always use them things get very messy when they're used for the waterfalls on xrally
 			// as they never get turned back off again for the objects after the waterfalls
 			// Must be a conditional enable?
-			if (0)
+			// 0x0100 is set on the cars, but not the waterfall
+			// 0x0080 is set on the cars, and the waterfall - maybe correct?
+			if ((packet[1] & 0x0080))
 			{
 				currentPoly.texscrollx = m_texturescrollx;
 				currentPoly.texscrolly = m_texturescrolly;
+			}
+			else
+			{
+				currentPoly.texscrollx = 0;
+				currentPoly.texscrolly = 0;
 			}
 
 			uint8_t chunkLength = 0;

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -1191,20 +1191,33 @@ void hng64_state::hng64_fbscroll_w(offs_t offset, uint32_t data, uint32_t mem_ma
 	}
 }
 
-void hng64_state::hng64_fbunkbyte_w(offs_t offset, uint8_t data)
+void hng64_state::hng64_fbunkbyte_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	if (offset == 0)
-	{
-		// | ---- --?x | unknown, unsetted by Buriki One and set by Fatal Fury WA, buffering mode?
-		logerror("%s: hng64_unkbyte_w (%03x) %02x\n", machine().describe_context(), offset, data);
-	}
-	else
-	{
-		logerror("%s: hng64_unkbyte_w (%03x - unexpected) %02x \n", machine().describe_context(), offset, data);
-	}
+	COMBINE_DATA(&m_fbunk[offset]);
+
+	// | ---- --?x ---- ---- ---- ---- ---- ----| unknown
+	// is 02 in most games, 03 in samsh4 games
+	// could be related to how fbscrolly is applied?
+
+	logerror("%s: hng64_unkbyte_w %08x %08x\n", machine().describe_context(), data, mem_mask);
 }
 
-// this is a table filled with 0x0? data, seems to be 16-bit values
+/*
+this is a table filled with 0x0? data, seems to be 8-bit values
+ 
+roadedge  08080808 08080808 08080808 08080808 08080808 08080808 08080707 08080909 (ingame)
+          08080808 08080808 08080808 08080808 08080808 08080808 08080808 08080808 (hyper logo)
+
+xrally    08080808 08080808 08070707 08070807 07070807 08070707 08070707 07070808 (comms screen + ingame)
+          08080808 08080808 08080808 08080808 08080808 08080808 08080808 08080808 (hyper logo)
+
+buriki    08080808 08080808 08080808 08080808 08080808 08080808 08080808 08080808
+fatfurwa  08080808 08080808 08080808 08080808 08080808 08080808 08080808 08080808
+bbust2    08080808 08080808 08080808 08080808 08080808 08080808 08080808 08080808
+
+sams64    00000000 00000000 00000000 00000000 00000000 07070000 00000000 00000000 (only inits one value to 0707?)
+sams64_2  00000000 00000000 00000000 00000000 00000000 07070000 00000000 00000000 (only inits one value to 0707?)
+*/
 uint32_t hng64_state::hng64_fbtable_r(offs_t offset, uint32_t mem_mask)
 {
 	logerror("%s: hng64_fbtable_r (%03x) (%08x)\n", machine().describe_context(), offset * 4, mem_mask);

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -336,6 +336,7 @@ void hng64_state::recoverStandardVerts(polygon& currentPoly, int m, uint16_t* ch
 	// chunkOffset_verts[ xxxx+3 ] is set to 0x70 on some 'blended' objects (fatfurwa translucent globe, buriki shadows, but not on fatfurwa shadows)
 	// this might be the alpha level, rather than the enable, although that would mean more bits in the framebuffer (it could be the zbuffer isn't
 	// CPU visible, or at least not checked?)  3D can't blend against other 3D, it just cuts.
+	// this gets enabled on one side of the pirate ship stage in sams64, why would it be set there?
 	uint16_t maybe_blend = chunkOffset_verts[counter++];
 	if (maybe_blend != 0x80)
 		currentPoly.blend = true;

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -269,6 +269,13 @@ void hng64_state::set3dFlags(const uint16_t* packet)
 	m_texturescrollx = packet[1];
 	m_texturescrolly = packet[2];
 	m_paletteState3d = packet[8];
+
+#if 0
+	// like all the others in here, this cleary needs to have a per-poly/model enable as it's often invalid
+	if ((packet[5] != 0x100) || (packet[6] != 0x100) || (packet[7] != 0x100))
+		printf("set 3d scale flags %04x %04x %04x\n", packet[5], packet[6], packet[7]);
+#endif
+
 }
 
 // Operation 0012
@@ -278,15 +285,15 @@ void hng64_state::setCameraProjectionMatrix(const uint16_t* packet)
 	/*//////////////
 	// PACKET FORMAT
 	// [0]  - 0012 ... ID
-	// [1]  - ???? ... ? Contains a value in buriki's 'how to play' - probably a projection window/offset.
-	// [2]  - ???? ... ? Contains a value in buriki's 'how to play' - probably a projection window/offset.
-	// [3]  - ???? ... ? Contains a value
+	// [1]  - ???? ... ? Contains a value in buriki's 'how to play' - probably a projection window/offset.  value used is 0xffc0 ( -0x40 )  64 pixels?  not used anywhere else?
+	// [2]  - ???? ... ? Contains a value in buriki's 'how to play' - probably a projection window/offset.  value used is 0x0018            24 pixels?  not used anywhere else?
+	// [3]  - ???? ... ? Contains a value   (always? 0x0a00)
 	// [4]  - xxxx ... Camera projection Z scale
 	// [5]  - xxxx ... Camera projection near Z
 	// [6]  - xxxx ... Camera projection screen Z
-	// [7]  - xxxx ... Camera projection (?)
-	// [8]  - xxxx ... Camera projection (?)
-	// [9]  - xxxx ... Camera projection (?)
+	// [7]  - xxxx ... Camera projection (?)  (always? 0x0b10)
+	// [8]  - xxxx ... Camera projection (?)  (always? 0x0a00)
+	// [9]  - xxxx ... Camera projection (?)  (always? 0x0b00)
 	// [10] - xxxx ... Camera projection right  - confirmed by sams64_2
 	// [11] - xxxx ... Camera projection left   - confirmed by sams64_2
 	// [12] - xxxx ... Camera projection top    - confirmed by sams64_2
@@ -329,6 +336,23 @@ void hng64_state::setCameraProjectionMatrix(const uint16_t* packet)
 	m_projectionMatrix[13] = 0.0f;
 	m_projectionMatrix[14] = -((2.0f*far*near)/(far-near));
 	m_projectionMatrix[15] = 0.0f;
+
+#if 0
+	if ((packet[1] != 0x0000) || (packet[2] != 0x0000))
+		printf("camera packet[1] %04x packet[2] %04x\n", packet[1], packet[2]);
+
+	if (packet[3] != 0x0a00)
+		printf("camera packet[3] %04x\n", packet[3]);
+
+	if (packet[7] != 0x0b10)
+		printf("camera packet[7] %04x\n", packet[7]);
+
+	if (packet[8] != 0x0a00)
+		printf("camera packet[7] %04x\n", packet[8]);
+
+	if (packet[9] != 0x0b00)
+		printf("camera packet[9] %04x\n", packet[9]);
+#endif
 }
 
 void hng64_state::recoverStandardVerts(polygon& currentPoly, int m, uint16_t* chunkOffset_verts, int& counter)

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -343,6 +343,8 @@ void hng64_state::recoverStandardVerts(polygon& currentPoly, int m, uint16_t* ch
 	// this might be the alpha level, rather than the enable, although that would mean more bits in the framebuffer (it could be the zbuffer isn't
 	// CPU visible, or at least not checked?)  3D can't blend against other 3D, it just cuts.
 	// this gets enabled on one side of the pirate ship stage in sams64, why would it be set there?
+	// it's also set on the side of the houses in the ice stage on sams64, which appear darker than usual, maybe just a default 'brightness' setting for
+	// unlit polygons?
 	uint16_t maybe_blend = chunkOffset_verts[counter++];
 	if (maybe_blend != 0x80)
 		currentPoly.blend = true;

--- a/src/mame/snk/hng64_sprite.ipp
+++ b/src/mame/snk/hng64_sprite.ipp
@@ -10,14 +10,14 @@
  * offset | Bits                                    | Use
  *        | 3322 2222 2222 1111 1111 11             |
  * -------+-1098-7654-3210-9876-5432-1098-7654-3210-+----------------
- *   0    | yyyy yyyy yyyy yyyy xxxx xxxx xxxx xxxx | x/y position
- *   1    | YYYY YYYY YYYY YYYY XXXX XXXX XXXX XXXX | x/y zoom (*)
- *   2    | ---- Szzz zzzz zzzz ---- ---I cccc CCCC | S = set on CPU car markers above cars (in roadedge) z = Z-buffer value, i = 'Inline' chain flag, cC = x/y chain
- *   3    | ---- ---- pppp pppp ---- ---- ---- ---- | palette entry
- *   4    | mmmm -cfF aggg tttt tttt tttt tttt tttt | mosaic factor, unknown (x1), checkerboard, flip bits, blend, group?, tile number
- *   5    | ---- ---- ---- ---- ---- ---- ---- ---- | not used ??
- *   6    | ---- ---- ---- ---- ---- ---- ---- ---- | not used ??
- *   7    | ---- ---- ---- ---- ---- ---- ---- ---- | not used ??
+ *   0  0 | yyyy yyyy yyyy yyyy xxxx xxxx xxxx xxxx | x/y position
+ *   1  4 | YYYY YYYY YYYY YYYY XXXX XXXX XXXX XXXX | x/y zoom (*)
+ *   2  8 | ---- Szzz zzzz zzzz ---- ---I cccc CCCC | S = set on CPU car markers above cars (in roadedge) z = Z-buffer value, i = 'Inline' chain flag, cC = x/y chain
+ *   3  c | ---- ---- pppp pppp ---- ---- ---- ---- | palette entry
+ *   4 10 | mmmm -cfF aggg tttt tttt tttt tttt tttt | mosaic factor, unknown (x1), checkerboard, flip bits, blend, group?, tile number
+ *   5 14 | ---- ---- ---- ---- ---- ---- ---- ---- | not used ??
+ *   6 18 | ---- ---- ---- ---- ---- ---- ---- ---- | not used ??
+ *   7 1c | ---- ---- ---- ---- ---- ---- ---- ---- | not used ??
  *
  *  in (4) ggg seems to be either group, or priority against OTHER layers (7 being the lowest, 0 being the highest in normal situations eg most of the time in buriki)
  * 
@@ -311,8 +311,13 @@ void hng64_state::draw_sprites_buffer(screen_device& screen, const rectangle& cl
 
 		/* Calculate the zoom */
 		int zoom_factor = (m_spriteregs[0] & 0x08000000) ? 0x1000 : 0x100;
-		if (!zoomx) zoomx = zoom_factor;
-		if (!zoomy) zoomy = zoom_factor;
+
+		/* Sprites after 'Fair and Square' have a zoom of 0 in sams64 for one frame, they shouldn't be seen? */
+		if (!zoomx || !zoomy)
+		{
+			currentsprite = nextsprite;
+			continue;
+		};
 
 		int32_t dx, dy;
 

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -902,17 +902,17 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 
 	// copy sprites into display
 
-	// this correctly allows buriki intro sprites to use regular alpha, not additive
-	// while also being correct for sams64, which wants additive, but appears to be
-	// incorrect for Fatal Fury's hit effects which want additive
-	// 
-	// the 6 regs around here have the same values in fatfur and buriki, so are unlikely
-	// to control the blend type.
-	//uint8_t spriteblendtype = (m_tcram[0x10 / 4] >> 16) & 0x10;
-
-	// would be an odd place for it, after the 'vblank' flag but...
 	if (true)
 	{
+		// this correctly allows buriki intro sprites to use regular alpha, not additive
+		// while also being correct for sams64, which wants additive, but appears to be
+		// incorrect for Fatal Fury's hit effects which want additive
+		// 
+		// the 6 regs around here have the same values in fatfur and buriki, so are unlikely
+		// to control the blend type.
+		//uint8_t spriteblendtype = (m_tcram[0x10 / 4] >> 16) & 0x10;
+
+		// would be an odd place for it, after the 'vblank' flag but...
 		uint8_t spriteblendtype = (m_tcram[0x4c / 4] >> 16) & 0x01;
 
 		pen_t const* const clut = &m_palette->pen(0);

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -813,6 +813,13 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 	*/
 
 	// 3d gets drawn next
+	uint16_t palbase = 0x000;
+    if (m_fbcontrol[2] & 0x20)
+    {
+        if (!m_roadedge_3d_hack)
+            palbase = 0x800;
+    }
+
 	pen_t const *const clut_3d = &m_palette_3d->pen(0);
 	if (!(m_fbcontrol[0] & 0x01))
 	{
@@ -825,9 +832,16 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 			for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
 			{
 				uint16_t srcpix = *src;
-				if (srcpix & 0x0fff)
+				if (srcpix & 0x07ff)
 				{
-					*dst = clut_3d[srcpix];
+					if (srcpix & 0x0800)
+					{
+						*dst = alpha_blend_r32(*(uint32_t*)dst, clut_3d[(srcpix & 0x7ff) | palbase], 0x80);
+					}
+					else
+					{
+						*dst = clut_3d[(srcpix & 0x7ff) | palbase];
+					}
 				}
 
 				dst++;

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -870,15 +870,23 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 	pen_t const *const clut_3d = &m_palette_3d->pen(0);
 	if (!(m_fbcontrol[0] & 0x01))
 	{
+		// this moves the car in the xrally selection screen the correct number of pixels to the left
+		int xscroll = (m_fbscroll[0] >> 21);
+		if (xscroll & 0x400)
+			xscroll -= 0x800;
+
+		// value is midpoint?
+		xscroll += 256;
+
 		// Blit the color buffer into the primary bitmap
 		for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 		{
-			const uint16_t *src = &m_poly_renderer->colorBuffer3d().pix(y, cliprect.min_x);
+			const uint16_t *src = &m_poly_renderer->colorBuffer3d().pix(y, 0);
 			uint32_t *dst = &bitmap.pix(y, cliprect.min_x);
 
 			for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
 			{
-				uint16_t srcpix = *src;
+				uint16_t srcpix = src[((cliprect.min_x + x) + xscroll ) & 0x1ff];
 				if (srcpix & 0x07ff)
 				{
 					if (srcpix & 0x0800)
@@ -892,7 +900,6 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 				}
 
 				dst++;
-				src++;
 			}
 		}
 	}

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -920,7 +920,7 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 			m_videoregs[0x0d]);
 
 	if (1)
-		popmessage("TC: %08x MINX(%d) MINY(%d) MAXX(%d) MAXY(%d)\nBLEND ENABLES? %02x %02x %02x | %02x %02x %02x\nUNUSED?(%04x)\n%04x\n%04x\nMASTER FADES - ADD?(%08x) - SUBTRACT?(%08x)\nUNUSED?(%08x)\nBITFIELD REGS(%04x)\nPALEFFECT_ENABLES(%d %d %d %d %d %d %d %d)\n PALFADES?(%08x %08x : %08x %08x : %08x %08x : %08x %08x)\n % 08x % 08x : % 08x % 08x % 08x % 08x",
+		popmessage("TC: %08x MINX(%d) MINY(%d) MAXX(%d) MAXY(%d)\nBLEND ENABLES? %02x %02x %02x | %02x %02x %02x\nUNUSED?(%04x)\n%04x\n(%d %d %d %d %d %d %d %d)\nMASTER FADES - FADE1?(%08x) - FADE2?(%08x)\nUNUSED?(%08x)\nBITFIELD REGS(%04x)\nPALEFFECT_ENABLES(%d %d %d %d %d %d %d %d)\n PALFADES?(%08x %08x : %08x %08x : %08x %08x : %08x %08x)\n % 08x % 08x : % 08x % 08x % 08x % 08x",
 			m_tcram[0x00 / 4], // 0007 00e4 (fatfurwa, bbust2)
 			(m_tcram[0x04 / 4] >> 16) & 0xffff, (m_tcram[0x04 / 4] >> 0) & 0xffff, // 0000 0010 (fatfurwa) 0000 0000 (bbust2, xrally)
 			(m_tcram[0x08 / 4] >> 16) & 0xffff, (m_tcram[0x08 / 4] >> 0) & 0xffff, // 0200 01b0 (fatfurwa) 0200 01c0 (bbust2, xrally)
@@ -936,17 +936,21 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 
 			m_tcram[0x10 / 4] & 0xffff, // unused?
 
+			// also seems fade mode related?
 			(m_tcram[0x14 / 4] >> 16) & 0xffff,  // typically 0007 or 0001, - 0011 on ss64 ingame, 0009 on continue screen
-			(m_tcram[0x14 / 4] >> 0) & 0xffff,   // 0xxx ?  (often 0555 or 0fff, seen 56a, 57f too)
+
+			// 0xxx ?  (often 0555 or 0fff, seen 56a, 57f too) -  register split into 2 bits - typically a bit will be 3 or 1 depending if the effect is additive / subtractive
+			// usually relate to the RGB pairings at m_tcram[0x18 / 4] & m_tcram[0x1c / 4] but m_tcram[0x20 / 4] being 1 may cause it to use the registers at m_tcram[0x28 / 4] instead?
+			(m_tcram[0x14 / 4] >> 0) & 0x3, (m_tcram[0x14 / 4] >> 2) & 0x3, (m_tcram[0x14 / 4] >> 4) & 0x3, (m_tcram[0x14 / 4] >> 6) & 0x3, (m_tcram[0x14 / 4] >> 8) & 0x3, (m_tcram[0x14 / 4] >> 10) & 0x3, (m_tcram[0x14 / 4] >> 12) & 0x3, (m_tcram[0x14 / 4] >> 14) & 0x3,
 
 			// these are used for 'fade to black' in most cases, but
 			// in xrally attract, when one image is meant to fade into another, one value increases while the other decreases
 			m_tcram[0x18 / 4],  // xRGB fade values? (roadedge attract)
 			m_tcram[0x1c / 4],  // xRGB fade values? (roadedge attract) fades on fatfurwa before buildings in intro
 
-			m_tcram[0x20 / 4],  //  unused?
+			m_tcram[0x20 / 4],  // does this somehow relate to which set of registers are used for certain effects? (the 8 below, at 0x28 / 4 or the 2 above?) only ever seems to be 0 or 1
 
-			// some kind of bitfields
+			// some kind of bitfields, these appear related to fade mode for the registers at 0x28 / 4, set to either 3 or 2 which is additive or subtractive
 			(m_tcram[0x24 / 4] >> 16) & 0xffff, // 0002 gets set in roadedge during some transitions (layers are disabled? blacked out?) 0001 set on SNK logo in roadedge 
 			(m_tcram[0x24 / 4] >> 0) & 0x3, // 0001 gets set when in a tunnel on roadedge in 1st person mode (state isn't updated otherwise, switching back to 3rd person in a tunnel leaves it set until you flick back to 1st person)  briefly set to 3c on roadedge car select during 'no fb clear' effect?
 			(m_tcram[0x24 / 4] >> 2) & 0x3,

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -911,37 +911,39 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 	//uint8_t spriteblendtype = (m_tcram[0x10 / 4] >> 16) & 0x10;
 
 	// would be an odd place for it, after the 'vblank' flag but...
-	uint8_t spriteblendtype = (m_tcram[0x4c / 4] >> 16) & 0x01;
-
-	pen_t const *const clut = &m_palette->pen(0);
-	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
+	if (true)
 	{
-		const uint16_t *src = &m_sprite_bitmap.pix(y, cliprect.min_x);
-		uint32_t *dst = &bitmap.pix(y, cliprect.min_x);
+		uint8_t spriteblendtype = (m_tcram[0x4c / 4] >> 16) & 0x01;
 
-		for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
+		pen_t const* const clut = &m_palette->pen(0);
+		for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 		{
-			uint16_t srcpix = *src;
-			if (srcpix & 0x7fff)
-			{
-				if (srcpix & 0x8000)
-				{
-					if (spriteblendtype)
-						*dst = alpha_blend_r32(*(uint32_t *)dst, clut[srcpix & 0x7fff], 0x80);
-					else
-						*dst = add_blend_r32(*dst, clut[srcpix & 0x7fff]);
-				}
-				else
-				{
-					*dst = clut[srcpix & 0x7fff];
-				}
-			}
+			const uint16_t* src = &m_sprite_bitmap.pix(y, cliprect.min_x);
+			uint32_t* dst = &bitmap.pix(y, cliprect.min_x);
 
-			dst++;
-			src++;
+			for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
+			{
+				uint16_t srcpix = *src;
+				if (srcpix & 0x7fff)
+				{
+					if (srcpix & 0x8000)
+					{
+						if (spriteblendtype)
+							*dst = alpha_blend_r32(*(uint32_t*)dst, clut[srcpix & 0x7fff], 0x80);
+						else
+							*dst = add_blend_r32(*dst, clut[srcpix & 0x7fff]);
+					}
+					else
+					{
+						*dst = clut[srcpix & 0x7fff];
+					}
+				}
+
+				dst++;
+				src++;
+			}
 		}
 	}
-
 
 
 #if HNG64_VIDEO_DEBUG
@@ -1073,7 +1075,7 @@ WRITE_LINE_MEMBER(hng64_state::screen_vblank_hng64)
 }
 
 
-/* Transition Control Video Registers
+/* Transition Control Video Registers  **OUTDATED, see notes with popmessage**
  * ----------------------------------
  *
  * uint32_t | Bits                                    | Use

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -940,7 +940,7 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 			(m_tcram[0x14 / 4] >> 16) & 0xffff,  // typically 0007 or 0001, - 0011 on ss64 ingame, 0009 on continue screen
 
 			// 0xxx ?  (often 0555 or 0fff, seen 56a, 57f too) -  register split into 2 bits - typically a bit will be 3 or 1 depending if the effect is additive / subtractive
-			// usually relate to the RGB pairings at m_tcram[0x18 / 4] & m_tcram[0x1c / 4] but m_tcram[0x20 / 4] being 1 may cause it to use the registers at m_tcram[0x28 / 4] instead?
+			// usually relate to the RGB pairings at m_tcram[0x18 / 4] & m_tcram[0x1c / 4] but m_tcram[0x24 / 4] & 1 may cause it to use the registers at m_tcram[0x28 / 4] instead?
 			(m_tcram[0x14 / 4] >> 0) & 0x3, (m_tcram[0x14 / 4] >> 2) & 0x3, (m_tcram[0x14 / 4] >> 4) & 0x3, (m_tcram[0x14 / 4] >> 6) & 0x3, (m_tcram[0x14 / 4] >> 8) & 0x3, (m_tcram[0x14 / 4] >> 10) & 0x3, (m_tcram[0x14 / 4] >> 12) & 0x3, (m_tcram[0x14 / 4] >> 14) & 0x3,
 
 			// these are used for 'fade to black' in most cases, but
@@ -948,10 +948,12 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 			m_tcram[0x18 / 4],  // xRGB fade values? (roadedge attract)
 			m_tcram[0x1c / 4],  // xRGB fade values? (roadedge attract) fades on fatfurwa before buildings in intro
 
-			m_tcram[0x20 / 4],  // does this somehow relate to which set of registers are used for certain effects? (the 8 below, at 0x28 / 4 or the 2 above?) only ever seems to be 0 or 1
+			m_tcram[0x20 / 4], // unused?
+
+			// 0001 may indicate if to use the 8 below for standard fade, or those above, 0002 appears to be display disable?
+			(m_tcram[0x24 / 4] >> 16) & 0xffff, // 0002 gets set in roadedge during some transitions (layers are disabled? blacked out?) 0001 set on SNK logo in roadedge 
 
 			// some kind of bitfields, these appear related to fade mode for the registers at 0x28 / 4, set to either 3 or 2 which is additive or subtractive
-			(m_tcram[0x24 / 4] >> 16) & 0xffff, // 0002 gets set in roadedge during some transitions (layers are disabled? blacked out?) 0001 set on SNK logo in roadedge 
 			(m_tcram[0x24 / 4] >> 0) & 0x3, // 0001 gets set when in a tunnel on roadedge in 1st person mode (state isn't updated otherwise, switching back to 3rd person in a tunnel leaves it set until you flick back to 1st person)  briefly set to 3c on roadedge car select during 'no fb clear' effect?
 			(m_tcram[0x24 / 4] >> 2) & 0x3,
 			(m_tcram[0x24 / 4] >> 4) & 0x3,


### PR DESCRIPTION
- identified 'blend' flag for 3D objects, and did a minimal implementation (used in many places, eg. shadows in fatfurwa, buriki, final boss in sams64_2)
- emulated 'split' tilemap effect (needed by buriki one character introductions)
- don't draw sprites with '0' zoom values, rather than using an unscaled sprite (needed by sams64 text at start of round)
- make 'sprite erase' code less aggressive (prevent it from wiping out palette values) (needed by sams64 2nd intro)
- support 'texture scrolling' (used by windows on cars in xrally/roadedge, waterfalls in xrally)
