### PR TITLE
leapster.xml: Dumped five USA games

### DIFF
--- a/hash/leapster.xml
+++ b/hash/leapster.xml
@@ -14,6 +14,9 @@ Known games listed by part-no, (*) denotes undumped, (**) denotes acquired but n
 | 500-10093   |ENG| Learning with Leap                                        | LEAPSTER       | YES    |
 | 500-10441   |ENG| Math Baseball                                             | LEAPSTER       | YES    | Same ROM as 500-11004
 | 500-10587   |ENG| Letter Factory                                            | LEAPSTER       | YES    |
+| 500-10727-A |UK | Dora the Explorer - Animal Rescuer                        | LEAPSTER       | NO     |
+| 500-10730-A |UK | Mr. Pencil's - Learn to Draw & Write                      | LEAPSTER       | NO     |
+| 500-10732-A |UK | Learning with Leap                                        | LEAPSTER       | NO     |
 | 500-10775-A |ENG| Finding Nemo (two different sets dumped)                  | LEAPSTER       | YES    |
 | 500-10777-A |ENG| Top-Secret Personal Beeswax                               | LEAPSTER       | YES    |
 | 500-10810-A |ENG| Disney Princess - Enchanted Learning                      | LEAPSTER       | YES    |
@@ -36,15 +39,19 @@ Known games listed by part-no, (*) denotes undumped, (**) denotes acquired but n
 | 500-11202-A |ENG| Madagascar                                                | LEAPSTER L-MAX | YES    |
 | 500-11203-A |ENG| Batman - Multiply, Divide and Conquer                     | LEAPSTER       | YES    |
 | 500-11204-A |ENG| Thomas and Friends - Calling all Engines!                 | LEAPSTER       | YES    |
+| 500-11360-A | UK| Mole's Huge Nose - Reading with Phonics                   | LEAPSTER       | NO     |
 | 500-11493-A |GER| Mit Bruno Bleistift lernst du MALEN & SCHREIBEN           | LEAPSTER       | YES    |
 | 500-11494-A |GER| Grundschule 2 - Musik in Gefahr                           | LEAPSTER       | YES    |
 | 500-11495-A |GER| Findet Nemo                                               | LEAPSTER       | YES    |
+| 500-11495-B |GER| Findet Nemo                                               | LEAPSTER       | NO     |
 | 500-11496-A |GER| Disney Prinzessinnen - Zauberhaftes Lernen                | LEAPSTER       | YES    |
 | 500-11496-B |GER| Disney Prinzessinnen - Zauberhaftes Lernen                | LEAPSTER       | NO     |
 | 500-11497-A |GER| Spider-Man - Schachmatt den Schildersaboteuren!           | LEAPSTER       | YES    |
 | 500-11528-A |ENG| School House Rock! - Grammar Rock                         | LEAPSTER       | YES    |
 | 500-11529-A |ENG| School House Rock! - America Rock                         | LEAPSTER       | YES    |
+| 500-11577-A |UK | The Incredibles                                           | LEAPSTER       | NO     |
 | 500-11603-A |GER| DEMO - Herbst 2004 II                                     | LEAPSTER       | YES    |
+| 500-11703-A |ENG| Rock the World - A Reading Adventure                      | LEAPSTER L-MAX | NO     |
 | 500-11777-A |ENG| Numbers on the Run - Counting on Zero                     | LEAPSTER L-MAX | YES    |
 | 500-11779-A |ENG| Letters on the Loose                                      | LEAPSTER L-MAX | YES    |
 | 500-11898-A |ENG| Scholastic - Math Missions                                | LEAPSTER       | YES    |
@@ -52,6 +59,7 @@ Known games listed by part-no, (*) denotes undumped, (**) denotes acquired but n
 | 500-11904-A |ENG| Dora the Explorer - Wildlife Rescue                       | LEAPSTER L-MAX | YES    |
 | 500-11905-A |ENG| Spongebob Squarepants - Saves the Day                     | LEAPSTER L-MAX | YES    |
 | 500-11929-A |ENG| Scholastic I Spy - Challenger                             | LEAPSTER       | YES    |
+| 500-11966-A |ENG| Disney Princess                                           | LEAPSTER       | YES    |
 | 500-11972-A |GER| Batman - Multipliziere, dividiere und reagiere            | LEAPSTER       | YES    |
 | 500-11993-A |ENG| Number Raiders - Arcade-Style Learning                    | LEAPSTER       | YES    |
 | 500-11994-A |ENG| Cosmic Math - Arcade-Style Learning!                      | LEAPSTER       | YES    |
@@ -75,9 +83,10 @@ Known games listed by part-no, (*) denotes undumped, (**) denotes acquired but n
 | 500-12227-A |SPA| Buscando a Nemo - Leer Bajo el Mar                        | LEAPSTER       | YES    |
 | 500-12259-A |SPA| El Laberinto De Las Letras                                | LEAPSTER       | YES    |
 | 500-12293-A |ENG| Scholastic - Animal Genius                                | LEAPSTER       | YES    |
-| 500-12296-A |ENG| SonicX                                                    | LEAPSTER       | YES    |
+| 500-12296-A |ENG| Sonic X                                                   | LEAPSTER       | YES    |
 | 500-12339-A |FRA| Dora L'Exploratrice - Au Secours Des Animaux              | LEAPSTER       | YES    |
 | 500-12350-A |ENG| Letterpillar (v1.1)                                       | LEAPSTER       | YES    |
+| 500-12351-A |ENG| Number Raiders                                            | LEAPSTER       | YES    |
 | 500-12352-A |ENG| Cosmic Math - Arcade-Style Learning!                      | LEAPSTER       | NO     |
 | 500-12353-A |ENG| Word Chasers - Arcade-Style Learning!                     | LEAPSTER       | YES    |
 | 500-12392-A |FRA| Dora L'Exploratrice - Le Pont Casse                       | LEAPSTER       | YES    |
@@ -100,8 +109,10 @@ Known games listed by part-no, (*) denotes undumped, (**) denotes acquired but n
 | 500-12712-A |ENG| Cars : Supercharged                                       | LEAPSTER       | YES    |
 | 500-12713-A |ENG| Disney Princess - Worlds of Enchantment                   | LEAPSTER       | YES    |
 | 500-12715-A |ENG| Foster's Home for Imaginary Friends                       | LEAPSTER       | YES    |
+| 500-12718-A |ENG| Go Diego Go! - Animal Rescuer                             | LEAPSTER       | YES    |
 | 500-12719-A |ENG| Spongebob Squarepants - Through The Wormhole              | LEAPSTER       | YES    |
 | 500-12738-A |GER| Ratatouille                                               | LEAPSTER       | YES    |
+| 500-12798-A |UK | Noddy - Rainbow Adventures                                | LEAPSTER       | NO     |
 | 500-12799-A |FRA| Oui-Oui - Aventures Au Pays Des Jouet                     | LEAPSTER       | YES    |
 | 500-12800-A |FRA| Lapin Malin - Danse Avec Les Mots                         | LEAPSTER       | YES    |
 | 500-12824-A |SPA| Perrito Club - ¡Adopta Un Nuevo Amiguito Y Aprende!       | LEAPSTER       | YES    |
@@ -112,16 +123,19 @@ Known games listed by part-no, (*) denotes undumped, (**) denotes acquired but n
 | 500-13299-A |ENG| Scholastic OutWit!                                        | LEAPSTER       | YES    |
 | 500-13306-A |ENG| Star Wars - Jedi Math                                     | LEAPSTER       | YES    |
 | 500-13366-A |FRA| Dis Pourquoi Kirikou                                      | LEAPSTER       | YES    |
+| 500-13371-A |FRA| Star Wars - Maths Du Jedi                                 | LEAPSTER       | NO     |
 | 500-13405-A |ENG| Dora the Explorer - Camping Adventure                     | LEAPSTER       | YES    |
 | 500-13414-A |SPA| Wall-E                                                    | LEAPSTER       | YES    |
 | 500-13417-A |SPA| Star Wars - Matemáticas Jedi                              | LEAPSTER       | YES    |
 | 500-13441-A |GER| Wall-E                                                    | LEAPSTER       | YES    |
+| 500-13444-A |ENG| Sonic X                                                   | LEAPSTER       | YES    |
 | 500-13445-A |ENG| Ratatouille                                               | LEAPSTER       | YES    |
 | 500-13446-A |ENG| Pet Pals                                                  | LEAPSTER       | YES    |
 | 500-13447-A |ENG| Go Diego Go! - Animal Rescuer                             | LEAPSTER       | YES    |
 | 500-13448-A |ENG| Disney Princess - Worlds of Enchantment                   | LEAPSTER       | YES    |
 | 500-13451-A |ENG| Spongebob Squarepants - Saves the Day                     | LEAPSTER       | YES    |
 | 500-13453-A |ENG| The Backyardigans                                         | LEAPSTER       | YES    |
+| 500-13470-A |UK | Star Wars - Jedi Maths                                    | LEAPSTER       | NO     |
 | 500-13472-A |ENG| Star Wars - Jedi Reading                                  | LEAPSTER       | YES    |
 | 500-13514-A |ENG| Disney Princess                                           | LEAPSTER       | YES    |
 | 500-13556-A |ENG| The Princess and the Frog                                 | LEAPSTER       | YES    |
@@ -133,6 +147,7 @@ Known games listed by part-no, (*) denotes undumped, (**) denotes acquired but n
 | 500-13744-A |ENG| Wolverine and the X-Men                                   | LEAPSTER       | YES    |
 | 500-13748-A |ENG| Disney Fairies                                            | LEAPSTER       | YES    |
 | 500-13763-A |SPA| Disney Fairies                                            | LEAPSTER       | YES    |
+| 500-13818-A |USA| Leapster 2 Gaming Pop (Kiosk)                             | LEAPSTER       | YES    |
 | 500-13982-A |ENG| Toy Story 3                                               | LEAPSTER       | YES    |
 | 500-14005-A |ENG| Scooby Doo!                                               | LEAPSTER       | YES    |
 | 500-14007-B |ENG| The Penguins of Madagascar                                | LEAPSTER       | YES    |
@@ -153,8 +168,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11000" /> <!-- Same ROM as 500-01169 -->
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11000.bin" size="8388608" crc="db36283f" sha1="9f9509313a0ebdac84c2dc02566fedf04ea0eee7" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11000.bin" size="0x800000" crc="db36283f" sha1="9f9509313a0ebdac84c2dc02566fedf04ea0eee7" />
 			</dataarea>
 		</part>
 	</software>
@@ -165,8 +180,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10957-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="2nd Grade [500-10957-A].bin" size="8388608" crc="597418d4" sha1="b3933dca626e930fa89001fb256b5765e4d0a1f6" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="2nd Grade [500-10957-A].bin" size="0x800000" crc="597418d4" sha1="b3933dca626e930fa89001fb256b5765e4d0a1f6" />
 			</dataarea>
 		</part>
 	</software>
@@ -177,8 +192,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12475-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12475-a.bin" size="8388608" crc="b0ba6d76" sha1="d5bf632b9c2a7850f9a6e1ce855ac48af366f859" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12475-a.bin" size="0x800000" crc="b0ba6d76" sha1="d5bf632b9c2a7850f9a6e1ce855ac48af366f859" />
 			</dataarea>
 		</part>
 	</software>
@@ -189,8 +204,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12100-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="The Backyardigans [500-12100-A].bin" size="8388608" crc="d5c3876f" sha1="38f3a493c0312595a84ef9df2a93c8a95f3b9d40" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="The Backyardigans [500-12100-A].bin" size="0x800000" crc="d5c3876f" sha1="38f3a493c0312595a84ef9df2a93c8a95f3b9d40" />
 			</dataarea>
 		</part>
 	</software>
@@ -201,8 +216,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13453-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13453-a.bin" size="8388608" crc="de5fb26e" sha1="2a1df737ec907d1f1b837f9b58323ee908cb45a9" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13453-a.bin" size="0x800000" crc="de5fb26e" sha1="2a1df737ec907d1f1b837f9b58323ee908cb45a9" />
 			</dataarea>
 		</part>
 	</software>
@@ -213,8 +228,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11203-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Batman - Multiply, Divide and Conquer [500-11203-A].bin" size="8388608" crc="bf60ee5f" sha1="37b98a1bbb53fb0372c6c4e500d255c59d7585dd" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Batman - Multiply, Divide and Conquer [500-11203-A].bin" size="0x800000" crc="bf60ee5f" sha1="37b98a1bbb53fb0372c6c4e500d255c59d7585dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -225,8 +240,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11972-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11972-a.bin" size="8388608" crc="a0a362aa" sha1="442455a0bf2c3ca4c1084a1e8761eb80a4cd71e2" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11972-a.bin" size="0x800000" crc="a0a362aa" sha1="442455a0bf2c3ca4c1084a1e8761eb80a4cd71e2" />
 			</dataarea>
 		</part>
 	</software>
@@ -237,8 +252,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12711-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12711-a.bin" size="8388608" crc="7c934681" sha1="8db48ba9caa2f87922cb289520acd97d9931a178" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12711-a.bin" size="0x800000" crc="7c934681" sha1="8db48ba9caa2f87922cb289520acd97d9931a178" />
 			</dataarea>
 		</part>
 	</software>
@@ -249,8 +264,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12830-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12830-a.bin" size="8388608" crc="6a7afd1c" sha1="3ae1372253b852b2cef8bfd549050b324375bda9" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12830-a.bin" size="0x800000" crc="6a7afd1c" sha1="3ae1372253b852b2cef8bfd549050b324375bda9" />
 			</dataarea>
 		</part>
 	</software>
@@ -261,8 +276,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11201-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Bratz World The Jet Set [500-11201-A].bin" size="8388608" crc="5d4f7cd0" sha1="7af7c31ed911918f4ceab8394696cb76c42ad2fc" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Bratz World The Jet Set [500-11201-A].bin" size="0x800000" crc="5d4f7cd0" sha1="7af7c31ed911918f4ceab8394696cb76c42ad2fc" />
 			</dataarea>
 		</part>
 	</software>
@@ -273,8 +288,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12098-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12098-a.bin" size="8388608" crc="d4a7e5d4" sha1="c831db237e73e61e863e4f477dcc0298488b3d69" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12098-a.bin" size="0x800000" crc="d4a7e5d4" sha1="c831db237e73e61e863e4f477dcc0298488b3d69" />
 			</dataarea>
 		</part>
 	</software>
@@ -285,8 +300,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12414-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12414-a.bin" size="8388608" crc="b6aabb7b" sha1="82cc91536be8c18c10089c4ad85b9a82e63b824b" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12414-a.bin" size="0x800000" crc="b6aabb7b" sha1="82cc91536be8c18c10089c4ad85b9a82e63b824b" />
 			</dataarea>
 		</part>
 	</software>
@@ -297,8 +312,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12171-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12171-a.bin" size="8388608" crc="c7b62602" sha1="bbc2b70e588710b2096741046ae3e08095397ee9" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12171-a.bin" size="0x800000" crc="c7b62602" sha1="bbc2b70e588710b2096741046ae3e08095397ee9" />
 			</dataarea>
 		</part>
 	</software>
@@ -309,8 +324,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12223-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12223-a.bin" size="8388608" crc="2a704606" sha1="069f0e139231a3786472ab139e3d28bb2f2e098e" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12223-a.bin" size="0x800000" crc="2a704606" sha1="069f0e139231a3786472ab139e3d28bb2f2e098e" />
 			</dataarea>
 		</part>
 	</software>
@@ -321,8 +336,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-14320-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-14320-A - Cars 2 (US).bin" size="8388608" crc="29af42ba" sha1="01263c4b6b178599eca818a514f9a668bdf9081d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-14320-A - Cars 2 (US).bin" size="0x800000" crc="29af42ba" sha1="01263c4b6b178599eca818a514f9a668bdf9081d" />
 			</dataarea>
 		</part>
 	</software>
@@ -333,8 +348,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12712-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12712-a.bin" size="8388608" crc="beca3909" sha1="8cda80251d6e45427dba6acbae5dff306eb84d34" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12712-a.bin" size="0x800000" crc="beca3909" sha1="8cda80251d6e45427dba6acbae5dff306eb84d34" />
 			</dataarea>
 		</part>
 	</software>
@@ -345,8 +360,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12466-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12466-a.bin" size="8388608" crc="0134af49" sha1="29c3e2e9d56aeee09c752776bfd8c096e02b75c5" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12466-a.bin" size="0x800000" crc="0134af49" sha1="29c3e2e9d56aeee09c752776bfd8c096e02b75c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -357,8 +372,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11994-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11994-a.bin" size="4194304" crc="979346d5" sha1="ecd8d3f7bae4fea1710ee99c5637224180021dd6" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11994-a.bin" size="0x400000" crc="979346d5" sha1="ecd8d3f7bae4fea1710ee99c5637224180021dd6" />
 			</dataarea>
 		</part>
 	</software>
@@ -369,8 +384,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-14464-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Crayola Art Adventure [500-14464-A].bin" size="8388608" crc="0eec61a7" sha1="fee48855b67de532f64848dabaf41b6390841060" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Crayola Art Adventure [500-14464-A].bin" size="0x800000" crc="0eec61a7" sha1="fee48855b67de532f64848dabaf41b6390841060" />
 			</dataarea>
 		</part>
 	</software>
@@ -381,8 +396,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12677-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12677-A - Creature Create (US).bin" size="8388608" crc="9f08d02a" sha1="82a408b87ff5df6f17d314af17cd20ff4847b30f" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12677-A - Creature Create (US).bin" size="0x800000" crc="9f08d02a" sha1="82a408b87ff5df6f17d314af17cd20ff4847b30f" />
 			</dataarea>
 		</part>
 	</software>
@@ -393,8 +408,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11603-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11603-a.bin" size="8388608" crc="71062cd7" sha1="eaf0656d29f61d89b97c6d66e73a2fa7021a92e3" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11603-a.bin" size="0x800000" crc="71062cd7" sha1="eaf0656d29f61d89b97c6d66e73a2fa7021a92e3" />
 			</dataarea>
 		</part>
 	</software>
@@ -405,8 +420,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-14492-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-14492-A - The Disney-Pixar Collection (US).bin" size="8388608" crc="d8ac1a09" sha1="bb6ae8a09a69133a116bd6ffc2b2bf23724b6da5" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-14492-A - The Disney-Pixar Collection (US).bin" size="0x800000" crc="d8ac1a09" sha1="bb6ae8a09a69133a116bd6ffc2b2bf23724b6da5" />
 			</dataarea>
 		</part>
 	</software>
@@ -417,8 +432,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13366-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13366-a.bin" size="8388608" crc="fdcd1321" sha1="fbe422df83608a75f96168f83b32f45b700dacd5" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13366-a.bin" size="0x800000" crc="fdcd1321" sha1="fbe422df83608a75f96168f83b32f45b700dacd5" />
 			</dataarea>
 		</part>
 	</software>
@@ -429,8 +444,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13748-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Disney Fairies [500-13748-A].bin" size="8388608" crc="8a605512" sha1="5f22ab2fd695795267fba88bba19ddea3a2bf9f5" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Disney Fairies [500-13748-A].bin" size="0x800000" crc="8a605512" sha1="5f22ab2fd695795267fba88bba19ddea3a2bf9f5" />
 			</dataarea>
 		</part>
 	</software>
@@ -441,20 +456,32 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13763-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13763-a.bin" size="8388608" crc="d2f560c7" sha1="7a9a8f78eb245c3b8600b0658f1d1b1fa99e6a5c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13763-a.bin" size="0x800000" crc="d2f560c7" sha1="7a9a8f78eb245c3b8600b0658f1d1b1fa99e6a5c" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="princess" supported="no">
-		<description>Disney Princess (USA)</description>
-		<year>2003</year>
+		<description>Disney Princess (USA, set 1)</description>
+		<year>2008</year>
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13514-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13514-a.bin" size="8388608" crc="5ccb2ad3" sha1="42740f6597f4a2eb878a54ddbf75452a2cca301d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13514-a.bin" size="0x800000" crc="5ccb2ad3" sha1="42740f6597f4a2eb878a54ddbf75452a2cca301d" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="princessa" cloneof="princess" supported="no">
+		<description>Disney Princess (USA, set 2)</description>
+		<year>2004</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-11966-A" />
+		<part name="cart" interface="leapster_cart">
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11966-A - Disney Princess (USA).bin" size="0x800000" crc="88e25b03" sha1="45a955f9e0d8cf37d1c4dc500f708bb7aa82320b" />
 			</dataarea>
 		</part>
 	</software>
@@ -465,8 +492,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10810-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Disney Princess - Enchanted Learning [500-10810-A].bin" size="8388608" crc="8c2fe2e8" sha1="e4400ec8d505ff1e8def76757ed3d9251086f176" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Disney Princess - Enchanted Learning [500-10810-A].bin" size="0x800000" crc="8c2fe2e8" sha1="e4400ec8d505ff1e8def76757ed3d9251086f176" />
 			</dataarea>
 		</part>
 	</software>
@@ -477,8 +504,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11496-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11496-a.bin" size="8388608" crc="bb6d5375" sha1="743d07ee756b54e2c72bf94da56dd8d18c4cd106" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11496-a.bin" size="0x800000" crc="bb6d5375" sha1="743d07ee756b54e2c72bf94da56dd8d18c4cd106" />
 			</dataarea>
 		</part>
 	</software>
@@ -489,8 +516,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12411-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12411-a.bin" size="8388608" crc="69eaa1ea" sha1="a7072e5fe5d143ad65fb16ad13bf738b1b43552f" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12411-a.bin" size="0x800000" crc="69eaa1ea" sha1="a7072e5fe5d143ad65fb16ad13bf738b1b43552f" />
 			</dataarea>
 		</part>
 	</software>
@@ -501,8 +528,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12218-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12218-a.bin" size="8388608" crc="5a52d3f0" sha1="072353a79c124855c5904137f15e8a84ad622914" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12218-a.bin" size="0x800000" crc="5a52d3f0" sha1="072353a79c124855c5904137f15e8a84ad622914" />
 			</dataarea>
 		</part>
 	</software>
@@ -513,8 +540,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13448-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13448-a.bin" size="8388608" crc="2465f01d" sha1="d37d7ea21cf8ed01ecf497c3c99185529aee59af" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13448-a.bin" size="0x800000" crc="2465f01d" sha1="d37d7ea21cf8ed01ecf497c3c99185529aee59af" />
 			</dataarea>
 		</part>
 	</software>
@@ -525,8 +552,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12713-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Disney Princess - Worlds of Enchantment [500-12713-A].bin" size="8388608" crc="96a19f32" sha1="d338b4eee7c94f8647576288995623c7493d6dcc" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Disney Princess - Worlds of Enchantment [500-12713-A].bin" size="0x800000" crc="96a19f32" sha1="d338b4eee7c94f8647576288995623c7493d6dcc" />
 			</dataarea>
 		</part>
 	</software>
@@ -537,8 +564,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-01171" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Dora the Explorer - Animal Rescuer [500-01171].bin" size="8388608" crc="635f07e6" sha1="cd1772d874e5a3c1b9a82a420d251c7da473d525" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Dora the Explorer - Animal Rescuer [500-01171].bin" size="0x800000" crc="635f07e6" sha1="cd1772d874e5a3c1b9a82a420d251c7da473d525" />
 			</dataarea>
 		</part>
 	</software>
@@ -549,8 +576,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12562-B" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12562-b.bin" size="8388608" crc="242907d4" sha1="262ee3e208fff0fc362bc879416cbdf31bf38304" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12562-b.bin" size="0x800000" crc="242907d4" sha1="262ee3e208fff0fc362bc879416cbdf31bf38304" />
 			</dataarea>
 		</part>
 	</software>
@@ -561,8 +588,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12339-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12339-a.bin" size="8388608" crc="e557c760" sha1="964150dfd525188a0e8d6bcbc715f9a40e4c6779" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12339-a.bin" size="0x800000" crc="e557c760" sha1="964150dfd525188a0e8d6bcbc715f9a40e4c6779" />
 			</dataarea>
 		</part>
 	</software>
@@ -573,8 +600,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13405-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13405-a.bin" size="8388608" crc="71778536" sha1="9f8c5e02519def049078614dacc76b990e911add" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13405-a.bin" size="0x800000" crc="71778536" sha1="9f8c5e02519def049078614dacc76b990e911add" />
 			</dataarea>
 		</part>
 	</software>
@@ -585,8 +612,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12161-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-12161-a.bin" size="4194304" crc="ea544030" sha1="a9aaf73e5259db303f8bfc39bd6d7b40bddb127f" />
+			<dataarea name="rom" size="40 0000">
+				<rom name="500-12161-a.bin" size="0x400000" crc="ea544030" sha1="a9aaf73e5259db303f8bfc39bd6d7b40bddb127f" />
 			</dataarea>
 		</part>
 	</software>
@@ -597,8 +624,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11001" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Dora the Explorer - Wildlife Rescue [500-11001] 152-11577.bin" size="8388608" crc="991ced60" sha1="6cbf763c0e74438ac266501d20987b05cf8a3125" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Dora the Explorer - Wildlife Rescue [500-11001] 152-11577.bin" size="0x800000" crc="991ced60" sha1="6cbf763c0e74438ac266501d20987b05cf8a3125" />
 			</dataarea>
 		</part>
 	</software>
@@ -609,8 +636,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11001" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Dora the Explorer - Wildlife Rescue [500-11001] 152-10401.bin" size="8388608" crc="2a20cbbb" sha1="0ba77d84b84db63035688626dd3df6b10a676e17" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Dora the Explorer - Wildlife Rescue [500-11001] 152-10401.bin" size="0x800000" crc="2a20cbbb" sha1="0ba77d84b84db63035688626dd3df6b10a676e17" />
 			</dataarea>
 		</part>
 	</software>
@@ -621,8 +648,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12392-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-12392-a.bin" size="4194304" crc="b6607eee" sha1="278e89cdc99bdd9284447f31a1fd23de36eb8dca" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12392-a.bin" size="0x400000" crc="b6607eee" sha1="278e89cdc99bdd9284447f31a1fd23de36eb8dca" />
 			</dataarea>
 		</part>
 	</software>
@@ -633,8 +660,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10775-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-10775-a.bin" size="8388608" crc="1895f946" sha1="8baf4f44f64d17333a82ce29e59c62e51e45c0c0" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-10775-a.bin" size="0x800000" crc="1895f946" sha1="8baf4f44f64d17333a82ce29e59c62e51e45c0c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -645,8 +672,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10775-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Finding Nemo [500-10775-A].bin" size="8388608" crc="dd62dd31" sha1="5c28cddf6eb4271c2bd98a3545f1b9c0de164c15" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Finding Nemo [500-10775-A].bin" size="0x800000" crc="dd62dd31" sha1="5c28cddf6eb4271c2bd98a3545f1b9c0de164c15" />
 			</dataarea>
 		</part>
 	</software>
@@ -657,8 +684,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11495-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11495-a.bin" size="8388608" crc="6a5e20ba" sha1="984638e1d9b869611de8900d8f5a6a760cd40539" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11495-a.bin" size="0x800000" crc="6a5e20ba" sha1="984638e1d9b869611de8900d8f5a6a760cd40539" />
 			</dataarea>
 		</part>
 	</software>
@@ -669,8 +696,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12227-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12227-A - Buscando a Nemo (Spa).bin" size="8388608" crc="7aa17c75" sha1="798e2bf0d2decc08430ff5d3009b60dffa341aba" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12227-A - Buscando a Nemo (Spa).bin" size="0x800000" crc="7aa17c75" sha1="798e2bf0d2decc08430ff5d3009b60dffa341aba" />
 			</dataarea>
 		</part>
 	</software>
@@ -681,8 +708,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12715-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12715-a.bin" size="8388608" crc="e62d1684" sha1="e43820efe9dbd8dddf6312493a7967c75a29431a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12715-a.bin" size="0x800000" crc="e62d1684" sha1="e43820efe9dbd8dddf6312493a7967c75a29431a" />
 			</dataarea>
 		</part>
 	</software>
@@ -693,20 +720,32 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12692-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12692-a.bin" size="8388608" crc="05b608f0" sha1="04b3181f39e88b6cd47e39a7efb50fa14618ff2c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12692-a.bin" size="0x800000" crc="05b608f0" sha1="04b3181f39e88b6cd47e39a7efb50fa14618ff2c" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="diegogo" supported="no">
-		<description>Go Diego Go! - Animal Rescuer (USA)</description>
-		<year>2007?</year>
+		<description>Nick Jr. Go Diego Go! - Animal Rescuer (USA, set 1)</description>
+		<year>2007</year>
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13447-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13447-a.bin" size="8388608" crc="ebbf83a0" sha1="2412607b40f8e46881368607b4fe15ecf2f2e9eb" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13447-a.bin" size="0x800000" crc="ebbf83a0" sha1="2412607b40f8e46881368607b4fe15ecf2f2e9eb" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="diegogoa" cloneof="diegogo" supported="no">
+		<description>Nick Jr. Go Diego Go! - Animal Rescuer (USA, set 2)</description>
+		<year>2007</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-12718-A" />
+		<part name="cart" interface="leapster_cart">
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12718-A - Go Diego Go - Animal Rescuer (USA).bin" size="0x800000" crc="dcdd48bd" sha1="bf4f0eda3245664094e53f085a831a769e495042" />
 			</dataarea>
 		</part>
 	</software>
@@ -717,8 +756,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10935-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-10935-a.bin" size="8388608" crc="6fd44f1a" sha1="fe6e8e1aaf72901820ee99d22dcc40a01d627fac" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-10935-a.bin" size="0x800000" crc="6fd44f1a" sha1="fe6e8e1aaf72901820ee99d22dcc40a01d627fac" />
 			</dataarea>
 		</part>
 	</software>
@@ -729,8 +768,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11494-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11494-a.bin" size="8388608" crc="96d30f93" sha1="61dd156ae456a370a021061da9b3a4e33bda371e" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11494-a.bin" size="0x800000" crc="96d30f93" sha1="61dd156ae456a370a021061da9b3a4e33bda371e" />
 			</dataarea>
 		</part>
 	</software>
@@ -741,8 +780,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13298-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13298-a.bin" size="8388608" crc="7c716016" sha1="35512ea5c267f5540cbfa64a4d35ebc54464fd31" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13298-a.bin" size="0x800000" crc="7c716016" sha1="35512ea5c267f5540cbfa64a4d35ebc54464fd31" />
 			</dataarea>
 		</part>
 	</software>
@@ -753,8 +792,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10999" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-10999 - Kindergarten (US).bin" size="8388608" crc="db262164" sha1="2ece5050d65d020cce70e220af3c11c9827029ac" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-10999 - Kindergarten (US).bin" size="0x800000" crc="db262164" sha1="2ece5050d65d020cce70e220af3c11c9827029ac" />
 			</dataarea>
 		</part>
 	</software>
@@ -765,8 +804,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-01170" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Kindergarten [500-01170].bin" size="8388608" crc="70bfed0f" sha1="8eafada11a49c6c36f0c168e31984aa92c4516d1" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Kindergarten [500-01170].bin" size="0x800000" crc="70bfed0f" sha1="8eafada11a49c6c36f0c168e31984aa92c4516d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -777,8 +816,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12393-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-12393-a.bin" size="4194304" crc="e8c84241" sha1="dfdf21c90ce5807459c90d515f28f838effacde6" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12393-a.bin" size="0x400000" crc="e8c84241" sha1="dfdf21c90ce5807459c90d515f28f838effacde6" />
 			</dataarea>
 		</part>
 	</software>
@@ -789,8 +828,21 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12800-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12800-a.bin" size="8388608" crc="680f3323" sha1="fc28a2b4e86cbdbf5f3218bd36fb7b72d9bd44d3" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12800-a.bin" size="0x800000" crc="680f3323" sha1="fc28a2b4e86cbdbf5f3218bd36fb7b72d9bd44d3" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Cart used on Kiosk-Stations in the US -->
+	<software name="lgamingpop" supported="no">
+		<description>Leapster 2 Gaming Pop (USA)</description>
+		<year>2010</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="970-63191" />
+		<part name="cart" interface="leapster_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="500-13818-A - Leapster 2 Cartridge 2010 GAMING POP US_970-63191.bin" size="0x1000000" crc="c6fd5c24" sha1="10ab2248e8a8e85ebed2a4ce68b060ea630b0f5e" />
 			</dataarea>
 		</part>
 	</software>
@@ -801,8 +853,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10093" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-10093 - Learning with Leap (US).bin" size="8388608" crc="2c1fcf40" sha1="ee9dbfa8aabda493cc2a34dc82b253122fa96c91" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-10093 - Learning with Leap (US).bin" size="0x800000" crc="2c1fcf40" sha1="ee9dbfa8aabda493cc2a34dc82b253122fa96c91" />
 			</dataarea>
 		</part>
 	</software>
@@ -813,8 +865,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11078-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11078-a.bin" size="8388608" crc="e1f505e7" sha1="935eb17d3b6f9df2115a12445b3c8c977005481a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11078-a.bin" size="0x800000" crc="e1f505e7" sha1="935eb17d3b6f9df2115a12445b3c8c977005481a" />
 			</dataarea>
 		</part>
 	</software>
@@ -825,8 +877,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11493-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11493-a.bin" size="8388608" crc="e58eac06" sha1="a2f8c6df81fd5f72f6894b153306fd871fd20aac" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11493-a.bin" size="0x800000" crc="e58eac06" sha1="a2f8c6df81fd5f72f6894b153306fd871fd20aac" />
 			</dataarea>
 		</part>
 	</software>
@@ -849,8 +901,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12350-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-12350-A - Letterpillar (US).bin" size="4194304" crc="9b86a0fb" sha1="c7d5381205340f85b302342cbe518f20c959a193" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12350-A - Letterpillar (US).bin" size="0x400000" crc="9b86a0fb" sha1="c7d5381205340f85b302342cbe518f20c959a193" />
 			</dataarea>
 		</part>
 	</software>
@@ -861,8 +913,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11995-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-11995-A - Letterpillar (v1.0) (US).bin" size="4194304" crc="fa919dff" sha1="dfb24dda3c2ca692495d9ad78f209645bf6e1b67" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-11995-A - Letterpillar (v1.0) (US).bin" size="0x400000" crc="fa919dff" sha1="dfb24dda3c2ca692495d9ad78f209645bf6e1b67" />
 			</dataarea>
 		</part>
 	</software>
@@ -873,8 +925,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10441" /> <!-- Same ROM as 500-11004 -->
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Math Baseball [500-10441].bin" size="8388608" crc="fe8bd3fd" sha1="83c2cbc82826ba4aa8320463060b203641c86940" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Math Baseball [500-10441].bin" size="0x800000" crc="fe8bd3fd" sha1="83c2cbc82826ba4aa8320463060b203641c86940" />
 			</dataarea>
 		</part>
 	</software>
@@ -885,8 +937,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11003" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11003.bin" size="8388608" crc="dbb767cc" sha1="280b18a8cdf3ae09c5c7b32b8e592a8e2890302c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11003.bin" size="0x800000" crc="dbb767cc" sha1="280b18a8cdf3ae09c5c7b32b8e592a8e2890302c" />
 			</dataarea>
 		</part>
 	</software>
@@ -897,8 +949,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11003" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Mr. Pencils Learn to Draw and Write [500-11003] 152-11702.bin" size="8388608" crc="4e88e131" sha1="703d09b5b6c7c04cc892b0fbd2ade8854fe1e300" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Mr. Pencils Learn to Draw and Write [500-11003] 152-11702.bin" size="0x800000" crc="4e88e131" sha1="703d09b5b6c7c04cc892b0fbd2ade8854fe1e300" />
 			</dataarea>
 		</part>
 	</software>
@@ -909,8 +961,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12206-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12206-A - Don Lapiz - Aprender a Dibujar y Escribir (Spa).bin" size="8388608" crc="e6e50c84" sha1="9fb971ac661618bad549f37fbad28ffdd3873a30" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12206-A - Don Lapiz - Aprender a Dibujar y Escribir (Spa).bin" size="0x800000" crc="e6e50c84" sha1="9fb971ac661618bad549f37fbad28ffdd3873a30" />
 			</dataarea>
 		</part>
 	</software>
@@ -921,8 +973,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13682-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13682-a.bin" size="8388608" crc="2fc77c9d" sha1="266e08439be2c91fbc9942c3620f49459c157fcc" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13682-a.bin" size="0x800000" crc="2fc77c9d" sha1="266e08439be2c91fbc9942c3620f49459c157fcc" />
 			</dataarea>
 		</part>
 	</software>
@@ -940,13 +992,25 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 	</software>
 
 	<software name="numraid" supported="no">
-		<description>Number Raiders - Arcade-Style Learning (USA)</description>
+		<description>Number Raiders - Arcade-Style Learning! (USA, set 1)</description>
+		<year>2005</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-12351-A" />
+		<part name="cart" interface="leapster_cart">
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12351-A - Number Raiders (USA).bin" size="0x400000" crc="c7ac16a6" sha1="ad28c2751b4909ddb56abc4a16f71518a383cff1" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="numraida" cloneof="numraid" supported="no">
+		<description>Number Raiders - Arcade-Style Learning! (USA, set 2)</description>
 		<year>2005</year>
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11993-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-11993-A - Number Raiders (US).bin" size="4194304" crc="0f6d55cf" sha1="f30e7d55c5222e85aca08819ff613343b91138a4" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-11993-A - Number Raiders (US).bin" size="0x400000" crc="0f6d55cf" sha1="f30e7d55c5222e85aca08819ff613343b91138a4" />
 			</dataarea>
 		</part>
 	</software>
@@ -957,8 +1021,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12413-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-12413-a.bin" size="4194304" crc="c12334cf" sha1="b601d42a0cca30e3a4595cdd7f4ad24e89b82e41" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12413-a.bin" size="0x400000" crc="c12334cf" sha1="b601d42a0cca30e3a4595cdd7f4ad24e89b82e41" />
 			</dataarea>
 		</part>
 	</software>
@@ -969,8 +1033,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12141-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-12141-a.bin" size="4194304" crc="334ab5d0" sha1="00eb76e267bfaded25fdf8361e933dc4ec72d059" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12141-a.bin" size="0x400000" crc="334ab5d0" sha1="00eb76e267bfaded25fdf8361e933dc4ec72d059" />
 			</dataarea>
 		</part>
 	</software>
@@ -981,8 +1045,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12141-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-12202-A - La Conquista de los Numeros (Spa).bin" size="4194304" crc="2fb737c6" sha1="6490a57d98f83ef96b0f4f783632a97c0fa460e4" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12202-A - La Conquista de los Numeros (Spa).bin" size="0x400000" crc="2fb737c6" sha1="6490a57d98f83ef96b0f4f783632a97c0fa460e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -993,8 +1057,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12799-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12799-a.bin" size="8388608" crc="24c28bcd" sha1="f6af3d9629d66d71fcb0acf731bd0295e1142135" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12799-a.bin" size="0x800000" crc="24c28bcd" sha1="f6af3d9629d66d71fcb0acf731bd0295e1142135" />
 			</dataarea>
 		</part>
 	</software>
@@ -1005,8 +1069,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12676-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Pet Pals [500-12676-A].bin" size="8388608" crc="5a013b83" sha1="87df54e89d788716fe3a651a20d517b0c4c80654" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Pet Pals [500-12676-A].bin" size="0x800000" crc="5a013b83" sha1="87df54e89d788716fe3a651a20d517b0c4c80654" />
 			</dataarea>
 		</part>
 	</software>
@@ -1017,8 +1081,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13446-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13446-a.bin" size="8388608" crc="3c428a13" sha1="b90cdd518178849efabf7e3e17bf99072d964fad" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13446-a.bin" size="0x800000" crc="3c428a13" sha1="b90cdd518178849efabf7e3e17bf99072d964fad" />
 			</dataarea>
 		</part>
 	</software>
@@ -1029,8 +1093,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12824-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12824-a.bin" size="8388608" crc="b6d630e0" sha1="680508d157425523b8b0da3d99408e68c241acd0" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12824-a.bin" size="0x800000" crc="b6d630e0" sha1="680508d157425523b8b0da3d99408e68c241acd0" />
 			</dataarea>
 		</part>
 	</software>
@@ -1041,8 +1105,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13445-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13445-A - Ratatouille (US).bin" size="8388608" crc="d0c4de47" sha1="372c61285eee5c8ce2670d12bedb09150fdaaa45" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13445-A - Ratatouille (US).bin" size="0x800000" crc="d0c4de47" sha1="372c61285eee5c8ce2670d12bedb09150fdaaa45" />
 			</dataarea>
 		</part>
 	</software>
@@ -1053,8 +1117,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12654-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Ratatouille [500-12654-A].bin" size="8388608" crc="b8920c83" sha1="e3f2393e193a981305e738ea3314be5593a035b3" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Ratatouille [500-12654-A].bin" size="0x800000" crc="b8920c83" sha1="e3f2393e193a981305e738ea3314be5593a035b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -1065,8 +1129,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12674-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12674-a.bin" size="8388608" crc="8f835af7" sha1="f3a67125ac50ce793a80ac2978e4e656b6696642" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12674-a.bin" size="0x800000" crc="8f835af7" sha1="f3a67125ac50ce793a80ac2978e4e656b6696642" />
 			</dataarea>
 		</part>
 	</software>
@@ -1077,8 +1141,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12738-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12738-a.bin" size="8388608" crc="df729fe7" sha1="af3c6b80d075f469388395cb065efa8bd6aeeab1" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12738-a.bin" size="0x800000" crc="df729fe7" sha1="af3c6b80d075f469388395cb065efa8bd6aeeab1" />
 			</dataarea>
 		</part>
 	</software>
@@ -1089,8 +1153,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10829-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-10829-a.bin" size="8388608" crc="2c6e623e" sha1="c298181f00109b7f863fdb12b5bd462085c4ff4f" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-10829-a.bin" size="0x800000" crc="2c6e623e" sha1="c298181f00109b7f863fdb12b5bd462085c4ff4f" />
 			</dataarea>
 		</part>
 	</software>
@@ -1101,8 +1165,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12293-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Scholastic Animal Genius [500-12293-A].bin" size="8388608" crc="af063ba4" sha1="af22fdbb0466e1a078e68fe26752e606b529fcca" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Scholastic Animal Genius [500-12293-A].bin" size="0x800000" crc="af063ba4" sha1="af22fdbb0466e1a078e68fe26752e606b529fcca" />
 			</dataarea>
 		</part>
 	</software>
@@ -1113,8 +1177,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13681-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13681-a.bin" size="8388608" crc="822ca3da" sha1="ff0ac7f5fded346553e1a4697b45c27fc04ee3fe" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13681-a.bin" size="0x800000" crc="822ca3da" sha1="ff0ac7f5fded346553e1a4697b45c27fc04ee3fe" />
 			</dataarea>
 		</part>
 	</software>
@@ -1125,8 +1189,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11929-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11929-A - Scholastic I Spy - Challenger (US).bin" size="8388608" crc="da56181c" sha1="952a3135131b6543b7e6b4f784c7a239cfd6e75a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11929-A - Scholastic I Spy - Challenger (US).bin" size="0x800000" crc="da56181c" sha1="952a3135131b6543b7e6b4f784c7a239cfd6e75a" />
 			</dataarea>
 		</part>
 	</software>
@@ -1137,8 +1201,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11898-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Scholastic Math Missions [500-11898-A].bin" size="8388608" crc="df2cd38c" sha1="fa6f4ec1beb132dea9163a1b078c90e7e3a664ca" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Scholastic Math Missions [500-11898-A].bin" size="0x800000" crc="df2cd38c" sha1="fa6f4ec1beb132dea9163a1b078c90e7e3a664ca" />
 			</dataarea>
 		</part>
 	</software>
@@ -1149,8 +1213,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13299-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13299-A.bin" size="8388608" crc="9e69c26a" sha1="395de47ca1e89eb63f4ff316d15da9b0425488d1" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13299-A.bin" size="0x800000" crc="9e69c26a" sha1="395de47ca1e89eb63f4ff316d15da9b0425488d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -1185,8 +1249,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-14005-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-14005-A - Scooby Doo (US).bin" size="8388608" crc="4cd2c497" sha1="9f06cb4aba2399464a799910be9df1d5678bb23a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-14005-A - Scooby Doo (US).bin" size="0x800000" crc="4cd2c497" sha1="9f06cb4aba2399464a799910be9df1d5678bb23a" />
 			</dataarea>
 		</part>
 	</software>
@@ -1197,8 +1261,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12160-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-12160-A - Scooby Doo - Spooky Snacks (US).bin" size="4194304" crc="19da3dd8" sha1="8966d8d1e65ea0f778c9b435de94da793a874efe" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12160-A - Scooby Doo - Spooky Snacks (US).bin" size="0x400000" crc="19da3dd8" sha1="8966d8d1e65ea0f778c9b435de94da793a874efe" />
 			</dataarea>
 		</part>
 	</software>
@@ -1209,20 +1273,32 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12629-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-12629-a.bin" size="4194304" crc="648e3ee5" sha1="b483b8e04a287f3b6c2a80deabfd5812963b413b" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12629-a.bin" size="0x400000" crc="648e3ee5" sha1="b483b8e04a287f3b6c2a80deabfd5812963b413b" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="sonicx" supported="no">
-		<description>SonicX (USA)</description>
-		<year>2003</year>
+		<description>Sonic X (USA, set 1)</description>
+		<year>2006</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-13444-A" />
+		<part name="cart" interface="leapster_cart">
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13444-A - Sonic X (USA).bin" size="0x800000" crc="44000e5c" sha1="e37c5a562dac8675553879a96ec86f0b422a47a4" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sonicxa" cloneof="sonicx" supported="no">
+		<description>Sonic X (USA, set 2)</description>
+		<year>2006</year>
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12296-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12296-a.bin" size="8388608" crc="a9d2cdbd" sha1="e239b209239252f0f6cd2a4c71d2a46a3abfd5eb" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12296-a.bin" size="0x800000" crc="a9d2cdbd" sha1="e239b209239252f0f6cd2a4c71d2a46a3abfd5eb" />
 			</dataarea>
 		</part>
 	</software>
@@ -1233,8 +1309,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13451-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="SpongeBob SquarePants Saves the Day [500-13451-A].bin" size="8388608" crc="5fcfcf3c" sha1="6cc9f4d06ec24678aba1f2c9c856c1f4e25cd612" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="SpongeBob SquarePants Saves the Day [500-13451-A].bin" size="0x800000" crc="5fcfcf3c" sha1="6cc9f4d06ec24678aba1f2c9c856c1f4e25cd612" />
 			</dataarea>
 		</part>
 	</software>
@@ -1245,8 +1321,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11002" /> <!-- Same ROM as 500-01168 -->
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11002.bin" size="8388608" crc="0f2ad725" sha1="258e5b006086a7fd4cfa4460f3008604a5d87e1d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11002.bin" size="0x800000" crc="0f2ad725" sha1="258e5b006086a7fd4cfa4460f3008604a5d87e1d" />
 			</dataarea>
 		</part>
 	</software>
@@ -1257,8 +1333,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12415-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12415-a.bin" size="8388608" crc="7ccf1715" sha1="000a2658a787fb56a7b4597b8170a1ee4459bb1d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12415-a.bin" size="0x800000" crc="7ccf1715" sha1="000a2658a787fb56a7b4597b8170a1ee4459bb1d" />
 			</dataarea>
 		</part>
 	</software>
@@ -1269,8 +1345,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10933-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-10933-a.bin" size="8388608" crc="d11e7c30" sha1="71a844d9f38f7bc915e716d3d5485f558e9bffe9" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-10933-a.bin" size="0x800000" crc="d11e7c30" sha1="71a844d9f38f7bc915e716d3d5485f558e9bffe9" />
 			</dataarea>
 		</part>
 	</software>
@@ -1281,8 +1357,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12719-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-12719-a.bin" size="4194304" crc="6b24a3ef" sha1="34dfb9ddef02731440085f3a1dad80654ad29c76" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12719-a.bin" size="0x400000" crc="6b24a3ef" sha1="34dfb9ddef02731440085f3a1dad80654ad29c76" />
 			</dataarea>
 		</part>
 	</software>
@@ -1293,8 +1369,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13273-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="500-13273-a.bin" size="4194304" crc="8761fc61" sha1="90b0e1faf6964ec74643a45b46f0b064ebf9ea8a" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-13273-a.bin" size="0x400000" crc="8761fc61" sha1="90b0e1faf6964ec74643a45b46f0b064ebf9ea8a" />
 			</dataarea>
 		</part>
 	</software>
@@ -1305,8 +1381,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10825-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-10825-a.bin" size="8388608" crc="0ef61cbb" sha1="ff00b91ca8bcd2a5d1ead2c353d6d1c048994d69" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-10825-a.bin" size="0x800000" crc="0ef61cbb" sha1="ff00b91ca8bcd2a5d1ead2c353d6d1c048994d69" />
 			</dataarea>
 		</part>
 	</software>
@@ -1317,8 +1393,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12416-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12416-a.bin" size="8388608" crc="cbe0de6f" sha1="12245cfacd1b67fb4cb0cc176789a5b7c1de698a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12416-a.bin" size="0x800000" crc="cbe0de6f" sha1="12245cfacd1b67fb4cb0cc176789a5b7c1de698a" />
 			</dataarea>
 		</part>
 	</software>
@@ -1329,8 +1405,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11497-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11497-a.bin" size="8388608" crc="9dc2e5f6" sha1="089e6739142edaaa5c0e72ba7faf6f443e1ddc59" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11497-a.bin" size="0x800000" crc="9dc2e5f6" sha1="089e6739142edaaa5c0e72ba7faf6f443e1ddc59" />
 			</dataarea>
 		</part>
 	</software>
@@ -1341,8 +1417,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12210-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12210-A - Spider-Man - El Caso de Las Letras Revueltas (Spa).bin" size="8388608" crc="96468ab9" sha1="24fab31e1b0aec1c963867da485d22b97da10660" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12210-A - Spider-Man - El Caso de Las Letras Revueltas (Spa).bin" size="0x800000" crc="96468ab9" sha1="24fab31e1b0aec1c963867da485d22b97da10660" />
 			</dataarea>
 		</part>
 	</software>
@@ -1353,8 +1429,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13306-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13306-a.bin" size="8388608" crc="27000674" sha1="a7e8e63ab74931ad9546aba20755714df572badb" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13306-a.bin" size="0x800000" crc="27000674" sha1="a7e8e63ab74931ad9546aba20755714df572badb" />
 			</dataarea>
 		</part>
 	</software>
@@ -1365,8 +1441,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13417-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13417-a.bin" size="8388608" crc="cf835b84" sha1="31ab97019d5e1fafa05cdb3a359e3c512a089b01" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13417-a.bin" size="0x800000" crc="cf835b84" sha1="31ab97019d5e1fafa05cdb3a359e3c512a089b01" />
 			</dataarea>
 		</part>
 	</software>
@@ -1377,8 +1453,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13472-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13472-A - Star Wars - Jedi Reading (US).bin" size="8388608" crc="6239a178" sha1="55c09dbeaabfd21a12369aefa8eae6b7a8d7c1f3" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13472-A - Star Wars - Jedi Reading (US).bin" size="0x800000" crc="6239a178" sha1="55c09dbeaabfd21a12369aefa8eae6b7a8d7c1f3" />
 			</dataarea>
 		</part>
 	</software>
@@ -1401,8 +1477,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-14190-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Tangled [500-14190-A].bin" size="8388608" crc="ce9ce136" sha1="c13e3928456323935925a427dd74b55999582f28" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Tangled [500-14190-A].bin" size="0x800000" crc="ce9ce136" sha1="c13e3928456323935925a427dd74b55999582f28" />
 			</dataarea>
 		</part>
 	</software>
@@ -1413,8 +1489,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11204-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11204-A - Thomas and Friends - Calling all Engines (US).bin" size="8388608" crc="5303d366" sha1="a7a65b5027d742634dd0860d3db44981c2351a05" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11204-A - Thomas and Friends - Calling all Engines (US).bin" size="0x800000" crc="5303d366" sha1="a7a65b5027d742634dd0860d3db44981c2351a05" />
 			</dataarea>
 		</part>
 	</software>
@@ -1425,8 +1501,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10812-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="The Incredibles [500-10812-A].bin" size="8388608" crc="f1d6db36" sha1="ecb356d64b386b8f5a1aa8145995ef5ab0818b31" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="The Incredibles [500-10812-A].bin" size="0x800000" crc="f1d6db36" sha1="ecb356d64b386b8f5a1aa8145995ef5ab0818b31" />
 			</dataarea>
 		</part>
 	</software>
@@ -1437,8 +1513,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-14007-B" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="The Penguins of Madagascar [500-14007-B].bin" size="8388608" crc="076ad299" sha1="bcab8dc869c8e90bb54257fe0a030f4a8599a1b6" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="The Penguins of Madagascar [500-14007-B].bin" size="0x800000" crc="076ad299" sha1="bcab8dc869c8e90bb54257fe0a030f4a8599a1b6" />
 			</dataarea>
 		</part>
 	</software>
@@ -1449,8 +1525,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13556-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="The Princess and the Frog [500-13556-A].bin" size="8388608" crc="c29a72e2" sha1="f9e010565fee6d96a2b97a67fc3b960e2c754fee" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="The Princess and the Frog [500-13556-A].bin" size="0x800000" crc="c29a72e2" sha1="f9e010565fee6d96a2b97a67fc3b960e2c754fee" />
 			</dataarea>
 		</part>
 	</software>
@@ -1461,8 +1537,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10777-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Top-Secret Personal Beeswax [500-10777-A].bin" size="8388608" crc="78fce75a" sha1="7551e6e68daef057a2170d4dc9500af137ab4821" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Top-Secret Personal Beeswax [500-10777-A].bin" size="0x800000" crc="78fce75a" sha1="7551e6e68daef057a2170d4dc9500af137ab4821" />
 			</dataarea>
 		</part>
 	</software>
@@ -1473,8 +1549,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13982-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13982-a.bin" size="8388608" crc="a72c61fd" sha1="3524a9167e6139101a27fccef4a97ef30dd928fe" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13982-a.bin" size="0x800000" crc="a72c61fd" sha1="3524a9167e6139101a27fccef4a97ef30dd928fe" />
 			</dataarea>
 		</part>
 	</software>
@@ -1485,8 +1561,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13563-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13563-A - Up (US).bin" size="8388608" crc="1e2a5031" sha1="ab74239918208cc7dfa7377549086b59e6c40818" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13563-A - Up (US).bin" size="0x800000" crc="1e2a5031" sha1="ab74239918208cc7dfa7377549086b59e6c40818" />
 			</dataarea>
 		</part>
 	</software>
@@ -1497,8 +1573,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13643-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13643-a.bin" size="8388608" crc="975a0a85" sha1="d89e05c3afb2377efcdddf3099819541c28ee640" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13643-a.bin" size="0x800000" crc="975a0a85" sha1="d89e05c3afb2377efcdddf3099819541c28ee640" />
 			</dataarea>
 		</part>
 	</software>
@@ -1509,8 +1585,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10934-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-10934-a.bin" size="8388608" crc="4c5e775e" sha1="87819e1a95f0d435fc94697423fcfca13f463a34" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-10934-a.bin" size="0x800000" crc="4c5e775e" sha1="87819e1a95f0d435fc94697423fcfca13f463a34" />
 			</dataarea>
 		</part>
 	</software>
@@ -1521,8 +1597,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13272-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13272-A - Wall-E (US).bin" size="8388608" crc="c71cff35" sha1="ac31af80cf3dedf13ddb94595e2914377f85f819" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13272-A - Wall-E (US).bin" size="0x800000" crc="c71cff35" sha1="ac31af80cf3dedf13ddb94595e2914377f85f819" />
 			</dataarea>
 		</part>
 	</software>
@@ -1533,8 +1609,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13441-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13441-a.bin" size="8388608" crc="ee2c39ea" sha1="3606a63fb783ba1e16d0466766dd456eb84b4116" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13441-a.bin" size="0x800000" crc="ee2c39ea" sha1="3606a63fb783ba1e16d0466766dd456eb84b4116" />
 			</dataarea>
 		</part>
 	</software>
@@ -1545,8 +1621,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13414-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13414-a.bin" size="8388608" crc="c10ab3dd" sha1="001d00815e42cd01c650d4cce81ea2a9de6d422c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13414-a.bin" size="0x800000" crc="c10ab3dd" sha1="001d00815e42cd01c650d4cce81ea2a9de6d422c" />
 			</dataarea>
 		</part>
 	</software>
@@ -1557,8 +1633,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12140-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12140-a.bin" size="4194304" crc="75164c8e" sha1="6bebaef0d3b6f8a1a4b2bb957a00a0cce4ed65a2" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12140-a.bin" size="0x400000" crc="75164c8e" sha1="6bebaef0d3b6f8a1a4b2bb957a00a0cce4ed65a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -1569,8 +1645,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-13744-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-13744-a.bin" size="8388608" crc="67bd4a6a" sha1="70c35a12e368e19956ff43101f7125f9c5679cb2" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-13744-a.bin" size="0x800000" crc="67bd4a6a" sha1="70c35a12e368e19956ff43101f7125f9c5679cb2" />
 			</dataarea>
 		</part>
 	</software>
@@ -1581,8 +1657,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12353-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Word Chasers [500-12353-A].bin" size="4194304" crc="f5a3052a" sha1="9fbc15da1fbec24c8d37aeaf759619cb129d542a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Word Chasers [500-12353-A].bin" size="0x400000" crc="f5a3052a" sha1="9fbc15da1fbec24c8d37aeaf759619cb129d542a" />
 			</dataarea>
 		</part>
 	</software>
@@ -1593,8 +1669,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11996-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="Word Chasers [500-11996-A].bin" size="4194304" crc="9be0f98d" sha1="c86dcf16eae29d6fdf0277f2b1af63ed445082be" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Word Chasers [500-11996-A].bin" size="0x400000" crc="9be0f98d" sha1="c86dcf16eae29d6fdf0277f2b1af63ed445082be" />
 			</dataarea>
 		</part>
 	</software>
@@ -1605,8 +1681,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12142-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12142-a.bin" size="4194304" crc="a707de61" sha1="76689979f08d8c585576a138579fcfb147449db5" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12142-a.bin" size="0x400000" crc="a707de61" sha1="76689979f08d8c585576a138579fcfb147449db5" />
 			</dataarea>
 		</part>
 	</software>
@@ -1617,8 +1693,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12259-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12259-A - El Laberinto de las Letras (Spa).bin" size="4194304" crc="4a999f60" sha1="91f79a22a8f9f1af6d8ab11f7dc03858b58510d1" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12259-A - El Laberinto de las Letras (Spa).bin" size="0x400000" crc="4a999f60" sha1="91f79a22a8f9f1af6d8ab11f7dc03858b58510d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -1632,8 +1708,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11904-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11904-A.bin" size="8388608" crc="74af5d57" sha1="0436c64cc08089e9ca96b006d54bf00120685e6e" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11904-A.bin" size="0x800000" crc="74af5d57" sha1="0436c64cc08089e9ca96b006d54bf00120685e6e" />
 			</dataarea>
 		</part>
 	</software>
@@ -1644,8 +1720,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11779-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11779-A.bin" size="8388608" crc="b186a3bf" sha1="10bfa48a7627905bd9ba6af8399f70d35f814ded" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11779-A.bin" size="0x800000" crc="b186a3bf" sha1="10bfa48a7627905bd9ba6af8399f70d35f814ded" />
 			</dataarea>
 		</part>
 	</software>
@@ -1656,8 +1732,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11202-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11202-A.bin" size="8388608" crc="a9c75d90" sha1="3509eb76178a20037fb277d2d0cf062dedbaba47" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11202-A.bin" size="0x800000" crc="a9c75d90" sha1="3509eb76178a20037fb277d2d0cf062dedbaba47" />
 			</dataarea>
 		</part>
 	</software>
@@ -1668,8 +1744,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12099-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-12099-A.bin" size="8388608" crc="95c78f34" sha1="91619b2f1297b8d07c6122b92b8ff33f6f6c1629" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12099-A.bin" size="0x800000" crc="95c78f34" sha1="91619b2f1297b8d07c6122b92b8ff33f6f6c1629" />
 			</dataarea>
 		</part>
 	</software>
@@ -1680,8 +1756,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11777-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11777-a.bin" size="8388608" crc="01f12ce7" sha1="6e468f68b57d93777347d6a2e8ce15b79ccefb7f" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11777-a.bin" size="0x800000" crc="01f12ce7" sha1="6e468f68b57d93777347d6a2e8ce15b79ccefb7f" />
 			</dataarea>
 		</part>
 	</software>
@@ -1692,8 +1768,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11905-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11905-A.bin" size="8388608" crc="4d893b32" sha1="b108972cbd1408aa395af64ef0760e99cb956d28" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11905-A.bin" size="0x800000" crc="4d893b32" sha1="b108972cbd1408aa395af64ef0760e99cb956d28" />
 			</dataarea>
 		</part>
 	</software>
@@ -1704,8 +1780,8 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-11903-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="500-11903-A.bin" size="8388608" crc="2eee5925" sha1="e5cd4a48d027fef14bbfc1c1304ebe9138353110" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-11903-A.bin" size="0x800000" crc="2eee5925" sha1="e5cd4a48d027fef14bbfc1c1304ebe9138353110" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/leapster.xml
+++ b/hash/leapster.xml
@@ -612,7 +612,7 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-12161-A" />
 		<part name="cart" interface="leapster_cart">
-			<dataarea name="rom" size="40 0000">
+			<dataarea name="rom" size="0x400000">
 				<rom name="500-12161-a.bin" size="0x400000" crc="ea544030" sha1="a9aaf73e5259db303f8bfc39bd6d7b40bddb127f" />
 			</dataarea>
 		</part>


### PR DESCRIPTION
New NOT_WORKING software list additions
-----------------------------------------
leapster.xml:
  Disney Princess (USA, set 2) [TeamEurope]
  Nick Jr. Go Diego Go! - Animal Rescuer (USA, set 2) [TeamEurope]
  Leapster 2 Gaming Pop (USA) [TeamEurope]
  Number Raiders - Arcade-Style Learning! (USA, set 1) [TeamEurope]
  Sonic X (USA, set 1) [TeamEurope]

Also change ROM sizes to hexadecimal, fixed some game metadata and added some games to the missing/dumped list on comments.