### PR TITLE
Automatic IPS patch plugin

### DIFF
--- a/plugins/autopatch/README.md
+++ b/plugins/autopatch/README.md
@@ -1,0 +1,19 @@
+This plugin will locate and apply an IPS file found that matches a software system and name.
+Current only SNES and Mega Drive/Genesis are supported, and only IPS format patches are 
+supported. Place IPS patches in a directory to match the software list item you are running.
+For example, your autopatch directory should look something like this:
+
+plugins/
+plugins/autopatch/
+plugins/autopatch/init.lua
+plugins/autopatch/plugin.json
+plugins/autopatch/genesis
+plugins/autopatch/genesis/sonic.ips
+plugins/autopatch/snes/
+plugins/autopatch/snes/smwu.ips
+
+Execute MAME using the -plugin autopatch command line arguments, or edit the plugin.json file to set 
+the "start" variable to "true". If the IPS patching is successful there will be an indication on the 
+command line showing which file was applied. The patch is applied only in memory, the original ROM or 
+software list contents are not written to file. Note that the IPS format is simple and doesn't include 
+any validation for the patch or the file it is being applied to.

--- a/plugins/autopatch/README.md
+++ b/plugins/autopatch/README.md
@@ -3,14 +3,14 @@ Current only SNES and Mega Drive/Genesis are supported, and only IPS format patc
 supported. Place IPS patches in a directory to match the software list item you are running.
 For example, your autopatch directory should look something like this:
 
-plugins/
-plugins/autopatch/
-plugins/autopatch/init.lua
-plugins/autopatch/plugin.json
-plugins/autopatch/genesis
-plugins/autopatch/genesis/sonic.ips
-plugins/autopatch/snes/
-plugins/autopatch/snes/smwu.ips
+plugins/\
+plugins/autopatch/\
+plugins/autopatch/init.lua\
+plugins/autopatch/plugin.json\
+plugins/autopatch/genesis\
+plugins/autopatch/genesis/sonic.ips\
+plugins/autopatch/snes/\
+plugins/autopatch/snes/smwu.ips\
 
 Execute MAME using the -plugin autopatch command line arguments, or edit the plugin.json file to set 
 the "start" variable to "true". If the IPS patching is successful there will be an indication on the 

--- a/plugins/autopatch/init.lua
+++ b/plugins/autopatch/init.lua
@@ -1,0 +1,92 @@
+local exports = {
+	name = "autopatch",
+	version = "1",
+	description = "Automatically apply corresponding patch",
+	license = "CC0",
+	author = { name = "jflatt" }}
+
+local autopatch = exports
+
+function autopatch.startplugin()
+	emu.register_start(function()
+		--check if patch file exists
+		local basePath = manager.plugins['autopatch'].directory
+		local romName = emu.romname()
+		local softName = emu.softname()
+		local fullPath = basePath .. '/' .. romName .. '/' .. softName .. '.ips'
+		local file = io.open(fullPath, 'rb')
+
+		if file then
+		    --test that it's a valid IPS patch
+		    local patchTest = file:read(5)
+		    if not patchTest then
+			file:close()
+			emu.print_verbose("Could not read header")
+			return
+		    end
+		    if patchTest ~= 'PATCH' then
+			file:close()
+			emu.print_verbose("Invalid header")
+			return
+		    end
+
+		    local romRegion = ({
+			--['nes'] = ':nes_slot:cart:chr_rom',
+			['snes'] = ':snsslot:cart:rom',
+			['genesis'] = ':mdslot:cart:rom',
+			['megadriv'] = ':mdslot:cart:rom',
+		    })[romName];
+		    
+		    --read IPS file
+		    while true do
+			--each offset chunk is 3 bytes, and the EOF marker is 3 bytes
+			local offsetBytes = file:read(3)
+			if not offsetBytes then
+			    file:close()
+			    emu.print_verbose("Could not read offset")
+			    return
+			end
+			if offsetBytes == 'EOF' then
+			    emu.print_verbose("End of file found")
+			    break
+			end
+			local offset = string.unpack('>I3', offsetBytes)
+
+			--read in the data length
+			local lenBytes = file:read(2)
+			local length = string.unpack('>I2', lenBytes)
+			
+			if length == 0 then
+			    --It's an RLE chunk
+			    local runBytes = file:read(2) --run count
+			    local run = string.unpack('>I2', runBytes)
+			    local value = file:read(1) --byte to repeat
+			    
+			    --write to rom contents
+			    for i = offset, offset + run, 1 do
+				manager.machine.memory.regions[romRegion]:write_u8(i, value)
+			    end
+			elseif length > 0 then
+			    --It's a normal chunk
+			    local value = file:read(length)
+
+			    --write to rom contents
+			    for i = 0, length - 1, 1 do
+				manager.machine.memory.regions[romRegion]:write_u8(offset + i, value:byte(i + 1))
+			    end
+			else
+			    file:close()
+			    emu.print_verbose("Bad IPS file")
+			    return
+			end
+		    end
+
+		    file:close()
+		    local msg = "Auto patch plugin using " .. fullPath
+		    emu.print_info(msg)
+		    manager.machine:popmessage(msg)
+		end
+	end)
+end
+
+return exports

--- a/plugins/autopatch/plugin.json
+++ b/plugins/autopatch/plugin.json
@@ -1,0 +1,10 @@
+{
+  "plugin": {
+	"name": "autopatch",
+	"description": "Automatically apply corresponding patch",
+	"version": "1",
+	"author": "jflatt",
+	"type": "plugin",
+	"start": "false"
+  }
+}


### PR DESCRIPTION
This plugin will attempt to apply an IPS patch in-memory based on software list system and name.

TODO:  Add BPS format

TODO:  Investigate memory regions.  :mdslot:cart:rom or :snsslot:cart:rom are straightforward, and a multitude of existing IPS patches in the wild can be applied successfully.  What about the case of the NES though?  There are :nes_slot:cart:chr_rom and :nes_slot:cart:prg_rom regions, and I'm guessing many IPS patches were created for the combined iNES format with header.  Another issue is with arcade ROMS, perhaps it would be useful to expose the ROM filename somewhere that the lua engine could get to?  I didn't see any filenames from poking around.