### PR TITLE
Remove some cpc and msx softlist duplicates

### DIFF
--- a/hash/msx1_cart.xml
+++ b/hash/msx1_cart.xml
@@ -4138,6 +4138,7 @@ kept for now until finding out what those bytes affect...
 		</part>
 	</software>
 
+	<!-- The rom image works on both MSX and SMS. -->
 	<software name="cyborgz">
 		<description>Cyborg Z (Korea)</description>
 		<year>1991</year>
@@ -11524,6 +11525,7 @@ kept for now until finding out what those bytes affect...
 		</part>
 	</software>
 
+	<!-- The rom image works on both MSX and SMS. -->
 	<software name="sboy3">
 		<description>Super Boy 3 (Korea)</description>
 		<year>1991</year>
@@ -12800,6 +12802,7 @@ kept for now until finding out what those bytes affect...
 		</part>
 	</software>
 
+	<!-- The rom image works on both MSX and SMS. -->
 	<software name="wonsiin">
 		<description>Wonsiin (Korea)</description>
 		<year>1991</year>
@@ -18261,7 +18264,7 @@ legacy FM implementations cannot find it.
 		<part name="cart" interface="msx_cart">
 			<feature name="start_page" value="0"/>
 			<dataarea name="rom" size="0xc000">
-				<rom name="zero and the castle of infinite sadness - dioniso (2014) [msxdev2014].rom" size="0xc000" crc="7b6f90ef" sha1="b61b66e14574b683f75807a6aa18b7868cd628d8"/>
+				<rom name="zero and the castle of infinite sadness - dioniso (2014) [matra].rom" size="0xc000" crc="7b6f90ef" sha1="b61b66e14574b683f75807a6aa18b7868cd628d8"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/msx2_flop.xml
+++ b/hash/msx2_flop.xml
@@ -16104,11 +16104,14 @@ HOMEBREW
 		</part>
 	</software>
 
-	<software name="battlebo">
+	<!-- The readme mentions that the game should autoboot but this dump is missing an AUTOEXEC.BAT file. -->
+	<!-- GFX9000 is not supported yet. -->
+	<software name="battlebo" supported="no">
 		<description>Battle Bomber (UK?)</description>
 		<year>1996</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="BitBoyz" />
+		<info name="usage" value="Requires a system with at least 128KB memory mapper, MSX-DOS2, Moonsound, and a GFX9000 graphics card. Once in MSX-DOS2 type 'batlbomb' to start the software."/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="battle bomber.dsk" size="737280" crc="a318cfcd" sha1="75e6a558ac1f0346f951d9c6667e0b9ecb8557e8"/>
@@ -17419,18 +17422,6 @@ HOMEBREW
 		</part>
 	</software>
 
-	<software name="mobiusd">
-		<description>Mobius Debugger 2 - Eternal Striker (Japan, demo)</description>
-		<year>1995</year>
-		<publisher>&lt;doujin&gt;</publisher>
-		<info name="developer" value="Sequence" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="eternaldemo.dsk" size="737280" crc="19a45f75" sha1="20cbe1beaa164f2fc80a49caeadf320848881a74"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="moonland">
 		<description>Moon Landing (Japan)</description>
 		<year>1998</year>
@@ -18354,18 +18345,6 @@ HOMEBREW
 		</part>
 	</software>
 
-	<software name="shlblade">
-		<description>Shoulder Blade (Japan, bad dump?)</description>
-		<year>1997</year>
-		<publisher>&lt;doujin&gt;</publisher>
-		<info name="developer" value="GW's Workshop" />
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="blade (1997)(gw's workshop)[b].dsk" size="737280" crc="3dab74d6" sha1="8c0b7b32ec22840ce1dabd38863e1876232d3b9d"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="enigma">
 		<description>Shrines of Enigma (Netherlands)</description>
 		<year>1994</year>
@@ -18740,17 +18719,6 @@ HOMEBREW
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="wingmain.dsk" size="737280" crc="0e689ae8" sha1="bc1ddd03931f9834f5ddc76917e6b45b9cbdc81f"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="witchiz">
-		<description>The Witch 'Iz' (Japan)</description>
-		<year>1994</year>
-		<publisher>&lt;doujin&gt;</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="the witch iz.dsk" size="737280" crc="9eef4495" sha1="d096b1ef10c9d7b3ddffda0ec14b841c2c14cada"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/msx2p_flop.xml
+++ b/hash/msx2p_flop.xml
@@ -581,19 +581,6 @@ Known undumped:
 
 <!-- Homebrew / Doujin -->
 
-	<software name="btlbombr">
-		<description>Battle Bomber</description>
-		<year>1996</year>
-		<publisher>&lt;homebrew&gt;</publisher>
-		<info name="developer" value="Bitboyz" />
-
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="battle bomber.dsk" size="737280" crc="a318cfcd" sha1="75e6a558ac1f0346f951d9c6667e0b9ecb8557e8"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="gladius">
 		<description>Gladius (Germany)</description>
 		<year>1992</year>

--- a/hash/msxr_flop.xml
+++ b/hash/msxr_flop.xml
@@ -923,6 +923,7 @@ Known undumped:
 		<year>1997</year>
 		<publisher>&lt;doujin&gt;</publisher>
 		<info name="developer" value="GW's Workshop" />
+		<info name="usage" value="Requires MSX-DOS2"/>
 
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">


### PR DESCRIPTION
cpc_flop.xml:
Removed Livingv2 (msx2 software, livingst in msx2_flop.xml)
Removed LASTMIV2w (msx2 software, lastmiss in msx2_flop.xml)

msx1_cart.xml:
Fix duplicate rom name between zeroinfs and zeroinfsa

msx2_flop.xml:
Removed The Witch ‘Iz’ (Japan)   (duplicate from witchiz in  msx2p_flop.xml)
Removed Mobius Debugger 2 - Eternal Striker (Japan, demo) (duplicate from estriker in msxr_flop.xml)
Removed Shoulder Blade (Japan, bad dump?) (duplicate from shdblade in msxr_flop.xml)

msx2p_flop.xml:
Removed Battle Bomber (duplicate from battlebo in msx2_flop.xml)
