### PR TITLE
huc6270.cpp: fix RCR sync, it happens one line earlier

### DIFF
--- a/hash/pce.xml
+++ b/hash/pce.xml
@@ -375,10 +375,13 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="bombmn94">
+	<software name="bombmn94" supported="partial">
 		<description>Bomberman '94</description>
 		<year>1993</year>
 		<publisher>Hudson</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=6849
+]]></notes>
 		<info name="serial" value="HC93065"/>
 		<info name="release" value="19931210"/>
 		<info name="alt_title" value="ボンバーマン'94"/>
@@ -498,10 +501,13 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="cadash">
+	<software name="cadash" supported="partial">
 		<description>Cadash</description>
 		<year>1991</year>
 		<publisher>Taito</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=5193
+]]></notes>
 		<info name="serial" value="TP02015"/>
 		<info name="release" value="19910118"/>
 		<info name="alt_title" value="カダッシュ"/>
@@ -656,6 +662,9 @@ license:CC0-1.0
 		<description>Cross Wiber - Cyber Combat Police</description>
 		<year>1990</year>
 		<publisher>Face</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=7384 (fixed)
+]]></notes>
 		<info name="serial" value="FA02-008"/>
 		<info name="release" value="19901221"/>
 		<info name="alt_title" value="クロスワイバー CYBER-COMBAT-POLICE"/>
@@ -1233,10 +1242,13 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="fireprow">
+	<software name="fireprow" supported="partial">
 		<description>Fire Pro Wrestling - Combination Tag</description>
 		<year>1989</year>
 		<publisher>Human</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=7288 Sound LFO FM
+]]></notes>
 		<info name="serial" value="HM89001"/>
 		<info name="release" value="19890622"/>
 		<info name="alt_title" value="ファイヤープロレスリング コンビネーションタッグ"/>
@@ -1510,10 +1522,14 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="haniisky">
+	<software name="haniisky" supported="partial">
 		<description>Hanii in the Sky</description>
 		<year>1989</year>
 		<publisher>Face</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=7289 Uses sound LFO FM
+Verify sound mixing (stage 1 BGM starts with a left-right effect)
+]]></notes>
 		<info name="serial" value="FA64-0001"/>
 		<info name="release" value="19890301"/>
 		<info name="alt_title" value="はにい いんざ すかい"/>
@@ -3818,10 +3834,13 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="shingen">
+	<software name="shingen" supported="no">
 		<description>Takeda Shingen</description>
 		<year>1989</year>
 		<publisher>Aicom</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=6707 [pad]
+]]></notes>
 		<info name="serial" value="AC89002"/>
 		<info name="release" value="19890728"/>
 		<info name="alt_title" value="武田信玄"/>
@@ -3832,10 +3851,13 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="shingen1" cloneof="shingen">
+	<software name="shingen1" cloneof="shingen" supported="no">
 		<description>Takeda Shingen (alt)</description>
 		<year>1989</year>
 		<publisher>Aicom</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=6707 [pad]
+]]></notes>
 		<info name="serial" value="AC89002"/>
 		<info name="release" value="19890728"/>
 		<info name="alt_title" value="武田信玄"/>
@@ -3930,6 +3952,9 @@ license:CC0-1.0
 		<description>Thunder Blade</description>
 		<year>1990</year>
 		<publisher>NEC Avenue</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=8585 (fixed)
+]]></notes>
 		<info name="serial" value="NAPH-1015"/>
 		<info name="release" value="19901207"/>
 		<info name="alt_title" value="サンダーブレード"/>
@@ -4277,10 +4302,13 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="wonderm">
+	<software name="wonderm" supported="partial">
 		<description>Wonder Momo</description>
 		<year>1989</year>
 		<publisher>Namcot</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=6597
+]]></notes>
 		<info name="serial" value="NC64001"/>
 		<info name="release" value="19890421"/>
 		<info name="alt_title" value="ワンダーモモ"/>

--- a/hash/pcecd.xml
+++ b/hash/pcecd.xml
@@ -1681,10 +1681,13 @@ Cheat: Up, up, up, down, down, down, II, II, II, I, I, I during intro for "debug
 		</part>
 	</software>
 
-	<software name="flashhid">
+	<software name="flashhid" supported="partial">
 		<description>Flash Hiders (Japan)</description>
 		<year>1993</year>
 		<publisher>Right Stuff</publisher>
+		<notes><![CDATA[
+Uses sound LFO FM
+]]></notes>
 		<info name="serial" value="RSCD3004"/>
 		<info name="release" value="19931219"/>
 		<info name="alt_title" value="フラッシュハイダース"/>
@@ -2327,10 +2330,13 @@ Unsupported [セーブくん] joypad slot peripheral
 		</part>
 	</software>
 
-	<software name="hyperdyn">
+	<software name="hyperdyn" supported="partial">
 		<description>Hyper Dyne SideArms Special (Japan)</description>
 		<year>1989</year>
 		<publisher>NEC Avenue</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=8105 (verify)
+]]></notes>
 		<info name="serial" value="HACD9002"/>
 		<info name="release" value="19891215"/>
 		<info name="alt_title" value="サイドアームスペシャル"/>
@@ -2585,10 +2591,13 @@ New game intro sports glitchy portraits
 		</part>
 	</software>
 
-	<software name="juuouki">
+	<software name="juuouki" supported="partial">
 		<description>Juuouki (Japan)</description>
 		<year>1989</year>
 		<publisher>NEC Avenue</publisher>
+		<notes><![CDATA[
+Uses Sound LFO FM
+]]></notes>
 		<info name="serial" value="HACD9001"/>
 		<info name="release" value="19890922"/>
 		<info name="alt_title" value="獣王記"/>
@@ -7185,10 +7194,14 @@ Omake: Press U R D L II at menu to access Bomberman
 		</part>
 	</software>
 
-	<software name="addfam">
+	<software name="addfam" supported="no">
 		<description>The Addams Family (USA)</description>
 		<year>1991</year>
 		<publisher>ICOM Simulations</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=7261 check [ADPCM] irq ack
+Abruptly stops [ADPCM] playback on title screen
+]]></notes>
 		<info name="serial" value="TGXCD1019"/>
 		<info name="usage" value="CD-ROM System Card required" />
 		<sharedfeat name="requirement" value="cdsys"/>
@@ -7241,10 +7254,13 @@ Omake: Press U R D L II at menu to access Bomberman
 		</part>
 	</software>
 
-	<software name="campcali">
+	<software name="campcali" supported="no">
 		<description>Camp California (USA)</description>
 		<year>1993</year>
 		<publisher>ICOM Simulations</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=7262
+]]></notes>
 		<info name="serial" value="TGXCD1013"/>
 		<info name="usage" value="CD-ROM² Super System Card required" />
 		<sharedfeat name="requirement" value="scdsys"/>
@@ -7605,6 +7621,9 @@ Crashes after first action, [SCSI] timing sensitive
 		<description>Prince of Persia (USA)</description>
 		<year>1992</year>
 		<publisher>Brøderbund</publisher>
+		<notes><![CDATA[
+https://mametesters.org/view.php?id=7727 (fixed)
+]]></notes>
 		<info name="serial" value="TGXCD1027"/>
 		<info name="usage" value="CD-ROM² Super System Card required" />
 		<sharedfeat name="requirement" value="scdsys"/>

--- a/src/devices/bus/pce_ctrl/pcectrl.cpp
+++ b/src/devices/bus/pce_ctrl/pcectrl.cpp
@@ -193,5 +193,8 @@ void pce_control_port_devices(device_slot_interface &device)
 	// NEC Memory Base 128 (PI-AD19, ﾒﾓﾘﾍﾞｰｽ128)
 	// Koei Save-Kun (セーブくん), clone of above?
 
+	// Serial Monitor for PCEMon
+	// https://www.chrismcovell.com/PCEmon/index.html
+
 	// etc...
 }

--- a/src/devices/video/huc6270.cpp
+++ b/src/devices/video/huc6270.cpp
@@ -224,7 +224,7 @@ void huc6270_device::select_sprites()
 		static const int cgy_table[4] = { 16, 32, 64, 64 };
 		int cgy = ( m_sat[i+3] >> 12 ) & 0x03;
 		int height = cgy_table[ cgy ];
-		int sprite_line = m_raster_count - m_sat[i];
+		int sprite_line = m_raster_count - 1 - m_sat[i];
 
 		if ( sprite_line >= 0 && sprite_line < height )
 		{
@@ -532,7 +532,14 @@ WRITE_LINE_MEMBER( huc6270_device::hsync_changed )
 			m_horz_steps = 0;
 			m_byr_latched += 1;
 			m_raster_count += 1;
-			if ( m_vert_to_go == 1 && m_vert_state == v_state::VDS )
+			// raster count VSW latch happens one line earlier (cfr. +2 on assignment)
+			// This has been confirmed on real HW, where the last possible RCR with 
+			// 240 VDW is 0x130 (i.e. 64 + 240). m_vert_to_go == 1 will also 
+			// cause several side effects, namely:
+			// - draculax Stage 4' "all blue" Richter;
+			// - faussete Stage 2 excessive slowdown;
+			// - xwiber Stage 2 boss never spawning (MT#07384)
+			if ( m_vert_to_go == 2 && m_vert_state == v_state::VDS )
 			{
 				m_raster_count = 0x40;
 			}

--- a/src/devices/video/huc6270.cpp
+++ b/src/devices/video/huc6270.cpp
@@ -224,6 +224,9 @@ void huc6270_device::select_sprites()
 		static const int cgy_table[4] = { 16, 32, 64, 64 };
 		int cgy = ( m_sat[i+3] >> 12 ) & 0x03;
 		int height = cgy_table[ cgy ];
+		// TODO: we are one line off in alignment, is following compensation right?
+		// cfr. rennybla & draculax (at least), they are otherwise offset by 1
+		// compared to background.
 		int sprite_line = m_raster_count - 1 - m_sat[i];
 
 		if ( sprite_line >= 0 && sprite_line < height )


### PR DESCRIPTION
- fix: draculax Stage 4' "all blue" Richter;
- fix: faussete Stage 2 excessive slowdown and erratic water line;
- fix: xwiber Stage 2 boss never spawning [MT#07384](https://mametesters.org/view.php?id=7384)
- fix: ppersia misplaced line [MT#07727](https://mametesters.org/view.php?id=7727)
- fix: ddragon2 options menu display;
- fix: tblade hang after third person view [MT#08585](https://mametesters.org/view.php?id=8585)
