### PR TITLE
Notes update of supported games in Deco0

### DIFF
--- a/src/mame/dataeast/dec0.cpp
+++ b/src/mame/dataeast/dec0.cpp
@@ -7,33 +7,53 @@
 
   This file contains drivers for:
 
-    * Heavy Barrel                            (USA set)
-    * Heavy Barrel                            (World set)
-    * Bad Dudes vs. Dragonninja               (USA set)
-    * Dragonninja                             (Japanese version of above)
-    * Birdie Try                              (Japanese set)
-    * Robocop                                 (World bootleg rom set)
+	* Heavy Barrel         				      (USA)
+    * Heavy Barrel                            (World)
+    * Bad Dudes vs. Dragonninja     		  (USA rev 1)
+    * Dragonninja                             (Japan rev 1)
+    * Birdie Try                              (Japan rev 2, rev 1 MCU)
+    * Birdie Try                              (Japan rev 2)
+    * Birdie Try                              (Japan rev S)
+    * Robocop                                 (World rev 4)
     * Robocop                                 (World rev 3)
+    * Robocop                                 (Japan)
     * Robocop                                 (USA rev 1)
     * Robocop                                 (USA rev 0)
-    * Hippodrome                              (USA set)
-    * Fighting Fantasy                        (Japanese version of above)
+    * Bandit                                  (USA)
+    * Hippodrome                              (USA)
+    * Fighting Fantasy                        (Japan rev 3)
+    * Fighting Fantasy                        (Japan rev 2)
+    * Fighting Fantasy                        (Japan)
+    * Fighting Fantasy                        (Japan rev ?)
     * Secret Agent                            (World rev 3)
     * Secret Agent                            (Japan rev 2)
+    * Sly Spy                                 (USA rev 4)
     * Sly Spy                                 (USA rev 3)
     * Sly Spy                                 (USA rev 2)
-    * Midnight Resistance                     (World set)
-    * Midnight Resistance                     (USA set)
-    * Midnight Resistance                     (Japanese set)
-    * Boulder Dash                            (World set)
+    * Midnight Resistance                     (World rev1)
+    * Midnight Resistance                     (World rev 2)
+    * Midnight Resistance                     (US)
+    * Midnight Resistance                     (Japan)
+    * Boulder Dash / Boulder Dash Part 2      (World)
+    * Boulder Dash / Boulder Dash Part 2      (Japan)
     * Bandit                                  (USA set)
+    * Robocop                                 (World bootleg)
+    * Dragonninja                             (bootleg)
+    * Midnight Resistance                     (bootleg with 68705)
+    * Midnight Resistance                     (Joystick bootleg)
+    * Fighting Fantasy                        (bootleg with 68705)
+    * Dragonninja                             (bootleg with 68705)
+    * Automat                                 (bootleg of Robocop)
+    * Secret Agent                            (bootleg)
+    * Master Bond                             (bootleg of Secret Agent)
+
 
     Heavy Barrel, Bad Dudes, Robocop, Birdie Try & Hippodrome use the 'MEC-M1'
-motherboard and varying game boards.  Sly Spy, Midnight Resistance and
+motherboard and varying game boards. Sly Spy, Midnight Resistance and
 Boulder Dash use the same graphics chips but are different pcbs.
 
     Bandit (USA) is almost certainly a field test prototype, the software runs
-    on a Heavy Barrel board including the original Heavy Barrel MCU (which is effectively
+    on a Heavy Barrel board with the original Heavy Barrel MCU (which is effectively
     not used).  There is also Japanese version known to run on a DE-0321-1 top board.
 
     There are Secret Agent (bootleg) and Robocop (bootleg) sets to add.
@@ -1856,7 +1876,7 @@ void dec0_state::dec0(machine_config &config)
 	ym1.add_route(1, "mono", 0.81);
 	ym1.add_route(2, "mono", 0.81);
 	ym1.add_route(3, "mono", 0.32);
-	ym1.irq_handler().set_inputline(m_audiocpu, 0); // Schematics show both ym2203 and ym3812 can trigger IRQ, but Bandit is only game to program 2203 to do so
+	ym1.irq_handler().set_inputline(m_audiocpu, 0); // Schematics show both ym2203 and ym3812 can trigger IRQ, but Bandit is the only game to program 2203 to do so
 
 	ym3812_device &ym2(YM3812(config, "ym2", XTAL(12'000'000) / 4));
 	ym2.irq_handler().set_inputline(m_audiocpu, 0);


### PR DESCRIPTION
I've updated the list at the top of supported drivers/games to match what's in the file. I don't think the driver needs a list at the top, but it's already there, so I'm updating it. (I also changed the mix of 'revision, rev, set' to just 'rev'