### PR TITLE
atari/pong.cpp: Note about an orange overlay in Rebound

### DIFF
--- a/src/mame/atari/pong.cpp
+++ b/src/mame/atari/pong.cpp
@@ -36,7 +36,7 @@ Notes:
 TODO: Please see netlist include files
 TODO: Breakout Cocktail and Consolette are believed to use the Breakout PCB with different
       cabinet designs, this needs to be verified.
-TODO: Rebound is also known to have an orange overlay.
+TODO: Rebound is known to have an orange overlay.
 TODO: Coupe Davis is believed to use the Pong Doubles PCB, just a different cabinet design,
       this needs to be verified.
 TODO: Dr. Pong, Pong In-A-Barrel, Puppy Pong, Snoopy Pong, and Cocktail Pong are all

--- a/src/mame/atari/pong.cpp
+++ b/src/mame/atari/pong.cpp
@@ -36,7 +36,7 @@ Notes:
 TODO: Please see netlist include files
 TODO: Breakout Cocktail and Consolette are believed to use the Breakout PCB with different
       cabinet designs, this needs to be verified.
-TODO: Breakout is also known to have an orange overlay.
+TODO: Rebound is also known to have an orange overlay.
 TODO: Coupe Davis is believed to use the Pong Doubles PCB, just a different cabinet design,
       this needs to be verified.
 TODO: Dr. Pong, Pong In-A-Barrel, Puppy Pong, Snoopy Pong, and Cocktail Pong are all

--- a/src/mame/atari/pong.cpp
+++ b/src/mame/atari/pong.cpp
@@ -36,6 +36,7 @@ Notes:
 TODO: Please see netlist include files
 TODO: Breakout Cocktail and Consolette are believed to use the Breakout PCB with different
       cabinet designs, this needs to be verified.
+TODO: Breakout is also known to have an orange overlay.
 TODO: Coupe Davis is believed to use the Pong Doubles PCB, just a different cabinet design,
       this needs to be verified.
 TODO: Dr. Pong, Pong In-A-Barrel, Puppy Pong, Snoopy Pong, and Cocktail Pong are all


### PR DESCRIPTION
Seen some images where an orange overlay exists for Rebound.

![image](https://user-images.githubusercontent.com/95501796/236072364-79a6c541-2575-47d1-8718-8f61bdf283d2.png)
![image](https://user-images.githubusercontent.com/95501796/236072399-96dff372-7f4c-4d82-848f-827a10ff8347.png)
