### PR TITLE
snk/miconkit.cpp: Add orange overlay for Space Micon Kit

### DIFF
--- a/src/mame/layout/smiconk.lay
+++ b/src/mame/layout/smiconk.lay
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!--
+license:CC0-1.0
+-->
+<mamelayout version="2">
+	<element name="overlay">
+		<rect>
+			<bounds x="0" y="0" width="1" height="240" />
+			<color red="1" green="1" blue="0.2" />
+		</rect>
+	</element>
+
+	<view name="Color Overlay">
+		<screen index="0">
+			<bounds left="0" top="0" right="3" bottom="4" />
+		</screen>
+		<element ref="overlay" blend="multiply">
+			<bounds left="0" top="0" right="3" bottom="4" />
+		</element>
+	</view>
+</mamelayout>

--- a/src/mame/layout/smiconk.lay
+++ b/src/mame/layout/smiconk.lay
@@ -4,10 +4,7 @@ license:CC0-1.0
 -->
 <mamelayout version="2">
 	<element name="overlay">
-		<rect>
-			<bounds x="0" y="0" width="1" height="240" />
-			<color red="1" green="1" blue="0.2" />
-		</rect>
+		<rect><color red="1" green="0.6" blue="0.2" /></rect>
 	</element>
 
 	<view name="Color Overlay">

--- a/src/mame/snk/miconkit.cpp
+++ b/src/mame/snk/miconkit.cpp
@@ -50,6 +50,7 @@ TODO:
 #include "speaker.h"
 
 #include "micon2.lh"
+#include "smiconk.lh"
 
 
 namespace {
@@ -328,4 +329,4 @@ ROM_END
 
 //    YEAR  NAME     PARENT  MACHINE  INPUT    CLASS           INIT        SCREEN  COMPANY, FULLNAME, FLAGS
 GAMEL(1978, micon2,  0,      micon2,  micon2,  miconkit_state, empty_init, ROT90,  "SNK", "Micon-Kit Part II", MACHINE_SUPPORTS_SAVE, layout_micon2 )
-GAME (1978, smiconk, 0,      smiconk, smiconk, miconkit_state, empty_init, ROT90,  "SNK", "Space Micon Kit", MACHINE_SUPPORTS_SAVE ) // no color overlay
+GAMEL(1978, smiconk, 0,      smiconk, smiconk, miconkit_state, empty_init, ROT90,  "SNK", "Space Micon Kit", MACHINE_SUPPORTS_SAVE, layout_smiconk )


### PR DESCRIPTION
Verified with these images and from Dillweed via Discord
![image](https://user-images.githubusercontent.com/2461173/229388381-f91405e1-5872-43ad-a94d-475bc00d6732.jpg)
![image](https://user-images.githubusercontent.com/2461173/229388374-4a0976ac-04e8-4ca5-9175-b7a5896a4e28.jpg)
