### PR TITLE
atari/irobot_m.cpp: Initialise mathbox stack after loading decoding opcode PROMs

### DIFF
--- a/src/mame/atari/irobot_m.cpp
+++ b/src/mame/atari/irobot_m.cpp
@@ -385,13 +385,14 @@ void irobot_state::load_oproms()
 /* Init mathbox (only called once) */
 void irobot_state::init_irobot()
 {
+	load_oproms();
+
 	for (int i = 0; i < 16; i++)
 	{
-		m_irmb_stack[i] = nullptr;
+		m_irmb_stack[i] = &m_mbops[0];
 		m_irmb_regs[i] = 0;
 	}
 	m_irmb_latch = 0;
-	load_oproms();
 }
 
 TIMER_DEVICE_CALLBACK_MEMBER(irobot_state::irobot_irmb_done_callback)

--- a/src/mame/atari/irobot_m.cpp
+++ b/src/mame/atari/irobot_m.cpp
@@ -315,12 +315,11 @@ void irobot_state::irmb_dout(const irmb_ops *curop, uint32_t d)
 void irobot_state::load_oproms()
 {
 	uint8_t *MB = memregion("proms")->base() + 0x20;
-	int i;
 
 	/* allocate RAM */
 	m_mbops = std::make_unique<irmb_ops[]>(1024);
 
-	for (i = 0; i < 1024; i++)
+	for (int i = 0; i < 1024; i++)
 	{
 		int nxtadd, func, ramsel, diradd, latchmask, dirmask, time;
 
@@ -386,13 +385,13 @@ void irobot_state::load_oproms()
 /* Init mathbox (only called once) */
 void irobot_state::init_irobot()
 {
+	load_oproms();
 	for (int i = 0; i < 16; i++)
 	{
 		m_irmb_stack[i] = &m_mbops[0];
 		m_irmb_regs[i] = 0;
 	}
 	m_irmb_latch = 0;
-	load_oproms();
 }
 
 TIMER_DEVICE_CALLBACK_MEMBER(irobot_state::irobot_irmb_done_callback)

--- a/src/mame/atari/irobot_m.cpp
+++ b/src/mame/atari/irobot_m.cpp
@@ -385,13 +385,13 @@ void irobot_state::load_oproms()
 /* Init mathbox (only called once) */
 void irobot_state::init_irobot()
 {
-	load_oproms();
 	for (int i = 0; i < 16; i++)
 	{
-		m_irmb_stack[i] = &m_mbops[0];
+		m_irmb_stack[i] = nullptr;
 		m_irmb_regs[i] = 0;
 	}
 	m_irmb_latch = 0;
+	load_oproms();
 }
 
 TIMER_DEVICE_CALLBACK_MEMBER(irobot_state::irobot_irmb_done_callback)


### PR DESCRIPTION
Originally, irobot_state::init_irobot() starts first and sets up m_irmb_stack with addresses from m_mbops.  Then it called irobot_state::load_oproms() where m_mbops gets redefined on line 321.  This triggers an assertion in std::unique_ptr.h, something like "get() != pointer()".  Moving the load_oproms() call earlier does not cause the assertion to happen.