### PR TITLE
hng64.cpp - current progress, including using raster effect to enable fatfurwa floor

### DIFF
--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -2581,6 +2581,8 @@ void hng64_state::hng64(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(hng64_state::screen_vblank_hng64));
 
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_888, 0x1000);
+	PALETTE(config, m_palette_fade0).set_format(palette_device::xRGB_888, 0x1000);
+	PALETTE(config, m_palette_fade1).set_format(palette_device::xRGB_888, 0x1000);
 	PALETTE(config, m_palette_3d).set_format(palette_device::xRGB_888, 0x1000 * 0x10);
 
 	hng64_audio(config);

--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -1005,9 +1005,9 @@ void hng64_state::hng64_sysregs_w(offs_t offset, uint32_t data, uint32_t mem_mas
 	{
 		/*
 		case 0x0014:
-			break;
+		    break;
 		case 0x001c:
-			break;
+		    break;
 		*/
 		case 0x100c:
 			raster_irq_pos_w(data);
@@ -1015,13 +1015,13 @@ void hng64_state::hng64_sysregs_w(offs_t offset, uint32_t data, uint32_t mem_mas
 
 		/*
 		case 0x1014:
-			break;
+		    break;
 		case 0x101c:
-			break;
+		    break;
 		case 0x106c: // also reads from this one when writing 100c regs
-			break;
+		    break;
 		case 0x1074:
-			break;
+		    break;
 		*/
 		case 0x1084: //MIPS->MCU latch port
 			m_mcu_en = (data & 0xff); //command-based, i.e. doesn't control halt line and such?
@@ -1029,7 +1029,7 @@ void hng64_state::hng64_sysregs_w(offs_t offset, uint32_t data, uint32_t mem_mas
 			break;
 		/*
 		case 0x108c:
-			break;
+		    break;
 		*/
 		default:
 			logerror("%s: HNG64 writing to SYSTEM Registers %08x %08x (%08x) on scanline %d\n", machine().describe_context(), offset * 4, data, mem_mask, scanline);
@@ -1145,19 +1145,20 @@ void hng64_state::hng64_sprite_clear_odd_w(offs_t offset, uint32_t data, uint32_
 
 void hng64_state::hng64_vregs_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	uint32_t oldreg = m_videoregs[offset];
-
 	LOGMASKED(LOG_VREGS, "hng64_vregs_w %02x, %08x %08x\n", offset * 4, data, mem_mask);
-	COMBINE_DATA(&m_videoregs[offset]);
 
-	if (oldreg != m_videoregs[offset])
+	uint32_t newval = m_videoregs[offset];
+	COMBINE_DATA(&newval);
+
+	if (newval != m_videoregs[offset])
 	{
 		int vpos = m_screen->vpos();
 
 		if (vpos > 0)
 			m_screen->update_partial(vpos - 1);
-	}
 
+		m_videoregs[offset] = newval;
+	}
 }
 
 uint16_t hng64_state::main_sound_comms_r(offs_t offset)

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -290,6 +290,8 @@ private:
 	bitmap_ind16 m_sprite_bitmap;
 	bitmap_ind16 m_sprite_zbuffer;
 
+	uint8_t m_irq_pos_half;
+	uint32_t m_raster_irq_pos[2];
 
 	uint8_t m_screen_dis = 0U;
 
@@ -335,6 +337,7 @@ private:
 	uint32_t hng64_irqc_r(offs_t offset, uint32_t mem_mask = ~0);
 	void hng64_irqc_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	void hng64_mips_to_iomcu_irq_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void raster_irq_pos_w(uint32_t data);
 
 	uint8_t hng64_dualport_r(offs_t offset);
 	void hng64_dualport_w(offs_t offset, uint8_t data);

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -370,6 +370,7 @@ private:
 	void dl_unk_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	uint32_t dl_vreg_r();
 
+	void set_palette_entry_with_faderegs(int entry, uint8_t r, uint8_t g, uint8_t b, uint32_t rgbfade, uint8_t r_mode, uint8_t g_mode, uint8_t b_mode, palette_device *palette);
 	void set_single_palette_entry(int entry, uint8_t r, uint8_t g, uint8_t b);
 	void update_palette_entry(int entry);
 	void pal_w(offs_t offset, uint32_t data, uint32_t mem_mask);

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -144,6 +144,8 @@ public:
 		driver_device(mconfig, type, tag),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
+		m_palette_fade0(*this, "palette0"),
+		m_palette_fade1(*this, "palette1"),
 		m_palette_3d(*this, "palette3d"),
 		m_paletteram(*this, "paletteram"),
 		m_vblank(*this, "VBLANK"),
@@ -195,6 +197,8 @@ public:
 	uint8_t *m_texturerom = nullptr;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
+	required_device<palette_device> m_palette_fade0;
+	required_device<palette_device> m_palette_fade1;
 	required_device<palette_device> m_palette_3d;
 	required_shared_ptr<u32> m_paletteram;
 	required_ioport m_vblank;

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -468,9 +468,11 @@ private:
 	void clear3d();
 	bool hng64_command3d(const uint16_t* packet);
 
+	void mixsprites_test(screen_device& screen, bitmap_rgb32& bitmap, const rectangle& cliprect, uint16_t priority, int y);
+
 	void get_tile_details(bool chain, uint16_t spritenum, uint8_t xtile, uint8_t ytile, uint8_t xsize, uint8_t ysize, bool xflip, bool yflip, uint32_t& tileno, uint16_t& pal, uint8_t &gfxregion);
 	void draw_sprites_buffer(screen_device &screen, const rectangle &cliprect);
-	void draw_sprite_line(screen_device& screen, const rectangle& cliprect, int32_t curyy, int16_t cury, int16_t xpos, int chainx, int32_t dx, int32_t dy, int ytileblock, int chaini, int currentsprite, int chainy, int xflip, int yflip, uint16_t zval, bool zsort, bool blend, bool checkerboard, uint8_t mosaic);
+	void draw_sprite_line(screen_device& screen, const rectangle& cliprect, int32_t curyy, int16_t cury, int16_t xpos, int chainx, int32_t dx, int32_t dy, int ytileblock, int chaini, int currentsprite, int chainy, int xflip, int yflip, uint16_t zval, bool zsort, bool blend, uint16_t group, bool checkerboard, uint8_t mosaic);
 
 	void drawline(bitmap_ind16& dest, bitmap_ind16& destz, const rectangle& cliprect,
 		gfx_element* gfx, uint32_t code, uint32_t color, int flipy, int32_t xpos,
@@ -478,7 +480,7 @@ private:
 
 	void zoom_transpen(bitmap_ind16 &dest, bitmap_ind16 &destz, const rectangle &cliprect,
 		gfx_element *gfx, uint32_t code, uint32_t color, int flipx, int flipy, int32_t xpos, int32_t ypos,
-		int32_t dx, int32_t dy, uint32_t dstwidth, uint32_t trans_pen, uint32_t zval, bool zrev, bool blend, bool checkerboard, uint8_t mosaic, uint8_t &mosaic_count_x, int line, uint16_t &srcpix);
+		int32_t dx, int32_t dy, uint32_t dstwidth, uint32_t trans_pen, uint32_t zval, bool zrev, bool blend, uint16_t group, bool checkerboard, uint8_t mosaic, uint8_t &mosaic_count_x, int line, uint16_t &srcpix);
 
 	void setCameraTransformation(const uint16_t* packet);
 	void setLighting(const uint16_t* packet);

--- a/src/mame/snk/hng64_sprite.ipp
+++ b/src/mame/snk/hng64_sprite.ipp
@@ -148,7 +148,7 @@ inline void hng64_state::drawline(bitmap_ind16 & dest, bitmap_ind16 & destz, con
 
 inline void hng64_state::zoom_transpen(bitmap_ind16 &dest, bitmap_ind16 &destz, const rectangle &cliprect,
 		gfx_element *gfx, uint32_t code, uint32_t color, int flipx, int flipy, int32_t xpos, int32_t ypos,
-		int32_t dx, int32_t dy, uint32_t dstwidth, uint32_t trans_pen, uint32_t zval, bool zrev, bool blend, bool checkerboard, uint8_t mosaic, uint8_t &mosaic_count_x, int curyy, uint16_t &srcpix)
+		int32_t dx, int32_t dy, uint32_t dstwidth, uint32_t trans_pen, uint32_t zval, bool zrev, bool blend, uint16_t group, bool checkerboard, uint8_t mosaic, uint8_t &mosaic_count_x, int curyy, uint16_t &srcpix)
 {
 	// use pen usage to optimize
 	code %= gfx->elements();
@@ -165,6 +165,8 @@ inline void hng64_state::zoom_transpen(bitmap_ind16 &dest, bitmap_ind16 &destz, 
 
 	if (blend)
 		color |= 0x8000;
+
+	color |= group;
 
 	assert(dest.valid());
 	assert(dest.cliprect().contains(cliprect));
@@ -287,6 +289,7 @@ void hng64_state::draw_sprites_buffer(screen_device& screen, const rectangle& cl
 		ypos = util::sext(ypos, 10);
 
 		bool blend = (m_spriteram[(currentsprite * 8) + 4] & 0x00800000);
+		uint16_t group = (m_spriteram[(currentsprite * 8) + 4] & 0x00700000) >> 8;
 		bool checkerboard = (m_spriteram[(currentsprite * 8) + 4] & 0x04000000);
 		uint8_t mosaic = (m_spriteram[(currentsprite * 8) + 4] & 0xf0000000) >> 28;
 
@@ -368,7 +371,7 @@ void hng64_state::draw_sprites_buffer(screen_device& screen, const rectangle& cl
 				int used_ysource_pos = full_srcpix_y2 >> 16;
 				int ytilebbb = used_ysource_pos / 0x10;
 				int use_tile_line = used_ysource_pos & 0xf;
-				draw_sprite_line(screen, cliprect, use_tile_line, ypos, xpos, chainx, dx, dy, ytilebbb, chaini, currentsprite, chainy, xflip, yflip, zval, zsort, blend, checkerboard, mosaic);
+				draw_sprite_line(screen, cliprect, use_tile_line, ypos, xpos, chainx, dx, dy, ytilebbb, chaini, currentsprite, chainy, xflip, yflip, zval, zsort, blend, group, checkerboard, mosaic);
 			}
 			ypos++;
 		}
@@ -378,7 +381,7 @@ void hng64_state::draw_sprites_buffer(screen_device& screen, const rectangle& cl
 }
 
 
-inline void hng64_state::draw_sprite_line(screen_device& screen, const rectangle& cliprect, int32_t curyy, int16_t ypos, int16_t xpos, int chainx, int32_t dx, int32_t dy, int ytileblock, int chaini, int currentsprite, int chainy, int xflip, int yflip, uint16_t zval, bool zsort, bool blend, bool checkerboard, uint8_t mosaic)
+inline void hng64_state::draw_sprite_line(screen_device& screen, const rectangle& cliprect, int32_t curyy, int16_t ypos, int16_t xpos, int chainx, int32_t dx, int32_t dy, int ytileblock, int chaini, int currentsprite, int chainy, int xflip, int yflip, uint16_t zval, bool zsort, bool blend, uint16_t group, bool checkerboard, uint8_t mosaic)
 {
 	uint32_t srcpix_x = 0;
 	uint16_t srcpix = 0;
@@ -400,7 +403,7 @@ inline void hng64_state::draw_sprite_line(screen_device& screen, const rectangle
 		uint8_t gfxregion;
 
 		get_tile_details(chaini, currentsprite, xdrw, ytileblock, chainx, chainy, xflip, yflip, tileno, pal, gfxregion);
-		zoom_transpen(m_sprite_bitmap, m_sprite_zbuffer, cliprect, m_gfxdecode->gfx(gfxregion), tileno, pal, xflip, yflip, xpos, ypos, dx, dy, dstwidth, 0, zval, zsort, blend, checkerboard, mosaic, mosaic_count_x, curyy, srcpix);
+		zoom_transpen(m_sprite_bitmap, m_sprite_zbuffer, cliprect, m_gfxdecode->gfx(gfxregion), tileno, pal, xflip, yflip, xpos, ypos, dx, dy, dstwidth, 0, zval, zsort, blend, group, checkerboard, mosaic, mosaic_count_x, curyy, srcpix);
 		xpos += dstwidth;
 	}
 

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -664,12 +664,12 @@ int hng64_state::get_blend_mode(int tm)
 	uint8_t blendmode = 1;
 	if ((get_tileregs(tm) & 0x0020) >> 5) // for layers with L(1)
 	{
-		if ((m_tcram[0x0c / 4] >> 2) & 0x1) 
+		if ((m_tcram[0x0c / 4] >> 2) & 0x1)
 			blendmode = 2;
 	}
 	else // for layers with L(0)
 	{
-		if ((m_tcram[0x0c / 4] >> 26) & 0x1) 
+		if ((m_tcram[0x0c / 4] >> 26) & 0x1)
 			blendmode = 2;
 	}
 
@@ -778,7 +778,7 @@ void hng64_state::mixsprites_test(screen_device& screen, bitmap_rgb32& bitmap, c
 				//if ((srcpix & 0x7000) == 0x5000) // not used on buriki?
 				//if ((srcpix & 0x7000) == 0x4000) // character portraits on buriki select screen (still behind 3d)
 
-				//if ((srcpix & 0x7000) == 0x3000) // character names and bio (above 3D graphics) 
+				//if ((srcpix & 0x7000) == 0x3000) // character names and bio (above 3D graphics)
 
 				//if ((srcpix & 0x7000) == 0x2000) // select cursor, second system graphic, timers etc. (above ring tilemap, above 3d)
 
@@ -1073,7 +1073,7 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 			(m_tcram[0x0c / 4] >> 29) & 0x1,
 			(m_tcram[0x0c / 4] >> 28) & 0x1,
 			(m_tcram[0x0c / 4] >> 27) & 0x1,
-			(m_tcram[0x0c / 4] >> 26) & 0x1, // set for blends in on tm1 (pink bits on xrally etc.)  (U 1 1) E(1) L(0) DEPTH (0 1 0 0 1)   in sams64 intro it expects it on tm2, but it gets applied to tm1 TM2 = U(1 1) E(1) L(0) DEPTH(1 0 1 0 1)  
+			(m_tcram[0x0c / 4] >> 26) & 0x1, // set for blends in on tm1 (pink bits on xrally etc.)  (U 1 1) E(1) L(0) DEPTH (0 1 0 0 1)   in sams64 intro it expects it on tm2, but it gets applied to tm1 TM2 = U(1 1) E(1) L(0) DEPTH(1 0 1 0 1)
 
 			(m_tcram[0x0c / 4] >> 25) & 0x1,
 			(m_tcram[0x0c / 4] >> 24) & 0x1, // always set

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -827,9 +827,10 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 		}
 	}
 
+	// tilemaps with 'priority' 0x10 - 0x1f are always behind the 3d?
 	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
-		for (int i = 0x1f; i >= 0; i--)
+		for (int i = 0x1f; i >= 0x10; i--)
 		{
 			for (int j = 0; j < 4; j++)
 			{
@@ -906,6 +907,22 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 			}
 		}
 	}
+
+	// tilemaps with 'priority' 0x00 - 0x0f are always above the 3d? - could bit 0x10 really be a 'relative to 3d' bit, rather than a 'relative to other tilemaps' bit?
+	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
+	{
+		for (int i = 0x0f; i >= 0x00; i--)
+		{
+			for (int j = 0; j < 4; j++)
+			{
+				uint16_t pri = get_tileregs(j) & 0x1f;
+
+				if (pri == i)
+					hng64_drawtilemap(screen, bitmap, cliprect, j, 0, y);
+			}
+		}
+	}
+
 	// Draw the sprites on top of everything
 	draw_sprites_buffer(screen, cliprect);
 

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -12,7 +12,7 @@
     tilemap layers due to this
 */
 
-#define HNG64_VIDEO_DEBUG 0
+#define HNG64_VIDEO_DEBUG 1
 
 
 void hng64_state::hng64_mark_all_tiles_dirty(int tilemap)
@@ -621,19 +621,6 @@ void hng64_state::hng64_tilemap_draw_roz_core_line(screen_device &screen, bitmap
     // 08e0 - fatal fury wa during transitions
     // 0940 - samurai shodown 64
     // 0880 - buriki
-
-    // Individual tilemap regs format
-    // ------------------------------
-    // mmmm dbr? ??ez zzzz
-    // m = Tilemap mosaic level [0-15] - confirmed in sams64 demo mode
-    //  -- they seem to enable mosaic at the same time as rowscroll in several cases (floor in buriki / ff)
-    //     and also on the rotating logo in buriki.. does it cause some kind of aliasing side-effect, or.. ?
-    // d = line (floor) mode - buriki, fatafurwa, some backgrounds in ss64_2
-    // b = 4bpp/8bpp (seems correct) (beast busters, samsh64, sasm64 2, xrally switch it for some screens)
-    // r = tile size (seems correct)
-    // e = tilemap enable bit according to sams64_2
-    // z = z depth/priority? tilemaps might also be affected by min / max clip values somewhere?
-    //              (debug layer on buriki has priority 0x020, which would be highest)
  */
 
 
@@ -967,12 +954,23 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 		popmessage("%08x %08x %08x %08x %08x", m_spriteregs[0], m_spriteregs[1], m_spriteregs[2], m_spriteregs[3], m_spriteregs[4]);
 
 	// see notes at top for more detailed info on these
-	if (0)
-		popmessage("%08x %08x\nTR(%04x %04x %04x %04x)\nSB(%04x %04x %04x %04x)\n%08x %08x %08x\nSPLIT?(%04x %04x %04x %04x)\nAA(%08x %08x)\n%08x",
+	if (1)
+		popmessage("%08x %08x\n\
+			TR0(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) UNK(%d %d) SOMETIMES_ENABLE(%d) DEPTH( %d %d %d %d %d %d (%02x))\n\
+			TR1(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) UNK(%d %d) SOMETIMES_ENABLE(%d) DEPTH( %d %d %d %d %d %d (%02x))\n\
+			TR2(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) UNK(%d %d) SOMETIMES_ENABLE(%d) DEPTH( %d %d %d %d %d %d (%02x))\n\
+			TR3(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) UNK(%d %d) SOMETIMES_ENABLE(%d) DEPTH( %d %d %d %d %d %d (%02x))\n\
+			SB(%04x %04x %04x %04x)\n\
+			%08x %08x %08x\n\
+			SPLIT?(%04x %04x %04x %04x)\n\
+			AA(%08x %08x)\n%08x",
 			// global tilemap control regs?
 			m_videoregs[0x00], m_videoregs[0x01],
 			// general per-tilemap regs
-			(m_videoregs[0x02] >> 16) & 0xffff, (m_videoregs[0x02] >> 0) & 0xffff, (m_videoregs[0x03] >> 16) & 0xffff, (m_videoregs[0x03] >> 0) & 0xffff,
+			(get_tileregs(0) & 0xf000)>>12, (get_tileregs(0) & 0x0800)>>11, (get_tileregs(0) & 0x0400)>>10,(get_tileregs(0) & 0x0200)>>9,(get_tileregs(0) & 0x0100)>>8,(get_tileregs(0) & 0x0080)>>7,(get_tileregs(0) & 0x0040)>>6,(get_tileregs(0) & 0x0020)>>5,(get_tileregs(0) & 0x0010)>>4,(get_tileregs(0) & 0x0008)>>3,(get_tileregs(0) & 0x0004)>>2,(get_tileregs(0) & 0x0002)>>1,(get_tileregs(0) & 0x0001)>>0,(get_tileregs(0) & 0x003f)>>0,
+			(get_tileregs(1) & 0xf000)>>12, (get_tileregs(1) & 0x0800)>>11, (get_tileregs(1) & 0x0400)>>10,(get_tileregs(1) & 0x0200)>>9,(get_tileregs(1) & 0x0100)>>8,(get_tileregs(1) & 0x0080)>>7,(get_tileregs(1) & 0x0040)>>6,(get_tileregs(1) & 0x0020)>>5,(get_tileregs(1) & 0x0010)>>4,(get_tileregs(1) & 0x0008)>>3,(get_tileregs(1) & 0x0004)>>2,(get_tileregs(1) & 0x0002)>>1,(get_tileregs(1) & 0x0001)>>0,(get_tileregs(1) & 0x003f)>>0,
+			(get_tileregs(2) & 0xf000)>>12, (get_tileregs(2) & 0x0800)>>11, (get_tileregs(2) & 0x0400)>>10,(get_tileregs(2) & 0x0200)>>9,(get_tileregs(2) & 0x0100)>>8,(get_tileregs(2) & 0x0080)>>7,(get_tileregs(2) & 0x0040)>>6,(get_tileregs(2) & 0x0020)>>5,(get_tileregs(2) & 0x0010)>>4,(get_tileregs(2) & 0x0008)>>3,(get_tileregs(2) & 0x0004)>>2,(get_tileregs(2) & 0x0002)>>1,(get_tileregs(2) & 0x0001)>>0,(get_tileregs(2) & 0x003f)>>0,
+			(get_tileregs(3) & 0xf000)>>12, (get_tileregs(3) & 0x0800)>>11, (get_tileregs(3) & 0x0400)>>10,(get_tileregs(3) & 0x0200)>>9,(get_tileregs(3) & 0x0100)>>8,(get_tileregs(3) & 0x0080)>>7,(get_tileregs(3) & 0x0040)>>6,(get_tileregs(3) & 0x0020)>>5,(get_tileregs(3) & 0x0010)>>4,(get_tileregs(3) & 0x0008)>>3,(get_tileregs(3) & 0x0004)>>2,(get_tileregs(3) & 0x0002)>>1,(get_tileregs(3) & 0x0001)>>0,(get_tileregs(3) & 0x003f)>>0,
 			// scrollbase regs
 			(m_videoregs[0x04] >> 16) & 0xffff, (m_videoregs[0x04] >> 0) & 0xffff, (m_videoregs[0x05] >> 16) & 0xffff, (m_videoregs[0x05] >> 0) & 0xffff,
 			// initialized to fixed values?
@@ -983,6 +981,21 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 			m_videoregs[0x0b], m_videoregs[0x0c],
 			// unused?
 			m_videoregs[0x0d]);
+	
+    // Individual tilemap regs format
+    // ------------------------------
+    // mmmm dbr? ?Ezz zzzz
+    // m = Tilemap mosaic level [0-15] - confirmed in sams64 demo mode
+    //  -- they seem to enable mosaic at the same time as rowscroll in several cases (floor in buriki / ff)
+    //     and also on the rotating logo in buriki.. does it cause some kind of aliasing side-effect, or.. ?
+    // d = line (floor) mode - buriki, fatafurwa, some backgrounds in ss64_2
+    // b = 4bpp/8bpp (seems correct) (beast busters, samsh64, sasm64 2, xrally switch it for some screens)
+    // r = tile size (seems correct)
+    // E = tilemap enable bit according to sams64_2
+    // z = z depth/priority? tilemaps might also be affected by min / max clip values somewhere?
+    //              (debug layer on buriki has priority 0x020, which would be highest)
+
+
 
 	if (0)
 		popmessage("TC: %08x MINX(%d) MINY(%d) MAXX(%d) MAXY(%d)\nBLEND ENABLES? %02x %02x %02x | %02x %02x %02x\nUNUSED?(%04x)\n%04x\nUNUSED?(%d %d)\nFor FADE1 or 1st in PALFADES group per-RGB blend modes(%d %d %d)\nFor FADE2 or 2nd in PALFADES group per-RGB blend modes(%d %d %d)\nMASTER FADES - FADE1?(%08x)\nMASTER FADES - FADE2?(%08x)\nUNUSED?(%08x)\nUNUSED?&0xfffc(%04x) DISABLE_DISPLAY(%d) ALSO USE REGS BELOW FOR MASTER FADE(%d)\nPALEFFECT_ENABLES(%d %d %d %d %d %d %d %d)\n PALFADES?(%08x %08x : %08x %08x : %08x %08x : %08x %08x)\n %08x SPRITE_BLEND_TYPE?(%08x) : %08x %08x %08x %08x",

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -823,11 +823,11 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 
 	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
-		for (int i = 0x3f; i >= 0; i--)
+		for (int i = 0x1f; i >= 0; i--)
 		{
 			for (int j = 0; j < 4; j++)
 			{
-				uint16_t pri = get_tileregs(j) & 0x3f;
+				uint16_t pri = get_tileregs(j) & 0x1f;
 
 				if (pri == i)
 					hng64_drawtilemap(screen, bitmap, cliprect, j, 0, y);
@@ -954,12 +954,12 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 		popmessage("%08x %08x %08x %08x %08x", m_spriteregs[0], m_spriteregs[1], m_spriteregs[2], m_spriteregs[3], m_spriteregs[4]);
 
 	// see notes at top for more detailed info on these
-	if (1)
+	if (0)
 		popmessage("%08x %08x\n\
-			TR0(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) UNK(%d %d) SOMETIMES_ENABLE(%d) DEPTH( %d %d %d %d %d %d (%02x))\n\
-			TR1(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) UNK(%d %d) SOMETIMES_ENABLE(%d) DEPTH( %d %d %d %d %d %d (%02x))\n\
-			TR2(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) UNK(%d %d) SOMETIMES_ENABLE(%d) DEPTH( %d %d %d %d %d %d (%02x))\n\
-			TR3(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) UNK(%d %d) SOMETIMES_ENABLE(%d) DEPTH( %d %d %d %d %d %d (%02x))\n\
+			TR0(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) U(%d) DEPTH( %d %d %d %d %d (%02x))\n\
+			TR1(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) U(%d) DEPTH( %d %d %d %d %d (%02x))\n\
+			TR2(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) U(%d) DEPTH( %d %d %d %d %d (%02x))\n\
+			TR3(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) U(%d) DEPTH( %d %d %d %d %d (%02x))\n\
 			SB(%04x %04x %04x %04x)\n\
 			%08x %08x %08x\n\
 			SPLIT?(%04x %04x %04x %04x)\n\
@@ -967,10 +967,10 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 			// global tilemap control regs?
 			m_videoregs[0x00], m_videoregs[0x01],
 			// general per-tilemap regs
-			(get_tileregs(0) & 0xf000)>>12, (get_tileregs(0) & 0x0800)>>11, (get_tileregs(0) & 0x0400)>>10,(get_tileregs(0) & 0x0200)>>9,(get_tileregs(0) & 0x0100)>>8,(get_tileregs(0) & 0x0080)>>7,(get_tileregs(0) & 0x0040)>>6,(get_tileregs(0) & 0x0020)>>5,(get_tileregs(0) & 0x0010)>>4,(get_tileregs(0) & 0x0008)>>3,(get_tileregs(0) & 0x0004)>>2,(get_tileregs(0) & 0x0002)>>1,(get_tileregs(0) & 0x0001)>>0,(get_tileregs(0) & 0x003f)>>0,
-			(get_tileregs(1) & 0xf000)>>12, (get_tileregs(1) & 0x0800)>>11, (get_tileregs(1) & 0x0400)>>10,(get_tileregs(1) & 0x0200)>>9,(get_tileregs(1) & 0x0100)>>8,(get_tileregs(1) & 0x0080)>>7,(get_tileregs(1) & 0x0040)>>6,(get_tileregs(1) & 0x0020)>>5,(get_tileregs(1) & 0x0010)>>4,(get_tileregs(1) & 0x0008)>>3,(get_tileregs(1) & 0x0004)>>2,(get_tileregs(1) & 0x0002)>>1,(get_tileregs(1) & 0x0001)>>0,(get_tileregs(1) & 0x003f)>>0,
-			(get_tileregs(2) & 0xf000)>>12, (get_tileregs(2) & 0x0800)>>11, (get_tileregs(2) & 0x0400)>>10,(get_tileregs(2) & 0x0200)>>9,(get_tileregs(2) & 0x0100)>>8,(get_tileregs(2) & 0x0080)>>7,(get_tileregs(2) & 0x0040)>>6,(get_tileregs(2) & 0x0020)>>5,(get_tileregs(2) & 0x0010)>>4,(get_tileregs(2) & 0x0008)>>3,(get_tileregs(2) & 0x0004)>>2,(get_tileregs(2) & 0x0002)>>1,(get_tileregs(2) & 0x0001)>>0,(get_tileregs(2) & 0x003f)>>0,
-			(get_tileregs(3) & 0xf000)>>12, (get_tileregs(3) & 0x0800)>>11, (get_tileregs(3) & 0x0400)>>10,(get_tileregs(3) & 0x0200)>>9,(get_tileregs(3) & 0x0100)>>8,(get_tileregs(3) & 0x0080)>>7,(get_tileregs(3) & 0x0040)>>6,(get_tileregs(3) & 0x0020)>>5,(get_tileregs(3) & 0x0010)>>4,(get_tileregs(3) & 0x0008)>>3,(get_tileregs(3) & 0x0004)>>2,(get_tileregs(3) & 0x0002)>>1,(get_tileregs(3) & 0x0001)>>0,(get_tileregs(3) & 0x003f)>>0,
+			(get_tileregs(0) & 0xf000)>>12, (get_tileregs(0) & 0x0800)>>11, (get_tileregs(0) & 0x0400)>>10,(get_tileregs(0) & 0x0200)>>9,(get_tileregs(0) & 0x0100)>>8,(get_tileregs(0) & 0x0080)>>7,(get_tileregs(0) & 0x0040)>>6,(get_tileregs(0) & 0x0020)>>5,(get_tileregs(0) & 0x0010)>>4,(get_tileregs(0) & 0x0008)>>3,(get_tileregs(0) & 0x0004)>>2,(get_tileregs(0) & 0x0002)>>1,(get_tileregs(0) & 0x0001)>>0,(get_tileregs(0) & 0x001f)>>0,
+			(get_tileregs(1) & 0xf000)>>12, (get_tileregs(1) & 0x0800)>>11, (get_tileregs(1) & 0x0400)>>10,(get_tileregs(1) & 0x0200)>>9,(get_tileregs(1) & 0x0100)>>8,(get_tileregs(1) & 0x0080)>>7,(get_tileregs(1) & 0x0040)>>6,(get_tileregs(1) & 0x0020)>>5,(get_tileregs(1) & 0x0010)>>4,(get_tileregs(1) & 0x0008)>>3,(get_tileregs(1) & 0x0004)>>2,(get_tileregs(1) & 0x0002)>>1,(get_tileregs(1) & 0x0001)>>0,(get_tileregs(1) & 0x001f)>>0,
+			(get_tileregs(2) & 0xf000)>>12, (get_tileregs(2) & 0x0800)>>11, (get_tileregs(2) & 0x0400)>>10,(get_tileregs(2) & 0x0200)>>9,(get_tileregs(2) & 0x0100)>>8,(get_tileregs(2) & 0x0080)>>7,(get_tileregs(2) & 0x0040)>>6,(get_tileregs(2) & 0x0020)>>5,(get_tileregs(2) & 0x0010)>>4,(get_tileregs(2) & 0x0008)>>3,(get_tileregs(2) & 0x0004)>>2,(get_tileregs(2) & 0x0002)>>1,(get_tileregs(2) & 0x0001)>>0,(get_tileregs(2) & 0x001f)>>0,
+			(get_tileregs(3) & 0xf000)>>12, (get_tileregs(3) & 0x0800)>>11, (get_tileregs(3) & 0x0400)>>10,(get_tileregs(3) & 0x0200)>>9,(get_tileregs(3) & 0x0100)>>8,(get_tileregs(3) & 0x0080)>>7,(get_tileregs(3) & 0x0040)>>6,(get_tileregs(3) & 0x0020)>>5,(get_tileregs(3) & 0x0010)>>4,(get_tileregs(3) & 0x0008)>>3,(get_tileregs(3) & 0x0004)>>2,(get_tileregs(3) & 0x0002)>>1,(get_tileregs(3) & 0x0001)>>0,(get_tileregs(3) & 0x001f)>>0,
 			// scrollbase regs
 			(m_videoregs[0x04] >> 16) & 0xffff, (m_videoregs[0x04] >> 0) & 0xffff, (m_videoregs[0x05] >> 16) & 0xffff, (m_videoregs[0x05] >> 0) & 0xffff,
 			// initialized to fixed values?
@@ -997,20 +997,83 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 
 
 
-	if (0)
-		popmessage("TC: %08x MINX(%d) MINY(%d) MAXX(%d) MAXY(%d)\nBLEND ENABLES? %02x %02x %02x | %02x %02x %02x\nUNUSED?(%04x)\n%04x\nUNUSED?(%d %d)\nFor FADE1 or 1st in PALFADES group per-RGB blend modes(%d %d %d)\nFor FADE2 or 2nd in PALFADES group per-RGB blend modes(%d %d %d)\nMASTER FADES - FADE1?(%08x)\nMASTER FADES - FADE2?(%08x)\nUNUSED?(%08x)\nUNUSED?&0xfffc(%04x) DISABLE_DISPLAY(%d) ALSO USE REGS BELOW FOR MASTER FADE(%d)\nPALEFFECT_ENABLES(%d %d %d %d %d %d %d %d)\n PALFADES?(%08x %08x : %08x %08x : %08x %08x : %08x %08x)\n %08x SPRITE_BLEND_TYPE?(%08x) : %08x %08x %08x %08x",
+	if (1)
+		popmessage("TC: %08x MINX(%d) MINY(%d) MAXX(%d) MAXY(%d)\n\
+			MIX BITSA Nv(%d%d%d%d) P:%d B:%d Nv(%d) Al(%d) : Nv(%d) p:%d Nv(%d%d%d) b:%d Nv(%d%d)  : Nv(%d) (%d) (%d %d %d) (%d %d %d)\n\
+			MIX BITSB Nv(%d%d%d%d) P:%d B:%d Nv(%d) Al(%d) : Nv(%d) p:%d Nv(%d%d%d) b:%d Nv(%d%d)  : Nv(%d) (%d) (%d %d %d) (%d %d %d)\n\
+			UNUSED?(%04x)\n%04x\nUNUSED?(%d %d)\n\
+			For FADE1 or 1st in PALFADES group per-RGB blend modes(%d %d %d)\n\
+			For FADE2 or 2nd in PALFADES group per-RGB blend modes(%d %d %d)\n\
+			MASTER FADES - FADE1?(%08x)\nMASTER FADES - FADE2?(%08x)\n\
+			UNUSED?(%08x)\n\
+			UNUSED?&0xfffc(%04x) DISABLE_DISPLAY(%d) ALSO USE REGS BELOW FOR MASTER FADE(%d)\n\
+			PALEFFECT_ENABLES(%d %d %d %d %d %d %d %d)\n PALFADES?(%08x %08x : %08x %08x : %08x %08x : %08x %08x)\n\
+			%08x SPRITE_BLEND_TYPE?(%08x) : %08x %08x %08x %08x",
 			m_tcram[0x00 / 4], // 0007 00e4 (fatfurwa, bbust2)
 			(m_tcram[0x04 / 4] >> 16) & 0xffff, (m_tcram[0x04 / 4] >> 0) & 0xffff, // 0000 0010 (fatfurwa) 0000 0000 (bbust2, xrally)
 			(m_tcram[0x08 / 4] >> 16) & 0xffff, (m_tcram[0x08 / 4] >> 0) & 0xffff, // 0200 01b0 (fatfurwa) 0200 01c0 (bbust2, xrally)
 
 			// is this 2 groups of 3 regs?
-			(m_tcram[0x0c / 4] >> 24) & 0xff, // 04 = 'blend' on tm1
-			(m_tcram[0x0c / 4] >> 16) & 0xff, // 04 = set when fades are going on with blended sprites in buriki intro? otherwise usually 00
-			(m_tcram[0x0c / 4] >> 8) & 0xff,  // upper bit not used? value usually 2x, 4x, 5x or 6x
+			//(m_tcram[0x0c / 4] >> 24) & 0xff, // 04 = 'blend' on tm1
+			//(m_tcram[0x0c / 4] >> 16) & 0xff, // 04 = set when fades are going on with blended sprites in buriki intro? otherwise usually 00
+			//(m_tcram[0x0c / 4] >> 8) & 0xff,  // upper bit not used? value usually 2x, 4x, 5x or 6x
+			(m_tcram[0x0c / 4] >> 31) & 0x1,
+			(m_tcram[0x0c / 4] >> 30) & 0x1,
+			(m_tcram[0x0c / 4] >> 29) & 0x1,
+			(m_tcram[0x0c / 4] >> 28) & 0x1,
+			(m_tcram[0x0c / 4] >> 27) & 0x1,
+			(m_tcram[0x0c / 4] >> 26) & 0x1, // set for blends in on tm1 (pink bits on xrally etc.)
+			(m_tcram[0x0c / 4] >> 25) & 0x1,
+			(m_tcram[0x0c / 4] >> 24) & 0x1, // always set
+
+			(m_tcram[0x0c / 4] >> 23) & 0x1,
+			(m_tcram[0x0c / 4] >> 22) & 0x1, // set on POST in xrally etc.
+			(m_tcram[0x0c / 4] >> 21) & 0x1,
+			(m_tcram[0x0c / 4] >> 20) & 0x1,
+			(m_tcram[0x0c / 4] >> 19) & 0x1,
+			(m_tcram[0x0c / 4] >> 18) & 0x1, // set on some fades in buriki attract intro (related to the sprites being blended during the fade?)
+			(m_tcram[0x0c / 4] >> 17) & 0x1,
+			(m_tcram[0x0c / 4] >> 16) & 0x1,
+
+			(m_tcram[0x0c / 4] >> 15) & 0x1,
+			(m_tcram[0x0c / 4] >> 14) & 0x1,
+			(m_tcram[0x0c / 4] >> 13) & 0x1,
+			(m_tcram[0x0c / 4] >> 12) & 0x1,
+			(m_tcram[0x0c / 4] >> 11) & 0x1,
+			(m_tcram[0x0c / 4] >> 10) & 0x1,
+			(m_tcram[0x0c / 4] >> 9) & 0x1,
+			(m_tcram[0x0c / 4] >> 8) & 0x1,
+
 			// 2nd group?
-			(m_tcram[0x0c / 4] >> 0) & 0xff, //  04 = 'blend' on tm3  (used in transitions?)
-			(m_tcram[0x10 / 4] >> 24) & 0xff, // usually (always?) 00
-			(m_tcram[0x10 / 4] >> 16) & 0xff, // upper bit not used? value usually 2x, 4x, 5x or 6x
+			//(m_tcram[0x0c / 4] >> 0) & 0xff, //  04 = 'blend' on tm3  (used in transitions?)
+			//(m_tcram[0x10 / 4] >> 24) & 0xff, // usually (always?) 00
+			//(m_tcram[0x10 / 4] >> 16) & 0xff, // upper bit not used? value usually 2x, 4x, 5x or 6x
+			(m_tcram[0x0c / 4] >> 7) & 0x1,
+			(m_tcram[0x0c / 4] >> 6) & 0x1,
+			(m_tcram[0x0c / 4] >> 5) & 0x1,
+			(m_tcram[0x0c / 4] >> 4) & 0x1,
+			(m_tcram[0x0c / 4] >> 3) & 0x1, // set in POST on xrally etc.
+			(m_tcram[0x0c / 4] >> 2) & 0x1, // set on buriki when blends are used
+			(m_tcram[0x0c / 4] >> 1) & 0x1,
+			(m_tcram[0x0c / 4] >> 0) & 0x1, // always set
+
+			(m_tcram[0x10 / 4] >> 31) & 0x1,
+			(m_tcram[0x10 / 4] >> 30) & 0x1,
+			(m_tcram[0x10 / 4] >> 29) & 0x1,
+			(m_tcram[0x10 / 4] >> 28) & 0x1,
+			(m_tcram[0x10 / 4] >> 27) & 0x1,
+			(m_tcram[0x10 / 4] >> 26) & 0x1,
+			(m_tcram[0x10 / 4] >> 25) & 0x1,
+			(m_tcram[0x10 / 4] >> 24) & 0x1,
+
+			(m_tcram[0x10 / 4] >> 23) & 0x1,
+			(m_tcram[0x10 / 4] >> 22) & 0x1,
+			(m_tcram[0x10 / 4] >> 21) & 0x1,
+			(m_tcram[0x10 / 4] >> 20) & 0x1,
+			(m_tcram[0x10 / 4] >> 19) & 0x1,
+			(m_tcram[0x10 / 4] >> 18) & 0x1,
+			(m_tcram[0x10 / 4] >> 17) & 0x1,
+			(m_tcram[0x10 / 4] >> 16) & 0x1,
 
 			m_tcram[0x10 / 4] & 0xffff, // unused?
 

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -946,10 +946,10 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 
 	if (0)
 		popmessage("%08x %08x\n\
-			TR0(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) U(%d) DEPTH( %d %d %d %d %d (%02x))\n\
-			TR1(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) U(%d) DEPTH( %d %d %d %d %d (%02x))\n\
-			TR2(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) U(%d) DEPTH( %d %d %d %d %d (%02x))\n\
-			TR3(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) U(%d) DEPTH( %d %d %d %d %d (%02x))\n\
+			TR0(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) L(%d) DEPTH( %d %d %d %d %d (%02x))\n\
+			TR1(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) L(%d) DEPTH( %d %d %d %d %d (%02x))\n\
+			TR2(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) L(%d) DEPTH( %d %d %d %d %d (%02x))\n\
+			TR3(MO(%01x) NL(%d) BPP(%d) TSIZE(%d) U(%d %d) E(%d) L(%d) DEPTH( %d %d %d %d %d (%02x))\n\
 			SB(%04x %04x %04x %04x)\n\
 			%08x %08x %08x\n\
 			SPLIT?(%04x %04x %04x %04x)\n\
@@ -974,7 +974,7 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 	
     // Individual tilemap regs format
     // ------------------------------
-    // mmmm dbr? ?Ezz zzzz
+    // mmmm dbr? ?ELz zzzz
     // m = Tilemap mosaic level [0-15] - confirmed in sams64 demo mode
     //  -- they seem to enable mosaic at the same time as rowscroll in several cases (floor in buriki / ff)
     //     and also on the rotating logo in buriki.. does it cause some kind of aliasing side-effect, or.. ?
@@ -982,6 +982,7 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
     // b = 4bpp/8bpp (seems correct) (beast busters, samsh64, sasm64 2, xrally switch it for some screens)
     // r = tile size (seems correct)
     // E = tilemap enable bit according to sams64_2
+	// L = related to output layer? seems to be tied to which mixing bits are used to enable blending
     // z = z depth/priority? tilemaps might also be affected by min / max clip values somewhere?
     //              (debug layer on buriki has priority 0x020, which would be highest)
 
@@ -1012,7 +1013,7 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 			(m_tcram[0x0c / 4] >> 29) & 0x1,
 			(m_tcram[0x0c / 4] >> 28) & 0x1,
 			(m_tcram[0x0c / 4] >> 27) & 0x1,
-			(m_tcram[0x0c / 4] >> 26) & 0x1, // set for blends in on tm1 (pink bits on xrally etc.)  in sams64 intro it expects it on tm2, but it gets applied to tm1
+			(m_tcram[0x0c / 4] >> 26) & 0x1, // set for blends in on tm1 (pink bits on xrally etc.)  (U 1 1) E(1) L(0) DEPTH (0 1 0 0 1)   in sams64 intro it expects it on tm2, but it gets applied to tm1 TM2 = U(1 1) E(1) L(0) DEPTH(1 0 1 0 1)
 			(m_tcram[0x0c / 4] >> 25) & 0x1,
 			(m_tcram[0x0c / 4] >> 24) & 0x1, // always set
 
@@ -1043,7 +1044,7 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 			(m_tcram[0x0c / 4] >> 5) & 0x1,
 			(m_tcram[0x0c / 4] >> 4) & 0x1,
 			(m_tcram[0x0c / 4] >> 3) & 0x1, // set in POST on xrally etc.
-			(m_tcram[0x0c / 4] >> 2) & 0x1, // set on buriki when blends are used
+			(m_tcram[0x0c / 4] >> 2) & 0x1, // set on buriki when blends are used. tm0 blends on fatfurwa frontmost layer U(0 1) E(1) L(1) DEPTH ( 0 0 0 0 0 )
 			(m_tcram[0x0c / 4] >> 1) & 0x1,
 			(m_tcram[0x0c / 4] >> 0) & 0x1, // always set
 


### PR DESCRIPTION
- added support for raster interrupt, needed to enable fatfurwa floor without ignoring the 'enable' bit with a hack
- various experiments with priority, still needs a proper per pixel mixer, but this gives a ballpark idea of any special cases that will need further attention
- various experiments with the remaining colour mixer effects, still imperfect, but again this helps highlight areas in need of more attention