### PR TITLE
apple3: Add support for control-reset.

### DIFF
--- a/src/mame/apple/apple3_m.cpp
+++ b/src/mame/apple/apple3_m.cpp
@@ -1123,6 +1123,12 @@ TIMER_CALLBACK_MEMBER(apple3_state::scanend_cb)
 	m_via[1]->write_pb6(1);
 
 	m_scanstart->adjust(m_screen->time_until_pos((scanline+1) % 224, 0));
+
+	// check for ctrl-reset
+	if ((m_kbspecial->read() & 0x88) == 0x88)
+	{
+		m_maincpu->reset();
+	}
 }
 
 READ_LINE_MEMBER(apple3_state::ay3600_shift_r)


### PR DESCRIPTION
Apple /// Owner's guide page 12:

"If the power is already on, the procedure for booting is to hold down the CONTROL key while you press and release the RESET button behind the keyboard."

Additionally, control-open apple-reset will drop into the (very simple) monitor.