### PR TITLE
machine/wd_fdc.cpp: Don’t clear DRQ  on LDB/INTR, and fix spurious READ TRACk/ADDR FM mark syncs

### DIFF
--- a/src/devices/machine/wd_fdc.cpp
+++ b/src/devices/machine/wd_fdc.cpp
@@ -136,12 +136,12 @@ static const char *const states[] =
 	"WRITE_SECTOR_PRE_BYTE"
 };
 
-template <unsigned B> uint32_t wd_fdc_device_base::live_info::shift_reg_low() const
+template <unsigned B> inline uint32_t wd_fdc_device_base::live_info::shift_reg_low() const
 {
 	return shift_reg & make_bitmask<uint32_t>(B);
 }
 
-uint8_t wd_fdc_device_base::live_info::shift_reg_data() const
+inline uint8_t wd_fdc_device_base::live_info::shift_reg_data() const
 {
 	return bitswap<8>(shift_reg, 14, 12, 10, 8, 6, 4, 2, 0);
 }
@@ -2044,8 +2044,7 @@ void wd_fdc_device_base::live_run(attotime limit)
 
 			if(dden) {
 				//FM Prefix match
-				if(cur_live.shift_reg_low<17>() == 0xabd5)	// 17-bit match
-				{
+				if(cur_live.shift_reg_low<17>() == 0xabd5) { // 17-bit match
 					cur_live.data_separator_phase = false;
 					cur_live.bit_counter = 5*2;	// prefix is 5 of 8 bits
 					cur_live.data_reg = 0xff;

--- a/src/devices/machine/wd_fdc.cpp
+++ b/src/devices/machine/wd_fdc.cpp
@@ -136,9 +136,10 @@ static const char *const states[] =
 	"WRITE_SECTOR_PRE_BYTE"
 };
 
-uint32_t wd_fdc_device_base::live_info::shift_reg_low(int n) const
+//uint32_t wd_fdc_device_base::live_info::shift_reg_low(int n) const
+template <unsigned B> uint32_t wd_fdc_device_base::live_info::shift_reg_low() const
 {
-	return shift_reg & make_bitmask<uint32_t>(n);
+	return shift_reg & make_bitmask<uint32_t>(B);
 }
 
 uint8_t wd_fdc_device_base::live_info::shift_reg_data() const
@@ -1817,13 +1818,13 @@ void wd_fdc_device_base::live_run(attotime limit)
 					cur_live.shift_reg_data(),
 					cur_live.bit_counter);
 
-			if(!dden && cur_live.shift_reg_low(16) == 0x4489) {
+			if(!dden && cur_live.shift_reg_low<16>() == 0x4489) {
 				cur_live.crc = 0x443b;
 				reset_data_sync();
 				cur_live.state = READ_HEADER_BLOCK_HEADER;
 			}
 
-			if(dden && cur_live.shift_reg_low(23) == 0x2af57e) {
+			if(dden && cur_live.shift_reg_low<23>() == 0x2af57e) {
 				cur_live.crc = 0xef21;
 				reset_data_sync();
 				if(main_state == READ_ID)
@@ -1848,7 +1849,7 @@ void wd_fdc_device_base::live_run(attotime limit)
 			int slot = cur_live.bit_counter >> 4;
 
 			if(slot < 3) {
-				if(cur_live.shift_reg_low(16) != 0x4489)
+				if(cur_live.shift_reg_low<16>() != 0x4489)
 					cur_live.state = SEARCH_ADDRESS_MARK_HEADER;
 				break;
 			}
@@ -1929,7 +1930,7 @@ void wd_fdc_device_base::live_run(attotime limit)
 					return;
 				}
 
-				if(cur_live.bit_counter >= 28*16 && cur_live.shift_reg_low(16) == 0x4489) {
+				if(cur_live.bit_counter >= 28*16 && cur_live.shift_reg_low<16>() == 0x4489) {
 					cur_live.crc = 0x443b;
 					reset_data_sync();
 					cur_live.state = READ_DATA_BLOCK_HEADER;
@@ -1940,12 +1941,12 @@ void wd_fdc_device_base::live_run(attotime limit)
 					return;
 				}
 
-				if(cur_live.bit_counter >= 11*16 && (cur_live.shift_reg_low(16) == 0xf56a || cur_live.shift_reg_low(16) == 0xf56b ||
-														cur_live.shift_reg_low(16) == 0xf56e || cur_live.shift_reg_low(16) == 0xf56f)) {
+				if(cur_live.bit_counter >= 11*16 && (cur_live.shift_reg_low<16>() == 0xf56a || cur_live.shift_reg_low<16>() == 0xf56b ||
+														cur_live.shift_reg_low<16>() == 0xf56e || cur_live.shift_reg_low<16>() == 0xf56f)) {
 					cur_live.crc =
-						cur_live.shift_reg_low(16) == 0xf56a ? 0x8fe7 :
-						cur_live.shift_reg_low(16) == 0xf56b ? 0x9fc6 :
-						cur_live.shift_reg_low(16) == 0xf56e ? 0xafa5 :
+						cur_live.shift_reg_low<16>() == 0xf56a ? 0x8fe7 :
+						cur_live.shift_reg_low<16>() == 0xf56b ? 0x9fc6 :
+						cur_live.shift_reg_low<16>() == 0xf56e ? 0xafa5 :
 						0xbf84;
 
 					reset_data_sync();
@@ -1978,7 +1979,7 @@ void wd_fdc_device_base::live_run(attotime limit)
 			int slot = cur_live.bit_counter >> 4;
 
 			if(slot < 3) {
-				if(cur_live.shift_reg_low(16) != 0x4489) {
+				if(cur_live.shift_reg_low<16>() != 0x4489) {
 					live_delay(SEARCH_ADDRESS_MARK_DATA_FAILED);
 					return;
 				}
@@ -2044,7 +2045,7 @@ void wd_fdc_device_base::live_run(attotime limit)
 
 			if(dden) {
 				//FM Prefix match
-				if(cur_live.shift_reg_low(17) == 0xabd5)	// 17-bit match
+				if(cur_live.shift_reg_low<17>() == 0xabd5)	// 17-bit match
 				{
 					cur_live.data_separator_phase = false;
 					cur_live.bit_counter = 5*2;	// prefix is 5 of 8 bits
@@ -2061,8 +2062,8 @@ void wd_fdc_device_base::live_run(attotime limit)
 			// !dden
 			if(cur_live.bit_counter != 16
 				// MFM resyncs
-				&& !((cur_live.shift_reg_low(16) == 0x4489
-							|| cur_live.shift_reg_low(16) == 0x5224))
+				&& !((cur_live.shift_reg_low<16>() == 0x4489
+							|| cur_live.shift_reg_low<16>() == 0x5224))
 				)
 				break;
 

--- a/src/devices/machine/wd_fdc.cpp
+++ b/src/devices/machine/wd_fdc.cpp
@@ -136,6 +136,16 @@ static const char *const states[] =
 	"WRITE_SECTOR_PRE_BYTE"
 };
 
+uint32_t wd_fdc_device_base::live_info::shift_reg_low(int n) const
+{
+	return shift_reg & make_bitmask<uint32_t>(n);
+}
+
+uint8_t wd_fdc_device_base::live_info::shift_reg_data() const
+{
+	return bitswap<8>(shift_reg, 14, 12, 10, 8, 6, 4, 2, 0);
+}
+
 wd_fdc_device_base::wd_fdc_device_base(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, type, tag, owner, clock),
 	intrq_cb(*this),
@@ -2032,17 +2042,15 @@ void wd_fdc_device_base::live_run(attotime limit)
 			if(read_one_bit(limit))
 				return;
 
-			if (dden) {
+			if(dden) {
 				//FM Prefix match
-				if (cur_live.shift_reg_low(17) == 0xabd5)	// 17-bit match
+				if(cur_live.shift_reg_low(17) == 0xabd5)	// 17-bit match
 				{
 					cur_live.data_separator_phase = false;
 					cur_live.bit_counter = 5*2;	// prefix is 5 of 8 bits
 					cur_live.data_reg = 0xff;
 					break;
-				}
-				else if (cur_live.bit_counter == 16)
-				{
+				} else if(cur_live.bit_counter == 16) {
 					cur_live.data_separator_phase = false;
 					cur_live.bit_counter = 0;
 					live_delay(READ_TRACK_DATA_BYTE);

--- a/src/devices/machine/wd_fdc.cpp
+++ b/src/devices/machine/wd_fdc.cpp
@@ -1079,7 +1079,6 @@ void wd_fdc_device_base::interrupt_start()
 		main_state = sub_state = cur_live.state = IDLE;
 		cur_live.tm = attotime::never;
 		status &= ~S_BUSY;
-		drop_drq();
 		motor_timeout = 0;
 	} else {
 		// when a force interrupt command is issued and there is no
@@ -1718,7 +1717,7 @@ void wd_fdc_device_base::reset_data_sync()
 	cur_live.data_separator_phase = false;
 	cur_live.bit_counter = 0;
 
-	cur_live.data_reg = bitswap<8>(cur_live.shift_reg, 14, 12, 10, 8, 6, 4, 2, 0);
+	cur_live.data_reg = cur_live.shift_reg_data();
 }
 
 bool wd_fdc_device_base::write_one_bit(const attotime &limit)
@@ -1804,24 +1803,17 @@ void wd_fdc_device_base::live_run(attotime limit)
 			if(read_one_bit(limit))
 				return;
 
-			LOGSHIFT("%s: shift = %04x data=%02x c=%d\n", cur_live.tm.to_string(), cur_live.shift_reg,
-					(cur_live.shift_reg & 0x4000 ? 0x80 : 0x00) |
-					(cur_live.shift_reg & 0x1000 ? 0x40 : 0x00) |
-					(cur_live.shift_reg & 0x0400 ? 0x20 : 0x00) |
-					(cur_live.shift_reg & 0x0100 ? 0x10 : 0x00) |
-					(cur_live.shift_reg & 0x0040 ? 0x08 : 0x00) |
-					(cur_live.shift_reg & 0x0010 ? 0x04 : 0x00) |
-					(cur_live.shift_reg & 0x0004 ? 0x02 : 0x00) |
-					(cur_live.shift_reg & 0x0001 ? 0x01 : 0x00),
+			LOGSHIFT("%s: shift = %08x data=%02x c=%d\n", cur_live.tm.to_string(), cur_live.shift_reg,
+					cur_live.shift_reg_data(),
 					cur_live.bit_counter);
 
-			if(!dden && cur_live.shift_reg == 0x4489) {
+			if(!dden && cur_live.shift_reg_low(16) == 0x4489) {
 				cur_live.crc = 0x443b;
 				reset_data_sync();
 				cur_live.state = READ_HEADER_BLOCK_HEADER;
 			}
 
-			if(dden && cur_live.shift_reg == 0xf57e) {
+			if(dden && cur_live.shift_reg_low(23) == 0x2af57e) {
 				cur_live.crc = 0xef21;
 				reset_data_sync();
 				if(main_state == READ_ID)
@@ -1836,15 +1828,8 @@ void wd_fdc_device_base::live_run(attotime limit)
 			if(read_one_bit(limit))
 				return;
 
-			LOGSHIFT("%s: shift = %04x data=%02x counter=%d\n", cur_live.tm.to_string(), cur_live.shift_reg,
-					(cur_live.shift_reg & 0x4000 ? 0x80 : 0x00) |
-					(cur_live.shift_reg & 0x1000 ? 0x40 : 0x00) |
-					(cur_live.shift_reg & 0x0400 ? 0x20 : 0x00) |
-					(cur_live.shift_reg & 0x0100 ? 0x10 : 0x00) |
-					(cur_live.shift_reg & 0x0040 ? 0x08 : 0x00) |
-					(cur_live.shift_reg & 0x0010 ? 0x04 : 0x00) |
-					(cur_live.shift_reg & 0x0004 ? 0x02 : 0x00) |
-					(cur_live.shift_reg & 0x0001 ? 0x01 : 0x00),
+			LOGSHIFT("%s: shift = %08x data=%02x counter=%d\n", cur_live.tm.to_string(), cur_live.shift_reg,
+					cur_live.shift_reg_data(),
 					cur_live.bit_counter);
 
 			if(cur_live.bit_counter & 15)
@@ -1853,7 +1838,7 @@ void wd_fdc_device_base::live_run(attotime limit)
 			int slot = cur_live.bit_counter >> 4;
 
 			if(slot < 3) {
-				if(cur_live.shift_reg != 0x4489)
+				if(cur_live.shift_reg_low(16) != 0x4489)
 					cur_live.state = SEARCH_ADDRESS_MARK_HEADER;
 				break;
 			}
@@ -1924,15 +1909,8 @@ void wd_fdc_device_base::live_run(attotime limit)
 			if(read_one_bit(limit))
 				return;
 
-			LOGSHIFT("%s: shift = %04x data=%02x c=%d.%x\n", cur_live.tm.to_string(), cur_live.shift_reg,
-					(cur_live.shift_reg & 0x4000 ? 0x80 : 0x00) |
-					(cur_live.shift_reg & 0x1000 ? 0x40 : 0x00) |
-					(cur_live.shift_reg & 0x0400 ? 0x20 : 0x00) |
-					(cur_live.shift_reg & 0x0100 ? 0x10 : 0x00) |
-					(cur_live.shift_reg & 0x0040 ? 0x08 : 0x00) |
-					(cur_live.shift_reg & 0x0010 ? 0x04 : 0x00) |
-					(cur_live.shift_reg & 0x0004 ? 0x02 : 0x00) |
-					(cur_live.shift_reg & 0x0001 ? 0x01 : 0x00),
+			LOGSHIFT("%s: shift = %08x data=%02x c=%d.%x\n", cur_live.tm.to_string(), cur_live.shift_reg,
+					cur_live.shift_reg_data(),
 					cur_live.bit_counter >> 4, cur_live.bit_counter & 15);
 
 			if(!dden) {
@@ -1941,7 +1919,7 @@ void wd_fdc_device_base::live_run(attotime limit)
 					return;
 				}
 
-				if(cur_live.bit_counter >= 28*16 && cur_live.shift_reg == 0x4489) {
+				if(cur_live.bit_counter >= 28*16 && cur_live.shift_reg_low(16) == 0x4489) {
 					cur_live.crc = 0x443b;
 					reset_data_sync();
 					cur_live.state = READ_DATA_BLOCK_HEADER;
@@ -1952,12 +1930,12 @@ void wd_fdc_device_base::live_run(attotime limit)
 					return;
 				}
 
-				if(cur_live.bit_counter >= 11*16 && (cur_live.shift_reg == 0xf56a || cur_live.shift_reg == 0xf56b ||
-														cur_live.shift_reg == 0xf56e || cur_live.shift_reg == 0xf56f)) {
+				if(cur_live.bit_counter >= 11*16 && (cur_live.shift_reg_low(16) == 0xf56a || cur_live.shift_reg_low(16) == 0xf56b ||
+														cur_live.shift_reg_low(16) == 0xf56e || cur_live.shift_reg_low(16) == 0xf56f)) {
 					cur_live.crc =
-						cur_live.shift_reg == 0xf56a ? 0x8fe7 :
-						cur_live.shift_reg == 0xf56b ? 0x9fc6 :
-						cur_live.shift_reg == 0xf56e ? 0xafa5 :
+						cur_live.shift_reg_low(16) == 0xf56a ? 0x8fe7 :
+						cur_live.shift_reg_low(16) == 0xf56b ? 0x9fc6 :
+						cur_live.shift_reg_low(16) == 0xf56e ? 0xafa5 :
 						0xbf84;
 
 					reset_data_sync();
@@ -1980,15 +1958,8 @@ void wd_fdc_device_base::live_run(attotime limit)
 			if(read_one_bit(limit))
 				return;
 
-			LOGSHIFT("%s: shift = %04x data=%02x counter=%d\n", cur_live.tm.to_string(), cur_live.shift_reg,
-					(cur_live.shift_reg & 0x4000 ? 0x80 : 0x00) |
-					(cur_live.shift_reg & 0x1000 ? 0x40 : 0x00) |
-					(cur_live.shift_reg & 0x0400 ? 0x20 : 0x00) |
-					(cur_live.shift_reg & 0x0100 ? 0x10 : 0x00) |
-					(cur_live.shift_reg & 0x0040 ? 0x08 : 0x00) |
-					(cur_live.shift_reg & 0x0010 ? 0x04 : 0x00) |
-					(cur_live.shift_reg & 0x0004 ? 0x02 : 0x00) |
-					(cur_live.shift_reg & 0x0001 ? 0x01 : 0x00),
+			LOGSHIFT("%s: shift = %08x data=%02x counter=%d\n", cur_live.tm.to_string(), cur_live.shift_reg,
+					cur_live.shift_reg_data(),
 					cur_live.bit_counter);
 
 			if(cur_live.bit_counter & 15)
@@ -1997,7 +1968,7 @@ void wd_fdc_device_base::live_run(attotime limit)
 			int slot = cur_live.bit_counter >> 4;
 
 			if(slot < 3) {
-				if(cur_live.shift_reg != 0x4489) {
+				if(cur_live.shift_reg_low(16) != 0x4489) {
 					live_delay(SEARCH_ADDRESS_MARK_DATA_FAILED);
 					return;
 				}
@@ -2061,17 +2032,29 @@ void wd_fdc_device_base::live_run(attotime limit)
 			if(read_one_bit(limit))
 				return;
 
+			if (dden) {
+				//FM Prefix match
+				if (cur_live.shift_reg_low(17) == 0xabd5)	// 17-bit match
+				{
+					cur_live.data_separator_phase = false;
+					cur_live.bit_counter = 5*2;	// prefix is 5 of 8 bits
+					cur_live.data_reg = 0xff;
+					break;
+				}
+				else if (cur_live.bit_counter == 16)
+				{
+					cur_live.data_separator_phase = false;
+					cur_live.bit_counter = 0;
+					live_delay(READ_TRACK_DATA_BYTE);
+					return;
+				}
+				break;
+			}
+			// !dden
 			if(cur_live.bit_counter != 16
 				// MFM resyncs
-				&& !(!dden && (cur_live.shift_reg == 0x4489
-							|| cur_live.shift_reg == 0x5224))
-				// FM resyncs
-				&& !(dden && (cur_live.shift_reg == 0xf57e      // FM IDAM
-							|| cur_live.shift_reg == 0xf56f     // FM DAM
-							|| cur_live.shift_reg == 0xf56a     // FM DDAM
-							|| cur_live.shift_reg == 0xf56b     // FM DDAM
-							|| cur_live.shift_reg == 0xf56e     // FM DDAM
-							|| cur_live.shift_reg == 0xf56f))   // FM DDAM
+				&& !((cur_live.shift_reg_low(16) == 0x4489
+							|| cur_live.shift_reg_low(16) == 0x5224))
 				)
 				break;
 
@@ -2387,9 +2370,6 @@ void wd_fdc_device_base::set_drq()
 {
 	if(drq) {
 		status |= S_LOST;
-		drq = false;
-		if(!drq_cb.isnull())
-			drq_cb(false);
 	} else if(!(status & S_LOST)) {
 		drq = true;
 		if(!drq_cb.isnull())

--- a/src/devices/machine/wd_fdc.cpp
+++ b/src/devices/machine/wd_fdc.cpp
@@ -136,7 +136,6 @@ static const char *const states[] =
 	"WRITE_SECTOR_PRE_BYTE"
 };
 
-//uint32_t wd_fdc_device_base::live_info::shift_reg_low(int n) const
 template <unsigned B> uint32_t wd_fdc_device_base::live_info::shift_reg_low() const
 {
 	return shift_reg & make_bitmask<uint32_t>(B);

--- a/src/devices/machine/wd_fdc.h
+++ b/src/devices/machine/wd_fdc.h
@@ -260,7 +260,7 @@ private:
 		bool data_separator_phase, data_bit_context;
 		uint8_t data_reg;
 		uint8_t idbuf[6];
-		uint32_t shift_reg_low(int n) const;
+		template <unsigned B> uint32_t shift_reg_low() const;
 		uint8_t shift_reg_data() const;
 	};
 

--- a/src/devices/machine/wd_fdc.h
+++ b/src/devices/machine/wd_fdc.h
@@ -260,8 +260,8 @@ private:
 		bool data_separator_phase, data_bit_context;
 		uint8_t data_reg;
 		uint8_t idbuf[6];
-		template <unsigned B> inline uint32_t shift_reg_low() const;
-		inline uint8_t shift_reg_data() const;
+		template <unsigned B> uint32_t shift_reg_low() const;
+		uint8_t shift_reg_data() const;
 	};
 
 	enum {

--- a/src/devices/machine/wd_fdc.h
+++ b/src/devices/machine/wd_fdc.h
@@ -260,8 +260,8 @@ private:
 		bool data_separator_phase, data_bit_context;
 		uint8_t data_reg;
 		uint8_t idbuf[6];
-		template <unsigned B> uint32_t shift_reg_low() const;
-		uint8_t shift_reg_data() const;
+		template <unsigned B> inline uint32_t shift_reg_low() const;
+		inline uint8_t shift_reg_data() const;
 	};
 
 	enum {

--- a/src/devices/machine/wd_fdc.h
+++ b/src/devices/machine/wd_fdc.h
@@ -254,12 +254,20 @@ private:
 
 		attotime tm;
 		int state, next_state;
-		uint16_t shift_reg;
+		uint32_t shift_reg;
 		uint16_t crc;
 		int bit_counter, byte_counter, previous_type;
 		bool data_separator_phase, data_bit_context;
 		uint8_t data_reg;
 		uint8_t idbuf[6];
+		uint32_t shift_reg_low(int n) const
+		{
+			return shift_reg & make_bitmask<uint32_t>(n);
+		}
+		uint8_t shift_reg_data() const
+		{
+			return bitswap<8>(shift_reg, 14, 12, 10, 8, 6, 4, 2, 0);
+		}
 	};
 
 	enum {

--- a/src/devices/machine/wd_fdc.h
+++ b/src/devices/machine/wd_fdc.h
@@ -260,14 +260,8 @@ private:
 		bool data_separator_phase, data_bit_context;
 		uint8_t data_reg;
 		uint8_t idbuf[6];
-		uint32_t shift_reg_low(int n) const
-		{
-			return shift_reg & make_bitmask<uint32_t>(n);
-		}
-		uint8_t shift_reg_data() const
-		{
-			return bitswap<8>(shift_reg, 14, 12, 10, 8, 6, 4, 2, 0);
-		}
+		uint32_t shift_reg_low(int n) const;
+		uint8_t shift_reg_data() const;
 	};
 
 	enum {


### PR DESCRIPTION
Patch from Peter Philips:
• DRQ fix for Marble Maze
• FM sync prefix fix for Marble Maze
• Fix for false FM sync bug (8511)
• live_info::shift_reg_low() which allows for exact bit matches (> 16)
• update all shift register comparisons to use shift_reg_low(16) (or approrpriate)
• live_info:shift_reg_data() which cleans up several LOGSHIFT() statements