### PR TITLE
psikyo/psikyo_v.cpp : Reduce input lag by 1 frame

### DIFF
--- a/src/mame/psikyo/psikyo_v.cpp
+++ b/src/mame/psikyo/psikyo_v.cpp
@@ -667,8 +667,8 @@ WRITE_LINE_MEMBER(psikyo_state::screen_vblank)
 	// rising edge
 	if (state)
 	{
-		get_sprites();
 		m_spriteram->copy();
+		get_sprites();
 	}
 }
 
@@ -677,7 +677,7 @@ WRITE_LINE_MEMBER(psikyo_state::screen_vblank_bootleg)
 	// rising edge
 	if (state)
 	{
-		get_sprites_bootleg(); // TODO : it's seems differ?
 		m_spriteram->copy();
+		get_sprites_bootleg(); // TODO : it's seems differ?
 	}
 }


### PR DESCRIPTION
Switch position of get_sprites and m_spriteram->copy in psikyo_v. TL;DR: This cuts one frame of input lag.

- Part1: Backstory on why I didn't look for this at first.

Basically I was wrong, in ways that were not completely obvious.

While this code change is trivial, there's some backstory here on why I didn't do it initially in https://github.com/mamedev/mame/commit/b5ead1f823afeead6ac7e66026a3948cd7c3b646

When measuring the input lag on PCBs, I could consistently see the behavior of:
- Input during frame 0
- No output during frame 1-3
- Output during frame 4 ... which does imply that the visible output is seen aprox 4 frame after the initial input, since there will always be 3 full frames rendered with no change. Some examples from pcb:
http://img.buffis.com/psikyo/lag_slow/
http://img.buffis.com/psikyo/lag_fast/

BUT, what actually happens here is that input gets sampled after the VBLANK interrupt between frame0 and frame1. Then three VBLANKs later, between frame 3-4, the graphics buffer is now in VRAM ready to be output line by line during frame 4.

My initial thinking was that I could:
- Pause the game in mame
- Hold an input and step forward frame by frame until output is visible
- This is currently 4 presses, so seemed to me to match pcb

... but since inputs are sampled immediately after the first pause VBLANK, this means that four presses means that one more VBLANK has passed compared to pcb until the VRAM data is ready for output (and rendered).

- Part2: Ok... so what does this change.

Current behavior in mame when drawing frame + VBLANK:
- Render data in m_spritelist
- Call get_sprites to copy data from m_spriteram->buffer to m_spritelist
- Call m_spriteram->copy() to store m_spriteram->live into m_spriteram->buffer

This PR swaps the last two operations here, to immediately have the get_sprites data be put into m_spritelist.

I believe that the original pull request that introduced the additional lag may have been: https://github.com/mamedev/mame/commit/30c92a304e025ea110164e0eceac55acc8608494 which split out the get_sprites from the draw operation, which should have caused one additional frame of lag.