### PR TITLE
taito/taito_f3_v.cpp: fix vram wrap width (bubble symphony platforms)

### DIFF
--- a/src/mame/taito/taito_f3_v.cpp
+++ b/src/mame/taito/taito_f3_v.cpp
@@ -1920,7 +1920,7 @@ void taito_f3_state::get_vram_info(tilemap_t *vram_tilemap, tilemap_t *pixel_til
 
 	u16 pri = 0;
 
-	const int vram_width_mask = 0x3ff;
+	const int vram_width_mask = 0x1ff;
 
 	if (m_flipscreen)
 	{


### PR DESCRIPTION
correct a mistake introduced in 819a5c4