### PR TITLE
Upgrade acorn sys1 to use ioport_array

### DIFF
--- a/src/mame/acorn/acrnsys1.cpp
+++ b/src/mame/acorn/acrnsys1.cpp
@@ -68,6 +68,7 @@ public:
 		, m_maincpu(*this, "maincpu")
 		, m_ttl74145(*this, "ic8_7445")
 		, m_cass(*this, "cassette")
+		, m_keyboard(*this, "X%u", 0U)
 		, m_display(*this, "digit%u", 0U)
 	{ }
 
@@ -85,6 +86,7 @@ private:
 	required_device<cpu_device> m_maincpu;
 	required_device<ttl74145_device> m_ttl74145;
 	required_device<cassette_image_device> m_cass;
+	required_ioport_array<8> m_keyboard;
 	output_finder<9> m_display;
 	uint8_t m_digit = 0;
 	uint8_t m_cass_data[4]{};
@@ -117,9 +119,7 @@ uint8_t acrnsys1_state::ins8154_b1_port_a_r()
 	{
 		if (BIT(key_line, i))
 		{
-			char kbdrow[6];
-			sprintf(kbdrow,"X%X",i);
-			data = (ioport(kbdrow)->read() & 0x38) | m_digit;
+			data = (m_keyboard[i]->read() & 0x38) | m_digit;
 			break;
 		}
 	}


### PR DESCRIPTION
Uploading one as a check I'm doing this correctly before doing more.

I didn't have to change much because the first 8 refs in INPUT_PORTS_START are the keyboard already.

Questions:

1) Does the zero in `m_keyboard(*this, "X%u", 0U)` mean start from the first def in INPUT_PORTS_START, or something else? Is it finding by name using the "X%u"?

2) Nothing appears to reference the port refs `reset` `switch` & `config`. Are these some standard names, or just not connected up?

3) I've noticed that (even before I changed anything) keys such as Esc and Tab don't work like other emulations. Is that expected?
