### PR TITLE
z80.cpp: Fix incorrect cycle counts when custom cycle tables are used.

### DIFF
--- a/hash/msx1_cart.xml
+++ b/hash/msx1_cart.xml
@@ -1317,8 +1317,7 @@ kept for now until finding out what those bytes affect...
 		</part>
 	</software>
 
-	<!-- Software does not start. -->
-	<software name="m36" supported="no">
+	<software name="m36">
 		<description>A Life Planet - M36 - Mother Brain has been aliving (Japan)</description>
 		<year>1987</year>
 		<publisher>Pixel</publisher>

--- a/src/devices/bus/msx/module/skw01.cpp
+++ b/src/devices/bus/msx/module/skw01.cpp
@@ -11,11 +11,6 @@ The PCB is labeled YMX-YWP.
 The software can be started from Basic by entering the command "CALL JWP"
 or "_JWP".
 
-TODO:
-- This module runs unstable on the cx5m128 driver.
-  The instability is mostly visible when pressing F1, causing the system
-  to reset, hang, or display a screen with random data.
-
 **************************************************************************/
 
 #include "emu.h"

--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -3834,7 +3834,8 @@ z80_device::z80_device(const machine_config &mconfig, device_type type, const ch
 	m_irqack_cb(*this),
 	m_refresh_cb(*this),
 	m_nomreq_cb(*this),
-	m_halt_cb(*this)
+	m_halt_cb(*this),
+	m_mtm_cycles(3)
 {
 }
 

--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -340,7 +340,7 @@ static const uint8_t cc_ex[0x100] = {
 } while (0)
 
 // T Memory Address
-#define MTM ((m_cc_op == nullptr ? 4 : m_cc_op[0])-1)
+#define MTM (m_mtm_cycles)
 
 #define EXEC(prefix,opcode) do { \
 	unsigned op = opcode; \
@@ -3811,6 +3811,12 @@ void z80_device::z80_set_cycle_tables(const uint8_t *op, const uint8_t *cb, cons
 	m_cc_xy = (xy != nullptr) ? xy : cc_xy;
 	m_cc_xycb = (xycb != nullptr) ? xycb : cc_xycb;
 	m_cc_ex = (ex != nullptr) ? ex : cc_ex;
+}
+
+
+void z80_device::set_mtm_cycles(uint8_t mtm_cycles)
+{
+	m_mtm_cycles = mtm_cycles;
 }
 
 

--- a/src/devices/cpu/z80/z80.h
+++ b/src/devices/cpu/z80/z80.h
@@ -33,6 +33,7 @@ public:
 	z80_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	void z80_set_cycle_tables(const uint8_t *op, const uint8_t *cb, const uint8_t *ed, const uint8_t *xy, const uint8_t *xycb, const uint8_t *ex);
+	void set_mtm_cycles(uint8_t mtm_cycles);
 	template <typename... T> void set_memory_map(T &&... args) { set_addrmap(AS_PROGRAM, std::forward<T>(args)...); }
 	template <typename... T> void set_m1_map(T &&... args) { set_addrmap(AS_OPCODES, std::forward<T>(args)...); }
 	template <typename... T> void set_io_map(T &&... args) { set_addrmap(AS_IO, std::forward<T>(args)...); }
@@ -291,6 +292,7 @@ protected:
 	const uint8_t *   m_cc_xy;
 	const uint8_t *   m_cc_xycb;
 	const uint8_t *   m_cc_ex;
+	uint8_t           m_mtm_cycles = 3;
 };
 
 DECLARE_DEVICE_TYPE(Z80, z80_device)

--- a/src/devices/cpu/z80/z80.h
+++ b/src/devices/cpu/z80/z80.h
@@ -292,7 +292,7 @@ protected:
 	const uint8_t *   m_cc_xy;
 	const uint8_t *   m_cc_xycb;
 	const uint8_t *   m_cc_ex;
-	uint8_t           m_mtm_cycles = 3;
+	uint8_t           m_mtm_cycles;
 };
 
 DECLARE_DEVICE_TYPE(Z80, z80_device)

--- a/src/mame/sega/system1.cpp
+++ b/src/mame/sega/system1.cpp
@@ -469,6 +469,7 @@ void system1_state::machine_start()
 	}
 
 	m_maincpu->z80_set_cycle_tables(cc_op, cc_cb, cc_ed, cc_xy, cc_xycb, cc_ex);
+	m_maincpu->set_mtm_cycles(3*5);
 
 	m_mute_xor = 0x00;
 	m_dakkochn_mux_data = 0x00;


### PR DESCRIPTION
z80.cpp: Fix incorrect cycle counts when custom cycle tables are used.

Software list items promoted to working
---------------------------------------
msx1_cart.xml:
A Life Planet - M36 - Mother Brain has been aliving (Japan)
