### PR TITLE
psikyo/psikyo.cpp: Fixed docs for sync timings of Tengai and Strikers 1945

### DIFF
--- a/src/mame/psikyo/psikyo.cpp
+++ b/src/mame/psikyo/psikyo.cpp
@@ -1752,9 +1752,8 @@ OSC:    16.000MHz
 SYNCS:  HSync 15.700kHz, VSync 59.923Hz
         HSync most likely derived from 14.3181MHz OSC (divided by 912)
         262 lines per frame consisting of:
-          - Visible lines: 223
-          - Vertical Back/Front Porch: 16 lines each
-          - VSync pulse: 7 lines
+          - Visible lines: 224
+          - VBlank lines: 38 (Front/Back porch: 15 lines, VSync pulse: 8 lines)
 Chips:  PS2001B
         PS3103
         PS3204

--- a/src/mame/psikyo/psikyo.cpp
+++ b/src/mame/psikyo/psikyo.cpp
@@ -30,8 +30,7 @@ Tengai              (J) 1996    SH404          SH404 has MCU, ymf278-b for sound
 To Do:
 
 - All games uses PORT_VBLANK and legacy screen parameters (which is already
-  bad per-se), with also naive and unlikely measurements (i.e. exactly 59.30
-  or 59.90 Hz).
+  bad per-se), with also naive and unlikely measurements (i.e. exactly 59.30).
   The most blunt examples of something being wrong with timings are with
   Gunbird and Tengai: they both have FOUR frames of input lag, the real thing
   doesn't sport anything like that.
@@ -1623,7 +1622,11 @@ OSC:    16.000MHz
         14.3181MHz
         33.8688MHz (YMF)
         4.000MHz (PIC)
-SYNCS:  HSync 15.2183kHz, VSync 59.9229Hz
+SYNCS:  HSync 15.700kHz, VSync 59.923Hz
+        HSync most likely derived from 14.3181MHz OSC (divided by 912)
+        262 lines per frame consisting of:
+          - Visible lines: 224
+          - VBlank lines: 38 (Front/Back porch: 15 lines, VSync pulse: 8 lines)
 1-U59   security (PIC16C57; not dumped)
 
 ***************************************************************************/


### PR DESCRIPTION
The code for Tengai was updated to be correct, but not the docs. This fixes the docs too.

I was looking at sync-pulses surrounding front/back-porch, and sync pulses during vblank previously. This is an incorrect way of looking at things.

See: http://img.buffis.com/psikyo/tengai/vblank.png which has a very easy to grasp visual representation of the VBlank lines.