### PR TITLE
emu/render.cpp: Add 'vector' render primitive type (#399)

### DIFF
--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -75,9 +75,10 @@ enum
 };
 
 
-enum
+enum  // for render_container::item::m_type
 {
 	CONTAINER_ITEM_LINE = 0,
+	CONTAINER_ITEM_VECTOR,
 	CONTAINER_ITEM_QUAD,
 	CONTAINER_ITEM_MAX
 };
@@ -620,6 +621,19 @@ void render_container::add_line(float x0, float y0, float x1, float y1, float wi
 
 
 //-------------------------------------------------
+//  add_vector - add a vector item to this container
+//-------------------------------------------------
+
+void render_container::add_vector(float x0, float y0, float x1, float y1, float width, rgb_t argb, double draw_duration, u32 flags)
+{
+	item &newitem = add_generic(CONTAINER_ITEM_VECTOR, x0, y0, x1, y1, argb);
+	newitem.m_width = width;
+	newitem.m_draw_duration = draw_duration;
+	newitem.m_flags = flags;
+}
+
+
+//-------------------------------------------------
 //  add_quad - add a quad item to this container
 //-------------------------------------------------
 
@@ -761,6 +775,7 @@ render_container::item &render_container::add_generic(u8 type, float x0, float y
 	newitem->m_internal = 0;
 	newitem->m_width = 0;
 	newitem->m_texture = nullptr;
+	newitem->m_draw_duration = 0;
 
 	// add the item to the container
 	return m_itemlist.append(*newitem);
@@ -2359,6 +2374,35 @@ void render_target::add_container_primitives(render_primitive_list &list, const 
 				}
 				break;
 
+			case CONTAINER_ITEM_VECTOR:
+				// adjust the color for brightness/contrast/gamma
+				prim->color.a = container.apply_brightness_contrast_gamma_fp(prim->color.a);
+				prim->color.r = container.apply_brightness_contrast_gamma_fp(prim->color.r);
+				prim->color.g = container.apply_brightness_contrast_gamma_fp(prim->color.g);
+				prim->color.b = container.apply_brightness_contrast_gamma_fp(prim->color.b);
+
+				// set the vector type
+				prim->type = render_primitive::VECTOR;
+				prim->flags |= PRIMFLAG_TYPE_VECTOR;
+
+				// scale the width by the minimum of X/Y scale factors
+				prim->width = curitem.width() * std::min(container_xform.xscale, container_xform.yscale);
+				prim->flags |= curitem.flags();
+
+				// copy vector-specific properties
+				prim->draw_duration = curitem.draw_duration();
+
+				// clip the primitive
+				if (!m_transform_container)// && PRIMFLAG_GET_VECTOR(curitem.flags()))
+				{
+					clipped = render_clip_line(prim->bounds, root_cliprect);
+				}
+				else
+				{
+					clipped = render_clip_line(prim->bounds, cliprect);
+				}
+				break;
+
 			case CONTAINER_ITEM_QUAD:
 				// set the quad type
 				prim->type = render_primitive::QUAD;
@@ -3043,6 +3087,9 @@ void render_target::add_clear_and_optimize_primitive_list(render_primitive_list 
 		switch (prim.type)
 		{
 			case render_primitive::LINE:
+				goto done;
+
+			case render_primitive::VECTOR:
 				goto done;
 
 			case render_primitive::QUAD:

--- a/src/emu/render.h
+++ b/src/emu/render.h
@@ -106,6 +106,7 @@ constexpr u32 PRIMFLAG_VECTORBUF_MASK = 1 << PRIMFLAG_VECTORBUF_SHIFT;
 constexpr int PRIMFLAG_TYPE_SHIFT = 19;
 constexpr u32 PRIMFLAG_TYPE_MASK = 3 << PRIMFLAG_TYPE_SHIFT;
 constexpr u32 PRIMFLAG_TYPE_LINE = 0 << PRIMFLAG_TYPE_SHIFT;
+constexpr u32 PRIMFLAG_TYPE_VECTOR = 2 << PRIMFLAG_TYPE_SHIFT;
 constexpr u32 PRIMFLAG_TYPE_QUAD = 1 << PRIMFLAG_TYPE_SHIFT;
 
 constexpr int PRIMFLAG_PACKABLE_SHIFT = 21;
@@ -215,6 +216,7 @@ public:
 	{
 		INVALID = 0,                        // invalid type
 		LINE,                               // a single line
+		VECTOR,                             // a single line with additional timing information
 		QUAD                                // a rectilinear quad
 	};
 
@@ -238,6 +240,7 @@ public:
 	float               width = 0.0F;       // width (for line primitives)
 	render_texinfo      texture;            // texture info (for quad primitives)
 	render_quad_texuv   texcoords;          // texture coordinates (for quad primitives)
+	double              draw_duration;      // period of time in milliseconds that the emulated machine took to draw this (for vector primitives)
 	render_container *  container = nullptr;// the render container we belong to
 
 private:
@@ -417,6 +420,7 @@ public:
 
 	// add items to the list
 	void add_line(float x0, float y0, float x1, float y1, float width, rgb_t argb, u32 flags);
+	void add_vector(float x0, float y0, float x1, float y1, float width, rgb_t argb, double draw_duration, u32 flags);
 	void add_quad(float x0, float y0, float x1, float y1, rgb_t argb, render_texture *texture, u32 flags);
 	void add_char(float x0, float y0, float height, float aspect, rgb_t argb, render_font &font, u16 ch);
 	void add_point(float x0, float y0, float diameter, rgb_t argb, u32 flags) { add_line(x0, y0, x0, y0, diameter, argb, flags); }
@@ -436,7 +440,7 @@ private:
 		friend class simple_list<item>;
 
 	public:
-		item() : m_next(nullptr), m_type(0), m_flags(0), m_internal(0), m_width(0), m_texture(nullptr) { }
+		item() : m_next(nullptr), m_type(0), m_flags(0), m_internal(0), m_width(0), m_texture(nullptr), m_draw_duration(0) { }
 
 		// getters
 		item *next() const { return m_next; }
@@ -447,17 +451,19 @@ private:
 		u32 internal() const { return m_internal; }
 		float width() const { return m_width; }
 		render_texture *texture() const { return m_texture; }
+		double draw_duration() const { return m_draw_duration; }
 
 	private:
 		// internal state
 		item *              m_next;             // pointer to the next element in the list
-		u8                  m_type;             // type of element
+		u8                  m_type;             // type of element (eg. CONTAINER_ITEM_LINE)
 		render_bounds       m_bounds;           // bounds of the element
 		render_color        m_color;            // RGBA factors
 		u32                 m_flags;            // option flags
 		u32                 m_internal;         // internal flags
 		float               m_width;            // width of the line (lines only)
 		render_texture *    m_texture;          // pointer to the source texture (quads only)
+		double              m_draw_duration;    // period of time in milliseconds that the emulated machine took to draw this (vectors only)
 	};
 
 	// generic screen overlay scaler


### PR DESCRIPTION
Like 'line' but with added draw duration.

Intended for more lifelike rendering of vector monitors in the future. Not used by any drivers yet.

-

Please could someone approve my registration at Bannister forums so I can write about what I'd like to do with this next? (@rb6502 ?-:)
login name: dnlopez, display name: z9k9