### PR TITLE
print out text from initial screens that require user input for `-video none`

### DIFF
--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -407,7 +407,7 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 
 	// disable everything if we are using -str for 300 or fewer seconds, or if we're the empty driver,
 	// or if we are debugging, or if there's no mame window to send inputs to
-	if (!first_time || (str > 0 && str < 60*5) || &machine().system() == &GAME_NAME(___empty) || (machine().debug_flags & DEBUG_FLAG_ENABLED) != 0 || video_none)
+	if (!first_time || (str > 0 && str < 60*5) || &machine().system() == &GAME_NAME(___empty) || (machine().debug_flags & DEBUG_FLAG_ENABLED) != 0)
 		show_gameinfo = show_warnings = show_mandatory_fileman = false;
 
 #if defined(__EMSCRIPTEN__)
@@ -462,8 +462,13 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 				warning_text = machine_info().game_info_string();
 			if (!warning_text.empty())
 			{
-				warning_text.append(_("\n\nPress any key to continue"));
-				set_handler(ui_callback_type::MODAL, handler_callback_func(handler_messagebox_anykey));
+				if (video_none)
+					osd_printf_info("%s\n\n", warning_text);
+				else
+				{
+					warning_text.append(_("\n\nPress any key to continue"));
+					set_handler(ui_callback_type::MODAL, handler_callback_func(handler_messagebox_anykey));
+				}
 			}
 			break;
 
@@ -535,9 +540,14 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 				}
 				if (need_warning)
 				{
-					warning_text.append(_("\n\nPress any key to continue"));
-					set_handler(ui_callback_type::MODAL, handler_callback_func(handler_messagebox_anykey));
-					warning_color = machine_info().warnings_color();
+					if (video_none)
+						osd_printf_warning("%s\n\n", warning_text);
+					else
+					{
+						warning_text.append(_("\n\nPress any key to continue"));
+						set_handler(ui_callback_type::MODAL, handler_callback_func(handler_messagebox_anykey));
+						warning_color = machine_info().warnings_color();
+					}
 				}
 			}
 			break;
@@ -553,7 +563,10 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 						[&warning](const std::reference_wrapper<const std::string> &img)    { warning << "\"" << img.get() << "\""; },
 						[&warning]()                                                        { warning << ","; });
 
-				ui::menu_file_manager::force_file_manager(*this, machine().render().ui_container(), warning.str().c_str());
+				if (video_none)
+					osd_printf_error("%s\n\n", warning.str().c_str());
+				else
+					ui::menu_file_manager::force_file_manager(*this, machine().render().ui_container(), warning.str().c_str());
 			}
 			break;
 		}


### PR DESCRIPTION
While `-video none` won't let us click a GUI window, there are some things we can still do from lua, so it makes sense to still print out all that text even for no GUI. In addition to just informing the user directly, this also allows to pass this info around by grabbing it from mame output.

My only question is maybe it's worth outputting it to console at all times? Seems more valuable than things like sound device info for example.