### PR TITLE
sanyo/mbc200.cpp: Fix floppy drive selection (was stuck on A:)

### DIFF
--- a/src/mame/sanyo/mbc200.cpp
+++ b/src/mame/sanyo/mbc200.cpp
@@ -80,6 +80,8 @@ public:
 		, m_fdc(*this, "fdc")
 		, m_floppy0(*this, "fdc:0")
 		, m_floppy1(*this, "fdc:1")
+		, m_floppy2(*this, "fdc:2")
+		, m_floppy3(*this, "fdc:3")
 	{ }
 
 	void mbc200(machine_config &config);
@@ -116,6 +118,8 @@ private:
 	required_device<mb8876_device> m_fdc;
 	required_device<floppy_connector> m_floppy0;
 	required_device<floppy_connector> m_floppy1;
+	required_device<floppy_connector> m_floppy2;
+	required_device<floppy_connector> m_floppy3;
 };
 
 
@@ -140,11 +144,14 @@ void mbc200_state::pm_portb_w(u8 data)
 {
 	floppy_image_device *floppy = nullptr;
 
-	// to be verified
-	switch (data & 0x01)
+	// The BIOS supports up tp 4 drives, (2 internal + 2 external)
+	// E: and F: are virtual swaps of A: and B:
+	switch ((data & 0x70)>>4)
 	{
 	case 0: floppy = m_floppy0->get_device(); break;
 	case 1: floppy = m_floppy1->get_device(); break;
+	case 2: floppy = m_floppy2->get_device(); break;
+	case 3: floppy = m_floppy3->get_device(); break;
 	}
 
 	m_fdc->set_floppy(floppy);
@@ -355,6 +362,8 @@ void mbc200_state::mbc200(machine_config &config)
 	MB8876(config, m_fdc, 8_MHz_XTAL / 8); // guess
 	FLOPPY_CONNECTOR(config, "fdc:0", mbc200_floppies, "qd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
 	FLOPPY_CONNECTOR(config, "fdc:1", mbc200_floppies, "qd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
+	FLOPPY_CONNECTOR(config, "fdc:2", mbc200_floppies, "qd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
+	FLOPPY_CONNECTOR(config, "fdc:3", mbc200_floppies, "qd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
 
 	/* Keyboard */
 	generic_keyboard_device &keyboard(GENERIC_KEYBOARD(config, "keyboard", 0));


### PR DESCRIPTION
This should recreate the exact behavior of the original floppy drive selector, driving a 74145 with bits 4..6 of port B of the 8255A PPI.
The original machines had only 1 or 2 floppy disk drives, but it was possible, as an option, to add 2 external drives,  a BIOS alteration source code for the 8" format was provided, but the boot disk loaded the same format/skew table for all the 4 devices.
