### PR TITLE
hng64.cpp - small video improvements

### DIFF
--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -1777,8 +1777,12 @@ static auto const &texlayout_xoffset_4(std::integer_sequence<uint32_t, Values...
 	return s_values;
 }
 
-static const uint32_t texlayout_yoffset_4[1024] = { STEP1024(0,4096) };
-
+template <uint32_t... Values>
+static auto const &texlayout_yoffset_4(std::integer_sequence<uint32_t, Values...>)
+{
+	static constexpr uint32_t const s_values[sizeof...(Values)] = { (Values * 4096)... };
+	return s_values;
+}
 
 static const gfx_layout hng64_1024x1024x8_texlayout =
 {
@@ -1793,17 +1797,18 @@ static const gfx_layout hng64_1024x1024x8_texlayout =
 	texlayout_yoffset
 };
 
+// it appears that 4bpp tiles can only be in the top 1024 part of this as indexing is the same as 8bpp?
 static const gfx_layout hng64_1024x1024x4_texlayout =
 {
-	1024, 1024,
+	1024, 2048,
 	RGN_FRAC(1,1),
 	4,
 	{ 0,1,2,3 },
 	EXTENDED_XOFFS,
 	EXTENDED_YOFFS,
-	1024*1024*4,
+	1024*2048*4,
 	texlayout_xoffset_4(std::make_integer_sequence<uint32_t, 1024>()),
-	texlayout_yoffset_4
+	texlayout_yoffset_4(std::make_integer_sequence<uint32_t, 2048>())
 };
 
 

--- a/src/mame/snk/hng64.cpp
+++ b/src/mame/snk/hng64.cpp
@@ -29,40 +29,6 @@ Notes:
 
   * The Japanese text on the Roads Edge network screen says : "waiting to connect network... please wait without touching machine"
 
-  * Xrally and Roads Edge have a symbols table at respectively 0xb2f30 and 0xe10c0
-
-ToDo:
-  * Sprite garbage in Beast Busters: Second Nightmare, another irq issue?
-  * Samurai Shodown 64 2 puts "Press 1p & 2p button" msg in gameplay, known to be a MCU simulation issue, i/o port 4 doesn't
-    seem to be just an input port but controls program flow too.
-  * Work out the purpose of the interrupts and how many are needed.
-  * Correct game speed (seems too fast).
-
-  2d:
-  * Scroll (base registers?)
-  * ROZ (4th tilemap in fatal fury should be floor [in progress], background should zoom)
-  * Find registers to control tilemap mode (4bpp/8bpp, 8x8, 16x16)
-  * Fix zooming sprites (zoom registers not understood, center versus edge pivot)
-  * Priorities
-  * Is all the bitmap decoding right?
-  * Upgrade to modern video timing.
-
-  3d:
-  * Find where the remainder of the 3d display list information is 'hiding'
-    -- should the 3d 'ram' be treated like a fifo, instead of like RAM (see Dreamcast etc.)
-  * Remaining 3d bits - glowing, etc.
-  * Populate the display buffers
-  * Does the hng64 do perspective-correct texture mapping?  Doesn't look like it...
-
-  Other:
-  * Translate KL5C80 docs and finish up the implementation
-  * Figure out what IO $54 & $72 are on the communications CPU
-  * Fix sound
-  * Backup ram etc.
-  * Correct cpu speed
-  * How to use the FPGA data ('ROM1')
-
-
 ------------------------------------------------------------------------------
 Hyper NeoGeo 64, SNK 1997-1999
 Hardware info by Guru

--- a/src/mame/snk/hng64.h
+++ b/src/mame/snk/hng64.h
@@ -48,10 +48,7 @@ struct polygon
 
 	uint8_t texIndex = 0;             // Which texture to draw from (0x00-0x0f)
 	uint8_t tex4bpp = 0;              // How to index into the texture
-	uint8_t texPageSmall = 0;         // Does this polygon use 'small' texture pages?
-	uint8_t texPageHorizOffset = 0;   // If it does use small texture pages, how far is this page horizontally offset?
-	uint8_t texPageVertOffset = 0;    // If it does use small texture pages, how far is this page vertically offset?
-
+	uint16_t texPageSmall = 0;         // Does this polygon use 'small' texture pages?
 	uint32_t palOffset = 0;           // The base offset where this object's palette starts.
 	uint16_t colorIndex = 0;
 
@@ -85,9 +82,7 @@ struct hng64_poly_data
 {
 	uint8_t tex4bpp = 0;
 	uint8_t texIndex = 0;
-	uint8_t texPageSmall = 0;
-	uint8_t texPageHorizOffset = 0;
-	uint8_t texPageVertOffset = 0;
+	uint16_t texPageSmall = 0;
 	uint32_t palOffset = 0;
 	uint16_t colorIndex = 0;
 	bool blend = false;

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -1352,8 +1352,8 @@ void hng64_poly_renderer::render_texture_scanline(int32_t scanline, const extent
 				textureS = sCorrect * 1024.0f;
 				textureT = tCorrect * 1024.0f;
 
-				textureS += (renderData.texscrolly & 0x3fff)>>4;
-				textureT += (renderData.texscrollx & 0x3fff)>>4;
+				textureS += (renderData.texscrolly & 0x3fff)>>5;
+				textureT += (renderData.texscrollx & 0x3fff)>>5;
 
 
 #if 1

--- a/src/mame/snk/hng64_sprite.ipp
+++ b/src/mame/snk/hng64_sprite.ipp
@@ -47,7 +47,7 @@ do \
 	uint32_t srcdata = (SOURCE); \
 	if (xdrawpos <= cliprect.right() && xdrawpos >= cliprect.left()) \
 	{ \
-		if (zval <= (DESTZ)) \
+		if (zval < (DESTZ)) \
 		{ \
 			if (srcdata != trans_pen) \
 			{ \

--- a/src/mame/snk/hng64_sprite.ipp
+++ b/src/mame/snk/hng64_sprite.ipp
@@ -47,7 +47,7 @@ do \
 	uint32_t srcdata = (SOURCE); \
 	if (xdrawpos <= cliprect.right() && xdrawpos >= cliprect.left()) \
 	{ \
-		if (zval < (DESTZ)) \
+		if (zval <= (DESTZ)) \
 		{ \
 			if (srcdata != trans_pen) \
 			{ \
@@ -66,7 +66,7 @@ do \
 	uint32_t srcdata = (SOURCE); \
 	if (xdrawpos <= cliprect.right() && xdrawpos >= cliprect.left()) \
 	{ \
-		if (zval > (DESTZ)) \
+		if (zval >= (DESTZ)) \
 		{ \
 			if (srcdata != trans_pen) \
 			{ \
@@ -277,6 +277,7 @@ void hng64_state::draw_sprites_buffer(screen_device& screen, const rectangle& cl
 	{
 		uint16_t zval = (m_spriteram[(currentsprite * 8) + 2] & 0x07ff0000) >> 16;
 
+
 		int16_t ypos = (m_spriteram[(currentsprite * 8) + 0] & 0xffff0000) >> 16;
 		int16_t xpos = (m_spriteram[(currentsprite * 8) + 0] & 0x0000ffff) >> 0;
 
@@ -321,6 +322,22 @@ void hng64_state::draw_sprites_buffer(screen_device& screen, const rectangle& cl
 			currentsprite = nextsprite;
 			continue;
 		};
+
+		// skip the lowest sprite priority depending on the zsort mode
+		// it was previously assumed the default buffer fill would take care of this
+		// but unless there's a sign bit, the roadedge name entry screen disagrees as it
+		// requires a higher/lower or equal check on the sprite draw, not just higher/lower
+		if (zsort && (zval == 0))
+		{
+			currentsprite = nextsprite;
+			continue;
+		}
+
+		if (!zsort && (zval == 0x7ff))
+		{
+			currentsprite = nextsprite;
+			continue;
+		}
 
 		int32_t dx, dy;
 

--- a/src/mame/snk/hng64_sprite.ipp
+++ b/src/mame/snk/hng64_sprite.ipp
@@ -326,14 +326,10 @@ void hng64_state::draw_sprites_buffer(screen_device& screen, const rectangle& cl
 		// skip the lowest sprite priority depending on the zsort mode
 		// it was previously assumed the default buffer fill would take care of this
 		// but unless there's a sign bit, the roadedge name entry screen disagrees as it
-		// requires a higher/lower or equal check on the sprite draw, not just higher/lower
+		// requires a >= check on the sprite draw, not >
+		//
+		// for the non-zsort/zrev case, fatfurywa char selectappears requires <, not <=
 		if (zsort && (zval == 0))
-		{
-			currentsprite = nextsprite;
-			continue;
-		}
-
-		if (!zsort && (zval == 0x7ff))
 		{
 			currentsprite = nextsprite;
 			continue;

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -837,6 +837,9 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 	if (m_screen_dis)
 		return 0;
 
+	// Draw sprites to buffer for later mixing
+	draw_sprites_buffer(screen, cliprect);
+
 	// set during transitions, could be 'disable all palette output'?
 	if ((m_tcram[0x24 / 4] >> 16) & 0x0002)
 		return 0;
@@ -989,12 +992,6 @@ uint32_t hng64_state::screen_update_hng64(screen_device &screen, bitmap_rgb32 &b
 				mixsprites_test(screen, bitmap, cliprect, (i/4)<<12, y);
 		}
 	}
-
-	// Draw the sprites on top of everything
-	draw_sprites_buffer(screen, cliprect);
-
-
-
 
 #if HNG64_VIDEO_DEBUG
 	if (0)


### PR DESCRIPTION
- fixed name entry screen on roadedge
- don't buffer sprites (render them in the same update call as we use them)
- fix extra texture scroll (was double what it should have been), fixes some tv screens/billboards in roadedge
- some additional code safety on texture fetches
- minor refactoring to better facilitate further experiments