### PR TITLE
msm5232: Envelope generator resistance values can be specified externally.

### DIFF
--- a/src/devices/sound/msm5232.cpp
+++ b/src/devices/sound/msm5232.cpp
@@ -3,10 +3,10 @@
 #include "emu.h"
 #include "msm5232.h"
 
-#define CLOCK_RATE_DIVIDER 16
+constexpr int CLOCK_RATE_DIVIDER = 16;
 
-#define R51 1400    /* charge resistance */
-#define R52 28750   /* discharge resistance */
+constexpr int R51 = 1400;    /* charge resistance */
+constexpr int R52 = 28750;   /* discharge resistance */
 
 /*
     OKI MSM5232RS
@@ -212,10 +212,6 @@ static FILE *sample[9];
  * external capacitor is discharged through R52
  * in approx. 5*28750 * 0.39e-6
  */
-
-
-//#define R51 1400    /* charge resistance */
-//#define R52 28750   /* discharge resistance */
 
 #if 0
 /*

--- a/src/devices/sound/msm5232.h
+++ b/src/devices/sound/msm5232.h
@@ -13,6 +13,8 @@ public:
 	msm5232_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	void set_capacitors(double cap1, double cap2, double cap3, double cap4, double cap5, double cap6, double cap7, double cap8);
+	void set_envelope_generator_resistances(double attack, double decay_rrf, double decay_rrs);
+	void set_envelope_generator_resistances_by_capacitance(double capacitance);
 	auto gate() { return m_gate_handler_cb.bind(); }
 
 	void write(offs_t offset, uint8_t data);
@@ -87,9 +89,13 @@ private:
 	int     m_rate;       /* sample rate in Hz */
 
 	double  m_external_capacity[8]; /* in Farads, eg 0.39e-6 = 0.36 uF (microFarads) */
+	double	m_envelope_generator_resistance_attack;
+	double	m_envelope_generator_resistance_decay_rrf;
+	double	m_envelope_generator_resistance_decay_rrs;
 	devcb_write_line m_gate_handler_cb;/* callback called when the GATE output pin changes state */
 
 	void init_tables();
+	void init_rate_tables();
 	void init_voice(int i);
 	void gate_update();
 	void init(int clock, int rate);


### PR DESCRIPTION
msm5232:
Envelope generator resistance values can be specified externally.
Separated the resistance value for decay for short period and long period.

The sound chip msm5232 calculates how attack and decay proceed in envelope generation using the capacitance of the externally connected capacitor and some internal resistance values.

In the current implementation, the msm5232 internal resistances for envelope generation is fixed values embedded in the source code.
This commit makes these values externally configurable.
The msm5232 operates exactly the same as before, unless the resistance value is specified externally.

Additionally,
msm5232's envelope generation uses two resistance values to determine a decay period.
The current implementation simplifies this process using a single resistance value.
This commit separates the resistance value that msm5232 uses to determine a decay period.
Again, msm5232 emulation works exactly the same as before, unless resistance values are specified externally.

The 3 types of resistance values for envelope generation that msm5232 has inside (1 for attack, 2 for decay) can be calculated from the capacitance of the connected capacitors and the decay period for each parameter value specified described in the document.
So, I made a function that takes the capacitance of the capacitor connected to msm5232 as an argument and sets the resistance values.

This commit does not actually call the functions added in this commit.
Therefore, this commit doesn't change MAME's output in any way.
