### PR TITLE
MSM5232: Use correct attack/decay time nominal value when certain attack/decay time data is specified

### DIFF
--- a/src/devices/sound/msm5232.cpp
+++ b/src/devices/sound/msm5232.cpp
@@ -251,14 +251,16 @@ void msm5232_device::init_tables()
 	for (i=0; i<8; i++)
 	{
 		double clockscale = (double)m_chip_clock / 2119040.0;
-		m_ar_tbl[i]   = ((1<<i) / clockscale) * (double)R51;
+		int rcp_duty_cycle = 1 << ( i<6 ? i : i-2 );
+		m_ar_tbl[i]   = (rcp_duty_cycle / clockscale) * (double)R51;
 	}
 
 	for (i=0; i<8; i++)
 	{
 		double clockscale = (double)m_chip_clock / 2119040.0;
-		m_dr_tbl[i]   = ((1<<i) / clockscale) * (double)R52;
-		m_dr_tbl[i+8] = ((1<<i) / clockscale) * (double)R53;
+		int rcp_duty_cycle = 1 << ( i<6 ? i : i-2 );
+		m_dr_tbl[i]   = (rcp_duty_cycle / clockscale) * (double)R52;
+		m_dr_tbl[i+8] = (rcp_duty_cycle / clockscale) * (double)R53;
 	}
 
 


### PR DESCRIPTION
MSM5232 determines the attack or decay duration of each note from the lower 3 bits of Attack Time Data(addr $8,$9), or the value specified in the lower 4 bits of Decay Time Data(addr $A,$B).

According to the datasheet, when the lower 3 bits of the Attack/Decay Time Data are 0x6 or 0x7, the second bit is ignored and the value for 0x4 or 0x5 is used.
The current msm5232 emulation implementation does not take this into account.
For example, with 0xE specified in the Decay Time Data, the decay duration of a note should be 4 seconds, but the current implementation decays for 16 seconds.

This commit corrects the Attack/Decay time to be in line with the datasheet when 0x6 or 0x7 is specified for the lower 3 bits of Attack/Decay Time Data.

[5232.pdf](https://github.com/mamedev/mame/files/11324280/5232.pdf)
The attached datasheet is the reference.
It is described on p.15-16, 25.