### PR TITLE
taito/tnzs.cpp: Use a single view for RAM/ROM bank

### DIFF
--- a/src/mame/taito/tnzs.cpp
+++ b/src/mame/taito/tnzs.cpp
@@ -765,9 +765,11 @@ void kageki_state::csport_w(uint8_t data)
 void tnzs_base_state::prompal_main_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
-	map(0x8000, 0xbfff).bankr(m_mainrombank);
 	map(0x8000, 0xbfff).view(m_ramromview);
-	m_ramromview[0](0x8000, 0xbfff).bankrw(m_mainrambank);
+	for (int i = 0; 2 > i; ++i)
+		m_ramromview[i](0x8000, 0xbfff).ram(); // instead of the first two banks of ROM being repeated redundantly the hardware maps RAM here
+	for (int i = 2; 8 > i; ++i)
+		m_ramromview[i](0x8000, 0xbfff).rom().region("maincpu", 0x4000 * i);
 	map(0xc000, 0xcfff).rw(m_spritegen, FUNC(x1_001_device::spritecodelow_r8), FUNC(x1_001_device::spritecodelow_w8));
 	map(0xd000, 0xdfff).rw(m_spritegen, FUNC(x1_001_device::spritecodehigh_r8), FUNC(x1_001_device::spritecodehigh_w8));
 	map(0xe000, 0xefff).ram().share("share1"); // WORK RAM (shared by the 2 Z80's)

--- a/src/mame/taito/tnzs.h
+++ b/src/mame/taito/tnzs.h
@@ -46,9 +46,6 @@ protected:
 		: tnzs_video_state_base(mconfig, type, tag)
 		, m_subcpu(*this, "sub")
 		, m_subbank(*this, "subbank")
-		, m_mainrombank(*this, "rombank")
-		, m_mainrambank(*this, "rambank")
-		, m_bankedram(*this, "bankedram", 0x8000, ENDIANNESS_LITTLE)
 		, m_ramromview(*this, "ramrom")
 	{ }
 
@@ -70,9 +67,6 @@ protected:
 	required_memory_bank m_subbank;
 
 private:
-	required_memory_bank m_mainrombank;
-	required_memory_bank m_mainrambank;
-	memory_share_creator<uint8_t> m_bankedram;
 	memory_view m_ramromview;
 };
 

--- a/src/mame/taito/tnzs_m.cpp
+++ b/src/mame/taito/tnzs_m.cpp
@@ -348,18 +348,11 @@ void tnzs_base_state::machine_start()
 {
 	tnzs_video_state_base::machine_start();
 
-	uint8_t *const main = memregion("maincpu")->base();
-	m_mainrombank->configure_entries(0, 8, &main[0], 0x4000);
-	m_mainrombank->set_entry(2);
-
-	m_mainrambank->configure_entries(0, 2, &m_bankedram[0], 0x4000);
-	m_mainrambank->set_entry(0);
-
-	m_ramromview.disable();
-
 	uint8_t *const sub = memregion("sub")->base();
 	m_subbank->configure_entries(0, 4, &sub[0x08000], 0x2000);
 	m_subbank->set_entry(0);
+
+	m_ramromview.select(2);
 }
 
 void arknoid2_state::machine_start()
@@ -405,14 +398,7 @@ void tnzs_base_state::ramrom_bankswitch_w(uint8_t data)
 	m_subcpu->set_input_line(INPUT_LINE_RESET, BIT(data, 4) ? CLEAR_LINE : ASSERT_LINE);
 
 	// bits 0-2 select RAM/ROM bank
-	m_mainrombank->set_entry(data & 0x07);
-	m_mainrambank->set_entry(data & 0x01);
-
-	// instead of the first two banks of ROM being repeated redundantly the hardware maps RAM here
-	if (data & 0x06)
-		m_ramromview.disable();
-	else
-		m_ramromview.select(0);
+	m_ramromview.select(data & 0x07);
 }
 
 void arknoid2_state::bankswitch1_w(uint8_t data)


### PR DESCRIPTION
This reduces the total number of lines, but unfortunately it doesn’t work due to RAM installed in the same range in multiple view entries getting the same save state name.  It dies with a fatal error:
```
Duplicate save state registration entry (memory/:maincpu/0/8000-bfff)
Fatal error: 1 duplicate save state entries found.
```

@galibert surely this is supposed to be possible?