### PR TITLE
ddr/kc: fix DAC output on KC 85/2

### DIFF
--- a/src/mame/ddr/kc.h
+++ b/src/mame/ddr/kc.h
@@ -185,9 +185,6 @@ protected:
 	// CTC callback
 	DECLARE_WRITE_LINE_MEMBER( ctc_zc0_callback );
 
-	// PIO callback
-	void pio_portb_w(uint8_t data) override;
-
 	// sound
 	virtual void speaker_update();
 };

--- a/src/mame/ddr/kc.h
+++ b/src/mame/ddr/kc.h
@@ -222,11 +222,11 @@ protected:
 	void video_control_w(int data);
 
 	// PIO callback
-	void pio_portb_w(uint8_t data) override;
+	virtual void pio_portb_w(uint8_t data) override;
 
 	// sound
-	void dac_update() override;
-	void speaker_update() override;
+	virtual void dac_update() override;
+	virtual void speaker_update() override;
 
 	void kc85_4_mem(address_map &map) ATTR_COLD;
 	void kc85_4_io(address_map &map) ATTR_COLD;

--- a/src/mame/ddr/kc_m.cpp
+++ b/src/mame/ddr/kc_m.cpp
@@ -595,17 +595,6 @@ void kc_state::pio_portb_w(uint8_t data)
 	update_0x08000();
 
 	// KC 85/2..3: 5-bit DAC
-	m_dac_level = (~data & 0x1f)>>1;
-	dac_update();
-}
-
-void kc85_3_state::pio_portb_w(uint8_t data)
-{
-	m_pio_data[1] = data;
-
-	update_0x08000();
-
-	// KC 85/2..3: 5-bit DAC
 	m_dac_level = (~data & 0x1f);
 	dac_update();
 }


### PR DESCRIPTION
Remove an erroneous shift on the output data on KC 85/2. Since the DAC works the same way on 85/2 and 85/3, there is no need to maintain a separate function for handling PIO B writes on 85/3. Thanks to @ValleyBell for catching this.

I also tested using a `dac_byte_device` instead of a `speaker_sound_device`, which would save some more code. Unfortunately this introduces some additional sound artifacts which don't happen with the latter (and neither on actual hardware), so I have abandoned this idea for now.