### PR TITLE
set accurate avi framerate instead of rough approximation

### DIFF
--- a/src/emu/recording.cpp
+++ b/src/emu/recording.cpp
@@ -179,8 +179,8 @@ bool avi_movie_recording::initialize(running_machine &machine, std::unique_ptr<e
 	// build up information about this new movie
 	avi_file::movie_info info;
 	info.video_format = 0;
-	info.video_timescale = 1000 * (screen() ? screen()->frame_period().as_hz() : screen_device::DEFAULT_FRAME_RATE);
-	info.video_sampletime = 1000;
+	info.video_timescale = 0xFFFF'FFF0;
+	info.video_sampletime = screen() ? screen()->frame_period().as_ticks(0xFFFF'FFF0) : 0x0444'4444;
 	info.video_numsamples = 0;
 	info.video_width = width;
 	info.video_height = height;
@@ -195,7 +195,7 @@ bool avi_movie_recording::initialize(running_machine &machine, std::unique_ptr<e
 	info.audio_samplerate = machine.sample_rate();
 
 	// compute the frame time
-	set_frame_period(attotime::from_seconds(1000) / info.video_timescale);
+	set_frame_period(attotime::from_seconds(info.video_sampletime) / info.video_timescale);
 
 	// create the file
 	avi_file::error avierr = avi_file::create(fullpath, info, m_avi_file);

--- a/src/emu/recording.cpp
+++ b/src/emu/recording.cpp
@@ -179,8 +179,8 @@ bool avi_movie_recording::initialize(running_machine &machine, std::unique_ptr<e
 	// build up information about this new movie
 	avi_file::movie_info info;
 	info.video_format = 0;
-	info.video_timescale = 0x7FFF'FFF8; // biggest int multiple of 60, for screenless machines
-	info.video_sampletime = screen() ? screen()->frame_period().as_ticks(info.video_timescale) : 0x0222'2222;
+	info.video_timescale = 0x3FFF'FFFC; // multiple of 60, for screenless machines
+	info.video_sampletime = screen() ? screen()->frame_period().as_ticks(info.video_timescale) : 0x0111'1111;
 	info.video_numsamples = 0;
 	info.video_width = width;
 	info.video_height = height;

--- a/src/emu/recording.cpp
+++ b/src/emu/recording.cpp
@@ -179,7 +179,7 @@ bool avi_movie_recording::initialize(running_machine &machine, std::unique_ptr<e
 	// build up information about this new movie
 	avi_file::movie_info info;
 	info.video_format = 0;
-	info.video_timescale = 0x3FFF'FFFC; // multiple of 60, for screenless machines
+	info.video_timescale = 0x3fff'fffc; // multiple of 60, for screenless machines
 	info.video_sampletime = screen() ? screen()->frame_period().as_ticks(info.video_timescale) : 0x0111'1111;
 	info.video_numsamples = 0;
 	info.video_width = width;
@@ -195,7 +195,7 @@ bool avi_movie_recording::initialize(running_machine &machine, std::unique_ptr<e
 	info.audio_samplerate = machine.sample_rate();
 
 	// compute the frame time
-	set_frame_period(attotime::from_seconds(info.video_sampletime) / info.video_timescale);
+	set_frame_period(attotime::from_ticks(info.video_sampletime, info.video_timescale);
 
 	// create the file
 	avi_file::error avierr = avi_file::create(fullpath, info, m_avi_file);

--- a/src/emu/recording.cpp
+++ b/src/emu/recording.cpp
@@ -179,8 +179,8 @@ bool avi_movie_recording::initialize(running_machine &machine, std::unique_ptr<e
 	// build up information about this new movie
 	avi_file::movie_info info;
 	info.video_format = 0;
-	info.video_timescale = 0xFFFF'FFF0;
-	info.video_sampletime = screen() ? screen()->frame_period().as_ticks(0xFFFF'FFF0) : 0x0444'4444;
+	info.video_timescale = 0x7FFF'FFF8; // biggest int multiple of 60, for screenless machines
+	info.video_sampletime = screen() ? screen()->frame_period().as_ticks(info.video_timescale) : 0x0222'2222;
 	info.video_numsamples = 0;
 	info.video_width = width;
 	info.video_height = height;


### PR DESCRIPTION
Before, mslugx (59.185606 Hz) would have this AVI framerate

```
framerate:   59.185000000000002
numerator:   59185
denominator: 1000
```

Now, it has

```
framerate:   59.185609563542229
numerator:   1000000000
denominator: 16895999
```

which is directly inherited from the internal refresh rate of the game.

This affects audio/video sync and timings. Here's a comparison of how the same shot at the very start and 200k frames in has audio that appears differently:
![изображение](https://user-images.githubusercontent.com/7092625/227743020-57ac4edd-9885-4e7e-9cd1-9b861328df1c.png)
![изображение](https://user-images.githubusercontent.com/7092625/227743031-59885d6a-7c91-4826-ad9e-1c57388fb3d2.png)

After my change, it appears the same in both cases (the sound effect now also appears on the same frame as the shot, but that's just a subjective observation without a recording of the real machine):
![изображение](https://user-images.githubusercontent.com/7092625/227743054-c62c8a1c-a2b1-4b6c-9643-17430cafea15.png)
![изображение](https://user-images.githubusercontent.com/7092625/227743061-9b7a28db-7c26-421c-9ee3-9c117e8c0b09.png)

Also notice how the same scene happens on entirely different frames. This is because fps value reduction results in duplicate or dropped frames in the video, depending if the original value was higher or lower.

PS: AVI duration of the BIOS startup is also different before and after my change (302 vs 261 frames), but I don't know why it happens. At least it now matches which internal frame "CREDIT 0" appears on.