### PR TITLE
KC 85 rework sound

### DIFF
--- a/src/mame/ddr/kc.cpp
+++ b/src/mame/ddr/kc.cpp
@@ -155,36 +155,30 @@ void kc_state::kc85_slots(machine_config &config)
 	SOFTWARE_LIST(config, "cass_list").set_original("kc_cass");
 }
 
-
-void kc_state::kc85_2(machine_config &config)
+void kc_state::kc85_base(machine_config &config, uint32_t clock)
 {
 	/* basic machine hardware */
-	Z80(config, m_maincpu, KC85_2_CLOCK);
-	m_maincpu->set_addrmap(AS_PROGRAM, &kc_state::kc85_2_mem);
-	m_maincpu->set_addrmap(AS_IO, &kc_state::kc85_2_io);
+	Z80(config, m_maincpu, clock);
 	m_maincpu->set_daisy_config(kc85_daisy_chain);
 
 	config.set_maximum_quantum(attotime::from_hz(60));
 
-	Z80PIO(config, m_z80pio, KC85_2_CLOCK);
+	Z80PIO(config, m_z80pio, clock);
 	m_z80pio->out_int_callback().set_inputline(m_maincpu, 0);
 	m_z80pio->in_pa_callback().set(FUNC(kc_state::pio_porta_r));
 	m_z80pio->out_pa_callback().set(FUNC(kc_state::pio_porta_w));
 	m_z80pio->out_ardy_callback().set(FUNC(kc_state::pio_ardy_cb));
 	m_z80pio->in_pb_callback().set(FUNC(kc_state::pio_portb_r));
-	m_z80pio->out_pb_callback().set(FUNC(kc_state::pio_portb_w));
 	m_z80pio->out_brdy_callback().set(FUNC(kc_state::pio_brdy_cb));
 
-	Z80CTC(config, m_z80ctc, KC85_2_CLOCK);
+	Z80CTC(config, m_z80ctc, clock);
 	m_z80ctc->intr_callback().set_inputline(m_maincpu, 0);
-	m_z80ctc->zc_callback<0>().set(FUNC(kc_state::ctc_zc0_callback));
 	m_z80ctc->zc_callback<1>().set(FUNC(kc_state::ctc_zc1_callback));
 	m_z80ctc->zc_callback<2>().set(FUNC(kc_state::video_toggle_blink_state));
 
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(XTAL(28'375'160)/2, 908, 0, 320, 312, 0, 256);
-	m_screen->set_screen_update(FUNC(kc_state::screen_update));
 	m_screen->set_palette("palette");
 	TIMER(config, "scantimer").configure_scanline(FUNC(kc_state::kc_scanline), "screen", 0, 1);
 
@@ -198,128 +192,67 @@ void kc_state::kc85_2(machine_config &config)
 	SPEAKER(config, "outl").front_left();
 	SPEAKER(config, "outr").front_right();
 	SPEAKER_SOUND(config, m_dac);
-	m_dac->set_levels(64, kc85_speaker_levels);
 	m_dac->add_route(ALL_OUTPUTS, "mono", 0.5);
 	SPEAKER_SOUND(config, m_tapeout_left).add_route(ALL_OUTPUTS, "outl", 0.25);
 	SPEAKER_SOUND(config, m_tapeout_right).add_route(ALL_OUTPUTS, "outr", 0.25);
 
 	kc85_slots(config);
+}
 
-	/* internal ram */
+void kc_state::kc85_2_3(machine_config &config, uint32_t clock)
+{
+      	kc85_base(config, KC85_2_CLOCK);
+
+	m_maincpu->set_addrmap(AS_PROGRAM, &kc_state::kc85_2_mem);
+	m_maincpu->set_addrmap(AS_IO, &kc_state::kc85_2_io);
+
+	m_screen->set_screen_update(FUNC(kc_state::screen_update));
+
+	m_dac->set_levels(64, kc85_speaker_levels);
+
 	RAM(config, m_ram).set_default_size("16K");
+}
+
+void kc_state::kc85_2(machine_config &config)
+{
+	kc85_2_3(config, KC85_2_CLOCK);
+
+	m_z80pio->out_pb_callback().set(FUNC(kc_state::pio_portb_w));
+	m_z80ctc->zc_callback<0>().set(FUNC(kc_state::ctc_zc0_callback));
 }
 
 void kc85_3_state::kc85_3(machine_config &config)
 {
-	/* basic machine hardware */
-	Z80(config, m_maincpu, KC85_2_CLOCK);
-	m_maincpu->set_addrmap(AS_PROGRAM, &kc_state::kc85_2_mem);
-	m_maincpu->set_addrmap(AS_IO, &kc_state::kc85_2_io);
-	m_maincpu->set_daisy_config(kc85_daisy_chain);
+	kc85_2_3(config, KC85_2_CLOCK);
 
-	config.set_maximum_quantum(attotime::from_hz(60));
-
-	Z80PIO(config, m_z80pio, KC85_2_CLOCK);
-	m_z80pio->out_int_callback().set_inputline(m_maincpu, 0);
-	m_z80pio->in_pa_callback().set(FUNC(kc_state::pio_porta_r));
-	m_z80pio->out_pa_callback().set(FUNC(kc_state::pio_porta_w));
-	m_z80pio->out_ardy_callback().set(FUNC(kc_state::pio_ardy_cb));
-	m_z80pio->in_pb_callback().set(FUNC(kc_state::pio_portb_r));
 	m_z80pio->out_pb_callback().set(FUNC(kc85_3_state::pio_portb_w));
-	m_z80pio->out_brdy_callback().set(FUNC(kc_state::pio_brdy_cb));
-
-	Z80CTC(config, m_z80ctc, KC85_2_CLOCK);
-	m_z80ctc->intr_callback().set_inputline(m_maincpu, 0);
 	m_z80ctc->zc_callback<0>().set(FUNC(kc85_3_state::ctc_zc0_callback));
-	m_z80ctc->zc_callback<1>().set(FUNC(kc_state::ctc_zc1_callback));
-	m_z80ctc->zc_callback<2>().set(FUNC(kc_state::video_toggle_blink_state));
 
-	/* video hardware */
-	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_raw(XTAL(28'375'160)/2, 908, 0, 320, 312, 0, 256);
-	m_screen->set_screen_update(FUNC(kc_state::screen_update));
-	m_screen->set_palette("palette");
-	TIMER(config, "scantimer").configure_scanline(FUNC(kc_state::kc_scanline), "screen", 0, 1);
-
-	PALETTE(config, "palette", FUNC(kc_state::kc85_palette), KC85_PALETTE_SIZE);
-
-	kc_keyboard_device &keyboard(KC_KEYBOARD(config, "keyboard", XTAL(4'000'000)));
-	keyboard.out_wr_callback().set(FUNC(kc_state::keyboard_cb));
-
-	/* sound hardware */
-	SPEAKER(config, "mono").front_center();
-	SPEAKER(config, "outl").front_left();
-	SPEAKER(config, "outr").front_right();
 	SPEAKER_SOUND(config, "speaker").add_route(ALL_OUTPUTS, "mono", 0.125);
-	SPEAKER_SOUND(config, m_dac);
-	m_dac->set_levels(64, kc85_speaker_levels);
-	m_dac->add_route(ALL_OUTPUTS, "mono", 0.5);
-	SPEAKER_SOUND(config, m_tapeout_left).add_route(ALL_OUTPUTS, "outl", 0.25);
-	SPEAKER_SOUND(config, m_tapeout_right).add_route(ALL_OUTPUTS, "outr", 0.25);
-
-	kc85_slots(config);
-
-	/* internal ram */
-	RAM(config, m_ram).set_default_size("16K");
 }
 
 void kc85_4_state::kc85_4(machine_config &config)
 {
-	/* basic machine hardware */
-	Z80(config, m_maincpu, KC85_4_CLOCK);
+	kc85_base(config, KC85_4_CLOCK);
+
 	m_maincpu->set_addrmap(AS_PROGRAM, &kc85_4_state::kc85_4_mem);
 	m_maincpu->set_addrmap(AS_IO, &kc85_4_state::kc85_4_io);
-	m_maincpu->set_daisy_config(kc85_daisy_chain);
-	config.set_maximum_quantum(attotime::from_hz(60));
 
-	Z80PIO(config, m_z80pio, KC85_4_CLOCK);
-	m_z80pio->out_int_callback().set_inputline(m_maincpu, 0);
-	m_z80pio->in_pa_callback().set(FUNC(kc_state::pio_porta_r));
-	m_z80pio->out_pa_callback().set(FUNC(kc_state::pio_porta_w));
-	m_z80pio->out_ardy_callback().set(FUNC(kc_state::pio_ardy_cb));
-	m_z80pio->in_pb_callback().set(FUNC(kc_state::pio_portb_r));
 	m_z80pio->out_pb_callback().set(FUNC(kc85_4_state::pio_portb_w));
-	m_z80pio->out_brdy_callback().set(FUNC(kc_state::pio_brdy_cb));
-
-	Z80CTC(config, m_z80ctc, KC85_4_CLOCK);
-	m_z80ctc->intr_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ0);
 	m_z80ctc->zc_callback<0>().set(FUNC(kc85_3_state::ctc_zc0_callback));
-	m_z80ctc->zc_callback<1>().set(FUNC(kc_state::ctc_zc1_callback));
-	m_z80ctc->zc_callback<2>().set(FUNC(kc_state::video_toggle_blink_state));
 
-	/* video hardware */
-	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_raw(XTAL(28'375'160)/2, 908, 0, 320, 312, 0, 256);
 	m_screen->set_screen_update(FUNC(kc85_4_state::screen_update));
-	m_screen->set_palette("palette");
-	TIMER(config, "scantimer").configure_scanline(FUNC(kc85_4_state::kc_scanline), "screen", 0, 1);
 
-	PALETTE(config, "palette", FUNC(kc85_4_state::kc85_palette), KC85_PALETTE_SIZE);
-
-	kc_keyboard_device &keyboard(KC_KEYBOARD(config, "keyboard", XTAL(4'000'000)));
-	keyboard.out_wr_callback().set(FUNC(kc_state::keyboard_cb));
-
-	/* sound hardware */
-	SPEAKER(config, "mono").front_center();
-	SPEAKER(config, "outl").front_left();
-	SPEAKER(config, "outr").front_right();
 	SPEAKER_SOUND(config, "speaker").add_route(ALL_OUTPUTS, "mono", 0.125);
-	SPEAKER_SOUND(config, m_dac);
 	m_dac->set_levels(32, kc85_4_speaker_levels);
-	m_dac->add_route(ALL_OUTPUTS, "mono", 0.5);
-	SPEAKER_SOUND(config, m_tapeout_left).add_route(ALL_OUTPUTS, "outl", 0.25);
-	SPEAKER_SOUND(config, m_tapeout_right).add_route(ALL_OUTPUTS, "outr", 0.25);
 
-	kc85_slots(config);
-
-	/* internal ram */
 	RAM(config, m_ram).set_default_size("64K");
 }
 
 void kc85_4_state::kc85_5(machine_config &config)
 {
 	kc85_4(config);
-	/* internal ram */
+
 	m_ram->set_default_size("256K");
 }
 

--- a/src/mame/ddr/kc.cpp
+++ b/src/mame/ddr/kc.cpp
@@ -195,9 +195,13 @@ void kc_state::kc85_2(machine_config &config)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
+	SPEAKER(config, "outl").front_left();
+	SPEAKER(config, "outr").front_right();
 	SPEAKER_SOUND(config, m_dac);
 	m_dac->set_levels(64, kc85_speaker_levels);
 	m_dac->add_route(ALL_OUTPUTS, "mono", 0.5);
+	SPEAKER_SOUND(config, m_tapeout_left).add_route(ALL_OUTPUTS, "outl", 0.25);
+	SPEAKER_SOUND(config, m_tapeout_right).add_route(ALL_OUTPUTS, "outr", 0.25);
 
 	kc85_slots(config);
 
@@ -244,10 +248,14 @@ void kc85_3_state::kc85_3(machine_config &config)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
+	SPEAKER(config, "outl").front_left();
+	SPEAKER(config, "outr").front_right();
 	SPEAKER_SOUND(config, "speaker").add_route(ALL_OUTPUTS, "mono", 0.125);
 	SPEAKER_SOUND(config, m_dac);
 	m_dac->set_levels(64, kc85_speaker_levels);
 	m_dac->add_route(ALL_OUTPUTS, "mono", 0.5);
+	SPEAKER_SOUND(config, m_tapeout_left).add_route(ALL_OUTPUTS, "outl", 0.25);
+	SPEAKER_SOUND(config, m_tapeout_right).add_route(ALL_OUTPUTS, "outr", 0.25);
 
 	kc85_slots(config);
 
@@ -293,10 +301,14 @@ void kc85_4_state::kc85_4(machine_config &config)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
+	SPEAKER(config, "outl").front_left();
+	SPEAKER(config, "outr").front_right();
 	SPEAKER_SOUND(config, "speaker").add_route(ALL_OUTPUTS, "mono", 0.125);
 	SPEAKER_SOUND(config, m_dac);
 	m_dac->set_levels(32, kc85_4_speaker_levels);
 	m_dac->add_route(ALL_OUTPUTS, "mono", 0.5);
+	SPEAKER_SOUND(config, m_tapeout_left).add_route(ALL_OUTPUTS, "outl", 0.25);
+	SPEAKER_SOUND(config, m_tapeout_right).add_route(ALL_OUTPUTS, "outr", 0.25);
 
 	kc85_slots(config);
 

--- a/src/mame/ddr/kc.cpp
+++ b/src/mame/ddr/kc.cpp
@@ -45,7 +45,7 @@ void kc85_4_state::kc85_4_mem(address_map &map)
 	map(0xe000, 0xffff).bankr("bank5");
 }
 
-void kc_state::kc85_3_mem(address_map &map)
+void kc_state::kc85_2_mem(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x0000, 0x3fff).bankrw("bank1");
@@ -55,7 +55,7 @@ void kc_state::kc85_3_mem(address_map &map)
 	map(0xe000, 0xffff).bankr("bank5");
 }
 
-void kc_state::kc85_3_io(address_map &map)
+void kc_state::kc85_2_io(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x0000, 0xffff).rw(FUNC(kc_state::expansion_io_read), FUNC(kc_state::expansion_io_write));
@@ -74,6 +74,24 @@ static const z80_daisy_config kc85_daisy_chain[] =
 	{ "z80ctc" },
 	{ "z80pio" },
 	{ nullptr }
+};
+
+static const double kc85_speaker_levels[64] = {
+	-1.0, -0.96875, -0.9375, -0.90625, -0.875, -0.84375, -0.8125, -0.78125,
+	-0.75, -0.71875, -0.6875, -0.65625, -0.625, -0.59375, -0.5625, -0.53125,
+	-0.5, -0.46875, -0.4375, -0.40625, -0.375, -0.34375, -0.3125, -0.28125,
+	-0.25, -0.21875, -0.1875, -0.15625, -0.125, -0.09375, -0.0625, -0.03125,
+	0.0, 0.03125, 0.0625, 0.09375, 0.125, 0.15625, 0.1875, 0.21875,
+	0.25, 0.28125, 0.3125, 0.34375, 0.375, 0.40625, 0.4375, 0.46875,
+	0.5, 0.53125, 0.5625, 0.59375, 0.625, 0.65625, 0.6875, 0.71875,
+	0.75, 0.78125, 0.8125, 0.84375, 0.875, 0.90625, 0.9375, 0.96875
+};
+
+static const double kc85_4_speaker_levels[32] = {
+	-1.0, -0.9375, -0.875, -0.8125, -0.75, -0.6875, -0.625, -0.5625,
+	-0.5, -0.4375, -0.375, -0.3125, -0.25, -0.1875, -0.125, -0.0625,
+	0.0, 0.0625, 0.125, 0.1875, 0.25, 0.3125, 0.375, 0.4375,
+	0.5, 0.5625, 0.625, 0.6875, 0.75, 0.8125, 0.875, 0.9375
 };
 
 void kc85_cart(device_slot_interface &device)
@@ -138,17 +156,17 @@ void kc_state::kc85_slots(machine_config &config)
 }
 
 
-void kc_state::kc85_3(machine_config &config)
+void kc_state::kc85_2(machine_config &config)
 {
 	/* basic machine hardware */
-	Z80(config, m_maincpu, KC85_3_CLOCK);
-	m_maincpu->set_addrmap(AS_PROGRAM, &kc_state::kc85_3_mem);
-	m_maincpu->set_addrmap(AS_IO, &kc_state::kc85_3_io);
+	Z80(config, m_maincpu, KC85_2_CLOCK);
+	m_maincpu->set_addrmap(AS_PROGRAM, &kc_state::kc85_2_mem);
+	m_maincpu->set_addrmap(AS_IO, &kc_state::kc85_2_io);
 	m_maincpu->set_daisy_config(kc85_daisy_chain);
 
 	config.set_maximum_quantum(attotime::from_hz(60));
 
-	Z80PIO(config, m_z80pio, KC85_3_CLOCK);
+	Z80PIO(config, m_z80pio, KC85_2_CLOCK);
 	m_z80pio->out_int_callback().set_inputline(m_maincpu, 0);
 	m_z80pio->in_pa_callback().set(FUNC(kc_state::pio_porta_r));
 	m_z80pio->out_pa_callback().set(FUNC(kc_state::pio_porta_w));
@@ -157,7 +175,7 @@ void kc_state::kc85_3(machine_config &config)
 	m_z80pio->out_pb_callback().set(FUNC(kc_state::pio_portb_w));
 	m_z80pio->out_brdy_callback().set(FUNC(kc_state::pio_brdy_cb));
 
-	Z80CTC(config, m_z80ctc, KC85_3_CLOCK);
+	Z80CTC(config, m_z80ctc, KC85_2_CLOCK);
 	m_z80ctc->intr_callback().set_inputline(m_maincpu, 0);
 	m_z80ctc->zc_callback<0>().set(FUNC(kc_state::ctc_zc0_callback));
 	m_z80ctc->zc_callback<1>().set(FUNC(kc_state::ctc_zc1_callback));
@@ -177,7 +195,59 @@ void kc_state::kc85_3(machine_config &config)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
-	SPEAKER_SOUND(config, "speaker").add_route(ALL_OUTPUTS, "mono", 0.50);
+	SPEAKER_SOUND(config, m_dac);
+	m_dac->set_levels(64, kc85_speaker_levels);
+	m_dac->add_route(ALL_OUTPUTS, "mono", 0.5);
+
+	kc85_slots(config);
+
+	/* internal ram */
+	RAM(config, m_ram).set_default_size("16K");
+}
+
+void kc85_3_state::kc85_3(machine_config &config)
+{
+	/* basic machine hardware */
+	Z80(config, m_maincpu, KC85_2_CLOCK);
+	m_maincpu->set_addrmap(AS_PROGRAM, &kc_state::kc85_2_mem);
+	m_maincpu->set_addrmap(AS_IO, &kc_state::kc85_2_io);
+	m_maincpu->set_daisy_config(kc85_daisy_chain);
+
+	config.set_maximum_quantum(attotime::from_hz(60));
+
+	Z80PIO(config, m_z80pio, KC85_2_CLOCK);
+	m_z80pio->out_int_callback().set_inputline(m_maincpu, 0);
+	m_z80pio->in_pa_callback().set(FUNC(kc_state::pio_porta_r));
+	m_z80pio->out_pa_callback().set(FUNC(kc_state::pio_porta_w));
+	m_z80pio->out_ardy_callback().set(FUNC(kc_state::pio_ardy_cb));
+	m_z80pio->in_pb_callback().set(FUNC(kc_state::pio_portb_r));
+	m_z80pio->out_pb_callback().set(FUNC(kc85_3_state::pio_portb_w));
+	m_z80pio->out_brdy_callback().set(FUNC(kc_state::pio_brdy_cb));
+
+	Z80CTC(config, m_z80ctc, KC85_2_CLOCK);
+	m_z80ctc->intr_callback().set_inputline(m_maincpu, 0);
+	m_z80ctc->zc_callback<0>().set(FUNC(kc85_3_state::ctc_zc0_callback));
+	m_z80ctc->zc_callback<1>().set(FUNC(kc_state::ctc_zc1_callback));
+	m_z80ctc->zc_callback<2>().set(FUNC(kc_state::video_toggle_blink_state));
+
+	/* video hardware */
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_raw(XTAL(28'375'160)/2, 908, 0, 320, 312, 0, 256);
+	m_screen->set_screen_update(FUNC(kc_state::screen_update));
+	m_screen->set_palette("palette");
+	TIMER(config, "scantimer").configure_scanline(FUNC(kc_state::kc_scanline), "screen", 0, 1);
+
+	PALETTE(config, "palette", FUNC(kc_state::kc85_palette), KC85_PALETTE_SIZE);
+
+	kc_keyboard_device &keyboard(KC_KEYBOARD(config, "keyboard", XTAL(4'000'000)));
+	keyboard.out_wr_callback().set(FUNC(kc_state::keyboard_cb));
+
+	/* sound hardware */
+	SPEAKER(config, "mono").front_center();
+	SPEAKER_SOUND(config, "speaker").add_route(ALL_OUTPUTS, "mono", 0.125);
+	SPEAKER_SOUND(config, m_dac);
+	m_dac->set_levels(64, kc85_speaker_levels);
+	m_dac->add_route(ALL_OUTPUTS, "mono", 0.5);
 
 	kc85_slots(config);
 
@@ -200,12 +270,12 @@ void kc85_4_state::kc85_4(machine_config &config)
 	m_z80pio->out_pa_callback().set(FUNC(kc_state::pio_porta_w));
 	m_z80pio->out_ardy_callback().set(FUNC(kc_state::pio_ardy_cb));
 	m_z80pio->in_pb_callback().set(FUNC(kc_state::pio_portb_r));
-	m_z80pio->out_pb_callback().set(FUNC(kc_state::pio_portb_w));
+	m_z80pio->out_pb_callback().set(FUNC(kc85_4_state::pio_portb_w));
 	m_z80pio->out_brdy_callback().set(FUNC(kc_state::pio_brdy_cb));
 
-	Z80CTC(config, m_z80ctc, 0);
+	Z80CTC(config, m_z80ctc, KC85_4_CLOCK);
 	m_z80ctc->intr_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ0);
-	m_z80ctc->zc_callback<0>().set(FUNC(kc_state::ctc_zc0_callback));
+	m_z80ctc->zc_callback<0>().set(FUNC(kc85_3_state::ctc_zc0_callback));
 	m_z80ctc->zc_callback<1>().set(FUNC(kc_state::ctc_zc1_callback));
 	m_z80ctc->zc_callback<2>().set(FUNC(kc_state::video_toggle_blink_state));
 
@@ -223,7 +293,10 @@ void kc85_4_state::kc85_4(machine_config &config)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
-	SPEAKER_SOUND(config, "speaker").add_route(ALL_OUTPUTS, "mono", 0.50);
+	SPEAKER_SOUND(config, "speaker").add_route(ALL_OUTPUTS, "mono", 0.125);
+	SPEAKER_SOUND(config, m_dac);
+	m_dac->set_levels(32, kc85_4_speaker_levels);
+	m_dac->add_route(ALL_OUTPUTS, "mono", 0.5);
 
 	kc85_slots(config);
 
@@ -292,7 +365,7 @@ ROM_START(kc85_5)
 ROM_END
 
 //    YEAR  NAME    PARENT  COMPAT  MACHINE  INPUT  CLASS         INIT        COMPANY, FULLNAME, FLAGS
-COMP( 1987, kc85_2, 0,      0,      kc85_3,  kc85,  kc_state,     empty_init, u8"VEB Mikroelektronik \"Wilhelm Pieck\" Mühlhausen", "HC900 / KC 85/2", MACHINE_NOT_WORKING)
-COMP( 1987, kc85_3, kc85_2, 0,      kc85_3,  kc85,  kc_state,     empty_init, u8"VEB Mikroelektronik \"Wilhelm Pieck\" Mühlhausen", "KC 85/3",         MACHINE_NOT_WORKING)
+COMP( 1987, kc85_2, 0,      0,      kc85_2,  kc85,  kc_state,     empty_init, u8"VEB Mikroelektronik \"Wilhelm Pieck\" Mühlhausen", "HC900 / KC 85/2", MACHINE_NOT_WORKING)
+COMP( 1987, kc85_3, kc85_2, 0,      kc85_3,  kc85,  kc85_3_state, empty_init, u8"VEB Mikroelektronik \"Wilhelm Pieck\" Mühlhausen", "KC 85/3",         MACHINE_NOT_WORKING)
 COMP( 1989, kc85_4, kc85_2, 0,      kc85_4,  kc85,  kc85_4_state, empty_init, u8"VEB Mikroelektronik \"Wilhelm Pieck\" Mühlhausen", "KC 85/4",         MACHINE_NOT_WORKING)
 COMP( 1989, kc85_5, kc85_2, 0,      kc85_5,  kc85,  kc85_4_state, empty_init, u8"VEB Mikroelektronik \"Wilhelm Pieck\" Mühlhausen", "KC 85/5",         MACHINE_NOT_WORKING)

--- a/src/mame/ddr/kc.h
+++ b/src/mame/ddr/kc.h
@@ -64,6 +64,8 @@ public:
 		, m_z80pio(*this, "z80pio")
 		, m_z80ctc(*this, "z80ctc")
 		, m_ram(*this, RAM_TAG)
+		, m_tapeout_left(*this, "tapel")
+		, m_tapeout_right(*this, "taper")
 		, m_dac(*this, "dac")
 		, m_cassette(*this, "cassette")
 		, m_screen(*this, "screen")
@@ -74,6 +76,8 @@ public:
 	required_device<z80pio_device> m_z80pio;
 	required_device<z80ctc_device> m_z80ctc;
 	required_device<ram_device> m_ram;
+	required_device<speaker_sound_device> m_tapeout_left;
+	required_device<speaker_sound_device> m_tapeout_right;
 	required_device<speaker_sound_device> m_dac;
 	required_device<cassette_image_device> m_cassette;
 	required_device<screen_device> m_screen;
@@ -125,6 +129,7 @@ public:
 
 	// sound
 	virtual void dac_update();
+	void tapeout_update();
 
 	// defined in video/kc.cpp
 	virtual void video_start() override;

--- a/src/mame/ddr/kc.h
+++ b/src/mame/ddr/kc.h
@@ -83,10 +83,6 @@ public:
 	required_device<screen_device> m_screen;
 	required_device_array<kcexp_slot_device, 3> m_expansions;
 
-	// defined in machine/kc.cpp
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-
 	// modules read/write
 	uint8_t expansion_read(offs_t offset);
 	void expansion_write(offs_t offset, uint8_t data);
@@ -100,6 +96,13 @@ public:
 	void expansion_e000_w(offs_t offset, uint8_t data);
 	uint8_t expansion_io_read(offs_t offset);
 	void expansion_io_write(offs_t offset, uint8_t data);
+
+	void kc85_2(machine_config &config);
+
+protected:
+	// defined in machine/kc.cpp
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
 
 	// bankswitch
 	virtual void update_0x00000();
@@ -163,9 +166,8 @@ public:
 	DECLARE_QUICKLOAD_LOAD_MEMBER(quickload_cb);
 	void kc85_slots(machine_config &config);
 
-        void kc85_base(machine_config &config, uint32_t clock);
-        void kc85_2_3(machine_config &config, uint32_t clock);
-	void kc85_2(machine_config &config);
+	void kc85_base(machine_config &config, uint32_t clock);
+	void kc85_2_3(machine_config &config, uint32_t clock);
 	void kc85_2_io(address_map &map);
 	void kc85_2_mem(address_map &map);
 };
@@ -184,6 +186,9 @@ public:
 	// CTC callback
 	DECLARE_WRITE_LINE_MEMBER( ctc_zc0_callback );
 
+	void kc85_3(machine_config &config);
+
+protected:
 	// PIO callback
 	void pio_portb_w(uint8_t data) override;
 
@@ -192,8 +197,6 @@ public:
 
 	// driver state
 	uint8_t		    m_speaker_level = 0U;
-
-	void kc85_3(machine_config &config);
 };
 
 
@@ -204,6 +207,10 @@ public:
 		: kc85_3_state(mconfig, type, tag)
 	{ }
 
+	void kc85_4(machine_config &config);
+	void kc85_5(machine_config &config);
+
+protected:
 	// defined in machine/kc.cpp
 	virtual void machine_reset() override;
 
@@ -232,8 +239,6 @@ public:
 	uint8_t               m_port_84_data = 0U;
 	uint8_t               m_port_86_data = 0U;
 	uint8_t *             m_display_video_ram = 0U;
-	void kc85_4(machine_config &config);
-	void kc85_5(machine_config &config);
 	void kc85_4_io(address_map &map);
 	void kc85_4_mem(address_map &map);
 };

--- a/src/mame/ddr/kc.h
+++ b/src/mame/ddr/kc.h
@@ -163,6 +163,8 @@ public:
 	DECLARE_QUICKLOAD_LOAD_MEMBER(quickload_cb);
 	void kc85_slots(machine_config &config);
 
+        void kc85_base(machine_config &config, uint32_t clock);
+        void kc85_2_3(machine_config &config, uint32_t clock);
 	void kc85_2(machine_config &config);
 	void kc85_2_io(address_map &map);
 	void kc85_2_mem(address_map &map);

--- a/src/mame/ddr/kc_m.cpp
+++ b/src/mame/ddr/kc_m.cpp
@@ -705,6 +705,7 @@ WRITE_LINE_MEMBER( kc_state::ctc_zc0_callback )
 	{
 		m_k0_line^=1;
 		dac_update();
+		tapeout_update();
 	}
 }
 
@@ -715,6 +716,7 @@ WRITE_LINE_MEMBER( kc85_3_state::ctc_zc0_callback )
 		m_k0_line^=1;
 		dac_update();
 		speaker_update();
+		tapeout_update();
 	}
 }
 
@@ -725,6 +727,7 @@ WRITE_LINE_MEMBER( kc_state::ctc_zc1_callback)
 	{
 		m_k1_line^=1;
 		dac_update();
+		tapeout_update();
 
 		// K1 line is also cassette output
 		m_cassette->output((m_k1_line & 1) ? +1 : -1);
@@ -769,6 +772,12 @@ void kc_state::dac_update()
 void kc85_4_state::dac_update()
 {
 	m_dac->level_w((m_k0_line + m_k1_line) * m_dac_level);
+}
+
+void kc_state::tapeout_update()
+{
+	m_tapeout_left->level_w(m_k0_line);
+	m_tapeout_right->level_w(m_k1_line);
 }
 
 /* keyboard callback */

--- a/src/mame/ddr/kc_m.cpp
+++ b/src/mame/ddr/kc_m.cpp
@@ -593,9 +593,37 @@ void kc_state::pio_portb_w(uint8_t data)
 
 	update_0x08000();
 
-	/* 16 speaker levels */
-	m_speaker_level = (data>>1) & 0x0f;
+	// KC 85/2..3: 5-bit DAC
+	m_dac_level = (~data & 0x1f)>>1;
+	dac_update();
+}
 
+void kc85_3_state::pio_portb_w(uint8_t data)
+{
+	m_pio_data[1] = data;
+
+	update_0x08000();
+
+	// KC 85/2..3: 5-bit DAC
+	m_dac_level = (~data & 0x1f);
+	dac_update();
+}
+
+void kc85_4_state::pio_portb_w(uint8_t data)
+{
+	// reset tone flip-flops
+	if (((m_pio_data[1] & 1) == 1) & ((data & 1) == 0)) {
+		m_k0_line = 0;
+		m_k1_line = 0;
+	}
+
+	m_pio_data[1] = data;
+
+	update_0x08000();
+
+	// KC 85/4: 4-bit DAC
+	m_dac_level = (~data & 0x1e)>>1;
+	dac_update();
 	speaker_update();
 }
 
@@ -676,6 +704,16 @@ WRITE_LINE_MEMBER( kc_state::ctc_zc0_callback )
 	if (state)
 	{
 		m_k0_line^=1;
+		dac_update();
+	}
+}
+
+WRITE_LINE_MEMBER( kc85_3_state::ctc_zc0_callback )
+{
+	if (state)
+	{
+		m_k0_line^=1;
+		dac_update();
 		speaker_update();
 	}
 }
@@ -686,12 +724,11 @@ WRITE_LINE_MEMBER( kc_state::ctc_zc1_callback)
 	if (state)
 	{
 		m_k1_line^=1;
-		speaker_update();
+		dac_update();
 
 		// K1 line is also cassette output
 		m_cassette->output((m_k1_line & 1) ? +1 : -1);
 	}
-
 }
 
 TIMER_DEVICE_CALLBACK_MEMBER(kc_state::kc_scanline)
@@ -714,10 +751,24 @@ TIMER_DEVICE_CALLBACK_MEMBER(kc_state::kc_scanline)
 	}
 }
 
-void kc_state::speaker_update()
+void kc85_3_state::speaker_update()
 {
-	/* this might not be correct, the range might be logarithmic and not linear! */
-	m_speaker->level_w(m_k0_line ? (m_speaker_level | (m_k1_line ? 0x01 : 0)) : 0);
+	m_speaker->level_w(m_k0_line);
+}
+
+void kc85_4_state::speaker_update()
+{
+	m_speaker->level_w(m_dac_level ? m_k0_line : 0);
+}
+
+void kc_state::dac_update()
+{
+	m_dac->level_w((m_k0_line + m_k1_line) * m_dac_level);
+}
+
+void kc85_4_state::dac_update()
+{
+	m_dac->level_w((m_k0_line + m_k1_line) * m_dac_level);
 }
 
 /* keyboard callback */


### PR DESCRIPTION
This is an overhaul of the sound emulation for the VEB Mikroelektronik KC 85/2..4 (ddr/kc).

The KC 85 series has 3 distinct sound outputs, which are currently not emulated as such:

1. Two 1-bit channels K0 and K1, driven by flip-flops via CTC channels 0 and 1, connected to the left and right channels on the Tape output. This feature is commonly used in music editors from the era. K0 and K1 are always in an undefined state (so they can be toggled but not set to a specific state), except on KC 85/4, where they can be reset to a known state via PIO B.
2. A binary weighted DAC that outputs on the RGB/FBAS port, with volume control via PIO B. Offers 5 bits of volume control on KC 85/2 and 85/3, and 4 bits of volume control on the KC 85/4. The signal sum of K0 and K1 is routed through the DAC. This feature was not used much back in the day as RGB monitors were largely unavailable, but is used by some modern demos (eg. [Ancient Civilizations](https://demozoo.org/productions/277065/)).
3. An internal speaker, driven by K0. KC 85/2 does not have this feature. On KC 85/4, K0 is only passed through if the volume level on the DAC is at least 1.

In order to handle the differences between the various KC models, I split up the combined KC 85/2+85/3 driver, so each of the KC models now has its own, separate driver (except KC 85/5 which is just a mod of KC 85/4 with extra RAM). I re-used the existing `speaker_sound_device` for emulating the internal speaker, and used additional `speaker_sound_device`s for the DAC and Tape outputs. I also fixed a bug in the KC 85/4 driver, where the CTC was not connected to the system clock.

As far as I can tell, this completes emulation of these machines for the most part, so you might consider promoting them to 'working' status. The only remaining major issue seems to be that quickload on KC 85/2 and 85/3 happens prematurely (ie. before the system has finished booting). I'm unsure how to fix this, however.