### PR TITLE
Fixed GH issue #10977, broken bloom in HLSL mode.

### DIFF
--- a/hlsl/bloom.fx
+++ b/hlsl/bloom.fx
@@ -419,7 +419,7 @@ float4 ps_main(PS_INPUT Input) : COLOR
 		blend = lerp(blend, texelH, Level8Weight * BloomScale);
 	}
 
-	return float4(blend, texel.a);
+	return float4(blend, 1.0f);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
-bloom.fx: Return an alpha of 1 rather than texel alpha. Fixes #10977 [Ryan Holtz]