### PR TITLE
Stop endless beep on Heathkit H19

### DIFF
--- a/src/mame/heathkit/h19.cpp
+++ b/src/mame/heathkit/h19.cpp
@@ -148,7 +148,7 @@ TIMER_CALLBACK_MEMBER(h19_state::key_click_off)
 
 TIMER_CALLBACK_MEMBER(h19_state::bell_off)
 {
-	m_keyclickactive = false;
+	m_bellactive = false;
 
 	if (!m_keyclickactive && !m_bellactive)
 		m_beep->set_state(0);


### PR DESCRIPTION
Fix an apparent copy-n-paste issue that was introduced with restructure of device timer from https://github.com/mamedev/mame/pull/9788