### PR TITLE
taito/taito_f3_v.cpp: Ignore first line zoom value (appears to fix MT08593)

### DIFF
--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -1760,31 +1760,36 @@ void taito_f3_state::get_line_ram_info(tilemap_t *tmap, int sx, int sy, int pos,
 			if (m_line_ram[0x700 + y] & bit_select)
 				pri = m_line_ram[pri_base / 2] & 0xffff;
 
-			// Zoom for playfields 1 & 3 is interleaved, as is the latch select
-			switch (pos)
+			// HW bug? skip fixes landmakr intro, gekiridn title, recalh title
+			// (1 px discrepancies with pcb recordings on some layers)
+			if (y != y_start)
 			{
-			case 0:
-				if (m_line_ram[0x400 + y] & bit_select)
-					line_zoom = m_line_ram[(zoom_base + 0x000) / 2] & 0xffff;
-				break;
-			case 1:
-				if (m_line_ram[0x400 + y] & 0x2)
-					line_zoom = ((m_line_ram[(zoom_base + 0x200) / 2] & 0xffff) & 0xff00) | (line_zoom & 0x00ff);
-				if (m_line_ram[0x400 + y] & 0x8)
-					line_zoom = ((m_line_ram[(zoom_base + 0x600) / 2] & 0xffff) & 0x00ff) | (line_zoom & 0xff00);
-				break;
-			case 2:
-				if (m_line_ram[0x400 + y] & bit_select)
-					line_zoom = m_line_ram[(zoom_base + 0x400) / 2] & 0xffff;
-				break;
-			case 3:
-				if (m_line_ram[0x400 + y] & 0x8)
-					line_zoom = ((m_line_ram[(zoom_base + 0x600) / 2] & 0xffff) & 0xff00) | (line_zoom & 0x00ff);
-				if (m_line_ram[0x400 + y] & 0x2)
-					line_zoom = ((m_line_ram[(zoom_base + 0x200) / 2] & 0xffff) & 0x00ff) | (line_zoom & 0xff00);
-				break;
-			default:
-				break;
+				// Zoom for playfields 1 & 3 is interleaved, as is the latch select
+				switch (pos)
+				{
+				case 0:
+					if (m_line_ram[0x400 + y] & bit_select)
+						line_zoom = m_line_ram[(zoom_base + 0x000) / 2] & 0xffff;
+					break;
+				case 1:
+					if (m_line_ram[0x400 + y] & 0x2)
+						line_zoom = ((m_line_ram[(zoom_base + 0x200) / 2] & 0xffff) & 0xff00) | (line_zoom & 0x00ff);
+					if (m_line_ram[0x400 + y] & 0x8)
+						line_zoom = ((m_line_ram[(zoom_base + 0x600) / 2] & 0xffff) & 0x00ff) | (line_zoom & 0xff00);
+					break;
+				case 2:
+					if (m_line_ram[0x400 + y] & bit_select)
+						line_zoom = m_line_ram[(zoom_base + 0x400) / 2] & 0xffff;
+					break;
+				case 3:
+					if (m_line_ram[0x400 + y] & 0x8)
+						line_zoom = ((m_line_ram[(zoom_base + 0x600) / 2] & 0xffff) & 0xff00) | (line_zoom & 0x00ff);
+					if (m_line_ram[0x400 + y] & 0x2)
+						line_zoom = ((m_line_ram[(zoom_base + 0x200) / 2] & 0xffff) & 0x00ff) | (line_zoom & 0xff00);
+					break;
+				default:
+					break;
+				}
 			}
 
 			// Column scroll only affects playfields 2 & 3


### PR DESCRIPTION
fixes mt08593: landmakr and clones: ending slide has wrong vertical offset

checked against pcb recordings for
landmakr(+) pbobble2(+) dariusg(+) recalh(+) elvactr(+) gekiridn(+)
arabianm(=) lightbr(=) bublbob2(=) trstar(=) ringrage(=) kaiserkn(=) bubblem(=)

this... feels questionable without hw testing, and there are certainly other places tilemap offset problems could come from, but this is a relatively clean solution, not out of the question for this hardware, and seems to make sense when considering that the affected playfields are 2/3 and the way affected games write line zoom for those playfields.