### PR TITLE
fmtowns_cd.xml: 12 new dumps, 2 replacements

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -15,7 +15,6 @@ Items with * are in the list, but are bad dumps or incomplete.
 
                             Title                                         Publisher             Release date  Media
 4D Boxing (Marty compatible)                                  Electronic Arts Victor            1993/7     CD
-4D Driving (Marty compatible)                                 Electronic Arts Victor            1993/7     CD
 A Christmas Carol                                             DynEd Japan                       1993/3     SET(CD+FD)
 A Jack in the Box                                             Raison                            1989/11    CD
 A Night in Tunisia                                            Raison                            1991/9     CD
@@ -157,7 +156,6 @@ Gendai Yougo no Kiso Chishiki (1992)                          Fujitsu           
 Gendai Yougo no Kiso Chishiki (1993)                          Fujitsu                           1993/9     CD
 Gendai Yougo no Kiso Chishiki (1994)                          Fujitsu                           1994/9     CD
 Ge-Ten 2                                                      Hokusho                           1993/?     ?
-Ginga Uchuu Odyssey 1                                         Fujitsu                           1991/3     CD
 Ginga Uchuu Odyssey 2 (Marty-compatible)                      Fujitsu                           1992/4     CD
 Ginga Yuukyou Densetsu Tobakker                               Ponytail Soft                     1995/11    CD
 Gomen ne Angel: Yokohama Monogatari                           JAST                              1992/1     ?
@@ -178,7 +176,6 @@ Heisei 6-nendo-ban Keizai Hakusho                             Fujitsu           
 Hello Kitty: Asobi no Omochabako                              Fujitsu Parex                     1995/9     CD
 High C Compiler Multimedia Kaihatsu Kit V3.2                  Fujitsu                           ?          CD
 High School War                                               ISC                               1994/9     CD
-HomeSTUDIO V1.1                                               Fujitsu                           1992/12    SET(CD+FD)
 Hot de Art na Barcelona                                       Media Art                         1991/9     CD
 Hyoutan Shima Kouryaku-ki                                     Nihon Dennou Koubou               1994/?     ?
 * Hyper Address Ver. 2.0                                      Datt Japan                        1991/4     SET(CD+FD)
@@ -268,7 +265,6 @@ Mohan Roppou Heisei 6-nendo-ban                               Fujitsu           
 Mokkoriman RPG                                                Illusion                          1994/6     CD
 Moko                                                          Fujitsu Social Science Laboratory 1995/3     CD×03
 Monoshiri Jiyuugaku Bannin Isshu-hen                          Shinkou Human Create              1994/10    CD
-Monster Planet 2255                                           Nihon Media Programming           1990/12    CD
 Moon Crystal                                                  Orange House                      1992/6     ?
 Multimedia Nihon no Rekishi Dai-1-Shou: Kariya-ryou no Kurashi  Tokyo Shoseki                     ?          CD
 Multimedia Nihon no Rekishi Dai-2-Shou: Kome-zukuri no Mura kara Kofun no Kuni e    Tokyo Shoseki                     1995/4     CD
@@ -324,7 +320,6 @@ Petit Collage                                                 Pandora Box       
 Powers of Ten                                                 Datt Japan                        1995/10    CD
 Present                                                       Orange House                      1991/6     ?
 Primary Health Care System                                    Raison                            1990/9     CD
-Psychic Detective Series Vol. 2: Memories (Remake)            Data West                         1994/4     SET(CD+FD)
 * Psychic Detective Series Vol. 5: Nightmare (Remake)         Data West                         1995/4     SET(CD+FD)
 Pyoko-tan no Niji no Shima: Nanairo no Ninjin wo Sagase       Nanken Koubou                     1994/3     CD
 Queen of Duellist Gaiden + Gaiden Alpha Light                 Agumix                            1994/4     CD
@@ -395,7 +390,6 @@ The Book of MIDI                                              Fujitsu           
 The Lost Secret                                               DynEd Japan                       1993/7     SET(CD+FD)
 The Manhole 2                                                 Sun Denshi                        1993/5     ?
 The Sea in Your Eyes: Umi wo Mitsumete                        Inter Limited Logic               1995/4     CD
-The Yachtman                                                  Raison                            1989/11    CD
 Think Read: Chuugaku Series                                   Catena                            ?          SET(CD+FD)
 Think Read: Shougaku Series                                   Catena                            ?          SET(CD+FD)
 Total English 1-nen                                           Uchida Youkou                     1993/9     CD
@@ -1281,6 +1275,37 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="4d driving (japan)" sha1="68794807a59b1095c2b10bf2e6a4da3eb6371f8f" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="4ddrivinm" cloneof="4ddrivin">
+		<!--
+		Origin: redump.org
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 01).bin" size="10231200" crc="1e390b90" sha1="cf375b85c09afb8d3104f0417fc46f7975febd28"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 02).bin" size="8643600" crc="ab5f071b" sha1="3f2dbd7e0ec41dadd6e374065eb2df1cc01a0bc7"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 03).bin" size="4762800" crc="f1b9040f" sha1="33930f5755172ac37f192c0dac50ede38f3a3117"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 04).bin" size="7938000" crc="5af6f044" sha1="5729c270b493d74ef24eef51aaa66eb2242931f4"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 05).bin" size="7232400" crc="5d877a88" sha1="7e6b2783c25521c59e3da7e706a36cd972c81271"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 06).bin" size="7938000" crc="37541ef0" sha1="6f93d7add53d6ee7a66e55d59b6b87cd7043af52"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 07).bin" size="6526800" crc="440e0a71" sha1="0aa104dd90c71d856eff36c9dfe92ee3b13dffa4"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 08).bin" size="7938000" crc="e30827c1" sha1="eada05052c104fb96340d1114f17a90c906f243c"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 09).bin" size="1587600" crc="e0ea7260" sha1="301c09953eb42e9766d8c5b62b85b8a738782db8"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 10).bin" size="3880800" crc="6abdbae0" sha1="bd6003b1595c10b8167f19970af556b552479275"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 11).bin" size="11113200" crc="881174cd" sha1="97ffa1ac92c65802d40437217a2d8153a26bd0e6"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease) (Track 12).bin" size="7585200" crc="4dd0b5a3" sha1="f81d02f3e788b112fc75b11d69ce975bc3bf0c90"/>
+		<rom name="4D Driving (Japan) (FM Towns Marty Rerelease).cue" size="1662" crc="f6ffd662" sha1="a34fb5ec6a31cd17d34931b7f605581b6676de77"/>
+		-->
+		<description>4D Driving (FM Towns Marty version)</description>
+		<year>1993</year>
+		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="serial" value="HMD-222A / EFT-7005"/>
+		<info name="alt_title" value="4D ドライビング" />
+		<info name="release" value="199307xx" />
+		<info name="usage" value="Only works on the 386SX-based models (Marty/UX)"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="4d driving (japan) (fm towns marty rerelease)" sha1="fa4dc65e57a643b3b717454515318a3552a88f39" />
 			</diskarea>
 		</part>
 	</software>
@@ -6189,6 +6214,52 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- PC-9821 / FM Towns hybrid -->
+	<software name="dokidok2">
+		<!--
+		Origin: redump.org
+		<rom name="Doki Doki Disk CD-ban Vol. 2 (Japan) (Track 1).bin" size="14568288" crc="48c72b16" sha1="c8348182dec2be426914437d510a276cad25ca59"/>
+		<rom name="Doki Doki Disk CD-ban Vol. 2 (Japan) (Track 2).bin" size="14779968" crc="5609cadb" sha1="91118ad71a004ccc4a153746e37e526aafaf15f7"/>
+		<rom name="Doki Doki Disk CD-ban Vol. 2 (Japan) (Track 3).bin" size="13726272" crc="66911235" sha1="d30afa8c34ad0302cd447f08db65203aac4f1c0d"/>
+		<rom name="Doki Doki Disk CD-ban Vol. 2 (Japan) (Track 4).bin" size="9132816" crc="a61b2083" sha1="22eda086491881a770be22e006e6894781ac4e39"/>
+		<rom name="Doki Doki Disk CD-ban Vol. 2 (Japan) (Track 5).bin" size="9765504" crc="e626f8df" sha1="c6e0acba72316425cb9a5839b1da6f965c3bb516"/>
+		<rom name="Doki Doki Disk CD-ban Vol. 2 (Japan) (Track 6).bin" size="13030080" crc="c7d623b5" sha1="37c9ee416e255eecce380297dcc19eacd8bc304b"/>
+		<rom name="Doki Doki Disk CD-ban Vol. 2 (Japan) (Track 7).bin" size="18263280" crc="f66ebbc0" sha1="2d1c4c2c59fc55f0ea1629d1c5faefc1e08eb058"/>
+		<rom name="Doki Doki Disk CD-ban Vol. 2 (Japan) (Track 8).bin" size="15706656" crc="ef261e0e" sha1="64e5bcc6a025f92020a373ee54f1c5bcf2af1219"/>
+		<rom name="Doki Doki Disk CD-ban Vol. 2 (Japan).cue" size="884" crc="28bb602b" sha1="4f1c4c5ae5ca8e357a16ab8436774e0f6a6e46a0"/>
+		-->
+		<description>Doki Doki Disk CD-ban - Club D.O. Vol. 2</description>
+		<year>1994</year>
+		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="DCD-0004"/>
+		<info name="alt_title" value="どきどきディスクＣＤ版　Ｃｌｕｂ　Ｄ．Ｏ．　ｖｏｌ．２" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="doki doki disk cd-ban vol. 2 (japan)" sha1="7f724424639975dcbc6aa7e003862bf74ce4f199" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- PC-9821 / Windows / FM Towns hybrid -->
+	<software name="dokidok3">
+		<!--
+		Origin: redump.org
+		<rom name="Doki Doki Disk CD-ban Vol. 3 (Japan).bin" size="567871584" crc="608f3a81" sha1="f2da2948f916c0beaa6e0e25b4a230757c82b5e0"/>
+		<rom name="Doki Doki Disk CD-ban Vol. 3 (Japan).cue" size="102" crc="f3037a84" sha1="647b8aa52ab66fde65b4385a044ce86d58e417f9"/>
+		-->
+		<description>Doki Doki Disk CD-ban - Club D.O. Vol. 3</description>
+		<year>1995</year>
+		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="alt_title" value="どきどきディスクＣＤ版　Ｃｌｕｂ　Ｄ．Ｏ．　ｖｏｌ．３" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="doki doki disk cd-ban vol. 3 (japan)" sha1="b69090b18762165bc2f4a90623900a87abb3b35b" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="dokivact">
 		<!--
 		Origin: redump.org (CD) / wiggy2k (floppy)
@@ -8821,6 +8892,34 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="fmtstdema" cloneof="fmtstdem">
+		<!--
+		Origin: redump.org
+		<rom name="FM Towns Super Technology Demo 1993 (Japan) (Hibaihin) (Track 01).bin" size="249782400" crc="f38e305f" sha1="fd61c4a161477811e970421f2d5d3d94e309c45f"/>
+		<rom name="FM Towns Super Technology Demo 1993 (Japan) (Hibaihin) (Track 02).bin" size="1237152" crc="0ecfb684" sha1="a3b988b06aa284f4b707a92e8dd8b768e3d7e097"/>
+		<rom name="FM Towns Super Technology Demo 1993 (Japan) (Hibaihin) (Track 03).bin" size="1764000" crc="e7887563" sha1="923937048d6b3fe908cbe4115a099a3b7a195d0b"/>
+		<rom name="FM Towns Super Technology Demo 1993 (Japan) (Hibaihin) (Track 04).bin" size="37220400" crc="5e0dbea7" sha1="bbf0062aeadff4b037b405cf75afab237b3c1be2"/>
+		<rom name="FM Towns Super Technology Demo 1993 (Japan) (Hibaihin) (Track 05).bin" size="10231200" crc="20e9edc0" sha1="0b67150bfbb44a70049560c957f2c8f62e14a1b5"/>
+		<rom name="FM Towns Super Technology Demo 1993 (Japan) (Hibaihin) (Track 06).bin" size="25225200" crc="c2f2d7e4" sha1="462fbd4895a6b5979fcd790781e2105f67eb27b0"/>
+		<rom name="FM Towns Super Technology Demo 1993 (Japan) (Hibaihin) (Track 07).bin" size="10584000" crc="3eb77f9e" sha1="d0933ce25ea10cf0c6a1140c20abcc11634f97cc"/>
+		<rom name="FM Towns Super Technology Demo 1993 (Japan) (Hibaihin) (Track 08).bin" size="2646000" crc="532e15b5" sha1="9d214a27b9fe0d5d07540ef682797790ac0e171e"/>
+		<rom name="FM Towns Super Technology Demo 1993 (Japan) (Hibaihin) (Track 09).bin" size="14994000" crc="5d29156b" sha1="886e7fc4bb1b667313ace60439dc0b19e370fd94"/>
+		<rom name="FM Towns Super Technology Demo 1993 (Japan) (Hibaihin) (Track 10).bin" size="75852000" crc="34785a10" sha1="e41e60dca4707cb417334d24d398d85d727cd634"/>
+		<rom name="FM Towns Super Technology Demo 1993 (Japan) (Hibaihin).cue" size="1495" crc="5e4a9cb4" sha1="a14ea5d2a212ac7dd7d37fcb0390d1672b08c8f5"/>
+		-->
+		<description>FM Towns Super Technology Demo 1993 (HME-919)</description>
+		<year>1993</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-919"/>
+		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="fm towns super technology demo 1993 (japan) (hibaihin)" sha1="97be055f8df22d433faf088a3ae27d465097057c" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="fmtworld">
 		<!--
 		Origin: redump.org
@@ -9440,7 +9539,8 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<software name="hstudio">
+	<!-- Video capture requires the FMT-411/412/418 Video Card, which is not currently emulated. Audio recording is also not supported by MAME. -->
+	<software name="hstudio" supported="partial">
 		<!--
 		Origin: redump.org
 		<rom name="HomeStudio V1.2L10 (Japan).bin" size="52567200" crc="92e93784" sha1="abc6e6e30fb071e5ddcf1502e698f20b2b0cca62"/>
@@ -9455,6 +9555,25 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="homestudio v1.2l10 (japan)" sha1="2248f1e971cd4f96f40b57cd6659af2fe64d531d" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="hstudio11" cloneof="hstudio" supported="partial">
+		<!--
+		Origin: redump.org
+		<rom name="HomeStudio V1.1 L10 (Japan).bin" size="41983200" crc="4836df39" sha1="1ff6e17b1dd6b1391f60fb4707bb626db4a8b001"/>
+		<rom name="HomeStudio V1.1 L10 (Japan).cue" size="93" crc="2454051a" sha1="c7e49b8a5629c729e5089ecd4ef3099ad3611708"/>
+		-->
+		<description>HomeStudio V1.1L10</description>
+		<year>1992</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="BD276D060"/>
+		<info name="release" value="199212xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="homestudio v1.1 l10 (japan)" sha1="338e4a26aaae5fc330a2e90efda23cfe1fd0ab53" />
 			</diskarea>
 		</part>
 	</software>
@@ -9978,6 +10097,27 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ginga eiyuu densetsu iii sp (japan)" sha1="a490e0279fbb11f6e0b3d97e1cceb74c0cc09c09" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="gingaod1">
+		<!--
+		Origin: redump.org
+		<rom name="NHK Special - Ginga Uchuu Odyssey Vol. 1 - Tabidachi Waga Taiyoukei (Japan) (Track 1).bin" size="104958000" crc="406c1014" sha1="c59792722f910b107dc71586de4035c58e627a7f"/>
+		<rom name="NHK Special - Ginga Uchuu Odyssey Vol. 1 - Tabidachi Waga Taiyoukei (Japan) (Track 2).bin" size="407484000" crc="7eccede9" sha1="db103fef8a2709bccb6c887c55c4d5d3e4a3f865"/>
+		<rom name="NHK Special - Ginga Uchuu Odyssey Vol. 1 - Tabidachi Waga Taiyoukei (Japan).cue" size="320" crc="3669b6a0" sha1="81bee34885a6acb50c5c7513e21ee6974dcd0856"/>
+		-->
+		<description>NHK Special - Ginga Uchuu Odyssey Vol. 1 - Tabidachi Waga Taiyoukei</description>
+		<year>1991</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-108 / A2760150 / TSC150"/>
+		<info name="alt_title" value="ＮＨＫスペシャル　銀河宇宙オデッセイ①　「旅立ち　わが太陽系」" />
+		<info name="release" value="199103xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="nhk special - ginga uchuu odyssey vol. 1 - tabidachi waga taiyoukei (japan)" sha1="93f1ba6fe8419f7d7a45fe94776c39def396dfd9" />
 			</diskarea>
 		</part>
 	</software>
@@ -15871,11 +16011,23 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="mparadox">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Mad Paradox.ccd" size="3420" crc="ef9f40be" sha1="16e92f8dd2fc987dc1f10fd390fafa77b32cd4f8"/>
-		<rom name="Mad Paradox.cue" size="627" crc="7c437d47" sha1="65fd2011b2cfc913d3a1f4b58d7a1f0ea174eb2e"/>
-		<rom name="Mad Paradox.img" size="432885600" crc="62688cfe" sha1="60b19a3d179ae982b1a60ea4749f5bb3f493fc12"/>
-		<rom name="Mad Paradox.sub" size="17668800" crc="956a82e4" sha1="a85595868e9ce1dc80527695a4c1786eae994541"/>
+		Origin: redump.org
+		<rom name="Mad-Paradox (Japan) (Track 01).bin" size="10231200" crc="2447c4ad" sha1="9af243d162319b3bdc024687d13fe90777a1160d"/>
+		<rom name="Mad-Paradox (Japan) (Track 02).bin" size="20991600" crc="3db6f1da" sha1="6e69310f5c49068001f44641a488c50809bd1611"/>
+		<rom name="Mad-Paradox (Japan) (Track 03).bin" size="21697200" crc="eaf3d7fa" sha1="17c778ec6fa2daeea98aea900dad046be7766cc1"/>
+		<rom name="Mad-Paradox (Japan) (Track 04).bin" size="32986800" crc="047f148b" sha1="41313ceb4f473584f2b5df5e07079b60db44ae3f"/>
+		<rom name="Mad-Paradox (Japan) (Track 05).bin" size="25930800" crc="d7d2257a" sha1="c1fda4e237f7d6597a9335ebdb235ace1ec696cd"/>
+		<rom name="Mad-Paradox (Japan) (Track 06).bin" size="24343200" crc="d89ba44f" sha1="dc06302886a4180dc6d0764417278df115e20245"/>
+		<rom name="Mad-Paradox (Japan) (Track 07).bin" size="29635200" crc="66325ac4" sha1="a2b5d6b5a5399d1d593aeaff3e893bd89914215f"/>
+		<rom name="Mad-Paradox (Japan) (Track 08).bin" size="32457600" crc="5b059dc3" sha1="496114ba158f14a84712224ff3ab31548dd8ea62"/>
+		<rom name="Mad-Paradox (Japan) (Track 09).bin" size="31575600" crc="41f0e035" sha1="ca731d4c7897c5a2d1c6dc4298f66289813c3ced"/>
+		<rom name="Mad-Paradox (Japan) (Track 10).bin" size="26107200" crc="4616f292" sha1="80b977b1c93d4e2f84c357786c7d5592909efa9a"/>
+		<rom name="Mad-Paradox (Japan) (Track 11).bin" size="19051200" crc="74637eb8" sha1="b61c5ab1f90773e8be2adea71f1a1efa3e7b8323"/>
+		<rom name="Mad-Paradox (Japan) (Track 12).bin" size="34398000" crc="ac7fdbbe" sha1="5f396cdacb0bfa04ce9fce918ac7f6568db2005e"/>
+		<rom name="Mad-Paradox (Japan) (Track 13).bin" size="46040400" crc="a395cd23" sha1="b9ec544343edb3419fae1c489aadca777854ffd9"/>
+		<rom name="Mad-Paradox (Japan) (Track 14).bin" size="38808000" crc="49437506" sha1="d3aa1f26d0786379a6d4063cf2d8a9f20fa11b8e"/>
+		<rom name="Mad-Paradox (Japan) (Track 15).bin" size="38631600" crc="9c1ab721" sha1="4175603e77030aed19a7f5c48371edd55db45db4"/>
+		<rom name="Mad-Paradox (Japan).cue" size="1692" crc="00231d06" sha1="bd68f8cfb10e80c91bb8b114f4e3b4ba61353830"/>
 		-->
 		<description>Mad Paradox</description>
 		<year>1994</year>
@@ -15886,7 +16038,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mad paradox" sha1="da8146ef3fcffb9e8679b3f64bb80efc48785e80" />
+				<disk name="mad-paradox (japan)" sha1="71f14435b9b91a85fa069c4d7343bdd603e2ee16" />
 			</diskarea>
 		</part>
 	</software>
@@ -16878,6 +17030,31 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="martydemo">
+		<!--
+		Origin: redump.org
+		<rom name="FM Towns Marty Tentou Auto Demo '93 Natsu (Japan) (Track 1).bin" size="36227856" crc="03695aab" sha1="8c0ad554deeb2164db5d7865d5a69cfc9dbed799"/>
+		<rom name="FM Towns Marty Tentou Auto Demo '93 Natsu (Japan) (Track 2).bin" size="1674624" crc="41707720" sha1="ebce5abab94017a8cadc0895a1ff6e63177c6bdc"/>
+		<rom name="FM Towns Marty Tentou Auto Demo '93 Natsu (Japan) (Track 3).bin" size="2022720" crc="41f5714c" sha1="815105b8dc8bef106b70a8fb131750ea98bcbed7"/>
+		<rom name="FM Towns Marty Tentou Auto Demo '93 Natsu (Japan) (Track 4).bin" size="2018016" crc="686c8368" sha1="4ab2cd93447f0dd8d71622f4e9ab1d8ef91810b7"/>
+		<rom name="FM Towns Marty Tentou Auto Demo '93 Natsu (Japan) (Track 5).bin" size="2168544" crc="d99a2a3d" sha1="a3be4828b491f1443dc304359a912edfb0cc5786"/>
+		<rom name="FM Towns Marty Tentou Auto Demo '93 Natsu (Japan) (Track 6).bin" size="5503680" crc="2ef9e988" sha1="c2636fbd120fe9b40ded9f02417ea25e31710b5d"/>
+		<rom name="FM Towns Marty Tentou Auto Demo '93 Natsu (Japan) (Track 7).bin" size="7808640" crc="8ed24187" sha1="cb10463072c786bb5157bd25cb53d8e07a7451ea"/>
+		<rom name="FM Towns Marty Tentou Auto Demo '93 Natsu (Japan).cue" size="983" crc="75a5125e" sha1="83d84e16178858bf07734b6550060695820912f6"/>
+		-->
+		<description>FM Towns Marty Tentou Auto Demo '93 Natsu</description>
+		<year>1993</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-903-2"/>
+		<info name="alt_title" value="ＦＭ　ＴＯＷＮＳ　マーティ　店頭オート・デモ’９３夏" />
+		<info name="usage" value="Only works on the 386SX-based models (Marty/UX)"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="fm towns marty tentou auto demo '93 natsu (japan)" sha1="0088a64464bf16103ad42cd6729828591bd84306" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="manyoshu">
 		<!--
 		Origin: redump.org
@@ -17049,6 +17226,49 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="microcosm (japan)" sha1="4dbbbd66b018fc9145e990e00adc611c98a58d7a" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="medicco">
+		<!--
+		Origin: redump.org
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 01).bin" size="20817552" crc="6384e3cb" sha1="0ff7f862ee234501488f0afef447f70f8ebe1cb0"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 02).bin" size="8464848" crc="c1bc3474" sha1="84660ee1cf827898fb4dd22e6a705997700a6119"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 03).bin" size="16581600" crc="833ecbbe" sha1="25489f26b5db14e305549972a4c6fe3e6b291151"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 04).bin" size="12348000" crc="262436e5" sha1="e2adf0357bfdeffa89a47b45debf5c4e505957ac"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 05).bin" size="2646000" crc="b5633f99" sha1="b0cd60acd9fd40be5944eaa2cdd9c9cd5561c6f0"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 06).bin" size="3528000" crc="062d29e8" sha1="1010c48141e846fcc6de5402836670e8d4ea03cc"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 07).bin" size="8467200" crc="b756e62b" sha1="82af836e0e1fda5819a0bda93d2e6c6a3d27c532"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 08).bin" size="9172800" crc="c1671dec" sha1="245a88e5d5e93f748fe70cd8d98ec0a5e2809450"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 09).bin" size="3880800" crc="5d204ba5" sha1="3d7aa704268a6e6edf174af5ab3775732bbcacf5"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 10).bin" size="4233600" crc="ade29a64" sha1="257f17728937d16e8ec60f148d81abc34577621a"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 11).bin" size="4057200" crc="6eec86c1" sha1="c5c0220e32bcefc62565a1b3afad27dfcd90fe50"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 12).bin" size="7173600" crc="a7210624" sha1="ad7a2e887a5451acda3d1f4ba3ce33d35d0f6e98"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 13).bin" size="8937600" crc="4be3813e" sha1="ea3cad1c822c580f95afd6cc474e8e7f160d8b8e"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 14).bin" size="3292800" crc="3146d649" sha1="5888c613239edd41db510d2faac6f3c346bb0d2b"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 15).bin" size="11642400" crc="e74a9827" sha1="7fc7cfa54e88abe8c435cf7e2297f02900580b4c"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 16).bin" size="16758000" crc="a823a977" sha1="48973804ec1ad34e73776b851dc41a4ae3ae7d37"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 17).bin" size="18522000" crc="d70ee066" sha1="445bf4c93ca98b2e4874c439efae35f867efb654"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 18).bin" size="22050000" crc="f1d3c2ce" sha1="1af88084dfbbe568b2b84a010375223402524afd"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 19).bin" size="17992800" crc="26c25e12" sha1="6fc3eadd381ef3d70886ef2e7d2b46c94f2f536c"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 20).bin" size="13406400" crc="f8f79cbc" sha1="9b31029bc807627b2a859bf3d78405d76a203230"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 21).bin" size="13406400" crc="00ace9b2" sha1="7f5c76fd3851f399a70b14b6af15ebcb35065cf9"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 22).bin" size="21344400" crc="4be4592f" sha1="9a78cfd013c1bd656df9f88301c4d4e22acd584b"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 23).bin" size="14288400" crc="7500a5e0" sha1="8b672b6f9c6611abd5097ed89bc7d7f6317e6612"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 24).bin" size="22579200" crc="a7251670" sha1="152f0112f1c9c9c3443232d719d4a3815f1a1642"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan) (Track 25).bin" size="25754400" crc="8c1ea776" sha1="a7ccdcd1f799573b8282a20f429ab61149bc8b47"/>
+		<rom name="Medicco to Asobou - Kazu Katachi Ryou (Japan).cue" size="3344" crc="bdfd0c26" sha1="99f0f242b11a9f1b66519b4278a940d06158728c"/>
+		-->
+		<description>Medicco to Asobou - Kazu-Katachi-Ryou</description>
+		<year>1994</year>
+		<publisher>創研 (Souken)</publisher>
+		<info name="serial" value="HMF-173"/>
+		<info name="alt_title" value="″メディッコ″とあそぼう　～かず・かたち・りょう～" />
+		<info name="usage" value="Requires 2 MB RAM. Needs a floppy disk in drive 0 to boot."/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="medicco to asobou - kazu katachi ryou (japan)" sha1="5ddfa986849fdc457e147c7f88d85f79299e271a" />
 			</diskarea>
 		</part>
 	</software>
@@ -17805,6 +18025,25 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mirumiru sagasu konchuu series vol. 2 - mori no ninkimono - jueki ni atsumaru mushi-tachi (japan)" sha1="749d299f974b412faf5bb1eced4a6da1f9c915a8" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="mplanet">
+		<!--
+		Origin: redump.org
+		<rom name="Monster Planet 2255 (Japan).bin" size="105487200" crc="3135652f" sha1="e4022b0e94c48ccfa23afbe591b5bf255b82cd31"/>
+		<rom name="Monster Planet 2255 (Japan).cue" size="93" crc="5785af64" sha1="028e00c502155c01702ca04036cddc9fa80a1ced"/>
+		-->
+		<description>Monster Planet 2255</description>
+		<year>1990</year>
+		<publisher>JAMP</publisher>
+		<info name="serial" value="HMB-226"/>
+		<info name="alt_title" value="モンスタープラネット２２５５" />
+		<info name="release" value="199012xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="monster planet 2255 (japan)" sha1="51373149edb963869f40d65c5a80235caf8b170a" />
 			</diskarea>
 		</part>
 	</software>
@@ -21280,6 +21519,27 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!--
+		Bundled with the book of the same title (ISBN 978-4756106001). Disc 4 contains software for X68000, FM Towns and UNIX-based systems.
+		The other discs (currently not dumped) contain DOS/Windows software for IBM compatibles.
+	-->
+	<software name="pack13k">
+		<!--
+		Origin: redump.org
+		<rom name="Pack 13000 Free Soft &amp; Shareware (Japan) (Disc 4).bin" size="680200752" crc="3f6f315b" sha1="4141ad74052022cbacf899133695747a4adb6d5e"/>
+		<rom name="Pack 13000 Free Soft &amp; Shareware (Japan) (Disc 4).cue" size="138" crc="b58121fe" sha1="e83e5d3e62b79b4d9b23a216ab6ae3ce316879e2"/>
+		-->
+		<description>Pack 13000 Free Soft &amp; Shareware</description>
+		<year>1996</year>
+		<publisher>ベクターデザイン (Vector Design)</publisher>
+		<part name="cdrom" interface="fmt_cdrom">
+			<feature name="part_id" value="Disc 4"/>
+			<diskarea name="cdrom">
+				<disk name="pack 13000 free soft &amp; shareware (japan) (disc 4)" sha1="8dfb747d1b6f22fe779507c493c07ad3846f4e26" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="paipai">
 		<!--
 		Origin: redump.org
@@ -22160,11 +22420,11 @@ User/save disks that can be created from the game itself are not included.
 	<!-- Runs too fast -->
 	<software name="provvdnz" supported="partial">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Provvidenza.ccd" size="1179" crc="f0a1a16b" sha1="a7ef5529bf6c6532223ed683d41c4207833d8d56"/>
-		<rom name="Provvidenza.cue" size="180" crc="998968b0" sha1="5fd75cb0ea61390be09128e4ce05868bbca39599"/>
-		<rom name="Provvidenza.img" size="64562400" crc="ce38ece3" sha1="e10bd585a8e60c806e5cfba2129d79e3bdfb975b"/>
-		<rom name="Provvidenza.sub" size="2635200" crc="8da409c6" sha1="1db91a5e42f8df0ece1a3762a52a465d1422994b"/>
+		Origin: redump.org
+		<rom name="Provvidenza (Japan) (Track 1).bin" size="20815200" crc="dd512cf1" sha1="7e0071cee789e9de42b3ed6a02318af81bde9f05"/>
+		<rom name="Provvidenza (Japan) (Track 2).bin" size="21803040" crc="fa90ec55" sha1="fd2febd10f329802f2e53274be96175a41cc737f"/>
+		<rom name="Provvidenza (Japan) (Track 3).bin" size="21944160" crc="4f6aad52" sha1="d7014f4b7ac00c5adcfeb84a6a055b65f8e96f18"/>
+		<rom name="Provvidenza (Japan).cue" size="344" crc="65de4444" sha1="4c1dadfda1f33eeaf4225b8a9ed274da5a996a5c"/>
 		-->
 		<description>Provvidenza - Legenda la Spada di Alfa</description>
 		<year>1991</year>
@@ -22175,7 +22435,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="provvidenza" sha1="a104b48ade5fbe34b324f0c7f3a3fa0de7b482fc" />
+				<disk name="provvidenza (japan)" sha1="b6dfc03cdf118e01bb33e43c5344c2f8294a106b" />
 			</diskarea>
 		</part>
 	</software>
@@ -22341,6 +22601,40 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="psychic detective series vol. 2 - memories (japan) (demo)" sha1="9066c9e1a44fe71db90d435ed1a72a8b4cdc2e4f" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="psydet2r">
+		<!--
+		Origin: redump.org (CD) / cyo.the.vile (floppy)
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (DCCS) (Track 1).bin" size="154408800" crc="06cc6b63" sha1="3fd6918ce160c2d71ad6f0c3b12cd2bbafdd2ae0"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (DCCS) (Track 2).bin" size="59606736" crc="bf88d997" sha1="95ced84ebb70039c1d60cb0dcde5bcb21452dc72"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (DCCS) (Track 3).bin" size="17957520" crc="edb6daec" sha1="caa2aaef7e75387af788d99a98843a33c4d0e78e"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (DCCS) (Track 4).bin" size="20777568" crc="5d495539" sha1="664c50d425c896628ee0f11794c42b8ffef6b7d9"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (DCCS) (Track 5).bin" size="11400144" crc="9c01fed1" sha1="be51217750f6e8b0740e6c2b2fce808bab9a8d7a"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (DCCS) (Track 6).bin" size="14387184" crc="c452db38" sha1="c37f7a5cd86d8ec4277ccc7642c5821990600799"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (DCCS) (Track 7).bin" size="12733728" crc="7c71e12f" sha1="a9643b99815a482c5ceab0a86212ac0a1746a79b"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (DCCS) (Track 8).bin" size="15306816" crc="955da58b" sha1="7529962c13bde82640df4e10098092f795d254ac"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (DCCS) (Track 9).bin" size="49850640" crc="a97077a9" sha1="a6a5876182bd52b6c571a84486557a7e1501e2f9"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (DCCS).cue" size="1364" crc="8e068e2b" sha1="eb473350e9531df986de20fba15ba1ba0d018da0"/>
+		-->
+		<description>Psychic Detective Series Vol. 2 - Memories (DCCS remake)</description>
+		<year>1994</year>
+		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWDC4022"/>
+		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.2　メモリーズ" />
+		<info name="release" value="199407xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Key-Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="psychic_detective_series_vol_2_memories_remake.hdm" size="1261568" crc="7989bedc" sha1="1cf90d32fae70b917926f8e64c4d7d1675193ef5" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="psychic detective series vol. 2 - memories (japan) (dccs)" sha1="3275b87415f0e72ce72a248ef3a9b0a3aaefdd1a" />
 			</diskarea>
 		</part>
 	</software>
@@ -30043,6 +30337,60 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="xenon - mugen no shitai (japan)" sha1="f6b0e7e7562b0e81c5e91a97203681e631602e62" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="yachtman">
+		<!--
+		Origin: redump.org
+		<rom name="Yacht Man, The (Japan) (Track 01).bin" size="10231200" crc="f0502459" sha1="9461aaa0422ce1e1e7268aa240a964c5188408b7"/>
+		<rom name="Yacht Man, The (Japan) (Track 02).bin" size="1411200" crc="2c942711" sha1="fb69c7d459c1aa42c8cd0899a49417557f20aaaf"/>
+		<rom name="Yacht Man, The (Japan) (Track 03).bin" size="1587600" crc="f6c8d28c" sha1="04d6a37fde37208e2a8a17a3a3a467dea8653f71"/>
+		<rom name="Yacht Man, The (Japan) (Track 04).bin" size="2116800" crc="ecdc1ffa" sha1="b5b044720623179873a94a0c98c232c390beefa7"/>
+		<rom name="Yacht Man, The (Japan) (Track 05).bin" size="2293200" crc="7e88b46f" sha1="dfe94ad26a122f159a52aac5e4d46860fe9999aa"/>
+		<rom name="Yacht Man, The (Japan) (Track 06).bin" size="1940400" crc="16142d67" sha1="207cbab25cfcbb030008607605315db332dced5f"/>
+		<rom name="Yacht Man, The (Japan) (Track 07).bin" size="2293200" crc="a5100db3" sha1="27822d047933d7fccdb817b8571ddc170ce5c3b7"/>
+		<rom name="Yacht Man, The (Japan) (Track 08).bin" size="2293200" crc="a648fbf0" sha1="a2c3e028d148043a37078d428065e0c4d4859c07"/>
+		<rom name="Yacht Man, The (Japan) (Track 09).bin" size="2116800" crc="4e17daa7" sha1="88d0395d4e63eed2e73ba64691100859553c4754"/>
+		<rom name="Yacht Man, The (Japan) (Track 10).bin" size="2822400" crc="09747c77" sha1="f21613cd868132ba2cfcb651d3d2bb00975c94a1"/>
+		<rom name="Yacht Man, The (Japan) (Track 11).bin" size="2116800" crc="8ee23daf" sha1="6f63699c3d97d7232b64965863de9aa910c20831"/>
+		<rom name="Yacht Man, The (Japan) (Track 12).bin" size="1587600" crc="62932679" sha1="c35b60bef0750bedfa39879baff405b47c6939f8"/>
+		<rom name="Yacht Man, The (Japan) (Track 13).bin" size="1058400" crc="4237c39d" sha1="fa9f303a8c9fe389f1b86fee74d318b863de7a9d"/>
+		<rom name="Yacht Man, The (Japan) (Track 14).bin" size="2646000" crc="02916ab5" sha1="fa602954f2a1c3a9fdfc772d6d488f0562710478"/>
+		<rom name="Yacht Man, The (Japan) (Track 15).bin" size="1940400" crc="6db6be59" sha1="a7091675552bd793b688a8d8c584d3be088ef77e"/>
+		<rom name="Yacht Man, The (Japan) (Track 16).bin" size="1587600" crc="b2c78d13" sha1="a175405cc86c8f89b37c04ae69eacb0c96cbe1bf"/>
+		<rom name="Yacht Man, The (Japan) (Track 17).bin" size="2469600" crc="84deb4de" sha1="c9cbb178ede6ef7a1d97d0d4a57f8f31e5154cbd"/>
+		<rom name="Yacht Man, The (Japan) (Track 18).bin" size="1587600" crc="ca9dad41" sha1="8f5949b022b3c2a2a6c4d51272922e16ce1a9ac6"/>
+		<rom name="Yacht Man, The (Japan) (Track 19).bin" size="1764000" crc="a2a4a5e8" sha1="b2b4f42b3575ee9db580056075bc8f8ac5b761fa"/>
+		<rom name="Yacht Man, The (Japan) (Track 20).bin" size="1587600" crc="ca093c7b" sha1="f440f14be8be483f7c9cab3d37b621e92fc462a7"/>
+		<rom name="Yacht Man, The (Japan) (Track 21).bin" size="2822400" crc="b4b1cb25" sha1="47aacd088a06c272c855387b1a72a3ef571e419c"/>
+		<rom name="Yacht Man, The (Japan) (Track 22).bin" size="1940400" crc="cb22b1a7" sha1="3428d7ac3073d45a6011c693f8760f2948ab749c"/>
+		<rom name="Yacht Man, The (Japan) (Track 23).bin" size="1764000" crc="7d53a1ca" sha1="13cbc85fce9b030df82d0cf48501d469e80067f3"/>
+		<rom name="Yacht Man, The (Japan) (Track 24).bin" size="9349200" crc="f49058d6" sha1="6c4a40c9fb3ee93aaab539a0dddc45f9c15890cc"/>
+		<rom name="Yacht Man, The (Japan) (Track 25).bin" size="10231200" crc="2f0ff433" sha1="316089bfaf756df30709b2a5c2614f69fa2107c0"/>
+		<rom name="Yacht Man, The (Japan) (Track 26).bin" size="4586400" crc="5ff5ed78" sha1="9e5770bc31c505eba3d2e983a3baa2e7265eb33e"/>
+		<rom name="Yacht Man, The (Japan) (Track 27).bin" size="29635200" crc="e158fba3" sha1="913a98452168ffb61924e49bdd53d9218a37cd65"/>
+		<rom name="Yacht Man, The (Japan) (Track 28).bin" size="7056000" crc="6090e6d7" sha1="92483580f104880299121e57f5a325eb05de9800"/>
+		<rom name="Yacht Man, The (Japan) (Track 29).bin" size="15699600" crc="a917e093" sha1="a6cfa339e09e8dd6719ec313ced697d359b24c98"/>
+		<rom name="Yacht Man, The (Japan) (Track 30).bin" size="24519600" crc="4a7f35b8" sha1="023b3a7633bd8bb763f9fcbe264c223887ca713f"/>
+		<rom name="Yacht Man, The (Japan) (Track 31).bin" size="31222800" crc="8740bf2a" sha1="728ab1bd66eb0c4e73bae026e0af3615a6ac0ab4"/>
+		<rom name="Yacht Man, The (Japan) (Track 32).bin" size="21697200" crc="c5f62cb9" sha1="94dbd081f716734a58e922588d9405c5a2019889"/>
+		<rom name="Yacht Man, The (Japan) (Track 33).bin" size="24343200" crc="6e96fe00" sha1="c42e5e9e72da514ee6f738375a06bbf7e4a99b35"/>
+		<rom name="Yacht Man, The (Japan) (Track 34).bin" size="20109600" crc="791b0ec6" sha1="69b44b2b14dd9aca4d8804c0a3397fd35165e0db"/>
+		<rom name="Yacht Man, The (Japan) (Track 35).bin" size="13582800" crc="bd1828bc" sha1="d03f4533d385f8c87b8de83f56fa877154eaf73f"/>
+		<rom name="Yacht Man, The (Japan) (Track 36).bin" size="4233600" crc="4580866a" sha1="aaefaba5020efb03452df764e2897d0f278e3151"/>
+		<rom name="Yacht Man, The (Japan).cue" size="4194" crc="25fc05e9" sha1="49eff678d1bf3a944eba56c3204128a5e3723b91"/>
+		-->
+		<description>The Yachtman</description> <!-- Uses "Yacht Man" in the file icon and "The Yachtman" in the title screen -->
+		<year>1989</year>
+		<publisher>レイゾン (Raison)</publisher>
+		<info name="serial" value="HMA-243"/>
+		<info name="alt_title" value="ザ・ヨットマン" />
+		<info name="release" value="198911xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="yacht man, the (japan)" sha1="c70e8267ad28617595616182a0ca6d7d8bc02242" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
New working software list additions
-----------------------------------
4D Driving (FM Towns Marty version) [redump.org]
Doki Doki Disk CD-ban - Club D.O. Vol. 2 [redump.org]
Doki Doki Disk CD-ban - Club D.O. Vol. 3 [redump.org]
FM Towns Marty Tentou Auto Demo '93 Natsu [redump.org]
FM Towns Super Technology Demo 1993 (HME-919) [redump.org]
HomeStudio V1.1L10 [redump.org]
Medicco to Asobou - Kazu-Katachi-Ryou [redump.org]
Monster Planet 2255 [redump.org]
NHK Special - Ginga Uchuu Odyssey Vol. 1 - Tabidachi Waga Taiyoukei [redump.org]
Pack 13000 Free Soft & Shareware [redump.org]
Psychic Detective Series Vol. 2 - Memories (DCCS remake) [redump.org, cyo.the.vile]
The Yachtman [redump.org]

Replaced software list items
----------------------------
Mad Paradox [redump.org]
Provvidenza - Legenda la Spada di Alfa [redump.org]