### PR TITLE
More sprintf warning fixes

### DIFF
--- a/src/devices/cpu/h8/h8_sci.cpp
+++ b/src/devices/cpu/h8/h8_sci.cpp
@@ -20,7 +20,7 @@ h8_sci_device::h8_sci_device(const machine_config &mconfig, const char *tag, dev
 	cpu(*this, DEVICE_SELF_OWNER),
 	tx_cb(*this),
 	clk_cb(*this), intc(nullptr), intc_tag(nullptr), external_to_internal_ratio(0), internal_to_external_ratio(0), sync_timer(nullptr), eri_int(0), rxi_int(0), txi_int(0), tei_int(0),
-	tx_state(0), rx_state(0), tx_bit(0), rx_bit(0), clock_state(0), tx_parity(0), rx_parity(0), ext_clock_counter(0), clock_mode(ClockMode::INTERNAL_ASYNC), clock_value(false), ext_clock_value(false), rx_value(false),
+	tx_state(0), rx_state(0), tx_bit(0), rx_bit(0), clock_state(0), tx_parity(0), rx_parity(0), ext_clock_counter(0), clock_mode(clock_mode::INTERNAL_ASYNC), clock_value(false), ext_clock_value(false), rx_value(false),
 	rdr(0), tdr(0), smr(0), scr(0), ssr(0), brr(0), rsr(0), tsr(0), clock_base(0), divider(0)
 {
 	external_clock_period = attotime::never;
@@ -192,51 +192,51 @@ void h8_sci_device::clock_update()
 
 	if(smr & SMR_CA) {
 		if(scr & SCR_CKE1)
-			clock_mode = ClockMode::EXTERNAL_SYNC;
+			clock_mode = clock_mode::EXTERNAL_SYNC;
 		else
-			clock_mode = ClockMode::INTERNAL_SYNC_OUT;
+			clock_mode = clock_mode::INTERNAL_SYNC_OUT;
 	} else {
 		if(scr & SCR_CKE1)
-			clock_mode = ClockMode::EXTERNAL_ASYNC;
+			clock_mode = clock_mode::EXTERNAL_ASYNC;
 		else if(scr & SCR_CKE0)
-			clock_mode = ClockMode::INTERNAL_ASYNC_OUT;
+			clock_mode = clock_mode::INTERNAL_ASYNC_OUT;
 		else
-			clock_mode = ClockMode::INTERNAL_ASYNC;
+			clock_mode = clock_mode::INTERNAL_ASYNC;
 	}
 
-	if(clock_mode == ClockMode::EXTERNAL_ASYNC && !external_clock_period.is_never())
-		clock_mode = ClockMode::EXTERNAL_RATE_ASYNC;
-	if(clock_mode == ClockMode::EXTERNAL_SYNC && !external_clock_period.is_never())
-		clock_mode = ClockMode::EXTERNAL_RATE_SYNC;
+	if(clock_mode == clock_mode::EXTERNAL_ASYNC && !external_clock_period.is_never())
+		clock_mode = clock_mode::EXTERNAL_RATE_ASYNC;
+	if(clock_mode == clock_mode::EXTERNAL_SYNC && !external_clock_period.is_never())
+		clock_mode = clock_mode::EXTERNAL_RATE_SYNC;
 
 	if(V>=1) {
 		std::string new_message;
 		switch(clock_mode) {
-		case ClockMode::INTERNAL_ASYNC:
+		case clock_mode::INTERNAL_ASYNC:
 			new_message = util::string_format("clock internal at %d Hz, async, bitrate %d bps\n", int(cpu->clock() / divider), int(cpu->clock() / (divider*16)));
 			break;
-		case ClockMode::INTERNAL_ASYNC_OUT:
+		case clock_mode::INTERNAL_ASYNC_OUT:
 			new_message = util::string_format("clock internal at %d Hz, async, bitrate %d bps, output\n", int(cpu->clock() / divider), int(cpu->clock() / (divider*16)));
 			break;
-		case ClockMode::EXTERNAL_ASYNC:
+		case clock_mode::EXTERNAL_ASYNC:
 			new_message = "clock external, async\n";
 			break;
-		case ClockMode::EXTERNAL_RATE_ASYNC:
+		case clock_mode::EXTERNAL_RATE_ASYNC:
 			new_message = util::string_format("clock external at %d Hz, async, bitrate %d bps\n", int(cpu->clock()*internal_to_external_ratio), int(cpu->clock()*internal_to_external_ratio/16));
 			break;
-		case ClockMode::INTERNAL_SYNC_OUT:
+		case clock_mode::INTERNAL_SYNC_OUT:
 			new_message = util::string_format("clock internal at %d Hz, sync, output\n", int(cpu->clock() / (divider*2)));
 			break;
-		case ClockMode::EXTERNAL_SYNC:
+		case clock_mode::EXTERNAL_SYNC:
 			new_message = "clock external, sync\n";
 			break;
-		case ClockMode::EXTERNAL_RATE_SYNC:
+		case clock_mode::EXTERNAL_RATE_SYNC:
 			new_message = util::string_format("clock external at %d Hz, sync\n", int(cpu->clock()*internal_to_external_ratio));
 			break;
 		}
 		if(new_message != last_clock_message) {
-			last_clock_message = new_message;
 			logerror(new_message);
+			last_clock_message = std::move(new_message);
 		}
 	}
 }
@@ -294,7 +294,7 @@ void h8_sci_device::device_reset()
 	tx_state = ST_IDLE;
 	rx_state = ST_IDLE;
 	clock_state = 0;
-	clock_mode = ClockMode::INTERNAL_ASYNC;
+	clock_mode = clock_mode::INTERNAL_ASYNC;
 	clock_base = 0;
 	clock_update();
 	clock_value = true;
@@ -325,7 +325,7 @@ WRITE_LINE_MEMBER(h8_sci_device::clk_w)
 		ext_clock_value = state;
 		if(clock_state) {
 			switch(clock_mode) {
-			case ClockMode::EXTERNAL_ASYNC:
+			case clock_mode::EXTERNAL_ASYNC:
 				if(ext_clock_value) {
 					ext_clock_counter = (ext_clock_counter+1) & 15;
 
@@ -336,7 +336,7 @@ WRITE_LINE_MEMBER(h8_sci_device::clk_w)
 				}
 				break;
 
-			case ClockMode::EXTERNAL_SYNC:
+			case clock_mode::EXTERNAL_SYNC:
 				if((!ext_clock_value) && (clock_state & CLK_TX))
 					tx_dropped_edge();
 
@@ -355,7 +355,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 {
 	uint64_t event = 0;
 	switch(clock_mode) {
-	case ClockMode::INTERNAL_SYNC_OUT:
+	case clock_mode::INTERNAL_SYNC_OUT:
 		if(clock_state || !clock_value) {
 			uint64_t fp = divider*2;
 			if(current_time >= clock_base) {
@@ -384,8 +384,8 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case ClockMode::INTERNAL_ASYNC:
-	case ClockMode::INTERNAL_ASYNC_OUT:
+	case clock_mode::INTERNAL_ASYNC:
+	case clock_mode::INTERNAL_ASYNC_OUT:
 		if(clock_state || !clock_value) {
 			uint64_t fp = divider*16;
 			if(current_time >= clock_base) {
@@ -405,7 +405,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 						rx_raised_edge();
 
 					clock_value = new_clock;
-					if(clock_mode == ClockMode::INTERNAL_ASYNC_OUT && (clock_state || !clock_value))
+					if(clock_mode == clock_mode::INTERNAL_ASYNC_OUT && (clock_state || !clock_value))
 						clk_cb(clock_value);
 				}
 			}
@@ -414,7 +414,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case ClockMode::EXTERNAL_RATE_SYNC:
+	case clock_mode::EXTERNAL_RATE_SYNC:
 		if(clock_state || !clock_value) {
 			uint64_t ctime = uint64_t(current_time*internal_to_external_ratio*2);
 			if(ctime >= clock_base) {
@@ -438,7 +438,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case ClockMode::EXTERNAL_RATE_ASYNC:
+	case clock_mode::EXTERNAL_RATE_ASYNC:
 		if(clock_state || !clock_value) {
 			uint64_t ctime = uint64_t(current_time*internal_to_external_ratio);
 			if(ctime >= clock_base) {
@@ -462,8 +462,8 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case ClockMode::EXTERNAL_ASYNC:
-	case ClockMode::EXTERNAL_SYNC:
+	case clock_mode::EXTERNAL_ASYNC:
+	case clock_mode::EXTERNAL_SYNC:
 		break;
 	}
 	if(event) {
@@ -488,32 +488,32 @@ void h8_sci_device::clock_start(int mode)
 		machine().scheduler().synchronize();
 		clock_state = mode;
 		switch(clock_mode) {
-		case ClockMode::INTERNAL_ASYNC:
-		case ClockMode::INTERNAL_ASYNC_OUT:
-		case ClockMode::INTERNAL_SYNC_OUT:
+		case clock_mode::INTERNAL_ASYNC:
+		case clock_mode::INTERNAL_ASYNC_OUT:
+		case clock_mode::INTERNAL_SYNC_OUT:
 			if(V>=2) logerror("Starting internal clock\n");
 			clock_base = cpu->total_cycles();
 			cpu->internal_update();
 			break;
 
-		case ClockMode::EXTERNAL_RATE_ASYNC:
+		case clock_mode::EXTERNAL_RATE_ASYNC:
 			if(V>=2) logerror("Simulating external clock async\n");
 			clock_base = uint64_t(cpu->total_cycles()*internal_to_external_ratio);
 			cpu->internal_update();
 			break;
 
-		case ClockMode::EXTERNAL_RATE_SYNC:
+		case clock_mode::EXTERNAL_RATE_SYNC:
 			if(V>=2) logerror("Simulating external clock sync\n");
 			clock_base = uint64_t(cpu->total_cycles()*2*internal_to_external_ratio);
 			cpu->internal_update();
 			break;
 
-		case ClockMode::EXTERNAL_ASYNC:
+		case clock_mode::EXTERNAL_ASYNC:
 			if(V>=2) logerror("Waiting for external clock async\n");
 			ext_clock_counter = 15;
 			break;
 
-		case ClockMode::EXTERNAL_SYNC:
+		case clock_mode::EXTERNAL_SYNC:
 			if(V>=2) logerror("Waiting for external clock sync\n");
 			break;
 		}

--- a/src/devices/cpu/h8/h8_sci.cpp
+++ b/src/devices/cpu/h8/h8_sci.cpp
@@ -20,7 +20,7 @@ h8_sci_device::h8_sci_device(const machine_config &mconfig, const char *tag, dev
 	cpu(*this, DEVICE_SELF_OWNER),
 	tx_cb(*this),
 	clk_cb(*this), intc(nullptr), intc_tag(nullptr), external_to_internal_ratio(0), internal_to_external_ratio(0), sync_timer(nullptr), eri_int(0), rxi_int(0), txi_int(0), tei_int(0),
-	tx_state(0), rx_state(0), tx_bit(0), rx_bit(0), clock_state(0), clock_mode(0), tx_parity(0), rx_parity(0), ext_clock_counter(0), clock_value(false), ext_clock_value(false), rx_value(false),
+	tx_state(0), rx_state(0), tx_bit(0), rx_bit(0), clock_state(0), tx_parity(0), rx_parity(0), ext_clock_counter(0), clock_mode(ClockMode::INTERNAL_ASYNC), clock_value(false), ext_clock_value(false), rx_value(false),
 	rdr(0), tdr(0), smr(0), scr(0), ssr(0), brr(0), rsr(0), tsr(0), clock_base(0), divider(0)
 {
 	external_clock_period = attotime::never;
@@ -192,54 +192,51 @@ void h8_sci_device::clock_update()
 
 	if(smr & SMR_CA) {
 		if(scr & SCR_CKE1)
-			clock_mode = CLKM_EXTERNAL_SYNC;
+			clock_mode = ClockMode::EXTERNAL_SYNC;
 		else
-			clock_mode = CLKM_INTERNAL_SYNC_OUT;
+			clock_mode = ClockMode::INTERNAL_SYNC_OUT;
 	} else {
 		if(scr & SCR_CKE1)
-			clock_mode = CLKM_EXTERNAL_ASYNC;
+			clock_mode = ClockMode::EXTERNAL_ASYNC;
 		else if(scr & SCR_CKE0)
-			clock_mode = CLKM_INTERNAL_ASYNC_OUT;
+			clock_mode = ClockMode::INTERNAL_ASYNC_OUT;
 		else
-			clock_mode = CLKM_INTERNAL_ASYNC;
+			clock_mode = ClockMode::INTERNAL_ASYNC;
 	}
 
-	if(clock_mode == CLKM_EXTERNAL_ASYNC && !external_clock_period.is_never())
-		clock_mode = CLKM_EXTERNAL_RATE_ASYNC;
-	if(clock_mode == CLKM_EXTERNAL_SYNC && !external_clock_period.is_never())
-		clock_mode = CLKM_EXTERNAL_RATE_SYNC;
+	if(clock_mode == ClockMode::EXTERNAL_ASYNC && !external_clock_period.is_never())
+		clock_mode = ClockMode::EXTERNAL_RATE_ASYNC;
+	if(clock_mode == ClockMode::EXTERNAL_SYNC && !external_clock_period.is_never())
+		clock_mode = ClockMode::EXTERNAL_RATE_SYNC;
 
 	if(V>=1) {
-		char buf[4096];
+		std::string new_message;
 		switch(clock_mode) {
-		case CLKM_INTERNAL_ASYNC:
-			sprintf(buf, "clock internal at %d Hz, async, bitrate %d bps\n", int(cpu->clock() / divider), int(cpu->clock() / (divider*16)));
+		case ClockMode::INTERNAL_ASYNC:
+			new_message = util::string_format("clock internal at %d Hz, async, bitrate %d bps\n", int(cpu->clock() / divider), int(cpu->clock() / (divider*16)));
 			break;
-		case CLKM_INTERNAL_ASYNC_OUT:
-			sprintf(buf, "clock internal at %d Hz, async, bitrate %d bps, output\n", int(cpu->clock() / divider), int(cpu->clock() / (divider*16)));
+		case ClockMode::INTERNAL_ASYNC_OUT:
+			new_message = util::string_format("clock internal at %d Hz, async, bitrate %d bps, output\n", int(cpu->clock() / divider), int(cpu->clock() / (divider*16)));
 			break;
-
-		case CLKM_EXTERNAL_ASYNC:
-			sprintf(buf, "clock external, async\n");
+		case ClockMode::EXTERNAL_ASYNC:
+			new_message = "clock external, async\n";
 			break;
-		case CLKM_EXTERNAL_RATE_ASYNC:
-			sprintf(buf, "clock external at %d Hz, async, bitrate %d bps\n", int(cpu->clock()*internal_to_external_ratio), int(cpu->clock()*internal_to_external_ratio/16));
+		case ClockMode::EXTERNAL_RATE_ASYNC:
+			new_message = util::string_format("clock external at %d Hz, async, bitrate %d bps\n", int(cpu->clock()*internal_to_external_ratio), int(cpu->clock()*internal_to_external_ratio/16));
 			break;
-
-		case CLKM_INTERNAL_SYNC_OUT:
-			sprintf(buf, "clock internal at %d Hz, sync, output\n", int(cpu->clock() / (divider*2)));
+		case ClockMode::INTERNAL_SYNC_OUT:
+			new_message = util::string_format("clock internal at %d Hz, sync, output\n", int(cpu->clock() / (divider*2)));
 			break;
-
-		case CLKM_EXTERNAL_SYNC:
-			sprintf(buf, "clock external, sync\n");
+		case ClockMode::EXTERNAL_SYNC:
+			new_message = "clock external, sync\n";
 			break;
-		case CLKM_EXTERNAL_RATE_SYNC:
-			sprintf(buf, "clock external at %d Hz, sync\n", int(cpu->clock()*internal_to_external_ratio));
+		case ClockMode::EXTERNAL_RATE_SYNC:
+			new_message = util::string_format("clock external at %d Hz, sync\n", int(cpu->clock()*internal_to_external_ratio));
 			break;
 		}
-		if(buf != last_clock_message) {
-			last_clock_message = buf;
-			logerror("%s", buf);
+		if(new_message != last_clock_message) {
+			last_clock_message = new_message;
+			logerror(new_message);
 		}
 	}
 }
@@ -297,7 +294,7 @@ void h8_sci_device::device_reset()
 	tx_state = ST_IDLE;
 	rx_state = ST_IDLE;
 	clock_state = 0;
-	clock_mode = CLKM_INTERNAL_ASYNC;
+	clock_mode = ClockMode::INTERNAL_ASYNC;
 	clock_base = 0;
 	clock_update();
 	clock_value = true;
@@ -328,7 +325,7 @@ WRITE_LINE_MEMBER(h8_sci_device::clk_w)
 		ext_clock_value = state;
 		if(clock_state) {
 			switch(clock_mode) {
-			case CLKM_EXTERNAL_ASYNC:
+			case ClockMode::EXTERNAL_ASYNC:
 				if(ext_clock_value) {
 					ext_clock_counter = (ext_clock_counter+1) & 15;
 
@@ -339,12 +336,15 @@ WRITE_LINE_MEMBER(h8_sci_device::clk_w)
 				}
 				break;
 
-			case CLKM_EXTERNAL_SYNC:
+			case ClockMode::EXTERNAL_SYNC:
 				if((!ext_clock_value) && (clock_state & CLK_TX))
 					tx_dropped_edge();
 
 				else if(ext_clock_value && (clock_state & CLK_RX))
 					rx_raised_edge();
+				break;
+			default:
+				// Do nothing
 				break;
 			}
 		}
@@ -355,7 +355,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 {
 	uint64_t event = 0;
 	switch(clock_mode) {
-	case CLKM_INTERNAL_SYNC_OUT:
+	case ClockMode::INTERNAL_SYNC_OUT:
 		if(clock_state || !clock_value) {
 			uint64_t fp = divider*2;
 			if(current_time >= clock_base) {
@@ -384,8 +384,8 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case CLKM_INTERNAL_ASYNC:
-	case CLKM_INTERNAL_ASYNC_OUT:
+	case ClockMode::INTERNAL_ASYNC:
+	case ClockMode::INTERNAL_ASYNC_OUT:
 		if(clock_state || !clock_value) {
 			uint64_t fp = divider*16;
 			if(current_time >= clock_base) {
@@ -405,7 +405,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 						rx_raised_edge();
 
 					clock_value = new_clock;
-					if(clock_mode == CLKM_INTERNAL_ASYNC_OUT && (clock_state || !clock_value))
+					if(clock_mode == ClockMode::INTERNAL_ASYNC_OUT && (clock_state || !clock_value))
 						clk_cb(clock_value);
 				}
 			}
@@ -414,7 +414,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case CLKM_EXTERNAL_RATE_SYNC:
+	case ClockMode::EXTERNAL_RATE_SYNC:
 		if(clock_state || !clock_value) {
 			uint64_t ctime = uint64_t(current_time*internal_to_external_ratio*2);
 			if(ctime >= clock_base) {
@@ -438,7 +438,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case CLKM_EXTERNAL_RATE_ASYNC:
+	case ClockMode::EXTERNAL_RATE_ASYNC:
 		if(clock_state || !clock_value) {
 			uint64_t ctime = uint64_t(current_time*internal_to_external_ratio);
 			if(ctime >= clock_base) {
@@ -462,8 +462,8 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case CLKM_EXTERNAL_ASYNC:
-	case CLKM_EXTERNAL_SYNC:
+	case ClockMode::EXTERNAL_ASYNC:
+	case ClockMode::EXTERNAL_SYNC:
 		break;
 	}
 	if(event) {
@@ -488,32 +488,32 @@ void h8_sci_device::clock_start(int mode)
 		machine().scheduler().synchronize();
 		clock_state = mode;
 		switch(clock_mode) {
-		case CLKM_INTERNAL_ASYNC:
-		case CLKM_INTERNAL_ASYNC_OUT:
-		case CLKM_INTERNAL_SYNC_OUT:
+		case ClockMode::INTERNAL_ASYNC:
+		case ClockMode::INTERNAL_ASYNC_OUT:
+		case ClockMode::INTERNAL_SYNC_OUT:
 			if(V>=2) logerror("Starting internal clock\n");
 			clock_base = cpu->total_cycles();
 			cpu->internal_update();
 			break;
 
-		case CLKM_EXTERNAL_RATE_ASYNC:
+		case ClockMode::EXTERNAL_RATE_ASYNC:
 			if(V>=2) logerror("Simulating external clock async\n");
 			clock_base = uint64_t(cpu->total_cycles()*internal_to_external_ratio);
 			cpu->internal_update();
 			break;
 
-		case CLKM_EXTERNAL_RATE_SYNC:
+		case ClockMode::EXTERNAL_RATE_SYNC:
 			if(V>=2) logerror("Simulating external clock sync\n");
 			clock_base = uint64_t(cpu->total_cycles()*2*internal_to_external_ratio);
 			cpu->internal_update();
 			break;
 
-		case CLKM_EXTERNAL_ASYNC:
+		case ClockMode::EXTERNAL_ASYNC:
 			if(V>=2) logerror("Waiting for external clock async\n");
 			ext_clock_counter = 15;
 			break;
 
-		case CLKM_EXTERNAL_SYNC:
+		case ClockMode::EXTERNAL_SYNC:
 			if(V>=2) logerror("Waiting for external clock sync\n");
 			break;
 		}

--- a/src/devices/cpu/h8/h8_sci.cpp
+++ b/src/devices/cpu/h8/h8_sci.cpp
@@ -20,7 +20,7 @@ h8_sci_device::h8_sci_device(const machine_config &mconfig, const char *tag, dev
 	cpu(*this, DEVICE_SELF_OWNER),
 	tx_cb(*this),
 	clk_cb(*this), intc(nullptr), intc_tag(nullptr), external_to_internal_ratio(0), internal_to_external_ratio(0), sync_timer(nullptr), eri_int(0), rxi_int(0), txi_int(0), tei_int(0),
-	tx_state(0), rx_state(0), tx_bit(0), rx_bit(0), clock_state(0), tx_parity(0), rx_parity(0), ext_clock_counter(0), clock_mode(clock_mode::INTERNAL_ASYNC), clock_value(false), ext_clock_value(false), rx_value(false),
+	tx_state(0), rx_state(0), tx_bit(0), rx_bit(0), clock_state(0), tx_parity(0), rx_parity(0), ext_clock_counter(0), clock_mode(clock_mode_t::INTERNAL_ASYNC), clock_value(false), ext_clock_value(false), rx_value(false),
 	rdr(0), tdr(0), smr(0), scr(0), ssr(0), brr(0), rsr(0), tsr(0), clock_base(0), divider(0)
 {
 	external_clock_period = attotime::never;
@@ -192,45 +192,45 @@ void h8_sci_device::clock_update()
 
 	if(smr & SMR_CA) {
 		if(scr & SCR_CKE1)
-			clock_mode = clock_mode::EXTERNAL_SYNC;
+			clock_mode = clock_mode_t::EXTERNAL_SYNC;
 		else
-			clock_mode = clock_mode::INTERNAL_SYNC_OUT;
+			clock_mode = clock_mode_t::INTERNAL_SYNC_OUT;
 	} else {
 		if(scr & SCR_CKE1)
-			clock_mode = clock_mode::EXTERNAL_ASYNC;
+			clock_mode = clock_mode_t::EXTERNAL_ASYNC;
 		else if(scr & SCR_CKE0)
-			clock_mode = clock_mode::INTERNAL_ASYNC_OUT;
+			clock_mode = clock_mode_t::INTERNAL_ASYNC_OUT;
 		else
-			clock_mode = clock_mode::INTERNAL_ASYNC;
+			clock_mode = clock_mode_t::INTERNAL_ASYNC;
 	}
 
-	if(clock_mode == clock_mode::EXTERNAL_ASYNC && !external_clock_period.is_never())
-		clock_mode = clock_mode::EXTERNAL_RATE_ASYNC;
-	if(clock_mode == clock_mode::EXTERNAL_SYNC && !external_clock_period.is_never())
-		clock_mode = clock_mode::EXTERNAL_RATE_SYNC;
+	if(clock_mode == clock_mode_t::EXTERNAL_ASYNC && !external_clock_period.is_never())
+		clock_mode = clock_mode_t::EXTERNAL_RATE_ASYNC;
+	if(clock_mode == clock_mode_t::EXTERNAL_SYNC && !external_clock_period.is_never())
+		clock_mode = clock_mode_t::EXTERNAL_RATE_SYNC;
 
 	if(V>=1) {
 		std::string new_message;
 		switch(clock_mode) {
-		case clock_mode::INTERNAL_ASYNC:
+		case clock_mode_t::INTERNAL_ASYNC:
 			new_message = util::string_format("clock internal at %d Hz, async, bitrate %d bps\n", int(cpu->clock() / divider), int(cpu->clock() / (divider*16)));
 			break;
-		case clock_mode::INTERNAL_ASYNC_OUT:
+		case clock_mode_t::INTERNAL_ASYNC_OUT:
 			new_message = util::string_format("clock internal at %d Hz, async, bitrate %d bps, output\n", int(cpu->clock() / divider), int(cpu->clock() / (divider*16)));
 			break;
-		case clock_mode::EXTERNAL_ASYNC:
+		case clock_mode_t::EXTERNAL_ASYNC:
 			new_message = "clock external, async\n";
 			break;
-		case clock_mode::EXTERNAL_RATE_ASYNC:
+		case clock_mode_t::EXTERNAL_RATE_ASYNC:
 			new_message = util::string_format("clock external at %d Hz, async, bitrate %d bps\n", int(cpu->clock()*internal_to_external_ratio), int(cpu->clock()*internal_to_external_ratio/16));
 			break;
-		case clock_mode::INTERNAL_SYNC_OUT:
+		case clock_mode_t::INTERNAL_SYNC_OUT:
 			new_message = util::string_format("clock internal at %d Hz, sync, output\n", int(cpu->clock() / (divider*2)));
 			break;
-		case clock_mode::EXTERNAL_SYNC:
+		case clock_mode_t::EXTERNAL_SYNC:
 			new_message = "clock external, sync\n";
 			break;
-		case clock_mode::EXTERNAL_RATE_SYNC:
+		case clock_mode_t::EXTERNAL_RATE_SYNC:
 			new_message = util::string_format("clock external at %d Hz, sync\n", int(cpu->clock()*internal_to_external_ratio));
 			break;
 		}
@@ -294,7 +294,7 @@ void h8_sci_device::device_reset()
 	tx_state = ST_IDLE;
 	rx_state = ST_IDLE;
 	clock_state = 0;
-	clock_mode = clock_mode::INTERNAL_ASYNC;
+	clock_mode = clock_mode_t::INTERNAL_ASYNC;
 	clock_base = 0;
 	clock_update();
 	clock_value = true;
@@ -304,6 +304,12 @@ void h8_sci_device::device_reset()
 	clk_cb(clock_value);
 	tx_cb(1);
 	cur_sync_time = attotime::never;
+}
+
+void h8_sci_device::device_post_load()
+{
+	// Set clock_mode correctly as it's not saved
+	clock_update();
 }
 
 TIMER_CALLBACK_MEMBER(h8_sci_device::sync_tick)
@@ -325,7 +331,7 @@ WRITE_LINE_MEMBER(h8_sci_device::clk_w)
 		ext_clock_value = state;
 		if(clock_state) {
 			switch(clock_mode) {
-			case clock_mode::EXTERNAL_ASYNC:
+			case clock_mode_t::EXTERNAL_ASYNC:
 				if(ext_clock_value) {
 					ext_clock_counter = (ext_clock_counter+1) & 15;
 
@@ -336,7 +342,7 @@ WRITE_LINE_MEMBER(h8_sci_device::clk_w)
 				}
 				break;
 
-			case clock_mode::EXTERNAL_SYNC:
+			case clock_mode_t::EXTERNAL_SYNC:
 				if((!ext_clock_value) && (clock_state & CLK_TX))
 					tx_dropped_edge();
 
@@ -355,7 +361,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 {
 	uint64_t event = 0;
 	switch(clock_mode) {
-	case clock_mode::INTERNAL_SYNC_OUT:
+	case clock_mode_t::INTERNAL_SYNC_OUT:
 		if(clock_state || !clock_value) {
 			uint64_t fp = divider*2;
 			if(current_time >= clock_base) {
@@ -384,8 +390,8 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case clock_mode::INTERNAL_ASYNC:
-	case clock_mode::INTERNAL_ASYNC_OUT:
+	case clock_mode_t::INTERNAL_ASYNC:
+	case clock_mode_t::INTERNAL_ASYNC_OUT:
 		if(clock_state || !clock_value) {
 			uint64_t fp = divider*16;
 			if(current_time >= clock_base) {
@@ -405,7 +411,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 						rx_raised_edge();
 
 					clock_value = new_clock;
-					if(clock_mode == clock_mode::INTERNAL_ASYNC_OUT && (clock_state || !clock_value))
+					if(clock_mode == clock_mode_t::INTERNAL_ASYNC_OUT && (clock_state || !clock_value))
 						clk_cb(clock_value);
 				}
 			}
@@ -414,7 +420,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case clock_mode::EXTERNAL_RATE_SYNC:
+	case clock_mode_t::EXTERNAL_RATE_SYNC:
 		if(clock_state || !clock_value) {
 			uint64_t ctime = uint64_t(current_time*internal_to_external_ratio*2);
 			if(ctime >= clock_base) {
@@ -438,7 +444,7 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case clock_mode::EXTERNAL_RATE_ASYNC:
+	case clock_mode_t::EXTERNAL_RATE_ASYNC:
 		if(clock_state || !clock_value) {
 			uint64_t ctime = uint64_t(current_time*internal_to_external_ratio);
 			if(ctime >= clock_base) {
@@ -462,8 +468,8 @@ uint64_t h8_sci_device::internal_update(uint64_t current_time)
 		}
 		break;
 
-	case clock_mode::EXTERNAL_ASYNC:
-	case clock_mode::EXTERNAL_SYNC:
+	case clock_mode_t::EXTERNAL_ASYNC:
+	case clock_mode_t::EXTERNAL_SYNC:
 		break;
 	}
 	if(event) {
@@ -488,32 +494,32 @@ void h8_sci_device::clock_start(int mode)
 		machine().scheduler().synchronize();
 		clock_state = mode;
 		switch(clock_mode) {
-		case clock_mode::INTERNAL_ASYNC:
-		case clock_mode::INTERNAL_ASYNC_OUT:
-		case clock_mode::INTERNAL_SYNC_OUT:
+		case clock_mode_t::INTERNAL_ASYNC:
+		case clock_mode_t::INTERNAL_ASYNC_OUT:
+		case clock_mode_t::INTERNAL_SYNC_OUT:
 			if(V>=2) logerror("Starting internal clock\n");
 			clock_base = cpu->total_cycles();
 			cpu->internal_update();
 			break;
 
-		case clock_mode::EXTERNAL_RATE_ASYNC:
+		case clock_mode_t::EXTERNAL_RATE_ASYNC:
 			if(V>=2) logerror("Simulating external clock async\n");
 			clock_base = uint64_t(cpu->total_cycles()*internal_to_external_ratio);
 			cpu->internal_update();
 			break;
 
-		case clock_mode::EXTERNAL_RATE_SYNC:
+		case clock_mode_t::EXTERNAL_RATE_SYNC:
 			if(V>=2) logerror("Simulating external clock sync\n");
 			clock_base = uint64_t(cpu->total_cycles()*2*internal_to_external_ratio);
 			cpu->internal_update();
 			break;
 
-		case clock_mode::EXTERNAL_ASYNC:
+		case clock_mode_t::EXTERNAL_ASYNC:
 			if(V>=2) logerror("Waiting for external clock async\n");
 			ext_clock_counter = 15;
 			break;
 
-		case clock_mode::EXTERNAL_SYNC:
+		case clock_mode_t::EXTERNAL_SYNC:
 			if(V>=2) logerror("Waiting for external clock sync\n");
 			break;
 		}

--- a/src/devices/cpu/h8/h8_sci.h
+++ b/src/devices/cpu/h8/h8_sci.h
@@ -63,14 +63,14 @@ protected:
 		CLK_RX = 2
 	};
 
-	enum {
-		CLKM_INTERNAL_ASYNC,
-		CLKM_INTERNAL_ASYNC_OUT,
-		CLKM_EXTERNAL_ASYNC,
-		CLKM_EXTERNAL_RATE_ASYNC,
-		CLKM_INTERNAL_SYNC_OUT,
-		CLKM_EXTERNAL_SYNC,
-		CLKM_EXTERNAL_RATE_SYNC
+	enum class ClockMode {
+		INTERNAL_ASYNC,
+		INTERNAL_ASYNC_OUT,
+		EXTERNAL_ASYNC,
+		EXTERNAL_RATE_ASYNC,
+		INTERNAL_SYNC_OUT,
+		EXTERNAL_SYNC,
+		EXTERNAL_RATE_SYNC
 	};
 
 	enum {
@@ -112,7 +112,8 @@ protected:
 
 	int eri_int, rxi_int, txi_int, tei_int;
 
-	int tx_state, rx_state, tx_bit, rx_bit, clock_state, clock_mode, tx_parity, rx_parity, ext_clock_counter;
+	int tx_state, rx_state, tx_bit, rx_bit, clock_state, tx_parity, rx_parity, ext_clock_counter;
+	ClockMode clock_mode;
 	bool clock_value, ext_clock_value, rx_value;
 
 	uint8_t rdr, tdr, smr, scr, ssr, brr, rsr, tsr;

--- a/src/devices/cpu/h8/h8_sci.h
+++ b/src/devices/cpu/h8/h8_sci.h
@@ -63,7 +63,7 @@ protected:
 		CLK_RX = 2
 	};
 
-	enum class clock_mode {
+	enum class clock_mode_t {
 		INTERNAL_ASYNC,
 		INTERNAL_ASYNC_OUT,
 		EXTERNAL_ASYNC,
@@ -113,7 +113,7 @@ protected:
 	int eri_int, rxi_int, txi_int, tei_int;
 
 	int tx_state, rx_state, tx_bit, rx_bit, clock_state, tx_parity, rx_parity, ext_clock_counter;
-	clock_mode clock_mode;
+	clock_mode_t clock_mode;
 	bool clock_value, ext_clock_value, rx_value;
 
 	uint8_t rdr, tdr, smr, scr, ssr, brr, rsr, tsr;
@@ -121,8 +121,9 @@ protected:
 
 	std::string last_clock_message;
 
-	virtual void device_start() override;
-	virtual void device_reset() override;
+	void device_start() override;
+	void device_reset() override;
+	void device_post_load() override;
 
 	TIMER_CALLBACK_MEMBER(sync_tick);
 

--- a/src/devices/cpu/h8/h8_sci.h
+++ b/src/devices/cpu/h8/h8_sci.h
@@ -63,7 +63,7 @@ protected:
 		CLK_RX = 2
 	};
 
-	enum class ClockMode {
+	enum class clock_mode {
 		INTERNAL_ASYNC,
 		INTERNAL_ASYNC_OUT,
 		EXTERNAL_ASYNC,
@@ -113,7 +113,7 @@ protected:
 	int eri_int, rxi_int, txi_int, tei_int;
 
 	int tx_state, rx_state, tx_bit, rx_bit, clock_state, tx_parity, rx_parity, ext_clock_counter;
-	ClockMode clock_mode;
+	clock_mode clock_mode;
 	bool clock_value, ext_clock_value, rx_value;
 
 	uint8_t rdr, tdr, smr, scr, ssr, brr, rsr, tsr;

--- a/src/devices/cpu/h8/h8_timer8.cpp
+++ b/src/devices/cpu/h8/h8_timer8.cpp
@@ -65,73 +65,73 @@ void h8_timer8_channel_device::set_extra_clock_bit(bool bit)
 
 void h8_timer8_channel_device::update_tcr()
 {
-	char buf[4096];
-	char *p = buf;
+	std::ostringstream message;
 	switch(tcr & TCR_CKS) {
 	case 0:
 		clock_type = STOPPED;
 		clock_divider = 0;
-		if(V>=1) p += sprintf(p, "clock stopped");
+		if(V>=1) message << "clock stopped";
 		break;
 
 	case 1: case 2: case 3:
 		clock_type = DIV;
 		clock_divider = div_tab[((tcr & TCR_CKS)-1)*2 + extra_clock_bit];
-		if(V>=1) p += sprintf(p, "clock %dHz", cpu->clock()/clock_divider);
+		if(V>=1) util::stream_format(message, "clock %dHz", cpu->clock()/clock_divider);
 		break;
 
 	case 4:
 		clock_type = chain_type;
 		clock_divider = 0;
-		if(V>=1) p += sprintf(p, "clock chained %s", clock_type == CHAIN_A ? "tcora" : "overflow");
+		if(V>=1) util::stream_format(message, "clock chained %s", clock_type == CHAIN_A ? "tcora" : "overflow");
 		break;
 
 	case 5:
 		clock_type = INPUT_UP;
 		clock_divider = 0;
-		if(V>=1) p += sprintf(p, "clock external raising edge");
+		if(V>=1) message << "clock external raising edge";
 		break;
 
 	case 6:
 		clock_type = INPUT_DOWN;
 		clock_divider = 0;
-		if(V>=1) p += sprintf(p, "clock external falling edge");
+		if(V>=1) message << "clock external falling edge";
 		break;
 
 	case 7:
 		clock_type = INPUT_UPDOWN;
 		clock_divider = 0;
-		if(V>=1) p += sprintf(p, "clock external both edges");
+		if(V>=1) message << "clock external both edges";
 		break;
 	}
 
 	switch(tcr & TCR_CCLR) {
 	case 0x00:
 		clear_type = CLEAR_NONE;
-		if(V>=1) p += sprintf(p, ", no clear");
+		if(V>=1) message << ", no clear";
 		break;
 
 	case 0x08:
 		clear_type = CLEAR_A;
-		if(V>=1) p += sprintf(p, ", clear on tcora");
+		if(V>=1) message << ", clear on tcora";
 		break;
 
 	case 0x10:
 		clear_type = CLEAR_B;
-		if(V>=1) p += sprintf(p, ", clear on tcorb");
+		if(V>=1) message << ", clear on tcorb";
 		break;
 
 	case 0x18:
 		clear_type = CLEAR_EXTERNAL;
-		if(V>=1) p += sprintf(p, ", clear on external");
+		if(V>=1) message << ", clear on external";
 		break;
 	}
 
-	if(V>=1) p += sprintf(p, ", irq=%c%c%c\n",
+	if(V>=1) util::stream_format(message, ", irq=%c%c%c\n",
 						tcr & TCR_CMIEB ? 'b' : '-',
 						tcr & TCR_CMIEA ? 'a' : '-',
 						tcr & TCR_OVIE  ? 'o' : '-');
-	logerror(buf);
+
+	logerror(message.str());
 }
 
 uint8_t h8_timer8_channel_device::tcsr_r()

--- a/src/devices/cpu/h8/h8_timer8.cpp
+++ b/src/devices/cpu/h8/h8_timer8.cpp
@@ -131,7 +131,7 @@ void h8_timer8_channel_device::update_tcr()
 						tcr & TCR_CMIEA ? 'a' : '-',
 						tcr & TCR_OVIE  ? 'o' : '-');
 
-	logerror(message.str());
+	logerror(std::move(message).str());
 }
 
 uint8_t h8_timer8_channel_device::tcsr_r()

--- a/src/devices/cpu/h8/h8s2245.cpp
+++ b/src/devices/cpu/h8/h8s2245.cpp
@@ -348,6 +348,6 @@ void h8s2245_device::mstpcr_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 		if(mstpcr & 0x2000) message << " timer16";
 		if(mstpcr & 0x4000) message << " dtc";
 		message << "\n";
-		logerror(message.str());
+		logerror(std::move(message).str());
 	}
 }

--- a/src/devices/cpu/h8/h8s2245.cpp
+++ b/src/devices/cpu/h8/h8s2245.cpp
@@ -338,17 +338,16 @@ void h8s2245_device::mstpcr_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 	uint16_t omstpcr = mstpcr;
 	COMBINE_DATA(&mstpcr);
 	if((omstpcr ^ mstpcr) & 0x72e0) {
-		char buf[4096];
-		char *p = buf;
-		p += sprintf(p, "Online modules:");
-		if(mstpcr & 0x0020) p += sprintf(p, " sci0");
-		if(mstpcr & 0x0040) p += sprintf(p, " sci1");
-		if(mstpcr & 0x0080) p += sprintf(p, " sci2");
-		if(mstpcr & 0x0200) p += sprintf(p, " adc");
-		if(mstpcr & 0x1000) p += sprintf(p, " timer8");
-		if(mstpcr & 0x2000) p += sprintf(p, " timer16");
-		if(mstpcr & 0x4000) p += sprintf(p, " dtc");
-		p += sprintf(p, "\n");
-		logerror(buf);
+		std::ostringstream message;
+		message << "Online modules:";
+		if(mstpcr & 0x0020) message << " sci0";
+		if(mstpcr & 0x0040) message << " sci1";
+		if(mstpcr & 0x0080) message << " sci2";
+		if(mstpcr & 0x0200) message << " adc";
+		if(mstpcr & 0x1000) message << " timer8";
+		if(mstpcr & 0x2000) message << " timer16";
+		if(mstpcr & 0x4000) message << " dtc";
+		message << "\n";
+		logerror(message.str());
 	}
 }

--- a/src/devices/cpu/tms32010/32010dsm.cpp
+++ b/src/devices/cpu/tms32010/32010dsm.cpp
@@ -275,28 +275,26 @@ offs_t tms32010_disassembler::disassemble(std::ostream &stream, offs_t pc, const
 	{
 		if (*cp == '%')
 		{
-			char num[20];
 			cp++;
 			switch (*cp++)
 			{
-				case 'A': sprintf(num,"%02Xh",a); break; // was $%02X
+				case 'A': util::stream_format(stream,"%02Xh",a); break;
 				case 'B':
 					if (strncmp(cp, "b  ", 3) && strncmp(cp, "cal", 3))
 						flags = STEP_COND;
-					sprintf(num,"%04Xh",b); // was $%04X
+					util::stream_format(stream,"%04Xh",b);
 					break;
-				case 'D': sprintf(num,"%02Xh",d); break;
-				case 'K': sprintf(num,"%d",k); break;
-				case 'N': sprintf(num,"%s",nextar[n]); break;
-				case 'M': sprintf(num,"%s",arith[m]); break;
-				case 'P': sprintf(num,"PA%d",p); break;
-				case 'R': sprintf(num,"AR%d",r); break;
-				case 'S': sprintf(num,",%d",s); break;
-				case 'W': sprintf(num,"%04Xh",w); break;
+				case 'D': util::stream_format(stream,"%02Xh",d); break;
+				case 'K': util::stream_format(stream,"%d",k); break;
+				case 'N': stream << nextar[n]; break;
+				case 'M': stream << arith[m]; break;
+				case 'P': util::stream_format(stream,"PA%d",p); break;
+				case 'R': util::stream_format(stream,"AR%d",r); break;
+				case 'S': util::stream_format(stream,",%d",s); break;
+				case 'W': util::stream_format(stream,"%04Xh",w); break;
 				default:
 					throw std::logic_error(util::string_format("illegal escape character in format '%s'\n",Op[op].fmt));
 			}
-			stream << num;
 		}
 		else
 		{

--- a/src/devices/cpu/tms32025/32025dsm.cpp
+++ b/src/devices/cpu/tms32025/32025dsm.cpp
@@ -445,27 +445,25 @@ offs_t tms32025_disassembler::disassemble(std::ostream &stream, offs_t pc, const
 	{
 		if (*cp == '%')
 		{
-			char num[30];
 			cp++;
 			switch (*cp++)
 			{
-				case 'A': sprintf(num,"%02Xh",a); break;
-				case 'B': sprintf(num,"%04Xh",b); break;
-				case 'C': sprintf(num,"%s",cmpmode[c]); break;
-				case 'D': sprintf(num,"%02Xh",d); break;
-				case 'K': sprintf(num,"%d",k); break;
-				case 'M': sprintf(num,"%s",arith[m]); break;
-				case 'N': sprintf(num,"%s",nextar[n]); break;
-				case 'P': sprintf(num,"PA$%01X",p); break;
-				case 'R': sprintf(num,"AR%d",r); break;
-				case 'S': sprintf(num,",%d",s); break;
-				case 'T': sprintf(num,"%01Xh",t); break;
-				case 'W': sprintf(num,"%04Xh",w); break;
+				case 'A': util::stream_format(stream,"%02Xh",a); break;
+				case 'B': util::stream_format(stream,"%04Xh",b); break;
+				case 'C': stream << cmpmode[c]; break;
+				case 'D': util::stream_format(stream,"%02Xh",d); break;
+				case 'K': util::stream_format(stream,"%d",k); break;
+				case 'M': stream << arith[m]; break;
+				case 'N': stream << nextar[n]; break;
+				case 'P': util::stream_format(stream,"PA$%01X",p); break;
+				case 'R': util::stream_format(stream,"AR%d",r); break;
+				case 'S': util::stream_format(stream,",%d",s); break;
+				case 'T': util::stream_format(stream,"%01Xh",t); break;
+				case 'W': util::stream_format(stream,"%04Xh",w); break;
 				case 'X': break;
 				default:
 					throw std::logic_error(util::string_format("illegal escape character in format '%s'\n",Op[op].fmt));
 			}
-			stream << num;
 		}
 		else
 		{


### PR DESCRIPTION
Trying to keep these smaller to help review.
Some more sprintf removal to fix compiler warnings.
The slightly controversial part of this one is promoting the clock_mode enum to an enum class.
Not sure about the name ClockMode; the codebase has a mix of case styles, and generally seem to be all lower case?