### PR TITLE
Mame0252 bn

### DIFF
--- a/src/devices/bus/coco/coco_fdc.cpp
+++ b/src/devices/bus/coco/coco_fdc.cpp
@@ -121,22 +121,22 @@ template class device_finder<coco_family_fdc_device_base, true>;
 class coco_fdc_device_base : public coco_family_fdc_device_base
 {
 protected:
-	// construction/destruction
-	coco_fdc_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+        // construction/destruction
+        coco_fdc_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
-	// device-level overrides
-	virtual u8 cts_read(offs_t offset) override;
-	virtual u8 scs_read(offs_t offset) override;
-	virtual void scs_write(offs_t offset, u8 data) override;
-	virtual void device_add_mconfig(machine_config &config) override;
+        // device-level overrides
+        virtual u8 cts_read(offs_t offset) override;
+        virtual u8 scs_read(offs_t offset) override;
+        virtual void scs_write(offs_t offset, u8 data) override;
+        virtual void device_add_mconfig(machine_config &config) override;
 
-	// methods
-	virtual void update_lines() override;
-	void dskreg_w(u8 data);
+        // methods
+        virtual void update_lines() override;
+        void dskreg_w(u8 data);
 
-	// devices
-	required_device<wd1773_device>              m_wd17xx;
-	required_device_array<floppy_connector, 4>  m_floppies;
+        // devices
+        required_device<wd1773_device>              m_wd17xx;
+        required_device_array<floppy_connector, 4>  m_floppies;
 };
 
 
@@ -146,35 +146,35 @@ protected:
 
 void coco_family_fdc_device_base::floppy_formats(format_registration &fr)
 {
-	fr.add_mfm_containers();
-	fr.add(FLOPPY_DMK_FORMAT);
-	fr.add(FLOPPY_JVC_FORMAT);
-	fr.add(FLOPPY_VDK_FORMAT);
-	fr.add(FLOPPY_SDF_FORMAT);
-	fr.add(FLOPPY_OS9_FORMAT);
-	fr.add(fs::COCO_RSDOS);
-	fr.add(fs::COCO_OS9);
+        fr.add_mfm_containers();
+        fr.add(FLOPPY_DMK_FORMAT);
+        fr.add(FLOPPY_JVC_FORMAT);
+        fr.add(FLOPPY_VDK_FORMAT);
+        fr.add(FLOPPY_SDF_FORMAT);
+        fr.add(FLOPPY_OS9_FORMAT);
+        fr.add(fs::COCO_RSDOS);
+        fr.add(fs::COCO_OS9);
 }
 
 static void coco_fdc_floppies(device_slot_interface &device)
 {
-	device.option_add("525qd", FLOPPY_525_QD);
-	device.option_add("525dd", FLOPPY_525_DD);
-	device.option_add("35dd", FLOPPY_35_DD);
+        device.option_add("525qd", FLOPPY_525_QD);
+        device.option_add("525dd", FLOPPY_525_DD);
+        device.option_add("35dd", FLOPPY_35_DD);
 }
 
 void coco_fdc_device_base::device_add_mconfig(machine_config &config)
 {
-	WD1773(config, m_wd17xx, 8_MHz_XTAL);
-	m_wd17xx->intrq_wr_callback().set(FUNC(coco_fdc_device_base::fdc_intrq_w));
-	m_wd17xx->drq_wr_callback().set(FUNC(coco_fdc_device_base::fdc_drq_w));
-	m_wd17xx->set_disable_motor_control(true);
-	m_wd17xx->set_force_ready(true);
+        WD1773(config, m_wd17xx, 8_MHz_XTAL);
+        m_wd17xx->intrq_wr_callback().set(FUNC(coco_fdc_device_base::fdc_intrq_w));
+        m_wd17xx->drq_wr_callback().set(FUNC(coco_fdc_device_base::fdc_drq_w));
+        m_wd17xx->set_disable_motor_control(true);
+        m_wd17xx->set_force_ready(true);
 
-	FLOPPY_CONNECTOR(config, m_floppies[0], coco_fdc_floppies, "525dd", coco_fdc_device_base::floppy_formats).enable_sound(true);
-	FLOPPY_CONNECTOR(config, m_floppies[1], coco_fdc_floppies, "525dd", coco_fdc_device_base::floppy_formats).enable_sound(true);
-	FLOPPY_CONNECTOR(config, m_floppies[2], coco_fdc_floppies, nullptr, coco_fdc_device_base::floppy_formats).enable_sound(true);
-	FLOPPY_CONNECTOR(config, m_floppies[3], coco_fdc_floppies, nullptr, coco_fdc_device_base::floppy_formats).enable_sound(true);
+        FLOPPY_CONNECTOR(config, m_floppies[0], coco_fdc_floppies, "525dd", coco_fdc_device_base::floppy_formats).enable_sound(true);
+        FLOPPY_CONNECTOR(config, m_floppies[1], coco_fdc_floppies, "525dd", coco_fdc_device_base::floppy_formats).enable_sound(true);
+        FLOPPY_CONNECTOR(config, m_floppies[2], coco_fdc_floppies, "525dd", coco_fdc_device_base::floppy_formats).enable_sound(true);
+        FLOPPY_CONNECTOR(config, m_floppies[3], coco_fdc_floppies, nullptr, coco_fdc_device_base::floppy_formats).enable_sound(true);
 }
 
 
@@ -188,9 +188,9 @@ void coco_fdc_device_base::device_add_mconfig(machine_config &config)
 
 void coco_family_fdc_device_base::device_start()
 {
-	save_item(NAME(m_dskreg));
-	save_item(NAME(m_intrq));
-	save_item(NAME(m_drq));
+        save_item(NAME(m_dskreg));
+        save_item(NAME(m_intrq));
+        save_item(NAME(m_drq));
 }
 
 
@@ -200,9 +200,9 @@ void coco_family_fdc_device_base::device_start()
 
 void coco_family_fdc_device_base::device_reset()
 {
-	m_dskreg = 0x00;
-	m_intrq = false;
-	m_drq = true;
+        m_dskreg = 0x00;
+        m_intrq = false;
+        m_drq = true;
 }
 
 
@@ -212,7 +212,7 @@ void coco_family_fdc_device_base::device_reset()
 
 u8 *coco_family_fdc_device_base::get_cart_base()
 {
-	return memregion("eprom")->base();
+        return memregion("eprom")->base();
 }
 
 
@@ -222,7 +222,7 @@ u8 *coco_family_fdc_device_base::get_cart_base()
 
 memory_region *coco_family_fdc_device_base::get_cart_memregion()
 {
-	return memregion("eprom");
+        return memregion("eprom");
 }
 
 
@@ -235,9 +235,9 @@ memory_region *coco_family_fdc_device_base::get_cart_memregion()
 //-------------------------------------------------
 
 coco_fdc_device_base::coco_fdc_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
-	: coco_family_fdc_device_base(mconfig, type, tag, owner, clock)
-	, m_wd17xx(*this, WD_TAG)
-	, m_floppies(*this, WD_TAG ":%u", 0)
+        : coco_family_fdc_device_base(mconfig, type, tag, owner, clock)
+        , m_wd17xx(*this, WD_TAG)
+        , m_floppies(*this, WD_TAG ":%u", 0)
 {
 }
 
@@ -249,15 +249,15 @@ coco_fdc_device_base::coco_fdc_device_base(const machine_config &mconfig, device
 
 void coco_fdc_device_base::update_lines()
 {
-	// clear HALT enable under certain circumstances
-	if (intrq() && (dskreg() & 0x20))
-		set_dskreg(dskreg() & ~0x80);  // clear halt enable
+        // clear HALT enable under certain circumstances
+        if (intrq() && (dskreg() & 0x20))
+                set_dskreg(dskreg() & ~0x80);  // clear halt enable
 
-	// set the NMI line
-	set_line_value(line::NMI, intrq() && (dskreg() & 0x20));
+        // set the NMI line
+        set_line_value(line::NMI, intrq() && (dskreg() & 0x20));
 
-	// set the HALT line
-	set_line_value(line::HALT, !drq() && (dskreg() & 0x80));
+        // set the HALT line
+        set_line_value(line::HALT, !drq() && (dskreg() & 0x80));
 }
 
 
@@ -267,56 +267,56 @@ void coco_fdc_device_base::update_lines()
 
 void coco_fdc_device_base::dskreg_w(u8 data)
 {
-	u8 drive = 0;
-	u8 head;
+        u8 drive = 0;
+        u8 head;
 
-	LOG("fdc_coco_dskreg_w(): %c%c%c%c%c%c%c%c ($%02x)\n",
-		data & 0x80 ? 'H' : 'h',
-		data & 0x40 ? '3' : '.',
-		data & 0x20 ? 'D' : 'S',
-		data & 0x10 ? 'P' : 'p',
-		data & 0x08 ? 'M' : 'm',
-		data & 0x04 ? '2' : '.',
-		data & 0x02 ? '1' : '.',
-		data & 0x01 ? '0' : '.',
-		data);
+        LOG("fdc_coco_dskreg_w(): %c%c%c%c%c%c%c%c ($%02x)\n",
+                data & 0x80 ? 'H' : 'h',
+                data & 0x40 ? '3' : '.',
+                data & 0x20 ? 'D' : 'S',
+                data & 0x10 ? 'P' : 'p',
+                data & 0x08 ? 'M' : 'm',
+                data & 0x04 ? '2' : '.',
+                data & 0x02 ? '1' : '.',
+                data & 0x01 ? '0' : '.',
+                data);
 
-	// An email from John Kowalski informed me that if the DS3 is
-	// high, and one of the other drive bits is selected (DS0-DS2), then the
-	// second side of DS0, DS1, or DS2 is selected. If multiple bits are
-	// selected in other situations, then both drives are selected, and any
-	// read signals get yucky.
+        // An email from John Kowalski informed me that if the DS3 is
+        // high, and one of the other drive bits is selected (DS0-DS2), then the
+        // second side of DS0, DS1, or DS2 is selected. If multiple bits are
+        // selected in other situations, then both drives are selected, and any
+        // read signals get yucky.
 
-	if (data & 0x04)
-		drive = 2;
-	else if (data & 0x02)
-		drive = 1;
-	else if (data & 0x01)
-		drive = 0;
-	else if (data & 0x40)
-		drive = 3;
+        if (data & 0x04)
+                drive = 2;
+        else if (data & 0x02)
+                drive = 1;
+        else if (data & 0x01)
+                drive = 0;
+        else if (data & 0x40)
+                drive = 3;
 
-	// the motor is always turned on or off for all drives
-	for (int i = 0; i < 4; i++)
-	{
-		floppy_image_device *floppy = m_floppies[i]->get_device();
-		if (floppy)
-			floppy->mon_w(BIT(data, 3) ? 0 : 1);
-	}
+        // the motor is always turned on or off for all drives
+        for (int i = 0; i < 4; i++)
+        {
+                floppy_image_device *floppy = m_floppies[i]->get_device();
+                if (floppy)
+                        floppy->mon_w(BIT(data, 3) ? 0 : 1);
+        }
 
-	head = ((data & 0x40) && (drive != 3)) ? 1 : 0;
+        head = ((data & 0x40) && (drive != 3)) ? 1 : 0;
 
-	set_dskreg(data);
+        set_dskreg(data);
 
-	update_lines();
+        update_lines();
 
-	floppy_image_device *selected_floppy = m_floppies[drive]->get_device();
-	m_wd17xx->set_floppy(selected_floppy);
+        floppy_image_device *selected_floppy = m_floppies[drive]->get_device();
+        m_wd17xx->set_floppy(selected_floppy);
 
-	if (selected_floppy)
-		selected_floppy->ss_w(head);
+        if (selected_floppy)
+                selected_floppy->ss_w(head);
 
-	m_wd17xx->dden_w(!BIT(dskreg(), 5));
+        m_wd17xx->dden_w(!BIT(dskreg(), 5));
 }
 
 
@@ -326,7 +326,7 @@ void coco_fdc_device_base::dskreg_w(u8 data)
 
 u8 coco_fdc_device_base::cts_read(offs_t offset)
 {
-	return memregion("eprom")->base()[offset];
+        return memregion("eprom")->base()[offset];
 }
 
 
@@ -336,29 +336,29 @@ u8 coco_fdc_device_base::cts_read(offs_t offset)
 
 u8 coco_fdc_device_base::scs_read(offs_t offset)
 {
-	u8 result = 0;
+        u8 result = 0;
 
-	switch(offset & 0x1F)
-	{
-		case 8:
-			result = m_wd17xx->status_r();
-			LOGWDFDC("m_wd17xx->status_r: %02x\n", result );
-			break;
-		case 9:
-			result = m_wd17xx->track_r();
-			LOGWDFDC("m_wd17xx->track_r: %02x\n", result );
-			break;
-		case 10:
-			result = m_wd17xx->sector_r();
-			LOGWDFDC("m_wd17xx->sector_r: %02x\n", result );
-			break;
-		case 11:
-			result = m_wd17xx->data_r();
-			LOGWDIO("m_wd17xx->data_r: %02x\n", result );
-			break;
-	}
+        switch(offset & 0x1F)
+        {
+                case 8:
+                        result = m_wd17xx->status_r();
+                        LOGWDFDC("m_wd17xx->status_r: %02x\n", result );
+                        break;
+                case 9:
+                        result = m_wd17xx->track_r();
+                        LOGWDFDC("m_wd17xx->track_r: %02x\n", result );
+                        break;
+                case 10:
+                        result = m_wd17xx->sector_r();
+                        LOGWDFDC("m_wd17xx->sector_r: %02x\n", result );
+                        break;
+                case 11:
+                        result = m_wd17xx->data_r();
+                        LOGWDIO("m_wd17xx->data_r: %02x\n", result );
+                        break;
+        }
 
-	return result;
+        return result;
 }
 
 
@@ -368,29 +368,29 @@ u8 coco_fdc_device_base::scs_read(offs_t offset)
 
 void coco_fdc_device_base::scs_write(offs_t offset, u8 data)
 {
-	switch(offset & 0x1F)
-	{
-		case 0: case 1: case 2: case 3:
-		case 4: case 5: case 6: case 7:
-			dskreg_w(data);
-			break;
-		case 8:
-			LOGWDFDC("m_wd17xx->cmd_w: %02x\n", data );
-			m_wd17xx->cmd_w(data);
-			break;
-		case 9:
-			LOGWDFDC("m_wd17xx->track_w: %02x\n", data );
-			m_wd17xx->track_w(data);
-			break;
-		case 10:
-			LOGWDFDC("m_wd17xx->sector_w: %02x\n", data );
-			m_wd17xx->sector_w(data);
-			break;
-		case 11:
-			LOGWDIO("m_wd17xx->data_w: %02x\n", data );
-			m_wd17xx->data_w(data);
-			break;
-	};
+        switch(offset & 0x1F)
+        {
+                case 0: case 1: case 2: case 3:
+                case 4: case 5: case 6: case 7:
+                        dskreg_w(data);
+                        break;
+                case 8:
+                        LOGWDFDC("m_wd17xx->cmd_w: %02x\n", data );
+                        m_wd17xx->cmd_w(data);
+                        break;
+                case 9:
+                        LOGWDFDC("m_wd17xx->track_w: %02x\n", data );
+                        m_wd17xx->track_w(data);
+                        break;
+                case 10:
+                        LOGWDFDC("m_wd17xx->sector_w: %02x\n", data );
+                        m_wd17xx->sector_w(data);
+                        break;
+                case 11:
+                        LOGWDIO("m_wd17xx->data_w: %02x\n", data );
+                        m_wd17xx->data_w(data);
+                        break;
+        };
 }
 
 
@@ -399,52 +399,52 @@ void coco_fdc_device_base::scs_write(offs_t offset, u8 data)
 //**************************************************************************
 
 ROM_START(coco_fdc)
-	ROM_REGION(0x4000, "eprom", ROMREGION_ERASE00)
-	ROM_LOAD("disk10.rom", 0x0000, 0x2000, CRC(b4f9968e) SHA1(04115be3f97952b9d9310b52f806d04f80b40d03))
+        ROM_REGION(0x4000, "eprom", ROMREGION_ERASE00)
+        ROM_LOAD("disk10.rom", 0x0000, 0x2000, CRC(b4f9968e) SHA1(04115be3f97952b9d9310b52f806d04f80b40d03))
 ROM_END
 
 ROM_START(coco_fdc_v11)
-	ROM_REGION(0x8000, "eprom", ROMREGION_ERASE00)
-	ROM_LOAD("disk11.rom", 0x0000, 0x2000, CRC(0b9c5415) SHA1(10bdc5aa2d7d7f205f67b47b19003a4bd89defd1))
-	ROM_RELOAD(0x2000, 0x2000)
-	ROM_RELOAD(0x4000, 0x2000)
-	ROM_RELOAD(0x6000, 0x2000)
+        ROM_REGION(0x8000, "eprom", ROMREGION_ERASE00)
+        ROM_LOAD("disk11.rom", 0x0000, 0x2000, CRC(0b9c5415) SHA1(10bdc5aa2d7d7f205f67b47b19003a4bd89defd1))
+        ROM_RELOAD(0x2000, 0x2000)
+        ROM_RELOAD(0x4000, 0x2000)
+        ROM_RELOAD(0x6000, 0x2000)
 ROM_END
 
 ROM_START(coco_scii_cc1)
-	ROM_REGION(0x8000, "eprom", ROMREGION_ERASE00)
-	ROM_LOAD("cdos 4 4-6-89 cc1.bin", 0x0000, 0x4000, CRC(9da6db28) SHA1(2cc6e275178ca8d8f281d845792fb0ae069aaeda))
+        ROM_REGION(0x8000, "eprom", ROMREGION_ERASE00)
+        ROM_LOAD("cdos 4 4-6-89 cc1.bin", 0x0000, 0x4000, CRC(9da6db28) SHA1(2cc6e275178ca8d8f281d845792fb0ae069aaeda))
 ROM_END
 
 ROM_START(coco_scii_cc3)
-	ROM_REGION(0x8000, "eprom", ROMREGION_ERASE00)
-	ROM_LOAD("cdos 1_2 3-30-89 cc3.bin", 0x0000, 0x4000, CRC(891c0094) SHA1(c1fa0fcbf1202a9b63aafd98dce777b502584230))
+        ROM_REGION(0x8000, "eprom", ROMREGION_ERASE00)
+        ROM_LOAD("cdos 1_2 3-30-89 cc3.bin", 0x0000, 0x4000, CRC(891c0094) SHA1(c1fa0fcbf1202a9b63aafd98dce777b502584230))
 ROM_END
 
 ROM_START(coco3_hdb1)
-	ROM_REGION(0x8000, "eprom", ROMREGION_ERASE00)
-	ROM_LOAD("hdbdw3bc3.rom", 0x0000, 0x2000, CRC(309a9efd) SHA1(671605d61811953860466f771c1594bbade331f4))
-	ROM_RELOAD(0x2000, 0x2000)
-	ROM_RELOAD(0x4000, 0x2000)
-	ROM_RELOAD(0x6000, 0x2000)
+        ROM_REGION(0x8000, "eprom", ROMREGION_ERASE00)
+        ROM_LOAD("hdbdw3bc3.rom", 0x0000, 0x2000, CRC(309a9efd) SHA1(671605d61811953860466f771c1594bbade331f4))
+        ROM_RELOAD(0x2000, 0x2000)
+        ROM_RELOAD(0x4000, 0x2000)
+        ROM_RELOAD(0x6000, 0x2000)
 ROM_END
 
 ROM_START(coco2_hdb1)
-	ROM_REGION(0x8000, "eprom", ROMREGION_ERASE00)
-	ROM_LOAD("hdbdw3bck.rom", 0x0000, 0x2000, CRC(867a3f42) SHA1(8fd64f1c246489e0bf2b3743ae76332ff324716a))
-	ROM_RELOAD(0x2000, 0x2000)
-	ROM_RELOAD(0x4000, 0x2000)
-	ROM_RELOAD(0x6000, 0x2000)
+        ROM_REGION(0x8000, "eprom", ROMREGION_ERASE00)
+        ROM_LOAD("hdbdw3bck.rom", 0x0000, 0x2000, CRC(867a3f42) SHA1(8fd64f1c246489e0bf2b3743ae76332ff324716a))
+        ROM_RELOAD(0x2000, 0x2000)
+        ROM_RELOAD(0x4000, 0x2000)
+        ROM_RELOAD(0x6000, 0x2000)
 ROM_END
 
 ROM_START(cp450_fdc)
-	ROM_REGION(0x4000, "eprom", ROMREGION_ERASE00)
-	ROM_LOAD("cp450_basic_disco_v1.0.rom", 0x0000, 0x2000, CRC(e9ad60a0) SHA1(827697fa5b755f5dc1efb054cdbbeb04e405405b))
+        ROM_REGION(0x4000, "eprom", ROMREGION_ERASE00)
+        ROM_LOAD("cp450_basic_disco_v1.0.rom", 0x0000, 0x2000, CRC(e9ad60a0) SHA1(827697fa5b755f5dc1efb054cdbbeb04e405405b))
 ROM_END
 
 ROM_START(cd6809_fdc)
-	ROM_REGION(0x4000, "eprom", ROMREGION_ERASE00)
-	ROM_LOAD("cd6809dsk.u16", 0x0000, 0x2000, CRC(3c35bda8) SHA1(9b2eec25188bed4326b84739a666435884e4ddf4))
+        ROM_REGION(0x4000, "eprom", ROMREGION_ERASE00)
+        ROM_LOAD("cd6809dsk.u16", 0x0000, 0x2000, CRC(3c35bda8) SHA1(9b2eec25188bed4326b84739a666435884e4ddf4))
 ROM_END
 
 
@@ -454,381 +454,381 @@ ROM_END
 
 namespace
 {
-	class coco_fdc_device : public coco_fdc_device_base
-	{
-	public:
-		// construction/destruction
-		coco_fdc_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-			: coco_fdc_device_base(mconfig, COCO_FDC, tag, owner, clock)
-		{
-		}
+        class coco_fdc_device : public coco_fdc_device_base
+        {
+        public:
+                // construction/destruction
+                coco_fdc_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+                        : coco_fdc_device_base(mconfig, COCO_FDC, tag, owner, clock)
+                {
+                }
 
-	protected:
-		// optional information overrides
-		virtual const tiny_rom_entry *device_rom_region() const override
-		{
-			return ROM_NAME(coco_fdc);
-		}
-	};
+        protected:
+                // optional information overrides
+                virtual const tiny_rom_entry *device_rom_region() const override
+                {
+                        return ROM_NAME(coco_fdc);
+                }
+        };
 
 
 //**************************************************************************
 //              COCO FDC v1.1
 //**************************************************************************
 
-	class coco_fdc_v11_device : public coco_fdc_device_base
-	{
-	public:
-		// construction/destruction
-		coco_fdc_v11_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-			: coco_fdc_device_base(mconfig, COCO_FDC_V11, tag, owner, clock)
-		{
-		}
+        class coco_fdc_v11_device : public coco_fdc_device_base
+        {
+        public:
+                // construction/destruction
+                coco_fdc_v11_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+                        : coco_fdc_device_base(mconfig, COCO_FDC_V11, tag, owner, clock)
+                {
+                }
 
-	protected:
-		// optional information overrides
-		virtual const tiny_rom_entry *device_rom_region() const override
-		{
-			return ROM_NAME(coco_fdc_v11);
-		}
-	};
+        protected:
+                // optional information overrides
+                virtual const tiny_rom_entry *device_rom_region() const override
+                {
+                        return ROM_NAME(coco_fdc_v11);
+                }
+        };
 
 
 //**************************************************************************
 //              Disto / CRC Super Controller II Base
 //**************************************************************************
 
-	class coco_scii_device_base
-		: public coco_fdc_device_base
-	{
-	public:
-		// construction/destruction
-		coco_scii_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
-			: coco_fdc_device_base(mconfig, type, tag, owner, clock)
-			, m_slot(*this, MEB_TAG)
-			, m_carts(*this, "cart_line")
-		{
-		}
+        class coco_scii_device_base
+                : public coco_fdc_device_base
+        {
+        public:
+                // construction/destruction
+                coco_scii_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
+                        : coco_fdc_device_base(mconfig, type, tag, owner, clock)
+                        , m_slot(*this, MEB_TAG)
+                        , m_carts(*this, "cart_line")
+                {
+                }
 
-	protected:
-		// device-level overrides
-		virtual void device_start() override;
-		virtual void device_reset() override;
-		virtual u8 scs_read(offs_t offset) override;
-		virtual void scs_write(offs_t offset, u8 data) override;
+        protected:
+                // device-level overrides
+                virtual void device_start() override;
+                virtual void device_reset() override;
+                virtual u8 scs_read(offs_t offset) override;
+                virtual void scs_write(offs_t offset, u8 data) override;
 
-		// optional information overrides
-		virtual void device_add_mconfig(machine_config &config) override;
+                // optional information overrides
+                virtual void device_add_mconfig(machine_config &config) override;
 
-		// methods
-		virtual void update_lines() override;
+                // methods
+                virtual void update_lines() override;
 
-		// Disto no halt registers
-		u8 ff74_read(offs_t offset);
-		void ff74_write(offs_t offset, u8 data);
+                // Disto no halt registers
+                u8 ff74_read(offs_t offset);
+                void ff74_write(offs_t offset, u8 data);
 
-		// device references
-		required_device<distomeb_slot_device> m_slot;
-		required_device<input_merger_device> m_carts;
+                // device references
+                required_device<distomeb_slot_device> m_slot;
+                required_device<input_merger_device> m_carts;
 
-	private:
-		// registers
-		std::unique_ptr<uint8_t[]> m_cache;
-		u8 m_cache_pointer;
-		u8 m_cache_controler;
-	};
+        private:
+                // registers
+                std::unique_ptr<uint8_t[]> m_cache;
+                u8 m_cache_pointer;
+                u8 m_cache_controler;
+        };
 
 
 //-------------------------------------------------
 //  device_start - device-specific start
 //-------------------------------------------------
 
-	void coco_scii_device_base::device_start()
-	{
-		coco_family_fdc_device_base::device_start();
+        void coco_scii_device_base::device_start()
+        {
+                coco_family_fdc_device_base::device_start();
 
-		m_cache = std::make_unique<uint8_t[]>(0x200);
+                m_cache = std::make_unique<uint8_t[]>(0x200);
 
-		install_readwrite_handler(0xFF74, 0xFF77,
-				read8sm_delegate(*this, FUNC(coco_scii_device_base::ff74_read)),
-				write8sm_delegate(*this, FUNC(coco_scii_device_base::ff74_write)));
+                install_readwrite_handler(0xFF74, 0xFF77,
+                                read8sm_delegate(*this, FUNC(coco_scii_device_base::ff74_read)),
+                                write8sm_delegate(*this, FUNC(coco_scii_device_base::ff74_write)));
 
-		save_pointer(NAME(m_cache), 0x200);
-		save_item(NAME(m_cache_pointer));
-		save_item(NAME(m_cache_controler));
-	}
+                save_pointer(NAME(m_cache), 0x200);
+                save_item(NAME(m_cache_pointer));
+                save_item(NAME(m_cache_controler));
+        }
 
 
 //-------------------------------------------------
 //  device_reset - device-specific reset
 //-------------------------------------------------
 
-	void coco_scii_device_base::device_reset()
-	{
-		coco_family_fdc_device_base::device_reset();
+        void coco_scii_device_base::device_reset()
+        {
+                coco_family_fdc_device_base::device_reset();
 
-		m_cache_controler = 0x80;
-		m_cache_pointer = 0;
-	}
+                m_cache_controler = 0x80;
+                m_cache_pointer = 0;
+        }
 
-	static void disto_meb_slot(device_slot_interface &device)
-	{
-		disto_meb_add_basic_devices(device);
-	}
+        static void disto_meb_slot(device_slot_interface &device)
+        {
+                disto_meb_add_basic_devices(device);
+        }
 
 
 //-------------------------------------------------
 //  device_add_mconfig - device-specific machine config
 //-------------------------------------------------
 
-	void coco_scii_device_base::device_add_mconfig(machine_config &config)
-	{
-		coco_fdc_device_base::device_add_mconfig(config);
+        void coco_scii_device_base::device_add_mconfig(machine_config &config)
+        {
+                coco_fdc_device_base::device_add_mconfig(config);
 
-		INPUT_MERGER_ANY_HIGH(config, m_carts).output_handler().set([this](int state) { set_line_value(line::CART, state); });
+                INPUT_MERGER_ANY_HIGH(config, m_carts).output_handler().set([this](int state) { set_line_value(line::CART, state); });
 
-		DISTOMEB_SLOT(config, m_slot, DERIVED_CLOCK(1, 1), disto_meb_slot, "rtime");
-		m_slot->cart_callback().set(m_carts, FUNC(input_merger_device::in_w<1>));
-	}
+                DISTOMEB_SLOT(config, m_slot, DERIVED_CLOCK(1, 1), disto_meb_slot, "rtime");
+                m_slot->cart_callback().set(m_carts, FUNC(input_merger_device::in_w<1>));
+        }
 
 
 //-------------------------------------------------
 //  scs_read
 //-------------------------------------------------
 
-	u8 coco_scii_device_base::scs_read(offs_t offset)
-	{
-		if (offset > 0x0f && offset < 0x18)
-			return m_slot->meb_read(offset - 0x10);
+        u8 coco_scii_device_base::scs_read(offs_t offset)
+        {
+                if (offset > 0x0f && offset < 0x18)
+                        return m_slot->meb_read(offset - 0x10);
 
-		return coco_fdc_device_base::scs_read(offset);
-	}
+                return coco_fdc_device_base::scs_read(offset);
+        }
 
 
 //-------------------------------------------------
 //  scs_write
 //-------------------------------------------------
 
-	void coco_scii_device_base::scs_write(offs_t offset, u8 data)
-	{
-		if (offset > 0x0f && offset < 0x18)
-			m_slot->meb_write(offset - 0x10, data);
-		else
-		{
-			coco_fdc_device_base::scs_write(offset, data);
-		}
-	}
+        void coco_scii_device_base::scs_write(offs_t offset, u8 data)
+        {
+                if (offset > 0x0f && offset < 0x18)
+                        m_slot->meb_write(offset - 0x10, data);
+                else
+                {
+                        coco_fdc_device_base::scs_write(offset, data);
+                }
+        }
 
 
 //-------------------------------------------------
 //  update_lines - SCII controller lines
 //-------------------------------------------------
 
-	void coco_scii_device_base::update_lines()
-	{
-		// clear HALT enable under certain circumstances
-		if (intrq() && (dskreg() & 0x20))
-			set_dskreg(dskreg() & ~0x80);  // clear halt enable
+        void coco_scii_device_base::update_lines()
+        {
+                // clear HALT enable under certain circumstances
+                if (intrq() && (dskreg() & 0x20))
+                        set_dskreg(dskreg() & ~0x80);  // clear halt enable
 
-		if ((m_cache_controler & 0x02) == 0) /* cache disabled */
-		{
-			// set the HALT line
-			set_line_value(line::HALT, !drq() && (dskreg() & 0x80));
-		}
-		else
-		{
-			set_line_value(line::HALT, CLEAR_LINE);
+                if ((m_cache_controler & 0x02) == 0) /* cache disabled */
+                {
+                        // set the HALT line
+                        set_line_value(line::HALT, !drq() && (dskreg() & 0x80));
+                }
+                else
+                {
+                        set_line_value(line::HALT, CLEAR_LINE);
 
-			if (drq() == ASSERT_LINE)
-			{
-				if ((m_cache_controler & 0x01) == 0x01) /* Read cache on */
-				{
-					u8 data = m_wd17xx->data_r();
-					LOGWDSCII("cache drq read: %02x\n", data );
-					m_cache[m_cache_pointer++] = data;
-				}
-				else /* Write cache on */
-				{
-					u8 data = m_cache[m_cache_pointer++];
-					LOGWDSCII("cache drq write: %02x\n", data );
-					m_wd17xx->data_w(data);
-				}
+                        if (drq() == ASSERT_LINE)
+                        {
+                                if ((m_cache_controler & 0x01) == 0x01) /* Read cache on */
+                                {
+                                        u8 data = m_wd17xx->data_r();
+                                        LOGWDSCII("cache drq read: %02x\n", data );
+                                        m_cache[m_cache_pointer++] = data;
+                                }
+                                else /* Write cache on */
+                                {
+                                        u8 data = m_cache[m_cache_pointer++];
+                                        LOGWDSCII("cache drq write: %02x\n", data );
+                                        m_wd17xx->data_w(data);
+                                }
 
-				m_cache_pointer &= 0x1ff;
-			}
-		}
+                                m_cache_pointer &= 0x1ff;
+                        }
+                }
 
-		if ((m_cache_controler & 0x08) == 0x08)
-		{
-			m_carts->in_w<0>(intrq());
-		}
-		else
-		{
-			m_carts->in_w<0>(CLEAR_LINE);
-		}
+                if ((m_cache_controler & 0x08) == 0x08)
+                {
+                        m_carts->in_w<0>(intrq());
+                }
+                else
+                {
+                        m_carts->in_w<0>(CLEAR_LINE);
+                }
 
-		if ((m_cache_controler & 0x04) == 0x00)
-		{
-			set_line_value(line::NMI, intrq() && (dskreg() & 0x20));
-		}
-		else
-		{
-			set_line_value(line::NMI, CLEAR_LINE);
-		}
-	}
+                if ((m_cache_controler & 0x04) == 0x00)
+                {
+                        set_line_value(line::NMI, intrq() && (dskreg() & 0x20));
+                }
+                else
+                {
+                        set_line_value(line::NMI, CLEAR_LINE);
+                }
+        }
 
 
 //-------------------------------------------------
 //  ff74_read - no halt registers
 //-------------------------------------------------
 
-	u8 coco_scii_device_base::ff74_read(offs_t offset)
-	{
-		u8 data = 0x0;
+        u8 coco_scii_device_base::ff74_read(offs_t offset)
+        {
+                u8 data = 0x0;
 
-		switch(offset)
-		{
-			case 0x0:
-			case 0x1:
-				data = m_cache[m_cache_pointer++];
-				LOGWDSCII("cache read: %04x = %02x\n", m_cache_pointer, data);
-				m_cache_pointer &= 0x1ff;
-				break;
+                switch(offset)
+                {
+                        case 0x0:
+                        case 0x1:
+                                data = m_cache[m_cache_pointer++];
+                                LOGWDSCII("cache read: %04x = %02x\n", m_cache_pointer, data);
+                                m_cache_pointer &= 0x1ff;
+                                break;
 
-			case 0x2:
-			case 0x3:
-				if (intrq() == ASSERT_LINE)
-				{
-					m_cache_controler &= 0x7f;
-				}
-				else
-				{
-					m_cache_controler |= 0x80;
-				}
+                        case 0x2:
+                        case 0x3:
+                                if (intrq() == ASSERT_LINE)
+                                {
+                                        m_cache_controler &= 0x7f;
+                                }
+                                else
+                                {
+                                        m_cache_controler |= 0x80;
+                                }
 
-				data = m_cache_controler;
-				LOGWDSCII("control read:  %02x\n", data);
-				break;
-		}
+                                data = m_cache_controler;
+                                LOGWDSCII("control read:  %02x\n", data);
+                                break;
+                }
 
-		return data;
-	}
+                return data;
+        }
 
 
 //-------------------------------------------------
 //  ff74_write - no halt registers
 //-------------------------------------------------
 
-	void coco_scii_device_base::ff74_write(offs_t offset, u8 data)
-	{
-		switch(offset)
-		{
-			case 0x0:
-			case 0x1:
-				LOGWDSCII("cache write: %04x = %02x\n", m_cache_pointer, data);
-				m_cache[m_cache_pointer++] = data;
-				m_cache_pointer &= 0x1ff;
-				break;
-			case 0x2:
-			case 0x3:
-				LOGWDSCII("control write: %02x\n", data);
+        void coco_scii_device_base::ff74_write(offs_t offset, u8 data)
+        {
+                switch(offset)
+                {
+                        case 0x0:
+                        case 0x1:
+                                LOGWDSCII("cache write: %04x = %02x\n", m_cache_pointer, data);
+                                m_cache[m_cache_pointer++] = data;
+                                m_cache_pointer &= 0x1ff;
+                                break;
+                        case 0x2:
+                        case 0x3:
+                                LOGWDSCII("control write: %02x\n", data);
 
-				// reset static ram buffer pointer on any write
-				m_cache_pointer = 0;
+                                // reset static ram buffer pointer on any write
+                                m_cache_pointer = 0;
 
-				m_cache_controler = data;
-				update_lines();
-				break;
-		}
-	}
+                                m_cache_controler = data;
+                                update_lines();
+                                break;
+                }
+        }
 
 
 //**************************************************************************
 //  Disto / CRC  Super Controller II, CoCo 1 / 2 ROM
 //**************************************************************************
 
-	class coco_scii_device_cc1 : public coco_scii_device_base
-	{
-	public:
-		// construction/destruction
-		coco_scii_device_cc1(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-			: coco_scii_device_base(mconfig, COCO_SCII_CC1, tag, owner, clock)
-		{
-		}
+        class coco_scii_device_cc1 : public coco_scii_device_base
+        {
+        public:
+                // construction/destruction
+                coco_scii_device_cc1(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+                        : coco_scii_device_base(mconfig, COCO_SCII_CC1, tag, owner, clock)
+                {
+                }
 
-	protected:
-		// optional information overrides
-		virtual const tiny_rom_entry *device_rom_region() const override
-		{
-			return ROM_NAME(coco_scii_cc1);
-		}
-	};
+        protected:
+                // optional information overrides
+                virtual const tiny_rom_entry *device_rom_region() const override
+                {
+                        return ROM_NAME(coco_scii_cc1);
+                }
+        };
 
 
 //**************************************************************************
 //  Disto / CRC  Super Controller II, CoCo 3 ROM
 //**************************************************************************
 
-	class coco_scii_device_cc3 : public coco_scii_device_base
-	{
-	public:
-		// construction/destruction
-		coco_scii_device_cc3(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-			: coco_scii_device_base(mconfig, COCO_SCII_CC3, tag, owner, clock)
-		{
-		}
+        class coco_scii_device_cc3 : public coco_scii_device_base
+        {
+        public:
+                // construction/destruction
+                coco_scii_device_cc3(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+                        : coco_scii_device_base(mconfig, COCO_SCII_CC3, tag, owner, clock)
+                {
+                }
 
-	protected:
-		// optional information overrides
-		virtual const tiny_rom_entry *device_rom_region() const override
-		{
-			return ROM_NAME(coco_scii_cc3);
-		}
-	};
+        protected:
+                // optional information overrides
+                virtual const tiny_rom_entry *device_rom_region() const override
+                {
+                        return ROM_NAME(coco_scii_cc3);
+                }
+        };
 
 
 //**************************************************************************
 //              COCO-3 HDB-DOS
 //**************************************************************************
 
-	class coco3_hdb1_device : public coco_fdc_device_base
-	{
-	public:
-		// construction/destruction
-		coco3_hdb1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-			: coco_fdc_device_base(mconfig, COCO3_HDB1, tag, owner, clock)
-		{
-		}
+        class coco3_hdb1_device : public coco_fdc_device_base
+        {
+        public:
+                // construction/destruction
+                coco3_hdb1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+                        : coco_fdc_device_base(mconfig, COCO3_HDB1, tag, owner, clock)
+                {
+                }
 
-	protected:
-		// optional information overrides
-		virtual const tiny_rom_entry *device_rom_region() const override
-		{
-			return ROM_NAME(coco3_hdb1);
-		}
-	};
+        protected:
+                // optional information overrides
+                virtual const tiny_rom_entry *device_rom_region() const override
+                {
+                        return ROM_NAME(coco3_hdb1);
+                }
+        };
 
 
 //**************************************************************************
 //              COCO-2 HDB-DOS
 //**************************************************************************
 
-	class coco2_hdb1_device : public coco_fdc_device_base
-	{
-	public:
-		// construction/destruction
-		coco2_hdb1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-			: coco_fdc_device_base(mconfig, COCO2_HDB1, tag, owner, clock)
-		{
-		}
+        class coco2_hdb1_device : public coco_fdc_device_base
+        {
+        public:
+                // construction/destruction
+                coco2_hdb1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+                        : coco_fdc_device_base(mconfig, COCO2_HDB1, tag, owner, clock)
+                {
+                }
 
-	protected:
-		// optional information overrides
-		virtual const tiny_rom_entry *device_rom_region() const override
-		{
-			return ROM_NAME(coco2_hdb1);
-		}
-	};
+        protected:
+                // optional information overrides
+                virtual const tiny_rom_entry *device_rom_region() const override
+                {
+                        return ROM_NAME(coco2_hdb1);
+                }
+        };
 
 
 //**************************************************************************
@@ -840,22 +840,22 @@ namespace
 //
 //**************************************************************************
 
-	class cp450_fdc_device : public coco_fdc_device_base
-	{
-	public:
-		// construction/destruction
-		cp450_fdc_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-			: coco_fdc_device_base(mconfig, CP450_FDC, tag, owner, clock)
-		{
-		}
+        class cp450_fdc_device : public coco_fdc_device_base
+        {
+        public:
+                // construction/destruction
+                cp450_fdc_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+                        : coco_fdc_device_base(mconfig, CP450_FDC, tag, owner, clock)
+                {
+                }
 
-	protected:
-		// optional information overrides
-		virtual const tiny_rom_entry *device_rom_region() const override
-		{
-			return ROM_NAME(cp450_fdc);
-		}
-	};
+        protected:
+                // optional information overrides
+                virtual const tiny_rom_entry *device_rom_region() const override
+                {
+                        return ROM_NAME(cp450_fdc);
+                }
+        };
 
 
 //**************************************************************************
@@ -865,24 +865,56 @@ namespace
 // More ifo at: http://amxproject.com/?p=2747
 //**************************************************************************
 
-	class cd6809_fdc_device : public coco_fdc_device_base
-	{
-	public:
-		// construction/destruction
-		cd6809_fdc_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-			: coco_fdc_device_base(mconfig, CD6809_FDC, tag, owner, clock)
-		{
-		}
+        class cd6809_fdc_device : public coco_fdc_device_base
+        {
+        public:
+                // construction/destruction
+                cd6809_fdc_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+                        : coco_fdc_device_base(mconfig, CD6809_FDC, tag, owner, clock)
+                {
+                }
 
-	protected:
-		// optional information overrides
-		virtual const tiny_rom_entry *device_rom_region() const override
-		{
-			return ROM_NAME(cd6809_fdc);
-		}
-	};
+        protected:
+                // optional information overrides
+                virtual const tiny_rom_entry *device_rom_region() const override
+                {
+                        return ROM_NAME(cd6809_fdc);
+                }
+        };
 } // Anonymous namepace
+//**************************************************************************
+//              COCO RGB-DOS local
+//**************************************************************************
 
+ROM_START(coco_rgbdos)
+        ROM_REGION(0x8000, "eprom", ROMREGION_ERASE00)
+        ROM_LOAD("rgbdos_mess.rom", 0x0000, 0x2000, CRC(0b0e64db) SHA1(062ffab14dc788ec7744e528bf9bb425c3ec60ed))
+        ROM_RELOAD(0x2000, 0x2000)
+        ROM_RELOAD(0x4000, 0x2000)
+        ROM_RELOAD(0x6000, 0x2000)
+ROM_END
+
+namespace
+{
+        class coco_rgbdos_device : public coco_fdc_device_base
+        {
+        public:
+                // construction/destruction
+                coco_rgbdos_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+                        : coco_fdc_device_base(mconfig, COCO_LOCAL, tag, owner, clock)
+                {
+                }
+
+        protected:
+                // optional information overrides
+                virtual const tiny_rom_entry *device_rom_region() const override
+                {
+                        return ROM_NAME(coco_rgbdos);
+                }
+        };
+}
+
+DEFINE_DEVICE_TYPE_PRIVATE(COCO_LOCAL, coco_family_fdc_device_base, coco_rgbdos_device, "coco_rgbdos", "CoCo RGB-DOS MAME")
 DEFINE_DEVICE_TYPE_PRIVATE(COCO_FDC, coco_family_fdc_device_base, coco_fdc_device, "coco_fdc", "CoCo FDC")
 DEFINE_DEVICE_TYPE_PRIVATE(COCO_FDC_V11, coco_family_fdc_device_base, coco_fdc_v11_device, "coco_fdc_v11", "CoCo FDC v1.1")
 DEFINE_DEVICE_TYPE_PRIVATE(COCO_SCII_CC1, coco_family_fdc_device_base, coco_scii_device_cc1, "coco_scii_cc1", "Disto Super Controller II (CoCo 1/2 ROM)")

--- a/src/devices/bus/coco/coco_fdc.h
+++ b/src/devices/bus/coco/coco_fdc.h
@@ -22,48 +22,49 @@
 // ======================> coco_family_fdc_device_base
 
 class coco_family_fdc_device_base :
-		public device_t,
-		public device_cococart_interface
+                public device_t,
+                public device_cococart_interface
 {
 public:
-	DECLARE_WRITE_LINE_MEMBER(fdc_intrq_w) { m_intrq = state; update_lines(); }
-	DECLARE_WRITE_LINE_MEMBER(fdc_drq_w) { m_drq = state; update_lines(); }
+        DECLARE_WRITE_LINE_MEMBER(fdc_intrq_w) { m_intrq = state; update_lines(); }
+        DECLARE_WRITE_LINE_MEMBER(fdc_drq_w) { m_drq = state; update_lines(); }
 
-	static void floppy_formats(format_registration &fr);
+        static void floppy_formats(format_registration &fr);
 
 protected:
-	// construction/destruction
-	coco_family_fdc_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
-		: device_t(mconfig, type, tag, owner, clock)
-		, device_cococart_interface(mconfig, *this)
-	{
-	};
+        // construction/destruction
+        coco_family_fdc_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
+                : device_t(mconfig, type, tag, owner, clock)
+                , device_cococart_interface(mconfig, *this)
+        {
+        };
 
-	// device-level overrides
-	virtual void device_start() override;
-	virtual void device_reset() override;
+        // device-level overrides
+        virtual void device_start() override;
+        virtual void device_reset() override;
 
-	// FDC overrides
-	virtual void update_lines() = 0;
-	virtual u8 *get_cart_base() override;
-	virtual memory_region *get_cart_memregion() override;
+        // FDC overrides
+        virtual void update_lines() = 0;
+        virtual u8 *get_cart_base() override;
+        virtual memory_region *get_cart_memregion() override;
 
-	// accessors
-	u8 dskreg() const { return m_dskreg; }
-	bool intrq() const { return m_intrq; }
-	bool drq() const { return m_drq; }
-	void set_dskreg(u8 data) { m_dskreg = data; }
+        // accessors
+        u8 dskreg() const { return m_dskreg; }
+        bool intrq() const { return m_intrq; }
+        bool drq() const { return m_drq; }
+        void set_dskreg(u8 data) { m_dskreg = data; }
 
 private:
-	// registers
-	u8 m_dskreg;
-	bool m_intrq;
-	bool m_drq;
+        // registers
+        u8 m_dskreg;
+        bool m_intrq;
+        bool m_drq;
 };
 
 // device type definitions - CoCo FDC
 DECLARE_DEVICE_TYPE(COCO_FDC,       coco_family_fdc_device_base)
 DECLARE_DEVICE_TYPE(COCO_FDC_V11,   coco_family_fdc_device_base)
+DECLARE_DEVICE_TYPE(COCO_LOCAL,     coco_family_fdc_device_base)
 DECLARE_DEVICE_TYPE(COCO_SCII_CC1,  coco_family_fdc_device_base)
 DECLARE_DEVICE_TYPE(COCO_SCII_CC3,  coco_family_fdc_device_base)
 DECLARE_DEVICE_TYPE(COCO3_HDB1,     coco_family_fdc_device_base)

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -93,17 +93,17 @@
 // definitions of RPK PCBs in layout.xml
 static const char *coco_rpk_pcbdefs[] =
 {
-	"standard",
-	"paged16k",
-	nullptr
+        "standard",
+        "paged16k",
+        nullptr
 };
 
 
 // ...and their mappings to "default card slots"
 static const char *coco_rpk_cardslottypes[] =
 {
-	"pak",
-	"banked_16k"
+        "pak",
+        "banked_16k"
 };
 
 
@@ -124,12 +124,12 @@ ALLOW_SAVE_TYPE(cococart_slot_device::line_value);
 //  cococart_slot_device - constructor
 //-------------------------------------------------
 cococart_slot_device::cococart_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
-	device_t(mconfig, COCOCART_SLOT, tag, owner, clock),
-	device_single_card_slot_interface<device_cococart_interface>(mconfig, *this),
-	device_cartrom_image_interface(mconfig, *this),
-	m_cart_callback(*this),
-	m_nmi_callback(*this),
-	m_halt_callback(*this), m_cart(nullptr)
+        device_t(mconfig, COCOCART_SLOT, tag, owner, clock),
+        device_single_card_slot_interface<device_cococart_interface>(mconfig, *this),
+        device_cartrom_image_interface(mconfig, *this),
+        m_cart_callback(*this),
+        m_nmi_callback(*this),
+        m_halt_callback(*this), m_cart(nullptr)
 {
 }
 
@@ -141,56 +141,56 @@ cococart_slot_device::cococart_slot_device(const machine_config &mconfig, const 
 
 void cococart_slot_device::device_start()
 {
-	for(int i=0; i < TIMER_POOL; i++ )
-	{
-		m_cart_line.timer[i]    = timer_alloc(FUNC(cococart_slot_device::cart_line_timer_tick), this);
-		m_nmi_line.timer[i]     = timer_alloc(FUNC(cococart_slot_device::nmi_line_timer_tick), this);
-		m_halt_line.timer[i]    = timer_alloc(FUNC(cococart_slot_device::halt_line_timer_tick), this);
-	}
+        for(int i=0; i < TIMER_POOL; i++ )
+        {
+                m_cart_line.timer[i]    = timer_alloc(FUNC(cococart_slot_device::cart_line_timer_tick), this);
+                m_nmi_line.timer[i]     = timer_alloc(FUNC(cococart_slot_device::nmi_line_timer_tick), this);
+                m_halt_line.timer[i]    = timer_alloc(FUNC(cococart_slot_device::halt_line_timer_tick), this);
+        }
 
-	m_cart_line.timer_index     = 0;
-	m_cart_line.delay           = 0;
-	m_cart_line.value           = line_value::CLEAR;
-	m_cart_line.line            = 0;
-	m_cart_line.q_count         = 0;
-	m_cart_callback.resolve_safe();
-	m_cart_line.callback = &m_cart_callback;
+        m_cart_line.timer_index     = 0;
+        m_cart_line.delay           = 0;
+        m_cart_line.value           = line_value::CLEAR;
+        m_cart_line.line            = 0;
+        m_cart_line.q_count         = 0;
+        m_cart_callback.resolve_safe();
+        m_cart_line.callback = &m_cart_callback;
 
-	m_nmi_line.timer_index      = 0;
-	m_nmi_line.delay            = 0;
-	m_nmi_line.value            = line_value::CLEAR;
-	m_nmi_line.line             = 0;
-	m_nmi_line.q_count          = 0;
-	m_nmi_callback.resolve_safe();
-	m_nmi_line.callback = &m_nmi_callback;
+        m_nmi_line.timer_index      = 0;
+        m_nmi_line.delay            = 0;
+        m_nmi_line.value            = line_value::CLEAR;
+        m_nmi_line.line             = 0;
+        m_nmi_line.q_count          = 0;
+        m_nmi_callback.resolve_safe();
+        m_nmi_line.callback = &m_nmi_callback;
 
-	m_halt_line.timer_index     = 0;
-	m_halt_line.delay           = 0;
-	m_halt_line.value           = line_value::CLEAR;
-	m_halt_line.line            = 0;
-	m_halt_line.q_count         = 0;
-	m_halt_callback.resolve_safe();
-	m_halt_line.callback = &m_halt_callback;
+        m_halt_line.timer_index     = 0;
+        m_halt_line.delay           = 0;
+        m_halt_line.value           = line_value::CLEAR;
+        m_halt_line.line            = 0;
+        m_halt_line.q_count         = 0;
+        m_halt_callback.resolve_safe();
+        m_halt_line.callback = &m_halt_callback;
 
-	m_cart = get_card_device();
+        m_cart = get_card_device();
 
-	save_item(STRUCT_MEMBER(m_cart_line, timer_index));
-	save_item(STRUCT_MEMBER(m_cart_line, delay));
-	save_item(STRUCT_MEMBER(m_cart_line, value));
-	save_item(STRUCT_MEMBER(m_cart_line, line));
-	save_item(STRUCT_MEMBER(m_cart_line, q_count));
+        save_item(STRUCT_MEMBER(m_cart_line, timer_index));
+        save_item(STRUCT_MEMBER(m_cart_line, delay));
+        save_item(STRUCT_MEMBER(m_cart_line, value));
+        save_item(STRUCT_MEMBER(m_cart_line, line));
+        save_item(STRUCT_MEMBER(m_cart_line, q_count));
 
-	save_item(STRUCT_MEMBER(m_nmi_line, timer_index));
-	save_item(STRUCT_MEMBER(m_nmi_line, delay));
-	save_item(STRUCT_MEMBER(m_nmi_line, value));
-	save_item(STRUCT_MEMBER(m_nmi_line, line));
-	save_item(STRUCT_MEMBER(m_nmi_line, q_count));
+        save_item(STRUCT_MEMBER(m_nmi_line, timer_index));
+        save_item(STRUCT_MEMBER(m_nmi_line, delay));
+        save_item(STRUCT_MEMBER(m_nmi_line, value));
+        save_item(STRUCT_MEMBER(m_nmi_line, line));
+        save_item(STRUCT_MEMBER(m_nmi_line, q_count));
 
-	save_item(STRUCT_MEMBER(m_halt_line, timer_index));
-	save_item(STRUCT_MEMBER(m_halt_line, delay));
-	save_item(STRUCT_MEMBER(m_halt_line, value));
-	save_item(STRUCT_MEMBER(m_halt_line, line));
-	save_item(STRUCT_MEMBER(m_halt_line, q_count));
+        save_item(STRUCT_MEMBER(m_halt_line, timer_index));
+        save_item(STRUCT_MEMBER(m_halt_line, delay));
+        save_item(STRUCT_MEMBER(m_halt_line, value));
+        save_item(STRUCT_MEMBER(m_halt_line, line));
+        save_item(STRUCT_MEMBER(m_halt_line, q_count));
 }
 
 
@@ -202,7 +202,7 @@ void cococart_slot_device::device_start()
 
 TIMER_CALLBACK_MEMBER(cococart_slot_device::cart_line_timer_tick)
 {
-	set_line(line::CART, m_cart_line, (line_value) param);
+        set_line(line::CART, m_cart_line, (line_value) param);
 }
 
 //-------------------------------------------------
@@ -212,7 +212,7 @@ TIMER_CALLBACK_MEMBER(cococart_slot_device::cart_line_timer_tick)
 
 TIMER_CALLBACK_MEMBER(cococart_slot_device::nmi_line_timer_tick)
 {
-	set_line(line::NMI, m_nmi_line, (line_value) param);
+        set_line(line::NMI, m_nmi_line, (line_value) param);
 }
 
 //-------------------------------------------------
@@ -222,7 +222,7 @@ TIMER_CALLBACK_MEMBER(cococart_slot_device::nmi_line_timer_tick)
 
 TIMER_CALLBACK_MEMBER(cococart_slot_device::halt_line_timer_tick)
 {
-	set_line(line::HALT, m_halt_line, (line_value) param);
+        set_line(line::HALT, m_halt_line, (line_value) param);
 }
 
 
@@ -233,10 +233,10 @@ TIMER_CALLBACK_MEMBER(cococart_slot_device::halt_line_timer_tick)
 
 u8 cococart_slot_device::cts_read(offs_t offset)
 {
-	u8 result = 0x00;
-	if (m_cart)
-		result = m_cart->cts_read(offset);
-	return result;
+        u8 result = 0x00;
+        if (m_cart)
+                result = m_cart->cts_read(offset);
+        return result;
 }
 
 
@@ -246,8 +246,8 @@ u8 cococart_slot_device::cts_read(offs_t offset)
 
 void cococart_slot_device::cts_write(offs_t offset, u8 data)
 {
-	if (m_cart)
-		m_cart->cts_write(offset, data);
+        if (m_cart)
+                m_cart->cts_write(offset, data);
 }
 
 
@@ -257,10 +257,10 @@ void cococart_slot_device::cts_write(offs_t offset, u8 data)
 
 u8 cococart_slot_device::scs_read(offs_t offset)
 {
-	u8 result = 0x00;
-	if (m_cart)
-		result = m_cart->scs_read(offset);
-	return result;
+        u8 result = 0x00;
+        if (m_cart)
+                result = m_cart->scs_read(offset);
+        return result;
 }
 
 
@@ -270,8 +270,8 @@ u8 cococart_slot_device::scs_read(offs_t offset)
 
 void cococart_slot_device::scs_write(offs_t offset, u8 data)
 {
-	if (m_cart)
-		m_cart->scs_write(offset, data);
+        if (m_cart)
+                m_cart->scs_write(offset, data);
 }
 
 
@@ -282,22 +282,22 @@ void cococart_slot_device::scs_write(offs_t offset, u8 data)
 
 const char *cococart_slot_device::line_value_string(line_value value)
 {
-	const char *s;
-	switch(value)
-	{
-		case line_value::CLEAR:
-			s = "CLEAR";
-			break;
-		case line_value::ASSERT:
-			s = "ASSERT";
-			break;
-		case line_value::Q:
-			s = "Q";
-			break;
-		default:
-			throw false && "Invalid value";
-	}
-	return s;
+        const char *s;
+        switch(value)
+        {
+                case line_value::CLEAR:
+                        s = "CLEAR";
+                        break;
+                case line_value::ASSERT:
+                        s = "ASSERT";
+                        break;
+                case line_value::Q:
+                        s = "Q";
+                        break;
+                default:
+                        throw false && "Invalid value";
+        }
+        return s;
 }
 
 
@@ -307,48 +307,48 @@ const char *cococart_slot_device::line_value_string(line_value value)
 
 void cococart_slot_device::set_line(line ln, coco_cartridge_line &line, cococart_slot_device::line_value value)
 {
-	if ((line.value != value) || (value == line_value::Q))
-	{
-		line.value = value;
+        if ((line.value != value) || (value == line_value::Q))
+        {
+                line.value = value;
 
-		switch (ln)
-		{
-		case line::CART:
-			LOGCART( "set_line: CART, value: %s\n", line_value_string(value));
-			break;
-		case line::NMI:
-			LOGNMI( "set_line: NMI, value: %s\n", line_value_string(value));
-			break;
-		case line::HALT:
-			LOGHALT( "set_line: HALT, value: %s\n", line_value_string(value));
-			break;
-		case line::SOUND_ENABLE:
-			break;
-		}
+                switch (ln)
+                {
+                case line::CART:
+                        LOGCART( "set_line: CART, value: %s\n", line_value_string(value));
+                        break;
+                case line::NMI:
+                        LOGNMI( "set_line: NMI, value: %s\n", line_value_string(value));
+                        break;
+                case line::HALT:
+                        LOGHALT( "set_line: HALT, value: %s\n", line_value_string(value));
+                        break;
+                case line::SOUND_ENABLE:
+                        break;
+                }
 
-		// engage in a bit of gymnastics for this odious 'Q' value
-		switch(line.value)
-		{
-			case line_value::CLEAR:
-				line.line = 0x00;
-				line.q_count = 0;
-				break;
+                // engage in a bit of gymnastics for this odious 'Q' value
+                switch(line.value)
+                {
+                        case line_value::CLEAR:
+                                line.line = 0x00;
+                                line.q_count = 0;
+                                break;
 
-			case line_value::ASSERT:
-				line.line = 0x01;
-				line.q_count = 0;
-				break;
+                        case line_value::ASSERT:
+                                line.line = 0x01;
+                                line.q_count = 0;
+                                break;
 
-			case line_value::Q:
-				line.line = line.line ? 0x00 : 0x01;
-				if (line.q_count++ < 4)
-					set_line_timer(line, value);
-				break;
-		}
+                        case line_value::Q:
+                                line.line = line.line ? 0x00 : 0x01;
+                                if (line.q_count++ < 4)
+                                        set_line_timer(line, value);
+                                break;
+                }
 
-		/* invoke the callback */
-		(*line.callback)(line.line);
-	}
+                /* invoke the callback */
+                (*line.callback)(line.line);
+        }
 }
 
 
@@ -358,13 +358,13 @@ void cococart_slot_device::set_line(line ln, coco_cartridge_line &line, cococart
 
 void cococart_slot_device::set_line_timer(coco_cartridge_line &line, cococart_slot_device::line_value value)
 {
-	// calculate delay; delay dependant on cycles per second
-	attotime delay = (line.delay != 0)
-			? clocks_to_attotime(line.delay)
-			: attotime::zero;
+        // calculate delay; delay dependant on cycles per second
+        attotime delay = (line.delay != 0)
+                        ? clocks_to_attotime(line.delay)
+                        : attotime::zero;
 
-	line.timer[line.timer_index]->adjust(delay, (int) value);
-	line.timer_index = (line.timer_index + 1) % TIMER_POOL;
+        line.timer[line.timer_index]->adjust(delay, (int) value);
+        line.timer_index = (line.timer_index + 1) % TIMER_POOL;
 }
 
 
@@ -374,11 +374,11 @@ void cococart_slot_device::set_line_timer(coco_cartridge_line &line, cococart_sl
 
 void cococart_slot_device::twiddle_line_if_q(coco_cartridge_line &line)
 {
-	if (line.value == line_value::Q)
-	{
-		line.q_count = 0;
-		set_line_timer(line, line_value::Q);
-	}
+        if (line.value == line_value::Q)
+        {
+                line.q_count = 0;
+                set_line_timer(line, line_value::Q);
+        }
 }
 
 
@@ -389,9 +389,9 @@ void cococart_slot_device::twiddle_line_if_q(coco_cartridge_line &line)
 
 void cococart_slot_device::twiddle_q_lines()
 {
-	twiddle_line_if_q(m_cart_line);
-	twiddle_line_if_q(m_nmi_line);
-	twiddle_line_if_q(m_halt_line);
+        twiddle_line_if_q(m_cart_line);
+        twiddle_line_if_q(m_nmi_line);
+        twiddle_line_if_q(m_halt_line);
 }
 
 
@@ -401,25 +401,25 @@ void cococart_slot_device::twiddle_q_lines()
 
 void cococart_slot_device::set_line_value(cococart_slot_device::line which, cococart_slot_device::line_value value)
 {
-	switch (which)
-	{
-	case cococart_slot_device::line::CART:
-		set_line_timer(m_cart_line, value);
-		break;
+        switch (which)
+        {
+        case cococart_slot_device::line::CART:
+                set_line_timer(m_cart_line, value);
+                break;
 
-	case cococart_slot_device::line::NMI:
-		set_line_timer(m_nmi_line, value);
-		break;
+        case cococart_slot_device::line::NMI:
+                set_line_timer(m_nmi_line, value);
+                break;
 
-	case cococart_slot_device::line::HALT:
-		set_line_timer(m_halt_line, value);
-		break;
+        case cococart_slot_device::line::HALT:
+                set_line_timer(m_halt_line, value);
+                break;
 
-	case cococart_slot_device::line::SOUND_ENABLE:
-		if (m_cart)
-			m_cart->set_sound_enable(value != cococart_slot_device::line_value::CLEAR);
-		break;
-	}
+        case cococart_slot_device::line::SOUND_ENABLE:
+                if (m_cart)
+                        m_cart->set_sound_enable(value != cococart_slot_device::line_value::CLEAR);
+                break;
+        }
 }
 
 
@@ -429,23 +429,23 @@ void cococart_slot_device::set_line_value(cococart_slot_device::line which, coco
 
 void cococart_slot_device::set_line_delay(cococart_slot_device::line which, int cycles)
 {
-	switch (which)
-	{
-	case cococart_slot_device::line::CART:
-		m_cart_line.delay = cycles;
-		break;
+        switch (which)
+        {
+        case cococart_slot_device::line::CART:
+                m_cart_line.delay = cycles;
+                break;
 
-	case cococart_slot_device::line::NMI:
-		m_nmi_line.delay = cycles;
-		break;
+        case cococart_slot_device::line::NMI:
+                m_nmi_line.delay = cycles;
+                break;
 
-	case cococart_slot_device::line::HALT:
-		m_halt_line.delay = cycles;
-		break;
+        case cococart_slot_device::line::HALT:
+                m_halt_line.delay = cycles;
+                break;
 
-	default:
-		throw false;
-	}
+        default:
+                throw false;
+        }
 }
 
 
@@ -455,26 +455,26 @@ void cococart_slot_device::set_line_delay(cococart_slot_device::line which, int 
 
 cococart_slot_device::line_value cococart_slot_device::get_line_value(cococart_slot_device::line which) const
 {
-	line_value result;
-	switch (which)
-	{
-	case cococart_slot_device::line::CART:
-		result = m_cart_line.value;
-		break;
+        line_value result;
+        switch (which)
+        {
+        case cococart_slot_device::line::CART:
+                result = m_cart_line.value;
+                break;
 
-	case cococart_slot_device::line::NMI:
-		result = m_nmi_line.value;
-		break;
+        case cococart_slot_device::line::NMI:
+                result = m_nmi_line.value;
+                break;
 
-	case cococart_slot_device::line::HALT:
-		result = m_halt_line.value;
-		break;
+        case cococart_slot_device::line::HALT:
+                result = m_halt_line.value;
+                break;
 
-	default:
-		result = line_value::CLEAR;
-		break;
-	}
-	return result;
+        default:
+                result = line_value::CLEAR;
+                break;
+        }
+        return result;
 }
 
 
@@ -484,9 +484,9 @@ cococart_slot_device::line_value cococart_slot_device::get_line_value(cococart_s
 
 u8 *cococart_slot_device::get_cart_base()
 {
-	if (m_cart != nullptr)
-		return m_cart->get_cart_base();
-	return nullptr;
+        if (m_cart != nullptr)
+                return m_cart->get_cart_base();
+        return nullptr;
 }
 
 
@@ -496,10 +496,10 @@ u8 *cococart_slot_device::get_cart_base()
 
 u32 cococart_slot_device::get_cart_size()
 {
-	if (m_cart != nullptr)
-		return m_cart->get_cart_size();
+        if (m_cart != nullptr)
+                return m_cart->get_cart_size();
 
-	return 0x8000;
+        return 0x8000;
 }
 
 //-------------------------------------------------
@@ -508,8 +508,8 @@ u32 cococart_slot_device::get_cart_size()
 
 void cococart_slot_device::set_cart_base_update(cococart_base_update_delegate update)
 {
-	if (m_cart)
-		m_cart->set_cart_base_update(update);
+        if (m_cart)
+                m_cart->set_cart_base_update(update);
 }
 
 
@@ -519,14 +519,14 @@ void cococart_slot_device::set_cart_base_update(cococart_base_update_delegate up
 
 static std::error_condition read_coco_rpk(std::unique_ptr<util::random_read> &&stream, rpk_file::ptr &result)
 {
-	// sanity checks
-	static_assert(std::size(coco_rpk_pcbdefs) - 1 == std::size(coco_rpk_cardslottypes));
+        // sanity checks
+        static_assert(std::size(coco_rpk_pcbdefs) - 1 == std::size(coco_rpk_cardslottypes));
 
-	// set up the RPK reader
-	rpk_reader reader(coco_rpk_pcbdefs, false);
+        // set up the RPK reader
+        rpk_reader reader(coco_rpk_pcbdefs, false);
 
-	// and read the RPK file
-	return reader.read(std::move(stream), result);
+        // and read the RPK file
+        return reader.read(std::move(stream), result);
 }
 
 
@@ -536,37 +536,37 @@ static std::error_condition read_coco_rpk(std::unique_ptr<util::random_read> &&s
 
 static std::error_condition read_coco_rpk(std::unique_ptr<util::random_read> &&stream, u8 *mem, offs_t cart_length, offs_t &actual_length)
 {
-	actual_length = 0;
+        actual_length = 0;
 
-	// open the RPK
-	rpk_file::ptr file;
-	std::error_condition err = read_coco_rpk(std::move(stream), file);
-	if (err)
-		return err;
+        // open the RPK
+        rpk_file::ptr file;
+        std::error_condition err = read_coco_rpk(std::move(stream), file);
+        if (err)
+                return err;
 
-	// for now, we are just going to load all sockets into the contiguous block of memory
-	// that cartridges use
-	offs_t pos = 0;
-	for (const rpk_socket &socket : file->sockets())
-	{
-		// only ROM supported for now; if we see anything else it should have been caught in the RPK code
-		assert(socket.type() == rpk_socket::socket_type::ROM);
+        // for now, we are just going to load all sockets into the contiguous block of memory
+        // that cartridges use
+        offs_t pos = 0;
+        for (const rpk_socket &socket : file->sockets())
+        {
+                // only ROM supported for now; if we see anything else it should have been caught in the RPK code
+                assert(socket.type() == rpk_socket::socket_type::ROM);
 
-		// read all bytes
-		std::vector<uint8_t> contents;
-		err = socket.read_file(contents);
-		if (err)
-			return err;
+                // read all bytes
+                std::vector<uint8_t> contents;
+                err = socket.read_file(contents);
+                if (err)
+                        return err;
 
-		// copy the bytes
-		offs_t size = (offs_t) std::min(contents.size(), (size_t)cart_length - pos);
-		memcpy(&mem[pos], &contents[0], size);
-		pos += size;
-	}
+                // copy the bytes
+                offs_t size = (offs_t) std::min(contents.size(), (size_t)cart_length - pos);
+                memcpy(&mem[pos], &contents[0], size);
+                pos += size;
+        }
 
-	// we're done!
-	actual_length = pos;
-	return std::error_condition();
+        // we're done!
+        actual_length = pos;
+        return std::error_condition();
 }
 
 
@@ -576,42 +576,42 @@ static std::error_condition read_coco_rpk(std::unique_ptr<util::random_read> &&s
 
 image_init_result cococart_slot_device::call_load()
 {
-	if (m_cart)
-	{
-		memory_region *cart_mem = m_cart->get_cart_memregion();
-		u8 *base = cart_mem->base();
-		offs_t read_length, cart_length = cart_mem->bytes();
+        if (m_cart)
+        {
+                memory_region *cart_mem = m_cart->get_cart_memregion();
+                u8 *base = cart_mem->base();
+                offs_t read_length, cart_length = cart_mem->bytes();
 
-		if (loaded_through_softlist())
-		{
-			// loaded through softlist
-			read_length = get_software_region_length("rom");
-			memcpy(base, get_software_region("rom"), read_length);
-		}
-		else if (is_filetype("rpk"))
-		{
-			// RPK file
-			util::core_file::ptr proxy;
-			std::error_condition err = util::core_file::open_proxy(image_core_file(), proxy);
-			if (!err)
-				err = read_coco_rpk(std::move(proxy), base, cart_length, read_length);
-			if (err)
-				return image_init_result::FAIL;
-		}
-		else
-		{
-			// conventional ROM image
-			read_length = fread(base, cart_length);
-		}
+                if (loaded_through_softlist())
+                {
+                        // loaded through softlist
+                        read_length = get_software_region_length("rom");
+                        memcpy(base, get_software_region("rom"), read_length);
+                }
+                else if (is_filetype("rpk"))
+                {
+                        // RPK file
+                        util::core_file::ptr proxy;
+                        std::error_condition err = util::core_file::open_proxy(image_core_file(), proxy);
+                        if (!err)
+                                err = read_coco_rpk(std::move(proxy), base, cart_length, read_length);
+                        if (err)
+                                return image_init_result::FAIL;
+                }
+                else
+                {
+                        // conventional ROM image
+                        read_length = fread(base, cart_length);
+                }
 
-		while (read_length < cart_length)
-		{
-			offs_t len = std::min(read_length, cart_length - read_length);
-			memcpy(base + read_length, base, len);
-			read_length += len;
-		}
-	}
-	return image_init_result::PASS;
+                while (read_length < cart_length)
+                {
+                        offs_t len = std::min(read_length, cart_length - read_length);
+                        memcpy(base + read_length, base, len);
+                        read_length += len;
+                }
+        }
+        return image_init_result::PASS;
 }
 
 
@@ -621,24 +621,24 @@ image_init_result cococart_slot_device::call_load()
 
 std::string cococart_slot_device::get_default_card_software(get_default_card_software_hook &hook) const
 {
-	// this is the default for anything not in an RPK file
-	int pcb_type = 0;
+        // this is the default for anything not in an RPK file
+        int pcb_type = 0;
 
-	// is this an RPK?
-	if (hook.is_filetype("rpk"))
-	{
-		// RPK file
-		rpk_file::ptr file;
-		util::core_file::ptr proxy;
-		std::error_condition err = util::core_file::open_proxy(*hook.image_file(), proxy);
-		if (!err)
-			err = read_coco_rpk(std::move(proxy), file);
-		if (!err)
-			pcb_type = file->pcb_type();
-	}
+        // is this an RPK?
+        if (hook.is_filetype("rpk"))
+        {
+                // RPK file
+                rpk_file::ptr file;
+                util::core_file::ptr proxy;
+                std::error_condition err = util::core_file::open_proxy(*hook.image_file(), proxy);
+                if (!err)
+                        err = read_coco_rpk(std::move(proxy), file);
+                if (!err)
+                        pcb_type = file->pcb_type();
+        }
 
-	// lookup the default slot
-	return software_get_default_slot(coco_rpk_cardslottypes[pcb_type]);
+        // lookup the default slot
+        return software_get_default_slot(coco_rpk_cardslottypes[pcb_type]);
 }
 
 
@@ -655,9 +655,9 @@ template class device_finder<device_cococart_interface, true>;
 //-------------------------------------------------
 
 device_cococart_interface::device_cococart_interface(const machine_config &mconfig, device_t &device)
-	: device_interface(device, "cococart")
-	, m_owning_slot(dynamic_cast<cococart_slot_device *>(device.owner()))
-	, m_host(nullptr)
+        : device_interface(device, "cococart")
+        , m_owning_slot(dynamic_cast<cococart_slot_device *>(device.owner()))
+        , m_host(nullptr)
 {
 }
 
@@ -677,9 +677,9 @@ device_cococart_interface::~device_cococart_interface()
 
 void device_cococart_interface::interface_config_complete()
 {
-	m_host = m_owning_slot
-			? dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner())
-			: nullptr;
+        m_host = m_owning_slot
+                        ? dynamic_cast<device_cococart_host_interface *>(m_owning_slot->owner())
+                        : nullptr;
 }
 
 
@@ -689,10 +689,10 @@ void device_cococart_interface::interface_config_complete()
 
 void device_cococart_interface::interface_pre_start()
 {
-	if (!m_owning_slot)
-		throw emu_fatalerror("Expected device().owner() to be of type cococart_slot_device");
-	if (!m_host)
-		throw emu_fatalerror("Expected m_owning_slot->owner() to be of type device_cococart_host_interface");
+        if (!m_owning_slot)
+                throw emu_fatalerror("Expected device().owner() to be of type cococart_slot_device");
+        if (!m_host)
+                throw emu_fatalerror("Expected m_owning_slot->owner() to be of type device_cococart_host_interface");
 }
 
 
@@ -703,7 +703,7 @@ void device_cococart_interface::interface_pre_start()
 
 u8 device_cococart_interface::cts_read(offs_t offset)
 {
-	return 0x00;
+        return 0x00;
 }
 
 
@@ -724,7 +724,7 @@ void device_cococart_interface::cts_write(offs_t offset, u8 data)
 
 u8 device_cococart_interface::scs_read(offs_t offset)
 {
-	return 0x00;
+        return 0x00;
 }
 
 
@@ -753,7 +753,7 @@ void device_cococart_interface::set_sound_enable(bool sound_enable)
 
 u8 *device_cococart_interface::get_cart_base()
 {
-	return nullptr;
+        return nullptr;
 }
 
 
@@ -763,7 +763,7 @@ u8 *device_cococart_interface::get_cart_base()
 
 u32 device_cococart_interface::get_cart_size()
 {
-	return 0x8000;
+        return 0x8000;
 }
 
 
@@ -773,7 +773,7 @@ u32 device_cococart_interface::get_cart_size()
 
 void device_cococart_interface::set_cart_base_update(cococart_base_update_delegate update)
 {
-	m_update = update;
+        m_update = update;
 }
 
 
@@ -783,14 +783,14 @@ void device_cococart_interface::set_cart_base_update(cococart_base_update_delega
 
 void device_cococart_interface::cart_base_changed(void)
 {
-	if (!m_update.isnull())
-		m_update(get_cart_base());
-	else
-	{
-		// propagate up to host interface
-		device_cococart_interface *host = dynamic_cast<device_cococart_interface*>(m_host);
-		host->cart_base_changed();
-	}
+        if (!m_update.isnull())
+                m_update(get_cart_base());
+        else
+        {
+                // propagate up to host interface
+                device_cococart_interface *host = dynamic_cast<device_cococart_interface*>(m_host);
+                host->cart_base_changed();
+        }
 }
 
 /*-------------------------------------------------
@@ -799,7 +799,7 @@ void device_cococart_interface::cart_base_changed(void)
 
 memory_region *device_cococart_interface::get_cart_memregion()
 {
-	return 0;
+        return 0;
 }
 
 //-------------------------------------------------
@@ -808,7 +808,7 @@ memory_region *device_cococart_interface::get_cart_memregion()
 
 address_space &device_cococart_interface::cartridge_space()
 {
-	return host().cartridge_space();
+        return host().cartridge_space();
 }
 
 
@@ -818,7 +818,7 @@ address_space &device_cococart_interface::cartridge_space()
 
 void device_cococart_interface::set_line_value(cococart_slot_device::line line, cococart_slot_device::line_value value)
 {
-	owning_slot().set_line_value(line, value);
+        owning_slot().set_line_value(line, value);
 }
 
 
@@ -828,26 +828,35 @@ void device_cococart_interface::set_line_value(cococart_slot_device::line line, 
 
 void coco_cart_add_basic_devices(device_slot_interface &device)
 {
-	// basic devices, on both the main slot and the Multi-Pak interface
-	device.option_add_internal("banked_16k", COCO_PAK_BANKED);
-	device.option_add_internal("pak", COCO_PAK);
-	device.option_add("ccpsg", COCO_PSG);
-	device.option_add("dcmodem", COCO_DCMODEM);
-	device.option_add("gmc", COCO_PAK_GMC);
-	device.option_add("ide", COCO_IDE);
-	device.option_add("max", COCO_PAK_MAX);
-	device.option_add("midi", COCO_MIDI);
-	device.option_add("orch90", COCO_ORCH90);
-	device.option_add("ram", COCO_PAK_RAM);
-	device.option_add("rs232", COCO_RS232);
-	device.option_add("ssc", COCO_SSC);
-	device.option_add("ssfm", DRAGON_MSX2);
-	device.option_add("stecomp", COCO_STEREO_COMPOSER);
-	device.option_add("sym12", COCO_SYM12);
-	device.option_add("wpk", COCO_WPK);
-	device.option_add("wpk2", COCO_WPK2);
-	device.option_add("wpkrs", COCO_WPKRS);
-	device.option_add("wpk2p", COCO_WPK2P);
+        // basic devices, on both the main slot and the Multi-Pak interface
+        device.option_add_internal("banked_16k", COCO_PAK_BANKED);
+        device.option_add_internal("pak", COCO_PAK);
+        device.option_add("ccpsg", COCO_PSG);
+        device.option_add("dcmodem", COCO_DCMODEM);
+        device.option_add("gmc", COCO_PAK_GMC);
+        device.option_add("ide", COCO_IDE);
+        device.option_add("max", COCO_PAK_MAX);
+        device.option_add("midi", COCO_MIDI);
+        device.option_add("orch90", COCO_ORCH90);
+        device.option_add("ram", COCO_PAK_RAM);
+        device.option_add("rs232", COCO_RS232);
+        device.option_add("ssc", COCO_SSC);
+        device.option_add("ssfm", DRAGON_MSX2);
+        device.option_add("stecomp", COCO_STEREO_COMPOSER);
+        device.option_add("sym12", COCO_SYM12);
+        device.option_add("wpk", COCO_WPK);
+        device.option_add("wpk2", COCO_WPK2);
+        device.option_add("wpkrs", COCO_WPKRS);
+        device.option_add("wpk2p", COCO_WPK2P);
+        device.option_add("cc2hdb1", COCO2_HDB1);
+        device.option_add("cc3hdb1", COCO3_HDB1);
+        device.option_add("rgbdos", COCO_LOCAL);
+        device.option_add("cd6809_fdc", CD6809_FDC);
+        device.option_add("cp450_fdc", CP450_FDC);
+        device.option_add("fdc", COCO_FDC);
+        device.option_add("fdcv11", COCO_FDC_V11);
+        device.option_add("scii_cc1", COCO_SCII_CC1);
+        device.option_add("scii_cc3", COCO_SCII_CC3);
 }
 
 
@@ -857,16 +866,6 @@ void coco_cart_add_basic_devices(device_slot_interface &device)
 
 void coco_cart_add_fdcs(device_slot_interface &device)
 {
-	// FDCs are optional because if they are on a Multi-Pak interface, they must
-	// be on Slot 4
-	device.option_add("cc2hdb1", COCO2_HDB1);
-	device.option_add("cc3hdb1", COCO3_HDB1);
-	device.option_add("cd6809_fdc", CD6809_FDC);
-	device.option_add("cp450_fdc", CP450_FDC);
-	device.option_add("fdc", COCO_FDC);
-	device.option_add("fdcv11", COCO_FDC_V11);
-	device.option_add("scii_cc1", COCO_SCII_CC1);
-	device.option_add("scii_cc3", COCO_SCII_CC3);
 }
 
 
@@ -876,8 +875,8 @@ void coco_cart_add_fdcs(device_slot_interface &device)
 
 void coco_cart_add_multi_pak(device_slot_interface &device)
 {
-	// and the Multi-Pak itself is optional because they cannot be daisy chained
-	device.option_add("multi", COCO_MULTIPAK);
+        // and the Multi-Pak itself is optional because they cannot be daisy chained
+        device.option_add("multi", COCO_MULTIPAK);
 }
 
 
@@ -887,24 +886,24 @@ void coco_cart_add_multi_pak(device_slot_interface &device)
 
 void dragon_cart_add_basic_devices(device_slot_interface &device)
 {
-	device.option_add_internal("amtor", DRAGON_AMTOR);
-	device.option_add("ccpsg", COCO_PSG);
-	device.option_add("claw", DRAGON_CLAW);
-	device.option_add("gmc", COCO_PAK_GMC);
-	device.option_add("jcbsnd", DRAGON_JCBSND);
-	device.option_add("jcbspch", DRAGON_JCBSPCH);
-	device.option_add("max", COCO_PAK_MAX);
-	device.option_add("midi", DRAGON_MIDI);
-	device.option_add("orch90", COCO_ORCH90);
-	device.option_add("pak", COCO_PAK);
-	device.option_add("serial", DRAGON_SERIAL);
-	device.option_add("ram", COCO_PAK_RAM);
-	device.option_add("sprites", DRAGON_SPRITES);
-	device.option_add("ssc", COCO_SSC);
-	device.option_add("ssfm", DRAGON_MSX2);
-	device.option_add("stecomp", COCO_STEREO_COMPOSER);
-	device.option_add("sym12", COCO_SYM12);
-	device.option_add("wpk2p", COCO_WPK2P);
+        device.option_add_internal("amtor", DRAGON_AMTOR);
+        device.option_add("ccpsg", COCO_PSG);
+        device.option_add("claw", DRAGON_CLAW);
+        device.option_add("gmc", COCO_PAK_GMC);
+        device.option_add("jcbsnd", DRAGON_JCBSND);
+        device.option_add("jcbspch", DRAGON_JCBSPCH);
+        device.option_add("max", COCO_PAK_MAX);
+        device.option_add("midi", DRAGON_MIDI);
+        device.option_add("orch90", COCO_ORCH90);
+        device.option_add("pak", COCO_PAK);
+        device.option_add("serial", DRAGON_SERIAL);
+        device.option_add("ram", COCO_PAK_RAM);
+        device.option_add("sprites", DRAGON_SPRITES);
+        device.option_add("ssc", COCO_SSC);
+        device.option_add("ssfm", DRAGON_MSX2);
+        device.option_add("stecomp", COCO_STEREO_COMPOSER);
+        device.option_add("sym12", COCO_SYM12);
+        device.option_add("wpk2p", COCO_WPK2P);
 }
 
 
@@ -914,9 +913,9 @@ void dragon_cart_add_basic_devices(device_slot_interface &device)
 
 void dragon_cart_add_fdcs(device_slot_interface &device)
 {
-	device.option_add("dragon_fdc", DRAGON_FDC);
-	device.option_add("premier_fdc", PREMIER_FDC);
-	device.option_add("sdtandy_fdc", SDTANDY_FDC);
+        device.option_add("dragon_fdc", DRAGON_FDC);
+        device.option_add("premier_fdc", PREMIER_FDC);
+        device.option_add("sdtandy_fdc", SDTANDY_FDC);
 }
 
 
@@ -926,5 +925,5 @@ void dragon_cart_add_fdcs(device_slot_interface &device)
 
 void dragon_cart_add_multi_pak(device_slot_interface &device)
 {
-	device.option_add("multi", DRAGON_MULTIPAK);
+        device.option_add("multi", DRAGON_MULTIPAK);
 }


### PR DESCRIPTION
Allow floppy controller in any multi pak slot. Even though the manual states that floppy controller should be used in slot 4, they do in fact work in any slot on the real hardware, I know, I've done it more than once.

Add floppy controller with custom RGBDOS ROM, adds support for emulated HD in RSDOS.
