### PR TITLE
psikyo.cpp : Fixes an off-by-one error in m_screen->set_raw

### DIFF
--- a/src/mame/psikyo/psikyo.cpp
+++ b/src/mame/psikyo/psikyo.cpp
@@ -1174,7 +1174,7 @@ void psikyo_state::s1945(machine_config &config)
 
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_raw(14.318181_MHz_XTAL / 2, 456, 0, 320, 262, 0, 223);  // Approximately 59.923Hz, 39 HSync pulses in VBlank
+	m_screen->set_raw(14.318181_MHz_XTAL / 2, 456, 0, 320, 262, 0, 224);  // Approximately 59.923Hz, 38 Lines in VBlank
 	m_screen->set_screen_update(FUNC(psikyo_state::screen_update));
 	m_screen->screen_vblank().set(FUNC(psikyo_state::screen_vblank));
 


### PR DESCRIPTION
Fixes a off-by-one error where number of visible lines were 223 instead of 224.

There are indeed 39 HSync PULSES between the visible color data... but the first one of those are signaling the end of the previous visible frame, and the last one of them is signaling the start of first visible row of the next frame, which means that there's 38 "non-visible" lines during blanking.

This means:
262 total lines. 224 visible. 38 blanking.