### PR TITLE
Lua engine: run everything in coroutines

### DIFF
--- a/plugins/console/init.lua
+++ b/plugins/console/init.lua
@@ -267,6 +267,7 @@ function console.startplugin()
 				end
 			else
 				cmdbuf = cmdbuf .. "\n" .. cmd
+				ln.historyadd(cmd)
 				local func, err = load(cmdbuf)
 				if not func then
 					if err:match("<eof>") then
@@ -276,14 +277,15 @@ function console.startplugin()
 						cmdbuf = ""
 					end
 				else
+					cmdbuf = ""
+					stopped = true
 					local status
 					status, err = pcall(func)
 					if not status then
 						print("error: ", err)
 					end
-					cmdbuf = ""
+					stopped = false
 				end
-				ln.historyadd(cmd)
 			end
 		end
 		conth:start(scr:gsub("$PROMPT", prompt))

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1073,7 +1073,7 @@ end
 				"-Wimplicit-fallthrough",
 			}
 			buildoptions {
-				"-Wno-unused-result", -- needed for fgets,fread on linux
+				"-Wno-error=unused-result", -- needed for fgets,fread on linux
 				-- array bounds checking seems to be buggy in 4.8.1 (try it on video/stvvdp1.c and video/model1.c without -Wno-array-bounds)
 				"-Wno-array-bounds",
 				"-Wno-error=attributes", -- GCC fails to recognize some uses of [[maybe_unused]]

--- a/src/devices/cpu/arm7/arm7drc.hxx
+++ b/src/devices/cpu/arm7/arm7drc.hxx
@@ -330,7 +330,7 @@ void arm7_cpu_device::code_compile_block(uint8_t mode, offs_t pc)
 	const opcode_desc *seqlast;
 	bool override = false;
 
-	g_profiler.start(PROFILER_DRC_COMPILE);
+	auto profile = g_profiler.start(PROFILER_DRC_COMPILE);
 
 	/* get a description of this sequence */
 	// TODO FIXME
@@ -418,7 +418,6 @@ void arm7_cpu_device::code_compile_block(uint8_t mode, offs_t pc)
 
 			/* end the sequence */
 			block.end();
-			g_profiler.stop();
 			succeeded = true;
 		}
 		catch (drcuml_block::abort_compilation &)

--- a/src/devices/cpu/dspp/dsppdrc.cpp
+++ b/src/devices/cpu/dspp/dsppdrc.cpp
@@ -187,7 +187,7 @@ void dspp_device::compile_block(offs_t pc)
 	const opcode_desc *seqhead, *seqlast;
 	int override = false;
 
-	g_profiler.start(PROFILER_DRC_COMPILE);
+	auto profile = g_profiler.start(PROFILER_DRC_COMPILE);
 
 	/* get a description of this sequence */
 	const opcode_desc *desclist = m_drcfe->describe_code(pc);
@@ -268,7 +268,6 @@ void dspp_device::compile_block(offs_t pc)
 
 			/* end the sequence */
 			block.end();
-			g_profiler.stop();
 			succeeded = true;
 		}
 		catch (drcuml_block::abort_compilation &)

--- a/src/devices/cpu/e132xs/e132xsdrc.cpp
+++ b/src/devices/cpu/e132xs/e132xsdrc.cpp
@@ -215,7 +215,7 @@ void hyperstone_device::code_compile_block(offs_t pc)
 	const opcode_desc *seqhead, *seqlast;
 	bool override = false;
 
-	g_profiler.start(PROFILER_DRC_COMPILE);
+	auto profile = g_profiler.start(PROFILER_DRC_COMPILE);
 
 	/* get a description of this sequence */
 	const opcode_desc *desclist = m_drcfe->describe_code(pc);
@@ -296,7 +296,6 @@ void hyperstone_device::code_compile_block(offs_t pc)
 
 			/* end the sequence */
 			block.end();
-			g_profiler.stop();
 			succeeded = true;
 		}
 		catch (drcuml_block::abort_compilation &)

--- a/src/devices/cpu/mips/mips3drc.cpp
+++ b/src/devices/cpu/mips/mips3drc.cpp
@@ -300,7 +300,7 @@ void mips3_device::code_compile_block(uint8_t mode, offs_t pc)
 	const opcode_desc *desclist;
 	bool override = false;
 
-	g_profiler.start(PROFILER_DRC_COMPILE);
+	auto profile = g_profiler.start(PROFILER_DRC_COMPILE);
 
 	/* get a description of this sequence */
 	desclist = m_drcfe->describe_code(pc);
@@ -395,7 +395,6 @@ void mips3_device::code_compile_block(uint8_t mode, offs_t pc)
 
 			/* end the sequence */
 			block.end();
-			g_profiler.stop();
 			succeeded = true;
 		}
 		catch (drcuml_block::abort_compilation &)

--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -381,7 +381,7 @@ void ppc_device::code_compile_block(uint8_t mode, offs_t pc)
 	const opcode_desc *desclist;
 	bool override = false;
 
-	g_profiler.start(PROFILER_DRC_COMPILE);
+	auto profile = g_profiler.start(PROFILER_DRC_COMPILE);
 
 	/* get a description of this sequence */
 	desclist = m_drcfe->describe_code(pc);
@@ -465,7 +465,6 @@ void ppc_device::code_compile_block(uint8_t mode, offs_t pc)
 
 			/* end the sequence */
 			block.end();
-			g_profiler.stop();
 			succeeded = true;
 		}
 		catch (drcuml_block::abort_compilation &)

--- a/src/devices/cpu/sh/sh.cpp
+++ b/src/devices/cpu/sh/sh.cpp
@@ -2343,7 +2343,7 @@ void sh_common_execution::code_compile_block(uint8_t mode, offs_t pc)
 	const opcode_desc *desclist;
 	bool override = false;
 
-	g_profiler.start(PROFILER_DRC_COMPILE);
+	auto profile = g_profiler.start(PROFILER_DRC_COMPILE);
 
 	/* get a description of this sequence */
 	desclist = get_desclist(pc);
@@ -2436,7 +2436,6 @@ void sh_common_execution::code_compile_block(uint8_t mode, offs_t pc)
 
 			/* end the sequence */
 			block.end();
-			g_profiler.stop();
 			succeeded = true;
 		}
 		catch (drcuml_block::abort_compilation &)

--- a/src/devices/cpu/unsp/unspdrc.cpp
+++ b/src/devices/cpu/unsp/unspdrc.cpp
@@ -154,7 +154,7 @@ void unsp_device::code_compile_block(offs_t pc)
 	const opcode_desc *seqhead, *seqlast;
 	bool override = false;
 
-	g_profiler.start(PROFILER_DRC_COMPILE);
+	auto profile = g_profiler.start(PROFILER_DRC_COMPILE);
 
 	/* get a description of this sequence */
 	const opcode_desc *desclist = m_drcfe->describe_code(pc);
@@ -230,7 +230,6 @@ void unsp_device::code_compile_block(offs_t pc)
 
 			/* end the sequence */
 			block.end();
-			g_profiler.stop();
 			succeeded = true;
 		}
 		catch (drcuml_block::abort_compilation &)

--- a/src/devices/video/epic12.cpp
+++ b/src/devices/video/epic12.cpp
@@ -757,7 +757,7 @@ void epic12_device::gfx_exec_w(address_space &space, offs_t offset, u32 data, u3
 	{
 		if (data & 1)
 		{
-			//g_profiler.start(PROFILER_USER1);
+			//auto profile = g_profiler.start(PROFILER_USER1);
 			// make sure we've not already got a request running
 			if (m_blitter_request)
 			{
@@ -784,7 +784,6 @@ void epic12_device::gfx_exec_w(address_space &space, offs_t offset, u32 data, u3
 			m_gfx_scroll_1_x_shadowcopy = m_gfx_scroll_1_x;
 			m_gfx_scroll_1_y_shadowcopy = m_gfx_scroll_1_y;
 			m_blitter_request = osd_work_item_queue(m_work_queue, blit_request_callback, (void*)this, 0);
-			//g_profiler.stop();
 		}
 	}
 }
@@ -796,7 +795,7 @@ void epic12_device::gfx_exec_w_unsafe(offs_t offset, u32 data, u32 mem_mask)
 	{
 		if (data & 1)
 		{
-			//g_profiler.start(PROFILER_USER1);
+			//auto profile = g_profiler.start(PROFILER_USER1);
 			// make sure we've not already got a request running
 			if (m_blitter_request)
 			{
@@ -821,7 +820,6 @@ void epic12_device::gfx_exec_w_unsafe(offs_t offset, u32 data, u32 mem_mask)
 			}
 
 			m_blitter_request = osd_work_item_queue(m_work_queue, blit_request_callback_unsafe, (void*)this, 0);
-			//g_profiler.stop();
 		}
 	}
 }

--- a/src/devices/video/gb_lcd.cpp
+++ b/src/devices/video/gb_lcd.cpp
@@ -1136,7 +1136,7 @@ void dmg_ppu_device::update_scanline(uint32_t cycles_to_go)
 		return;
 	}
 
-	g_profiler.start(PROFILER_VIDEO);
+	auto profile = g_profiler.start(PROFILER_VIDEO);
 
 	/* Make sure we're in mode 3 */
 	if ((LCDSTAT & 0x03) == 0x03)
@@ -1270,8 +1270,6 @@ void dmg_ppu_device::update_scanline(uint32_t cycles_to_go)
 			}
 		}
 	}
-
-	g_profiler.stop();
 }
 
 /* --- Super Game Boy Specific --- */
@@ -1425,7 +1423,7 @@ void sgb_ppu_device::refresh_border()
 
 void sgb_ppu_device::update_scanline(uint32_t cycles_to_go)
 {
-	g_profiler.start(PROFILER_VIDEO);
+	auto profile = g_profiler.start(PROFILER_VIDEO);
 
 	if ((LCDSTAT & 0x03) == 0x03)
 	{
@@ -1594,8 +1592,6 @@ void sgb_ppu_device::update_scanline(uint32_t cycles_to_go)
 			}
 		}
 	}
-
-	g_profiler.stop();
 }
 
 /* --- Game Boy Color Specific --- */
@@ -1715,7 +1711,7 @@ void cgb_ppu_device::update_sprites()
 
 void cgb_ppu_device::update_scanline(uint32_t cycles_to_go)
 {
-	g_profiler.start(PROFILER_VIDEO);
+	auto profile = g_profiler.start(PROFILER_VIDEO);
 
 	if ((LCDSTAT & 0x03) == 0x03)
 	{
@@ -1891,8 +1887,6 @@ void cgb_ppu_device::update_scanline(uint32_t cycles_to_go)
 			}
 		}
 	}
-
-	g_profiler.stop();
 }
 
 

--- a/src/devices/video/huc6260.cpp
+++ b/src/devices/video/huc6260.cpp
@@ -75,10 +75,9 @@ TIMER_CALLBACK_MEMBER(huc6260_device::update_events)
 	{
 		if ( m_pixel_clock == 0 )
 		{
-			g_profiler.start( PROFILER_VIDEO );
+			auto profile = g_profiler.start(PROFILER_VIDEO);
 			/* Get next pixel information */
 			m_pixel_data = m_next_pixel_data_cb();
-			g_profiler.stop();
 		}
 
 		bitmap_line[ h ] = m_palette[ m_pixel_data ] | m_greyscales;

--- a/src/devices/video/huc6261.cpp
+++ b/src/devices/video/huc6261.cpp
@@ -106,14 +106,12 @@ TIMER_CALLBACK_MEMBER(huc6261_device::update_events)
 	{
 		if ( m_pixel_clock == 0 )
 		{
-			g_profiler.start( PROFILER_VIDEO );
+			auto profile = g_profiler.start( PROFILER_VIDEO );
 			/* Get next pixel information */
 			m_pixel_data_a = m_huc6270_a->next_pixel();
 			m_pixel_data_b = m_huc6270_b->next_pixel();
 			apply_pal_offs(&m_pixel_data_a);
 			apply_pal_offs(&m_pixel_data_b);
-
-			g_profiler.stop();
 		}
 
 		bitmap_line[ h ] = yuv2rgb( m_palette[ m_pixel_data_a ] );

--- a/src/devices/video/mc6847.cpp
+++ b/src/devices/video/mc6847.cpp
@@ -279,7 +279,7 @@ std::string mc6847_friend_device::scanline_zone_string(scanline_zone zone) const
 TIMER_CALLBACK_MEMBER(mc6847_friend_device::change_horizontal_sync)
 {
 	bool line = (bool)param;
-	g_profiler.start(PROFILER_USER1);
+	auto profile1 = g_profiler.start(PROFILER_USER1);
 
 	// are we on a rising edge?
 	if (line && !m_horizontal_sync)
@@ -288,30 +288,32 @@ TIMER_CALLBACK_MEMBER(mc6847_friend_device::change_horizontal_sync)
 			logerror("%s: change_horizontal_sync():  Recording scanline\n", describe_context());
 
 		// first store the scanline
-		g_profiler.start(PROFILER_USER2);
-		switch((scanline_zone) m_logical_scanline_zone)
 		{
-			case SCANLINE_ZONE_TOP_BORDER:
-			case SCANLINE_ZONE_BOTTOM_BORDER:
-				record_border_scanline(m_physical_scanline);
-				break;
+			auto profile2 = g_profiler.start(PROFILER_USER2);
+			switch((scanline_zone) m_logical_scanline_zone)
+			{
+				case SCANLINE_ZONE_TOP_BORDER:
+				case SCANLINE_ZONE_BOTTOM_BORDER:
+					record_border_scanline(m_physical_scanline);
+					break;
 
-			case SCANLINE_ZONE_BODY:
-				m_recording_scanline = true;
-				if (m_partial_scanline_clocks > 0)
-					record_partial_body_scanline(m_physical_scanline, m_logical_scanline, m_partial_scanline_clocks, 228);
-				else
-					record_body_scanline(m_physical_scanline, m_logical_scanline);
-				m_recording_scanline = false;
-				break;
+				case SCANLINE_ZONE_BODY:
+					m_recording_scanline = true;
+					if (m_partial_scanline_clocks > 0)
+						record_partial_body_scanline(m_physical_scanline, m_logical_scanline, m_partial_scanline_clocks, 228);
+					else
+						record_body_scanline(m_physical_scanline, m_logical_scanline);
+					m_recording_scanline = false;
+					break;
 
-			case SCANLINE_ZONE_RETRACE:
-			case SCANLINE_ZONE_VBLANK:
-			case SCANLINE_ZONE_FRAME_END:
-				// do nothing
-				break;
+				case SCANLINE_ZONE_RETRACE:
+				case SCANLINE_ZONE_VBLANK:
+				case SCANLINE_ZONE_FRAME_END:
+					// do nothing
+					break;
+			}
+			// stop profiling USER2
 		}
-		g_profiler.stop();
 
 		// advance to next scanline
 		next_scanline();
@@ -335,8 +337,6 @@ TIMER_CALLBACK_MEMBER(mc6847_friend_device::change_horizontal_sync)
 		// call virtual function
 		horizontal_sync_changed(m_horizontal_sync);
 	}
-
-	g_profiler.stop();
 }
 
 

--- a/src/devices/video/ppu2c0x.cpp
+++ b/src/devices/video/ppu2c0x.cpp
@@ -1000,33 +1000,26 @@ void ppu2c0x_device::render_scanline()
 {
 	uint8_t line_priority[VISIBLE_SCREEN_WIDTH];
 
-	/* lets see how long it takes */
-	g_profiler.start(PROFILER_USER1);
+	// lets see how long it takes
+	auto profile = g_profiler.start(PROFILER_USER1);
 
-	/* clear the line priority for this scanline */
+	// clear the line priority for this scanline
 	memset(line_priority, 0, VISIBLE_SCREEN_WIDTH);
 
 	m_draw_phase = PPU_DRAW_BG;
 
-	/* see if we need to render the background */
+	// see if we need to render the background
 	if (m_regs[PPU_CONTROL1] & PPU_CONTROL1_BACKGROUND)
-	{
 		draw_background(line_priority);
-	}
 	else
-	{
 		draw_background_pen();
-	}
 
 	m_draw_phase = PPU_DRAW_OAM;
 
-	/* if sprites are on, draw them, but we call always to process them */
+	// if sprites are on, draw them, but we call always to process them
 	draw_sprites(line_priority);
 
 	m_draw_phase = PPU_DRAW_BG;
-
-	/* done updating, whew */
-	g_profiler.stop();
 }
 
 void ppu2c0x_device::scanline_increment_fine_ycounter()

--- a/src/devices/video/snes_ppu.cpp
+++ b/src/devices/video/snes_ppu.cpp
@@ -1254,7 +1254,7 @@ void snes_ppu_device::refresh_scanline( bitmap_rgb32 &bitmap, uint16_t curline )
 {
 	bool blurring = m_options.read_safe(0) & 0x01;
 
-	g_profiler.start(PROFILER_VIDEO);
+	auto profile = g_profiler.start(PROFILER_VIDEO);
 
 	cache_background();
 
@@ -1282,10 +1282,7 @@ void snes_ppu_device::refresh_scanline( bitmap_rgb32 &bitmap, uint16_t curline )
 		struct SNES_SCANLINE *below = &m_scanlines[SNES_SUBSCREEN];
 #if SNES_LAYER_DEBUG
 		if (dbg_video(curline))
-		{
-			g_profiler.stop();
 			return;
-		}
 
 		/* Toggle drawing of SNES_SUBSCREEN or SNES_MAINSCREEN */
 		if (m_debug_options.draw_subscreen)
@@ -1357,8 +1354,6 @@ void snes_ppu_device::refresh_scanline( bitmap_rgb32 &bitmap, uint16_t curline )
 			}
 		}
 	}
-
-	g_profiler.stop();
 }
 
 uint16_t snes_ppu_device::pixel(uint16_t x, SNES_SCANLINE *above, SNES_SCANLINE *below, uint8_t *window_above, uint8_t *window_below)

--- a/src/devices/video/voodoo.cpp
+++ b/src/devices/video/voodoo.cpp
@@ -2889,7 +2889,7 @@ void voodoo_1_device::recompute_video_memory_common(u32 config, u32 rowpixels)
 
 s32 voodoo_1_device::triangle()
 {
-	g_profiler.start(PROFILER_USER2);
+	auto profile = g_profiler.start(PROFILER_USER2);
 
 	// allocate polygon information now
 	auto &poly = m_renderer->alloc_poly();
@@ -3021,7 +3021,7 @@ s32 voodoo_1_device::triangle()
 	if (DEBUG_STATS)
 		m_stats.m_triangles++;
 
-	g_profiler.stop();
+	profile.stop();
 
 	if (LOG_REGISTERS)
 		logerror("cycles = %d\n", TRIANGLE_SETUP_CLOCKS + pixels);

--- a/src/emu/device.ipp
+++ b/src/emu/device.ipp
@@ -93,7 +93,7 @@ inline void device_t::logerror(Format &&fmt, Params &&... args) const
 {
 	if (m_machine != nullptr && m_machine->allow_logging())
 	{
-		g_profiler.start(PROFILER_LOGERROR);
+		auto profile = g_profiler.start(PROFILER_LOGERROR);
 
 		// dump to the buffer
 		m_string_buffer.clear();
@@ -103,8 +103,6 @@ inline void device_t::logerror(Format &&fmt, Params &&... args) const
 		m_string_buffer.put('\0');
 
 		m_machine->strlog(&m_string_buffer.vec()[0]);
-
-		g_profiler.stop();
 	}
 }
 

--- a/src/emu/drawgfxt.ipp
+++ b/src/emu/drawgfxt.ipp
@@ -421,7 +421,7 @@ while (0)
 template <typename BitmapType, typename FunctionClass>
 inline void gfx_element::drawgfx_core(BitmapType &dest, const rectangle &cliprect, u32 code, int flipx, int flipy, s32 destx, s32 desty, FunctionClass pixel_op)
 {
-	g_profiler.start(PROFILER_DRAWGFX);
+	auto profile = g_profiler.start(PROFILER_DRAWGFX);
 	do {
 		assert(dest.valid());
 		assert(dest.cliprect().contains(cliprect));
@@ -551,14 +551,13 @@ inline void gfx_element::drawgfx_core(BitmapType &dest, const rectangle &cliprec
 			}
 		}
 	} while (0);
-	g_profiler.stop();
 }
 
 
 template <typename BitmapType, typename PriorityType, typename FunctionClass>
 inline void gfx_element::drawgfx_core(BitmapType &dest, const rectangle &cliprect, u32 code, int flipx, int flipy, s32 destx, s32 desty, PriorityType &priority, FunctionClass pixel_op)
 {
-	g_profiler.start(PROFILER_DRAWGFX);
+	auto profile = g_profiler.start(PROFILER_DRAWGFX);
 	do {
 		assert(dest.valid());
 		assert(priority.valid());
@@ -695,7 +694,6 @@ inline void gfx_element::drawgfx_core(BitmapType &dest, const rectangle &cliprec
 			}
 		}
 	} while (0);
-	g_profiler.stop();
 }
 
 
@@ -724,7 +722,7 @@ inline void gfx_element::drawgfx_core(BitmapType &dest, const rectangle &cliprec
 template <typename BitmapType, typename FunctionClass>
 inline void gfx_element::drawgfxzoom_core(BitmapType &dest, const rectangle &cliprect, u32 code, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, FunctionClass pixel_op)
 {
-	g_profiler.start(PROFILER_DRAWGFX);
+	auto profile = g_profiler.start(PROFILER_DRAWGFX);
 	do {
 		assert(dest.valid());
 		assert(dest.cliprect().contains(cliprect));
@@ -830,14 +828,13 @@ inline void gfx_element::drawgfxzoom_core(BitmapType &dest, const rectangle &cli
 			}
 		}
 	} while (0);
-	g_profiler.stop();
 }
 
 
 template <typename BitmapType, typename PriorityType, typename FunctionClass>
 inline void gfx_element::drawgfxzoom_core(BitmapType &dest, const rectangle &cliprect, u32 code, int flipx, int flipy, s32 destx, s32 desty, u32 scalex, u32 scaley, PriorityType &priority, FunctionClass pixel_op)
 {
-	g_profiler.start(PROFILER_DRAWGFX);
+	auto profile = g_profiler.start(PROFILER_DRAWGFX);
 	do {
 		assert(dest.valid());
 		assert(priority.valid());
@@ -877,10 +874,7 @@ inline void gfx_element::drawgfxzoom_core(BitmapType &dest, const rectangle &cli
 		// compute final pixel in Y and exit if we are entirely clipped
 		s32 destendy = desty + dstheight - 1;
 		if (desty > cliprect.bottom() || destendy < cliprect.top())
-		{
-			g_profiler.stop();
 			return;
-		}
 
 		// apply top clip
 		s32 srcy = 0;
@@ -950,7 +944,6 @@ inline void gfx_element::drawgfxzoom_core(BitmapType &dest, const rectangle &cli
 			}
 		}
 	} while (0);
-	g_profiler.stop();
 }
 
 
@@ -975,7 +968,7 @@ inline void gfx_element::drawgfxzoom_core(BitmapType &dest, const rectangle &cli
 template <typename BitmapType, typename FunctionClass>
 inline void copybitmap_core(BitmapType &dest, const BitmapType &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, FunctionClass pixel_op)
 {
-	g_profiler.start(PROFILER_COPYBITMAP);
+	auto profile = g_profiler.start(PROFILER_COPYBITMAP);
 	do {
 		assert(dest.valid());
 		assert(src.valid());
@@ -1108,14 +1101,13 @@ inline void copybitmap_core(BitmapType &dest, const BitmapType &src, int flipx, 
 			}
 		}
 	} while (0);
-	g_profiler.stop();
 }
 
 
 template <typename BitmapType, typename PriorityType, typename FunctionClass>
 inline void copybitmap_core(BitmapType &dest, const BitmapType &src, int flipx, int flipy, s32 destx, s32 desty, const rectangle &cliprect, PriorityType &priority, FunctionClass pixel_op)
 {
-	g_profiler.start(PROFILER_COPYBITMAP);
+	auto profile = g_profiler.start(PROFILER_COPYBITMAP);
 	do {
 		assert(dest.valid());
 		assert(src.valid());
@@ -1255,7 +1247,6 @@ inline void copybitmap_core(BitmapType &dest, const BitmapType &src, int flipx, 
 			}
 		}
 	} while (0);
-	g_profiler.stop();
 }
 
 
@@ -1283,7 +1274,7 @@ inline void copybitmap_core(BitmapType &dest, const BitmapType &src, int flipx, 
 template <typename BitmapType, typename FunctionClass>
 inline void copyrozbitmap_core(BitmapType &dest, const rectangle &cliprect, const BitmapType &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, bool wraparound, FunctionClass pixel_op)
 {
-	g_profiler.start(PROFILER_COPYBITMAP);
+	auto profile = g_profiler.start(PROFILER_COPYBITMAP);
 
 	assert(dest.valid());
 	assert(dest.valid());
@@ -1293,10 +1284,7 @@ inline void copyrozbitmap_core(BitmapType &dest, const rectangle &cliprect, cons
 
 	// ignore empty/invalid cliprects
 	if (cliprect.empty())
-	{
-		g_profiler.stop();
 		return;
-	}
 
 	// compute fixed-point 16.16 size of the source bitmap
 	u32 srcfixwidth = src.width() << 16;
@@ -1537,14 +1525,13 @@ inline void copyrozbitmap_core(BitmapType &dest, const rectangle &cliprect, cons
 			}
 		}
 	}
-	g_profiler.stop();
 }
 
 
 template <typename BitmapType, typename PriorityType, typename FunctionClass>
 inline void copyrozbitmap_core(BitmapType &dest, const rectangle &cliprect, const BitmapType &src, s32 startx, s32 starty, s32 incxx, s32 incxy, s32 incyx, s32 incyy, bool wraparound, PriorityType &priority, FunctionClass pixel_op)
 {
-	g_profiler.start(PROFILER_COPYBITMAP);
+	auto profile = g_profiler.start(PROFILER_COPYBITMAP);
 
 	assert(dest.valid());
 	assert(dest.valid());
@@ -1555,10 +1542,7 @@ inline void copyrozbitmap_core(BitmapType &dest, const rectangle &cliprect, cons
 
 	// ignore empty/invalid cliprects
 	if (cliprect.empty())
-	{
-		g_profiler.stop();
 		return;
-	}
 
 	// compute fixed-point 16.16 size of the source bitmap
 	u32 srcfixwidth = src.width() << 16;
@@ -1811,7 +1795,6 @@ inline void copyrozbitmap_core(BitmapType &dest, const rectangle &cliprect, cons
 			}
 		}
 	}
-	g_profiler.stop();
 }
 
 

--- a/src/emu/input.cpp
+++ b/src/emu/input.cpp
@@ -466,42 +466,38 @@ osd::input_device &input_manager::add_device(input_device_class devclass, std::s
 
 s32 input_manager::code_value(input_code code)
 {
-	g_profiler.start(PROFILER_INPUT);
-	s32 result = 0;
+	auto profile = g_profiler.start(PROFILER_INPUT);
 
-	// dummy loop to allow clean early exits
-	do
+	// return 0 for any invalid devices
+	input_device *const device = device_from_code(code);
+	if (!device)
+		return 0;
+
+	// also return 0 if the device class is disabled
+	input_class &devclass = *m_class[code.device_class()];
+	if (!devclass.enabled())
+		return 0;
+
+	// if this is not a multi device, only return data for item 0 and iterate over all
+	int startindex = code.device_index();
+	int stopindex = startindex;
+	if (!devclass.multi())
 	{
-		// return 0 for any invalid devices
-		input_device *device = device_from_code(code);
-		if (device == nullptr)
-			break;
+		if (startindex != 0)
+			return 0;
+		stopindex = devclass.maxindex();
+	}
 
-		// also return 0 if the device class is disabled
-		input_class &devclass = *m_class[code.device_class()];
-		if (!devclass.enabled())
-			break;
-
-		// if this is not a multi device, only return data for item 0 and iterate over all
-		int startindex = code.device_index();
-		int stopindex = startindex;
-		if (!devclass.multi())
+	// iterate over all device indices
+	s32 result = 0;
+	input_item_class targetclass = code.item_class();
+	for (int curindex = startindex; curindex <= stopindex; curindex++)
+	{
+		// lookup the item for the appropriate index
+		code.set_device_index(curindex);
+		input_device_item *const item = item_from_code(code);
+		if (item)
 		{
-			if (startindex != 0)
-				break;
-			stopindex = devclass.maxindex();
-		}
-
-		// iterate over all device indices
-		input_item_class targetclass = code.item_class();
-		for (int curindex = startindex; curindex <= stopindex; curindex++)
-		{
-			// lookup the item for the appropriate index
-			code.set_device_index(curindex);
-			input_device_item *item = item_from_code(code);
-			if (item == nullptr)
-				continue;
-
 			// process items according to their native type
 			switch (targetclass)
 			{
@@ -522,10 +518,8 @@ s32 input_manager::code_value(input_code code)
 				break;
 			}
 		}
-	} while (0);
+	}
 
-	// stop the profiler before exiting
-	g_profiler.stop();
 	return result;
 }
 

--- a/src/emu/ioport.cpp
+++ b/src/emu/ioport.cpp
@@ -2134,7 +2134,7 @@ void ioport_manager::frame_update_callback()
 
 void ioport_manager::frame_update()
 {
-	g_profiler.start(PROFILER_INPUT);
+	auto profile = g_profiler.start(PROFILER_INPUT);
 
 	// record/playback information about the current frame
 	attotime curtime = machine().time();
@@ -2171,8 +2171,6 @@ void ioport_manager::frame_update()
 			if (dynfield.field().type() != IPT_OUTPUT)
 				dynfield.write(newvalue);
 	}
-
-	g_profiler.stop();
 }
 
 

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -323,7 +323,7 @@ int running_machine::run(bool quiet)
 		// run the CPUs until a reset or exit
 		while ((!m_hard_reset_pending && !m_exit_pending) || m_saveload_schedule != saveload_schedule::NONE)
 		{
-			g_profiler.start(PROFILER_EXTRA);
+			auto profile = g_profiler.start(PROFILER_EXTRA);
 
 			// execute CPUs if not paused
 			if (!m_paused)
@@ -335,8 +335,6 @@ int running_machine::run(bool quiet)
 			// handle save/load
 			if (m_saveload_schedule != saveload_schedule::NONE)
 				handle_saveload();
-
-			g_profiler.stop();
 		}
 		m_manager.http()->clear();
 
@@ -1299,7 +1297,7 @@ void running_machine::emscripten_main_loop()
 {
 	running_machine *machine = emscripten_running_machine;
 
-	g_profiler.start(PROFILER_EXTRA);
+	auto profile = g_profiler.start(PROFILER_EXTRA);
 
 	// execute CPUs if not paused
 	if (!machine->m_paused)
@@ -1332,8 +1330,6 @@ void running_machine::emscripten_main_loop()
 	{
 		emscripten_cancel_main_loop();
 	}
-
-	g_profiler.stop();
 }
 
 void running_machine::emscripten_set_running_machine(running_machine *machine)

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -397,7 +397,7 @@ inline void running_machine::logerror(Format &&fmt, Params &&... args) const
 	// process only if there is a target
 	if (allow_logging())
 	{
-		g_profiler.start(PROFILER_LOGERROR);
+		auto profile = g_profiler.start(PROFILER_LOGERROR);
 
 		// dump to the buffer
 		m_string_buffer.clear();
@@ -406,9 +406,7 @@ inline void running_machine::logerror(Format &&fmt, Params &&... args) const
 		m_string_buffer.put('\0');
 
 		strlog(&m_string_buffer.vec()[0]);
-
-		g_profiler.stop();
 	}
 }
 
-#endif  /* MAME_EMU_MACHINE_H */
+#endif // MAME_EMU_MACHINE_H

--- a/src/emu/profiler.cpp
+++ b/src/emu/profiler.cpp
@@ -91,6 +91,8 @@ real_profiler_state::real_profiler_state()
 
 void real_profiler_state::reset(bool enabled)
 {
+	assert(!m_filoptr || (m_filoptr == m_filo));
+
 	m_text_time = attotime::never;
 
 	if (enabled)
@@ -117,10 +119,10 @@ void real_profiler_state::reset(bool enabled)
 
 const char *real_profiler_state::text(running_machine &machine)
 {
-	start(PROFILER_PROFILER);
+	auto profile = start(PROFILER_PROFILER);
 
 	// get the current time
-	attotime current_time = machine.scheduler().time();
+	attotime const current_time = machine.scheduler().time();
 
 	// we only want to update the text periodically
 	if ((m_text_time == attotime::never) || ((current_time - m_text_time).as_double() >= TEXT_UPDATE_TIME))
@@ -129,7 +131,6 @@ const char *real_profiler_state::text(running_machine &machine)
 		m_text_time = current_time;
 	}
 
-	stop();
 	return m_text.c_str();
 }
 

--- a/src/emu/recording.cpp
+++ b/src/emu/recording.cpp
@@ -222,14 +222,13 @@ bool avi_movie_recording::append_single_video_frame(bitmap_rgb32 &bitmap, const 
 
 bool avi_movie_recording::add_sound_to_recording(const s16 *sound, int numsamples)
 {
-	g_profiler.start(PROFILER_MOVIE_REC);
+	auto profile = g_profiler.start(PROFILER_MOVIE_REC);
 
 	// write the next frame
 	avi_file::error avierr = m_avi_file->append_sound_samples(0, sound + 0, numsamples, 1);
 	if (avierr == avi_file::error::NONE)
 		avierr = m_avi_file->append_sound_samples(1, sound + 1, numsamples, 1);
 
-	g_profiler.stop();
 	return avierr == avi_file::error::NONE;
 }
 

--- a/src/emu/schedule.cpp
+++ b/src/emu/schedule.cpp
@@ -445,7 +445,7 @@ void device_scheduler::timeslice()
 					// if we're not suspended, actually execute
 					if (exec->m_suspend == 0)
 					{
-						g_profiler.start(exec->m_profiler);
+						auto profile = g_profiler.start(exec->m_profiler);
 
 						// note that this global variable cycles_stolen can be modified
 						// via the call to cpu_execute
@@ -466,7 +466,6 @@ void device_scheduler::timeslice()
 						ran -= *exec->m_icountptr;
 						assert(ran >= exec->m_cycles_stolen);
 						ran -= exec->m_cycles_stolen;
-						g_profiler.stop();
 					}
 
 					// account for these cycles
@@ -944,15 +943,13 @@ inline void device_scheduler::execute_timers()
 		// call the callback
 		if (was_enabled)
 		{
-			g_profiler.start(PROFILER_TIMER_CALLBACK);
+			auto profile = g_profiler.start(PROFILER_TIMER_CALLBACK);
 
 			if (!timer.m_callback.isnull())
 			{
 				LOG("execute_timers: timer callback %s\n", timer.m_callback.name());
 				timer.m_callback(timer.m_param);
 			}
-
-			g_profiler.stop();
 		}
 
 		// reset or remove the timer, but only if it wasn't modified during the callback

--- a/src/emu/schedule.cpp
+++ b/src/emu/schedule.cpp
@@ -704,6 +704,7 @@ void device_scheduler::postload()
 			assert(!timer.expire().is_never());
 
 			// temporary timers go away entirely (except our special never-expiring one)
+			timer.m_callback.reset();
 			m_timer_allocator.reclaim(timer_list_remove(timer));
 		}
 		else
@@ -965,6 +966,7 @@ inline void device_scheduler::execute_timers()
 			else
 			{
 				// otherwise, remove it now
+				timer.m_callback.reset();
 				m_timer_allocator.reclaim(timer_list_remove(timer));
 			}
 		}

--- a/src/emu/screen.cpp
+++ b/src/emu/screen.cpp
@@ -1183,48 +1183,49 @@ bool screen_device::update_partial(int scanline)
 
 	// otherwise, render
 	LOG_PARTIAL_UPDATES(("updating %d-%d\n", clip.top(), clip.bottom()));
-	g_profiler.start(PROFILER_VIDEO);
 
 	u32 flags = 0;
-	if (m_video_attributes & VIDEO_VARIABLE_WIDTH)
 	{
-		rectangle scan_clip(clip);
-		for (int y = clip.top(); y <= clip.bottom(); y++)
+		auto profile = g_profiler.start(PROFILER_VIDEO);
+		if (m_video_attributes & VIDEO_VARIABLE_WIDTH)
 		{
-			scan_clip.sety(y, y);
-			pre_update_scanline(y);
-
-			screen_bitmap &curbitmap = m_bitmap[m_curbitmap];
-			switch (curbitmap.format())
+			rectangle scan_clip(clip);
+			for (int y = clip.top(); y <= clip.bottom(); y++)
 			{
-				default:
-				case BITMAP_FORMAT_IND16:   flags |= m_screen_update_ind16(*this, *(bitmap_ind16 *)m_scan_bitmaps[m_curbitmap][y], scan_clip);   break;
-				case BITMAP_FORMAT_RGB32:   flags |= m_screen_update_rgb32(*this, *(bitmap_rgb32 *)m_scan_bitmaps[m_curbitmap][y], scan_clip);   break;
-			}
+				scan_clip.sety(y, y);
+				pre_update_scanline(y);
 
-			m_partial_updates_this_frame++;
-		}
-	}
-	else
-	{
-		if (m_type != SCREEN_TYPE_SVG)
-		{
-			screen_bitmap &curbitmap = m_bitmap[m_curbitmap];
-			switch (curbitmap.format())
-			{
-				default:
-				case BITMAP_FORMAT_IND16:   flags = m_screen_update_ind16(*this, curbitmap.as_ind16(), clip);   break;
-				case BITMAP_FORMAT_RGB32:   flags = m_screen_update_rgb32(*this, curbitmap.as_rgb32(), clip);   break;
+				screen_bitmap &curbitmap = m_bitmap[m_curbitmap];
+				switch (curbitmap.format())
+				{
+					default:
+					case BITMAP_FORMAT_IND16:   flags |= m_screen_update_ind16(*this, *(bitmap_ind16 *)m_scan_bitmaps[m_curbitmap][y], scan_clip);   break;
+					case BITMAP_FORMAT_RGB32:   flags |= m_screen_update_rgb32(*this, *(bitmap_rgb32 *)m_scan_bitmaps[m_curbitmap][y], scan_clip);   break;
+				}
+
+				m_partial_updates_this_frame++;
 			}
 		}
 		else
 		{
-			flags = m_svg->render(*this, m_bitmap[m_curbitmap].as_rgb32(), clip);
+			if (m_type != SCREEN_TYPE_SVG)
+			{
+				screen_bitmap &curbitmap = m_bitmap[m_curbitmap];
+				switch (curbitmap.format())
+				{
+					default:
+					case BITMAP_FORMAT_IND16:   flags = m_screen_update_ind16(*this, curbitmap.as_ind16(), clip);   break;
+					case BITMAP_FORMAT_RGB32:   flags = m_screen_update_rgb32(*this, curbitmap.as_rgb32(), clip);   break;
+				}
+			}
+			else
+			{
+				flags = m_svg->render(*this, m_bitmap[m_curbitmap].as_rgb32(), clip);
+			}
+			m_partial_updates_this_frame++;
 		}
-		m_partial_updates_this_frame++;
+		// stop profiling
 	}
-
-	g_profiler.stop();
 
 	// if we modified the bitmap, we have to commit
 	m_changed |= ~flags & UPDATE_HAS_NOT_CHANGED;
@@ -1296,7 +1297,7 @@ void screen_device::update_now()
 			// if there's something to draw, do it
 			if (!clip.empty())
 			{
-				g_profiler.start(PROFILER_VIDEO);
+				auto profile = g_profiler.start(PROFILER_VIDEO);
 
 				u32 flags = 0;
 				screen_bitmap &curbitmap = m_bitmap[m_curbitmap];
@@ -1320,7 +1321,6 @@ void screen_device::update_now()
 					}
 				}
 
-				g_profiler.stop();
 				m_partial_updates_this_frame++;
 
 				// if we modified the bitmap, we have to commit
@@ -1349,7 +1349,7 @@ void screen_device::update_now()
 		// and if there's something to draw, do it
 		if (!clip.empty())
 		{
-			g_profiler.start(PROFILER_VIDEO);
+			auto profile = g_profiler.start(PROFILER_VIDEO);
 
 			LOG_PARTIAL_UPDATES(("doing scanline partial draw: Y %d X %d-%d\n", clip.bottom(), clip.left(), clip.right()));
 
@@ -1376,7 +1376,6 @@ void screen_device::update_now()
 			}
 
 			m_partial_updates_this_frame++;
-			g_profiler.stop();
 
 			// if we modified the bitmap, we have to commit
 			m_changed |= ~flags & UPDATE_HAS_NOT_CHANGED;

--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -712,7 +712,7 @@ read_stream_view sound_stream::update_view(attotime start, attotime end, u32 out
 	if (start > end)
 		start = end;
 
-	g_profiler.start(PROFILER_SOUND);
+	auto profile = g_profiler.start(PROFILER_SOUND);
 
 	// reposition our start to coincide with the current buffer end
 	attotime update_start = m_output[outputnum].end_time();
@@ -760,7 +760,6 @@ read_stream_view sound_stream::update_view(attotime start, attotime end, u32 out
 #endif
 		}
 	}
-	g_profiler.stop();
 
 	// return the requested view
 	return read_stream_view(m_output_view[outputnum], start);
@@ -1482,7 +1481,7 @@ void sound_manager::update(int param)
 {
 	LOG("sound_update\n");
 
-	g_profiler.start(PROFILER_SOUND);
+	auto profile = g_profiler.start(PROFILER_SOUND);
 
 	// determine the duration of this update
 	attotime update_period = machine().time() - m_last_update;
@@ -1618,6 +1617,4 @@ void sound_manager::update(int param)
 
 	// notify that new samples have been generated
 	emulator_info::sound_hook();
-
-	g_profiler.stop();
 }

--- a/src/emu/tilemap.cpp
+++ b/src/emu/tilemap.cpp
@@ -772,7 +772,7 @@ void tilemap_t::pixmap_update()
 	if (m_all_tiles_clean)
 		return;
 
-g_profiler.start(PROFILER_TILEMAP_DRAW);
+	auto profile = g_profiler.start(PROFILER_TILEMAP_DRAW);
 
 	// flush the dirty state to all tiles as appropriate
 	realize_all_dirty_tiles();
@@ -786,8 +786,6 @@ g_profiler.start(PROFILER_TILEMAP_DRAW);
 
 	// mark it all clean
 	m_all_tiles_clean = true;
-
-g_profiler.stop();
 }
 
 
@@ -797,7 +795,7 @@ g_profiler.stop();
 
 void tilemap_t::tile_update(logical_index logindex, u32 col, u32 row)
 {
-g_profiler.start(PROFILER_TILEMAP_UPDATE);
+	auto profile = g_profiler.start(PROFILER_TILEMAP_UPDATE);
 
 	// call the get info callback for the associated memory index
 	tilemap_memory_index memindex = m_logical_to_memory[logindex];
@@ -822,8 +820,6 @@ g_profiler.start(PROFILER_TILEMAP_UPDATE);
 		m_gfx_used |= 1 << m_tileinfo.gfxnum;
 		m_gfx_dirtyseq[m_tileinfo.gfxnum] = m_tileinfo.decoder->gfx(m_tileinfo.gfxnum)->dirtyseq();
 	}
-
-g_profiler.stop();
 }
 
 
@@ -997,7 +993,8 @@ void tilemap_t::draw_common(screen_device &screen, _BitmapClass &dest, const rec
 	if (!m_enable)
 		return;
 
-g_profiler.start(PROFILER_TILEMAP_DRAW);
+	auto profile = g_profiler.start(PROFILER_TILEMAP_DRAW);
+
 	// configure the blit parameters based on the input parameters
 	blit_parameters blit;
 	configure_blit_parameters(blit, screen.priority(), cliprect, flags, priority, priority_mask);
@@ -1095,7 +1092,6 @@ g_profiler.start(PROFILER_TILEMAP_DRAW);
 			}
 		}
 	}
-g_profiler.stop();
 }
 
 void tilemap_t::draw(screen_device &screen, bitmap_ind16 &dest, const rectangle &cliprect, u32 flags, u8 priority, u8 priority_mask)
@@ -1134,7 +1130,8 @@ void tilemap_t::draw_roz_common(screen_device &screen, _BitmapClass &dest, const
 		return;
 	}
 
-g_profiler.start(PROFILER_TILEMAP_DRAW_ROZ);
+	auto profile = g_profiler.start(PROFILER_TILEMAP_DRAW_ROZ);
+
 	// configure the blit parameters
 	blit_parameters blit;
 	configure_blit_parameters(blit, screen.priority(), cliprect, flags, priority, priority_mask);
@@ -1146,7 +1143,6 @@ g_profiler.start(PROFILER_TILEMAP_DRAW_ROZ);
 
 	// then do the roz copy
 	draw_roz_core(screen, dest, blit, startx, starty, incxx, incxy, incyx, incyy, wraparound);
-g_profiler.stop();
 }
 
 void tilemap_t::draw_roz(screen_device &screen, bitmap_ind16 &dest, const rectangle &cliprect,

--- a/src/emu/uiinput.cpp
+++ b/src/emu/uiinput.cpp
@@ -254,7 +254,7 @@ bool ui_input_manager::pressed_repeat(int code, int speed)
 {
 	bool pressed;
 
-g_profiler.start(PROFILER_INPUT);
+	auto profile = g_profiler.start(PROFILER_INPUT);
 
 	/* get the status of this key (assumed to be only in the defaults) */
 	assert(code > IPT_UI_FIRST && code < IPT_UI_LAST);
@@ -288,8 +288,6 @@ g_profiler.start(PROFILER_INPUT);
 	/* if we're not pressed, reset the memory field */
 	else
 		m_next_repeat[code] = 0;
-
-g_profiler.stop();
 
 	return pressed;
 }

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -239,9 +239,10 @@ void video_manager::frame_update(bool from_debugger)
 		update_throttle(current_time);
 
 	// ask the OSD to update
-	g_profiler.start(PROFILER_BLIT);
-	machine().osd().update(!from_debugger && skipped_it);
-	g_profiler.stop();
+	{
+		auto profile = g_profiler.start(PROFILER_BLIT);
+		machine().osd().update(!from_debugger && skipped_it);
+	}
 
 	// we synchronize after rendering instead of before, if low latency mode is enabled
 	if (!from_debugger && phase > machine_phase::INIT && m_low_latency && effective_throttle())
@@ -806,7 +807,7 @@ osd_ticks_t video_manager::throttle_until_ticks(osd_ticks_t target_ticks)
 	bool const allowed_to_sleep = (machine().options().sleep() && (!effective_autoframeskip() || effective_frameskip() == 0)) || machine().paused();
 
 	// loop until we reach our target
-	g_profiler.start(PROFILER_IDLE);
+	auto profile = g_profiler.start(PROFILER_IDLE);
 	osd_ticks_t current_ticks = osd_ticks();
 	while (current_ticks < target_ticks)
 	{
@@ -842,7 +843,6 @@ osd_ticks_t video_manager::throttle_until_ticks(osd_ticks_t target_ticks)
 		}
 		current_ticks = new_ticks;
 	}
-	g_profiler.stop();
 
 	return current_ticks;
 }
@@ -1233,7 +1233,7 @@ void video_manager::record_frame()
 		return;
 
 	// start the profiler and get the current time
-	g_profiler.start(PROFILER_MOVIE_REC);
+	auto profile = g_profiler.start(PROFILER_MOVIE_REC);
 	attotime curtime = machine().time();
 
 	bool error = false;
@@ -1252,7 +1252,6 @@ void video_manager::record_frame()
 
 	if (error)
 		end_recording();
-	g_profiler.stop();
 }
 
 

--- a/src/frontend/mame/luaengine.h
+++ b/src/frontend/mame/luaengine.h
@@ -124,20 +124,11 @@ public:
 	template <typename Func, typename... Params>
 	sol::protected_function_result invoke(Func &&func, Params&&... args)
 	{
-		g_profiler.start(PROFILER_LUA);
-		try
-		{
-			sol::thread th = sol::thread::create(m_lua_state);
-			sol::coroutine cr(th.state(), std::forward<Func>(func));
-			auto result = cr(std::forward<Params>(args)...);
-			g_profiler.stop();
-			return result;
-		}
-		catch (...)
-		{
-			g_profiler.stop();
-			throw;
-		}
+		auto profile = g_profiler.start(PROFILER_LUA);
+
+		sol::thread th = sol::thread::create(m_lua_state);
+		sol::coroutine cr(th.state(), std::forward<Func>(func));
+		return cr(std::forward<Params>(args)...);
 	}
 
 private:

--- a/src/frontend/mame/luaengine.h
+++ b/src/frontend/mame/luaengine.h
@@ -123,12 +123,14 @@ public:
 	sol::state_view &sol() const { return *m_sol_state; }
 
 	template <typename Func, typename... Params>
-	static std::decay_t<std::invoke_result_t<Func, Params...> > invoke(Func &&func, Params&&... args)
+	sol::protected_function_result invoke(Func &&func, Params&&... args)
 	{
 		g_profiler.start(PROFILER_LUA);
 		try
 		{
-			auto result = func(std::forward<Params>(args)...);
+			sol::thread th = sol::thread::create(m_lua_state);
+			sol::coroutine cr(th.state(), std::forward<Func>(func));
+			auto result = cr(std::forward<Params>(args)...);
 			g_profiler.stop();
 			return result;
 		}

--- a/src/frontend/mame/luaengine.h
+++ b/src/frontend/mame/luaengine.h
@@ -57,9 +57,8 @@ public:
 	std::pair<bool, std::optional<long> > menu_callback(const std::string &menu, int index, const std::string &event);
 
 	void set_machine(running_machine *machine);
-	std::vector<std::string> &get_menu() { return m_menu; }
+	std::vector<std::string> const &get_menu() { return m_menu; }
 	void attach_notifiers();
-	void on_frame_done();
 	void on_sound_update();
 	void on_periodic();
 	bool on_missing_mandatory_image(const std::string &instance_name);
@@ -168,6 +167,9 @@ private:
 	running_machine *m_machine;
 
 	std::vector<std::string> m_menu;
+
+	std::vector<int> m_update_tasks;
+	std::vector<int> m_frame_tasks;
 
 	template <typename R, typename T, typename D>
 	auto make_simple_callback_setter(void (T::*setter)(delegate<R ()> &&), D &&dflt, const char *name, const char *desc);

--- a/src/frontend/mame/luaengine.ipp
+++ b/src/frontend/mame/luaengine.ipp
@@ -585,7 +585,7 @@ template <typename R, typename T, typename D>
 auto lua_engine::make_simple_callback_setter(void (T::*setter)(delegate<R ()> &&), D &&dflt, const char *name, const char *desc)
 {
 	return
-		[setter, dflt, name, desc] (T &self, sol::object cb)
+		[this, setter, dflt, name, desc] (T &self, sol::object cb)
 		{
 			if (cb == sol::lua_nil)
 			{
@@ -594,7 +594,7 @@ auto lua_engine::make_simple_callback_setter(void (T::*setter)(delegate<R ()> &&
 			else if (cb.is<sol::protected_function>())
 			{
 				(self.*setter)(delegate<R ()>(
-							[dflt, desc, cbfunc = cb.as<sol::protected_function>()] () -> R
+							[this, dflt, desc, cbfunc = cb.as<sol::protected_function>()] () -> R
 							{
 								if constexpr (std::is_same_v<R, void>)
 								{

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -74,6 +74,7 @@ mame_machine_manager::mame_machine_manager(emu_options &options,osd_interface &o
 
 mame_machine_manager::~mame_machine_manager()
 {
+	m_autoboot_script.reset();
 	m_lua.reset();
 	s_manager = nullptr;
 }

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -336,7 +336,7 @@ TIMER_CALLBACK_MEMBER(mame_machine_manager::autoboot_callback)
 		strreplace(cmd, "'", "\\'");
 		std::string val = std::string("emu.keypost('").append(cmd).append("')");
 		auto &l(*lua());
-		l.invoke(l.load_string(val));
+		l.invoke(l.load_string(val).get<sol::protected_function>());
 	}
 }
 

--- a/src/frontend/mame/ui/pluginopt.cpp
+++ b/src/frontend/mame/ui/pluginopt.cpp
@@ -24,7 +24,7 @@ bool menu_plugin::handle(event const *ev)
 	if (ev && ev->itemref)
 	{
 		if (ev->iptkey == IPT_UI_SELECT)
-			menu::stack_push<menu_plugin_opt>(ui(), container(), (char *)ev->itemref);
+			menu::stack_push<menu_plugin_opt>(ui(), container(), (char *)ev->itemref, false);
 	}
 	return false;
 }
@@ -43,30 +43,25 @@ void menu_plugin::populate()
 	item_append(menu_item_type::SEPARATOR);
 }
 
-void menu_plugin::show_menu(mame_ui_manager &mui, render_container &container, char *menu)
+void menu_plugin::show_menu(mame_ui_manager &mui, render_container &container, std::string_view menu)
 {
-	// reset the menu stack
-	menu::stack_reset(mui);
-
 	// add the plugin menu entry
-	menu::stack_push<menu_plugin_opt>(mui, container, menu);
+	menu::stack_push<menu_plugin_opt>(mui, container, menu, true);
 
 	// force the menus on
 	mui.show_menu();
-
-	// make sure MAME is paused
-	mui.machine().pause();
 }
 
 menu_plugin::~menu_plugin()
 {
 }
 
-menu_plugin_opt::menu_plugin_opt(mame_ui_manager &mui, render_container &container, std::string_view menu) :
+menu_plugin_opt::menu_plugin_opt(mame_ui_manager &mui, render_container &container, std::string_view menu, bool one_shot) :
 	ui::menu(mui, container),
 	m_menu(menu),
 	m_need_idle(false)
 {
+	set_one_shot(one_shot);
 }
 
 bool menu_plugin_opt::handle(event const *ev)

--- a/src/frontend/mame/ui/pluginopt.h
+++ b/src/frontend/mame/ui/pluginopt.h
@@ -27,7 +27,7 @@ class menu_plugin : public menu
 public:
 	menu_plugin(mame_ui_manager &mui, render_container &container);
 
-	static void show_menu(mame_ui_manager &mui, render_container &container, char *menu);
+	static void show_menu(mame_ui_manager &mui, render_container &container, std::string_view menu);
 
 	virtual ~menu_plugin();
 
@@ -35,14 +35,14 @@ private:
 	virtual void populate() override;
 	virtual bool handle(event const *ev) override;
 
-	std::vector<std::string> &m_plugins;
+	std::vector<std::string> const &m_plugins;
 };
 
 
 class menu_plugin_opt : public menu
 {
 public:
-	menu_plugin_opt(mame_ui_manager &mui, render_container &container, std::string_view menu);
+	menu_plugin_opt(mame_ui_manager &mui, render_container &container, std::string_view menu, bool one_shot);
 	virtual ~menu_plugin_opt();
 
 protected:

--- a/src/mame/atari/irobot_m.cpp
+++ b/src/mame/atari/irobot_m.cpp
@@ -514,273 +514,276 @@ TIMER_DEVICE_CALLBACK_MEMBER(irobot_state::irobot_irmb_done_callback)
 /* Run mathbox */
 void irobot_state::irmb_run()
 {
-	const irmb_ops *prevop = &m_mbops[0];
-	const irmb_ops *curop = &m_mbops[0];
-
-	uint32_t Q = 0;
-	uint32_t Y = 0;
-	uint32_t nflag = 0;
-	uint32_t vflag = 0;
-	uint32_t cflag = 0;
-	uint32_t zresult = 1;
-	uint32_t CI = 0;
-	uint32_t SP = 0;
 	uint32_t icount = 0;
 
-	g_profiler.start(PROFILER_USER1);
-
-	while ((prevop->flags & (FL_DPSEL | FL_carry)) != (FL_DPSEL | FL_carry))
 	{
-		uint32_t result;
-		uint32_t fu;
-		uint32_t tmp;
+		const irmb_ops *prevop = &m_mbops[0];
+		const irmb_ops *curop = &m_mbops[0];
 
-		icount += curop->cycles;
+		uint32_t Q = 0;
+		uint32_t Y = 0;
+		uint32_t nflag = 0;
+		uint32_t vflag = 0;
+		uint32_t cflag = 0;
+		uint32_t zresult = 1;
+		uint32_t CI = 0;
+		uint32_t SP = 0;
 
-		/* Get function code */
-		fu = curop->func;
+		auto profile = g_profiler.start(PROFILER_USER1);
 
-		/* Modify function for MULT */
-		if (!(prevop->flags & FL_MULT) || (Q & 1))
-			fu = fu ^ 0x02;
-		else
-			fu = fu | 0x02;
-
-		/* Modify function for DIV */
-		if ((prevop->flags & FL_DIV) || nflag)
-			fu = fu ^ 0x08;
-		else
-			fu = fu | 0x08;
-
-		/* Do source and operation */
-		switch (fu & 0x03f)
+		while ((prevop->flags & (FL_DPSEL | FL_carry)) != (FL_DPSEL | FL_carry))
 		{
-			case 0x00:  ADD(*curop->areg, Q);                               break;
-			case 0x01:  ADD(*curop->areg, *curop->breg);                    break;
-			case 0x02:  ADD(0, Q);                                          break;
-			case 0x03:  ADD(0, *curop->breg);                               break;
-			case 0x04:  ADD(0, *curop->areg);                               break;
-			case 0x05:  tmp = irmb_din(curop); ADD(tmp, *curop->areg);       break;
-			case 0x06:  tmp = irmb_din(curop); ADD(tmp, Q);                  break;
-			case 0x07:  tmp = irmb_din(curop); ADD(tmp, 0);                  break;
-			case 0x08:  SUBR(*curop->areg, Q);                              break;
-			case 0x09:  SUBR(*curop->areg, *curop->breg);                   break;
-			case 0x0a:  SUBR(0, Q);                                         break;
-			case 0x0b:  SUBR(0, *curop->breg);                              break;
-			case 0x0c:  SUBR(0, *curop->areg);                              break;
-			case 0x0d:  tmp = irmb_din(curop); SUBR(tmp, *curop->areg);      break;
-			case 0x0e:  tmp = irmb_din(curop); SUBR(tmp, Q);             break;
-			case 0x0f:  tmp = irmb_din(curop); SUBR(tmp, 0);             break;
-			case 0x10:  SUB(*curop->areg, Q);                               break;
-			case 0x11:  SUB(*curop->areg, *curop->breg);                    break;
-			case 0x12:  SUB(0, Q);                                          break;
-			case 0x13:  SUB(0, *curop->breg);                               break;
-			case 0x14:  SUB(0, *curop->areg);                               break;
-			case 0x15:  tmp = irmb_din(curop); SUB(tmp, *curop->areg);       break;
-			case 0x16:  tmp = irmb_din(curop); SUB(tmp, Q);                  break;
-			case 0x17:  tmp = irmb_din(curop); SUB(tmp, 0);                  break;
-			case 0x18:  OR(*curop->areg, Q);                                break;
-			case 0x19:  OR(*curop->areg, *curop->breg);                     break;
-			case 0x1a:  OR(0, Q);                                           break;
-			case 0x1b:  OR(0, *curop->breg);                                break;
-			case 0x1c:  OR(0, *curop->areg);                                break;
-			case 0x1d:  OR(irmb_din(curop), *curop->areg);                   break;
-			case 0x1e:  OR(irmb_din(curop), Q);                              break;
-			case 0x1f:  OR(irmb_din(curop), 0);                              break;
-			case 0x20:  AND(*curop->areg, Q);                               break;
-			case 0x21:  AND(*curop->areg, *curop->breg);                    break;
-			case 0x22:  AND(0, Q);                                          break;
-			case 0x23:  AND(0, *curop->breg);                               break;
-			case 0x24:  AND(0, *curop->areg);                               break;
-			case 0x25:  AND(irmb_din(curop), *curop->areg);                  break;
-			case 0x26:  AND(irmb_din(curop), Q);                         break;
-			case 0x27:  AND(irmb_din(curop), 0);                         break;
-			case 0x28:  IAND(*curop->areg, Q);                              break;
-			case 0x29:  IAND(*curop->areg, *curop->breg);                   break;
-			case 0x2a:  IAND(0, Q);                                         break;
-			case 0x2b:  IAND(0, *curop->breg);                              break;
-			case 0x2c:  IAND(0, *curop->areg);                              break;
-			case 0x2d:  IAND(irmb_din(curop), *curop->areg);             break;
-			case 0x2e:  IAND(irmb_din(curop), Q);                            break;
-			case 0x2f:  IAND(irmb_din(curop), 0);                            break;
-			case 0x30:  XOR(*curop->areg, Q);                               break;
-			case 0x31:  XOR(*curop->areg, *curop->breg);                    break;
-			case 0x32:  XOR(0, Q);                                          break;
-			case 0x33:  XOR(0, *curop->breg);                               break;
-			case 0x34:  XOR(0, *curop->areg);                               break;
-			case 0x35:  XOR(irmb_din(curop), *curop->areg);                  break;
-			case 0x36:  XOR(irmb_din(curop), Q);                         break;
-			case 0x37:  XOR(irmb_din(curop), 0);                         break;
-			case 0x38:  IXOR(*curop->areg, Q);                              break;
-			case 0x39:  IXOR(*curop->areg, *curop->breg);                   break;
-			case 0x3a:  IXOR(0, Q);                                         break;
-			case 0x3b:  IXOR(0, *curop->breg);                              break;
-			case 0x3c:  IXOR(0, *curop->areg);                              break;
-			case 0x3d:  IXOR(irmb_din(curop), *curop->areg);             break;
-			case 0x3e:  IXOR(irmb_din(curop), Q);                            break;
-default:    case 0x3f:  IXOR(irmb_din(curop), 0);                            break;
-		}
+			uint32_t result;
+			uint32_t fu;
+			uint32_t tmp;
 
-		/* Evaluate flags */
-		zresult = result & 0xFFFF;
-		nflag = zresult >> 15;
+			icount += curop->cycles;
 
-		prevop = curop;
+			/* Get function code */
+			fu = curop->func;
 
-		/* Do destination and jump */
-		switch (fu >> 6)
-		{
-			case 0x00:
-			case 0x08:  DEST0;          JUMP0;  break;
-			case 0x01:
-			case 0x09:  DEST1;          JUMP0;  break;
-			case 0x02:
-			case 0x0a:  DEST2;          JUMP0;  break;
-			case 0x03:
-			case 0x0b:  DEST3;          JUMP0;  break;
-			case 0x04:  DEST4_NOSHIFT;  JUMP0;  break;
-			case 0x05:  DEST5_NOSHIFT;  JUMP0;  break;
-			case 0x06:  DEST6_NOSHIFT;  JUMP0;  break;
-			case 0x07:  DEST7_NOSHIFT;  JUMP0;  break;
-			case 0x0c:  DEST4_SHIFT;    JUMP0;  break;
-			case 0x0d:  DEST5_SHIFT;    JUMP0;  break;
-			case 0x0e:  DEST6_SHIFT;    JUMP0;  break;
-			case 0x0f:  DEST7_SHIFT;    JUMP0;  break;
-
-			case 0x10:
-			case 0x18:  DEST0;          JUMP1;  break;
-			case 0x11:
-			case 0x19:  DEST1;          JUMP1;  break;
-			case 0x12:
-			case 0x1a:  DEST2;          JUMP1;  break;
-			case 0x13:
-			case 0x1b:  DEST3;          JUMP1;  break;
-			case 0x14:  DEST4_NOSHIFT;  JUMP1;  break;
-			case 0x15:  DEST5_NOSHIFT;  JUMP1;  break;
-			case 0x16:  DEST6_NOSHIFT;  JUMP1;  break;
-			case 0x17:  DEST7_NOSHIFT;  JUMP1;  break;
-			case 0x1c:  DEST4_SHIFT;    JUMP1;  break;
-			case 0x1d:  DEST5_SHIFT;    JUMP1;  break;
-			case 0x1e:  DEST6_SHIFT;    JUMP1;  break;
-			case 0x1f:  DEST7_SHIFT;    JUMP1;  break;
-
-			case 0x20:
-			case 0x28:  DEST0;          JUMP2;  break;
-			case 0x21:
-			case 0x29:  DEST1;          JUMP2;  break;
-			case 0x22:
-			case 0x2a:  DEST2;          JUMP2;  break;
-			case 0x23:
-			case 0x2b:  DEST3;          JUMP2;  break;
-			case 0x24:  DEST4_NOSHIFT;  JUMP2;  break;
-			case 0x25:  DEST5_NOSHIFT;  JUMP2;  break;
-			case 0x26:  DEST6_NOSHIFT;  JUMP2;  break;
-			case 0x27:  DEST7_NOSHIFT;  JUMP2;  break;
-			case 0x2c:  DEST4_SHIFT;    JUMP2;  break;
-			case 0x2d:  DEST5_SHIFT;    JUMP2;  break;
-			case 0x2e:  DEST6_SHIFT;    JUMP2;  break;
-			case 0x2f:  DEST7_SHIFT;    JUMP2;  break;
-
-			case 0x30:
-			case 0x38:  DEST0;          JUMP3;  break;
-			case 0x31:
-			case 0x39:  DEST1;          JUMP3;  break;
-			case 0x32:
-			case 0x3a:  DEST2;          JUMP3;  break;
-			case 0x33:
-			case 0x3b:  DEST3;          JUMP3;  break;
-			case 0x34:  DEST4_NOSHIFT;  JUMP3;  break;
-			case 0x35:  DEST5_NOSHIFT;  JUMP3;  break;
-			case 0x36:  DEST6_NOSHIFT;  JUMP3;  break;
-			case 0x37:  DEST7_NOSHIFT;  JUMP3;  break;
-			case 0x3c:  DEST4_SHIFT;    JUMP3;  break;
-			case 0x3d:  DEST5_SHIFT;    JUMP3;  break;
-			case 0x3e:  DEST6_SHIFT;    JUMP3;  break;
-			case 0x3f:  DEST7_SHIFT;    JUMP3;  break;
-
-			case 0x40:
-			case 0x48:  DEST0;          JUMP4;  break;
-			case 0x41:
-			case 0x49:  DEST1;          JUMP4;  break;
-			case 0x42:
-			case 0x4a:  DEST2;          JUMP4;  break;
-			case 0x43:
-			case 0x4b:  DEST3;          JUMP4;  break;
-			case 0x44:  DEST4_NOSHIFT;  JUMP4;  break;
-			case 0x45:  DEST5_NOSHIFT;  JUMP4;  break;
-			case 0x46:  DEST6_NOSHIFT;  JUMP4;  break;
-			case 0x47:  DEST7_NOSHIFT;  JUMP4;  break;
-			case 0x4c:  DEST4_SHIFT;    JUMP4;  break;
-			case 0x4d:  DEST5_SHIFT;    JUMP4;  break;
-			case 0x4e:  DEST6_SHIFT;    JUMP4;  break;
-			case 0x4f:  DEST7_SHIFT;    JUMP4;  break;
-
-			case 0x50:
-			case 0x58:  DEST0;          JUMP5;  break;
-			case 0x51:
-			case 0x59:  DEST1;          JUMP5;  break;
-			case 0x52:
-			case 0x5a:  DEST2;          JUMP5;  break;
-			case 0x53:
-			case 0x5b:  DEST3;          JUMP5;  break;
-			case 0x54:  DEST4_NOSHIFT;  JUMP5;  break;
-			case 0x55:  DEST5_NOSHIFT;  JUMP5;  break;
-			case 0x56:  DEST6_NOSHIFT;  JUMP5;  break;
-			case 0x57:  DEST7_NOSHIFT;  JUMP5;  break;
-			case 0x5c:  DEST4_SHIFT;    JUMP5;  break;
-			case 0x5d:  DEST5_SHIFT;    JUMP5;  break;
-			case 0x5e:  DEST6_SHIFT;    JUMP5;  break;
-			case 0x5f:  DEST7_SHIFT;    JUMP5;  break;
-
-			case 0x60:
-			case 0x68:  DEST0;          JUMP6;  break;
-			case 0x61:
-			case 0x69:  DEST1;          JUMP6;  break;
-			case 0x62:
-			case 0x6a:  DEST2;          JUMP6;  break;
-			case 0x63:
-			case 0x6b:  DEST3;          JUMP6;  break;
-			case 0x64:  DEST4_NOSHIFT;  JUMP6;  break;
-			case 0x65:  DEST5_NOSHIFT;  JUMP6;  break;
-			case 0x66:  DEST6_NOSHIFT;  JUMP6;  break;
-			case 0x67:  DEST7_NOSHIFT;  JUMP6;  break;
-			case 0x6c:  DEST4_SHIFT;    JUMP6;  break;
-			case 0x6d:  DEST5_SHIFT;    JUMP6;  break;
-			case 0x6e:  DEST6_SHIFT;    JUMP6;  break;
-			case 0x6f:  DEST7_SHIFT;    JUMP6;  break;
-
-			case 0x70:
-			case 0x78:  DEST0;          JUMP7;  break;
-			case 0x71:
-			case 0x79:  DEST1;          JUMP7;  break;
-			case 0x72:
-			case 0x7a:  DEST2;          JUMP7;  break;
-			case 0x73:
-			case 0x7b:  DEST3;          JUMP7;  break;
-			case 0x74:  DEST4_NOSHIFT;  JUMP7;  break;
-			case 0x75:  DEST5_NOSHIFT;  JUMP7;  break;
-			case 0x76:  DEST6_NOSHIFT;  JUMP7;  break;
-			case 0x77:  DEST7_NOSHIFT;  JUMP7;  break;
-			case 0x7c:  DEST4_SHIFT;    JUMP7;  break;
-			case 0x7d:  DEST5_SHIFT;    JUMP7;  break;
-			case 0x7e:  DEST6_SHIFT;    JUMP7;  break;
-			case 0x7f:  DEST7_SHIFT;    JUMP7;  break;
-		}
-
-		/* Do write */
-		if (!(prevop->flags & FL_MBRW))
-			irmb_dout(prevop, Y);
-
-		/* ADDEN */
-		if (!(prevop->flags & FL_ADDEN))
-		{
-			if (prevop->flags & FL_MBRW)
-				m_irmb_latch = irmb_din(prevop);
+			/* Modify function for MULT */
+			if (!(prevop->flags & FL_MULT) || (Q & 1))
+				fu = fu ^ 0x02;
 			else
-				m_irmb_latch = Y;
+				fu = fu | 0x02;
+
+			/* Modify function for DIV */
+			if ((prevop->flags & FL_DIV) || nflag)
+				fu = fu ^ 0x08;
+			else
+				fu = fu | 0x08;
+
+			/* Do source and operation */
+			switch (fu & 0x03f)
+			{
+				case 0x00:  ADD(*curop->areg, Q);                               break;
+				case 0x01:  ADD(*curop->areg, *curop->breg);                    break;
+				case 0x02:  ADD(0, Q);                                          break;
+				case 0x03:  ADD(0, *curop->breg);                               break;
+				case 0x04:  ADD(0, *curop->areg);                               break;
+				case 0x05:  tmp = irmb_din(curop); ADD(tmp, *curop->areg);       break;
+				case 0x06:  tmp = irmb_din(curop); ADD(tmp, Q);                  break;
+				case 0x07:  tmp = irmb_din(curop); ADD(tmp, 0);                  break;
+				case 0x08:  SUBR(*curop->areg, Q);                              break;
+				case 0x09:  SUBR(*curop->areg, *curop->breg);                   break;
+				case 0x0a:  SUBR(0, Q);                                         break;
+				case 0x0b:  SUBR(0, *curop->breg);                              break;
+				case 0x0c:  SUBR(0, *curop->areg);                              break;
+				case 0x0d:  tmp = irmb_din(curop); SUBR(tmp, *curop->areg);      break;
+				case 0x0e:  tmp = irmb_din(curop); SUBR(tmp, Q);             break;
+				case 0x0f:  tmp = irmb_din(curop); SUBR(tmp, 0);             break;
+				case 0x10:  SUB(*curop->areg, Q);                               break;
+				case 0x11:  SUB(*curop->areg, *curop->breg);                    break;
+				case 0x12:  SUB(0, Q);                                          break;
+				case 0x13:  SUB(0, *curop->breg);                               break;
+				case 0x14:  SUB(0, *curop->areg);                               break;
+				case 0x15:  tmp = irmb_din(curop); SUB(tmp, *curop->areg);       break;
+				case 0x16:  tmp = irmb_din(curop); SUB(tmp, Q);                  break;
+				case 0x17:  tmp = irmb_din(curop); SUB(tmp, 0);                  break;
+				case 0x18:  OR(*curop->areg, Q);                                break;
+				case 0x19:  OR(*curop->areg, *curop->breg);                     break;
+				case 0x1a:  OR(0, Q);                                           break;
+				case 0x1b:  OR(0, *curop->breg);                                break;
+				case 0x1c:  OR(0, *curop->areg);                                break;
+				case 0x1d:  OR(irmb_din(curop), *curop->areg);                   break;
+				case 0x1e:  OR(irmb_din(curop), Q);                              break;
+				case 0x1f:  OR(irmb_din(curop), 0);                              break;
+				case 0x20:  AND(*curop->areg, Q);                               break;
+				case 0x21:  AND(*curop->areg, *curop->breg);                    break;
+				case 0x22:  AND(0, Q);                                          break;
+				case 0x23:  AND(0, *curop->breg);                               break;
+				case 0x24:  AND(0, *curop->areg);                               break;
+				case 0x25:  AND(irmb_din(curop), *curop->areg);                  break;
+				case 0x26:  AND(irmb_din(curop), Q);                         break;
+				case 0x27:  AND(irmb_din(curop), 0);                         break;
+				case 0x28:  IAND(*curop->areg, Q);                              break;
+				case 0x29:  IAND(*curop->areg, *curop->breg);                   break;
+				case 0x2a:  IAND(0, Q);                                         break;
+				case 0x2b:  IAND(0, *curop->breg);                              break;
+				case 0x2c:  IAND(0, *curop->areg);                              break;
+				case 0x2d:  IAND(irmb_din(curop), *curop->areg);             break;
+				case 0x2e:  IAND(irmb_din(curop), Q);                            break;
+				case 0x2f:  IAND(irmb_din(curop), 0);                            break;
+				case 0x30:  XOR(*curop->areg, Q);                               break;
+				case 0x31:  XOR(*curop->areg, *curop->breg);                    break;
+				case 0x32:  XOR(0, Q);                                          break;
+				case 0x33:  XOR(0, *curop->breg);                               break;
+				case 0x34:  XOR(0, *curop->areg);                               break;
+				case 0x35:  XOR(irmb_din(curop), *curop->areg);                  break;
+				case 0x36:  XOR(irmb_din(curop), Q);                         break;
+				case 0x37:  XOR(irmb_din(curop), 0);                         break;
+				case 0x38:  IXOR(*curop->areg, Q);                              break;
+				case 0x39:  IXOR(*curop->areg, *curop->breg);                   break;
+				case 0x3a:  IXOR(0, Q);                                         break;
+				case 0x3b:  IXOR(0, *curop->breg);                              break;
+				case 0x3c:  IXOR(0, *curop->areg);                              break;
+				case 0x3d:  IXOR(irmb_din(curop), *curop->areg);             break;
+				case 0x3e:  IXOR(irmb_din(curop), Q);                            break;
+	default:    case 0x3f:  IXOR(irmb_din(curop), 0);                            break;
+			}
+
+			/* Evaluate flags */
+			zresult = result & 0xFFFF;
+			nflag = zresult >> 15;
+
+			prevop = curop;
+
+			/* Do destination and jump */
+			switch (fu >> 6)
+			{
+				case 0x00:
+				case 0x08:  DEST0;          JUMP0;  break;
+				case 0x01:
+				case 0x09:  DEST1;          JUMP0;  break;
+				case 0x02:
+				case 0x0a:  DEST2;          JUMP0;  break;
+				case 0x03:
+				case 0x0b:  DEST3;          JUMP0;  break;
+				case 0x04:  DEST4_NOSHIFT;  JUMP0;  break;
+				case 0x05:  DEST5_NOSHIFT;  JUMP0;  break;
+				case 0x06:  DEST6_NOSHIFT;  JUMP0;  break;
+				case 0x07:  DEST7_NOSHIFT;  JUMP0;  break;
+				case 0x0c:  DEST4_SHIFT;    JUMP0;  break;
+				case 0x0d:  DEST5_SHIFT;    JUMP0;  break;
+				case 0x0e:  DEST6_SHIFT;    JUMP0;  break;
+				case 0x0f:  DEST7_SHIFT;    JUMP0;  break;
+
+				case 0x10:
+				case 0x18:  DEST0;          JUMP1;  break;
+				case 0x11:
+				case 0x19:  DEST1;          JUMP1;  break;
+				case 0x12:
+				case 0x1a:  DEST2;          JUMP1;  break;
+				case 0x13:
+				case 0x1b:  DEST3;          JUMP1;  break;
+				case 0x14:  DEST4_NOSHIFT;  JUMP1;  break;
+				case 0x15:  DEST5_NOSHIFT;  JUMP1;  break;
+				case 0x16:  DEST6_NOSHIFT;  JUMP1;  break;
+				case 0x17:  DEST7_NOSHIFT;  JUMP1;  break;
+				case 0x1c:  DEST4_SHIFT;    JUMP1;  break;
+				case 0x1d:  DEST5_SHIFT;    JUMP1;  break;
+				case 0x1e:  DEST6_SHIFT;    JUMP1;  break;
+				case 0x1f:  DEST7_SHIFT;    JUMP1;  break;
+
+				case 0x20:
+				case 0x28:  DEST0;          JUMP2;  break;
+				case 0x21:
+				case 0x29:  DEST1;          JUMP2;  break;
+				case 0x22:
+				case 0x2a:  DEST2;          JUMP2;  break;
+				case 0x23:
+				case 0x2b:  DEST3;          JUMP2;  break;
+				case 0x24:  DEST4_NOSHIFT;  JUMP2;  break;
+				case 0x25:  DEST5_NOSHIFT;  JUMP2;  break;
+				case 0x26:  DEST6_NOSHIFT;  JUMP2;  break;
+				case 0x27:  DEST7_NOSHIFT;  JUMP2;  break;
+				case 0x2c:  DEST4_SHIFT;    JUMP2;  break;
+				case 0x2d:  DEST5_SHIFT;    JUMP2;  break;
+				case 0x2e:  DEST6_SHIFT;    JUMP2;  break;
+				case 0x2f:  DEST7_SHIFT;    JUMP2;  break;
+
+				case 0x30:
+				case 0x38:  DEST0;          JUMP3;  break;
+				case 0x31:
+				case 0x39:  DEST1;          JUMP3;  break;
+				case 0x32:
+				case 0x3a:  DEST2;          JUMP3;  break;
+				case 0x33:
+				case 0x3b:  DEST3;          JUMP3;  break;
+				case 0x34:  DEST4_NOSHIFT;  JUMP3;  break;
+				case 0x35:  DEST5_NOSHIFT;  JUMP3;  break;
+				case 0x36:  DEST6_NOSHIFT;  JUMP3;  break;
+				case 0x37:  DEST7_NOSHIFT;  JUMP3;  break;
+				case 0x3c:  DEST4_SHIFT;    JUMP3;  break;
+				case 0x3d:  DEST5_SHIFT;    JUMP3;  break;
+				case 0x3e:  DEST6_SHIFT;    JUMP3;  break;
+				case 0x3f:  DEST7_SHIFT;    JUMP3;  break;
+
+				case 0x40:
+				case 0x48:  DEST0;          JUMP4;  break;
+				case 0x41:
+				case 0x49:  DEST1;          JUMP4;  break;
+				case 0x42:
+				case 0x4a:  DEST2;          JUMP4;  break;
+				case 0x43:
+				case 0x4b:  DEST3;          JUMP4;  break;
+				case 0x44:  DEST4_NOSHIFT;  JUMP4;  break;
+				case 0x45:  DEST5_NOSHIFT;  JUMP4;  break;
+				case 0x46:  DEST6_NOSHIFT;  JUMP4;  break;
+				case 0x47:  DEST7_NOSHIFT;  JUMP4;  break;
+				case 0x4c:  DEST4_SHIFT;    JUMP4;  break;
+				case 0x4d:  DEST5_SHIFT;    JUMP4;  break;
+				case 0x4e:  DEST6_SHIFT;    JUMP4;  break;
+				case 0x4f:  DEST7_SHIFT;    JUMP4;  break;
+
+				case 0x50:
+				case 0x58:  DEST0;          JUMP5;  break;
+				case 0x51:
+				case 0x59:  DEST1;          JUMP5;  break;
+				case 0x52:
+				case 0x5a:  DEST2;          JUMP5;  break;
+				case 0x53:
+				case 0x5b:  DEST3;          JUMP5;  break;
+				case 0x54:  DEST4_NOSHIFT;  JUMP5;  break;
+				case 0x55:  DEST5_NOSHIFT;  JUMP5;  break;
+				case 0x56:  DEST6_NOSHIFT;  JUMP5;  break;
+				case 0x57:  DEST7_NOSHIFT;  JUMP5;  break;
+				case 0x5c:  DEST4_SHIFT;    JUMP5;  break;
+				case 0x5d:  DEST5_SHIFT;    JUMP5;  break;
+				case 0x5e:  DEST6_SHIFT;    JUMP5;  break;
+				case 0x5f:  DEST7_SHIFT;    JUMP5;  break;
+
+				case 0x60:
+				case 0x68:  DEST0;          JUMP6;  break;
+				case 0x61:
+				case 0x69:  DEST1;          JUMP6;  break;
+				case 0x62:
+				case 0x6a:  DEST2;          JUMP6;  break;
+				case 0x63:
+				case 0x6b:  DEST3;          JUMP6;  break;
+				case 0x64:  DEST4_NOSHIFT;  JUMP6;  break;
+				case 0x65:  DEST5_NOSHIFT;  JUMP6;  break;
+				case 0x66:  DEST6_NOSHIFT;  JUMP6;  break;
+				case 0x67:  DEST7_NOSHIFT;  JUMP6;  break;
+				case 0x6c:  DEST4_SHIFT;    JUMP6;  break;
+				case 0x6d:  DEST5_SHIFT;    JUMP6;  break;
+				case 0x6e:  DEST6_SHIFT;    JUMP6;  break;
+				case 0x6f:  DEST7_SHIFT;    JUMP6;  break;
+
+				case 0x70:
+				case 0x78:  DEST0;          JUMP7;  break;
+				case 0x71:
+				case 0x79:  DEST1;          JUMP7;  break;
+				case 0x72:
+				case 0x7a:  DEST2;          JUMP7;  break;
+				case 0x73:
+				case 0x7b:  DEST3;          JUMP7;  break;
+				case 0x74:  DEST4_NOSHIFT;  JUMP7;  break;
+				case 0x75:  DEST5_NOSHIFT;  JUMP7;  break;
+				case 0x76:  DEST6_NOSHIFT;  JUMP7;  break;
+				case 0x77:  DEST7_NOSHIFT;  JUMP7;  break;
+				case 0x7c:  DEST4_SHIFT;    JUMP7;  break;
+				case 0x7d:  DEST5_SHIFT;    JUMP7;  break;
+				case 0x7e:  DEST6_SHIFT;    JUMP7;  break;
+				case 0x7f:  DEST7_SHIFT;    JUMP7;  break;
+			}
+
+			/* Do write */
+			if (!(prevop->flags & FL_MBRW))
+				irmb_dout(prevop, Y);
+
+			/* ADDEN */
+			if (!(prevop->flags & FL_ADDEN))
+			{
+				if (prevop->flags & FL_MBRW)
+					m_irmb_latch = irmb_din(prevop);
+				else
+					m_irmb_latch = Y;
+			}
 		}
+		// stop profiling USER1
 	}
-	g_profiler.stop();
 
 	logerror("%d instructions for Mathbox \n", icount);
 

--- a/src/mame/atari/jaguar_v.cpp
+++ b/src/mame/atari/jaguar_v.cpp
@@ -453,7 +453,7 @@ void jaguar_state::blitter_run()
 	uint32_t a1flags = m_blitter_regs[A1_FLAGS] & STATIC_FLAGS_MASK;
 	uint32_t a2flags = m_blitter_regs[A2_FLAGS] & STATIC_FLAGS_MASK;
 
-	g_profiler.start(PROFILER_USER1);
+	auto profile = g_profiler.start(PROFILER_USER1);
 
 	if (a1flags == a2flags)
 	{
@@ -504,42 +504,45 @@ void jaguar_state::blitter_run()
 		return;
 	}
 
-if (LOG_BLITTER_STATS)
-{
-static uint32_t blitter_stats[1000][4];
-static uint64_t blitter_pixels[1000];
-static int blitter_count = 0;
-static int reps = 0;
-int i;
-for (i = 0; i < blitter_count; i++)
-	if (blitter_stats[i][0] == (m_blitter_regs[B_CMD] & STATIC_COMMAND_MASK) &&
-		blitter_stats[i][1] == (m_blitter_regs[A1_FLAGS] & STATIC_FLAGS_MASK) &&
-		blitter_stats[i][2] == (m_blitter_regs[A2_FLAGS] & STATIC_FLAGS_MASK))
-		break;
-if (i == blitter_count)
-{
-	blitter_stats[i][0] = m_blitter_regs[B_CMD] & STATIC_COMMAND_MASK;
-	blitter_stats[i][1] = m_blitter_regs[A1_FLAGS] & STATIC_FLAGS_MASK;
-	blitter_stats[i][2] = m_blitter_regs[A2_FLAGS] & STATIC_FLAGS_MASK;
-	blitter_stats[i][3] = 0;
-	blitter_pixels[i] = 0;
-	blitter_count++;
-}
-blitter_stats[i][3]++;
-blitter_pixels[i] += (m_blitter_regs[B_COUNT] & 0xffff) * (m_blitter_regs[B_COUNT] >> 16);
-if (++reps % 100 == 99)
-{
-	osd_printf_debug("---\nBlitter stats:\n");
-	for (i = 0; i < blitter_count; i++)
-		osd_printf_debug("  CMD=%08X A1=%08X A2=%08X %6d times, %016X pixels\n",
-				blitter_stats[i][0], blitter_stats[i][1], blitter_stats[i][2],
-				blitter_stats[i][3], blitter_pixels[i]);
-	osd_printf_debug("---\n");
-}
-}
+	if (LOG_BLITTER_STATS)
+	{
+		static uint32_t blitter_stats[1000][4];
+		static uint64_t blitter_pixels[1000];
+		static int blitter_count = 0;
+		static int reps = 0;
+		int i;
+		for (i = 0; i < blitter_count; i++)
+		{
+			if (blitter_stats[i][0] == (m_blitter_regs[B_CMD] & STATIC_COMMAND_MASK) &&
+				blitter_stats[i][1] == (m_blitter_regs[A1_FLAGS] & STATIC_FLAGS_MASK) &&
+				blitter_stats[i][2] == (m_blitter_regs[A2_FLAGS] & STATIC_FLAGS_MASK))
+				break;
+		}
+		if (i == blitter_count)
+		{
+			blitter_stats[i][0] = m_blitter_regs[B_CMD] & STATIC_COMMAND_MASK;
+			blitter_stats[i][1] = m_blitter_regs[A1_FLAGS] & STATIC_FLAGS_MASK;
+			blitter_stats[i][2] = m_blitter_regs[A2_FLAGS] & STATIC_FLAGS_MASK;
+			blitter_stats[i][3] = 0;
+			blitter_pixels[i] = 0;
+			blitter_count++;
+		}
+		blitter_stats[i][3]++;
+		blitter_pixels[i] += (m_blitter_regs[B_COUNT] & 0xffff) * (m_blitter_regs[B_COUNT] >> 16);
+		if (++reps % 100 == 99)
+		{
+			osd_printf_debug("---\nBlitter stats:\n");
+			for (i = 0; i < blitter_count; i++)
+			{
+				osd_printf_debug("  CMD=%08X A1=%08X A2=%08X %6d times, %016X pixels\n",
+						blitter_stats[i][0], blitter_stats[i][1], blitter_stats[i][2],
+						blitter_stats[i][3], blitter_pixels[i]);
+			}
+			osd_printf_debug("---\n");
+		}
+	}
 
 	generic_blitter(m_blitter_regs[B_CMD], m_blitter_regs[A1_FLAGS], m_blitter_regs[A2_FLAGS]);
-	g_profiler.stop();
 }
 
 uint32_t jaguar_state::blitter_r(offs_t offset, uint32_t mem_mask)

--- a/src/mame/bfm/bfm_dm01.cpp
+++ b/src/mame/bfm/bfm_dm01.cpp
@@ -167,7 +167,7 @@ uint8_t bfm_dm01_device::mux_r()
 
 void bfm_dm01_device::mux_w(uint8_t data)
 {
-	g_profiler.start(PROFILER_USER2);
+	auto profile = g_profiler.start(PROFILER_USER2);
 
 	if (m_xcounter < BYTES_PER_ROW)
 	{
@@ -203,8 +203,6 @@ void bfm_dm01_device::mux_w(uint8_t data)
 			}
 		}
 	}
-
-	g_profiler.stop();
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/mame/bfm/bfm_sc2.cpp
+++ b/src/mame/bfm/bfm_sc2.cpp
@@ -701,23 +701,20 @@ void bfm_sc2_state::mmtr_w(uint8_t data)
 void bfm_sc2_state::mux_output_w(offs_t offset, uint8_t data)
 {
 	// this is a useful profiler point to make sure the artwork writes / lookups are performing properly.
-	g_profiler.start(PROFILER_USER6);
+	auto profile = g_profiler.start(PROFILER_USER6);
 
-	int i;
-	int off = offset<<3;
+	int const off = offset<<3;
 
-	for (i = 0; i < 8; i++)
+	for (int i = 0; i < 8; i++)
 	{
-		int oldbit = BIT(m_lamps_old[offset], i);
-		int newbit = BIT(data, i);
+		int const oldbit = BIT(m_lamps_old[offset], i);
+		int const newbit = BIT(data, i);
 
 		if (oldbit != newbit)
 			m_lamps[off + i] = newbit;
 	}
 
 	m_lamps_old[offset] = data;
-
-	g_profiler.stop();
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/mame/dynax/ddenlovr.cpp
+++ b/src/mame/dynax/ddenlovr.cpp
@@ -1162,7 +1162,7 @@ void ddenlovr_state::blitter_w(int blitter, offs_t offset, uint8_t data)
 {
 	int hi_bits;
 
-g_profiler.start(PROFILER_VIDEO);
+	auto profile = g_profiler.start(PROFILER_VIDEO);
 
 	switch (offset)
 	{
@@ -1302,8 +1302,6 @@ g_profiler.start(PROFILER_VIDEO);
 			break;
 		}
 	}
-
-g_profiler.stop();
 }
 
 
@@ -1314,7 +1312,7 @@ void ddenlovr_state::blitter_w_funkyfig(int blitter, offs_t offset, uint8_t data
 {
 	int hi_bits;
 
-g_profiler.start(PROFILER_VIDEO);
+	auto profile = g_profiler.start(PROFILER_VIDEO);
 
 	switch(offset)
 	{
@@ -1459,8 +1457,6 @@ g_profiler.start(PROFILER_VIDEO);
 			break;
 		}
 	}
-
-g_profiler.stop();
 }
 
 
@@ -1476,7 +1472,7 @@ void hanakanz_state::hanakanz_blitter_data_w(uint8_t data)
 {
 	int hi_bits;
 
-g_profiler.start(PROFILER_VIDEO);
+	auto profile = g_profiler.start(PROFILER_VIDEO);
 
 	hi_bits = (m_ddenlovr_blit_latch & 0x03) << 8;
 
@@ -1657,8 +1653,6 @@ g_profiler.start(PROFILER_VIDEO);
 			logerror("%06x: Blitter 0 reg %02x = %02x\n", m_maincpu->pc(), m_ddenlovr_blit_latch, data);
 			break;
 	}
-
-g_profiler.stop();
 }
 
 

--- a/src/mame/exidy/vertigo_v.cpp
+++ b/src/mame/exidy/vertigo_v.cpp
@@ -388,7 +388,7 @@ void vertigo_state::vertigo_vproc(int cycles, int irq4)
 
 	if (irq4) m_vector->clear_list();
 
-	g_profiler.start(PROFILER_USER1);
+	auto profile = g_profiler.start(PROFILER_USER1);
 
 	while (cycles--)
 	{
@@ -563,6 +563,4 @@ void vertigo_state::vertigo_vproc(int cycles, int irq4)
 			m_vs.pc = (m_vs.pc & 0x100) | ((m_vs.pc + 1) & 0xff);
 		}
 	}
-
-	g_profiler.stop();
 }

--- a/src/mame/itech/itech32_v.cpp
+++ b/src/mame/itech/itech32_v.cpp
@@ -8,8 +8,10 @@
 ***************************************************************************/
 
 #include "emu.h"
-#include "cpu/m68000/m68000.h"
 #include "itech32.h"
+
+#include "cpu/m68000/m68000.h"
+
 #include <algorithm>
 
 
@@ -1236,13 +1238,13 @@ void itech32_state::handle_video_command()
 
 		/* command 2: blit RLE-compressed data */
 		case 2:
-			g_profiler.start(PROFILER_USER2);
-			if (BLIT_LOGGING) logblit("Blit RLE");
+			{
+				auto profile = g_profiler.start(PROFILER_USER2);
+				if (BLIT_LOGGING) logblit("Blit RLE");
 
-			if (m_enable_latch[0]) draw_rle(m_videoplane[0], m_color_latch[0]);
-			if (m_enable_latch[1]) draw_rle(m_videoplane[1], m_color_latch[1]);
-
-			g_profiler.stop();
+				if (m_enable_latch[0]) draw_rle(m_videoplane[0], m_color_latch[0]);
+				if (m_enable_latch[1]) draw_rle(m_videoplane[1], m_color_latch[1]);
+			}
 			break;
 
 		/* command 3: set up raw data transfer */
@@ -1279,7 +1281,7 @@ void itech32_state::handle_video_command()
 
 void itech32_state::command_blit_raw()
 {
-	g_profiler.start(PROFILER_USER1);
+	auto profile = g_profiler.start(PROFILER_USER1);
 	if (BLIT_LOGGING) logblit("Blit Raw");
 
 	if (VIDEO_TRANSFER_FLAGS & XFERFLAG_WIDTHPIX)
@@ -1292,39 +1294,31 @@ void itech32_state::command_blit_raw()
 		if (m_enable_latch[0]) draw_raw(m_videoplane[0], m_color_latch[0]);
 		if (m_enable_latch[1]) draw_raw(m_videoplane[1], m_color_latch[1]);
 	}
-
-	g_profiler.stop();
 }
 
 void drivedge_state::command_blit_raw()
 {
-	g_profiler.start(PROFILER_USER1);
+	auto profile = g_profiler.start(PROFILER_USER1);
 	if (BLIT_LOGGING) logblit("Blit Raw");
 
 	if (m_enable_latch[0]) draw_raw(m_videoplane[0], m_videoplane[1], m_color_latch[0]);
-
-	g_profiler.stop();
 }
 
 void itech32_state::command_shift_reg()
 {
-	g_profiler.start(PROFILER_USER3);
+	auto profile = g_profiler.start(PROFILER_USER3);
 	if (BLIT_LOGGING) logblit("ShiftReg");
 
 	if (m_enable_latch[0]) shiftreg_clear(m_videoplane[0], nullptr);
 	if (m_enable_latch[1]) shiftreg_clear(m_videoplane[1], nullptr);
-
-	g_profiler.stop();
 }
 
 void drivedge_state::command_shift_reg()
 {
-	g_profiler.start(PROFILER_USER3);
+	auto profile = g_profiler.start(PROFILER_USER3);
 	if (BLIT_LOGGING) logblit("ShiftReg");
 
 	if (m_enable_latch[0]) shiftreg_clear(m_videoplane[0], m_videoplane[1]);
-
-	g_profiler.stop();
 }
 
 

--- a/src/mame/midway/midtunit_v.cpp
+++ b/src/mame/midway/midtunit_v.cpp
@@ -711,7 +711,7 @@ void midtunit_video_device::midtunit_dma_w(offs_t offset, uint16_t data, uint16_
 	if (!(command & 0x8000))
 		return;
 
-	g_profiler.start(PROFILER_USER1);
+	auto profile = g_profiler.start(PROFILER_USER1);
 
 	/* determine bpp */
 	int bpp = (command >> 12) & 7;
@@ -828,8 +828,6 @@ void midtunit_video_device::midtunit_dma_w(offs_t offset, uint16_t data, uint16_
 	/* signal we're done */
 skipdma:
 	m_dma_timer->adjust(attotime::from_nsec(41 * pixels));
-
-	g_profiler.stop();
 }
 
 

--- a/src/mame/misc/artmagic_v.cpp
+++ b/src/mame/misc/artmagic_v.cpp
@@ -184,7 +184,7 @@ void artmagic_state::execute_blit()
 }
 #endif
 
-	g_profiler.start(PROFILER_VIDEO);
+	auto profile = g_profiler.start(PROFILER_VIDEO);
 
 	last = 0;
 	sy = y;
@@ -288,8 +288,6 @@ void artmagic_state::execute_blit()
 		}
 		offset += w/4;
 	}
-
-	g_profiler.stop();
 
 #if (!INSTANT_BLIT)
 	m_blitter_busy_until = machine.time() + attotime::from_nsec(w*h*20);

--- a/src/mame/misc/mcatadv.cpp
+++ b/src/mame/misc/mcatadv.cpp
@@ -416,12 +416,11 @@ u32 mcatadv_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, co
 				draw_tilemap_part(screen, 1, i | 0x8, bitmap, cliprect);
 	}
 
-	g_profiler.start(PROFILER_USER1);
+	auto profile = g_profiler.start(PROFILER_USER1);
 #ifdef MAME_DEBUG
 	if (!machine().input().code_pressed(KEYCODE_E))
 #endif
 		draw_sprites(screen, bitmap, cliprect);
-	g_profiler.stop();
 	return 0;
 }
 

--- a/src/mame/nintendo/n64_m.cpp
+++ b/src/mame/nintendo/n64_m.cpp
@@ -964,17 +964,15 @@ void n64_periphs::dp_reg_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 				m_n64->rdp()->set_status(status & ~DP_STATUS_START_VALID);
 				m_n64->rdp()->set_current(m_n64->rdp()->get_start());
 				m_n64->rdp()->set_end(data & ~7);
-				g_profiler.start(PROFILER_USER1);
+				auto profile = g_profiler.start(PROFILER_USER1);
 				m_n64->rdp()->process_command_list();
-				g_profiler.stop();
 				break;
 			}
 			else
 			{
 				m_n64->rdp()->set_end(data & ~7);
-				g_profiler.start(PROFILER_USER1);
+				auto profile = g_profiler.start(PROFILER_USER1);
 				m_n64->rdp()->process_command_list();
-				g_profiler.stop();
 				break;
 			}
 

--- a/src/mame/nintendo/vboy.cpp
+++ b/src/mame/nintendo/vboy.cpp
@@ -257,40 +257,32 @@ void vboy_state::fill_ovr_char(uint16_t code, uint8_t pal)
 
 inline int8_t vboy_state::get_bg_map_pixel(int num, int xpos, int ypos)
 {
-//  g_profiler.start(PROFILER_USER1);
-	int x, y;
-	uint8_t stepx, stepy;
+//  auto profile1 = g_profiler.start(PROFILER_USER1);
 
-	y = ypos >>3;
-	x = xpos >>3;
+	int const y = ypos >>3;
+	int const x = xpos >>3;
 
-	stepx = (x & 0x1c0) >> 6;
-	stepy = ((y & 0x1c0) >> 6) * (stepx+1);
-	uint16_t val = READ_BGMAP((x & 0x3f) + (64 * (y & 0x3f)) + ((num + stepx + stepy) * 0x1000));
-	int pal = m_vip_regs.GPLT[(val >> 14) & 3];
-	int code = val & 0x3fff;
+	uint8_t const stepx = (x & 0x1c0) >> 6;
+	uint8_t const stepy = ((y & 0x1c0) >> 6) * (stepx+1);
+	uint16_t const val = READ_BGMAP((x & 0x3f) + (64 * (y & 0x3f)) + ((num + stepx + stepy) * 0x1000));
+	int const pal = m_vip_regs.GPLT[(val >> 14) & 3];
+	int const code = val & 0x3fff;
 
-	uint16_t data;
-	uint8_t yi, xi, dat;
-
-	yi = ypos & 7;
-	data = READ_FONT(code * 8 + yi);
-	xi = xpos & 7;
-	dat = ((data >> (xi << 1)) & 0x03);
+	uint8_t const yi = ypos & 7;
+	uint16_t const data = READ_FONT(code * 8 + yi);
+	uint8_t const xi = xpos & 7;
+	uint8_t const dat = ((data >> (xi << 1)) & 0x03);
 
 	if(dat == 0)
-	{
-		//g_profiler.stop();
 		return -1;
-	}
-	//  g_profiler.stop();
-	return (pal >> (dat*2)) & 3;
+	else
+		return (pal >> (dat*2)) & 3;
 }
 
 void vboy_state::draw_bg_map(bitmap_ind16 &bitmap, const rectangle &cliprect, uint16_t param_base, int mode, int gx, int gp, int gy, int mx, int mp, int my, int h, int w,
 													uint16_t x_mask, uint16_t y_mask, uint8_t ovr, bool right, int bg_map_num)
 {
-//  g_profiler.start(PROFILER_USER2);
+//  auto profile2 = g_profiler.start(PROFILER_USER2);
 
 	for(int y=0;y<=h;y++)
 	{
@@ -323,9 +315,8 @@ void vboy_state::draw_bg_map(bitmap_ind16 &bitmap, const rectangle &cliprect, ui
 			{
 				if ((src_x > x_mask || src_y > y_mask || src_x < 0 || src_y < 0))
 				{
-					g_profiler.start(PROFILER_USER3);
+					auto profile3 = g_profiler.start(PROFILER_USER3);
 					pix = READ_OVR_TEMPDRAW_MAP((src_y & 7)*8+(src_x & 7));
-					g_profiler.stop();
 				}
 				else
 				{
@@ -341,13 +332,12 @@ void vboy_state::draw_bg_map(bitmap_ind16 &bitmap, const rectangle &cliprect, ui
 				bitmap.pix(y1, x1) = m_palette->pen(pix & 3);
 		}
 	}
-//  g_profiler.stop();
 }
 
 void vboy_state::draw_affine_map(bitmap_ind16 &bitmap, const rectangle &cliprect, uint16_t param_base, int gx, int gp, int gy, int h, int w,
 														uint16_t x_mask, uint16_t y_mask, uint8_t ovr, bool right, int bg_map_num)
 {
-//  g_profiler.start(PROFILER_USER3);
+//  auto profile3 = g_profiler.start(PROFILER_USER3);
 
 	for(int y=0;y<=h;y++)
 	{
@@ -385,7 +375,6 @@ void vboy_state::draw_affine_map(bitmap_ind16 &bitmap, const rectangle &cliprect
 					bitmap.pix(y1, x1) = m_palette->pen(pix & 3);
 		}
 	}
-//  g_profiler.stop();
 }
 
 /*

--- a/src/mame/sega/powervr2.cpp
+++ b/src/mame/sega/powervr2.cpp
@@ -999,7 +999,7 @@ void powervr2_device::softreset_w(offs_t offset, uint32_t data, uint32_t mem_mas
 void powervr2_device::startrender_w(address_space &space, uint32_t data)
 {
 	dc_state *state = machine().driver_data<dc_state>();
-	g_profiler.start(PROFILER_USER1);
+	auto profile = g_profiler.start(PROFILER_USER1);
 
 	LOGTACMD("Start render, region=%08x, params=%08x\n", region_base, param_base);
 
@@ -1465,6 +1465,7 @@ uint32_t powervr2_device::ta_list_init_r()
 void powervr2_device::ta_list_init_w(uint32_t data)
 {
 	if(data & 0x80000000) {
+		auto profile = g_profiler.start(PROFILER_USER2);
 		tafifo_pos=0;
 		tafifo_mask=7;
 		tafifo_vertexwords=8;
@@ -1521,8 +1522,6 @@ void powervr2_device::ta_list_init_w(uint32_t data)
 		for (int group = 0; group < DISPLAY_LIST_COUNT; group++) {
 			grab[grabsel].groups[group].strips_size=0;
 		}
-
-		g_profiler.stop();
 	}
 }
 

--- a/src/mame/sega/saturn_v.cpp
+++ b/src/mame/sega/saturn_v.cpp
@@ -7611,13 +7611,7 @@ void saturn_state::stv_vdp2_draw_NBG3(bitmap_rgb32 &bitmap, const rectangle &cli
 
 void saturn_state::stv_vdp2_draw_rotation_screen(bitmap_rgb32 &bitmap, const rectangle &cliprect, int iRP)
 {
-	rectangle roz_clip_rect;
-	int planesizex = 0, planesizey = 0;
-	int planerenderedsizex, planerenderedsizey;
-	uint8_t colour_calculation_enabled;
-	uint8_t fade_control;
-
-	if ( iRP == 1)
+	if (iRP == 1)
 	{
 		stv2_current_tilemap.bitmap_map = STV_VDP2_RAMP_;
 		stv2_current_tilemap.map_offset[0] = STV_VDP2_RAMPA | (STV_VDP2_RAMP_ << 6);
@@ -7671,6 +7665,7 @@ void saturn_state::stv_vdp2_draw_rotation_screen(bitmap_rgb32 &bitmap, const rec
 		stv2_current_tilemap.plane_size = STV_VDP2_RBPLSZ;
 	}
 
+	int planesizex = 0, planesizey = 0;
 	if (stv2_current_tilemap.bitmap_enable)
 	{
 		switch (stv2_current_tilemap.bitmap_size)
@@ -7746,7 +7741,9 @@ void saturn_state::stv_vdp2_draw_rotation_screen(bitmap_rgb32 &bitmap, const rec
 		if ( !m_vdp2.roz_bitmap[iRP-1].valid() )
 			m_vdp2.roz_bitmap[iRP-1].allocate(4096, 4096);
 
+		rectangle roz_clip_rect;
 		roz_clip_rect.min_x = roz_clip_rect.min_y = 0;
+		int planerenderedsizex, planerenderedsizey;
 		if ( (iRP == 1 && STV_VDP2_RAOVR == 3) ||
 				(iRP == 2 && STV_VDP2_RBOVR == 3) )
 		{
@@ -7770,32 +7767,33 @@ void saturn_state::stv_vdp2_draw_rotation_screen(bitmap_rgb32 &bitmap, const rec
 		}
 
 
-		colour_calculation_enabled = stv2_current_tilemap.colour_calculation_enabled;
+		uint8_t const colour_calculation_enabled = stv2_current_tilemap.colour_calculation_enabled;
 		stv2_current_tilemap.colour_calculation_enabled = 0;
 //      window_control = stv2_current_tilemap.window_control;
 //      stv2_current_tilemap.window_control = 0;
-		fade_control = stv2_current_tilemap.fade_control;
+		uint8_t const fade_control = stv2_current_tilemap.fade_control;
 		stv2_current_tilemap.fade_control = 0;
-		g_profiler.start(PROFILER_USER1);
-		if ( LOG_VDP2 ) logerror( "Checking for cached RBG bitmap, cache_dirty = %d, memcmp() = %d\n", stv_rbg_cache_data.is_cache_dirty, memcmp(&stv_rbg_cache_data.layer_data[iRP-1],&stv2_current_tilemap,sizeof(stv2_current_tilemap)));
-		if ( (stv_rbg_cache_data.is_cache_dirty & iRP) ||
-			memcmp(&stv_rbg_cache_data.layer_data[iRP-1],&stv2_current_tilemap,sizeof(stv2_current_tilemap)) != 0 )
 		{
-			m_vdp2.roz_bitmap[iRP-1].fill(m_palette->black_pen(), roz_clip_rect );
-			stv_vdp2_check_tilemap(m_vdp2.roz_bitmap[iRP-1], roz_clip_rect);
-			// prepare cache data
-			stv_rbg_cache_data.watch_vdp2_vram_writes |= iRP;
-			stv_rbg_cache_data.is_cache_dirty &= ~iRP;
-			memcpy(&stv_rbg_cache_data.layer_data[iRP-1], &stv2_current_tilemap, sizeof(stv2_current_tilemap));
-			stv_rbg_cache_data.map_offset_min[iRP-1] = stv_vdp2_layer_data_placement.map_offset_min;
-			stv_rbg_cache_data.map_offset_max[iRP-1] = stv_vdp2_layer_data_placement.map_offset_max;
-			stv_rbg_cache_data.tile_offset_min[iRP-1] = stv_vdp2_layer_data_placement.tile_offset_min;
-			stv_rbg_cache_data.tile_offset_max[iRP-1] = stv_vdp2_layer_data_placement.tile_offset_max;
-			if ( LOG_VDP2 ) logerror( "Cache watch: map = %06X - %06X, tile = %06X - %06X\n", stv_rbg_cache_data.map_offset_min[iRP-1],
-				stv_rbg_cache_data.map_offset_max[iRP-1], stv_rbg_cache_data.tile_offset_min[iRP-1], stv_rbg_cache_data.tile_offset_max[iRP-1] );
+			auto profile1 = g_profiler.start(PROFILER_USER1);
+			if ( LOG_VDP2 ) logerror( "Checking for cached RBG bitmap, cache_dirty = %d, memcmp() = %d\n", stv_rbg_cache_data.is_cache_dirty, memcmp(&stv_rbg_cache_data.layer_data[iRP-1],&stv2_current_tilemap,sizeof(stv2_current_tilemap)));
+			if ( (stv_rbg_cache_data.is_cache_dirty & iRP) ||
+				memcmp(&stv_rbg_cache_data.layer_data[iRP-1],&stv2_current_tilemap,sizeof(stv2_current_tilemap)) != 0 )
+			{
+				m_vdp2.roz_bitmap[iRP-1].fill(m_palette->black_pen(), roz_clip_rect );
+				stv_vdp2_check_tilemap(m_vdp2.roz_bitmap[iRP-1], roz_clip_rect);
+				// prepare cache data
+				stv_rbg_cache_data.watch_vdp2_vram_writes |= iRP;
+				stv_rbg_cache_data.is_cache_dirty &= ~iRP;
+				memcpy(&stv_rbg_cache_data.layer_data[iRP-1], &stv2_current_tilemap, sizeof(stv2_current_tilemap));
+				stv_rbg_cache_data.map_offset_min[iRP-1] = stv_vdp2_layer_data_placement.map_offset_min;
+				stv_rbg_cache_data.map_offset_max[iRP-1] = stv_vdp2_layer_data_placement.map_offset_max;
+				stv_rbg_cache_data.tile_offset_min[iRP-1] = stv_vdp2_layer_data_placement.tile_offset_min;
+				stv_rbg_cache_data.tile_offset_max[iRP-1] = stv_vdp2_layer_data_placement.tile_offset_max;
+				if ( LOG_VDP2 ) logerror( "Cache watch: map = %06X - %06X, tile = %06X - %06X\n", stv_rbg_cache_data.map_offset_min[iRP-1],
+					stv_rbg_cache_data.map_offset_max[iRP-1], stv_rbg_cache_data.tile_offset_min[iRP-1], stv_rbg_cache_data.tile_offset_max[iRP-1] );
+			}
+			// stop profiling USER1
 		}
-
-		g_profiler.stop();
 
 		stv2_current_tilemap.colour_calculation_enabled = colour_calculation_enabled;
 		if ( colour_calculation_enabled )
@@ -7818,9 +7816,8 @@ void saturn_state::stv_vdp2_draw_rotation_screen(bitmap_rgb32 &bitmap, const rec
 
 		stv2_current_tilemap.fade_control = fade_control;
 
-		g_profiler.start(PROFILER_USER2);
+		auto profile2 = g_profiler.start(PROFILER_USER2);
 		stv_vdp2_copy_roz_bitmap(bitmap, m_vdp2.roz_bitmap[iRP-1], cliprect, iRP, planesizex, planesizey, planerenderedsizex, planerenderedsizey );
-		g_profiler.stop();
 	}
 
 }

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -1644,7 +1644,7 @@ void segas32_state::sprite_render_list()
 	int numentries = 0;
 	int spritenum = 0;
 
-	g_profiler.start(PROFILER_USER2);
+	auto profile = g_profiler.start(PROFILER_USER2);
 
 //  logerror("----\n");
 
@@ -1714,8 +1714,6 @@ void segas32_state::sprite_render_list()
 				break;
 		}
 	}
-
-	g_profiler.stop();
 }
 
 
@@ -2200,9 +2198,10 @@ uint32_t segas32_state::screen_update_system32(screen_device &screen, bitmap_rgb
 	}
 
 	/* update the tilemaps */
-	g_profiler.start(PROFILER_USER1);
-	enablemask = update_tilemaps(screen, cliprect);
-	g_profiler.stop();
+	{
+		auto profile = g_profiler.start(PROFILER_USER1);
+		enablemask = update_tilemaps(screen, cliprect);
+	}
 
 	/* debugging */
 #if QWERTY_LAYER_ENABLE
@@ -2215,9 +2214,10 @@ uint32_t segas32_state::screen_update_system32(screen_device &screen, bitmap_rgb
 #endif
 
 	/* do the mixing */
-	g_profiler.start(PROFILER_USER3);
-	mix_all_layers(0, 0, bitmap, cliprect, enablemask);
-	g_profiler.stop();
+	{
+		auto profile = g_profiler.start(PROFILER_USER3);
+		mix_all_layers(0, 0, bitmap, cliprect, enablemask);
+	}
 
 	if (LOG_SPRITES && machine().input().code_pressed(KEYCODE_L))
 	{
@@ -2378,9 +2378,10 @@ uint32_t segas32_state::multi32_update(screen_device &screen, bitmap_rgb32 &bitm
 	}
 
 	/* update the tilemaps */
-	g_profiler.start(PROFILER_USER1);
-	enablemask = update_tilemaps(screen, cliprect);
-	g_profiler.stop();
+	{
+		auto profile = g_profiler.start(PROFILER_USER1);
+		enablemask = update_tilemaps(screen, cliprect);
+	}
 
 	/* debugging */
 #if QWERTY_LAYER_ENABLE
@@ -2393,15 +2394,16 @@ uint32_t segas32_state::multi32_update(screen_device &screen, bitmap_rgb32 &bitm
 #endif
 
 	/* do the mixing */
-	g_profiler.start(PROFILER_USER3);
-	mix_all_layers(index, 0, bitmap, cliprect, enablemask);
-	g_profiler.stop();
+	{
+		auto profile = g_profiler.start(PROFILER_USER3);
+		mix_all_layers(index, 0, bitmap, cliprect, enablemask);
+	}
 
-if (PRINTF_MIXER_DATA)
-{
-	if (!screen.machine().input().code_pressed(KEYCODE_M)) print_mixer_data(0);
-	else print_mixer_data(1);
-}
+	if (PRINTF_MIXER_DATA)
+	{
+		if (!screen.machine().input().code_pressed(KEYCODE_M)) print_mixer_data(0);
+		else print_mixer_data(1);
+	}
 	if (LOG_SPRITES && screen.machine().input().code_pressed(KEYCODE_L))
 	{
 		const rectangle &visarea = screen.visible_area();

--- a/src/mame/snk/hng64_3d.ipp
+++ b/src/mame/snk/hng64_3d.ipp
@@ -74,7 +74,7 @@ void hng64_state::dl_upload_w(uint32_t data)
 	// This is written after the game uploads 16 packets, each 16 words long
 	// We're assuming it to be a 'send to 3d hardware' trigger.
 	// This can be called multiple times per frame (at least 2, as long as it gets the expected interrupt / status flags)
-g_profiler.start(PROFILER_USER1);
+	auto profile = g_profiler.start(PROFILER_USER1);
 	for(int packetStart = 0; packetStart < 0x100; packetStart += 16)
 	{
 		// Send it off to the 3d subsystem.
@@ -84,7 +84,6 @@ g_profiler.start(PROFILER_USER1);
 
 	// Schedule a small amount of time to let the 3d hardware rasterize the display buffer
 	m_3dfifo_timer->adjust(m_maincpu->cycles_to_attotime(0x200*8));
-g_profiler.stop();
 }
 
 TIMER_CALLBACK_MEMBER(hng64_state::hng64_3dfifo_processed)

--- a/src/mame/snk/hng64_v.cpp
+++ b/src/mame/snk/hng64_v.cpp
@@ -721,7 +721,7 @@ void hng64_state::hng64_drawtilemap(screen_device &screen, bitmap_rgb32 &bitmap,
 	rectangle clip = cliprect;
 	clip.min_y = clip.max_y = line;
 
-g_profiler.start(PROFILER_TILEMAP_DRAW_ROZ);
+	auto profile = g_profiler.start(PROFILER_TILEMAP_DRAW_ROZ);
 	/* get the full pixmap for the tilemap */
 	tilemap->pixmap();
 
@@ -745,9 +745,6 @@ g_profiler.start(PROFILER_TILEMAP_DRAW_ROZ);
 	{
 		hng64_tilemap_draw_roz_core_line(screen, bitmap, clip, tilemap, wrap, get_blend_mode(tm), 0x80, mosaic, tm, 0);
 	}
-
-g_profiler.stop();
-
 }
 
 void hng64_state::mixsprites_test(screen_device& screen, bitmap_rgb32& bitmap, const rectangle& cliprect, uint16_t priority, int y)

--- a/src/mame/sunelectronics/shangha3_v.cpp
+++ b/src/mame/sunelectronics/shangha3_v.cpp
@@ -111,7 +111,7 @@ void shangha3_state::blitter_go_w(uint16_t data)
 	int offs;
 
 
-	g_profiler.start(PROFILER_VIDEO);
+	auto profile = g_profiler.start(PROFILER_VIDEO);
 
 	for (offs = m_gfxlist_addr << 3; offs < m_ram.bytes()/2; offs += 16)
 	{
@@ -250,8 +250,6 @@ void shangha3_state::blitter_go_w(uint16_t data)
 			}
 		}
 	}
-
-	g_profiler.stop();
 }
 
 

--- a/src/mame/taito/buggychl.cpp
+++ b/src/mame/taito/buggychl.cpp
@@ -360,7 +360,7 @@ void buggychl_state::draw_fg(bitmap_ind16 &bitmap, const rectangle &cliprect)
 
 void buggychl_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	g_profiler.start(PROFILER_USER1);
+	auto profile = g_profiler.start(PROFILER_USER1);
 
 	for (int offs = 0; offs < m_spriteram.bytes(); offs += 4)
 	{
@@ -411,8 +411,6 @@ void buggychl_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprec
 			}
 		}
 	}
-
-	g_profiler.stop();
 }
 
 

--- a/src/mame/taito/tc0180vcu.cpp
+++ b/src/mame/taito/tc0180vcu.cpp
@@ -516,17 +516,14 @@ void tc0180vcu_device::draw_framebuffer( bitmap_ind16 &bitmap, const rectangle &
 {
 	rectangle myclip = cliprect;
 
-g_profiler.start(PROFILER_USER1);
+	auto profile = g_profiler.start(PROFILER_USER1);
 
 	priority <<= 4;
 
 	if (m_video_control & 0x08)
 	{
 		if (priority)
-		{
-			g_profiler.stop();
 			return;
-		}
 
 		if (m_video_control & 0x10)   /*flip screen*/
 		{
@@ -606,7 +603,6 @@ g_profiler.start(PROFILER_USER1);
 			}
 		}
 	}
-g_profiler.stop();
 }
 
 void tc0180vcu_device::vblank_update()


### PR DESCRIPTION
This has two visible effects:
* `emu.wait(...)` works in most places
* the argument to `emu.wait` can be an attotime rather than a double

This lets you use `emu.wait(...)` directly from autoboot scripts without mucking around creating coroutines.  I haven’t checked the performance impact.  Plugins work, script bindings that return values to C++ still work (e.g. for layout scripting).