### PR TITLE
nintendo/dkong.cpp: add trainer ROM set

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -33570,6 +33570,7 @@ dkongjrc                        // hack
 dkongddk                        // hack
 dkongx                          // hack
 dkongx11                        // hack
+dkongtr                         // hack
 drakton                         // (c) 1984 Epos Corporation
 drktnjr                         // (c) 1984 Epos Corporation
 herbiedk                        // (c) 1984 CVS

--- a/src/mame/nintendo/dkong.cpp
+++ b/src/mame/nintendo/dkong.cpp
@@ -2428,6 +2428,34 @@ ROM_START( dkongx11 )
 	ROM_LOAD( "v-5e.bpr",     0x0200, 0x0100, CRC(b869b8f5) SHA1(c2bdccbf2654b64ea55cd589fd21323a9178a660) ) /* character color codes on a per-column basis */
 ROM_END
 
+ROM_START( dkongtr ) /* Trainer ROM set from https://donkeykongforum.net/index.php?topic=1642.0 */
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "tr_5et_g.bin", 0x0000, 0x1000, CRC(c7dc68c4) SHA1(5cc76f41e09132143620230ed9f63cc7621203c9) )
+	ROM_LOAD( "tr_5ct_g.bin", 0x1000, 0x1000, CRC(1a7c2bb8) SHA1(e6b6d17331e3fc74d83285b74563955f8e97ee66) )
+	ROM_LOAD( "tr_5bt_g.bin", 0x2000, 0x1000, CRC(dc4cbd2f) SHA1(eaf87adb9252b6bbdceaee9f7c5e791e939cc25f) )
+	ROM_LOAD( "tr_5at_g.bin", 0x3000, 0x1000, CRC(36e333d2) SHA1(207f51d7ef53e7c6d9db2b7cb7a2ded49ffa2db5) )
+
+	ROM_REGION( 0x1800, "soundcpu", 0 ) /* sound */
+	ROM_LOAD( "s_3i_b.bin",   0x0000, 0x0800, CRC(45a4ed06) SHA1(144d24464c1f9f01894eb12f846952290e6e32ef) )
+	ROM_RELOAD(               0x0800, 0x0800 )
+	ROM_LOAD( "s_3j_b.bin",   0x1000, 0x0800, CRC(4743fe92) SHA1(6c82b57637c0212a580591397e6a5a1718f19fd2) )
+
+	ROM_REGION( 0x1000, "gfx1", 0 )
+	ROM_LOAD( "v_5h_b.bin",   0x0000, 0x0800, CRC(12c8c95d) SHA1(a57ff5a231c45252a63b354137c920a1379b70a3) )
+	ROM_LOAD( "v_3pt.bin",    0x0800, 0x0800, CRC(15e9c5e9) SHA1(976eb1e18c74018193a35aa86cff482ebfc5cc4e) )
+
+	ROM_REGION( 0x2000, "gfx2", 0 )
+	ROM_LOAD( "l_4m_b.bin",   0x0000, 0x0800, CRC(59f8054d) SHA1(793dba9bf5a5fe76328acdfb90815c243d2a65f1) )
+	ROM_LOAD( "l_4n_b.bin",   0x0800, 0x0800, CRC(672e4714) SHA1(92e5d379f4838ac1fa44d448ce7d142dae42102f) )
+	ROM_LOAD( "l_4r_b.bin",   0x1000, 0x0800, CRC(feaa59ee) SHA1(ecf95db5a20098804fc8bd59232c66e2e0ed3db4) )
+	ROM_LOAD( "l_4s_b.bin",   0x1800, 0x0800, CRC(20f2ef7e) SHA1(3bc482a38bf579033f50082748ee95205b0f673d) )
+
+	ROM_REGION( 0x0300, "proms", 0 )
+	ROM_LOAD( "c-2k.bpr",     0x0000, 0x0100, CRC(e273ede5) SHA1(b50ec9e1837c00c20fb2a4369ec7dd0358321127) ) /* palette low 4 bits (inverted) */
+	ROM_LOAD( "c-2j.bpr",     0x0100, 0x0100, CRC(d6412358) SHA1(f9c872da2fe8e800574ae3bf483fb3ccacc92eb3) ) /* palette high 4 bits (inverted) */
+	ROM_LOAD( "v-5e.bpr",     0x0200, 0x0100, CRC(b869b8f5) SHA1(c2bdccbf2654b64ea55cd589fd21323a9178a660) ) /* character color codes on a per-column basis */
+ROM_END
+
 ROM_START( dkongjr )
 	ROM_REGION( 0x10000, "maincpu", 0 )
 	ROM_LOAD( "djr1-c_5b_f-2.5b", 0x0000, 0x1000, CRC(dea28158) SHA1(08baf84ae6f9b40a2c743fe1d8c158c74a40e95a) )
@@ -3775,6 +3803,7 @@ GAME( 2001, dkongddk,  dkongjr,  ddk_braze, dkongx,   dkong_state, init_dkonghs,
 GAME( 2006, dkongx,    dkong,    dk_braze,  dkongx,   dkong_state, init_dkongx,   ROT270, "hack (Braze Technologies)",         "Donkey Kong II: Jumpman Returns (hack, V1.2)",    MACHINE_SUPPORTS_SAVE )
 GAME( 2006, dkongx11,  dkong,    dk_braze,  dkongx,   dkong_state, init_dkongx,   ROT270, "hack (Braze Technologies)",         "Donkey Kong II: Jumpman Returns (hack, V1.1)",    MACHINE_SUPPORTS_SAVE )
 GAME( 2013, dkongpe,   dkong,    dkong2b,   dkong,    dkong_state, empty_init,    ROT270, "hack (Clay Cowgill and Mike Mika)", "Donkey Kong: Pauline Edition Rev 5 (2013-04-22)", MACHINE_SUPPORTS_SAVE )
+GAME( 2016, dkongtr,   dkong,    dkong2b,   dkong,    dkong_state, empty_init,    ROT270, "hack (Sock Master)",                "Donkey Kong Trainer (hack, V1.01)",               MACHINE_SUPPORTS_SAVE )
 
 GAME( 1982, dkongjr,   0,        dkongjr,   dkongjr,  dkong_state, empty_init,    ROT270, "Nintendo of America", "Donkey Kong Junior (US set F-2)",              MACHINE_SUPPORTS_SAVE )
 GAME( 1982, dkongjr2,  dkongjr,  dkongjr,   dkongjr,  dkong_state, empty_init,    ROT270, "Nintendo of America", "Donkey Kong Junior (US, bootleg?)",            MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
This hacked version of Donkey Kong is made to help “train” players on the game as they learn the game mechanics and all the subtle details involved with player and enemy object movement.

There was an older version 1.00 of the ROM set, but I do not believe it was backed up by the WayBack Machine.  At least I was unable to find it.

From: https://donkeykongforum.net/index.php?topic=1642.90