### PR TITLE
3rdparty/linenoise: Support keypad Enter on Windows

### DIFF
--- a/3rdparty/linenoise/linenoise-win32.c
+++ b/3rdparty/linenoise/linenoise-win32.c
@@ -345,6 +345,8 @@ static int fd_read(struct current *current)
                         return SPECIAL_PAGE_UP;
                      case VK_NEXT:
                         return SPECIAL_PAGE_DOWN;
+                     case VK_RETURN:
+                        return k->uChar.UnicodeChar;
                     }
                 }
                 /* Note that control characters are already translated in AsciiChar */


### PR DESCRIPTION
restores d73b585d65936a5b9736e23cf85e543ef5bd2779