### PR TITLE
Hash updates to softlist chds for dreamcast, psx, and sega/mega cd

### DIFF
--- a/hash/dc.xml
+++ b/hash/dc.xml
@@ -458,7 +458,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="0 31719 20990 3"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="4 wheel thunder (usa)" sha1="023e6d8c232ae0ef22b0315ff7a8f14ad5f686fc"/>
+				<disk name="4 wheel thunder (usa)" sha1="4852db60cda2b22a15e11dce047a1d080b629e72"/>
 			</diskarea>
 		</part>
 	</software>
@@ -530,7 +530,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="6 63593 12014 4"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="4x4 evo (usa)" sha1="fc8c5e09e1f6902a52fc79ae54392d700be6fdad"/>
+				<disk name="4x4 evo (usa)" sha1="2ade88e88f99c27362b68608d2983729994cf0b8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -592,7 +592,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="0 10086 51064 5"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="18 wheeler american pro trucker (usa)" sha1="c03adc04607282f755d10abb9b69975b74b25869"/>
+				<disk name="18 wheeler american pro trucker (usa)" sha1="59b96c6f851e9698ae920d80e7ba88ba02eabe8c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -636,7 +636,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;HDR-0080-0529&gt;HK919C"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="18 wheeler american pro trucker (jpn)" sha1="a385da8a0d05c8df88774f8f4417342d126f40b8"/>
+				<disk name="18 wheeler american pro trucker (jpn)" sha1="c874cd4c18f709d737702d5d48e566dd9aa26a0a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -700,7 +700,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 560101 361036"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="21 two one (jpn)" sha1="46468591b751dab05b8fcc92e8d02959b3b11d9c"/>
+				<disk name="21 two one (jpn)" sha1="68fde82b29cf1d12f169240910290bece4aa25dd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -721,7 +721,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="MK-51190-0478SS EMI CD HOLLAND   @ 2"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="90 minutes sega championship football (euro)" sha1="295606d64f2700d497b640df7d6d56beb6fc4889"/>
+				<disk name="90 minutes sega championship football (euro)" sha1="7b08c41c6313df96e7a1ca0a662e9133af5cf187"/>
 			</diskarea>
 		</part>
 	</software>
@@ -770,7 +770,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 501587"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="advanced daisenryaku 2001 (jpn)" sha1="6a5aad10b604951e8ad1506d1c0e97fb3d4070df"/>
+				<disk name="advanced daisenryaku 2001 (jpn)" sha1="d7e78aec9e907a84866ddd8e570f251842b0319b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -796,7 +796,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 500665"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="advanced daisenryaku sturm uber europa - der deutsche blitzkrieg (jpn)" sha1="665a179438e4da74267acfc5e808bfbf883ad124"/>
+				<disk name="advanced daisenryaku sturm uber europa - der deutsche blitzkrieg (jpn)" sha1="34b0f9b0a12b8ec6cd37956d7f760d9c92535cfd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -820,7 +820,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 208605"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing i (jpn)" sha1="afa616065462af5ad362b0599c320d82a2e27b42"/>
+				<disk name="aero dancing i (jpn)" sha1="89bc7b2a8102bf00ec2b7915446f7e4093f91f7b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -844,7 +844,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 209008"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing i jikai-saku made matemasen (jpn)" sha1="a06d7f06ba0b94785ea40cbd29119ba1061a738f"/>
+				<disk name="aero dancing i jikai-saku made matemasen (jpn)" sha1="b8b7885b1a970b3e5f9856d2207d8325af3cd0a6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -865,7 +865,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="6 50008 79913 2"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aerowings (usa)" sha1="73094cec1b4bd3b264832d7400d85a381471acda"/>
+				<disk name="aerowings (usa)" sha1="f97ef130e0e6d20ff686176981019503bab1bf0f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -931,7 +931,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 208209"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing todoroki taichou no himitsu disc (jpn)" sha1="1006fbc3b55c5dca5aa1dba71d926ac59564b275"/>
+				<disk name="aero dancing todoroki taichou no himitsu disc (jpn)" sha1="0b2cfcad53608c399e854b38d4143430483e653e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -967,7 +967,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="6 50008 79921 7"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aerowings 2 airstrike (usa)" sha1="2cb80043518a27527432799636f1ad1ff451d472"/>
+				<disk name="aerowings 2 airstrike (usa)" sha1="c4d6c0467a42e78ba10f1d37dc86e6b6eaaa5d0a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1077,7 +1077,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 208407"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing f todoroki tsubasa no hatsu hikou (jpn)" sha1="61d31e4edb69f054693d42b176b1917beeec659b"/>
+				<disk name="aero dancing f todoroki tsubasa no hatsu hikou (jpn)" sha1="f8cd4b0de87c4e786097fa10481922a6d37a8460"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1143,7 +1143,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="After...: Wasureenu Kizuna"/>
 			<diskarea name="cdrom">
-				<disk name="after... wasureenu kizuna (jpn)" sha1="4ca05216dd45b9a5218186e7c2c0b5cd0be76d13"/>
+				<disk name="after... wasureenu kizuna (jpn)" sha1="7a0996757c21bcaafd830a5faae235b069c8e72d"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -1193,7 +1193,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 513244 900884"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aikagi hidamari to kanojo no heyagi (jpn)" sha1="13e335cf3ed86fbdbcbac4f3f59c1d05c1056a84"/>
+				<disk name="aikagi hidamari to kanojo no heyagi (jpn)" sha1="d803288952774eaba27a81394400b68164a9f907"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1214,7 +1214,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-20112M-0752A   10MM1   C   19, T-20112M-0752A   11M4   C   19, T-20112M-0752A   12M1   C   19"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="air (jpn, rev. a)" sha1="7e17b8331ac245ee22e9150922058cee580ff113"/>
+				<disk name="air (jpn, rev. a)" sha1="4144ef52ba7ddca4e937f6529913e30a468b4492"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1673,10 +1673,10 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<!--
 		<rom name="ALIENFRONT_ONLINE.gdi" size="143" md5="0a3db521ea34e40a63967a0108d4bc78" sha1="397340cf23de1f66776741a3b9da8914c9b48203"/>
 		<rom name="track01.iso" size="921600" md5="98de8e5db931c9106cbf5c53b75f7cc7" sha1="5e23b9e4a63d4720e114bc777640bd65f0edca9b"/>
-		<rom name="track02.raw" size="13 994 400" md5="a55424800b9a45851b3670fa8afbf6a9" sha1="6cd6c33fc86f008d87f9d4385371e5df684c4c60"/>
-		<rom name="track03.iso" size="876 550 144" md5="17f9a991a2b7758f5ae1b2c2a08adb65" sha1="e99bcff45222f59148463dab5833ddf5e8aa93bd"/>
-		<rom name="track04.raw" size="13 818 000" md5="52d4f2952f4aca03f15d23825f5609b0" sha1="b00cc2ffa6abbd0908675ced977586fd9111d881"/>
-		<rom name="track05.iso" size="143 302 656" md5="d4ca27065a01df92300d240093d61ff5" sha1="2db3177f076caaa5e779a70f1ba546ac1b709e26"/>
+		<rom name="track02.raw" size="13994400" md5="a55424800b9a45851b3670fa8afbf6a9" sha1="6cd6c33fc86f008d87f9d4385371e5df684c4c60"/>
+		<rom name="track03.iso" size="876550144" md5="17f9a991a2b7758f5ae1b2c2a08adb65" sha1="e99bcff45222f59148463dab5833ddf5e8aa93bd"/>
+		<rom name="track04.raw" size="13818000" md5="52d4f2952f4aca03f15d23825f5609b0" sha1="b00cc2ffa6abbd0908675ced977586fd9111d881"/>
+		<rom name="track05.iso" size="143302656" md5="d4ca27065a01df92300d240093d61ff5" sha1="2db3177f076caaa5e779a70f1ba546ac1b709e26"/>
 		-->
 		<description>Alien Front Online (USA, prototype 20010625)</description>
 		<year>2001</year>
@@ -1902,7 +1902,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 988658 041148"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="angel wish kimi no egao ni chu (jpn)" sha1="65c1da4807da03a1600219f5d90d8b725d190e98"/>
+				<disk name="angel wish kimi no egao ni chu (jpn)" sha1="9979bec207a0fbb9d1e1240ff2d569dc908677cd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2136,7 +2136,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 501211"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="atsumare guru guru onsen bb (jpn)" sha1="d03900d542524f937ac8ab4d7e9a9b60063f7c49"/>
+				<disk name="atsumare guru guru onsen bb (jpn)" sha1="f882d15f60efe7c658e7ba2756c720efec4249af"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2409,7 +2409,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 959359 009010"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="bass rush dream ecogear powerworm championship (jpn)" sha1="5600ccd51aaa3e2417ea51980a0033cc54b55350"/>
+				<disk name="bass rush dream ecogear powerworm championship (jpn)" sha1="94b6e4e503066f9412b939de4816afd2b5898fa9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2431,7 +2431,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 541823 000014"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle beaster (jpn)" sha1="9df8e6349fda2fe264f0f0536b38f77296ace077"/>
+				<disk name="battle beaster (jpn)" sha1="11ff4bbb2cd5f47e50ee7e7a64eb6978ad347c6e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3103,7 +3103,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Blue-Sky-Blue[s]: Sora o Mau Tsubasa"/>
 			<diskarea name="cdrom">
-				<disk name="blue-sky-blue[s] sora o mau tsubasa (jpn)" sha1="1b6db61f78b11afc250aac17f5ad4cfa651c9e19"/>
+				<disk name="blue-sky-blue[s] sora o mau tsubasa (jpn)" sha1="2959be03664d42eebcb1692337ea6b2e93bfb9fb"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -3131,7 +3131,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 995161 013104"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="bokomu no tatsujin (jpn)" sha1="f702c8b81c69c7212a22e0b428f7c7f2e087f56d"/>
+				<disk name="bokomu no tatsujin (jpn)" sha1="b74abada79deadb627f05b50ec7e15a9b3f0c0cc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3156,7 +3156,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 979750 891021"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="boku doraemon (jpn)" sha1="1638034edd680f6a073a97bcd220b6f2dd356ecc"/>
+				<disk name="boku doraemon (jpn)" sha1="934fae7912ab6ff035fc40b33a191f22dfc86eec"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3201,7 +3201,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 528311 000022"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="boku no tennis jinsei (jpn)" sha1="31828b64c80c1b1c7632c35c0203b48b391904c5"/>
+				<disk name="boku no tennis jinsei (jpn)" sha1="4153be8019da5c56a5b3dd272be301350375b819"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3223,7 +3223,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-19717M-0855   1MM1   C   28"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="boku to, bokura no natsu (jpn)" sha1="52b64f02d20b31a3eaec988337548733639e3199"/>
+				<disk name="boku to, bokura no natsu (jpn)" sha1="7ea6ab499462b72bd9ac072070eec3b181527b99"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3244,7 +3244,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-42903M-0774   1MM1   C   1X"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="bomber hehhe (jpn)" sha1="73e7be4dc7ea5a8ee965cc7b265122aecf0bc630"/>
+				<disk name="bomber hehhe (jpn)" sha1="4d7898bc1f25ec339b08f3bd5ba0260dbc2a4fda"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3712,7 +3712,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-46513M-0877&gt;HN412A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cafe little wish (jpn)" sha1="117edcda020625b9e0e91b0c099eab704d5cd0a9"/>
+				<disk name="cafe little wish (jpn)" sha1="d2b3533c731c4c154a53a3f1cff9c795fec9552c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4067,7 +4067,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Card of Destiny: Hikari to Yami no Tougousha"/>
 			<diskarea name="cdrom">
-				<disk name="card of destiny hikari to yami no tougousha - genteiban (jpn)" sha1="79a8dccf13f16beaa3b6293672c08d90d0c5f64e"/>
+				<disk name="card of destiny hikari to yami no tougousha - genteiban (jpn)" sha1="0bafa0d05b50037cc5da023c0db6ed768de2c475"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -4237,7 +4237,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46901M-0807   1MM1   C   24"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="castle fantasia seima taisen (jpn)" sha1="e0702100801e79e1b039b44c6d604d89ec1849b5"/>
+				<disk name="castle fantasia seima taisen (jpn)" sha1="0903f283296b8ff60b722e753145be313c0cedb3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4571,7 +4571,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-37912M-0913   1MS1   C   43"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cherry blossom (jpn)" sha1="0d6e60904f091dc3cba5bf72e4dc0073b66f1564"/>
+				<disk name="cherry blossom (jpn)" sha1="9969ae4c62c048fc6d8c2b6c786f673716338cf5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4686,7 +4686,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-47107M-0904   3MS1   C   3Z"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="chocolat maid cafe curio (jpn)" sha1="92ddb0d5acf83f3fb6bec362b19082f807f13fe6"/>
+				<disk name="chocolat maid cafe curio (jpn)" sha1="0469b9ffc5202fa5ffa6d94abbbaff5341f16c66"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4823,13 +4823,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Message Disc"/>
 			<diskarea name="cdrom">
-				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - message kit (jpn) (message disc)" sha1="044e7326bfaa8d676541a783cd4ca2484108ed85"/>
+				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - message kit (jpn) (message disc)" sha1="fb4a61854adf81ee83008aeb4dd172121e661a31"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Present Disc"/>
 			<diskarea name="cdrom">
-				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="d04cb12d5dd9b674688b665084944851cbe68bf9"/>
+				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="7bcaa8d42df6e7920cbbb64fdcf95f7c7b6865df"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4850,7 +4850,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-39404M-0241   2M1   C   9Z"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="d04cb12d5dd9b674688b665084944851cbe68bf9"/>
+				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="7bcaa8d42df6e7920cbbb64fdcf95f7c7b6865df"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5294,13 +5294,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="comic party (jpn) (disc 1)" sha1="4a26b68634360f6ec4c39763e1ec3aef1d46dff9"/>
+				<disk name="comic party (jpn) (disc 1)" sha1="8710002d130ef4e3fa4d10b645003075e3bacdb4"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="comic party (jpn) (disc 2)" sha1="2b43c0f46256eaa5d9709985d79cffc90c594b9e"/>
+				<disk name="comic party (jpn) (disc 2)" sha1="2d9cd2bbb7e52d09b3276c633230395457df483e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5361,7 +5361,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;HDR-0160-0695&gt;HL425A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="confidential mission (jpn)" sha1="be5a2cc59ee335b29821607c617c19ade454fcea"/>
+				<disk name="confidential mission (jpn)" sha1="dd7652f2efdf6144d6e872e0f2d08a5a19ae4144"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5468,7 +5468,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-3106M-0437   1M1   C   06"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool cool toon (jpn)" sha1="77e8df8a4136d8be06dc63f0ce596d629557710f"/>
+				<disk name="cool cool toon (jpn)" sha1="77905a50ab7b98ab69855f512147ca065a241500"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5541,7 +5541,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-45801M-0737&gt;HL710C"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cr hissatsu shigotonin pachitte chonmage vpachi (jpn)" sha1="893801607b6e2f91137e626924ae706dcafe6931"/>
+				<disk name="cr hissatsu shigotonin pachitte chonmage vpachi (jpn)" sha1="0313fde372d8718b16fc158732fad3cc3a0e5a52"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5950,7 +5950,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="D+Vine [Luv]"/>
 			<diskarea name="cdrom">
-				<disk name="d+vine [luv] - shokai genteiban (jpn)" sha1="a55d24f09e8d191a8671fd1fcb63fc2e5c1ceb9c"/>
+				<disk name="d+vine [luv] - shokai genteiban (jpn)" sha1="57c9224d5598180a95b9267922e6f284774eada5"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -7226,7 +7226,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-40801M-0206&gt;HJA30A, &lt;T-40801M-0206&gt;HL712A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="dengen tenshi taisen mahjong shangri-la (jpn)" sha1="da7ca58149c1c2ac838e28d8c319e0b2ac21ec5e"/>
+				<disk name="dengen tenshi taisen mahjong shangri-la (jpn)" sha1="54ed775c45303731b083ed527ba5920b7c4b3583"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7285,7 +7285,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-1102M-0255&gt;HJC18D"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="densha de go 2 kousoku-hen 3000 bandai (jpn)" sha1="9728cf52bb82a33812898c27cf9d96410175f9d4"/>
+				<disk name="densha de go 2 kousoku-hen 3000 bandai (jpn)" sha1="a3bc9e59efa6567d302f926644d4870cde2cc2dd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7397,7 +7397,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46302M-0753 MT   B04"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="di gi charat fantasy (jpn)" sha1="20c245d693f0d4701be99d71ea164d0cf0468539"/>
+				<disk name="di gi charat fantasy (jpn)" sha1="79a22372a1d8441dfe16a80c6ea86bfaa89f12b7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7432,7 +7432,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Di Gi Charat Fantasy"/>
 			<diskarea name="cdrom">
-				<disk name="di gi charat fantasy (jpn)" sha1="20c245d693f0d4701be99d71ea164d0cf0468539"/>
+				<disk name="di gi charat fantasy (jpn)" sha1="79a22372a1d8441dfe16a80c6ea86bfaa89f12b7"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -8017,7 +8017,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46701M-0798   2M1   C   1Z"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="doki doki idol star seeker remix (jpn)" sha1="7f23fb341aa35695fdd5208f4b4bb8395b08224d"/>
+				<disk name="doki doki idol star seeker remix (jpn)" sha1="bd589bc417fc2cd8f19180a4111a1e27856a1525"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11352,7 +11352,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-9503M-0080 MT   B01"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="eisei meijin iii game creator yoshimura nobuhiro no zunou (jpn)" sha1="3d8f2e655829790ee2cf83f252c9d05257234fb4"/>
+				<disk name="eisei meijin iii game creator yoshimura nobuhiro no zunou (jpn)" sha1="c35585083c71fa8f12fc16afbecf31ffc3a47456"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11516,7 +11516,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 976219 555500"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="eldorado gate dai-7-kan (jpn)" sha1="f21855a78f2511c2faa4c679bd3d9b031d896654"/>
+				<disk name="eldorado gate dai-7-kan (jpn)" sha1="8e624fa15e7ae9e8adc75681da07f41b7137c455"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11576,7 +11576,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-20116M-0839&gt;HM707B"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="elysion eien no sanctuary (jpn)" sha1="ec02aba1dd210bc39c6e94926cbb091fbadfdcb2"/>
+				<disk name="elysion eien no sanctuary (jpn)" sha1="4440564fd55c7845f30bde7c462f44bea6b8d3a7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11598,7 +11598,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 933516 306273"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="erde nezu no ki no shita de (jpn)" sha1="e12bc896c2fc1f7d1bae56e5e28f89734edfb2d7"/>
+				<disk name="erde nezu no ki no shita de (jpn)" sha1="b0d35dc9a1f4ac1bfd7284f55248a73f40eba6a7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11631,19 +11631,19 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="es (jpn) (disc 1)" sha1="6715ff835ceb413c4b52609e078fac1401c69e93"/>
+				<disk name="es (jpn) (disc 1)" sha1="8c9bd2032470d1f50c63c3e14f5f182458619c7a"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="es (jpn) (disc 2)" sha1="b0d04e113e15db3b76f5ad78f712ac85ba10a980"/>
+				<disk name="es (jpn) (disc 2)" sha1="2b853f187c1c918ee629388d2bb10112c31c2ff4"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom3">
 			<feature name="part_id" value="Disc 3"/>
 			<diskarea name="cdrom">
-				<disk name="es (jpn) (disc 3)" sha1="5f01bb4d23c2f95e2064b91917ffbf5db31e02b7"/>
+				<disk name="es (jpn) (disc 3)" sha1="4f2e75f95c1260f3001bbc1f700865f45eb5390f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11784,13 +11784,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 1)" sha1="5cebcca9f26156e1309be7184cfd1dac7c0d664f"/>
+				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 1)" sha1="4516f8a68cd03109c0176ca337ca7b3ed5cdbb52"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 2)" sha1="a5dc69f88b42e53ef7f64ec60d5cd14816a6ba31"/>
+				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 2)" sha1="a703d033949f833c228c508a556a74a28d7e7f21"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11812,7 +11812,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 933516 206160"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="ever 17 the out of infinity (jpn)" sha1="0f73c51638e72f419ca1a52ca258297c57801499"/>
+				<disk name="ever 17 the out of infinity (jpn)" sha1="3fc448657d87294f21ae52fdb60054c6f75060a4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12078,7 +12078,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-44404M-0684   1M1   C   15"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="exodus guilty neos (jpn)" sha1="3d296c323a04fe6d2a4e87ccb89e8e9f462db045"/>
+				<disk name="exodus guilty neos (jpn)" sha1="7183ce6a92cb39dbdb090a8c06c006b4d19b49f8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12930,7 +12930,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="*12S*   T-36801NA   B"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fighting force 2 (usa, alt 2)" sha1="7814c912238861742b2375d25017ee0cc6d76d81"/>
+				<disk name="fighting force 2 (usa, alt 2)" sha1="ed7852cac7328ed43fb96d8942f76646184fbf7e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13139,7 +13139,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 940261 502461"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fire pro wrestling d (jpn)" sha1="cc87da492ad9339b1e76eb8fd52d1fc846fc1e8a"/>
+				<disk name="fire pro wrestling d (jpn)" sha1="3018edeaeb29e75a7c8cc832e08c4ea08934a6b0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13169,13 +13169,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="fb04ed48d61fe558335df7631149c99c1654a670"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="1b4b691ef7d3c0e1c048eaefaa8ba70d5a957341"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="2fdbc76f083c0d1a58e15b8224ba62f4e8a21d89"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="ccd40b88896b0c0497ab15185b0a0d2aff414d51"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13220,25 +13220,25 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="First Kiss Story II: Anata ga Iru kara - Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="fb04ed48d61fe558335df7631149c99c1654a670"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="1b4b691ef7d3c0e1c048eaefaa8ba70d5a957341"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="First Kiss Story II: Anata ga Iru kara - Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="2fdbc76f083c0d1a58e15b8224ba62f4e8a21d89"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="ccd40b88896b0c0497ab15185b0a0d2aff414d51"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom3">
 			<feature name="part_id" value="First Kiss Story - Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story (jpn) (disc 1)" sha1="12c0921eecbf28c00b1e9b35b1a132250c786d55"/>
+				<disk name="first kiss story (jpn) (disc 1)" sha1="ea75b417abf8e64e83a63281201ba6799bd0a52d"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom4">
 			<feature name="part_id" value="First Kiss Story - Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story (jpn) (disc 2)" sha1="25c02a1de0790767237920e2b8b9ae31d257ad46"/>
+				<disk name="first kiss story (jpn) (disc 2)" sha1="356f27f8e85cf931e2eaba2f1093a3a6e47d261a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13482,7 +13482,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 520644 020043"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fragrance tale (jpn)" sha1="a6061b180e70725d3d44c8a63ca8f7c5b0948238"/>
+				<disk name="fragrance tale (jpn)" sha1="c9698934858848c6bbdb4038de2e301247bb59df"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13709,7 +13709,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="HDR-0187-0794 1M1 C 21, HDR-0187-0794 1MM1 C 21"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fushigi no dungeon fuurai no shiren gaiden onnakenshi asuka kenzan (jpn)" sha1="82fdc8677f6b24e4c75ff5191fbce47b820dc30b"/>
+				<disk name="fushigi no dungeon fuurai no shiren gaiden onnakenshi asuka kenzan (jpn)" sha1="1fc5129168a5af516e47926f1a54138854351503"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14704,7 +14704,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 500047"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="godzilla generations (jpn)" sha1="562f2a2c8e77f9e89b09a4f497f04c386fc169e5"/>
+				<disk name="godzilla generations (jpn)" sha1="7cdf962b7038a7878ef027162d24aaf5ef4021ce"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14746,7 +14746,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 540129 000018"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="golem no maigo (jpn)" sha1="6b28518eaca82598ee5f9801d67ec0e4eb3d19dd"/>
+				<disk name="golem no maigo (jpn)" sha1="f30afafc87c37940c95a9b68f44f8d4eebe02ad2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15368,7 +15368,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-2402M-0562A   10M2   C   0Y"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="guilty gear x (jpn)" sha1="6f2d7b2da9300e3db6cf9a4921af8dca728b3679"/>
+				<disk name="guilty gear x (jpn)" sha1="e454ea7eb4988aaaf5dc4ed2374e2410a58ec811"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15613,7 +15613,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-13303M-0250   3MM1   C   9Y"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kidou senshi gundam gaiden colony no ochita chi de... - tokubetsuban (jpn)" sha1="64b3fbf8cd6012f6ed28fd8a4d0928f9025b945b"/>
+				<disk name="kidou senshi gundam gaiden colony no ochita chi de... - tokubetsuban (jpn)" sha1="7d10000af76100b944407a67f79f3bddb58472b4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15807,7 +15807,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-46512M-0870&gt;HN202A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="happy breeding (jpn)" sha1="a6a9dba133f5e8717fd2d2fcde80605025ed128e"/>
+				<disk name="happy breeding (jpn)" sha1="b1defc4ad6b1f7a0e6324680b6ada70c4a619eda"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15869,7 +15869,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-20106M-0655 3"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="harusame youbi (jpn)" sha1="44b5c1359a672e59cac6cbb9a758e8eae0c001b2"/>
+				<disk name="harusame youbi (jpn)" sha1="0c2821d1cc3171117086ee217683ebde74815cb7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16012,7 +16012,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-2202M-0540   2MM1   C   09"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="heisei mahjong-sou (jpn)" sha1="501b56e244082e5cf43efdce3800b9c8cf910f58"/>
+				<disk name="heisei mahjong-sou (jpn)" sha1="9d3e78cb07831da6bb183b37ed55749e58052296"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16056,7 +16056,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="610-7381-0209 1"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="hello kitty no garden panic (jpn)" sha1="a7bd2309fb7c3a1a726e6600a87913260545ac90"/>
+				<disk name="hello kitty no garden panic (jpn)" sha1="2bd64a0f0a8acdbdb4abaa6cb5c9788a1bb721ba"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16232,7 +16232,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46101M-0730 1"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="himitsu yui ga ita natsu (jpn)" sha1="a0ed3fbac2dd23c6038165d9238e091705f822c2"/>
+				<disk name="himitsu yui ga ita natsu (jpn)" sha1="e066d34d072ce2d8f41bcfdfd30c24a029986944"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16617,7 +16617,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-5703M-0150   1M1   C   98"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="idol janshi o tsukucchaou (jpn)" sha1="f31ee28505fdd303caead1160915dc11ee712ca4"/>
+				<disk name="idol janshi o tsukucchaou (jpn)" sha1="a388bc1b87f905c316662a1c8f78543bd50c1dc9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16701,7 +16701,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-45601M-0658   1M2   C   13"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="illbleed (jpn)" sha1="cb6c69e42599a9526e41e78876a8acf9d50cdff8"/>
+				<disk name="illbleed (jpn)" sha1="4def52884214c334074bbad6ac9a96f14acc4f85"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16975,7 +16975,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-19506M-0779&gt;HLA12A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="inoue ryouko last scene (jpn)" sha1="23423fbfae0e2274d158f20495ebcfc8453869e1"/>
+				<disk name="inoue ryouko last scene (jpn)" sha1="3a465b82c2c94cc6e93f904a08ffae6cd646b8f0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17014,7 +17014,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-20117M-0874&gt;HN316D"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="interlude (jpn)" sha1="f0602aa16434efd302ab92ee2f7bc2700073dc96"/>
+				<disk name="interlude (jpn)" sha1="81b7e9419a0cb394ba3adc9dc1b87645ff337c1c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17088,7 +17088,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-19722M-0891 MT   B03"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="iris (jpn)" sha1="ca801678eb8ccffc1b6aa9c0713f5d575491304d"/>
+				<disk name="iris (jpn)" sha1="6a8f7ae5cbb51a4649d695fe076c7354b2a091ac"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17207,7 +17207,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="HDR-0028-0165   1M1   C   99, HDR-0028-0165   3M3   C   99"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="j.league pro soccer club o tsukurou (jpn)" sha1="e412efe15d1a924cc3389ab7e7da2bf8f567db56"/>
+				<disk name="j.league pro soccer club o tsukurou (jpn)" sha1="301d48ae9453f59cae5ba14610da7bf1997b4fde"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17234,7 +17234,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-43401M-0462&gt;HK711H"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="jahmong (jpn)" sha1="bb96e19026ebf3e12f212c2bbd3c3a95610eec25"/>
+				<disk name="jahmong (jpn)" sha1="f48495ede4aa81aad5904b8c6bb24e05223ff7dd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17367,7 +17367,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-41201M-0531&gt;HKA02A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet coaster dream 2 (jpn)" sha1="8858b6252cdc67600ab26a6b9a12767726b5bd17"/>
+				<disk name="jet coaster dream 2 (jpn)" sha1="3181d15a34b34584cdc48a7647ce5a32652f4424"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17859,13 +17859,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 1)" sha1="585635db615d091f6cce5c7156e475e1f7e92daf"/>
+				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 1)" sha1="486fa13f2cc89b494b59c7e501814d5e3093c04c"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 2)" sha1="7a07dfcde19ecdaf4ead28b5afa9f01468aac576"/>
+				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 2)" sha1="ae9bcd48abe94cc6f79887cecfd4a367a8ed5699"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17909,7 +17909,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-20105M-0486&gt;HL516C"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kanon (jpn)" sha1="4c915bc782f743c6f87812041c9baccb0e947825"/>
+				<disk name="kanon (jpn)" sha1="81f49e0823557f91ea98e312304c05c5691931d5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18128,7 +18128,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Kaze no Uta"/>
 			<diskarea name="cdrom">
-				<disk name="kaze no uta (jpn)" sha1="96f44ea17e9de2d47061737f7528a7064fc530c2"/>
+				<disk name="kaze no uta (jpn)" sha1="279a9d2dfd1526e4b224203184275396647ab937"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
@@ -18159,7 +18159,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="T4997766300085"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kidou senkan nadesico nadesico the mission (jpn)" sha1="21dda612cdc3ee96cd9baea01054b167665920f3"/>
+				<disk name="kidou senkan nadesico nadesico the mission (jpn)" sha1="c7aa3b1016252a124a9b6d9d45f78e42e05192ea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18281,7 +18281,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 519898 002240"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kimi ga nozomu eien (jpn)" sha1="5c2afe4fa9eea00a0e1f503bd1a328f9ce627c9c"/>
+				<disk name="kimi ga nozomu eien (jpn)" sha1="7622b56158e60972f5ea2b6f82142a9a6c0054f9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18416,7 +18416,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-14301M-0057A   2M1   C   93"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kita e. white illumination (jpn)" sha1="e389aff777840f4bf82f26573fefff2434b8867a"/>
+				<disk name="kita e. white illumination (jpn)" sha1="acb35e852a28693580ef0380123a29acc7e6b88e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19125,7 +19125,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="HDR-0139-0645   2M1   C   12"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="love hina smile again (jpn)" sha1="31d6be18dad7207813b905ca422714e78b3c8b21"/>
+				<disk name="love hina smile again (jpn)" sha1="63af4720ff7fcaa14d48a47958eb3c11c167dd84"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/dc.xml
+++ b/hash/dc.xml
@@ -250,6 +250,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 
 197***       : All Brazilian games' serials start with 197.
 -->
+
 <softwarelist name="dc" description="Sega Dreamcast GD-ROMs">
 
 	<!-- DEVBOX SOFTWARE -->
@@ -457,7 +458,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="0 31719 20990 3"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="4 wheel thunder (usa)" sha1="4852db60cda2b22a15e11dce047a1d080b629e72"/>
+				<disk name="4 wheel thunder (usa)" sha1="023e6d8c232ae0ef22b0315ff7a8f14ad5f686fc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -529,7 +530,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="6 63593 12014 4"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="4x4 evo (usa)" sha1="2ade88e88f99c27362b68608d2983729994cf0b8"/>
+				<disk name="4x4 evo (usa)" sha1="fc8c5e09e1f6902a52fc79ae54392d700be6fdad"/>
 			</diskarea>
 		</part>
 	</software>
@@ -591,7 +592,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="0 10086 51064 5"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="18 wheeler american pro trucker (usa)" sha1="59b96c6f851e9698ae920d80e7ba88ba02eabe8c"/>
+				<disk name="18 wheeler american pro trucker (usa)" sha1="c03adc04607282f755d10abb9b69975b74b25869"/>
 			</diskarea>
 		</part>
 	</software>
@@ -635,7 +636,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;HDR-0080-0529&gt;HK919C"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="18 wheeler american pro trucker (jpn)" sha1="c874cd4c18f709d737702d5d48e566dd9aa26a0a"/>
+				<disk name="18 wheeler american pro trucker (jpn)" sha1="a385da8a0d05c8df88774f8f4417342d126f40b8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -699,7 +700,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 560101 361036"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="21 two one (jpn)" sha1="68fde82b29cf1d12f169240910290bece4aa25dd"/>
+				<disk name="21 two one (jpn)" sha1="46468591b751dab05b8fcc92e8d02959b3b11d9c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -720,7 +721,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="MK-51190-0478SS EMI CD HOLLAND   @ 2"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="90 minutes sega championship football (euro)" sha1="7b08c41c6313df96e7a1ca0a662e9133af5cf187"/>
+				<disk name="90 minutes sega championship football (euro)" sha1="295606d64f2700d497b640df7d6d56beb6fc4889"/>
 			</diskarea>
 		</part>
 	</software>
@@ -769,7 +770,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 501587"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="advanced daisenryaku 2001 (jpn)" sha1="d7e78aec9e907a84866ddd8e570f251842b0319b"/>
+				<disk name="advanced daisenryaku 2001 (jpn)" sha1="6a5aad10b604951e8ad1506d1c0e97fb3d4070df"/>
 			</diskarea>
 		</part>
 	</software>
@@ -795,7 +796,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 500665"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="advanced daisenryaku sturm uber europa - der deutsche blitzkrieg (jpn)" sha1="34b0f9b0a12b8ec6cd37956d7f760d9c92535cfd"/>
+				<disk name="advanced daisenryaku sturm uber europa - der deutsche blitzkrieg (jpn)" sha1="665a179438e4da74267acfc5e808bfbf883ad124"/>
 			</diskarea>
 		</part>
 	</software>
@@ -819,7 +820,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 208605"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing i (jpn)" sha1="89bc7b2a8102bf00ec2b7915446f7e4093f91f7b"/>
+				<disk name="aero dancing i (jpn)" sha1="afa616065462af5ad362b0599c320d82a2e27b42"/>
 			</diskarea>
 		</part>
 	</software>
@@ -843,7 +844,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 209008"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing i jikai-saku made matemasen (jpn)" sha1="b8b7885b1a970b3e5f9856d2207d8325af3cd0a6"/>
+				<disk name="aero dancing i jikai-saku made matemasen (jpn)" sha1="a06d7f06ba0b94785ea40cbd29119ba1061a738f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -864,7 +865,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="6 50008 79913 2"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aerowings (usa)" sha1="f97ef130e0e6d20ff686176981019503bab1bf0f"/>
+				<disk name="aerowings (usa)" sha1="73094cec1b4bd3b264832d7400d85a381471acda"/>
 			</diskarea>
 		</part>
 	</software>
@@ -930,7 +931,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 208209"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing todoroki taichou no himitsu disc (jpn)" sha1="0b2cfcad53608c399e854b38d4143430483e653e"/>
+				<disk name="aero dancing todoroki taichou no himitsu disc (jpn)" sha1="1006fbc3b55c5dca5aa1dba71d926ac59564b275"/>
 			</diskarea>
 		</part>
 	</software>
@@ -966,7 +967,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="6 50008 79921 7"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aerowings 2 airstrike (usa)" sha1="c4d6c0467a42e78ba10f1d37dc86e6b6eaaa5d0a"/>
+				<disk name="aerowings 2 airstrike (usa)" sha1="2cb80043518a27527432799636f1ad1ff451d472"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1076,7 +1077,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 208407"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing f todoroki tsubasa no hatsu hikou (jpn)" sha1="f8cd4b0de87c4e786097fa10481922a6d37a8460"/>
+				<disk name="aero dancing f todoroki tsubasa no hatsu hikou (jpn)" sha1="61d31e4edb69f054693d42b176b1917beeec659b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1142,7 +1143,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="After...: Wasureenu Kizuna"/>
 			<diskarea name="cdrom">
-				<disk name="after... wasureenu kizuna (jpn)" sha1="7a0996757c21bcaafd830a5faae235b069c8e72d"/>
+				<disk name="after... wasureenu kizuna (jpn)" sha1="4ca05216dd45b9a5218186e7c2c0b5cd0be76d13"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -1192,7 +1193,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 513244 900884"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aikagi hidamari to kanojo no heyagi (jpn)" sha1="d803288952774eaba27a81394400b68164a9f907"/>
+				<disk name="aikagi hidamari to kanojo no heyagi (jpn)" sha1="13e335cf3ed86fbdbcbac4f3f59c1d05c1056a84"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1213,7 +1214,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-20112M-0752A   10MM1   C   19, T-20112M-0752A   11M4   C   19, T-20112M-0752A   12M1   C   19"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="air (jpn, rev. a)" sha1="4144ef52ba7ddca4e937f6529913e30a468b4492"/>
+				<disk name="air (jpn, rev. a)" sha1="7e17b8331ac245ee22e9150922058cee580ff113"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1672,10 +1673,10 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<!--
 		<rom name="ALIENFRONT_ONLINE.gdi" size="143" md5="0a3db521ea34e40a63967a0108d4bc78" sha1="397340cf23de1f66776741a3b9da8914c9b48203"/>
 		<rom name="track01.iso" size="921600" md5="98de8e5db931c9106cbf5c53b75f7cc7" sha1="5e23b9e4a63d4720e114bc777640bd65f0edca9b"/>
-		<rom name="track02.raw" size="13994400" md5="a55424800b9a45851b3670fa8afbf6a9" sha1="6cd6c33fc86f008d87f9d4385371e5df684c4c60"/>
-		<rom name="track03.iso" size="876550144" md5="17f9a991a2b7758f5ae1b2c2a08adb65" sha1="e99bcff45222f59148463dab5833ddf5e8aa93bd"/>
-		<rom name="track04.raw" size="13818000" md5="52d4f2952f4aca03f15d23825f5609b0" sha1="b00cc2ffa6abbd0908675ced977586fd9111d881"/>
-		<rom name="track05.iso" size="143302656" md5="d4ca27065a01df92300d240093d61ff5" sha1="2db3177f076caaa5e779a70f1ba546ac1b709e26"/>
+		<rom name="track02.raw" size="13 994 400" md5="a55424800b9a45851b3670fa8afbf6a9" sha1="6cd6c33fc86f008d87f9d4385371e5df684c4c60"/>
+		<rom name="track03.iso" size="876 550 144" md5="17f9a991a2b7758f5ae1b2c2a08adb65" sha1="e99bcff45222f59148463dab5833ddf5e8aa93bd"/>
+		<rom name="track04.raw" size="13 818 000" md5="52d4f2952f4aca03f15d23825f5609b0" sha1="b00cc2ffa6abbd0908675ced977586fd9111d881"/>
+		<rom name="track05.iso" size="143 302 656" md5="d4ca27065a01df92300d240093d61ff5" sha1="2db3177f076caaa5e779a70f1ba546ac1b709e26"/>
 		-->
 		<description>Alien Front Online (USA, prototype 20010625)</description>
 		<year>2001</year>
@@ -1901,7 +1902,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 988658 041148"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="angel wish kimi no egao ni chu (jpn)" sha1="9979bec207a0fbb9d1e1240ff2d569dc908677cd"/>
+				<disk name="angel wish kimi no egao ni chu (jpn)" sha1="65c1da4807da03a1600219f5d90d8b725d190e98"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2135,7 +2136,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 501211"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="atsumare guru guru onsen bb (jpn)" sha1="f882d15f60efe7c658e7ba2756c720efec4249af"/>
+				<disk name="atsumare guru guru onsen bb (jpn)" sha1="d03900d542524f937ac8ab4d7e9a9b60063f7c49"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2408,7 +2409,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 959359 009010"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="bass rush dream ecogear powerworm championship (jpn)" sha1="94b6e4e503066f9412b939de4816afd2b5898fa9"/>
+				<disk name="bass rush dream ecogear powerworm championship (jpn)" sha1="5600ccd51aaa3e2417ea51980a0033cc54b55350"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2430,7 +2431,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 541823 000014"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle beaster (jpn)" sha1="11ff4bbb2cd5f47e50ee7e7a64eb6978ad347c6e"/>
+				<disk name="battle beaster (jpn)" sha1="9df8e6349fda2fe264f0f0536b38f77296ace077"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3102,7 +3103,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Blue-Sky-Blue[s]: Sora o Mau Tsubasa"/>
 			<diskarea name="cdrom">
-				<disk name="blue-sky-blue[s] sora o mau tsubasa (jpn)" sha1="2959be03664d42eebcb1692337ea6b2e93bfb9fb"/>
+				<disk name="blue-sky-blue[s] sora o mau tsubasa (jpn)" sha1="1b6db61f78b11afc250aac17f5ad4cfa651c9e19"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -3130,7 +3131,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 995161 013104"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="bokomu no tatsujin (jpn)" sha1="b74abada79deadb627f05b50ec7e15a9b3f0c0cc"/>
+				<disk name="bokomu no tatsujin (jpn)" sha1="f702c8b81c69c7212a22e0b428f7c7f2e087f56d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3155,7 +3156,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 979750 891021"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="boku doraemon (jpn)" sha1="934fae7912ab6ff035fc40b33a191f22dfc86eec"/>
+				<disk name="boku doraemon (jpn)" sha1="1638034edd680f6a073a97bcd220b6f2dd356ecc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3200,7 +3201,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 528311 000022"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="boku no tennis jinsei (jpn)" sha1="4153be8019da5c56a5b3dd272be301350375b819"/>
+				<disk name="boku no tennis jinsei (jpn)" sha1="31828b64c80c1b1c7632c35c0203b48b391904c5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3222,7 +3223,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-19717M-0855   1MM1   C   28"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="boku to, bokura no natsu (jpn)" sha1="7ea6ab499462b72bd9ac072070eec3b181527b99"/>
+				<disk name="boku to, bokura no natsu (jpn)" sha1="52b64f02d20b31a3eaec988337548733639e3199"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3243,7 +3244,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-42903M-0774   1MM1   C   1X"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="bomber hehhe (jpn)" sha1="4d7898bc1f25ec339b08f3bd5ba0260dbc2a4fda"/>
+				<disk name="bomber hehhe (jpn)" sha1="73e7be4dc7ea5a8ee965cc7b265122aecf0bc630"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3711,7 +3712,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-46513M-0877&gt;HN412A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cafe little wish (jpn)" sha1="d2b3533c731c4c154a53a3f1cff9c795fec9552c"/>
+				<disk name="cafe little wish (jpn)" sha1="117edcda020625b9e0e91b0c099eab704d5cd0a9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4066,7 +4067,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Card of Destiny: Hikari to Yami no Tougousha"/>
 			<diskarea name="cdrom">
-				<disk name="card of destiny hikari to yami no tougousha - genteiban (jpn)" sha1="0bafa0d05b50037cc5da023c0db6ed768de2c475"/>
+				<disk name="card of destiny hikari to yami no tougousha - genteiban (jpn)" sha1="79a8dccf13f16beaa3b6293672c08d90d0c5f64e"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -4236,7 +4237,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46901M-0807   1MM1   C   24"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="castle fantasia seima taisen (jpn)" sha1="0903f283296b8ff60b722e753145be313c0cedb3"/>
+				<disk name="castle fantasia seima taisen (jpn)" sha1="e0702100801e79e1b039b44c6d604d89ec1849b5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4570,7 +4571,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-37912M-0913   1MS1   C   43"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cherry blossom (jpn)" sha1="9969ae4c62c048fc6d8c2b6c786f673716338cf5"/>
+				<disk name="cherry blossom (jpn)" sha1="0d6e60904f091dc3cba5bf72e4dc0073b66f1564"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4685,7 +4686,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-47107M-0904   3MS1   C   3Z"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="chocolat maid cafe curio (jpn)" sha1="0469b9ffc5202fa5ffa6d94abbbaff5341f16c66"/>
+				<disk name="chocolat maid cafe curio (jpn)" sha1="92ddb0d5acf83f3fb6bec362b19082f807f13fe6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4822,13 +4823,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Message Disc"/>
 			<diskarea name="cdrom">
-				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - message kit (jpn) (message disc)" sha1="fb4a61854adf81ee83008aeb4dd172121e661a31"/>
+				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - message kit (jpn) (message disc)" sha1="044e7326bfaa8d676541a783cd4ca2484108ed85"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Present Disc"/>
 			<diskarea name="cdrom">
-				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="7bcaa8d42df6e7920cbbb64fdcf95f7c7b6865df"/>
+				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="d04cb12d5dd9b674688b665084944851cbe68bf9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4849,7 +4850,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-39404M-0241   2M1   C   9Z"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="7bcaa8d42df6e7920cbbb64fdcf95f7c7b6865df"/>
+				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="d04cb12d5dd9b674688b665084944851cbe68bf9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5293,13 +5294,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="comic party (jpn) (disc 1)" sha1="8710002d130ef4e3fa4d10b645003075e3bacdb4"/>
+				<disk name="comic party (jpn) (disc 1)" sha1="4a26b68634360f6ec4c39763e1ec3aef1d46dff9"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="comic party (jpn) (disc 2)" sha1="2d9cd2bbb7e52d09b3276c633230395457df483e"/>
+				<disk name="comic party (jpn) (disc 2)" sha1="2b43c0f46256eaa5d9709985d79cffc90c594b9e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5360,7 +5361,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;HDR-0160-0695&gt;HL425A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="confidential mission (jpn)" sha1="dd7652f2efdf6144d6e872e0f2d08a5a19ae4144"/>
+				<disk name="confidential mission (jpn)" sha1="be5a2cc59ee335b29821607c617c19ade454fcea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5467,7 +5468,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-3106M-0437   1M1   C   06"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool cool toon (jpn)" sha1="77905a50ab7b98ab69855f512147ca065a241500"/>
+				<disk name="cool cool toon (jpn)" sha1="77e8df8a4136d8be06dc63f0ce596d629557710f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5540,7 +5541,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-45801M-0737&gt;HL710C"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cr hissatsu shigotonin pachitte chonmage vpachi (jpn)" sha1="0313fde372d8718b16fc158732fad3cc3a0e5a52"/>
+				<disk name="cr hissatsu shigotonin pachitte chonmage vpachi (jpn)" sha1="893801607b6e2f91137e626924ae706dcafe6931"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5949,7 +5950,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="D+Vine [Luv]"/>
 			<diskarea name="cdrom">
-				<disk name="d+vine [luv] - shokai genteiban (jpn)" sha1="57c9224d5598180a95b9267922e6f284774eada5"/>
+				<disk name="d+vine [luv] - shokai genteiban (jpn)" sha1="a55d24f09e8d191a8671fd1fcb63fc2e5c1ceb9c"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -7225,7 +7226,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-40801M-0206&gt;HJA30A, &lt;T-40801M-0206&gt;HL712A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="dengen tenshi taisen mahjong shangri-la (jpn)" sha1="54ed775c45303731b083ed527ba5920b7c4b3583"/>
+				<disk name="dengen tenshi taisen mahjong shangri-la (jpn)" sha1="da7ca58149c1c2ac838e28d8c319e0b2ac21ec5e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7284,7 +7285,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-1102M-0255&gt;HJC18D"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="densha de go 2 kousoku-hen 3000 bandai (jpn)" sha1="a3bc9e59efa6567d302f926644d4870cde2cc2dd"/>
+				<disk name="densha de go 2 kousoku-hen 3000 bandai (jpn)" sha1="9728cf52bb82a33812898c27cf9d96410175f9d4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7396,7 +7397,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46302M-0753 MT   B04"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="di gi charat fantasy (jpn)" sha1="79a22372a1d8441dfe16a80c6ea86bfaa89f12b7"/>
+				<disk name="di gi charat fantasy (jpn)" sha1="20c245d693f0d4701be99d71ea164d0cf0468539"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7431,7 +7432,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Di Gi Charat Fantasy"/>
 			<diskarea name="cdrom">
-				<disk name="di gi charat fantasy (jpn)" sha1="79a22372a1d8441dfe16a80c6ea86bfaa89f12b7"/>
+				<disk name="di gi charat fantasy (jpn)" sha1="20c245d693f0d4701be99d71ea164d0cf0468539"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -8016,7 +8017,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46701M-0798   2M1   C   1Z"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="doki doki idol star seeker remix (jpn)" sha1="bd589bc417fc2cd8f19180a4111a1e27856a1525"/>
+				<disk name="doki doki idol star seeker remix (jpn)" sha1="7f23fb341aa35695fdd5208f4b4bb8395b08224d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11351,7 +11352,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-9503M-0080 MT   B01"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="eisei meijin iii game creator yoshimura nobuhiro no zunou (jpn)" sha1="c35585083c71fa8f12fc16afbecf31ffc3a47456"/>
+				<disk name="eisei meijin iii game creator yoshimura nobuhiro no zunou (jpn)" sha1="3d8f2e655829790ee2cf83f252c9d05257234fb4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11515,7 +11516,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 976219 555500"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="eldorado gate dai-7-kan (jpn)" sha1="8e624fa15e7ae9e8adc75681da07f41b7137c455"/>
+				<disk name="eldorado gate dai-7-kan (jpn)" sha1="f21855a78f2511c2faa4c679bd3d9b031d896654"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11575,7 +11576,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-20116M-0839&gt;HM707B"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="elysion eien no sanctuary (jpn)" sha1="4440564fd55c7845f30bde7c462f44bea6b8d3a7"/>
+				<disk name="elysion eien no sanctuary (jpn)" sha1="ec02aba1dd210bc39c6e94926cbb091fbadfdcb2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11597,7 +11598,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 933516 306273"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="erde nezu no ki no shita de (jpn)" sha1="b0d35dc9a1f4ac1bfd7284f55248a73f40eba6a7"/>
+				<disk name="erde nezu no ki no shita de (jpn)" sha1="e12bc896c2fc1f7d1bae56e5e28f89734edfb2d7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11630,19 +11631,19 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="es (jpn) (disc 1)" sha1="8c9bd2032470d1f50c63c3e14f5f182458619c7a"/>
+				<disk name="es (jpn) (disc 1)" sha1="6715ff835ceb413c4b52609e078fac1401c69e93"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="es (jpn) (disc 2)" sha1="2b853f187c1c918ee629388d2bb10112c31c2ff4"/>
+				<disk name="es (jpn) (disc 2)" sha1="b0d04e113e15db3b76f5ad78f712ac85ba10a980"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom3">
 			<feature name="part_id" value="Disc 3"/>
 			<diskarea name="cdrom">
-				<disk name="es (jpn) (disc 3)" sha1="4f2e75f95c1260f3001bbc1f700865f45eb5390f"/>
+				<disk name="es (jpn) (disc 3)" sha1="5f01bb4d23c2f95e2064b91917ffbf5db31e02b7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11783,13 +11784,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 1)" sha1="4516f8a68cd03109c0176ca337ca7b3ed5cdbb52"/>
+				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 1)" sha1="5cebcca9f26156e1309be7184cfd1dac7c0d664f"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 2)" sha1="a703d033949f833c228c508a556a74a28d7e7f21"/>
+				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 2)" sha1="a5dc69f88b42e53ef7f64ec60d5cd14816a6ba31"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11811,7 +11812,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 933516 206160"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="ever 17 the out of infinity (jpn)" sha1="3fc448657d87294f21ae52fdb60054c6f75060a4"/>
+				<disk name="ever 17 the out of infinity (jpn)" sha1="0f73c51638e72f419ca1a52ca258297c57801499"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12077,7 +12078,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-44404M-0684   1M1   C   15"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="exodus guilty neos (jpn)" sha1="7183ce6a92cb39dbdb090a8c06c006b4d19b49f8"/>
+				<disk name="exodus guilty neos (jpn)" sha1="3d296c323a04fe6d2a4e87ccb89e8e9f462db045"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12929,7 +12930,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="*12S*   T-36801NA   B"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fighting force 2 (usa, alt 2)" sha1="ed7852cac7328ed43fb96d8942f76646184fbf7e"/>
+				<disk name="fighting force 2 (usa, alt 2)" sha1="7814c912238861742b2375d25017ee0cc6d76d81"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13138,7 +13139,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 940261 502461"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fire pro wrestling d (jpn)" sha1="3018edeaeb29e75a7c8cc832e08c4ea08934a6b0"/>
+				<disk name="fire pro wrestling d (jpn)" sha1="cc87da492ad9339b1e76eb8fd52d1fc846fc1e8a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13168,13 +13169,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="1b4b691ef7d3c0e1c048eaefaa8ba70d5a957341"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="fb04ed48d61fe558335df7631149c99c1654a670"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="ccd40b88896b0c0497ab15185b0a0d2aff414d51"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="2fdbc76f083c0d1a58e15b8224ba62f4e8a21d89"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13219,25 +13220,25 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="First Kiss Story II: Anata ga Iru kara - Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="1b4b691ef7d3c0e1c048eaefaa8ba70d5a957341"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="fb04ed48d61fe558335df7631149c99c1654a670"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="First Kiss Story II: Anata ga Iru kara - Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="ccd40b88896b0c0497ab15185b0a0d2aff414d51"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="2fdbc76f083c0d1a58e15b8224ba62f4e8a21d89"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom3">
 			<feature name="part_id" value="First Kiss Story - Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story (jpn) (disc 1)" sha1="ea75b417abf8e64e83a63281201ba6799bd0a52d"/>
+				<disk name="first kiss story (jpn) (disc 1)" sha1="12c0921eecbf28c00b1e9b35b1a132250c786d55"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom4">
 			<feature name="part_id" value="First Kiss Story - Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story (jpn) (disc 2)" sha1="356f27f8e85cf931e2eaba2f1093a3a6e47d261a"/>
+				<disk name="first kiss story (jpn) (disc 2)" sha1="25c02a1de0790767237920e2b8b9ae31d257ad46"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13481,7 +13482,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 520644 020043"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fragrance tale (jpn)" sha1="c9698934858848c6bbdb4038de2e301247bb59df"/>
+				<disk name="fragrance tale (jpn)" sha1="a6061b180e70725d3d44c8a63ca8f7c5b0948238"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13708,7 +13709,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="HDR-0187-0794 1M1 C 21, HDR-0187-0794 1MM1 C 21"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fushigi no dungeon fuurai no shiren gaiden onnakenshi asuka kenzan (jpn)" sha1="1fc5129168a5af516e47926f1a54138854351503"/>
+				<disk name="fushigi no dungeon fuurai no shiren gaiden onnakenshi asuka kenzan (jpn)" sha1="82fdc8677f6b24e4c75ff5191fbce47b820dc30b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14703,7 +14704,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 500047"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="godzilla generations (jpn)" sha1="7cdf962b7038a7878ef027162d24aaf5ef4021ce"/>
+				<disk name="godzilla generations (jpn)" sha1="562f2a2c8e77f9e89b09a4f497f04c386fc169e5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14745,7 +14746,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 540129 000018"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="golem no maigo (jpn)" sha1="f30afafc87c37940c95a9b68f44f8d4eebe02ad2"/>
+				<disk name="golem no maigo (jpn)" sha1="6b28518eaca82598ee5f9801d67ec0e4eb3d19dd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15367,7 +15368,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-2402M-0562A   10M2   C   0Y"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="guilty gear x (jpn)" sha1="e454ea7eb4988aaaf5dc4ed2374e2410a58ec811"/>
+				<disk name="guilty gear x (jpn)" sha1="6f2d7b2da9300e3db6cf9a4921af8dca728b3679"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15612,7 +15613,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-13303M-0250   3MM1   C   9Y"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kidou senshi gundam gaiden colony no ochita chi de... - tokubetsuban (jpn)" sha1="7d10000af76100b944407a67f79f3bddb58472b4"/>
+				<disk name="kidou senshi gundam gaiden colony no ochita chi de... - tokubetsuban (jpn)" sha1="64b3fbf8cd6012f6ed28fd8a4d0928f9025b945b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15806,7 +15807,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-46512M-0870&gt;HN202A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="happy breeding (jpn)" sha1="b1defc4ad6b1f7a0e6324680b6ada70c4a619eda"/>
+				<disk name="happy breeding (jpn)" sha1="a6a9dba133f5e8717fd2d2fcde80605025ed128e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15868,7 +15869,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-20106M-0655 3"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="harusame youbi (jpn)" sha1="0c2821d1cc3171117086ee217683ebde74815cb7"/>
+				<disk name="harusame youbi (jpn)" sha1="44b5c1359a672e59cac6cbb9a758e8eae0c001b2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16011,7 +16012,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-2202M-0540   2MM1   C   09"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="heisei mahjong-sou (jpn)" sha1="9d3e78cb07831da6bb183b37ed55749e58052296"/>
+				<disk name="heisei mahjong-sou (jpn)" sha1="501b56e244082e5cf43efdce3800b9c8cf910f58"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16055,7 +16056,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="610-7381-0209 1"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="hello kitty no garden panic (jpn)" sha1="2bd64a0f0a8acdbdb4abaa6cb5c9788a1bb721ba"/>
+				<disk name="hello kitty no garden panic (jpn)" sha1="a7bd2309fb7c3a1a726e6600a87913260545ac90"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16231,7 +16232,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46101M-0730 1"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="himitsu yui ga ita natsu (jpn)" sha1="e066d34d072ce2d8f41bcfdfd30c24a029986944"/>
+				<disk name="himitsu yui ga ita natsu (jpn)" sha1="a0ed3fbac2dd23c6038165d9238e091705f822c2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16616,7 +16617,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-5703M-0150   1M1   C   98"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="idol janshi o tsukucchaou (jpn)" sha1="a388bc1b87f905c316662a1c8f78543bd50c1dc9"/>
+				<disk name="idol janshi o tsukucchaou (jpn)" sha1="f31ee28505fdd303caead1160915dc11ee712ca4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16700,7 +16701,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-45601M-0658   1M2   C   13"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="illbleed (jpn)" sha1="4def52884214c334074bbad6ac9a96f14acc4f85"/>
+				<disk name="illbleed (jpn)" sha1="cb6c69e42599a9526e41e78876a8acf9d50cdff8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16974,7 +16975,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-19506M-0779&gt;HLA12A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="inoue ryouko last scene (jpn)" sha1="3a465b82c2c94cc6e93f904a08ffae6cd646b8f0"/>
+				<disk name="inoue ryouko last scene (jpn)" sha1="23423fbfae0e2274d158f20495ebcfc8453869e1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17013,7 +17014,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-20117M-0874&gt;HN316D"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="interlude (jpn)" sha1="81b7e9419a0cb394ba3adc9dc1b87645ff337c1c"/>
+				<disk name="interlude (jpn)" sha1="f0602aa16434efd302ab92ee2f7bc2700073dc96"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17087,7 +17088,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-19722M-0891 MT   B03"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="iris (jpn)" sha1="6a8f7ae5cbb51a4649d695fe076c7354b2a091ac"/>
+				<disk name="iris (jpn)" sha1="ca801678eb8ccffc1b6aa9c0713f5d575491304d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17206,7 +17207,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="HDR-0028-0165   1M1   C   99, HDR-0028-0165   3M3   C   99"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="j.league pro soccer club o tsukurou (jpn)" sha1="301d48ae9453f59cae5ba14610da7bf1997b4fde"/>
+				<disk name="j.league pro soccer club o tsukurou (jpn)" sha1="e412efe15d1a924cc3389ab7e7da2bf8f567db56"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17233,7 +17234,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-43401M-0462&gt;HK711H"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="jahmong (jpn)" sha1="f48495ede4aa81aad5904b8c6bb24e05223ff7dd"/>
+				<disk name="jahmong (jpn)" sha1="bb96e19026ebf3e12f212c2bbd3c3a95610eec25"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17366,7 +17367,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-41201M-0531&gt;HKA02A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet coaster dream 2 (jpn)" sha1="3181d15a34b34584cdc48a7647ce5a32652f4424"/>
+				<disk name="jet coaster dream 2 (jpn)" sha1="8858b6252cdc67600ab26a6b9a12767726b5bd17"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17858,13 +17859,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 1)" sha1="486fa13f2cc89b494b59c7e501814d5e3093c04c"/>
+				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 1)" sha1="585635db615d091f6cce5c7156e475e1f7e92daf"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 2)" sha1="ae9bcd48abe94cc6f79887cecfd4a367a8ed5699"/>
+				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 2)" sha1="7a07dfcde19ecdaf4ead28b5afa9f01468aac576"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17908,7 +17909,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-20105M-0486&gt;HL516C"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kanon (jpn)" sha1="81f49e0823557f91ea98e312304c05c5691931d5"/>
+				<disk name="kanon (jpn)" sha1="4c915bc782f743c6f87812041c9baccb0e947825"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18127,7 +18128,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Kaze no Uta"/>
 			<diskarea name="cdrom">
-				<disk name="kaze no uta (jpn)" sha1="279a9d2dfd1526e4b224203184275396647ab937"/>
+				<disk name="kaze no uta (jpn)" sha1="96f44ea17e9de2d47061737f7528a7064fc530c2"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
@@ -18158,7 +18159,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="T4997766300085"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kidou senkan nadesico nadesico the mission (jpn)" sha1="c7aa3b1016252a124a9b6d9d45f78e42e05192ea"/>
+				<disk name="kidou senkan nadesico nadesico the mission (jpn)" sha1="21dda612cdc3ee96cd9baea01054b167665920f3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18280,7 +18281,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 519898 002240"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kimi ga nozomu eien (jpn)" sha1="7622b56158e60972f5ea2b6f82142a9a6c0054f9"/>
+				<disk name="kimi ga nozomu eien (jpn)" sha1="5c2afe4fa9eea00a0e1f503bd1a328f9ce627c9c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18415,7 +18416,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-14301M-0057A   2M1   C   93"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kita e. white illumination (jpn)" sha1="acb35e852a28693580ef0380123a29acc7e6b88e"/>
+				<disk name="kita e. white illumination (jpn)" sha1="e389aff777840f4bf82f26573fefff2434b8867a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19124,7 +19125,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="HDR-0139-0645   2M1   C   12"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="love hina smile again (jpn)" sha1="63af4720ff7fcaa14d48a47958eb3c11c167dd84"/>
+				<disk name="love hina smile again (jpn)" sha1="31d6be18dad7207813b905ca422714e78b3c8b21"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/dc.xml
+++ b/hash/dc.xml
@@ -250,7 +250,6 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 
 197***       : All Brazilian games' serials start with 197.
 -->
-
 <softwarelist name="dc" description="Sega Dreamcast GD-ROMs">
 
 	<!-- DEVBOX SOFTWARE -->
@@ -458,7 +457,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="0 31719 20990 3"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="4 wheel thunder (usa)" sha1="023e6d8c232ae0ef22b0315ff7a8f14ad5f686fc"/>
+				<disk name="4 wheel thunder (usa)" sha1="4852db60cda2b22a15e11dce047a1d080b629e72"/>
 			</diskarea>
 		</part>
 	</software>
@@ -530,7 +529,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="6 63593 12014 4"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="4x4 evo (usa)" sha1="fc8c5e09e1f6902a52fc79ae54392d700be6fdad"/>
+				<disk name="4x4 evo (usa)" sha1="2ade88e88f99c27362b68608d2983729994cf0b8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -592,7 +591,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="0 10086 51064 5"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="18 wheeler american pro trucker (usa)" sha1="c03adc04607282f755d10abb9b69975b74b25869"/>
+				<disk name="18 wheeler american pro trucker (usa)" sha1="59b96c6f851e9698ae920d80e7ba88ba02eabe8c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -636,7 +635,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;HDR-0080-0529&gt;HK919C"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="18 wheeler american pro trucker (jpn)" sha1="a385da8a0d05c8df88774f8f4417342d126f40b8"/>
+				<disk name="18 wheeler american pro trucker (jpn)" sha1="c874cd4c18f709d737702d5d48e566dd9aa26a0a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -700,7 +699,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 560101 361036"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="21 two one (jpn)" sha1="46468591b751dab05b8fcc92e8d02959b3b11d9c"/>
+				<disk name="21 two one (jpn)" sha1="68fde82b29cf1d12f169240910290bece4aa25dd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -721,7 +720,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="MK-51190-0478SS EMI CD HOLLAND   @ 2"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="90 minutes sega championship football (euro)" sha1="295606d64f2700d497b640df7d6d56beb6fc4889"/>
+				<disk name="90 minutes sega championship football (euro)" sha1="7b08c41c6313df96e7a1ca0a662e9133af5cf187"/>
 			</diskarea>
 		</part>
 	</software>
@@ -770,7 +769,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 501587"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="advanced daisenryaku 2001 (jpn)" sha1="6a5aad10b604951e8ad1506d1c0e97fb3d4070df"/>
+				<disk name="advanced daisenryaku 2001 (jpn)" sha1="d7e78aec9e907a84866ddd8e570f251842b0319b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -796,7 +795,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 500665"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="advanced daisenryaku sturm uber europa - der deutsche blitzkrieg (jpn)" sha1="665a179438e4da74267acfc5e808bfbf883ad124"/>
+				<disk name="advanced daisenryaku sturm uber europa - der deutsche blitzkrieg (jpn)" sha1="34b0f9b0a12b8ec6cd37956d7f760d9c92535cfd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -820,7 +819,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 208605"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing i (jpn)" sha1="afa616065462af5ad362b0599c320d82a2e27b42"/>
+				<disk name="aero dancing i (jpn)" sha1="89bc7b2a8102bf00ec2b7915446f7e4093f91f7b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -844,7 +843,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 209008"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing i jikai-saku made matemasen (jpn)" sha1="a06d7f06ba0b94785ea40cbd29119ba1061a738f"/>
+				<disk name="aero dancing i jikai-saku made matemasen (jpn)" sha1="b8b7885b1a970b3e5f9856d2207d8325af3cd0a6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -865,7 +864,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="6 50008 79913 2"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aerowings (usa)" sha1="73094cec1b4bd3b264832d7400d85a381471acda"/>
+				<disk name="aerowings (usa)" sha1="f97ef130e0e6d20ff686176981019503bab1bf0f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -931,7 +930,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 208209"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing todoroki taichou no himitsu disc (jpn)" sha1="1006fbc3b55c5dca5aa1dba71d926ac59564b275"/>
+				<disk name="aero dancing todoroki taichou no himitsu disc (jpn)" sha1="0b2cfcad53608c399e854b38d4143430483e653e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -967,7 +966,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="6 50008 79921 7"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aerowings 2 airstrike (usa)" sha1="2cb80043518a27527432799636f1ad1ff451d472"/>
+				<disk name="aerowings 2 airstrike (usa)" sha1="c4d6c0467a42e78ba10f1d37dc86e6b6eaaa5d0a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1077,7 +1076,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 981670 208407"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aero dancing f todoroki tsubasa no hatsu hikou (jpn)" sha1="61d31e4edb69f054693d42b176b1917beeec659b"/>
+				<disk name="aero dancing f todoroki tsubasa no hatsu hikou (jpn)" sha1="f8cd4b0de87c4e786097fa10481922a6d37a8460"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1143,7 +1142,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="After...: Wasureenu Kizuna"/>
 			<diskarea name="cdrom">
-				<disk name="after... wasureenu kizuna (jpn)" sha1="4ca05216dd45b9a5218186e7c2c0b5cd0be76d13"/>
+				<disk name="after... wasureenu kizuna (jpn)" sha1="7a0996757c21bcaafd830a5faae235b069c8e72d"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -1193,7 +1192,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 513244 900884"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="aikagi hidamari to kanojo no heyagi (jpn)" sha1="13e335cf3ed86fbdbcbac4f3f59c1d05c1056a84"/>
+				<disk name="aikagi hidamari to kanojo no heyagi (jpn)" sha1="d803288952774eaba27a81394400b68164a9f907"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1214,7 +1213,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-20112M-0752A   10MM1   C   19, T-20112M-0752A   11M4   C   19, T-20112M-0752A   12M1   C   19"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="air (jpn, rev. a)" sha1="7e17b8331ac245ee22e9150922058cee580ff113"/>
+				<disk name="air (jpn, rev. a)" sha1="4144ef52ba7ddca4e937f6529913e30a468b4492"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1673,10 +1672,10 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<!--
 		<rom name="ALIENFRONT_ONLINE.gdi" size="143" md5="0a3db521ea34e40a63967a0108d4bc78" sha1="397340cf23de1f66776741a3b9da8914c9b48203"/>
 		<rom name="track01.iso" size="921600" md5="98de8e5db931c9106cbf5c53b75f7cc7" sha1="5e23b9e4a63d4720e114bc777640bd65f0edca9b"/>
-		<rom name="track02.raw" size="13 994 400" md5="a55424800b9a45851b3670fa8afbf6a9" sha1="6cd6c33fc86f008d87f9d4385371e5df684c4c60"/>
-		<rom name="track03.iso" size="876 550 144" md5="17f9a991a2b7758f5ae1b2c2a08adb65" sha1="e99bcff45222f59148463dab5833ddf5e8aa93bd"/>
-		<rom name="track04.raw" size="13 818 000" md5="52d4f2952f4aca03f15d23825f5609b0" sha1="b00cc2ffa6abbd0908675ced977586fd9111d881"/>
-		<rom name="track05.iso" size="143 302 656" md5="d4ca27065a01df92300d240093d61ff5" sha1="2db3177f076caaa5e779a70f1ba546ac1b709e26"/>
+		<rom name="track02.raw" size="13994400" md5="a55424800b9a45851b3670fa8afbf6a9" sha1="6cd6c33fc86f008d87f9d4385371e5df684c4c60"/>
+		<rom name="track03.iso" size="876550144" md5="17f9a991a2b7758f5ae1b2c2a08adb65" sha1="e99bcff45222f59148463dab5833ddf5e8aa93bd"/>
+		<rom name="track04.raw" size="13818000" md5="52d4f2952f4aca03f15d23825f5609b0" sha1="b00cc2ffa6abbd0908675ced977586fd9111d881"/>
+		<rom name="track05.iso" size="143302656" md5="d4ca27065a01df92300d240093d61ff5" sha1="2db3177f076caaa5e779a70f1ba546ac1b709e26"/>
 		-->
 		<description>Alien Front Online (USA, prototype 20010625)</description>
 		<year>2001</year>
@@ -1902,7 +1901,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 988658 041148"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="angel wish kimi no egao ni chu (jpn)" sha1="65c1da4807da03a1600219f5d90d8b725d190e98"/>
+				<disk name="angel wish kimi no egao ni chu (jpn)" sha1="9979bec207a0fbb9d1e1240ff2d569dc908677cd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2136,7 +2135,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 501211"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="atsumare guru guru onsen bb (jpn)" sha1="d03900d542524f937ac8ab4d7e9a9b60063f7c49"/>
+				<disk name="atsumare guru guru onsen bb (jpn)" sha1="f882d15f60efe7c658e7ba2756c720efec4249af"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2409,7 +2408,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 959359 009010"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="bass rush dream ecogear powerworm championship (jpn)" sha1="5600ccd51aaa3e2417ea51980a0033cc54b55350"/>
+				<disk name="bass rush dream ecogear powerworm championship (jpn)" sha1="94b6e4e503066f9412b939de4816afd2b5898fa9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2431,7 +2430,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 541823 000014"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle beaster (jpn)" sha1="9df8e6349fda2fe264f0f0536b38f77296ace077"/>
+				<disk name="battle beaster (jpn)" sha1="11ff4bbb2cd5f47e50ee7e7a64eb6978ad347c6e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3103,7 +3102,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Blue-Sky-Blue[s]: Sora o Mau Tsubasa"/>
 			<diskarea name="cdrom">
-				<disk name="blue-sky-blue[s] sora o mau tsubasa (jpn)" sha1="1b6db61f78b11afc250aac17f5ad4cfa651c9e19"/>
+				<disk name="blue-sky-blue[s] sora o mau tsubasa (jpn)" sha1="2959be03664d42eebcb1692337ea6b2e93bfb9fb"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -3131,7 +3130,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 995161 013104"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="bokomu no tatsujin (jpn)" sha1="f702c8b81c69c7212a22e0b428f7c7f2e087f56d"/>
+				<disk name="bokomu no tatsujin (jpn)" sha1="b74abada79deadb627f05b50ec7e15a9b3f0c0cc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3156,7 +3155,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 979750 891021"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="boku doraemon (jpn)" sha1="1638034edd680f6a073a97bcd220b6f2dd356ecc"/>
+				<disk name="boku doraemon (jpn)" sha1="934fae7912ab6ff035fc40b33a191f22dfc86eec"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3201,7 +3200,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 528311 000022"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="boku no tennis jinsei (jpn)" sha1="31828b64c80c1b1c7632c35c0203b48b391904c5"/>
+				<disk name="boku no tennis jinsei (jpn)" sha1="4153be8019da5c56a5b3dd272be301350375b819"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3223,7 +3222,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-19717M-0855   1MM1   C   28"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="boku to, bokura no natsu (jpn)" sha1="52b64f02d20b31a3eaec988337548733639e3199"/>
+				<disk name="boku to, bokura no natsu (jpn)" sha1="7ea6ab499462b72bd9ac072070eec3b181527b99"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3244,7 +3243,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-42903M-0774   1MM1   C   1X"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="bomber hehhe (jpn)" sha1="73e7be4dc7ea5a8ee965cc7b265122aecf0bc630"/>
+				<disk name="bomber hehhe (jpn)" sha1="4d7898bc1f25ec339b08f3bd5ba0260dbc2a4fda"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3712,7 +3711,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-46513M-0877&gt;HN412A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cafe little wish (jpn)" sha1="117edcda020625b9e0e91b0c099eab704d5cd0a9"/>
+				<disk name="cafe little wish (jpn)" sha1="d2b3533c731c4c154a53a3f1cff9c795fec9552c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4067,7 +4066,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Card of Destiny: Hikari to Yami no Tougousha"/>
 			<diskarea name="cdrom">
-				<disk name="card of destiny hikari to yami no tougousha - genteiban (jpn)" sha1="79a8dccf13f16beaa3b6293672c08d90d0c5f64e"/>
+				<disk name="card of destiny hikari to yami no tougousha - genteiban (jpn)" sha1="0bafa0d05b50037cc5da023c0db6ed768de2c475"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -4237,7 +4236,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46901M-0807   1MM1   C   24"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="castle fantasia seima taisen (jpn)" sha1="e0702100801e79e1b039b44c6d604d89ec1849b5"/>
+				<disk name="castle fantasia seima taisen (jpn)" sha1="0903f283296b8ff60b722e753145be313c0cedb3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4571,7 +4570,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-37912M-0913   1MS1   C   43"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cherry blossom (jpn)" sha1="0d6e60904f091dc3cba5bf72e4dc0073b66f1564"/>
+				<disk name="cherry blossom (jpn)" sha1="9969ae4c62c048fc6d8c2b6c786f673716338cf5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4686,7 +4685,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-47107M-0904   3MS1   C   3Z"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="chocolat maid cafe curio (jpn)" sha1="92ddb0d5acf83f3fb6bec362b19082f807f13fe6"/>
+				<disk name="chocolat maid cafe curio (jpn)" sha1="0469b9ffc5202fa5ffa6d94abbbaff5341f16c66"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4823,13 +4822,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Message Disc"/>
 			<diskarea name="cdrom">
-				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - message kit (jpn) (message disc)" sha1="044e7326bfaa8d676541a783cd4ca2484108ed85"/>
+				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - message kit (jpn) (message disc)" sha1="fb4a61854adf81ee83008aeb4dd172121e661a31"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Present Disc"/>
 			<diskarea name="cdrom">
-				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="d04cb12d5dd9b674688b665084944851cbe68bf9"/>
+				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="7bcaa8d42df6e7920cbbb64fdcf95f7c7b6865df"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4850,7 +4849,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-39404M-0241   2M1   C   9Z"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="d04cb12d5dd9b674688b665084944851cbe68bf9"/>
+				<disk name="christmas seaman omoi o tsutaeru mou hitotsu no houhou - present disc (jpn)" sha1="7bcaa8d42df6e7920cbbb64fdcf95f7c7b6865df"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5294,13 +5293,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="comic party (jpn) (disc 1)" sha1="4a26b68634360f6ec4c39763e1ec3aef1d46dff9"/>
+				<disk name="comic party (jpn) (disc 1)" sha1="8710002d130ef4e3fa4d10b645003075e3bacdb4"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="comic party (jpn) (disc 2)" sha1="2b43c0f46256eaa5d9709985d79cffc90c594b9e"/>
+				<disk name="comic party (jpn) (disc 2)" sha1="2d9cd2bbb7e52d09b3276c633230395457df483e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5361,7 +5360,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;HDR-0160-0695&gt;HL425A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="confidential mission (jpn)" sha1="be5a2cc59ee335b29821607c617c19ade454fcea"/>
+				<disk name="confidential mission (jpn)" sha1="dd7652f2efdf6144d6e872e0f2d08a5a19ae4144"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5468,7 +5467,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-3106M-0437   1M1   C   06"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool cool toon (jpn)" sha1="77e8df8a4136d8be06dc63f0ce596d629557710f"/>
+				<disk name="cool cool toon (jpn)" sha1="77905a50ab7b98ab69855f512147ca065a241500"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5541,7 +5540,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-45801M-0737&gt;HL710C"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="cr hissatsu shigotonin pachitte chonmage vpachi (jpn)" sha1="893801607b6e2f91137e626924ae706dcafe6931"/>
+				<disk name="cr hissatsu shigotonin pachitte chonmage vpachi (jpn)" sha1="0313fde372d8718b16fc158732fad3cc3a0e5a52"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5950,7 +5949,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="D+Vine [Luv]"/>
 			<diskarea name="cdrom">
-				<disk name="d+vine [luv] - shokai genteiban (jpn)" sha1="a55d24f09e8d191a8671fd1fcb63fc2e5c1ceb9c"/>
+				<disk name="d+vine [luv] - shokai genteiban (jpn)" sha1="57c9224d5598180a95b9267922e6f284774eada5"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -7226,7 +7225,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-40801M-0206&gt;HJA30A, &lt;T-40801M-0206&gt;HL712A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="dengen tenshi taisen mahjong shangri-la (jpn)" sha1="da7ca58149c1c2ac838e28d8c319e0b2ac21ec5e"/>
+				<disk name="dengen tenshi taisen mahjong shangri-la (jpn)" sha1="54ed775c45303731b083ed527ba5920b7c4b3583"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7285,7 +7284,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-1102M-0255&gt;HJC18D"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="densha de go 2 kousoku-hen 3000 bandai (jpn)" sha1="9728cf52bb82a33812898c27cf9d96410175f9d4"/>
+				<disk name="densha de go 2 kousoku-hen 3000 bandai (jpn)" sha1="a3bc9e59efa6567d302f926644d4870cde2cc2dd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7397,7 +7396,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46302M-0753 MT   B04"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="di gi charat fantasy (jpn)" sha1="20c245d693f0d4701be99d71ea164d0cf0468539"/>
+				<disk name="di gi charat fantasy (jpn)" sha1="79a22372a1d8441dfe16a80c6ea86bfaa89f12b7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7432,7 +7431,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Di Gi Charat Fantasy"/>
 			<diskarea name="cdrom">
-				<disk name="di gi charat fantasy (jpn)" sha1="20c245d693f0d4701be99d71ea164d0cf0468539"/>
+				<disk name="di gi charat fantasy (jpn)" sha1="79a22372a1d8441dfe16a80c6ea86bfaa89f12b7"/>
 			</diskarea>
 		</part>
 		<part interface="dc_cdrom" name="cdrom2">
@@ -8017,7 +8016,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46701M-0798   2M1   C   1Z"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="doki doki idol star seeker remix (jpn)" sha1="7f23fb341aa35695fdd5208f4b4bb8395b08224d"/>
+				<disk name="doki doki idol star seeker remix (jpn)" sha1="bd589bc417fc2cd8f19180a4111a1e27856a1525"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11352,7 +11351,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-9503M-0080 MT   B01"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="eisei meijin iii game creator yoshimura nobuhiro no zunou (jpn)" sha1="3d8f2e655829790ee2cf83f252c9d05257234fb4"/>
+				<disk name="eisei meijin iii game creator yoshimura nobuhiro no zunou (jpn)" sha1="c35585083c71fa8f12fc16afbecf31ffc3a47456"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11516,7 +11515,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 976219 555500"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="eldorado gate dai-7-kan (jpn)" sha1="f21855a78f2511c2faa4c679bd3d9b031d896654"/>
+				<disk name="eldorado gate dai-7-kan (jpn)" sha1="8e624fa15e7ae9e8adc75681da07f41b7137c455"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11576,7 +11575,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-20116M-0839&gt;HM707B"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="elysion eien no sanctuary (jpn)" sha1="ec02aba1dd210bc39c6e94926cbb091fbadfdcb2"/>
+				<disk name="elysion eien no sanctuary (jpn)" sha1="4440564fd55c7845f30bde7c462f44bea6b8d3a7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11598,7 +11597,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 933516 306273"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="erde nezu no ki no shita de (jpn)" sha1="e12bc896c2fc1f7d1bae56e5e28f89734edfb2d7"/>
+				<disk name="erde nezu no ki no shita de (jpn)" sha1="b0d35dc9a1f4ac1bfd7284f55248a73f40eba6a7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11631,19 +11630,19 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="es (jpn) (disc 1)" sha1="6715ff835ceb413c4b52609e078fac1401c69e93"/>
+				<disk name="es (jpn) (disc 1)" sha1="8c9bd2032470d1f50c63c3e14f5f182458619c7a"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="es (jpn) (disc 2)" sha1="b0d04e113e15db3b76f5ad78f712ac85ba10a980"/>
+				<disk name="es (jpn) (disc 2)" sha1="2b853f187c1c918ee629388d2bb10112c31c2ff4"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom3">
 			<feature name="part_id" value="Disc 3"/>
 			<diskarea name="cdrom">
-				<disk name="es (jpn) (disc 3)" sha1="5f01bb4d23c2f95e2064b91917ffbf5db31e02b7"/>
+				<disk name="es (jpn) (disc 3)" sha1="4f2e75f95c1260f3001bbc1f700865f45eb5390f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11784,13 +11783,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 1)" sha1="5cebcca9f26156e1309be7184cfd1dac7c0d664f"/>
+				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 1)" sha1="4516f8a68cd03109c0176ca337ca7b3ed5cdbb52"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 2)" sha1="a5dc69f88b42e53ef7f64ec60d5cd14816a6ba31"/>
+				<disk name="eve zero kanzenban ark of the matter (jpn) (disc 2)" sha1="a703d033949f833c228c508a556a74a28d7e7f21"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11812,7 +11811,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 933516 206160"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="ever 17 the out of infinity (jpn)" sha1="0f73c51638e72f419ca1a52ca258297c57801499"/>
+				<disk name="ever 17 the out of infinity (jpn)" sha1="3fc448657d87294f21ae52fdb60054c6f75060a4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12078,7 +12077,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-44404M-0684   1M1   C   15"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="exodus guilty neos (jpn)" sha1="3d296c323a04fe6d2a4e87ccb89e8e9f462db045"/>
+				<disk name="exodus guilty neos (jpn)" sha1="7183ce6a92cb39dbdb090a8c06c006b4d19b49f8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12930,7 +12929,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="*12S*   T-36801NA   B"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fighting force 2 (usa, alt 2)" sha1="7814c912238861742b2375d25017ee0cc6d76d81"/>
+				<disk name="fighting force 2 (usa, alt 2)" sha1="ed7852cac7328ed43fb96d8942f76646184fbf7e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13139,7 +13138,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 940261 502461"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fire pro wrestling d (jpn)" sha1="cc87da492ad9339b1e76eb8fd52d1fc846fc1e8a"/>
+				<disk name="fire pro wrestling d (jpn)" sha1="3018edeaeb29e75a7c8cc832e08c4ea08934a6b0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13169,13 +13168,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="fb04ed48d61fe558335df7631149c99c1654a670"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="1b4b691ef7d3c0e1c048eaefaa8ba70d5a957341"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="2fdbc76f083c0d1a58e15b8224ba62f4e8a21d89"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="ccd40b88896b0c0497ab15185b0a0d2aff414d51"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13220,25 +13219,25 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="First Kiss Story II: Anata ga Iru kara - Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="fb04ed48d61fe558335df7631149c99c1654a670"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 1)" sha1="1b4b691ef7d3c0e1c048eaefaa8ba70d5a957341"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="First Kiss Story II: Anata ga Iru kara - Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="2fdbc76f083c0d1a58e15b8224ba62f4e8a21d89"/>
+				<disk name="first kiss story ii anata ga iru kara (jpn) (disc 2)" sha1="ccd40b88896b0c0497ab15185b0a0d2aff414d51"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom3">
 			<feature name="part_id" value="First Kiss Story - Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story (jpn) (disc 1)" sha1="12c0921eecbf28c00b1e9b35b1a132250c786d55"/>
+				<disk name="first kiss story (jpn) (disc 1)" sha1="ea75b417abf8e64e83a63281201ba6799bd0a52d"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom4">
 			<feature name="part_id" value="First Kiss Story - Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="first kiss story (jpn) (disc 2)" sha1="25c02a1de0790767237920e2b8b9ae31d257ad46"/>
+				<disk name="first kiss story (jpn) (disc 2)" sha1="356f27f8e85cf931e2eaba2f1093a3a6e47d261a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13482,7 +13481,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 520644 020043"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fragrance tale (jpn)" sha1="a6061b180e70725d3d44c8a63ca8f7c5b0948238"/>
+				<disk name="fragrance tale (jpn)" sha1="c9698934858848c6bbdb4038de2e301247bb59df"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13709,7 +13708,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="HDR-0187-0794 1M1 C 21, HDR-0187-0794 1MM1 C 21"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="fushigi no dungeon fuurai no shiren gaiden onnakenshi asuka kenzan (jpn)" sha1="82fdc8677f6b24e4c75ff5191fbce47b820dc30b"/>
+				<disk name="fushigi no dungeon fuurai no shiren gaiden onnakenshi asuka kenzan (jpn)" sha1="1fc5129168a5af516e47926f1a54138854351503"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14704,7 +14703,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 974365 500047"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="godzilla generations (jpn)" sha1="562f2a2c8e77f9e89b09a4f497f04c386fc169e5"/>
+				<disk name="godzilla generations (jpn)" sha1="7cdf962b7038a7878ef027162d24aaf5ef4021ce"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14746,7 +14745,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 540129 000018"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="golem no maigo (jpn)" sha1="6b28518eaca82598ee5f9801d67ec0e4eb3d19dd"/>
+				<disk name="golem no maigo (jpn)" sha1="f30afafc87c37940c95a9b68f44f8d4eebe02ad2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15368,7 +15367,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-2402M-0562A   10M2   C   0Y"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="guilty gear x (jpn)" sha1="6f2d7b2da9300e3db6cf9a4921af8dca728b3679"/>
+				<disk name="guilty gear x (jpn)" sha1="e454ea7eb4988aaaf5dc4ed2374e2410a58ec811"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15613,7 +15612,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-13303M-0250   3MM1   C   9Y"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kidou senshi gundam gaiden colony no ochita chi de... - tokubetsuban (jpn)" sha1="64b3fbf8cd6012f6ed28fd8a4d0928f9025b945b"/>
+				<disk name="kidou senshi gundam gaiden colony no ochita chi de... - tokubetsuban (jpn)" sha1="7d10000af76100b944407a67f79f3bddb58472b4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15807,7 +15806,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-46512M-0870&gt;HN202A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="happy breeding (jpn)" sha1="a6a9dba133f5e8717fd2d2fcde80605025ed128e"/>
+				<disk name="happy breeding (jpn)" sha1="b1defc4ad6b1f7a0e6324680b6ada70c4a619eda"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15869,7 +15868,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-20106M-0655 3"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="harusame youbi (jpn)" sha1="44b5c1359a672e59cac6cbb9a758e8eae0c001b2"/>
+				<disk name="harusame youbi (jpn)" sha1="0c2821d1cc3171117086ee217683ebde74815cb7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16012,7 +16011,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-2202M-0540   2MM1   C   09"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="heisei mahjong-sou (jpn)" sha1="501b56e244082e5cf43efdce3800b9c8cf910f58"/>
+				<disk name="heisei mahjong-sou (jpn)" sha1="9d3e78cb07831da6bb183b37ed55749e58052296"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16056,7 +16055,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="610-7381-0209 1"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="hello kitty no garden panic (jpn)" sha1="a7bd2309fb7c3a1a726e6600a87913260545ac90"/>
+				<disk name="hello kitty no garden panic (jpn)" sha1="2bd64a0f0a8acdbdb4abaa6cb5c9788a1bb721ba"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16232,7 +16231,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-46101M-0730 1"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="himitsu yui ga ita natsu (jpn)" sha1="a0ed3fbac2dd23c6038165d9238e091705f822c2"/>
+				<disk name="himitsu yui ga ita natsu (jpn)" sha1="e066d34d072ce2d8f41bcfdfd30c24a029986944"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16617,7 +16616,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-5703M-0150   1M1   C   98"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="idol janshi o tsukucchaou (jpn)" sha1="f31ee28505fdd303caead1160915dc11ee712ca4"/>
+				<disk name="idol janshi o tsukucchaou (jpn)" sha1="a388bc1b87f905c316662a1c8f78543bd50c1dc9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16701,7 +16700,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-45601M-0658   1M2   C   13"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="illbleed (jpn)" sha1="cb6c69e42599a9526e41e78876a8acf9d50cdff8"/>
+				<disk name="illbleed (jpn)" sha1="4def52884214c334074bbad6ac9a96f14acc4f85"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16975,7 +16974,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-19506M-0779&gt;HLA12A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="inoue ryouko last scene (jpn)" sha1="23423fbfae0e2274d158f20495ebcfc8453869e1"/>
+				<disk name="inoue ryouko last scene (jpn)" sha1="3a465b82c2c94cc6e93f904a08ffae6cd646b8f0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17014,7 +17013,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-20117M-0874&gt;HN316D"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="interlude (jpn)" sha1="f0602aa16434efd302ab92ee2f7bc2700073dc96"/>
+				<disk name="interlude (jpn)" sha1="81b7e9419a0cb394ba3adc9dc1b87645ff337c1c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17088,7 +17087,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-19722M-0891 MT   B03"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="iris (jpn)" sha1="ca801678eb8ccffc1b6aa9c0713f5d575491304d"/>
+				<disk name="iris (jpn)" sha1="6a8f7ae5cbb51a4649d695fe076c7354b2a091ac"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17207,7 +17206,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="HDR-0028-0165   1M1   C   99, HDR-0028-0165   3M3   C   99"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="j.league pro soccer club o tsukurou (jpn)" sha1="e412efe15d1a924cc3389ab7e7da2bf8f567db56"/>
+				<disk name="j.league pro soccer club o tsukurou (jpn)" sha1="301d48ae9453f59cae5ba14610da7bf1997b4fde"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17234,7 +17233,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-43401M-0462&gt;HK711H"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="jahmong (jpn)" sha1="bb96e19026ebf3e12f212c2bbd3c3a95610eec25"/>
+				<disk name="jahmong (jpn)" sha1="f48495ede4aa81aad5904b8c6bb24e05223ff7dd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17367,7 +17366,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-41201M-0531&gt;HKA02A"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet coaster dream 2 (jpn)" sha1="8858b6252cdc67600ab26a6b9a12767726b5bd17"/>
+				<disk name="jet coaster dream 2 (jpn)" sha1="3181d15a34b34584cdc48a7647ce5a32652f4424"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17859,13 +17858,13 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 1)" sha1="585635db615d091f6cce5c7156e475e1f7e92daf"/>
+				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 1)" sha1="486fa13f2cc89b494b59c7e501814d5e3093c04c"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
 			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 2)" sha1="7a07dfcde19ecdaf4ead28b5afa9f01468aac576"/>
+				<disk name="kaen seibo the virgin on megiddo (jpn) (disc 2)" sha1="ae9bcd48abe94cc6f79887cecfd4a367a8ed5699"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17909,7 +17908,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="&lt;T-20105M-0486&gt;HL516C"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kanon (jpn)" sha1="4c915bc782f743c6f87812041c9baccb0e947825"/>
+				<disk name="kanon (jpn)" sha1="81f49e0823557f91ea98e312304c05c5691931d5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18128,7 +18127,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Kaze no Uta"/>
 			<diskarea name="cdrom">
-				<disk name="kaze no uta (jpn)" sha1="96f44ea17e9de2d47061737f7528a7064fc530c2"/>
+				<disk name="kaze no uta (jpn)" sha1="279a9d2dfd1526e4b224203184275396647ab937"/>
 			</diskarea>
 		</part>
 		<part interface="cdrom" name="cdrom2">
@@ -18159,7 +18158,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="T4997766300085"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kidou senkan nadesico nadesico the mission (jpn)" sha1="21dda612cdc3ee96cd9baea01054b167665920f3"/>
+				<disk name="kidou senkan nadesico nadesico the mission (jpn)" sha1="c7aa3b1016252a124a9b6d9d45f78e42e05192ea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18281,7 +18280,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="barcode" value="4 519898 002240"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kimi ga nozomu eien (jpn)" sha1="5c2afe4fa9eea00a0e1f503bd1a328f9ce627c9c"/>
+				<disk name="kimi ga nozomu eien (jpn)" sha1="7622b56158e60972f5ea2b6f82142a9a6c0054f9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18416,7 +18415,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="T-14301M-0057A   2M1   C   93"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="kita e. white illumination (jpn)" sha1="e389aff777840f4bf82f26573fefff2434b8867a"/>
+				<disk name="kita e. white illumination (jpn)" sha1="acb35e852a28693580ef0380123a29acc7e6b88e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19125,7 +19124,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<info name="ring_code" value="HDR-0139-0645   2M1   C   12"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
-				<disk name="love hina smile again (jpn)" sha1="31d6be18dad7207813b905ca422714e78b3c8b21"/>
+				<disk name="love hina smile again (jpn)" sha1="63af4720ff7fcaa14d48a47958eb3c11c167dd84"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/megacd.xml
+++ b/hash/megacd.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
@@ -1027,7 +1027,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="ring_code" value="DADC AUSTRIA SCHTRMO2500 25"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="smurfs, the (europe) (en,fr,de,es,it)" sha1="3e31543e9e02595a1dd245c7f3907151fee40337"/>
+				<disk name="smurfs, the (europe) (en,fr,de,es,it)" sha1="ada0f992b04984aa20da0336e5e4ddf435c7c8f6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2229,7 +2229,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="serial" value="T-88025-50"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="marko's magic football (1994)(domark)(pal)(m4)" sha1="7cc03273fc4b3f5eed54a0598f20ac6425ea2692"/>
+				<disk name="marko's magic football (1994)(domark)(pal)(m4)" sha1="df33c08436e1b5c5a09604c29c1bed6fab7176b4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2712,7 +2712,7 @@ Requires [disc swap]
 		<info name="ring_code" value="610-5411P-00036A 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sega classics arcade collection - limited edition (1993)(sega)(pal)[compilation][610-5411p-00036a 2]" sha1="a7366d582fc0402789a04a3ec9b1713188e1c81f"/>
+				<disk name="sega classics arcade collection - limited edition (1993)(sega)(pal)[compilation][610-5411p-00036a 2]" sha1="8ff8cd77cb561454096993135cdf8fdc675b1871"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2823,7 +2823,7 @@ Requires [disc swap]
 		<info name="serial" value="T-93185-50"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sensible soccer (1993)(sony imagesoft)(pal)(m4)" sha1="4369233ffaf1362a0cd9a711c776d07f3259a340"/>
+				<disk name="sensible soccer (1993)(sony imagesoft)(pal)(m4)" sha1="702f56129dd6c2b0730c8cb776f0b549fbe2b229"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3226,7 +3226,7 @@ Requires [disc swap]
 		<info name="serial" value="T-88065-50"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="syndicate (1995)(domark)(pal)(m3)" sha1="2b747453c6065622eab178654193a301f138cbd8"/>
+				<disk name="syndicate (1995)(domark)(pal)(m3)" sha1="c17160c5a52b99cc6ca833d22433fb79ed43a1e2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3319,7 +3319,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT115015RE R4C"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="thunderhawk (1993)(core)(pal)(m4)[segat115015re r4c]" sha1="199ebc69bd5f6f95574547f72439f61ec31b1483"/>
+				<disk name="thunderhawk (1993)(core)(pal)(m4)[segat115015re r4c]" sha1="eb2891baf1df4a55124eef0cbe9ebed6b96c4cac"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/megacd.xml
+++ b/hash/megacd.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
@@ -1027,7 +1027,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="ring_code" value="DADC AUSTRIA SCHTRMO2500 25"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="smurfs, the (europe) (en,fr,de,es,it)" sha1="ada0f992b04984aa20da0336e5e4ddf435c7c8f6"/>
+				<disk name="smurfs, the (europe) (en,fr,de,es,it)" sha1="3e31543e9e02595a1dd245c7f3907151fee40337"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2229,7 +2229,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="serial" value="T-88025-50"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="marko's magic football (1994)(domark)(pal)(m4)" sha1="df33c08436e1b5c5a09604c29c1bed6fab7176b4"/>
+				<disk name="marko's magic football (1994)(domark)(pal)(m4)" sha1="7cc03273fc4b3f5eed54a0598f20ac6425ea2692"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2712,7 +2712,7 @@ Requires [disc swap]
 		<info name="ring_code" value="610-5411P-00036A 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sega classics arcade collection - limited edition (1993)(sega)(pal)[compilation][610-5411p-00036a 2]" sha1="8ff8cd77cb561454096993135cdf8fdc675b1871"/>
+				<disk name="sega classics arcade collection - limited edition (1993)(sega)(pal)[compilation][610-5411p-00036a 2]" sha1="a7366d582fc0402789a04a3ec9b1713188e1c81f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2823,7 +2823,7 @@ Requires [disc swap]
 		<info name="serial" value="T-93185-50"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sensible soccer (1993)(sony imagesoft)(pal)(m4)" sha1="702f56129dd6c2b0730c8cb776f0b549fbe2b229"/>
+				<disk name="sensible soccer (1993)(sony imagesoft)(pal)(m4)" sha1="4369233ffaf1362a0cd9a711c776d07f3259a340"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3226,7 +3226,7 @@ Requires [disc swap]
 		<info name="serial" value="T-88065-50"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="syndicate (1995)(domark)(pal)(m3)" sha1="c17160c5a52b99cc6ca833d22433fb79ed43a1e2"/>
+				<disk name="syndicate (1995)(domark)(pal)(m3)" sha1="2b747453c6065622eab178654193a301f138cbd8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3319,7 +3319,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT115015RE R4C"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="thunderhawk (1993)(core)(pal)(m4)[segat115015re r4c]" sha1="eb2891baf1df4a55124eef0cbe9ebed6b96c4cac"/>
+				<disk name="thunderhawk (1993)(core)(pal)(m4)[segat115015re r4c]" sha1="199ebc69bd5f6f95574547f72439f61ec31b1483"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/megacd.xml
+++ b/hash/megacd.xml
@@ -1027,7 +1027,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="ring_code" value="DADC AUSTRIA SCHTRMO2500 25"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="smurfs, the (europe) (en,fr,de,es,it)" sha1="ada0f992b04984aa20da0336e5e4ddf435c7c8f6"/>
+				<disk name="smurfs, the (europe) (en,fr,de,es,it)" sha1="3e31543e9e02595a1dd245c7f3907151fee40337"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2229,7 +2229,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="serial" value="T-88025-50"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="marko's magic football (1994)(domark)(pal)(m4)" sha1="df33c08436e1b5c5a09604c29c1bed6fab7176b4"/>
+				<disk name="marko's magic football (1994)(domark)(pal)(m4)" sha1="7cc03273fc4b3f5eed54a0598f20ac6425ea2692"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2712,7 +2712,7 @@ Requires [disc swap]
 		<info name="ring_code" value="610-5411P-00036A 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sega classics arcade collection - limited edition (1993)(sega)(pal)[compilation][610-5411p-00036a 2]" sha1="8ff8cd77cb561454096993135cdf8fdc675b1871"/>
+				<disk name="sega classics arcade collection - limited edition (1993)(sega)(pal)[compilation][610-5411p-00036a 2]" sha1="a7366d582fc0402789a04a3ec9b1713188e1c81f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2823,7 +2823,7 @@ Requires [disc swap]
 		<info name="serial" value="T-93185-50"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sensible soccer (1993)(sony imagesoft)(pal)(m4)" sha1="702f56129dd6c2b0730c8cb776f0b549fbe2b229"/>
+				<disk name="sensible soccer (1993)(sony imagesoft)(pal)(m4)" sha1="4369233ffaf1362a0cd9a711c776d07f3259a340"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3226,7 +3226,7 @@ Requires [disc swap]
 		<info name="serial" value="T-88065-50"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="syndicate (1995)(domark)(pal)(m3)" sha1="c17160c5a52b99cc6ca833d22433fb79ed43a1e2"/>
+				<disk name="syndicate (1995)(domark)(pal)(m3)" sha1="2b747453c6065622eab178654193a301f138cbd8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3319,7 +3319,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT115015RE R4C"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="thunderhawk (1993)(core)(pal)(m4)[segat115015re r4c]" sha1="eb2891baf1df4a55124eef0cbe9ebed6b96c4cac"/>
+				<disk name="thunderhawk (1993)(core)(pal)(m4)[segat115015re r4c]" sha1="199ebc69bd5f6f95574547f72439f61ec31b1483"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/megacdj.xml
+++ b/hash/megacdj.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
@@ -89,7 +89,7 @@ license:CC0-1.0
 		<info name="alt_title" value="バリ・アーム"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bari-arm (japan)" sha1="a14d376efd556bf05f37e696c01664b7dfa13dbe"/>
+				<disk name="bari-arm (japan)" sha1="f90d9dfc264ce4090b348713c235672bce43dd2a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -149,7 +149,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ブライ 八玉の勇士伝説"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="burai - hachigyoku no yuushi densetsu (japan)" sha1="fb036bacef4520c93cd3b9d3d2aaa64975e4a113"/>
+				<disk name="burai - hachigyoku no yuushi densetsu (japan)" sha1="d410d2636e81a163b6d30ed14a822276161c7e2d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -225,7 +225,7 @@ license:CC0-1.0
 		<info name="alt_title" value="コズミックファンタジー Stories"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cosmic fantasy stories (japan)" sha1="62bed0d8e461b8b118ce9d7dfc49d7944edf1c23"/>
+				<disk name="cosmic fantasy stories (japan)" sha1="d12bdaa19acc423de73a62acf8691282b5d625ad"/>
 			</diskarea>
 		</part>
 	</software>
@@ -276,7 +276,7 @@ license:CC0-1.0
 		<info name="alt_title" value="サイボーグ009"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cyborg 009 (japan)" sha1="19cdb90db8c92f6baafc188b83e8ea7a67adb6f1"/>
+				<disk name="cyborg 009 (japan)" sha1="78543b133aab93a87573ffec5692b92d44744083"/>
 			</diskarea>
 		</part>
 	</software>
@@ -348,7 +348,7 @@ license:CC0-1.0
 		<info name="alt_title" value="デトネイター・オーガン"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="detonator orgun (japan)" sha1="80a99c378610c903453fbb8efac9325f04db7700"/>
+				<disk name="detonator orgun (japan)" sha1="81d9c8783fce371a6887d87c8ac9781232d75418"/>
 			</diskarea>
 		</part>
 	</software>
@@ -377,7 +377,7 @@ license:CC0-1.0
 		<info name="alt_title" value="デバステイター"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="devastator (japan)" sha1="3859b4eed02a3b9ccbddfe750285f755d85316cb"/>
+				<disk name="devastator (japan)" sha1="6a515db113271804bb63c27a7393c4f1a28393da"/>
 			</diskarea>
 		</part>
 	</software>
@@ -428,7 +428,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ダイナミックカントリークラブ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dynamic country club (japan)" sha1="04e213ea91c03b9aa8a354a2b5f9d42003ca5dbf"/>
+				<disk name="dynamic country club (japan)" sha1="ece262909b3b242e20b8ad29d2559dec3b5edf03"/>
 			</diskarea>
 		</part>
 	</software>
@@ -471,7 +471,7 @@ license:CC0-1.0
 		<info name="alt_title" value="アーネストエバンス"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="earnest evans (japan)" sha1="9f0e70f629e32134a529b2784786cdac07e55780"/>
+				<disk name="earnest evans (japan)" sha1="7b3dd8e564d7a6f2f659b535c67d8a3d25553f08"/>
 			</diskarea>
 		</part>
 	</software>
@@ -524,7 +524,7 @@ license:CC0-1.0
 		<info name="alt_title" value="江川卓のスーパーリーグCD"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="egawa suguru no super league cd (japan)" sha1="4062f8fbc43963cc9305e14530379989f9543a30"/>
+				<disk name="egawa suguru no super league cd (japan)" sha1="4e8adf6b142de98089af20316be9b644e12ed565"/>
 			</diskarea>
 		</part>
 	</software>
@@ -571,7 +571,7 @@ license:CC0-1.0
 		<info name="alt_title" value="F1サーカスCD"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="f1 circus cd (japan)" sha1="e13e963d3386cd38143334011b6a4c239a871bfa"/>
+				<disk name="f1 circus cd (japan)" sha1="6f9a6324527d277ee36357f52f850f106016b6d8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -686,7 +686,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ぎゅわんぶらあ自己中心派2 激闘! 東京マージャンランド編"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gambler jiko chuushinha 2 - gekitou tokyo mahjongland hen (japan)" sha1="12cb45fafb9f63b41551150dc313eba51fa639c9"/>
+				<disk name="gambler jiko chuushinha 2 - gekitou tokyo mahjongland hen (japan)" sha1="b1d7b2c9f65f5976a4f2025a7464cd9480df0433"/>
 			</diskarea>
 		</part>
 	</software>
@@ -735,7 +735,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ゲームのかんづめ VOL.1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="game no kandume vol.1 (japan)" sha1="88a441b47cc53a088de1b95cc624176895882478"/>
+				<disk name="game no kandume vol.1 (japan)" sha1="4496b319dea8fde1a58411dbeff5f9d9887c8794"/>
 			</diskarea>
 		</part>
 	</software>
@@ -777,7 +777,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ゲームのかんづめ VOL.2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="game no kandume vol.2 (japan)" sha1="093b5a17ea088fe6714e4a095f5240cb6d918fcd"/>
+				<disk name="game no kandume vol.2 (japan)" sha1="a2837628ba846b4108cfbab702df451af2bef294"/>
 			</diskarea>
 		</part>
 	</software>
@@ -922,7 +922,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ヘビーノバ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heavy nova (japan)" sha1="aa7a040fc2b8c8d8264f82573dc5e16d31e2ed57"/>
+				<disk name="heavy nova (japan)" sha1="f476ecc8c9bc76daa3fd4274c1d052abbf7b07d5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1030,7 +1030,7 @@ license:CC0-1.0
 		<info name="alt_title" value="雀豪ワールドカップ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jangou world cup (japan)" sha1="5ce7ade2f0d4ca8b2919db189f5f9e8bfb7aebe4"/>
+				<disk name="jangou world cup (japan)" sha1="a61a656bee8aaedec046259f2f52b97d1f32db8d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1096,7 +1096,7 @@ license:CC0-1.0
 		<info name="alt_title" value="慶応遊撃隊"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="keiou yuugekitai (japan)" sha1="ef5af443f78c67caba7ec02590a3f3f0af93d387"/>
+				<disk name="keiou yuugekitai (japan)" sha1="9ff5dd2775ae157cd0d3fed8b5c877a12541ab5a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1128,7 +1128,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ロードス島戦記 英雄戦争"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lodoss tou senki - eiyuu sensou (japan)" sha1="15ed554b0a63e78648cf496c8b249be35c18420c"/>
+				<disk name="lodoss tou senki - eiyuu sensou (japan)" sha1="441685a5c2a392cf0804d95745600fea553351ca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1304,7 +1304,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ナイトストライカー"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="night striker (japan, korea)" sha1="0c8ba1a5ca12ec52de6b2febac14abd5d1126c84"/>
+				<disk name="night striker (japan, korea)" sha1="8a13f784fa7baf8b7f892429f221ac7c149215dd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1358,7 +1358,7 @@ Requires [disc swap]
 		<info name="alt_title" value="ノスタルジア1907"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nostalgia 1907 (japan)" sha1="c6718f18b5720b3c48abf9c8accdf6d7572e4a63"/>
+				<disk name="nostalgia 1907 (japan)" sha1="668a78fa1eb3c4aeca479f31513eb2d37c22b1ed"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1463,7 +1463,7 @@ Requires [disc swap]
 		<info name="alt_title" value="プロ野球スーパーリーグCD"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro yakyuu super league cd (japan)" sha1="87cf208ad060b8ef6ace3db18824152f45dc91b5"/>
+				<disk name="pro yakyuu super league cd (japan)" sha1="d0fd6311030ea46dfc74f7d03b0ca02618623849"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1522,7 +1522,7 @@ Requires [disc swap]
 		<info name="alt_title" value="クイズスクランブルスペシャル"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="quiz scramble special (japan) (rev b)" sha1="cc636ce3a99a01cdf3d34d93df74b143b6d239b7"/>
+				<disk name="quiz scramble special (japan) (rev b)" sha1="f357feb98bb355e1b8ceea346fbedd90332be49c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1542,7 +1542,7 @@ Requires [disc swap]
 		<info name="alt_title" value="クイズ殿様の野望"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="capcom no quiz - tonosama no yabou (japan)" sha1="9f09efae7369a1439cd85616c89f5d42a2eb741a"/>
+				<disk name="capcom no quiz - tonosama no yabou (japan)" sha1="82fbbe604709866420f64705beb902a4addb1f5c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1585,7 +1585,7 @@ Requires [disc swap]
 		<info name="alt_title" value="らんま½ 白蘭愛歌"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ranma 1-2 - byakuranaika (japan)" sha1="89f733676137b26b304d21eab6c5e50c4ee48389"/>
+				<disk name="ranma 1-2 - byakuranaika (japan)" sha1="ebbc76619d2a5353175083563326165ee89499b4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1676,7 +1676,7 @@ Requires [disc swap]
 		<info name="alt_title" value="三國志III"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sangokushi iii (japan)" sha1="4745bf0906999474645e1b4d515bc1b1902ca422"/>
+				<disk name="sangokushi iii (japan)" sha1="5e59329e50c979a0dbc5fd665a040fdd8af30e54"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1771,7 +1771,7 @@ Requires [disc swap]
 		<info name="alt_title" value="聖魔伝説 3×3EYES"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="seima densetsu 3x3 eyes (japan)" sha1="8a850d7cf8db54c48adb8ae8f485143cd27df8c6"/>
+				<disk name="seima densetsu 3x3 eyes (japan)" sha1="30be1bd4a12635c5aa4317974ffdf97c096003d8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1874,7 +1874,7 @@ Requires [disc swap]
 		<info name="alt_title" value="精霊神世紀フェイエリア"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="seirei shinseiki - fhey area (japan)" sha1="0eb59654214bf37e8493ec48f6d4f6cd5077fbb2"/>
+				<disk name="seirei shinseiki - fhey area (japan)" sha1="3842a33ed9fd130801a2c54c072b7d930f0aa38e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1953,7 +1953,7 @@ Requires [disc swap]
 		<info name="alt_title" value="真・女神転生"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="shin megami tensei (japan)" sha1="4ef3c263e909471ac27757c16423e66009726544"/>
+				<disk name="shin megami tensei (japan)" sha1="bbb6f22e314459a35bf118d17edbebb7c27af226"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2256,7 +2256,7 @@ Requires [disc swap]
 		<info name="alt_title" value="天舞メガCDスペシャル"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tenbu mega cd special (japan)" sha1="e973a5a3d51455b394eecccd99c7b62d407c1a82"/>
+				<disk name="tenbu mega cd special (japan)" sha1="d85c060847c769112f392c22795a4afa39e9fd46"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2293,7 +2293,7 @@ Requires [disc swap]
 		<info name="alt_title" value="天下布武 英雄たちの咆哮"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tenkafubu - eiyuutachi no houkou (japan)" sha1="9a97b0c278d0a5ba7c2df8e7343811f9a0ccd3f2"/>
+				<disk name="tenkafubu - eiyuutachi no houkou (japan)" sha1="d8375089c8979bee48210a46548aae3a82e48384"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2342,7 +2342,7 @@ Requires [disc swap]
 		<info name="alt_title" value="サンダーホーク"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="thunderhawk (japan)" sha1="0e729497bb3ab8c0614c32d1a3f4668584518356"/>
+				<disk name="thunderhawk (japan)" sha1="5571e029303d0b4f1bb2dcbf71f2af23127cb5af"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2365,7 +2365,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="タイムギャル"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="time gal (japan)" sha1="32fffda2ccc83602a0e6d96a18bb3355a4c3d3d5"/>
+				<disk name="time gal (japan)" sha1="891f864be9ccb762ccb0420d246171a5a2e38fe1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2386,7 +2386,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="うる星やつら ディア マイ フレンズ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="urusei yatsura - dear my friends (japan)" sha1="3d3e05daf5f3c4fe36c1d08eec1017daaac06c9e"/>
+				<disk name="urusei yatsura - dear my friends (japan)" sha1="f016d91cf16f8231979b863b43b9a1f4cdd10e66"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2444,7 +2444,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="惑星ウッドストック ファンキーホラーバンド"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wakusei woodstock - funky horror band (japan)" sha1="1bc0d49763960db4e7cd53661f07e9a4cd9f2f7b"/>
+				<disk name="wakusei woodstock - funky horror band (japan)" sha1="b8e62fcd47660354ebad5a26351872837efd9c5a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2505,7 +2505,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="ウイニングポスト"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="winning post (japan)" sha1="85f6dfa7125b37f9471206898d3b51e0ea2857f7"/>
+				<disk name="winning post (japan)" sha1="88e37f4ce5e4bb9ee9ffdbea0e1cfbd5c65e3287"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2615,7 +2615,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="ゆみみみっくす"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="yumimi mix (japan)" sha1="4adc66b222b7a26a3f00be9692a81ad343b07b41"/>
+				<disk name="yumimi mix (japan)" sha1="68812a953d4c88485427d415576b77382985f746"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2746,7 +2746,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="アフターハルマゲドン外伝 魔獣闘将伝エクリプス"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="after armageddon gaiden - majuu toushouden eclipse (1994)(sega)(ntsc)(jp)" sha1="1e86a6fbb394519c6248eaeff2421af8b50b61e2"/>
+				<disk name="after armageddon gaiden - majuu toushouden eclipse (1994)(sega)(ntsc)(jp)" sha1="fdccf03dd1052039b978f5547bb0e64f6dc565b8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2884,7 +2884,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="アネット再び"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="anett futatabi (1993)(wolf team)(ntsc)(jp)(en)" sha1="3b86f9d737a36266a72b46f148dbdb369356ff9b"/>
+				<disk name="anett futatabi (1993)(wolf team)(ntsc)(jp)(en)" sha1="c552b5375490890883a8ec70f6fd6ddea5b27ef3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3221,7 +3221,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="バトルファンタジー"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle fantasy (1994)(micronet)(ntsc)(jp)" sha1="763d75175e1a1fac6368c42b95c6260fbf14e865"/>
+				<disk name="battle fantasy (1994)(micronet)(ntsc)(jp)" sha1="4343c46832992952d9f2fdce0c118c105181c5f8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3348,7 +3348,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="キャプテン翼"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="captain tsubasa (1994)(tecmo)(ntsc)(jp)" sha1="60bf853778b6beedf2b715978b35b1aeed6181c0"/>
+				<disk name="captain tsubasa (1994)(tecmo)(ntsc)(jp)" sha1="9c4b2276304985460e4a666a0115a637bb1b2cff"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4363,7 +4363,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="ニンジャウォーリアーズ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ninjawarriors, the (1993)(taito)(ntsc)(jp)(en)" sha1="54139589ce904ddba72f9379949f3b6d0bfef2f6"/>
+				<disk name="ninjawarriors, the (1993)(taito)(ntsc)(jp)(en)" sha1="471a824e6729c65321fa8219fc40b23821a08b40"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4976,7 +4976,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="戦国伝承"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sengoku denshou (1993)(sammy)(ntsc)(jp)" sha1="a7068e9594b65c665796689bfe16c7ee0ecba041"/>
+				<disk name="sengoku denshou (1993)(sammy)(ntsc)(jp)" sha1="03699195ec6906653309f0ed76ec2151937fce6e"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/megacdj.xml
+++ b/hash/megacdj.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
@@ -89,7 +89,7 @@ license:CC0-1.0
 		<info name="alt_title" value="バリ・アーム"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bari-arm (japan)" sha1="f90d9dfc264ce4090b348713c235672bce43dd2a"/>
+				<disk name="bari-arm (japan)" sha1="a14d376efd556bf05f37e696c01664b7dfa13dbe"/>
 			</diskarea>
 		</part>
 	</software>
@@ -149,7 +149,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ブライ 八玉の勇士伝説"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="burai - hachigyoku no yuushi densetsu (japan)" sha1="d410d2636e81a163b6d30ed14a822276161c7e2d"/>
+				<disk name="burai - hachigyoku no yuushi densetsu (japan)" sha1="fb036bacef4520c93cd3b9d3d2aaa64975e4a113"/>
 			</diskarea>
 		</part>
 	</software>
@@ -225,7 +225,7 @@ license:CC0-1.0
 		<info name="alt_title" value="コズミックファンタジー Stories"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cosmic fantasy stories (japan)" sha1="d12bdaa19acc423de73a62acf8691282b5d625ad"/>
+				<disk name="cosmic fantasy stories (japan)" sha1="62bed0d8e461b8b118ce9d7dfc49d7944edf1c23"/>
 			</diskarea>
 		</part>
 	</software>
@@ -276,7 +276,7 @@ license:CC0-1.0
 		<info name="alt_title" value="サイボーグ009"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cyborg 009 (japan)" sha1="78543b133aab93a87573ffec5692b92d44744083"/>
+				<disk name="cyborg 009 (japan)" sha1="19cdb90db8c92f6baafc188b83e8ea7a67adb6f1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -348,7 +348,7 @@ license:CC0-1.0
 		<info name="alt_title" value="デトネイター・オーガン"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="detonator orgun (japan)" sha1="81d9c8783fce371a6887d87c8ac9781232d75418"/>
+				<disk name="detonator orgun (japan)" sha1="80a99c378610c903453fbb8efac9325f04db7700"/>
 			</diskarea>
 		</part>
 	</software>
@@ -377,7 +377,7 @@ license:CC0-1.0
 		<info name="alt_title" value="デバステイター"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="devastator (japan)" sha1="6a515db113271804bb63c27a7393c4f1a28393da"/>
+				<disk name="devastator (japan)" sha1="3859b4eed02a3b9ccbddfe750285f755d85316cb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -428,7 +428,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ダイナミックカントリークラブ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dynamic country club (japan)" sha1="ece262909b3b242e20b8ad29d2559dec3b5edf03"/>
+				<disk name="dynamic country club (japan)" sha1="04e213ea91c03b9aa8a354a2b5f9d42003ca5dbf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -471,7 +471,7 @@ license:CC0-1.0
 		<info name="alt_title" value="アーネストエバンス"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="earnest evans (japan)" sha1="7b3dd8e564d7a6f2f659b535c67d8a3d25553f08"/>
+				<disk name="earnest evans (japan)" sha1="9f0e70f629e32134a529b2784786cdac07e55780"/>
 			</diskarea>
 		</part>
 	</software>
@@ -524,7 +524,7 @@ license:CC0-1.0
 		<info name="alt_title" value="江川卓のスーパーリーグCD"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="egawa suguru no super league cd (japan)" sha1="4e8adf6b142de98089af20316be9b644e12ed565"/>
+				<disk name="egawa suguru no super league cd (japan)" sha1="4062f8fbc43963cc9305e14530379989f9543a30"/>
 			</diskarea>
 		</part>
 	</software>
@@ -571,7 +571,7 @@ license:CC0-1.0
 		<info name="alt_title" value="F1サーカスCD"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="f1 circus cd (japan)" sha1="6f9a6324527d277ee36357f52f850f106016b6d8"/>
+				<disk name="f1 circus cd (japan)" sha1="e13e963d3386cd38143334011b6a4c239a871bfa"/>
 			</diskarea>
 		</part>
 	</software>
@@ -686,7 +686,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ぎゅわんぶらあ自己中心派2 激闘! 東京マージャンランド編"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gambler jiko chuushinha 2 - gekitou tokyo mahjongland hen (japan)" sha1="b1d7b2c9f65f5976a4f2025a7464cd9480df0433"/>
+				<disk name="gambler jiko chuushinha 2 - gekitou tokyo mahjongland hen (japan)" sha1="12cb45fafb9f63b41551150dc313eba51fa639c9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -735,7 +735,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ゲームのかんづめ VOL.1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="game no kandume vol.1 (japan)" sha1="4496b319dea8fde1a58411dbeff5f9d9887c8794"/>
+				<disk name="game no kandume vol.1 (japan)" sha1="88a441b47cc53a088de1b95cc624176895882478"/>
 			</diskarea>
 		</part>
 	</software>
@@ -777,7 +777,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ゲームのかんづめ VOL.2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="game no kandume vol.2 (japan)" sha1="a2837628ba846b4108cfbab702df451af2bef294"/>
+				<disk name="game no kandume vol.2 (japan)" sha1="093b5a17ea088fe6714e4a095f5240cb6d918fcd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -922,7 +922,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ヘビーノバ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heavy nova (japan)" sha1="f476ecc8c9bc76daa3fd4274c1d052abbf7b07d5"/>
+				<disk name="heavy nova (japan)" sha1="aa7a040fc2b8c8d8264f82573dc5e16d31e2ed57"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1030,7 +1030,7 @@ license:CC0-1.0
 		<info name="alt_title" value="雀豪ワールドカップ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jangou world cup (japan)" sha1="a61a656bee8aaedec046259f2f52b97d1f32db8d"/>
+				<disk name="jangou world cup (japan)" sha1="5ce7ade2f0d4ca8b2919db189f5f9e8bfb7aebe4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1096,7 +1096,7 @@ license:CC0-1.0
 		<info name="alt_title" value="慶応遊撃隊"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="keiou yuugekitai (japan)" sha1="9ff5dd2775ae157cd0d3fed8b5c877a12541ab5a"/>
+				<disk name="keiou yuugekitai (japan)" sha1="ef5af443f78c67caba7ec02590a3f3f0af93d387"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1128,7 +1128,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ロードス島戦記 英雄戦争"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lodoss tou senki - eiyuu sensou (japan)" sha1="441685a5c2a392cf0804d95745600fea553351ca"/>
+				<disk name="lodoss tou senki - eiyuu sensou (japan)" sha1="15ed554b0a63e78648cf496c8b249be35c18420c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1304,7 +1304,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ナイトストライカー"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="night striker (japan, korea)" sha1="8a13f784fa7baf8b7f892429f221ac7c149215dd"/>
+				<disk name="night striker (japan, korea)" sha1="0c8ba1a5ca12ec52de6b2febac14abd5d1126c84"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1358,7 +1358,7 @@ Requires [disc swap]
 		<info name="alt_title" value="ノスタルジア1907"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nostalgia 1907 (japan)" sha1="668a78fa1eb3c4aeca479f31513eb2d37c22b1ed"/>
+				<disk name="nostalgia 1907 (japan)" sha1="c6718f18b5720b3c48abf9c8accdf6d7572e4a63"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1463,7 +1463,7 @@ Requires [disc swap]
 		<info name="alt_title" value="プロ野球スーパーリーグCD"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro yakyuu super league cd (japan)" sha1="d0fd6311030ea46dfc74f7d03b0ca02618623849"/>
+				<disk name="pro yakyuu super league cd (japan)" sha1="87cf208ad060b8ef6ace3db18824152f45dc91b5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1522,7 +1522,7 @@ Requires [disc swap]
 		<info name="alt_title" value="クイズスクランブルスペシャル"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="quiz scramble special (japan) (rev b)" sha1="f357feb98bb355e1b8ceea346fbedd90332be49c"/>
+				<disk name="quiz scramble special (japan) (rev b)" sha1="cc636ce3a99a01cdf3d34d93df74b143b6d239b7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1542,7 +1542,7 @@ Requires [disc swap]
 		<info name="alt_title" value="クイズ殿様の野望"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="capcom no quiz - tonosama no yabou (japan)" sha1="82fbbe604709866420f64705beb902a4addb1f5c"/>
+				<disk name="capcom no quiz - tonosama no yabou (japan)" sha1="9f09efae7369a1439cd85616c89f5d42a2eb741a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1585,7 +1585,7 @@ Requires [disc swap]
 		<info name="alt_title" value="らんま½ 白蘭愛歌"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ranma 1-2 - byakuranaika (japan)" sha1="ebbc76619d2a5353175083563326165ee89499b4"/>
+				<disk name="ranma 1-2 - byakuranaika (japan)" sha1="89f733676137b26b304d21eab6c5e50c4ee48389"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1676,7 +1676,7 @@ Requires [disc swap]
 		<info name="alt_title" value="三國志III"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sangokushi iii (japan)" sha1="5e59329e50c979a0dbc5fd665a040fdd8af30e54"/>
+				<disk name="sangokushi iii (japan)" sha1="4745bf0906999474645e1b4d515bc1b1902ca422"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1771,7 +1771,7 @@ Requires [disc swap]
 		<info name="alt_title" value="聖魔伝説 3×3EYES"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="seima densetsu 3x3 eyes (japan)" sha1="30be1bd4a12635c5aa4317974ffdf97c096003d8"/>
+				<disk name="seima densetsu 3x3 eyes (japan)" sha1="8a850d7cf8db54c48adb8ae8f485143cd27df8c6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1874,7 +1874,7 @@ Requires [disc swap]
 		<info name="alt_title" value="精霊神世紀フェイエリア"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="seirei shinseiki - fhey area (japan)" sha1="3842a33ed9fd130801a2c54c072b7d930f0aa38e"/>
+				<disk name="seirei shinseiki - fhey area (japan)" sha1="0eb59654214bf37e8493ec48f6d4f6cd5077fbb2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1953,7 +1953,7 @@ Requires [disc swap]
 		<info name="alt_title" value="真・女神転生"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="shin megami tensei (japan)" sha1="bbb6f22e314459a35bf118d17edbebb7c27af226"/>
+				<disk name="shin megami tensei (japan)" sha1="4ef3c263e909471ac27757c16423e66009726544"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2256,7 +2256,7 @@ Requires [disc swap]
 		<info name="alt_title" value="天舞メガCDスペシャル"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tenbu mega cd special (japan)" sha1="d85c060847c769112f392c22795a4afa39e9fd46"/>
+				<disk name="tenbu mega cd special (japan)" sha1="e973a5a3d51455b394eecccd99c7b62d407c1a82"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2293,7 +2293,7 @@ Requires [disc swap]
 		<info name="alt_title" value="天下布武 英雄たちの咆哮"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tenkafubu - eiyuutachi no houkou (japan)" sha1="d8375089c8979bee48210a46548aae3a82e48384"/>
+				<disk name="tenkafubu - eiyuutachi no houkou (japan)" sha1="9a97b0c278d0a5ba7c2df8e7343811f9a0ccd3f2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2342,7 +2342,7 @@ Requires [disc swap]
 		<info name="alt_title" value="サンダーホーク"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="thunderhawk (japan)" sha1="5571e029303d0b4f1bb2dcbf71f2af23127cb5af"/>
+				<disk name="thunderhawk (japan)" sha1="0e729497bb3ab8c0614c32d1a3f4668584518356"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2365,7 +2365,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="タイムギャル"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="time gal (japan)" sha1="891f864be9ccb762ccb0420d246171a5a2e38fe1"/>
+				<disk name="time gal (japan)" sha1="32fffda2ccc83602a0e6d96a18bb3355a4c3d3d5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2386,7 +2386,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="うる星やつら ディア マイ フレンズ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="urusei yatsura - dear my friends (japan)" sha1="f016d91cf16f8231979b863b43b9a1f4cdd10e66"/>
+				<disk name="urusei yatsura - dear my friends (japan)" sha1="3d3e05daf5f3c4fe36c1d08eec1017daaac06c9e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2444,7 +2444,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="惑星ウッドストック ファンキーホラーバンド"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wakusei woodstock - funky horror band (japan)" sha1="b8e62fcd47660354ebad5a26351872837efd9c5a"/>
+				<disk name="wakusei woodstock - funky horror band (japan)" sha1="1bc0d49763960db4e7cd53661f07e9a4cd9f2f7b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2505,7 +2505,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="ウイニングポスト"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="winning post (japan)" sha1="88e37f4ce5e4bb9ee9ffdbea0e1cfbd5c65e3287"/>
+				<disk name="winning post (japan)" sha1="85f6dfa7125b37f9471206898d3b51e0ea2857f7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2615,7 +2615,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="ゆみみみっくす"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="yumimi mix (japan)" sha1="68812a953d4c88485427d415576b77382985f746"/>
+				<disk name="yumimi mix (japan)" sha1="4adc66b222b7a26a3f00be9692a81ad343b07b41"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2746,7 +2746,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="アフターハルマゲドン外伝 魔獣闘将伝エクリプス"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="after armageddon gaiden - majuu toushouden eclipse (1994)(sega)(ntsc)(jp)" sha1="fdccf03dd1052039b978f5547bb0e64f6dc565b8"/>
+				<disk name="after armageddon gaiden - majuu toushouden eclipse (1994)(sega)(ntsc)(jp)" sha1="1e86a6fbb394519c6248eaeff2421af8b50b61e2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2884,7 +2884,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="アネット再び"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="anett futatabi (1993)(wolf team)(ntsc)(jp)(en)" sha1="c552b5375490890883a8ec70f6fd6ddea5b27ef3"/>
+				<disk name="anett futatabi (1993)(wolf team)(ntsc)(jp)(en)" sha1="3b86f9d737a36266a72b46f148dbdb369356ff9b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3221,7 +3221,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="バトルファンタジー"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle fantasy (1994)(micronet)(ntsc)(jp)" sha1="4343c46832992952d9f2fdce0c118c105181c5f8"/>
+				<disk name="battle fantasy (1994)(micronet)(ntsc)(jp)" sha1="763d75175e1a1fac6368c42b95c6260fbf14e865"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3348,7 +3348,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="キャプテン翼"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="captain tsubasa (1994)(tecmo)(ntsc)(jp)" sha1="9c4b2276304985460e4a666a0115a637bb1b2cff"/>
+				<disk name="captain tsubasa (1994)(tecmo)(ntsc)(jp)" sha1="60bf853778b6beedf2b715978b35b1aeed6181c0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4363,7 +4363,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="ニンジャウォーリアーズ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ninjawarriors, the (1993)(taito)(ntsc)(jp)(en)" sha1="471a824e6729c65321fa8219fc40b23821a08b40"/>
+				<disk name="ninjawarriors, the (1993)(taito)(ntsc)(jp)(en)" sha1="54139589ce904ddba72f9379949f3b6d0bfef2f6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4976,7 +4976,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="戦国伝承"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sengoku denshou (1993)(sammy)(ntsc)(jp)" sha1="03699195ec6906653309f0ed76ec2151937fce6e"/>
+				<disk name="sengoku denshou (1993)(sammy)(ntsc)(jp)" sha1="a7068e9594b65c665796689bfe16c7ee0ecba041"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/megacdj.xml
+++ b/hash/megacdj.xml
@@ -89,7 +89,7 @@ license:CC0-1.0
 		<info name="alt_title" value="バリ・アーム"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bari-arm (japan)" sha1="a14d376efd556bf05f37e696c01664b7dfa13dbe"/>
+				<disk name="bari-arm (japan)" sha1="f90d9dfc264ce4090b348713c235672bce43dd2a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -149,7 +149,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ブライ 八玉の勇士伝説"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="burai - hachigyoku no yuushi densetsu (japan)" sha1="fb036bacef4520c93cd3b9d3d2aaa64975e4a113"/>
+				<disk name="burai - hachigyoku no yuushi densetsu (japan)" sha1="d410d2636e81a163b6d30ed14a822276161c7e2d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -225,7 +225,7 @@ license:CC0-1.0
 		<info name="alt_title" value="コズミックファンタジー Stories"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cosmic fantasy stories (japan)" sha1="62bed0d8e461b8b118ce9d7dfc49d7944edf1c23"/>
+				<disk name="cosmic fantasy stories (japan)" sha1="d12bdaa19acc423de73a62acf8691282b5d625ad"/>
 			</diskarea>
 		</part>
 	</software>
@@ -276,7 +276,7 @@ license:CC0-1.0
 		<info name="alt_title" value="サイボーグ009"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cyborg 009 (japan)" sha1="19cdb90db8c92f6baafc188b83e8ea7a67adb6f1"/>
+				<disk name="cyborg 009 (japan)" sha1="78543b133aab93a87573ffec5692b92d44744083"/>
 			</diskarea>
 		</part>
 	</software>
@@ -348,7 +348,7 @@ license:CC0-1.0
 		<info name="alt_title" value="デトネイター・オーガン"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="detonator orgun (japan)" sha1="80a99c378610c903453fbb8efac9325f04db7700"/>
+				<disk name="detonator orgun (japan)" sha1="81d9c8783fce371a6887d87c8ac9781232d75418"/>
 			</diskarea>
 		</part>
 	</software>
@@ -377,7 +377,7 @@ license:CC0-1.0
 		<info name="alt_title" value="デバステイター"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="devastator (japan)" sha1="3859b4eed02a3b9ccbddfe750285f755d85316cb"/>
+				<disk name="devastator (japan)" sha1="6a515db113271804bb63c27a7393c4f1a28393da"/>
 			</diskarea>
 		</part>
 	</software>
@@ -428,7 +428,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ダイナミックカントリークラブ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dynamic country club (japan)" sha1="04e213ea91c03b9aa8a354a2b5f9d42003ca5dbf"/>
+				<disk name="dynamic country club (japan)" sha1="ece262909b3b242e20b8ad29d2559dec3b5edf03"/>
 			</diskarea>
 		</part>
 	</software>
@@ -471,7 +471,7 @@ license:CC0-1.0
 		<info name="alt_title" value="アーネストエバンス"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="earnest evans (japan)" sha1="9f0e70f629e32134a529b2784786cdac07e55780"/>
+				<disk name="earnest evans (japan)" sha1="7b3dd8e564d7a6f2f659b535c67d8a3d25553f08"/>
 			</diskarea>
 		</part>
 	</software>
@@ -524,7 +524,7 @@ license:CC0-1.0
 		<info name="alt_title" value="江川卓のスーパーリーグCD"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="egawa suguru no super league cd (japan)" sha1="4062f8fbc43963cc9305e14530379989f9543a30"/>
+				<disk name="egawa suguru no super league cd (japan)" sha1="4e8adf6b142de98089af20316be9b644e12ed565"/>
 			</diskarea>
 		</part>
 	</software>
@@ -571,7 +571,7 @@ license:CC0-1.0
 		<info name="alt_title" value="F1サーカスCD"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="f1 circus cd (japan)" sha1="e13e963d3386cd38143334011b6a4c239a871bfa"/>
+				<disk name="f1 circus cd (japan)" sha1="6f9a6324527d277ee36357f52f850f106016b6d8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -686,7 +686,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ぎゅわんぶらあ自己中心派2 激闘! 東京マージャンランド編"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gambler jiko chuushinha 2 - gekitou tokyo mahjongland hen (japan)" sha1="12cb45fafb9f63b41551150dc313eba51fa639c9"/>
+				<disk name="gambler jiko chuushinha 2 - gekitou tokyo mahjongland hen (japan)" sha1="b1d7b2c9f65f5976a4f2025a7464cd9480df0433"/>
 			</diskarea>
 		</part>
 	</software>
@@ -735,7 +735,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ゲームのかんづめ VOL.1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="game no kandume vol.1 (japan)" sha1="88a441b47cc53a088de1b95cc624176895882478"/>
+				<disk name="game no kandume vol.1 (japan)" sha1="4496b319dea8fde1a58411dbeff5f9d9887c8794"/>
 			</diskarea>
 		</part>
 	</software>
@@ -777,7 +777,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ゲームのかんづめ VOL.2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="game no kandume vol.2 (japan)" sha1="093b5a17ea088fe6714e4a095f5240cb6d918fcd"/>
+				<disk name="game no kandume vol.2 (japan)" sha1="a2837628ba846b4108cfbab702df451af2bef294"/>
 			</diskarea>
 		</part>
 	</software>
@@ -922,7 +922,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ヘビーノバ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heavy nova (japan)" sha1="aa7a040fc2b8c8d8264f82573dc5e16d31e2ed57"/>
+				<disk name="heavy nova (japan)" sha1="f476ecc8c9bc76daa3fd4274c1d052abbf7b07d5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1030,7 +1030,7 @@ license:CC0-1.0
 		<info name="alt_title" value="雀豪ワールドカップ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jangou world cup (japan)" sha1="5ce7ade2f0d4ca8b2919db189f5f9e8bfb7aebe4"/>
+				<disk name="jangou world cup (japan)" sha1="a61a656bee8aaedec046259f2f52b97d1f32db8d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1096,7 +1096,7 @@ license:CC0-1.0
 		<info name="alt_title" value="慶応遊撃隊"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="keiou yuugekitai (japan)" sha1="ef5af443f78c67caba7ec02590a3f3f0af93d387"/>
+				<disk name="keiou yuugekitai (japan)" sha1="9ff5dd2775ae157cd0d3fed8b5c877a12541ab5a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1128,7 +1128,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ロードス島戦記 英雄戦争"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lodoss tou senki - eiyuu sensou (japan)" sha1="15ed554b0a63e78648cf496c8b249be35c18420c"/>
+				<disk name="lodoss tou senki - eiyuu sensou (japan)" sha1="441685a5c2a392cf0804d95745600fea553351ca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1304,7 +1304,7 @@ license:CC0-1.0
 		<info name="alt_title" value="ナイトストライカー"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="night striker (japan, korea)" sha1="0c8ba1a5ca12ec52de6b2febac14abd5d1126c84"/>
+				<disk name="night striker (japan, korea)" sha1="8a13f784fa7baf8b7f892429f221ac7c149215dd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1358,7 +1358,7 @@ Requires [disc swap]
 		<info name="alt_title" value="ノスタルジア1907"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nostalgia 1907 (japan)" sha1="c6718f18b5720b3c48abf9c8accdf6d7572e4a63"/>
+				<disk name="nostalgia 1907 (japan)" sha1="668a78fa1eb3c4aeca479f31513eb2d37c22b1ed"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1463,7 +1463,7 @@ Requires [disc swap]
 		<info name="alt_title" value="プロ野球スーパーリーグCD"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro yakyuu super league cd (japan)" sha1="87cf208ad060b8ef6ace3db18824152f45dc91b5"/>
+				<disk name="pro yakyuu super league cd (japan)" sha1="d0fd6311030ea46dfc74f7d03b0ca02618623849"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1522,7 +1522,7 @@ Requires [disc swap]
 		<info name="alt_title" value="クイズスクランブルスペシャル"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="quiz scramble special (japan) (rev b)" sha1="cc636ce3a99a01cdf3d34d93df74b143b6d239b7"/>
+				<disk name="quiz scramble special (japan) (rev b)" sha1="f357feb98bb355e1b8ceea346fbedd90332be49c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1542,7 +1542,7 @@ Requires [disc swap]
 		<info name="alt_title" value="クイズ殿様の野望"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="capcom no quiz - tonosama no yabou (japan)" sha1="9f09efae7369a1439cd85616c89f5d42a2eb741a"/>
+				<disk name="capcom no quiz - tonosama no yabou (japan)" sha1="82fbbe604709866420f64705beb902a4addb1f5c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1585,7 +1585,7 @@ Requires [disc swap]
 		<info name="alt_title" value="らんま½ 白蘭愛歌"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ranma 1-2 - byakuranaika (japan)" sha1="89f733676137b26b304d21eab6c5e50c4ee48389"/>
+				<disk name="ranma 1-2 - byakuranaika (japan)" sha1="ebbc76619d2a5353175083563326165ee89499b4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1676,7 +1676,7 @@ Requires [disc swap]
 		<info name="alt_title" value="三國志III"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sangokushi iii (japan)" sha1="4745bf0906999474645e1b4d515bc1b1902ca422"/>
+				<disk name="sangokushi iii (japan)" sha1="5e59329e50c979a0dbc5fd665a040fdd8af30e54"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1771,7 +1771,7 @@ Requires [disc swap]
 		<info name="alt_title" value="聖魔伝説 3×3EYES"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="seima densetsu 3x3 eyes (japan)" sha1="8a850d7cf8db54c48adb8ae8f485143cd27df8c6"/>
+				<disk name="seima densetsu 3x3 eyes (japan)" sha1="30be1bd4a12635c5aa4317974ffdf97c096003d8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1874,7 +1874,7 @@ Requires [disc swap]
 		<info name="alt_title" value="精霊神世紀フェイエリア"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="seirei shinseiki - fhey area (japan)" sha1="0eb59654214bf37e8493ec48f6d4f6cd5077fbb2"/>
+				<disk name="seirei shinseiki - fhey area (japan)" sha1="3842a33ed9fd130801a2c54c072b7d930f0aa38e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1953,7 +1953,7 @@ Requires [disc swap]
 		<info name="alt_title" value="真・女神転生"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="shin megami tensei (japan)" sha1="4ef3c263e909471ac27757c16423e66009726544"/>
+				<disk name="shin megami tensei (japan)" sha1="bbb6f22e314459a35bf118d17edbebb7c27af226"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2256,7 +2256,7 @@ Requires [disc swap]
 		<info name="alt_title" value="天舞メガCDスペシャル"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tenbu mega cd special (japan)" sha1="e973a5a3d51455b394eecccd99c7b62d407c1a82"/>
+				<disk name="tenbu mega cd special (japan)" sha1="d85c060847c769112f392c22795a4afa39e9fd46"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2293,7 +2293,7 @@ Requires [disc swap]
 		<info name="alt_title" value="天下布武 英雄たちの咆哮"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tenkafubu - eiyuutachi no houkou (japan)" sha1="9a97b0c278d0a5ba7c2df8e7343811f9a0ccd3f2"/>
+				<disk name="tenkafubu - eiyuutachi no houkou (japan)" sha1="d8375089c8979bee48210a46548aae3a82e48384"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2342,7 +2342,7 @@ Requires [disc swap]
 		<info name="alt_title" value="サンダーホーク"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="thunderhawk (japan)" sha1="0e729497bb3ab8c0614c32d1a3f4668584518356"/>
+				<disk name="thunderhawk (japan)" sha1="5571e029303d0b4f1bb2dcbf71f2af23127cb5af"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2365,7 +2365,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="タイムギャル"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="time gal (japan)" sha1="32fffda2ccc83602a0e6d96a18bb3355a4c3d3d5"/>
+				<disk name="time gal (japan)" sha1="891f864be9ccb762ccb0420d246171a5a2e38fe1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2386,7 +2386,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="うる星やつら ディア マイ フレンズ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="urusei yatsura - dear my friends (japan)" sha1="3d3e05daf5f3c4fe36c1d08eec1017daaac06c9e"/>
+				<disk name="urusei yatsura - dear my friends (japan)" sha1="f016d91cf16f8231979b863b43b9a1f4cdd10e66"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2444,7 +2444,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="惑星ウッドストック ファンキーホラーバンド"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wakusei woodstock - funky horror band (japan)" sha1="1bc0d49763960db4e7cd53661f07e9a4cd9f2f7b"/>
+				<disk name="wakusei woodstock - funky horror band (japan)" sha1="b8e62fcd47660354ebad5a26351872837efd9c5a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2505,7 +2505,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="ウイニングポスト"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="winning post (japan)" sha1="85f6dfa7125b37f9471206898d3b51e0ea2857f7"/>
+				<disk name="winning post (japan)" sha1="88e37f4ce5e4bb9ee9ffdbea0e1cfbd5c65e3287"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2615,7 +2615,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="ゆみみみっくす"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="yumimi mix (japan)" sha1="4adc66b222b7a26a3f00be9692a81ad343b07b41"/>
+				<disk name="yumimi mix (japan)" sha1="68812a953d4c88485427d415576b77382985f746"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2746,7 +2746,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="アフターハルマゲドン外伝 魔獣闘将伝エクリプス"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="after armageddon gaiden - majuu toushouden eclipse (1994)(sega)(ntsc)(jp)" sha1="1e86a6fbb394519c6248eaeff2421af8b50b61e2"/>
+				<disk name="after armageddon gaiden - majuu toushouden eclipse (1994)(sega)(ntsc)(jp)" sha1="fdccf03dd1052039b978f5547bb0e64f6dc565b8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2884,7 +2884,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="アネット再び"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="anett futatabi (1993)(wolf team)(ntsc)(jp)(en)" sha1="3b86f9d737a36266a72b46f148dbdb369356ff9b"/>
+				<disk name="anett futatabi (1993)(wolf team)(ntsc)(jp)(en)" sha1="c552b5375490890883a8ec70f6fd6ddea5b27ef3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3221,7 +3221,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="バトルファンタジー"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle fantasy (1994)(micronet)(ntsc)(jp)" sha1="763d75175e1a1fac6368c42b95c6260fbf14e865"/>
+				<disk name="battle fantasy (1994)(micronet)(ntsc)(jp)" sha1="4343c46832992952d9f2fdce0c118c105181c5f8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3348,7 +3348,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="キャプテン翼"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="captain tsubasa (1994)(tecmo)(ntsc)(jp)" sha1="60bf853778b6beedf2b715978b35b1aeed6181c0"/>
+				<disk name="captain tsubasa (1994)(tecmo)(ntsc)(jp)" sha1="9c4b2276304985460e4a666a0115a637bb1b2cff"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4363,7 +4363,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="ニンジャウォーリアーズ"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ninjawarriors, the (1993)(taito)(ntsc)(jp)(en)" sha1="54139589ce904ddba72f9379949f3b6d0bfef2f6"/>
+				<disk name="ninjawarriors, the (1993)(taito)(ntsc)(jp)(en)" sha1="471a824e6729c65321fa8219fc40b23821a08b40"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4976,7 +4976,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="alt_title" value="戦国伝承"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sengoku denshou (1993)(sammy)(ntsc)(jp)" sha1="a7068e9594b65c665796689bfe16c7ee0ecba041"/>
+				<disk name="sengoku denshou (1993)(sammy)(ntsc)(jp)" sha1="03699195ec6906653309f0ed76ec2151937fce6e"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/psx.xml
+++ b/hash/psx.xml
@@ -43,7 +43,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="007 racing (usa)" sha1="c0fffd6939c403a0b7a179b472ae768c06c05c26"/>
+				<disk name="007 racing (usa)" sha1="b0d5e1641367d45c6f187c5c6249371c95636e5a"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/psx.xml
+++ b/hash/psx.xml
@@ -43,7 +43,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="007 racing (usa)" sha1="b0d5e1641367d45c6f187c5c6249371c95636e5a"/>
+				<disk name="007 racing (usa)" sha1="c0fffd6939c403a0b7a179b472ae768c06c05c26"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/psx.xml
+++ b/hash/psx.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
@@ -62,7 +62,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="007 - tomorrow never dies (usa)" sha1="f48f0e79572be7d676341fb9f6cb0ccb5a31e0d9"/>
+				<disk name="007 - tomorrow never dies (usa)" sha1="603abd8d718ddb72cf34a0d8eece062c03463dc5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -79,7 +79,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="007 - the world is not enough (usa)" sha1="d79f4b8ce9db7c5dacd841e7d7ebbb306f88de70"/>
+				<disk name="007 - the world is not enough (usa)" sha1="3af01c1f0a584751d161dc2c102639cd8c892ea9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -208,7 +208,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ten pin alley (usa)" sha1="9e54d18bdeeaac86a91d57e223271e0e4cadd6e1"/>
+				<disk name="ten pin alley (usa)" sha1="efa45b20a81d2d285bea24dddf87b1c758a8beb7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -313,7 +313,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="3d lemmings (usa)" sha1="ce0fe62049e1f2567b7e4e66f209d97713fb54d8"/>
+				<disk name="3d lemmings (usa)" sha1="4801d11a8fc06628bc972bfb5a9d5b411fe15101"/>
 			</diskarea>
 		</part>
 	</software>
@@ -359,7 +359,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="3xtreme (usa)" sha1="dbc36461c1491be04b9b41cdb43f5aacc5b8d219"/>
+				<disk name="3xtreme (usa)" sha1="a0678bbf322f512072f7a78f072fdbab6555559b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -402,7 +402,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fifth element, the (usa)" sha1="bf56ec6d782ed3df91a1d3a113bad7f0fca715b6"/>
+				<disk name="fifth element, the (usa)" sha1="edf59f00c16acfcb4f8e7f44e4c72c6ab44aaa5d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -419,7 +419,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="oddworld - abe's oddysee (usa) (v1.1)" sha1="15418f0f1bd9bb64e7c491e964eaff90ead7ff61"/>
+				<disk name="oddworld - abe's oddysee (usa) (v1.1)" sha1="fdf0041ff97101b468fe943c8461b906466add02"/>
 			</diskarea>
 		</part>
 	</software>
@@ -455,12 +455,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="oddworld - abe's exoddus (usa) (disc 1)" sha1="361b3a54f0716ab523f5ea3569df623f8cdc9872"/>
+				<disk name="oddworld - abe's exoddus (usa) (disc 1)" sha1="660edf4bddb298beff44964951af74b3443dc2bd"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="oddworld - abe's exoddus (usa) (disc 2)" sha1="36e619c28dafd7e4baed28a8d56ffebe93584de7"/>
+				<disk name="oddworld - abe's exoddus (usa) (disc 2)" sha1="5b806ee562fd9cd719a6cc47e0fd0b1353068c2f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -754,7 +754,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alien resurrection (usa)" sha1="a5c6b0c879e523ac7b19c209ac9c06eaf1ab3a01"/>
+				<disk name="alien resurrection (usa)" sha1="79de3fd8c2541398a4f26f7a81a617946fd1cbfa"/>
 			</diskarea>
 		</part>
 	</software>
@@ -796,7 +796,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alien trilogy (usa)" sha1="34268b5750155db04b9dd25991d98f428ae5fa68"/>
+				<disk name="alien trilogy (usa)" sha1="29b7f1384cef58ec2404a1aa53a30da71f2fa0fb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -879,7 +879,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alundra (usa) (v1.1)" sha1="cdfaed8c651dcb09d971bfc9d05f1daaf94d2df3"/>
+				<disk name="alundra (usa) (v1.1)" sha1="bdc6a648003469505ee47c7fa83b1b07a6aa2ea9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -896,7 +896,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alundra 2 - a new legend begins (usa)" sha1="16111c51d568e112f9e57c24da60a6e68347a58c"/>
+				<disk name="alundra 2 - a new legend begins (usa)" sha1="c0e152d67a02dd91e44660ae81099803d2ec0a11"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1035,7 +1035,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="army men - sarge's heroes (usa)" sha1="489c92c1eb6e6ad3ae4c952e38e0541d2ff90b0e"/>
+				<disk name="army men - sarge's heroes (usa)" sha1="b958c6c0f674d5c6508d204d1f913bee61dbab95"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1162,7 +1162,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ape escape (usa)" sha1="07f05352164077ea5726c3c89e00522bee8261ad"/>
+				<disk name="ape escape (usa)" sha1="11b04950f4300f0a44e3197cf6d57a34cc30f17c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1520,7 +1520,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="armorines - project s.w.a.r.m. (usa)" sha1="b88c2e6abc4f56ab17d3ea245d0c55aede617e5a"/>
+				<disk name="armorines - project s.w.a.r.m. (usa)" sha1="af534a5d5825174d58619669d748f97cf3902087"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1557,7 +1557,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="army men 3d (usa)" sha1="a2e29ff020e5db89de055a9fbed0812658b5acd1"/>
+				<disk name="army men 3d (usa)" sha1="66a85dfac355ba06fc9544eb36d240f3f07b7f8d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1592,7 +1592,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all-star baseball 97 featuring frank thomas (usa)" sha1="f821a4a160e0c958495c9c2d1d8978fee21c3dc2"/>
+				<disk name="all-star baseball 97 featuring frank thomas (usa)" sha1="e5891c4ef7dac37e97ce94c700f9fc1dcc9fb231"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1609,7 +1609,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all-star slammin' d-ball (usa)" sha1="ee0142e2f218cc38d24d0ab027e8ca8e4d953755"/>
+				<disk name="all-star slammin' d-ball (usa)" sha1="38d356d59ab2fa8cd6d7058afbe405e1b7338b5b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1633,7 +1633,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all star racing 2 (usa)" sha1="6b51229aadc6fcab51636481a3ec77579e22b22e"/>
+				<disk name="all star racing 2 (usa)" sha1="67d2403c1008244af761546bfdcee1e98b9a082c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1656,7 +1656,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all star racing (usa)" sha1="9a89181fe3c5bd9004f0a7525e7f844cc7616085"/>
+				<disk name="all star racing (usa)" sha1="0509a19e098bf71024d82703745b2c2cc2e50413"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1722,7 +1722,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="asteroids (usa)" sha1="04aea1e4423a4f1353288dd63e6911265feccf55"/>
+				<disk name="asteroids (usa)" sha1="e59d3a8fa874f6c01dde1905b63c8e60bd363b20"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1757,7 +1757,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's atlantis - the lost empire (usa)" sha1="9d4a654e3aff0e5c4527cbc4133db64be43b186b"/>
+				<disk name="disney's atlantis - the lost empire (usa)" sha1="b3f6094a44c22f50589ab7eaa3abee23d5190ac2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1988,7 +1988,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="baldies (usa)" sha1="b249bd2371cbcd4406ad9de138468b229b01469c"/>
+				<disk name="baldies (usa)" sha1="5f6075436bef2bd6c939b27bcdc666b775889d24"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2067,7 +2067,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ballistic (usa)" sha1="df2cf0f292b34d36045d3274b77a2b07879f85e4"/>
+				<disk name="ballistic (usa)" sha1="91ec8debbdc2b725eca16533fc73af5d7e1131dc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2098,7 +2098,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bust-a-move 2 - arcade edition (usa)" sha1="67a76852d1c4a729692011aca8f5a798c8ba049b"/>
+				<disk name="bust-a-move 2 - arcade edition (usa)" sha1="b1ff7f7289e80a8660de51792d27a843a6e37e3e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2137,7 +2137,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bust-a-move 4 (usa)" sha1="7354ae16e8bcaa39f1204b5372790ce8d60309b6"/>
+				<disk name="bust-a-move 4 (usa)" sha1="5fae962b40cfd65c71af587ad5f9bc7cd3f866c0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2173,7 +2173,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bust-a-move '99 (usa)" sha1="c7873febe1bb6a7cac45c0075a7e8d159e8dbc6c"/>
+				<disk name="bust-a-move '99 (usa)" sha1="33abb06e575e8b8369dd69e1156347bf22b7938c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2341,7 +2341,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="batman forever - the arcade game (usa)" sha1="88393684ae19946abfa096c2e56f53098c5cfa35"/>
+				<disk name="batman forever - the arcade game (usa)" sha1="5406a0cdb0849a48b318d44f8c7c773612c1a60d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2455,7 +2455,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bushido blade 2 (usa)" sha1="7f0603b6cc467b42156405465b270d8284fe1d50"/>
+				<disk name="bushido blade 2 (usa)" sha1="5d35481b47b07e51cb7011b48d505fa10e30b16f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2532,7 +2532,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="buster bros. collection (usa)" sha1="aec44fbab4d775ad54de562f2f36317848fad19b"/>
+				<disk name="buster bros. collection (usa)" sha1="f27b8779c8bdeba79c05f2964b27883d4e40402b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2740,7 +2740,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="frank thomas big hurt baseball (usa)" sha1="f558c913841efcc8f0089535603159222e16f264"/>
+				<disk name="frank thomas big hurt baseball (usa)" sha1="0f976975a6c425dc66381ae571b92bb3854c4c52"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2808,7 +2808,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bio f.r.e.a.k.s. (usa)" sha1="cbbef6452d8fefffc41b51476ef0f06a6e1cda90"/>
+				<disk name="bio f.r.e.a.k.s. (usa)" sha1="cdd4839e9276971f5d5206b6e183ea0ea18dfa70"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2876,7 +2876,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="black dawn (usa)" sha1="54eb6a39008efe1fbc3f9926b841517b28f95ec5"/>
+				<disk name="black dawn (usa)" sha1="c293e3a618769b28d3c0f6a45125809959178b62"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3072,7 +3072,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl blitz 2000 (usa)" sha1="8ee063c43415f1ffade34d0e5dd7d67ef466acf7"/>
+				<disk name="nfl blitz 2000 (usa)" sha1="57c5607b92a9842b4efb87b7fc663461928af4b9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3256,7 +3256,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="breath of fire iii (usa)" sha1="979b329df58855cd1cb2f60793abec33367409e7"/>
+				<disk name="breath of fire iii (usa)" sha1="b9cf8ac6c5b364898c28be663cc94134d2a6482a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3362,7 +3362,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bomberman - party edition (usa)" sha1="89f5e21e602e72dfee3fc3f930bbc2f7a89864c8"/>
+				<disk name="bomberman - party edition (usa)" sha1="9e8373fbd06c8752c3d47d8f6b5e305fbb98d32a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3379,7 +3379,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bomberman world (usa)" sha1="529e4527fa3b086e8860c84c70e3886dd20e5863"/>
+				<disk name="bomberman world (usa)" sha1="16b36158a7454cf6872a05c98f9c89dd539f302d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3942,7 +3942,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battlesport (usa)" sha1="a3026e6bd0555d065b5a5f01b2e94d070932d0c9"/>
+				<disk name="battlesport (usa)" sha1="ac7e9492b92ecbf78bc585ca489311efae331973"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3994,7 +3994,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bubble bobble also featuring rainbow islands (usa)" sha1="c43ba72269ba09a2311c112cf2f0889db327ce28"/>
+				<disk name="bubble bobble also featuring rainbow islands (usa)" sha1="1561fd3ea3e4b1426087c0d6d87003faef4d752f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4495,7 +4495,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="centipede (usa)" sha1="0f8b6ee552a0ae5ea36a342a513bdba477cd43b0"/>
+				<disk name="centipede (usa)" sha1="ee59aa0b53f4c6e964b33a6ff660dd267a39a354"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4653,7 +4653,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="chocobo racing (usa)" sha1="d64c6737893dec45980c2088e1a528ce20d00dac"/>
+				<disk name="chocobo racing (usa)" sha1="784566dd126798f9963c05a744ded12d390332ed"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4733,7 +4733,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cleopatra's fortune (usa)" sha1="3c8c19b3ab98d2098ffd168be7af0c75c2cb7057"/>
+				<disk name="cleopatra's fortune (usa)" sha1="109e3b9958e6dd7cc7251ff4faafb07034d4eff5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4997,7 +4997,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="college slam (usa)" sha1="0c315070fc9e6be87a1994618fc9a3bfe2ecbbdf"/>
+				<disk name="college slam (usa)" sha1="8e6d3a869461f9de6a2760ffbc314a3e5cbd9937"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5073,7 +5073,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="c - the contra adventure (usa)" sha1="681c9d33763a59fd1a65185d80b687ce24587e2c"/>
+				<disk name="c - the contra adventure (usa)" sha1="077cf80003bc72c6801cf8c95b6a98d3105a9d93"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5101,7 +5101,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="contra - legacy of war (usa)" sha1="9403c380d5f391c8c0adb18fe238cc6a2c5d3999"/>
+				<disk name="contra - legacy of war (usa)" sha1="2d251c9aeb30adead8bf9bb2c0d4e094d9b6969e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5155,7 +5155,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool boarders 2 (usa)" sha1="bdd071c0046fb44067b0d7282597b4ac8f5b4929"/>
+				<disk name="cool boarders 2 (usa)" sha1="990a6cac9659a572a1b73acfa7ee7d3ad60b4195"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5189,7 +5189,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool boarders 4 (usa)" sha1="b47be79d214644ef36c212ede129c09ef357be52"/>
+				<disk name="cool boarders 4 (usa)" sha1="3fbb6e924df7206cc07a75fa276e97007a9cf118"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5219,7 +5219,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool boarders (usa)" sha1="4a7db4f12f28fe2a2af805394ba96de0ef0a5a94"/>
+				<disk name="cool boarders (usa)" sha1="b0923041fcdac9288d73e571fd21e6240ccb34bf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5417,7 +5417,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="crash bandicoot (usa)" sha1="11ab0c2c674fe9bebc62927c8308cee6d6a1dff3"/>
+				<disk name="crash bandicoot (usa)" sha1="73c7cd894227a54a36a165c746371cc63283103b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5434,7 +5434,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="crash bandicoot 2 - cortex strikes back (usa)" sha1="2edb8097887880020387c168ff2bb04354b1ddf9"/>
+				<disk name="crash bandicoot 2 - cortex strikes back (usa)" sha1="3ff7ccb1b38a9f172f0a96b7c780913401c28b03"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5451,7 +5451,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="crash bandicoot - warped (usa)" sha1="1fc5f8aaf5def00ed131f6424483fe88991d920c"/>
+				<disk name="crash bandicoot - warped (usa)" sha1="80e68dbd89ea40ed6f09d7bdfe2ccc0fe46d766e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5486,7 +5486,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cardinal syn (usa)" sha1="0a5b77436723f66abc8ac7b7cbaf748bb0b0d044"/>
+				<disk name="cardinal syn (usa)" sha1="bbd9e3af8c886460fc8c4907f93ef4b5bc6cb868"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5740,7 +5740,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ctr - crash team racing (usa)" sha1="6ac9869bd696ed7ce6d3b734f774bdb82047ef3d"/>
+				<disk name="ctr - crash team racing (usa)" sha1="d9d5c97d9bc453c4b6339a3635f8d53353ffa7b2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5757,7 +5757,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy chronicles - chrono trigger (usa) (v1.1)" sha1="968de200edd4fc4e809105618a41696c0b0354c0"/>
+				<disk name="final fantasy chronicles - chrono trigger (usa) (v1.1)" sha1="3c76fb48973021b9b7b3f53efd6ff97d1d8a666e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5815,7 +5815,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="castlevania chronicles (usa)" sha1="7d39bbd905910eb1d31ae395c3a79224f725b82e"/>
+				<disk name="castlevania chronicles (usa)" sha1="545ee61ce191dd672056897988a8c9d9286497ea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5832,7 +5832,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="capcom vs. snk pro (usa)" sha1="d42a868cb769371d994ed903016a82a48715e065"/>
+				<disk name="capcom vs. snk pro (usa)" sha1="1df7e28ccb8ea8249d26e85c9bf6bb89c1797700"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5853,12 +5853,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colony wars (usa) (disc 1)" sha1="87a35925848ca127c53828bc738bfca668ebe7c1"/>
+				<disk name="colony wars (usa) (disc 1)" sha1="7c558a7f13d3c9a4d3e5e9d20ee0382bcf3c305c"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colony wars (usa) (disc 2)" sha1="97dfd9daf9be05574b4107ac74d12123e3f70114"/>
+				<disk name="colony wars (usa) (disc 2)" sha1="bd2c07643b93647fba705678411d83d42fd0af6f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5893,7 +5893,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colony wars - vengeance (usa)" sha1="c80c017209ab38cfe12192526e564a784b9d9cd7"/>
+				<disk name="colony wars - vengeance (usa)" sha1="2de0f44070c24e6df4cda0c32b24e635c4517082"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6076,17 +6076,17 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="d (usa) (disc 1)" sha1="59bfa30b9cd0cf6d467ffaaab4a5ac572dae5a62"/>
+				<disk name="d (usa) (disc 1)" sha1="ce5b1b1ac03c6623766ca310ecd1858f2287ea88"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="d (usa) (disc 2)" sha1="343ba13b3651b4e3038e97c494f8ae5aaca41f41"/>
+				<disk name="d (usa) (disc 2)" sha1="b5c259490f06acce90b935a7f4afc3acd28104fb"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="d (usa) (disc 3)" sha1="fca47f407610dfef163a36af2f15095d91d87683"/>
+				<disk name="d (usa) (disc 3)" sha1="14e5ac2aea74b93d34d472530bdbfeec66239aa0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6218,7 +6218,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="destruction derby (usa)" sha1="e45355a420d1ace0501f2f404b6b8b38db328c1c"/>
+				<disk name="destruction derby (usa)" sha1="b3e00cae226deb4f9061388ffb24196b8dc3dba0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6282,7 +6282,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="destruction derby raw (usa)" sha1="a360f3543e19c57c161b18bdd6bc420833d14667"/>
+				<disk name="destruction derby raw (usa)" sha1="3f0db6b6eef98b845c61f4f6f9f8bddd22b2a70c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6571,7 +6571,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragonheart - fire &amp; steel (usa)" sha1="f699e517400360896eb6662d1547a0cd1f38ca56"/>
+				<disk name="dragonheart - fire &amp; steel (usa)" sha1="7a463d7c50661e210aed0e971158fd64d1e3c7f4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6606,7 +6606,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="diablo (usa) (en,fr,de,sv)" sha1="98f6d32fd9318ea9c7e2177b9bc264b978a19412"/>
+				<disk name="diablo (usa) (en,fr,de,sv)" sha1="e45913154e69d68b73e81ec44abbb6bb2f37c274"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6623,7 +6623,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="die hard trilogy 2 - viva las vegas (usa)" sha1="db2f22501c2ad26eb9d80e0857956c588e717323"/>
+				<disk name="die hard trilogy 2 - viva las vegas (usa)" sha1="f9f23d720ab04990149d0a1c28d873d6ff8c9473"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6660,7 +6660,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="die hard trilogy (usa) (v1.1)" sha1="8c2819931074e83032d3290a74882be06c504dd9"/>
+				<disk name="die hard trilogy (usa) (v1.1)" sha1="015f4b16dcef0c0d2bd9fc0d119f27f97a32f7ac"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6800,7 +6800,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dino crisis (usa) (v1.1)" sha1="bcf33257cde0d08678f6880c264c1388cc1a73c8"/>
+				<disk name="dino crisis (usa) (v1.1)" sha1="d5bd911a9185dd137040bc43726f8d2248c7dd4c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6836,7 +6836,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dino crisis 2 (usa)" sha1="866ba69cfde3b56960078849dcb18c84c16d9c16"/>
+				<disk name="dino crisis 2 (usa)" sha1="7d9ac5ee241bc94ac64893893bbb4c82ebba250f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6889,7 +6889,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="discworld ii - mortality bytes (usa)" sha1="7b2297b7bd6a2bf37bf7eb6d97b942563987bb67"/>
+				<disk name="discworld ii - mortality bytes (usa)" sha1="43448cc290f1f53288b0501b7196bbd49d7fd7cb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7071,7 +7071,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="doom (usa)" sha1="dc8481ece400c356eba83373a2b77e5afae7f74f"/>
+				<disk name="doom (usa)" sha1="1fe56d1e220712bdc2681bb55f2e90b457cc593b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7170,7 +7170,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="driver - you are the wheelman (usa) (v1.1)" sha1="14fbbd4d4fa8111d0bba35bd1644366854395fe2"/>
+				<disk name="driver - you are the wheelman (usa) (v1.1)" sha1="608728b6e7e3e584535b5c39c2c0aee35be35510"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7189,12 +7189,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="driver 2 (usa) (disc 1) (v1.1)" sha1="6f14915496207e5694914acea4e4d9b4c83f2639"/>
+				<disk name="driver 2 (usa) (disc 1) (v1.1)" sha1="5a6c7c8177bd826a3b6e6fbb565e0c3002aa3855"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="driver 2 (usa) (disc 2) (v1.1)" sha1="d02381334ab2b96e92bc489bc51929dff57de86f"/>
+				<disk name="driver 2 (usa) (disc 2) (v1.1)" sha1="c5014e627310d3d719e04801a1b035844a7c0ee9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7333,7 +7333,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="darkstalkers - the night warriors (usa)" sha1="05abd2adc8fce631ec887b73e1974111160e9326"/>
+				<disk name="darkstalkers - the night warriors (usa)" sha1="9156b564c4cec38716e3bc204e80480c93dd974d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7350,7 +7350,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="darkstalkers 3 (usa)" sha1="1706692ada422550d4ea86637a5294afe0fae1d0"/>
+				<disk name="darkstalkers 3 (usa)" sha1="8e629c928e68454516571f8b4913f585b822b9a8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7413,7 +7413,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="duke nukem - time to kill (usa)" sha1="023db69cc8c8adc0b9c51c0aa22c7aca4e130bab"/>
+				<disk name="duke nukem - time to kill (usa)" sha1="33949530e9826e1078fe06adf1f69ba2e53953de"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7657,7 +7657,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ecw hardcore revolution (usa)" sha1="490d497f6d164f5965cfd1ca13c2327fce110112"/>
+				<disk name="ecw hardcore revolution (usa)" sha1="59284d988e456fb0ea191c0f43311f67eb443cfb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7710,7 +7710,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="einhaender (usa)" sha1="5de113ab0543445a0c6033e887c807620f8ff1f9"/>
+				<disk name="einhaender (usa)" sha1="dd2ba34301ace8399abb7a70b756b5f7f10ebf68"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8227,7 +8227,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="formula 1 98 (usa) (en,fr,de,es,it,fi)" sha1="fde45c916538081833a24abd5cb739d83884d733"/>
+				<disk name="formula 1 98 (usa) (en,fr,de,es,it,fi)" sha1="5b8407c8c5a16a302cf945dc8280a1c0b0291d49"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8245,7 +8245,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="formula 1 championship edition (usa) (en,fr,de,es,it)" sha1="affc201e03129bdf22b13e0b23c525e98bd1170d"/>
+				<disk name="formula 1 championship edition (usa) (en,fr,de,es,it)" sha1="f912bc68926779b42b0c7bbd9870ca0166ffef84"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8360,7 +8360,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="family card games fun pack (usa)" sha1="88e9487308500d1d2d6735bf603ae26f3c2a5e46"/>
+				<disk name="family card games fun pack (usa)" sha1="c4027956a0643350d71f621d268d37250aeeb1e9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8455,7 +8455,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fatal fury - wild ambition (usa)" sha1="dfda7b8134200fe49eb181736c88c93bf667d384"/>
+				<disk name="fatal fury - wild ambition (usa)" sha1="35cc9c62f2511ce4fc06e34d4d2a619addb3b90b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8637,7 +8637,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy chronicles - final fantasy iv (usa) (v1.1)" sha1="13c2db5ca21481ae16436fbe270e296a03371b8b"/>
+				<disk name="final fantasy chronicles - final fantasy iv (usa) (v1.1)" sha1="96a91cb6b297d0f0f601c56167bffbcb9ad0f7af"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8671,7 +8671,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy anthology - final fantasy v (usa) (v1.1)" sha1="561aa73f27b7bbe6d85cfc899aa544cba86c9ac1"/>
+				<disk name="final fantasy anthology - final fantasy v (usa) (v1.1)" sha1="9e82d3d6c8441fabea47dd652a6ea5196f2ef438"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8705,7 +8705,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy anthology - final fantasy vi (usa) (v1.1)" sha1="4fdce0a4c9aeda24839be92fbd52ec0b1c126ec8"/>
+				<disk name="final fantasy anthology - final fantasy vi (usa) (v1.1)" sha1="249bc9af1de0e75bbd7c30e1fb7b935103ff23c2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8743,17 +8743,17 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy vii (usa) (disc 1)" sha1="f53774b1c71a120cdb77d271e00c7bd54b928ca0"/>
+				<disk name="final fantasy vii (usa) (disc 1)" sha1="b5665fbb2895d0e4fa010e5e15d68c15ceac3688"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy vii (usa) (disc 2)" sha1="487a1a6c5d4feff03fb370f149d89e2d19986e26"/>
+				<disk name="final fantasy vii (usa) (disc 2)" sha1="ca80cb0c94936bef091364ef9060a675914a80bd"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy vii (usa) (disc 3)" sha1="9364f48f6f381ddc9d954c534951f686ac65f255"/>
+				<disk name="final fantasy vii (usa) (disc 3)" sha1="87223b2d6c54c4e8d5891d8ae485264cbb887d3c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8776,22 +8776,22 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 1)" sha1="998c8ff53258bc62ae4d9349aff763f954783295"/>
+				<disk name="final fantasy viii (usa) (disc 1)" sha1="4b589aed4dfdf9ec75c3351ed81d367ea2dd0e7f"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 2)" sha1="2f9bfa1b5f56bc62b70be6a6c66c27576d585593"/>
+				<disk name="final fantasy viii (usa) (disc 2)" sha1="4ca6918c519fc8505d637bc5b20e263eb57961c3"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 3)" sha1="11094511c2c764c12c2632802161f7c594a724fe"/>
+				<disk name="final fantasy viii (usa) (disc 3)" sha1="cd5b06dfa24506866694dfc1e0d799e958723045"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 4)" sha1="c4eadb3360a54f7c71756c7a4f5115aa538856f7"/>
+				<disk name="final fantasy viii (usa) (disc 4)" sha1="2e53f99d622be145cdaecd5fbb7d9e43440232d2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8814,22 +8814,22 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 1) (v1.1)" sha1="6cc195d41e08d485d957beb51e222f0c275a662c"/>
+				<disk name="final fantasy ix (usa) (disc 1) (v1.1)" sha1="aa95b490a84e95c18d8ac127ea6ab98ebe3d8d7f"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 2) (v1.1)" sha1="f0d7f01f7278ca3625d1654ee80526688a6731a1"/>
+				<disk name="final fantasy ix (usa) (disc 2) (v1.1)" sha1="3c7c71f6e0d37b31e26a2955d9f1f3ae3d61e95c"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 3) (v1.1)" sha1="2744357291b4ccc6527732f638eff5a0fcf4c9cc"/>
+				<disk name="final fantasy ix (usa) (disc 3) (v1.1)" sha1="66dd04783469215b1074552a222239da2ae21665"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 4) (v1.1)" sha1="308f3e7519293212f75fe7110c269fbcbe23e18e"/>
+				<disk name="final fantasy ix (usa) (disc 4) (v1.1)" sha1="ef8760c71d408d7492f8269f28ef9f5dbce02cef"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8884,7 +8884,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy tactics (usa)" sha1="f061d8a0e42a0f976b82bbdc4ae3a7b36d96f6a8"/>
+				<disk name="final fantasy tactics (usa)" sha1="f44672cbf59ac08e0ce5f7473ee9a0e352c6f061"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9048,7 +9048,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy origins (usa) (v1.1)" sha1="60ecf85c194d5aa096e39fff6d8300fdc818bb24"/>
+				<disk name="final fantasy origins (usa) (v1.1)" sha1="833a6bf605ab741b2258312874c9955de2086586"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9224,7 +9224,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fifa soccer 97 (usa)" sha1="173828198c0a07bf9c74216bd89bbaf5759655b1"/>
+				<disk name="fifa soccer 97 (usa)" sha1="a3944ff8ddd5fcd46ea6a914dbb087114c229fea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9316,7 +9316,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final doom (usa)" sha1="61b6eeefb1159b4c3a60b53e443c2d34d0c1ea37"/>
+				<disk name="final doom (usa)" sha1="569c9d342e6cad12cc7000a74141a006aa1aeaf3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9440,7 +9440,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="forsaken (usa)" sha1="29a6f5cd68d957569d91cd1a86f07e1b1afe4ce3"/>
+				<disk name="forsaken (usa)" sha1="8dd5e8d46f0367ab5bf9f6bf464b9bf0bd14d689"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9542,7 +9542,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="freestyle boardin' '99 (usa)" sha1="a114a132941abbe27b3a1172fd75a1e83ff500fc"/>
+				<disk name="freestyle boardin' '99 (usa)" sha1="7a6a4a694f6a744e9abe40de6dd28f3c55740c87"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9560,7 +9560,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="freestyle motocross - mcgrath vs. pastrana (usa)" sha1="2e8b9ccd2086b427193c8a5de9c4e14b1f8b9548"/>
+				<disk name="freestyle motocross - mcgrath vs. pastrana (usa)" sha1="6363a81040545fe3998909117f6fa9d579466adb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9578,7 +9578,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="frogger (usa)" sha1="dd9ef6dbde1c90923cf5c9078022f322b0f7ab07"/>
+				<disk name="frogger (usa)" sha1="fa22e611dba522775cac04e0412fbdb6b68b67f9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9681,7 +9681,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="galaga - destination earth (usa)" sha1="3a00321afb1228bf007f5d6b870e6f6c898843fc"/>
+				<disk name="galaga - destination earth (usa)" sha1="d4ac318914aaef6295985322b53e9b199feb8e66"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9729,7 +9729,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gauntlet legends (usa)" sha1="7e0f39f5e3fca397d679924836b18914a7989d57"/>
+				<disk name="gauntlet legends (usa)" sha1="9b924cd15c05f01bdd0b1a7090ae039dabf35938"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9764,7 +9764,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="g. darius (usa)" sha1="7c5e7cb9f9313f56b32ee3161a907a5bc6aaac41"/>
+				<disk name="g. darius (usa)" sha1="17aec6a72ea6a0f8dd41cc5c36cafafe8fd06b50"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9787,7 +9787,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gekido - urban fighters (usa)" sha1="99a03064684e94bd96ccedcf6258f18dd633181c"/>
+				<disk name="gekido - urban fighters (usa)" sha1="ebcdd5d5989ab745adbb2d817d42291cded54ef1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9804,7 +9804,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gekioh - shooting king (usa)" sha1="59b58f25ac0dbeadfd7d78aaa6ed7d993f2b18ed"/>
+				<disk name="gekioh - shooting king (usa)" sha1="d4c4b5956475322cfeb5e55a073ba1c70a2b00e9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9821,7 +9821,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gex (usa)" sha1="497f50122c31968587750a2ce69edfdfc10ae02e"/>
+				<disk name="gex (usa)" sha1="ec0f32b9f76e0bc6febe489f3e4903dc1c2e7e15"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9855,7 +9855,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gex 3 - deep cover gecko (usa)" sha1="9c12acdd9a223ed05086fc87f912c5f5df1c811e"/>
+				<disk name="gex 3 - deep cover gecko (usa)" sha1="631ce1a305a6a220b98bbb2b6d67eb6b15583411"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9911,7 +9911,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="guilty gear (usa) (v1.0)" sha1="42d1118faa2dac97d7c0a7daa6a64bda2973b570"/>
+				<disk name="guilty gear (usa) (v1.0)" sha1="b57095a1daf1ee30cbb3c9507aa501a7bf5617ca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9928,7 +9928,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ghost in the shell (usa)" sha1="c8403397712d75541a9a789a2f52e9696310be52"/>
+				<disk name="ghost in the shell (usa)" sha1="4910b272fc7edbe9da836b78a7db8acce4a4d9c0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10350,7 +10350,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gran turismo (usa) (v1.1)" sha1="cea9169f54157b01bbbdb530ebeee8b85a39c3f4"/>
+				<disk name="gran turismo (usa) (v1.1)" sha1="0f6bb343c0fc919de6b6e6076b6e5d97c27663e9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10388,7 +10388,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Arcade Mode"/>
 			<diskarea name="cdrom">
-				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="a30b84274435e2cac3b5232980d7217977e46c85"/>
+				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="67e07f8dcd580ccdf1745bc25520772fec5bb0d3"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -10415,7 +10415,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Arcade Mode"/>
 			<diskarea name="cdrom">
-				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="a30b84274435e2cac3b5232980d7217977e46c85"/>
+				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="e5c8728d348125aaadc5a51ce3692026f2138aa7"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -10511,7 +10511,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="grand theft auto 2 (usa)" sha1="87627fbb043f13c63392799cb327a503da9ab14f"/>
+				<disk name="grand theft auto 2 (usa)" sha1="3a4ee881dc53edc2c3c822182d742007e6e9356f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10543,7 +10543,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="grand theft auto - mission pack 1 - london 1969 (usa)" sha1="c7387613ee8abbabbc0d2549a538f0b0957a36d5"/>
+				<disk name="grand theft auto - mission pack 1 - london 1969 (usa)" sha1="1b62bc051314f36924a53885282e2332d2001816"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10610,7 +10610,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gubble (usa)" sha1="8a581696e5cbbf10f709d10002f1d263dac4a3b1"/>
+				<disk name="gubble (usa)" sha1="6780bdcd0cd766439c9b6bc3d9a832278bea4708"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10628,7 +10628,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gundam battle assault 2 (usa)" sha1="b7f2b3a9aef64706d20bfe17016fc9b82c6e8c29"/>
+				<disk name="gundam battle assault 2 (usa)" sha1="595fb715a6aaae0faa4adaedd482901c7303dde3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10665,7 +10665,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gundam battle assault (usa)" sha1="ece9d43daddd1a8a6c020cb18df9e2045ae1a5d2"/>
+				<disk name="gundam battle assault (usa)" sha1="08d96a6d7aa3fbeacf72d7ceb63575b80caedd70"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10826,7 +10826,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hbo boxing (usa)" sha1="96fe53a1b8adc1cf54eb0f4f154f1dcdbf24e763"/>
+				<disk name="hbo boxing (usa)" sha1="16462ae80de1c16041ca0128b6ec2c3761c48297"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11101,7 +11101,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hogs of war (usa)" sha1="cbae32df37fa854c0bea209f61940a41455a1a93"/>
+				<disk name="hogs of war (usa)" sha1="85899ca70527dbe81f2a6eaf5edbcd5ca871481f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11261,7 +11261,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hot wheels - extreme racing (usa)" sha1="5d4eeee81caabb3f1b977bee341d93bd56c7648d"/>
+				<disk name="hot wheels - extreme racing (usa)" sha1="f1fdaf5004f2b8046127e01c7ae852fe6dfb387e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11359,7 +11359,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hydro thunder (usa)" sha1="286b84560da424c10dd1391ce7f3cd49ff1048f8"/>
+				<disk name="hydro thunder (usa)" sha1="50a8b79a2c251b050f2a49760f5aa9b2950a5dc0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11415,7 +11415,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="impact racing (usa)" sha1="969605d72e0fb880c1dc5448a3ab09ef82076915"/>
+				<disk name="impact racing (usa)" sha1="821fba81b854ad8ec15c6e8644475ffeb3650bcc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11451,7 +11451,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="independence day (usa)" sha1="0c8222154bb994fcc615f9c39b73622d560f9804"/>
+				<disk name="independence day (usa)" sha1="dab6552233247e1ad05c656066f2dddec9ef7a76"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11497,7 +11497,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="in the hunt (usa)" sha1="ee934ab08575bc4d361046fdeace43fb32f57b76"/>
+				<disk name="in the hunt (usa)" sha1="e721dd560cc07498943e4b9959e324729e65a760"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11617,7 +11617,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="advanced dungeons &amp; dragons - iron &amp; blood - warriors of ravenloft (usa)" sha1="18245fa03c7b3e9ebadb1f4ddaa9a022c49ba58e"/>
+				<disk name="advanced dungeons &amp; dragons - iron &amp; blood - warriors of ravenloft (usa)" sha1="17801ddab215bcc26034feb352967b41cdc95d40"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11655,7 +11655,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="iron man &amp; x-o manowar in heavy metal (usa)" sha1="8d2aa21eedc311c45dfc6d074a54e5e3638adf3f"/>
+				<disk name="iron man &amp; x-o manowar in heavy metal (usa)" sha1="7e65d61c52f08b39933f57978710888153a475e0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11689,7 +11689,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="irritating stick (usa)" sha1="3c832ebbddb7bea03214de8ad8a79c081e516cf7"/>
+				<disk name="irritating stick (usa)" sha1="9289c8dabe05a5b590aea9a82a32324b8895525c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11790,7 +11790,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="international track &amp; field (usa)" sha1="de74c844ed802c43af60db60c652b03c53444588"/>
+				<disk name="international track &amp; field (usa)" sha1="dc937024fdeed3b294b1c3baae36bd6edebb65b9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11858,7 +11858,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="johnny bazookatone (usa)" sha1="e455f2d675034ce47d24feebe55cdd3e42ca70fd"/>
+				<disk name="johnny bazookatone (usa)" sha1="419614f7156fa21dd6996edba658546d9c6e219a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11892,7 +11892,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="judge dredd (usa)" sha1="4c139c872708cbf01506dddbabb1233c5e9271ef"/>
+				<disk name="judge dredd (usa)" sha1="cc74396b0e1b24feb5366f704029dab76c88b4fd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12020,7 +12020,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet moto 2 - championship edition (usa)" sha1="c7f10dc476869c636aa0826d03927e3f13332a3e"/>
+				<disk name="jet moto 2 - championship edition (usa)" sha1="b42cb27c9047e3a205ac705f103b84d9a9bb82bc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12050,7 +12050,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet moto (usa)" sha1="69496c1d35ac44334eb92121b3057b679c16d76c"/>
+				<disk name="jet moto (usa)" sha1="251e9d825407a0ca917c8dac11344b0f95698d29"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12100,7 +12100,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet moto 3 (usa)" sha1="c2540cd8102c7e5df1080565678cb62b0b36eac5"/>
+				<disk name="jet moto 3 (usa)" sha1="9b41ae93feb09afc8e876653209794f97ad09c70"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12198,7 +12198,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jojo's bizarre adventure (usa)" sha1="847680c54853a9bb551b848214f61a993f60ab55"/>
+				<disk name="jojo's bizarre adventure (usa)" sha1="1a535aab9dd8a47280f8ee71bce3a33ea2dd68c8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12297,7 +12297,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jupiter strike (usa)" sha1="c5e4aebe9edaf950e4303cccf88e334ff4ea4cb5"/>
+				<disk name="jupiter strike (usa)" sha1="db3044e8afc055ec72a6d6034d8a2a276ae75f92"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12382,7 +12382,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="k-1 grand prix (usa)" sha1="be79f2fabda5f7b7898ce19672170f3d4cd3535b"/>
+				<disk name="k-1 grand prix (usa)" sha1="a1262560ed86589598e03e50b3f8e372833a327f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12414,7 +12414,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="k-1 revenge (usa)" sha1="8f6e555cf4be7d60495b484fd0d51b56a9a41fe8"/>
+				<disk name="k-1 revenge (usa)" sha1="2ca9009bf2df2ce939a73bb4e837e16f0959fb99"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12448,7 +12448,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="blood omen - legacy of kain (usa)" sha1="86db9d235c28087c5d43d60e4816c3fd384a036b"/>
+				<disk name="blood omen - legacy of kain (usa)" sha1="b9d465144c3b42c1fa09e1a59c48d8992021aef9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12465,7 +12465,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legacy of kain - soul reaver (usa)" sha1="b66a08f5059e90203b62fe6c839c2e2a2aa03bfc"/>
+				<disk name="legacy of kain - soul reaver (usa)" sha1="7151e18c9833410a3b2d72602903f2968142042d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12633,7 +12633,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="killing zone (usa)" sha1="96347fadf418e31f762e2d2667dad71434a1fd74"/>
+				<disk name="killing zone (usa)" sha1="cf7c9338c633a29d841fd0327b5877c9fbbcee49"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12666,7 +12666,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kingsley's adventure (usa)" sha1="d9ff5035cdbfbb6c04a2a6f60cabdbcf9ea0a83d"/>
+				<disk name="kingsley's adventure (usa)" sha1="34e26047072db3fc7092c1ad0a825803f631bfe7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12683,7 +12683,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king's field ii (usa)" sha1="c343c9a6c44fa505cf35a9437c670009eddcd017"/>
+				<disk name="king's field ii (usa)" sha1="f43928ccc08fa097a775e1b8f777c8b32c3c1dff"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12700,7 +12700,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king's field (usa)" sha1="660f25acc3dab1352ef4d60d81d9541c11043d45"/>
+				<disk name="king's field (usa)" sha1="b41a6c67cab617b266e637eb10ef36ad54518b8b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12792,7 +12792,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king of fighters '95, the (usa)" sha1="559180dd465fc4333a920f74f586ad70735827e8"/>
+				<disk name="king of fighters '95, the (usa)" sha1="fb4f2e9bd9f855d851caed63240473bd41e38556"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12810,7 +12810,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king of fighters '99, the (usa)" sha1="953d566b5786bc1ed2726f93b0cdd5b3c2b8b5d8"/>
+				<disk name="king of fighters '99, the (usa)" sha1="280100c9b4613597f4ee0f89482c47dd078f00db"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13083,22 +13083,22 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 1)" sha1="dbab4b64e4f3b582486bb9d3e44149c691f3032d"/>
+				<disk name="legend of dragoon, the (usa) (disc 1)" sha1="e094a24456ffcdfaff840835f0759e1f86c88201"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 2)" sha1="f7a98165bcf919bcb721f50eaf4beb9f845160fb"/>
+				<disk name="legend of dragoon, the (usa) (disc 2)" sha1="ac8f2803d8fb0c7f43f356c86121a7b6fd2ede96"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 3)" sha1="05a4297cbb8c9accb6b4c40d3afd045fb68e74f0"/>
+				<disk name="legend of dragoon, the (usa) (disc 3)" sha1="f18594fcc92fd8925293459bab3f56beb0b15205"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 4)" sha1="7db94128cd99568980fe369620d10946d8aa401b"/>
+				<disk name="legend of dragoon, the (usa) (disc 4)" sha1="f1d1535770b6f15a75a90742bfde56d6b9ae378d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13147,7 +13147,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lode runner (usa)" sha1="a92cd56b8d7e0f554e5da6fe6c2e8cb49c00cf8f"/>
+				<disk name="lode runner (usa)" sha1="ce3155f60b6f0d5b349ebb3273c99f055cf4a3f6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13315,7 +13315,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's the lion king ii - simba's mighty adventure (usa)" sha1="b21b7e2ba91deb94a610d809ee89ba08c8f828c5"/>
+				<disk name="disney's the lion king ii - simba's mighty adventure (usa)" sha1="b14db1fa5383a32fb69089e43a5eb1436c9b4a17"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13361,7 +13361,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="loaded (usa) (en,fr)" sha1="fbc93540a150af582ff241fc9d49c0c1d8a11784"/>
+				<disk name="loaded (usa) (en,fr)" sha1="727bafe2c941a53ce7c52380aade32369017c664"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13419,7 +13419,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="looney tunes racing (usa) (en,fr,es)" sha1="79ebf67729f24b78cf13eedb736950171301f181"/>
+				<disk name="looney tunes racing (usa) (en,fr,es)" sha1="72032b1794885cdeae3301b3805da4f4f501e98b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13538,12 +13538,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar - silver star story complete (usa) (disc 1)" sha1="eb1fb6c49ffec47ac2b7bf26d7621d9bf90d2010"/>
+				<disk name="lunar - silver star story complete (usa) (disc 1)" sha1="51cfe14a5449efe6b6d4097d4b46d6e9e3623424"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar - silver star story complete (usa) (disc 2)" sha1="0461da91ed7dcbabe2f61444126951840b213ae6"/>
+				<disk name="lunar - silver star story complete (usa) (disc 2)" sha1="f664aa20deee48210e7a76c312f53d580b2d2985"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
@@ -13571,17 +13571,17 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar 2 - eternal blue complete (usa) (disc 1)" sha1="1ce47e3775e83b13d8c50662319dacb5e89d9743"/>
+				<disk name="lunar 2 - eternal blue complete (usa) (disc 1)" sha1="897a4777fa5cfbdd792982dd52f6ea9a5d053d9e"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar 2 - eternal blue complete (usa) (disc 2)" sha1="0172a2f6b924da9ab0d2caa12e1ddbce3f628678"/>
+				<disk name="lunar 2 - eternal blue complete (usa) (disc 2)" sha1="79ebabbce45631d667c4e3692f8b6195ec5dc16d"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar 2 - eternal blue complete (usa) (disc 3)" sha1="0e91e547f38869d91b86ee027c2c822083d2e840"/>
+				<disk name="lunar 2 - eternal blue complete (usa) (disc 3)" sha1="084395e85478b80230bf2d3fb67184970e2f7a65"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
@@ -13605,7 +13605,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="south park - chef's luv shack (usa)" sha1="3d143af6327f81e3d2a9b21429c69ffc10355f17"/>
+				<disk name="south park - chef's luv shack (usa)" sha1="7b9d8f83135f476983315718e9b1c77bc24dcb1e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13662,7 +13662,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="machine hunter (usa)" sha1="e4d2df64b8d1d0864f0173156f3502ee1f85edc2"/>
+				<disk name="machine hunter (usa)" sha1="383552eb1286d39f1ce409059b29700d59fa0926"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13798,7 +13798,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="madden nfl 98 (usa)" sha1="7124e21295dc612add3d8c7555e4bca2c2670bf5"/>
+				<disk name="madden nfl 98 (usa)" sha1="02c50904e0d3f20f154266c95f4acaee57263788"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13889,7 +13889,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="magic - the gathering - battlemage (usa)" sha1="3bcd8f733bb5ab8cd3726a9d59a51574d148bdea"/>
+				<disk name="magic - the gathering - battlemage (usa)" sha1="be87a3319fab8418b1d548e7787514f9d0a77cd6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14065,7 +14065,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colin mcrae rally (usa)" sha1="0765845afa78dc8a1572823294780b1765791667"/>
+				<disk name="colin mcrae rally (usa)" sha1="279449a95bf0b7fbd1215ed1dd4f2d8abfcc63fb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14083,7 +14083,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colin mcrae rally 2.0 (usa) (en,fr,es)" sha1="a451bc1214db4b0c0fe9aada8e9798f9fab44272"/>
+				<disk name="colin mcrae rally 2.0 (usa) (en,fr,es)" sha1="3974bfd4be890617807e3bfbfa78bf92030d323a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14210,7 +14210,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man 8 (usa)" sha1="355eb773d9f468cfa2a9ed36b7878f3814f0d263"/>
+				<disk name="mega man 8 (usa)" sha1="e4e71e460de78f5a571f46fb2e1f5b940c9477c3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14227,7 +14227,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x4 (usa)" sha1="35dc1d61ad36b70177107e20d257325790a3f347"/>
+				<disk name="mega man x4 (usa)" sha1="ad336c1d3481030735d7c10c434c564ec7b1d68d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14244,7 +14244,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x5 (usa)" sha1="077c266a0b9245def631058d1ea83e919cdbec9f"/>
+				<disk name="mega man x5 (usa)" sha1="c9c6246beb5b6bd6ae45498db2b8026ade8522f0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14261,7 +14261,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x6 (usa) (v1.1)" sha1="0c6435369163895a333e0df446844b1ae87d58be"/>
+				<disk name="mega man x6 (usa) (v1.1)" sha1="278c3ce12bafea06148777ebfc168d73ec62ddc1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14278,7 +14278,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x6 (usa) (v1.0)" sha1="0718095e485314c49914c274158b947d5199d21c"/>
+				<disk name="mega man x6 (usa) (v1.0)" sha1="576a04c12f3e635e3b48ebafcf7d1e1295ce07dc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14338,12 +14338,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal gear solid (usa) (disc 1) (v1.0)" sha1="ca11d3f7172718401b4a529e35aedcb5f6e0a6d9"/>
+				<disk name="metal gear solid (usa) (disc 1) (v1.0)" sha1="23c8ef7a30624c517271a9280ed85c9995ece418"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal gear solid (usa) (disc 2) (v1.0)" sha1="3f3560a2986639e33d2844239a8847945fca2cc1"/>
+				<disk name="metal gear solid (usa) (disc 2) (v1.0)" sha1="370361be299494ed7876fa80572870f52afa0a73"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14360,7 +14360,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal gear solid - vr missions (usa)" sha1="3b7ece83bd06c5802d7025b801c0f8d16b135d5f"/>
+				<disk name="metal gear solid - vr missions (usa)" sha1="19b873b051acc323a0b6b3bb98ddb2c10cac58a1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14377,7 +14377,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="medal of honor (usa)" sha1="56fbf554551f0f92c3e9795208a943d40dcf1706"/>
+				<disk name="medal of honor (usa)" sha1="f155640f176acd8638e38578a9d2ab9bc9087ea3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14394,7 +14394,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="medal of honor - underground (usa)" sha1="3bdad42aa0dfa1430ded815378764f3de5aec1ac"/>
+				<disk name="medal of honor - underground (usa)" sha1="c49f2fa8c648d5f7055ce1057c415050286ff8ba"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14449,7 +14449,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="foxkids.com - micro maniacs racing (usa)" sha1="60cc762c02dc1124439ac4306ba464878031c544"/>
+				<disk name="foxkids.com - micro maniacs racing (usa)" sha1="937f7b96e2f8098ab109e5eb971d3a649e1793a8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14468,7 +14468,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="micro machines v3 (usa)" sha1="30fba5a4fdc0ea1249fda0a4fb746202af4a4dfb"/>
+				<disk name="micro machines v3 (usa)" sha1="d0c9cf70cafaf2025f31c2404c1553f5dca672c3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14539,7 +14539,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="missile command (usa)" sha1="38179e41ea89de49e7c16908115b192a3258da90"/>
+				<disk name="missile command (usa)" sha1="1163e909b3a83421e7a7672c780c8f27ce4c1283"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14651,7 +14651,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat 3 (usa)" sha1="4d34f61a4555ab7ca047212b1101c89fb77f6cc5"/>
+				<disk name="mortal kombat 3 (usa)" sha1="60a313d72beefa8b19cb838623983ccc8b634c6c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14668,7 +14668,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat 4 (usa)" sha1="3eca48bcc496ea0d22648787d7e5e78c4930ce12"/>
+				<disk name="mortal kombat 4 (usa)" sha1="64b679e01f6984d689fa18aa5a51c6da0300d482"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14685,7 +14685,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat - special forces (usa)" sha1="e9919c72ccef3a0e8877fbe5f940e83d47bbfcda"/>
+				<disk name="mortal kombat - special forces (usa)" sha1="5e307fb758331fdee0a2d740c051bf6f98af3ae3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14731,7 +14731,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat trilogy (usa) (v1.1)" sha1="9713a08222b02d12f503c2296d28c215e9b07e91"/>
+				<disk name="mortal kombat trilogy (usa) (v1.1)" sha1="bb7ce7deff58cd2573b531b2d3e69ea73ba93631"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14964,7 +14964,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mobile light force (usa)" sha1="9316dad634ed08f3ad2cf3d242300973d8490632"/>
+				<disk name="mobile light force (usa)" sha1="f37e1d8593bb0714b16730ea341a592f27d1ddcb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14982,7 +14982,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man legends (usa)" sha1="594f3159b3a7b1392826197343059205732fed6b"/>
+				<disk name="mega man legends (usa)" sha1="77aab55210eac8354aa7c698ddf3476afccf356b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15000,7 +15000,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man legends 2 (usa)" sha1="8d1592a30125ad666ec5a1f1eaaafc209f06df6e"/>
+				<disk name="mega man legends 2 (usa)" sha1="183034a51563b69164b5cfc7995af86e9c37fed9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15208,7 +15208,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="monopoly (usa)" sha1="89d9a4e39b7532eb62cf18d37a44cd7758f19e22"/>
+				<disk name="monopoly (usa)" sha1="87b78ac3034312cc57dd94a86751064c93bf5ab2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15390,7 +15390,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="moto racer world tour (usa)" sha1="2dfef2f8f61302432df5711d8b7d2de87ee4b843"/>
+				<disk name="moto racer world tour (usa)" sha1="d75f1e4c85d6123cab908e484784a4dabe2ca5a4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15481,7 +15481,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="monster rancher battle card - episode ii (usa)" sha1="411ae96c5383b8f62d8e59893507f53218ef7667"/>
+				<disk name="monster rancher battle card - episode ii (usa)" sha1="91c00f8384f6f57c56f8e8b8b534b781a943b413"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15626,7 +15626,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="marvel super heroes (usa)" sha1="2e43e577c2ed880442e54d0d4976ba1ef75ae206"/>
+				<disk name="marvel super heroes (usa)" sha1="81592bf673c4dbe866cf7daad06b6965f370563d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15660,7 +15660,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal slug x (usa)" sha1="fcb065838e146998c3608b6d77d5a464cf1daea4"/>
+				<disk name="metal slug x (usa)" sha1="bc7953f15bd7b9d2154741b043d6c7dde73f444e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15683,7 +15683,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ms. pac-man maze madness (usa) (v1.1)" sha1="45fe7713732f29b177c7abb3e5b41adbda1b4e38"/>
+				<disk name="ms. pac-man maze madness (usa) (v1.1)" sha1="321629602dd4368a3aad449c3e75125a59ff40c0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15938,7 +15938,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="marvel vs. capcom - clash of super heroes (usa)" sha1="90e936d55824b807e9e956e62b00b086e680c9de"/>
+				<disk name="marvel vs. capcom - clash of super heroes (usa)" sha1="7d558cd1650bf313d8a1a5678b592180e2110f8c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16043,7 +16043,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nagano winter olympics '98 (usa)" sha1="0b986f1fe8805c5198ac936bbd6c7095fd36f01f"/>
+				<disk name="nagano winter olympics '98 (usa)" sha1="96e0e908a22d53cd60e9a1862371a5902b61fcbd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16069,7 +16069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="namco museum vol. 1 (usa) (v1.1)" sha1="50a37d173a660cfa9a05d2d07c7b25dc52c34755"/>
+				<disk name="namco museum vol. 1 (usa) (v1.1)" sha1="af19f724d9b57041b6ed0ab11f5977279ff85f3b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16213,7 +16213,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nanotek warrior (usa)" sha1="21f9021c62593b759d565ef5309cce39713b6ba6"/>
+				<disk name="nanotek warrior (usa)" sha1="4badc333c2390a7ebcd32d12aa31ed6912b12119"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16356,7 +16356,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nascar racing (usa)" sha1="3a109011c05a550085b4b2f86157b4fa29661042"/>
+				<disk name="nascar racing (usa)" sha1="21465648f2b7c6352650d13d48fb8740f57b451f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16496,7 +16496,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nba basketball 2000 (usa)" sha1="9caf6613ada46e2f3ae32779e8727f05826b1c24"/>
+				<disk name="nba basketball 2000 (usa)" sha1="5107f34115b589a0894d5038849b27c9f1cdc8df"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16594,7 +16594,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nba jam - tournament edition (usa)" sha1="840ac0e924c16224739bb6439a91952bb0fada12"/>
+				<disk name="nba jam - tournament edition (usa)" sha1="370523bd8a770b55a3a38be5b195ad9397f911e2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17363,7 +17363,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nightmare creatures (usa)" sha1="f2389e82bc41b3afc1ad12b43795e350b717f7c1"/>
+				<disk name="nightmare creatures (usa)" sha1="8592a07f87df446601902a137d69075dde4cf206"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17631,7 +17631,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl quarterback club 97 (usa)" sha1="580836aa0eaac13a581a98c67df8c23017b13c5a"/>
+				<disk name="nfl quarterback club 97 (usa)" sha1="bd689204eba515256d945f45b295bc23541b5480"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17701,7 +17701,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed ii (usa)" sha1="4771b65e81100ac28307b22f719cda2b7709df7c"/>
+				<disk name="need for speed ii (usa)" sha1="54d978f44c97fe927ce5a28d673a34600e1d619d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17735,7 +17735,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - high stakes (usa)" sha1="be8caf7a7eaa4e9999e78c3b8c84c9985e663fb5"/>
+				<disk name="need for speed - high stakes (usa)" sha1="7f231d785984b12ef6d67c77ffc91d6a60d54e0b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17766,7 +17766,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - porsche unleashed (usa)" sha1="3a5ba01e5c10a6e55945af093531119cd8a08b33"/>
+				<disk name="need for speed - porsche unleashed (usa)" sha1="6efeccdc5918c8d131afdfc53783ae5380c1fcc2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17852,7 +17852,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl open ice - 2 on 2 challenge (usa)" sha1="ba6fa14d4337bd030c681f6be920294b35a053fb"/>
+				<disk name="nhl open ice - 2 on 2 challenge (usa)" sha1="ba639897d02c043ae0db9369402930f8d73f948f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17877,7 +17877,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl 97 (usa)" sha1="5d488298c1e49531cd6e329fd51052e67c750550"/>
+				<disk name="nhl 97 (usa)" sha1="f2e1a333096d48d58ee5a4f47b71264d0648564f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17929,7 +17929,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl breakaway 98 (usa)" sha1="f241ed941b2fb1b7fe78cf842f779f0e1981746c"/>
+				<disk name="nhl breakaway 98 (usa)" sha1="ca21c54f8ed8a10913690a8b20ffe0fe98c144a0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17947,7 +17947,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl championship 2000 (usa)" sha1="e279abecb164f2cab5dcc2d430a0575315d91471"/>
+				<disk name="nhl championship 2000 (usa)" sha1="08343902480229df1175ff93c8776f49c172e0df"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18218,12 +18218,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="novastorm (usa) (disc 1)" sha1="b03235765aae4d84497f9c885d980139ca8e4410"/>
+				<disk name="novastorm (usa) (disc 1)" sha1="56b2709a371ddf8dc249d95453e9f80795b65333"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="novastorm (usa) (disc 2)" sha1="67221f49410f43cbbb6b55f706a5b5703cd4a670"/>
+				<disk name="novastorm (usa) (disc 2)" sha1="73329a95c40ad19e5a8e795a557de8a0d7b5460e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18268,7 +18268,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="next tetris, the (usa)" sha1="e4c71550fe89b90771c1aea8c276713eed06ca69"/>
+				<disk name="next tetris, the (usa)" sha1="7c9c36b4342b110eb0877f219f17adda181d0379"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18286,7 +18286,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="o.d.t. (usa)" sha1="ee356e30a34462ce35f15c7a1775fa2c64d5ab70"/>
+				<disk name="o.d.t. (usa)" sha1="10597fb61fc7b614fb1c5a6665114a0b4fab45d6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18386,7 +18386,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="olympic summer games (usa)" sha1="e0d8b762e01314cd2029921b7e4b53cbef438dc1"/>
+				<disk name="olympic summer games (usa)" sha1="d5bdc9a83a2bda1475adb3312ccf30ee5593a6e3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18497,7 +18497,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pac-man world (usa)" sha1="18dd91e41a5a39b6185d1f1ecdbc45d711bbb074"/>
+				<disk name="pac-man world (usa)" sha1="c17bfd790a0b71a711ed64b8ea91469be6569479"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18531,7 +18531,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pandemonium (usa)" sha1="40c7499febe8ccf3d62e81bac6876c128d845bca"/>
+				<disk name="pandemonium (usa)" sha1="01a0f5957cffc9c59d3b8196827e64116eaeea98"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18548,7 +18548,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="parappa the rapper (usa) (en,fr,de,es,it)" sha1="91a64f0ecf079964d5d8df0939157e8b53a9a2ff"/>
+				<disk name="parappa the rapper (usa) (en,fr,de,es,it)" sha1="a0228849bf77c2b59830bfc2c5a62cc88a8bb984"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18734,7 +18734,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pocket fighter (usa)" sha1="d859aefd472ebf7446e966ddcd6f003b8875d557"/>
+				<disk name="pocket fighter (usa)" sha1="e4709a85ed8e1b461295fa0a8585636fc44e2cca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18802,7 +18802,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pga tour 98 (usa)" sha1="8e6b6e5c474d11f08e738ea128f0aeaded9b0a09"/>
+				<disk name="pga tour 98 (usa)" sha1="4868ce46755c35c26962ecf50e36429fef1d831c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18819,7 +18819,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tiger woods 99 pga tour golf (usa) (v1.1)" sha1="7292af853c21299fe5b145e59d7395db0bc307ca"/>
+				<disk name="tiger woods 99 pga tour golf (usa) (v1.1)" sha1="aecc7ccfad0de21e55648a08a8da404e38704b3d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18870,7 +18870,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="philosoma (usa)" sha1="8ade448fec4d5dc2843067b584d0bc5031d61f1b"/>
+				<disk name="philosoma (usa)" sha1="2a8f5a57b6cb60179487eec66133f77e5e068b4d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18927,7 +18927,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pink panther - pinkadelic pursuit (usa)" sha1="d7244b9c1765858cacfdde9fdbcd9085c914599c"/>
+				<disk name="pink panther - pinkadelic pursuit (usa)" sha1="a90123d9053f7f5adfa6ef957f43bb4b06687a12"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18944,7 +18944,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pinobee (usa)" sha1="7c64c4dc449df84ef7af7a77342d8e89388ba10a"/>
+				<disk name="pinobee (usa)" sha1="6f366d9bea7d7f8d69da6ab6224e2eda766687c5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19028,7 +19028,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pitball (usa)" sha1="9d537ff80666fe7aa88ce91d0c32ac4ddd8340d1"/>
+				<disk name="pitball (usa)" sha1="6fe84ef777ca355d118e25b45f5f54f973a5cda3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19045,7 +19045,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pitfall 3d - beyond the jungle (usa)" sha1="9e2d24b34db59a19465087cd4888612d17114606"/>
+				<disk name="pitfall 3d - beyond the jungle (usa)" sha1="2ce1320196672709ae3719bfab10f183b306042b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19468,7 +19468,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro pinball - big race usa (usa)" sha1="42816c090226ef0d7942cfae336845b7120bf365"/>
+				<disk name="pro pinball - big race usa (usa)" sha1="082793fafe243b5d65882f9403a7b2bf10f44040"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19506,7 +19506,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro pinball - fantastic journey (usa)" sha1="b408150fb52b95e1e8eb85e2c6a609d0d11f0812"/>
+				<disk name="pro pinball - fantastic journey (usa)" sha1="83f8747f57ed1139eae35fcd1e531c812a5fb6f7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19556,7 +19556,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro pinball - timeshock (usa)" sha1="b167931677dc208d460f5a4ab4adf0efb8d82cfb"/>
+				<disk name="pro pinball - timeshock (usa)" sha1="ded80f6e94df5dfb0e04988078ad9aa9ab3603b8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19688,7 +19688,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="professional underground league of pain (usa)" sha1="383514e0d2311965243a141c5a5f18f23bb12ff4"/>
+				<disk name="professional underground league of pain (usa)" sha1="8f1933b0221455b27479ebe00d218ea865cb51a2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19893,7 +19893,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="point blank 3 (usa)" sha1="0c45fddde3c36091881c1302ecd39175eef88af3"/>
+				<disk name="point blank 3 (usa)" sha1="2817ab2414f3867454006f095f564d443994d3f0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20017,7 +20017,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="power shovel (usa)" sha1="b6dc87df1c42c65ab3785c8cd5158b128d71fcd3"/>
+				<disk name="power shovel (usa)" sha1="13936d1357e23408fb584e4b2f8f2a258fa04c15"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20034,7 +20034,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="q-bert (usa)" sha1="133c93ffd5af5241212ba5cad24172fa4f9cfee8"/>
+				<disk name="q-bert (usa)" sha1="fe1441d93e56657c6bc83d4fb036e85e241f606f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20069,7 +20069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="quake ii (usa)" sha1="42fd8eafadd029bc27887c9852a4aeb989283830"/>
+				<disk name="quake ii (usa)" sha1="5009e8ea4cdb4c24acf19db8d3190cf25c316d06"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20191,7 +20191,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="raiden project, the (usa)" sha1="cb1e4fae25d42e70fcb3eec5e1c1afcbdc5c2af3"/>
+				<disk name="raiden project, the (usa)" sha1="66d3217fe26ce9aa08023c20b098c365ffa90b0e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20287,7 +20287,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tom clancy's rainbow six (usa)" sha1="fe52e58df1cfffbae7bb25fa603662b87b84170c"/>
+				<disk name="tom clancy's rainbow six (usa)" sha1="2d30f33cd7c770bffa4b923ed8b5dbb0745dadf3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20415,7 +20415,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rascal (usa)" sha1="3c702834316424e1349c36c9757c56c9b758e9eb"/>
+				<disk name="rascal (usa)" sha1="8544b494fa90845e5fd25d3b4f873385e8609262"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20534,7 +20534,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rayman (usa)" sha1="bb97094982d27a44815198a57c7aedcaaab74e42"/>
+				<disk name="rayman (usa)" sha1="07f8272430ee6ec9d0707fef1667f0e4ebb5b23b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20552,7 +20552,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rayman 2 - the great escape (usa) (en,fr,es)" sha1="0060a539f78fdfe27a9e15b25c50bdb0a8957df7"/>
+				<disk name="rayman 2 - the great escape (usa) (en,fr,es)" sha1="580332fd7023842653c212cabd99421ad89dcb8c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20597,7 +20597,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rayman rush (usa)" sha1="d0cf85a4b454baaf9eb3ea3c9234fda9fcda05f0"/>
+				<disk name="rayman rush (usa)" sha1="dcf04b288d2c52ee0afb3068a393fdc6c28fd85c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20614,7 +20614,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="raystorm (usa)" sha1="c24a45839799dc4292e78faf79207e0e0bff6d37"/>
+				<disk name="raystorm (usa)" sha1="a1105f7e11b421df63d5c0586b1fd58a63077fd7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20674,7 +20674,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rc de go (usa)" sha1="6d5bd7305164593f1f1a085e3e517965a3e557a6"/>
+				<disk name="rc de go (usa)" sha1="d30a3a92467d1b32f969a63fa55567bdcc19fd12"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20743,7 +20743,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rc revenge (usa)" sha1="a0deb3cb7f06968d04b287dcea519bb5d2397165"/>
+				<disk name="rc revenge (usa)" sha1="1083fc28192252a2838db6dd46a576e53cfbf307"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20991,12 +20991,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 (usa) (disc 1)" sha1="7322b79e6d4d539d115388b0ce367af5f3df2a69"/>
+				<disk name="resident evil 2 (usa) (disc 1)" sha1="c0365d8e731a288fe91e48d530d613277984a7be"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 (usa) (disc 2)" sha1="646c4f732a16149a98756d27211ee4190c50fa3b"/>
+				<disk name="resident evil 2 (usa) (disc 2)" sha1="d31bc0f576bdde73fb5e5300645b4a88df01309a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21017,12 +21017,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 - dual shock ver. (usa) (disc 1) (leon)" sha1="163470a70ad2bf13a668665547dde90968efab8c"/>
+				<disk name="resident evil 2 - dual shock ver. (usa) (disc 1) (leon)" sha1="38c5a6c7c5cc25c4838f4b5e80f9fb0eb884ae55"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 - dual shock ver. (usa) (disc 2) (claire)" sha1="b84c429ddb5cbe366cc747e0a79f7f6e70a88f34"/>
+				<disk name="resident evil 2 - dual shock ver. (usa) (disc 2) (claire)" sha1="9c7a90f0566982068c69ae581b041ba5dde3baed"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21039,7 +21039,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 3 - nemesis (usa)" sha1="297ccfe24c4935f0869d6ba89d0e46fd9887773a"/>
+				<disk name="resident evil 3 - nemesis (usa)" sha1="e5c6cf477eb7bc69ea59ab1f464ef97446813548"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21074,7 +21074,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil - director's cut - dual shock ver. (usa)" sha1="bb90fb489cfb2182541d725b30c09621f32676e8"/>
+				<disk name="resident evil - director's cut - dual shock ver. (usa)" sha1="9ecd4c66e3ccd142a95a35b000e05546fab048b8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21091,7 +21091,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil - survivor (usa)" sha1="b5fa1bfc4a8932c9828eb30312daa9236fdd4bf5"/>
+				<disk name="resident evil - survivor (usa)" sha1="2a9eb069ef468dada08eb4415117289efaa491db"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21110,7 +21110,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="re-volt (usa)" sha1="70dea533f66ef91de0e37078eaed57d24f41226c"/>
+				<disk name="re-volt (usa)" sha1="76ff6ff0c3692626268e270a6707eb58a3786c26"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21191,7 +21191,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ridge racer (usa)" sha1="d8db80f9bea0310181454001d9305dbbd3123a55"/>
+				<disk name="ridge racer (usa)" sha1="8ac66ea834865a693bb2e437b8aedb9cd1256649"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21334,7 +21334,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="road rash (usa)" sha1="89336b0c8e5f90ce9ad5d9e6405a9ea81a5a99a7"/>
+				<disk name="road rash (usa)" sha1="0ad49eb687923de7363db773d57fad78bc5ceb31"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21359,7 +21359,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="roadsters (usa)" sha1="b5405e343a91f3e9522fe0c52efd5fe84398efd1"/>
+				<disk name="roadsters (usa)" sha1="870193bf83cb6ab12ca9c07bc19a9306d35f48ca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21389,7 +21389,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rock 'em sock 'em robots arena (usa)" sha1="a29a309b78a1c04e83a4837fff290d00eb390873"/>
+				<disk name="rock 'em sock 'em robots arena (usa)" sha1="0be803228de8c56dc37538af0434232081e4ddb1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21519,7 +21519,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rollcage stage ii (usa)" sha1="fdc91b071c77f3b374417c9413dfc88ab7d4da78"/>
+				<disk name="rollcage stage ii (usa)" sha1="508f6e5bf1321077b0936c7f9d25fc4c024c2f84"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21551,7 +21551,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rollcage (usa)" sha1="0a00e8466df9b31dbbbea0cec63254adc28eef65"/>
+				<disk name="rollcage (usa)" sha1="7799fdd199249cd3ada436656e0dc583845a8b9a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21668,7 +21668,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="r4 - ridge racer type 4 (usa)" sha1="5bf4db632745058203d3e622c559aadc9728c86e"/>
+				<disk name="r4 - ridge racer type 4 (usa)" sha1="f637a55052d40c054ea10b724e639658ab334617"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -21691,7 +21691,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="road rash 3d (usa)" sha1="6df63908f9c58acb6eacbe3ab86f1163a4724cd9"/>
+				<disk name="road rash 3d (usa)" sha1="34494c7346d55449a601ee2ebaffb497a0ef1061"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21744,7 +21744,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ridge racer revolution (usa)" sha1="567ed38059cb168a998ac535d592c283df3cdd48"/>
+				<disk name="ridge racer revolution (usa)" sha1="a5a87bf9383964e427e0785c84ee8a706e6e717f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21865,7 +21865,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="r-type delta (usa)" sha1="fd3cb15de17a3a917edd0edbc8e8d550cedbdf7b"/>
+				<disk name="r-type delta (usa)" sha1="aa58dfc96d015dae777f5c4bdef088bfcec50a64"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22069,7 +22069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rush hour (usa)" sha1="3a0d7c90676561f96c293055b92539f0a99503db"/>
+				<disk name="rush hour (usa)" sha1="cea81724f4684b8ef4d130a03d9c07c530bce5ee"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22092,7 +22092,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Arcade Disc"/>
 			<diskarea name="cdrom">
-				<disk name="rival schools - united by fate (usa) (disc 1) (arcade disc)" sha1="b22ced7cd2756472c021643bea839e88e24a0df2"/>
+				<disk name="rival schools - united by fate (usa) (disc 1) (arcade disc)" sha1="fb05951b30b08366d3f0f14370a98569bdfa4bdf"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -22132,7 +22132,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strikers 1945 (usa)" sha1="208b4b5701241daec9800bba33aa387576c7aa67"/>
+				<disk name="strikers 1945 (usa)" sha1="c46e5e4327047045802c714bb7e47777f4aa47f5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22344,7 +22344,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="samurai shodown iii - blades of blood (usa)" sha1="ec39b0de944008cfb464b339ffb219682890e7a6"/>
+				<disk name="samurai shodown iii - blades of blood (usa)" sha1="e4621a82a82f93253c29a7536e3ffa5030bbaeaf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22361,7 +22361,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="samurai shodown - warriors rage (usa)" sha1="5c406bc0e7e9306edd0a801864f43bb66e038d6d"/>
+				<disk name="samurai shodown - warriors rage (usa)" sha1="9ac2ddb993c8810740fd08ce4d4580ea231057b0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22395,7 +22395,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super bubble pop (usa)" sha1="86f5077178ba9ac862da42697a592c921a9f5b9a"/>
+				<disk name="super bubble pop (usa)" sha1="82185ff124636de2447919e348600b8a1079e36d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22484,7 +22484,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="scrabble (usa)" sha1="3f7d0a812be4e9ce6312f1adb39163ff641c0dfd"/>
+				<disk name="scrabble (usa)" sha1="4030820874124b74fc1535c6a39954c80d08008d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22556,7 +22556,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sentient (usa)" sha1="28e6a7d9f9de0247f3cbc9688de335f722711361"/>
+				<disk name="sentient (usa)" sha1="d140a7e2fe184ed72ea07fb881a500cffbc17a11"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22640,7 +22640,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter alpha - warriors' dreams (usa)" sha1="ae3168c4f6097e6fa7083411f76ba94d95d2037d"/>
+				<disk name="street fighter alpha - warriors' dreams (usa)" sha1="711afd8cc92d07f4d10462192cf48d202d9ab3d7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22658,7 +22658,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter alpha 2 (usa)" sha1="0bf01b34786c097489bcdaae0c84f07cc4a3ccc2"/>
+				<disk name="street fighter alpha 2 (usa)" sha1="a1c39448d2013c764eba9596e7857208ccb3ce27"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22676,7 +22676,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter alpha 3 (usa)" sha1="0f9efd002a0653925734af77d4d1fd38a0bed869"/>
+				<disk name="street fighter alpha 3 (usa)" sha1="950830b7b0ad50f58c300506d4b0484dd09e946c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22771,13 +22771,13 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Super Street Fighter II &amp; Super Street Fighter II Turbo"/>
 			<diskarea name="cdrom">
-				<disk name="street fighter collection (usa) (disc 1) (v1.1)" sha1="9eaab12a032b7e9d6a05f342752f1de8fe4d27b3"/>
+				<disk name="street fighter collection (usa) (disc 1) (v1.1)" sha1="15099186368611834f61ce1471b626e2b6071b2e"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<feature name="part_id" value="Super Street Fighter Alpha 2 Gold"/>
 			<diskarea name="cdrom">
-				<disk name="street fighter collection (usa) (disc 2) (v1.1)" sha1="b42293238b6b2dd5ebc9dc990bdc08ab6e6ec8c4"/>
+				<disk name="street fighter collection (usa) (disc 2) (v1.1)" sha1="56530bdbc1a3547a51695486be9865434a56a0fb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22899,7 +22899,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter collection 2 (usa)" sha1="56e122837fda765c8515dbd738faa316670538ed"/>
+				<disk name="street fighter collection 2 (usa)" sha1="0e64662c3c641d193fed1bffebb5a5a9e35e3b40"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22916,7 +22916,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter ex2 plus (usa)" sha1="2a4e2e8bd97b6b647068ba895d36527ef5432899"/>
+				<disk name="street fighter ex2 plus (usa)" sha1="7412bc70b906f05e50994ff80899dfb18073771b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22933,7 +22933,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter ex plus alpha (usa)" sha1="383b2a669ece1407d41cf2386e943e6257eaea57"/>
+				<disk name="street fighter ex plus alpha (usa)" sha1="9d9f2d5ad38ad742abb7c7ea3b80e03068a6084b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22979,7 +22979,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter - the movie (usa)" sha1="086d63873dea95a64c706202c1eb998f8c6904b7"/>
+				<disk name="street fighter - the movie (usa)" sha1="3a96da37e19cc988aff750d03705cf2f0457ad3a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23036,7 +23036,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="shadow man (usa)" sha1="485f80a243bff3a4bafa6015d931b3ff6bf78be8"/>
+				<disk name="shadow man (usa)" sha1="70718577aa4bb03dd1006c33094837859f6dee19"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23325,7 +23325,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="silent hill (usa)" sha1="ea7a7503593012e9e726c4549c193f956510ffee"/>
+				<disk name="silent hill (usa)" sha1="fd460847a57795d2368b6b1a2784fa077cffb37f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23421,7 +23421,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="simpsons wrestling, the (usa)" sha1="c4af5e47f91ab14aab2359a3a4826bd2c88342ec"/>
+				<disk name="simpsons wrestling, the (usa)" sha1="2901283291baa7f1e3e3d9bdc4adce514bd4215d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23523,7 +23523,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slam 'n jam '96 featuring magic &amp; kareem (usa)" sha1="d026e97d9bb15470718df2151bba33208ff9fe07"/>
+				<disk name="slam 'n jam '96 featuring magic &amp; kareem (usa)" sha1="1a91ab0f827b68509db476ed24314412de38e05f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23601,7 +23601,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slots (usa)" sha1="43b08f17ed50f7ca259f33903012b1609e140c62"/>
+				<disk name="slots (usa)" sha1="b93ee66bcb99189a3cc594736f94902bdd4233e0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23715,7 +23715,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="smurfs, the (usa) (en,fr,es)" sha1="9a12b993132ec4bb762e7949b1451b851bbdcc3f"/>
+				<disk name="smurfs, the (usa) (en,fr,es)" sha1="c2b14925b21eb5fb34a78ec885249950ff535239"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23758,7 +23758,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="snowboarding (usa)" sha1="15dcedb3041bc9fea57aabad56ee0b9188cc5f50"/>
+				<disk name="snowboarding (usa)" sha1="0a9b080ab657b422d6214939b3e7f83a77c7f860"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23855,7 +23855,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="castlevania - symphony of the night (usa)" sha1="37b2cdcaa49bf773406a6d886a2d5ba8f835cf76"/>
+				<disk name="castlevania - symphony of the night (usa)" sha1="5239b5c6c2f2da5f1d9356670fa614f31e4e3075"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23872,7 +23872,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="soul blade (usa) (v1.1)" sha1="4c8f306c713b7f1820a758f0e02e6410aaa57bed"/>
+				<disk name="soul blade (usa) (v1.1)" sha1="a66be2ea6ade0326bb40e75ffd949fef0e93d1d5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23924,7 +23924,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="south park (usa)" sha1="283070618ece8b9692baabc8f47735df1a779984"/>
+				<disk name="south park (usa)" sha1="cfa1847f45a5435157506def8e8bc437420cf745"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23942,7 +23942,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space invaders (usa)" sha1="aa41f19e38d7ffdf451b587433811bc6b4cb3857"/>
+				<disk name="space invaders (usa)" sha1="b3aa1b3e2f509e44d5f840cc2d9fa2aa8bceba82"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23960,7 +23960,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space jam (usa)" sha1="398d676f0aef38c079c53214bd8e9ff603478e62"/>
+				<disk name="space jam (usa)" sha1="24934636c63dbb820e6716e60aaecc283486636d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23977,7 +23977,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space shot (usa)" sha1="ab678f726c6841c2d657820a256f97fd59ed1427"/>
+				<disk name="space shot (usa)" sha1="79446aef0301e34210284080ad3208bdfb6cd265"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24069,7 +24069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="south park rally (usa)" sha1="dd9351c50f964035ad4d0d932d98970dcb2ba176"/>
+				<disk name="south park rally (usa)" sha1="ca945cf19c22bebd043ec005bb90e8f765b67c04"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24303,7 +24303,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super puzzle fighter ii turbo (usa)" sha1="23fdf03ffd002de06b2b6366a93d552c00798d45"/>
+				<disk name="super puzzle fighter ii turbo (usa)" sha1="8e42b8bcdfc295bd7cd90bf554f4f30efb36129a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24338,7 +24338,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spider - the video game (usa)" sha1="4f04f45cec47033616a45b0acc7550654030fff0"/>
+				<disk name="spider - the video game (usa)" sha1="e332ae9c41bf4385964db272c7ec003e21155421"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24355,7 +24355,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spider-man (usa)" sha1="66c09444240ddf96f194d2d2e63b42a2af77bc37"/>
+				<disk name="spider-man (usa)" sha1="196e5fb8bc1a96db65107abd338593198a207fae"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24483,7 +24483,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spyro the dragon (usa)" sha1="ab729c36603444bfde190542f0b42e9262eebeaa"/>
+				<disk name="spyro the dragon (usa)" sha1="1a861139d485f7fcfc3cfd839a4db5bdd95267f9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24500,7 +24500,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spyro 2 - ripto's rage (usa)" sha1="4df448b9cfe122821ac8f812f76891209f31d4fe"/>
+				<disk name="spyro 2 - ripto's rage (usa)" sha1="b31b6dfd9d16cb90b6cfcd9a5ea71663a4132d26"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24517,7 +24517,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spyro - year of the dragon (usa) (v1.1)" sha1="85fa6a1688326cb194d3423f3ddd4381712f2065"/>
+				<disk name="spyro - year of the dragon (usa) (v1.1)" sha1="ca1593703cb4c7a746f03b7f29ca9e788631de3a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24564,7 +24564,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street racer (usa)" sha1="67fdc6df29b2ab81d2bcc84d521af9c577b57f38"/>
+				<disk name="street racer (usa)" sha1="3653b9818f7aa8dc2c1f94fe0dd9530816de2949"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24628,7 +24628,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sports superbike 2 (usa)" sha1="3c3ff1484bd50d2d13e2ece3a86ab63995529647"/>
+				<disk name="sports superbike 2 (usa)" sha1="a119ec81e05090feab67521b45e107a4cb8c0620"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24765,7 +24765,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star gladiator - episode i - final crusade (usa)" sha1="ef090bb9a672649d6088c960405c3514a2e376c1"/>
+				<disk name="star gladiator - episode i - final crusade (usa)" sha1="cd617da2869cb015112634c449433c10c002933b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24901,7 +24901,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="streak hoverboard racing (usa)" sha1="ca792dbf94f57729390973a09f7fb5900932d34c"/>
+				<disk name="streak hoverboard racing (usa)" sha1="438af526e14d22d4d191ba48b8ff4ad3b3557a3c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24937,7 +24937,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strider (usa)" sha1="fa9e3f112aa7ecd854edb5ab2200e476c807453f"/>
+				<disk name="strider (usa)" sha1="250c17d0565edb1fede48aff809b3a80f5020f34"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24956,7 +24956,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strider 2 (usa)" sha1="5bae061e35040cae34914d40e4e51eb2b515f736"/>
+				<disk name="strider 2 (usa)" sha1="9d36dbde94c02d9209139ebea7497ad62a1ce969"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24975,7 +24975,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="striker 96 (usa)" sha1="b405a370a8f800edd0d5d1d6a5e25b3826132e5b"/>
+				<disk name="striker 96 (usa)" sha1="2b43bad6cdc0b3f754b41683c0b7c17f32ddd895"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25102,7 +25102,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat mythologies - sub-zero (usa)" sha1="d67cc625011a58b0abccbf864bcd7d2027d1bea7"/>
+				<disk name="mortal kombat mythologies - sub-zero (usa)" sha1="f1e1d9e2f54ba89b3da6a94a01c326dc20ade137"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25119,7 +25119,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="suikoden (usa) (v1.1)" sha1="55eeefa1a0afd329e85747d4afe6b038793c9919"/>
+				<disk name="suikoden (usa) (v1.1)" sha1="cdeb30e8cf297186a84eacfa523ce8204f5f604e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25136,7 +25136,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="suikoden (usa) (v1.0)" sha1="a969814a8fe8d2c7c7033192fc490045b3c1485d"/>
+				<disk name="suikoden (usa) (v1.0)" sha1="f949b37c1109d8650d8c4dcdc062c0d8e9c29440"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25153,7 +25153,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="suikoden ii (usa)" sha1="a47dbce42efb9dc0e2f2d0835d3534774e33dd6d"/>
+				<disk name="suikoden ii (usa)" sha1="37bd1800d6afdfb49d7fa5d33a361a4d9ab5925d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25214,7 +25214,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="swagman (usa)" sha1="ca6e3eda048cfc1135d794db0636b0cae9884684"/>
+				<disk name="swagman (usa)" sha1="cc4169335d7ba136153f77bda5a41292fe1b5003"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25276,7 +25276,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star wars - episode i - the phantom menace (usa)" sha1="8ab36c9e46e6bec0e27c611c2890fbfbeb0eeb31"/>
+				<disk name="star wars - episode i - the phantom menace (usa)" sha1="3b5e805896f8222b563e3ebc9c2ffd903a1c9894"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25536,7 +25536,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tail concerto (usa)" sha1="b3adcc6c634b5a8c7a24f9bcc649bba7d4a00848"/>
+				<disk name="tail concerto (usa)" sha1="e06ac367c9f1b2d408caa6c6748c60fdf892c765"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25598,7 +25598,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's tarzan (usa) (v1.1)" sha1="f2779268217aaacb3aa0fa18ea92e154a0d3e47a"/>
+				<disk name="disney's tarzan (usa) (v1.1)" sha1="cbc0f2b3cdddc73356662a5b5b45a037b1e23cde"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25616,7 +25616,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's tarzan (usa) (v1.0)" sha1="a9f0b4f770dbe12dfece2822f525852e0bc1f0b1"/>
+				<disk name="disney's tarzan (usa) (v1.0)" sha1="c4ddc339825d8398f9efaa1cc1962708be6faf87"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25766,7 +25766,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="team buddies (usa)" sha1="3f155d0e980d4ed84630b279da94af78cb339563"/>
+				<disk name="team buddies (usa)" sha1="0803b39feabeecdb224f54e4e1e8f59e3ca49f64"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25919,7 +25919,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tekken (usa)" sha1="b2d2c32c3ab3c597b7017c1d1f7cb7d69496ba17"/>
+				<disk name="tekken (usa)" sha1="cb5cd46bf8c7d5e1d34d4aa25ec54ce9a4632e46"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25938,7 +25938,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tekken 2 (usa) (v1.1)" sha1="ce046321efa2d377c0b241f725fd6f9fbac660ea"/>
+				<disk name="tekken 2 (usa) (v1.1)" sha1="2d3c614e5278f9189b6fdc803fe1b942ec97c442"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25976,7 +25976,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tekken 3 (usa)" sha1="e1537fb7c60ee4e39743847ffadfa33c94912652"/>
+				<disk name="tekken 3 (usa)" sha1="319ec7377eb0c3ef0b6049e440937d26ae743290"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26082,7 +26082,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tennis (usa)" sha1="000a5de8072f21f168f8663429673cd33acea5bf"/>
+				<disk name="tennis (usa)" sha1="213ea8a9a04f09cfb0154b1f3807e743b1b7abbc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26222,7 +26222,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tetris plus (usa)" sha1="d8d67a9c6eb5246fdc2e5ebb9233a429bbbd9b4f"/>
+				<disk name="tetris plus (usa)" sha1="26f26fc78fb2c507c9a72fdcdc2ed1910dcbc039"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26239,7 +26239,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="thunder force v - perfect system (usa)" sha1="0c01c35c0b08f87763277581abd19d2f082b6c29"/>
+				<disk name="thunder force v - perfect system (usa)" sha1="17658f39053eaed1028a1a470f59388553fd2ded"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26328,7 +26328,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tony hawk's pro skater (usa)" sha1="7a6b07b327d77cd27ebe161a3a64d149ebd19e3e"/>
+				<disk name="tony hawk's pro skater (usa)" sha1="b94afb759d5c2f289f5d4ec910b3d92c79316c0c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26345,7 +26345,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tony hawk's pro skater 2 (usa)" sha1="1069052c61fe99be3e938b98887355170ac91318"/>
+				<disk name="tony hawk's pro skater 2 (usa)" sha1="76ca2e86180f977c596a53c7257914f338e6a0de"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26379,7 +26379,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tony hawk's pro skater 4 (usa)" sha1="694bed9d4d9cd260d393b67b2825eb01e32c5eb1"/>
+				<disk name="tony hawk's pro skater 4 (usa)" sha1="1cf3955bb1a3e41343dc027985f1d615b8e9c9d6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26600,7 +26600,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tiny tank (usa)" sha1="87d08ea463c0096f7ca154e92805429d4f52bf5e"/>
+				<disk name="tiny tank (usa)" sha1="e61cd0f24d0afc8846e978e4e5a61d35ca99ffa6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26824,7 +26824,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomba (usa)" sha1="e543a25583ef211010dd6736b88c43f8b4132931"/>
+				<disk name="tomba (usa)" sha1="50d87fb5646c60fe419b56a53c20f112806f068b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26842,7 +26842,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomba 2 - the evil swine return (usa)" sha1="34859016049661e1083391e9015f73f67a919f24"/>
+				<disk name="tomba 2 - the evil swine return (usa)" sha1="21b5620e342529ea2dbd68ca47da5399eff71199"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26973,7 +26973,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle arena toshinden (usa)" sha1="c216b34a840255677fb7fd10bdaa60c5edf863f5"/>
+				<disk name="battle arena toshinden (usa)" sha1="64e5b9f4443b4770668d26c46a8d711017e5f41b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27007,7 +27007,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle arena toshinden 2 (usa)" sha1="2dbd6c7312e3c1edf1baaeea5e1ab1bac598a125"/>
+				<disk name="battle arena toshinden 2 (usa)" sha1="aca3e7f7da0527e3c94e43ab9650461b91fc0c87"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27025,7 +27025,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle arena toshinden 3 (usa) (en,ja)" sha1="bcc2a1583b44c4d087d94cb9a3bd152726b29884"/>
+				<disk name="battle arena toshinden 3 (usa) (en,ja)" sha1="03d70fde6dde4439b573c2272b8ad930960f3ae1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27110,7 +27110,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="triple play baseball (usa)" sha1="81f7c10f296db0136d5c749601270f6d36fc112f"/>
+				<disk name="triple play baseball (usa)" sha1="67642c3ab9777501904d3843f77d9e1a38bea64c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27310,7 +27310,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider (usa) (v1.6)" sha1="697842403e9a7e5f662d8d5a56b40480742fe3ac"/>
+				<disk name="tomb raider (usa) (v1.6)" sha1="294b08736f01ca7528a191ed5ee50f849b40dbff"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27387,7 +27387,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider ii - starring lara croft (usa) (v1.3)" sha1="459ef793bc4b451997c87054b6925afa5f4358d7"/>
+				<disk name="tomb raider ii - starring lara croft (usa) (v1.3)" sha1="bdf8850b894577ec723b82da59d3c53f40893236"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27635,7 +27635,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider iii - adventures of lara croft (usa) (v1.2)" sha1="0a883e2f47003f50b2b9793159d30421668bb2c6"/>
+				<disk name="tomb raider iii - adventures of lara croft (usa) (v1.2)" sha1="42badae97c44239c7bf61bb8bc1e35beb025a207"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27686,7 +27686,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider - the last revelation (usa) (v1.1)" sha1="53cd52f5f77979b2547d49db33fc554589733774"/>
+				<disk name="tomb raider - the last revelation (usa) (v1.1)" sha1="26761d10c047676960391d97bb1ce48498689bf0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28272,7 +28272,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="misadventures of tron bonne, the (usa)" sha1="0695a8d71036b2c3d15440aea80d7d722c26ad56"/>
+				<disk name="misadventures of tron bonne, the (usa)" sha1="7e4316ac95ae0f9d26b9b99820d283d318c276a3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28338,7 +28338,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="true pinball (usa)" sha1="87a1463306ed777635daf00b70f09212203a61bc"/>
+				<disk name="true pinball (usa)" sha1="a747481095f7860138e405c418e8ff32069e77c1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28499,7 +28499,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal - small brawl (usa)" sha1="7f4d093f996f2e1e6ceb1d8b13477aadedc47155"/>
+				<disk name="twisted metal - small brawl (usa)" sha1="4589bbc09de5f537f0809895fe32d69c26106678"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28527,7 +28527,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal 2 (usa)" sha1="ea300893c05cbf43ef4fba616112c542627e6016"/>
+				<disk name="twisted metal 2 (usa)" sha1="ed75cb9b039ce559118bdf624685e221e6dbf906"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28580,7 +28580,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal iii (usa) (v1.1)" sha1="0300b5d0bac4c7a24e541b5a9f83979b79cb1dbf"/>
+				<disk name="twisted metal iii (usa) (v1.1)" sha1="5339b19b908e44f34310a6a1ecbc60817665b8ca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28672,7 +28672,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal 4 (usa)" sha1="b6ea4d26c0172bce93825f483699b55988bad28a"/>
+				<disk name="twisted metal 4 (usa)" sha1="3420fe8dbb4b1718f971afffb790ac7e8f4fa1d3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28697,7 +28697,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal (usa)" sha1="b02c5da714570a23ac2f9a55d5a938dce5fd2d6b"/>
+				<disk name="twisted metal (usa)" sha1="67269637d563ed2ffafd842be8908b068548bc2b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28792,7 +28792,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ultimate brain games (usa)" sha1="a46038894503a5864a1b8ea23661553677789fdf"/>
+				<disk name="ultimate brain games (usa)" sha1="ef1229098eb2ee7ee9d0b4c84625b3875b8c8a0c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28913,7 +28913,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vagrant story (usa)" sha1="f70f1bce87e8c7a84953c4d7271cfb2f3622bb4a"/>
+				<disk name="vagrant story (usa)" sha1="d200433ef70d5a859fb49736dbcfea5cb030ba19"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29029,7 +29029,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vanishing point (usa)" sha1="5ded96e4907f70541f68088e2026d6786e5ed931"/>
+				<disk name="vanishing point (usa)" sha1="ac1adde7e60f76502636afa478308f728a830f08"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29063,7 +29063,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vegas games 2000 (usa)" sha1="950f66e7efae1a84aa6a1edeb4d7084c0d55153f"/>
+				<disk name="vegas games 2000 (usa)" sha1="f94739301a9352bb0b3f52a99393ef3b6ace448e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29099,7 +29099,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="viewpoint (usa)" sha1="2019a0a7f0cf294e9f93c5ef7d72243500f1aac2"/>
+				<disk name="viewpoint (usa)" sha1="495e5408ce67261120f5128d9ddb3c1e27320821"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29312,7 +29312,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - v-rally (usa)" sha1="02cb03c751ea2d22b065a6588649b6e5d25cd2d1"/>
+				<disk name="need for speed - v-rally (usa)" sha1="ea312ed2010a224acf94675342d5aeeb48214427"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29336,7 +29336,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - v-rally 2 (usa)" sha1="a0c2e8b268c5ce33a98ef66652fe7a9a16fa376c"/>
+				<disk name="need for speed - v-rally 2 (usa)" sha1="e4eb2e42ddd69a0e591c008adcb06b9c49260dc5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29446,7 +29446,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vr sports powerboat racing (usa)" sha1="5d5db014fbb80d764ea4583867880b0ac125281e"/>
+				<disk name="vr sports powerboat racing (usa)" sha1="922b7edf37558c03d93dd6e093177ceff1ad378d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29500,7 +29500,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="v-tennis (usa)" sha1="7f9f873b2462d06e13b96435483f0e25ec993587"/>
+				<disk name="v-tennis (usa)" sha1="d4f4d0548ce5014736b3cb842b7feaeafcb9ea99"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29517,7 +29517,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="warcraft ii - the dark saga (usa) (en,fr,de,es,it)" sha1="b33a8b1bd8a007725138b840e6baa386efd881b6"/>
+				<disk name="warcraft ii - the dark saga (usa) (en,fr,de,es,it)" sha1="0cbccd6e495156337aafd0b5d2ca21d287d8ad03"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29588,7 +29588,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="warhawk - the red mercury missions (usa)" sha1="27a6349c15269d5b5ea1cec65fdc6d598cdaf981"/>
+				<disk name="warhawk - the red mercury missions (usa)" sha1="7d0fbd0a88465353f4880746212726786e5bfdc3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29810,7 +29810,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="world destruction league - thunder tanks (usa)" sha1="2ab20dffff5961a1293b1ea77b50545b76c5d158"/>
+				<disk name="world destruction league - thunder tanks (usa)" sha1="e2834f6a373579793b1cbe475e11b8074aee9540"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29957,7 +29957,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="who wants to be a millionaire - 3rd edition (usa)" sha1="8905733e730fd883cc8ef73731e17c98c4cc1ef6"/>
+				<disk name="who wants to be a millionaire - 3rd edition (usa)" sha1="2bd8d522484e153d83ba40d4af29ff970e905cf5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30444,7 +30444,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf attitude (usa)" sha1="99705956be9321648758a86fa8921f3678649511"/>
+				<disk name="wwf attitude (usa)" sha1="b268502bd345e64ec78abf064fa7282cd879061c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30462,7 +30462,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf in your house (usa) (v1.1)" sha1="7f9ee48b66b97c00f825a252abb5e133f6f52a6b"/>
+				<disk name="wwf in your house (usa) (v1.1)" sha1="797f8d3655a02cdf231e973b662343580337e232"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30497,7 +30497,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf wrestlemania - the arcade game (usa)" sha1="887df77fc1b3d73c906f04b6509c1ab710fbb9bb"/>
+				<disk name="wwf wrestlemania - the arcade game (usa)" sha1="9b2b6d1d6d2793a321ece7409ae9a76e77db4ff4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30531,7 +30531,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf smackdown (usa)" sha1="188a1e58141544712ef6dc9e75ebbbe26831b40c"/>
+				<disk name="wwf smackdown (usa)" sha1="9fb74cc0699ee1a11ee3e2838ec7885636ef7862"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30549,7 +30549,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf war zone (usa) (v1.1)" sha1="17e6c6470688d54e5ec008fe085187afbcaec52c"/>
+				<disk name="wwf war zone (usa) (v1.1)" sha1="fbe408d78500a5441e280e7aaa59f11500c050fb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30680,12 +30680,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="xenogears (usa) (disc 1)" sha1="2b3ce2abb86c1ef68c4aa5baa54a95887f95015d"/>
+				<disk name="xenogears (usa) (disc 1)" sha1="64a49e3b3bcd14ef74f363d5a5ccf366e283d790"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="xenogears (usa) (disc 2)" sha1="bbb7eaea1bace092a96691ba604ba5c906d3da93"/>
+				<disk name="xenogears (usa) (disc 2)" sha1="918b8d1b36037e47ba87c9504f53f83d151dadc3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30702,7 +30702,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="xevious 3d-g+ (usa)" sha1="168b85cd3561c918ddb443fef133e2c13ae77519"/>
+				<disk name="xevious 3d-g+ (usa)" sha1="a8ab9950c8b627f67ac0b33731741f089d08f604"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30775,7 +30775,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men - children of the atom (usa)" sha1="da09e144894978fc306eff0e4a4ddcc74de88b38"/>
+				<disk name="x-men - children of the atom (usa)" sha1="db53105be644f4e24440b3e98bf8971feeb69d52"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30803,7 +30803,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men - mutant academy (usa)" sha1="5829f1227cca671c1bc29b820ee97932449730ad"/>
+				<disk name="x-men - mutant academy (usa)" sha1="f278224ff06ea10c46abe85145ab124b043ff000"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30832,7 +30832,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men - mutant academy 2 (usa)" sha1="c80819e5a50d971a3ff7c38650b4757aec5c015c"/>
+				<disk name="x-men - mutant academy 2 (usa)" sha1="7e021fc6b42cdfe18b8572e2d271182d3aa04e04"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30849,7 +30849,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men vs. street fighter (usa)" sha1="a5de42525daba6420653b835e01ea99d8e6b8799"/>
+				<disk name="x-men vs. street fighter (usa)" sha1="05be871ffb7e54985689a10a31638c1324cae3f7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -37182,8 +37182,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Creature Shock (Japan)</description>
 		<year>1996</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-00120~SLPS-00121" />
-		<info name="release" value="19960823" />
+		<info name="serial" value="SLPS-00120~SLPS-00121"/>
+		<info name="release" value="19960823"/>
 		<info name="alt_title" value="クリーチャーショック"/>
 		<info name="ring_code" value="SLPS-00120   1 (Disc 1), SLPS-00121   1 (Disc 2)"/>
 		<info name="barcode" value="4 961082 300081"/>
@@ -37208,7 +37208,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1996</year>
 		<publisher>Sony Computer Entertainment</publisher>
 		<info name="serial" value="SCPS 18003"/>
-		<info name="release" value="19961206" />
+		<info name="release" value="19961206"/>
 		<info name="barcode" value="4 948872 180030"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37229,7 +37229,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2003</year>
 		<publisher>Square Enix</publisher>
 		<info name="serial" value="SLPM-87317"/>
-		<info name="release" value="20031023" />
+		<info name="release" value="20031023"/>
 		<info name="alt_title" value="フロントミッション ザ・ファースト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37250,7 +37250,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1996</year>
 		<publisher>Harvest One</publisher>
 		<info name="serial" value="SLPS-00348"/>
-		<info name="release" value="19961011" />
+		<info name="release" value="19961011"/>
 		<info name="alt_title" value="リーディングジョッキーハイブリッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37267,7 +37267,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Hudson</publisher>
 		<info name="serial" value="SLPS-01866"/>
 		<info name="alt_title" value="Piとメール"/>
-		<info name="release" value="19990211" />
+		<info name="release" value="19990211"/>
 		<info name="barcode" value="4 988607 050252"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37287,8 +37287,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Raiden DX (Japan, Major Wave Series)</description>
 		<year>2000</year>
 		<publisher>Hamster</publisher>
-		<info name="serial" value="SLPM-86656" />
-		<info name="release" value="20001026" />
+		<info name="serial" value="SLPM-86656"/>
+		<info name="release" value="20001026"/>
 		<info name="alt_title" value="雷電ディー・エックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37308,8 +37308,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Raiden DX (Japan)</description>
 		<year>1997</year>
 		<publisher>Nihon System</publisher>
-		<info name="serial" value="SLPS-00728" />
-		<info name="release" value="19970411" />
+		<info name="serial" value="SLPS-00728"/>
+		<info name="release" value="19970411"/>
 		<info name="alt_title" value="雷電DX"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37328,8 +37328,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Raiden Project (Japan)</description>
 		<year>1995</year>
 		<publisher>Nihon System</publisher>
-		<info name="serial" value="SLPS-00013, SLPS-91002 (Playstation the Best)" />
-		<info name="release" value="19950127, 19960712 (Playstation the Best)" />
+		<info name="serial" value="SLPS-00013, SLPS-91002 (Playstation the Best)"/>
+		<info name="release" value="19950127, 19960712 (Playstation the Best)"/>
 		<info name="alt_title" value="雷電プロジェクト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37346,7 +37346,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Sony Computer Entertainment</publisher>
 		<info name="serial" value="SCPS 10015, SCPS 91008"/>
 		<info name="alt_title" value="戦闘国家 AIR LAND BATTLE"/>
-		<info name="release" value="19951201" />
+		<info name="release" value="19951201"/>
 		<info name="barcode" value="4 948872 100151, 4 948872 910088"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37367,7 +37367,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="SLPM-86344 (TCPS10011)"/>
-		<info name="release" value="19991111" />
+		<info name="release" value="19991111"/>
 		<info name="alt_title" value="サイドバイサイドスペシャル２０００"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37384,7 +37384,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Yutaka</publisher>
 		<info name="serial" value="SLPS 00596 (104017-0052421-9800), SLPS 00740 (104017-0051785-5800)"/>
 		<info name="alt_title" value="聖刻1092 操兵伝"/>
-		<info name="release" value="19971106" />
+		<info name="release" value="19971106"/>
 		<info name="barcode" value="4 974229 517853, 4 974229 524219"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37405,7 +37405,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>Riverhill Soft</publisher>
 		<info name="serial" value="SLPS-01037, SLPS-91086 (Playstation the Best)"/>
-		<info name="release" value="19971023, 19980806 (Playstation the Best)" />
+		<info name="release" value="19971023, 19980806 (Playstation the Best)"/>
 		<info name="alt_title" value="ワールド・ネバーランド ～オルルド王国物語～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37474,8 +37474,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>007 - Tomorrow Never Dies (Japan)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts Square</publisher>
-		<info name="serial" value="SLPS-02604" />
-		<info name="release" value="20000210" />
+		<info name="serial" value="SLPS-02604"/>
+		<info name="release" value="20000210"/>
 		<info name="alt_title" value="００７　～トゥモロー・ネバー・ダイ～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37509,8 +37509,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>10101 - "Will" the Starship (Japan)</description>
 		<year>1997</year>
 		<publisher>Sound Technology Japan</publisher>
-		<info name="serial" value="SLPS-01054" />
-		<info name="release" value="19971106" />
+		<info name="serial" value="SLPS-01054"/>
+		<info name="release" value="19971106"/>
 		<info name="alt_title" value="10101 スターシップ・ウィル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37530,8 +37530,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>19-ji 03-pun Ueno Hatsu Yakou Ressha (Japan)</description>
 		<year>1999</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPS-01865" />
-		<info name="release" value="19990304" />
+		<info name="serial" value="SLPS-01865"/>
+		<info name="release" value="19990304"/>
 		<info name="alt_title" value="19時03分　上野発夜光列車"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37551,8 +37551,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>1-on-1 - Single Basketball (Japan)</description>
 		<year>1998</year>
 		<publisher>Jorudan</publisher>
-		<info name="serial" value="SLPS-01706" />
-		<info name="release" value="19981126" />
+		<info name="serial" value="SLPS-01706"/>
+		<info name="release" value="19981126"/>
 		<info name="alt_title" value="ワン オン ワン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37575,8 +37575,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>First Kiss Monogatari (Japan)</description>
 		<year>1998</year>
 		<publisher>HuneX</publisher>
-		<info name="serial" value="SLPS-01708~SLPS-01709" />
-		<info name="release" value="19981126" />
+		<info name="serial" value="SLPS-01708~SLPS-01709"/>
+		<info name="release" value="19981126"/>
 		<info name="alt_title" value="ファーストKiss☆物語"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -37601,8 +37601,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>20 Seiki Striker Retsuden - The 20th Century's Real Strikers (Japan)</description>
 		<year>2000</year>
 		<publisher>DaZZ</publisher>
-		<info name="serial" value="SLPS-02348 (PS-0014)" />
-		<info name="release" value="20000210" />
+		<info name="serial" value="SLPS-02348 (PS-0014)"/>
+		<info name="release" value="20000210"/>
 		<info name="alt_title" value="20世紀ストライカー列伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37622,8 +37622,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Abe a GoGo (Japan)</description>
 		<year>1997</year>
 		<publisher>GameBank</publisher>
-		<info name="serial" value="SLPS-01118" />
-		<info name="release" value="19971211" />
+		<info name="serial" value="SLPS-01118"/>
+		<info name="release" value="19971211"/>
 		<info name="alt_title" value="エイブ・ア・ゴーゴー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37643,8 +37643,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Acid (Japan)</description>
 		<year>1999</year>
 		<publisher>Taki</publisher>
-		<info name="serial" value="SLPS-02119" />
-		<info name="release" value="19990708" />
+		<info name="serial" value="SLPS-02119"/>
+		<info name="release" value="19990708"/>
 		<info name="alt_title" value="アシッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37667,8 +37667,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aconcagua (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10131~SCPS-10132" />
-		<info name="release" value="20000601" />
+		<info name="serial" value="SCPS-10131~SCPS-10132"/>
+		<info name="release" value="20000601"/>
 		<info name="alt_title" value="アコンカグア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -37694,8 +37694,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ad Lib Ouji ...to Fuyukai na Nakamatachi!? (Japan)</description>
 		<year>2002</year>
 		<publisher>Nihon Telenet</publisher>
-		<info name="serial" value="SLPS-03510" />
-		<info name="release" value="20021219" />
+		<info name="serial" value="SLPS-03510"/>
+		<info name="release" value="20021219"/>
 		<info name="alt_title" value="アドリブ王子 …と不愉快な仲間達!?"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37716,8 +37716,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Advan Racing (Japan)</description>
 		<year>1998</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-01689" />
-		<info name="release" value="19981119" />
+		<info name="serial" value="SLPS-01689"/>
+		<info name="release" value="19981119"/>
 		<info name="alt_title" value="アドバン・レーシング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37737,8 +37737,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Afraid Gear Another (Japan)</description>
 		<year>2001</year>
 		<publisher>Office Create</publisher>
-		<info name="serial" value="SLPM-86834" />
-		<info name="release" value="20010614" />
+		<info name="serial" value="SLPM-86834"/>
+		<info name="release" value="20010614"/>
 		<info name="alt_title" value="アフレイドギア・アナザ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37768,8 +37768,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Afraid Gear (Japan)</description>
 		<year>1998</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-00995" />
-		<info name="release" value="19981029" />
+		<info name="serial" value="SLPS-00995"/>
+		<info name="release" value="19981029"/>
 		<info name="alt_title" value="アフレイドギア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37816,8 +37816,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Airgrave (Japan)</description>
 		<year>1996</year>
 		<publisher>Santos</publisher>
-		<info name="serial" value="SLPS-00559" />
-		<info name="release" value="19961129" />
+		<info name="serial" value="SLPS-00559"/>
+		<info name="release" value="19961129"/>
 		<info name="alt_title" value="エア・グレイヴ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37837,8 +37837,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Airs (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01916" />
-		<info name="release" value="19990325" />
+		<info name="serial" value="SLPS-01916"/>
+		<info name="release" value="19990325"/>
 		<info name="alt_title" value="エアーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37880,8 +37880,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aitakute... Your Smiles in My Heart (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86254~SLPM-86257 (VX058-J1)" />
-		<info name="release" value="20000316" />
+		<info name="serial" value="SLPM-86254~SLPM-86257 (VX058-J1)"/>
+		<info name="release" value="20000316"/>
 		<info name="alt_title" value="あいたくて・・・your smiles in my heart"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -37916,8 +37916,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aizouban Houshin Engi (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86209" />
-		<info name="release" value="19990401" />
+		<info name="serial" value="SLPM-86209"/>
+		<info name="release" value="19990401"/>
 		<info name="alt_title" value="愛蔵版 封神演義"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37937,8 +37937,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Akagawa Jirou Majo-tachi no Nemuri - Fukkatsu Matsuri (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01863" />
-		<info name="release" value="19990415" />
+		<info name="serial" value="SLPS-01863"/>
+		<info name="release" value="19990415"/>
 		<info name="alt_title" value="赤川次郎 魔女たちの眠り ―復活祭―"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37958,8 +37958,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Akagawa Jirou - Yasoukyoku 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-03213" />
-		<info name="release" value="20010614" />
+		<info name="serial" value="SLPS-03213"/>
+		<info name="release" value="20010614"/>
 		<info name="alt_title" value="赤川次郎 夜想曲2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37979,8 +37979,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pop de Cute na Shinri Test - Alabama (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPS-02961" />
-		<info name="release" value="20000921" />
+		<info name="serial" value="SLPS-02961"/>
+		<info name="release" value="20000921"/>
 		<info name="alt_title" value="ポップでキュートな心理テスト アラバマ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38001,8 +38001,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Albalea no Otome - Uruwashi no Seishikitachi (Japan)</description>
 		<year>1998</year>
 		<publisher>Masaya</publisher>
-		<info name="serial" value="SLPS-01578" />
-		<info name="release" value="19981008" />
+		<info name="serial" value="SLPS-01578"/>
+		<info name="release" value="19981008"/>
 		<info name="alt_title" value="アルバレアの乙女 麗しの聖騎士たち"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38022,8 +38022,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Alice in Cyberland (Japan)</description>
 		<year>1996</year>
 		<publisher>Glams</publisher>
-		<info name="serial" value="SLPS-00636" />
-		<info name="release" value="19961220" />
+		<info name="serial" value="SLPS-00636"/>
+		<info name="release" value="19961220"/>
 		<info name="alt_title" value="ありす イン サイバーランド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38049,8 +38049,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Alive (Japan)</description>
 		<year>1998</year>
 		<publisher>General Entertainment</publisher>
-		<info name="serial" value="SLPS-01527~SLPS-01529" />
-		<info name="release" value="19980806" />
+		<info name="serial" value="SLPS-01527~SLPS-01529"/>
+		<info name="release" value="19980806"/>
 		<info name="alt_title" value="アライブ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38080,8 +38080,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gensou no Altemis - Actress School Mystery Adventure (Japan)</description>
 		<year>2000</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-02563" />
-		<info name="release" value="20000127" />
+		<info name="serial" value="SLPS-02563"/>
+		<info name="release" value="20000127"/>
 		<info name="alt_title" value="幻想のアルテミス〜Actress School Mystery Adventure〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38101,8 +38101,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Alundra 2 - Mashinka no Nazo (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10115" />
-		<info name="release" value="19991118" />
+		<info name="serial" value="SCPS-10115"/>
+		<info name="release" value="19991118"/>
 		<info name="alt_title" value="アランドラ2 魔進化の謎"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38124,8 +38124,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Another Memories (Japan)</description>
 		<year>1998</year>
 		<publisher>Hearty Robin</publisher>
-		<info name="serial" value="SLPS-01431" />
-		<info name="release" value="19980618" />
+		<info name="serial" value="SLPS-01431"/>
+		<info name="release" value="19980618"/>
 		<info name="alt_title" value="アナザー メモリーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38145,8 +38145,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>A Nanjarin (Japan)</description>
 		<year>1998</year>
 		<publisher>To One</publisher>
-		<info name="serial" value="SLPS-01424" />
-		<info name="release" value="19980611" />
+		<info name="serial" value="SLPS-01424"/>
+		<info name="release" value="19980611"/>
 		<info name="alt_title" value="あっナンジャリン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38169,8 +38169,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ancient Roman - Power of the Dark Side (Japan)</description>
 		<year>1998</year>
 		<publisher>Nihon Systems</publisher>
-		<info name="serial" value="SLPS-01108~SLPS-01109" />
-		<info name="release" value="19980423" />
+		<info name="serial" value="SLPS-01108~SLPS-01109"/>
+		<info name="release" value="19980423"/>
 		<info name="alt_title" value="アンシャントロマン パワー・オブ・ダークサイド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38195,8 +38195,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angelique Duet (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01337" />
-		<info name="release" value="19980730" />
+		<info name="serial" value="SLPS-01337"/>
+		<info name="release" value="19980730"/>
 		<info name="alt_title" value="アンジェリーク デュエット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38218,8 +38218,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angel Blade (Japan)</description>
 		<year>1997</year>
 		<publisher>On DiMand</publisher>
-		<info name="serial" value="SLPS-00894" />
-		<info name="release" value="19970703" />
+		<info name="serial" value="SLPS-00894"/>
+		<info name="release" value="19970703"/>
 		<info name="alt_title" value="エンジェル・ブレード Neo Tokyo Guardians ~ Angel Blade - Neo Tokyo Guardians (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38240,8 +38240,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angel Graffiti - Anata e no Profile (Japan)</description>
 		<year>1996</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-00163" />
-		<info name="release" value="19960726" />
+		<info name="serial" value="SLPS-00163"/>
+		<info name="release" value="19960726"/>
 		<info name="alt_title" value="エンジェルグラフィティ あなたへのプロフィール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38261,8 +38261,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angolmois '99 (Japan, SuperLite 1500 Series)</description>
 		<year>1999</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86278" />
-		<info name="release" value="19990826" />
+		<info name="serial" value="SLPM-86278"/>
+		<info name="release" value="19990826"/>
 		<info name="alt_title" value="SuperLite 1500 シリーズ アンゴルモア99"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38284,8 +38284,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angelique Special (Japan)</description>
 		<year>1996</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00320" />
-		<info name="release" value="19960329" />
+		<info name="serial" value="SLPS-00320"/>
+		<info name="release" value="19960329"/>
 		<info name="alt_title" value="アンジェリークスペシャル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38305,8 +38305,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angelique Special 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00805" />
-		<info name="release" value="19970411" />
+		<info name="serial" value="SLPS-00805"/>
+		<info name="release" value="19970411"/>
 		<info name="alt_title" value="アンジェリークスペシャル2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38326,8 +38326,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angelique Tenkuu no Requiem (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86165" />
-		<info name="release" value="19990204" />
+		<info name="serial" value="SLPM-86165"/>
+		<info name="release" value="19990204"/>
 		<info name="alt_title" value="アンジェリーク 天空の鎮魂歌"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38350,8 +38350,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ayakashi Ninden Kunoichiban (Japan)</description>
 		<year>1997</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-00946~SLPS-00947" />
-		<info name="release" value="19970925" />
+		<info name="serial" value="SLPS-00946~SLPS-00947"/>
+		<info name="release" value="19970925"/>
 		<info name="alt_title" value="あやかし忍伝 くの一番"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38376,8 +38376,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kids Station - Soreike! Anpanman 2 - Anpanman to Daibouken! (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03197" />
-		<info name="release" value="20010726" />
+		<info name="serial" value="SLPS-03197"/>
+		<info name="release" value="20010726"/>
 		<info name="alt_title" value="キッズステーション それいけ！アンパンマン2 アンパンマンとだいぼうけん！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38400,8 +38400,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ao no Roku-gou - Antarctica (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02940~SLPS-02941" />
-		<info name="release" value="20000928" />
+		<info name="serial" value="SLPS-02940~SLPS-02941"/>
+		<info name="release" value="20000928"/>
 		<info name="alt_title" value="青の6号 アンタクティカ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38426,8 +38426,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ao Zora to Nakama Tachi - Yume No Bouken (Japan)</description>
 		<year>2003</year>
 		<publisher>MTO</publisher>
-		<info name="serial" value="SLPS-03564" />
-		<info name="release" value="20031113" />
+		<info name="serial" value="SLPS-03564"/>
+		<info name="release" value="20031113"/>
 		<info name="alt_title" value="アオ・ゾーラと仲間たち 夢の冒険プラス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38447,8 +38447,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Saru! Get You! (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10091" />
-		<info name="release" value="19990604" />
+		<info name="serial" value="SCPS-10091"/>
+		<info name="release" value="19990604"/>
 		<info name="alt_title" value="サルゲッチュ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38469,8 +38469,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aquanaut no Kyuujitsu 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-02141" />
-		<info name="release" value="19990701" />
+		<info name="serial" value="SLPS-02141"/>
+		<info name="release" value="19990701"/>
 		<info name="alt_title" value="アクアノートの休日2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38490,8 +38490,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aqua Paradise - Boku no Suizokukan (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-03095" />
-		<info name="release" value="20001228" />
+		<info name="serial" value="SLPS-03095"/>
+		<info name="release" value="20001228"/>
 		<info name="alt_title" value="アクアパラダイス ぼくの水族館"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38513,8 +38513,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aquarian Age - Tokyo Wars (Japan)</description>
 		<year>2000</year>
 		<publisher>ESP Software</publisher>
-		<info name="serial" value="SLPS-02731" />
-		<info name="release" value="20000525" />
+		<info name="serial" value="SLPS-02731"/>
+		<info name="release" value="20000525"/>
 		<info name="alt_title" value="アクエリアン・エイジ　～東京・ウォーズ～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38542,8 +38542,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>A5 - A Ressha de Ikou 5 (Japan, Playstation the Best)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-91124 (Playstation the Best)" />
-		<info name="release" value="19990325" />
+		<info name="serial" value="SLPS-91124 (Playstation the Best)"/>
+		<info name="release" value="19990325"/>
 		<info name="alt_title" value="A5 A列車で行こう5"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38569,8 +38569,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>A Ressha de Ikou Z - Mezase! Tairiku Oudan (Japan)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-02050" />
-		<info name="release" value="19990504" />
+		<info name="serial" value="SLPS-02050"/>
+		<info name="release" value="19990504"/>
 		<info name="alt_title" value="A列車で行こうZ 目指せ！大陸横断"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38592,8 +38592,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arkana Senki Ludo (Japan)</description>
 		<year>1998</year>
 		<publisher>Pai</publisher>
-		<info name="serial" value="SLPS-01438" />
-		<info name="release" value="19980709" />
+		<info name="serial" value="SLPS-01438"/>
+		<info name="release" value="19980709"/>
 		<info name="alt_title" value="アルカナ戦記ルド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38613,8 +38613,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arkanoid R 2000 (Japan)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86262 (TCPS10006)" />
-		<info name="release" value="19990701" />
+		<info name="serial" value="SLPM-86262 (TCPS10006)"/>
+		<info name="release" value="19990701"/>
 		<info name="alt_title" value="アルカノイドリターンズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38634,8 +38634,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Armed Fighter (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-01598" />
-		<info name="release" value="19990304" />
+		<info name="serial" value="SLPS-01598"/>
+		<info name="release" value="19990304"/>
 		<info name="alt_title" value="アームド・ファイター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38655,8 +38655,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Agent Armstrong - Himitsu Shirei Daisakusen (Japan)</description>
 		<year>1997</year>
 		<publisher>WENet</publisher>
-		<info name="serial" value="SLPS-01073 (WG 0005)" />
-		<info name="release" value="19971204" />
+		<info name="serial" value="SLPS-01073 (WG 0005)"/>
+		<info name="release" value="19971204"/>
 		<info name="alt_title" value="エージェントアームストロング 秘密司令大作戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38676,8 +38676,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Art Camion - Geijutsuden (Japan, re-release 2002)</description>
 		<year>2002</year>
 		<publisher>TYO</publisher>
-		<info name="serial" value="SLPM-87186" />
-		<info name="release" value="20021202" />
+		<info name="serial" value="SLPM-87186"/>
+		<info name="release" value="20021202"/>
 		<info name="alt_title" value="アートカミオン 芸術伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38697,8 +38697,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Art Camion - Geijutsuden (Japan)</description>
 		<year>1999</year>
 		<publisher>TYO</publisher>
-		<info name="serial" value="SLPS-02405" />
-		<info name="release" value="19991216" />
+		<info name="serial" value="SLPS-02405"/>
+		<info name="release" value="19991216"/>
 		<info name="alt_title" value="アートカミオン 芸術伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38721,8 +38721,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Astronoka (Japan)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86088~SLPM-86089" />
-		<info name="release" value="19980827" />
+		<info name="serial" value="SLPM-86088~SLPM-86089"/>
+		<info name="release" value="19980827"/>
 		<info name="alt_title" value="アストロノーカ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38748,8 +38748,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Asuka 120% Burning Fest. Excellent (Japan)</description>
 		<year>1997</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-00849" />
-		<info name="release" value="19970509" />
+		<info name="serial" value="SLPS-00849"/>
+		<info name="release" value="19970509"/>
 		<info name="alt_title" value="あすか120%エクセレント BURNING Fest. EXCELLENT"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38770,8 +38770,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Asuka 120% Burning Fest. Final (Japan)</description>
 		<year>1999</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-02074" />
-		<info name="release" value="19990527" />
+		<info name="serial" value="SLPS-02074"/>
+		<info name="release" value="19990527"/>
 		<info name="alt_title" value="あすか120%ファイナル BURNING Fest."/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38815,8 +38815,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Asuka 120% Burning Fest. Special (Japan)</description>
 		<year>1996</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-00231" />
-		<info name="release" value="19960329" />
+		<info name="serial" value="SLPS-00231"/>
+		<info name="release" value="19960329"/>
 		<info name="alt_title" value="あすか120％ スペシャル BURNING Fest."/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38868,8 +38868,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Asuncia - Matsue no Jubaku (Japan, XING Maru-yasu Series)</description>
 		<year>2000</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-03075" />
-		<info name="release" value="20001207" />
+		<info name="serial" value="SLPS-03075"/>
+		<info name="release" value="20001207"/>
 		<info name="alt_title" value="アサンシア ～魔杖の呪縛～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38897,8 +38897,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Athena - Awakening from the Ordinary Life (Japan, Koei the Best)</description>
 		<year>1999</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86185~SLPM-86187" />
-		<info name="release" value="19990311" />
+		<info name="serial" value="SLPM-86185~SLPM-86187"/>
+		<info name="release" value="19990311"/>
 		<info name="alt_title" value="アテナ ~Awakening from the ordinary life~"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38948,8 +38948,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Advanced V.G. (Japan)</description>
 		<year>1996</year>
 		<publisher>TGL</publisher>
-		<info name="serial" value="SLPS-00208" />
-		<info name="release" value="19960419" />
+		<info name="serial" value="SLPS-00208"/>
+		<info name="release" value="19960419"/>
 		<info name="alt_title" value="アドヴァンスト ヴァリアブル・ジオ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38973,8 +38973,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Advanced V.G. 2 (Japan, SuperLite 1500 Series)</description>
 		<year>2003</year>
 		<publisher>TGL</publisher>
-		<info name="serial" value="SLPM-87226" />
-		<info name="release" value="20030227" />
+		<info name="serial" value="SLPM-87226"/>
+		<info name="release" value="20030227"/>
 		<info name="alt_title" value="SuperLite1500シリーズ アドヴァンスト ヴァリアブル・ジオ2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39001,8 +39001,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Azito (Japan)</description>
 		<year>1997</year>
 		<publisher>Astec21</publisher>
-		<info name="serial" value="SLPS-00683" />
-		<info name="release" value="19970228" />
+		<info name="serial" value="SLPS-00683"/>
+		<info name="release" value="19970228"/>
 		<info name="alt_title" value="アジト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39023,8 +39023,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Azito 3 (Japan)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-02496" />
-		<info name="release" value="20000217" />
+		<info name="serial" value="SLPS-02496"/>
+		<info name="release" value="20000217"/>
 		<info name="alt_title" value="アジト3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39044,8 +39044,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Azumanga Donjara Daiou (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03424" />
-		<info name="release" value="20020418" />
+		<info name="serial" value="SLPS-03424"/>
+		<info name="release" value="20020418"/>
 		<info name="alt_title" value="あずまんがドンジャラ大王"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39071,8 +39071,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>BackGuiner - Yomigaeru Yuusha-tachi - Hishou-hen 'Uragiri no Senjou' (Japan)</description>
 		<year>1998</year>
 		<publisher>Ving</publisher>
-		<info name="serial" value="SLPS-01446~SLPS-01448" />
-		<info name="release" value="19980625" />
+		<info name="serial" value="SLPS-01446~SLPS-01448"/>
+		<info name="release" value="19980625"/>
 		<info name="alt_title" value="バックガイナー よみがえる勇者たち 飛翔編「うらぎりの戦場」"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -39102,8 +39102,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bakuretsu Hunter - Mahjong Special (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00541" />
-		<info name="release" value="19961025" />
+		<info name="serial" value="SLPS-00541"/>
+		<info name="release" value="19961025"/>
 		<info name="alt_title" value="爆れつハンター まあじゃんすぺしゃる"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39123,8 +39123,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Uchuu Goushou-den - Bakuretsu Akindo (Japan)</description>
 		<year>1996</year>
 		<publisher>Astec21</publisher>
-		<info name="serial" value="SLPS-00236" />
-		<info name="release" value="19960322" />
+		<info name="serial" value="SLPS-00236"/>
+		<info name="release" value="19960322"/>
 		<info name="alt_title" value="爆裂商人 宇宙豪商伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39145,8 +39145,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bakumatsu Roman - Gekka no Kenshi (Japan)</description>
 		<year>1999</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86118" />
-		<info name="release" value="19990225" />
+		<info name="serial" value="SLPM-86118"/>
+		<info name="release" value="19990225"/>
 		<info name="alt_title" value="幕末浪漫 月華の剣士"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39166,8 +39166,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bakuryu (Japan)</description>
 		<year>2000</year>
 		<publisher>Fujimic</publisher>
-		<info name="serial" value="SLPS-02429" />
-		<info name="release" value="20000914" />
+		<info name="serial" value="SLPS-02429"/>
+		<info name="release" value="20000914"/>
 		<info name="alt_title" value="爆流"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39187,8 +39187,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Barbapapa (Japan)</description>
 		<year>2001</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03301" />
-		<info name="release" value="20011004" />
+		<info name="serial" value="SLPS-03301"/>
+		<info name="release" value="20011004"/>
 		<info name="alt_title" value="バーバパパ (キッズステーションコントローラセット) [Kid Station Controller Set Package]"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39208,8 +39208,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bardysh (Japan)</description>
 		<year>1999</year>
 		<publisher>Imadio</publisher>
-		<info name="serial" value="SLPS-02187" />
-		<info name="release" value="19990722" />
+		<info name="serial" value="SLPS-02187"/>
+		<info name="release" value="19990722"/>
 		<info name="alt_title" value="バルディッシュ 〜クロムフォードの住人たち〜 ~ Bardysh - Kromeford no Juunin-tachi (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39229,8 +39229,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Baroque Syndrome (Japan)</description>
 		<year>2000</year>
 		<publisher>Sting</publisher>
-		<info name="serial" value="SLPM-86540" />
-		<info name="release" value="20000727" />
+		<info name="serial" value="SLPM-86540"/>
+		<info name="release" value="20000727"/>
 		<info name="alt_title" value="バロック▲シンドローム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39250,8 +39250,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Baroque - Yuganda Mousou (Japan)</description>
 		<year>1999</year>
 		<publisher>Sting</publisher>
-		<info name="serial" value="SLPM-86341" />
-		<info name="release" value="19991028" />
+		<info name="serial" value="SLPM-86341"/>
+		<info name="release" value="19991028"/>
 		<info name="alt_title" value="バロック 歪んだ妄想"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39271,8 +39271,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fishing Freaks - BassRise (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01931" />
-		<info name="release" value="19990325" />
+		<info name="serial" value="SLPS-01931"/>
+		<info name="release" value="19990325"/>
 		<info name="alt_title" value="フィッシングフリーク バスライズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39294,8 +39294,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Battle Master (Japan, Major Wave Series)</description>
 		<year>2000</year>
 		<publisher>Hamster</publisher>
-		<info name="serial" value="SLPM-86519" />
-		<info name="release" value="20000427" />
+		<info name="serial" value="SLPM-86519"/>
+		<info name="release" value="20000427"/>
 		<info name="alt_title" value="バトルマスター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39315,8 +39315,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Battle "Sugoroku" - The Hunter - A.R.0062 (Japan, SuperLite 1500 Series)</description>
 		<year>1999</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86400" />
-		<info name="release" value="19991222" />
+		<info name="serial" value="SLPM-86400"/>
+		<info name="release" value="19991222"/>
 		<info name="alt_title" value="SuperLite 1500シリーズ バトルすごろく ハンター A.R.0062"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39336,8 +39336,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bealphareth (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10138" />
-		<info name="release" value="20000928" />
+		<info name="serial" value="SCPS-10138"/>
+		<info name="release" value="20000928"/>
 		<info name="alt_title" value="ベアルファレス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39357,8 +39357,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beat Planet Music (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-18013" />
-		<info name="release" value="20000120" />
+		<info name="serial" value="SCPS-18013"/>
+		<info name="release" value="20000120"/>
 		<info name="alt_title" value="ビートプラネットミュージック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39378,8 +39378,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>MTV's Beavis and Butt-Head in Virtual Stupidity (Japan)</description>
 		<year>1998</year>
 		<publisher>B-Factory</publisher>
-		<info name="serial" value="SLPS-01219" />
-		<info name="release" value="19980129" />
+		<info name="serial" value="SLPS-01219"/>
+		<info name="release" value="19980129"/>
 		<info name="alt_title" value="ビーバス&amp;バットヘッド ヴァーチャル・アホ症候群 ~ MTV's Beavis and Butt-Head - Virtual Aho Shoukougun (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39400,8 +39400,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Susume! Kaizoku - Be Pirates! (Japan)</description>
 		<year>1998</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-01737" />
-		<info name="release" value="19981203" />
+		<info name="serial" value="SLPS-01737"/>
+		<info name="release" value="19981203"/>
 		<info name="alt_title" value="進め! 海賊"/>
 		<info name="usage" value="Requires 3 blocks to save on PocketStation"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -39437,8 +39437,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Soukou Kihei Votoms Gaiden - Ao no Kishi Berserga Monogatari (Japan)</description>
 		<year>1997</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-00982" />
-		<info name="release" value="19971030" />
+		<info name="serial" value="SLPS-00982"/>
+		<info name="release" value="19971030"/>
 		<info name="alt_title" value="装甲騎兵ボトムズ外伝 青の騎士 ベルゼルガ物語"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39458,8 +39458,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bass Fisherman - Texas (Japan)</description>
 		<year>1998</year>
 		<publisher>Sammy</publisher>
-		<info name="serial" value="SLPS-01304" />
-		<info name="release" value="19980611" />
+		<info name="serial" value="SLPS-01304"/>
+		<info name="release" value="19980611"/>
 		<info name="alt_title" value="バスフィッシャーマン TEXAS"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39480,8 +39480,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bishi Bashi Special (Japan, Konami the Best)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86825 (VX096-J2)" />
-		<info name="release" value="20010927" />
+		<info name="serial" value="SLPM-86825 (VX096-J2)"/>
+		<info name="release" value="20010927"/>
 		<info name="alt_title" value="ビシバシスペシャル (コナミ ザ・ベスト)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39501,8 +39501,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bishi Bashi Special 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86267 (VX149-J1)" />
-		<info name="release" value="19990902" />
+		<info name="serial" value="SLPM-86267 (VX149-J1)"/>
+		<info name="release" value="19990902"/>
 		<info name="alt_title" value="ビシバシスペシャル2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39522,8 +39522,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bishi Bashi Special 3 - Step Champ (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86539 (VX182-J1)" />
-		<info name="release" value="20000629" />
+		<info name="serial" value="SLPM-86539 (VX182-J1)"/>
+		<info name="release" value="20000629"/>
 		<info name="alt_title" value="ビシバシスペシャル3 〜ステップチャンプ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39543,8 +39543,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Break Volley (Japan)</description>
 		<year>1999</year>
 		<publisher>Aqua Rouge</publisher>
-		<info name="serial" value="SLPS-02375" />
-		<info name="release" value="19991102" />
+		<info name="serial" value="SLPS-02375"/>
+		<info name="release" value="19991102"/>
 		<info name="alt_title" value="ブレイクバレー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39564,8 +39564,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Black Jack vs. Matsuda Jun (Japan)</description>
 		<year>2000</year>
 		<publisher>Pony Canyon</publisher>
-		<info name="serial" value="SLPS-01983" />
-		<info name="release" value="20000810" />
+		<info name="serial" value="SLPS-01983"/>
+		<info name="release" value="20000810"/>
 		<info name="alt_title" value="ブラックジャック VS 松田純"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39588,8 +39588,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Black Matrix Zero OO (Japan, Shokai Genteiban)</description>
 		<year>2004</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-03571~SLPS-03572" />
-		<info name="release" value="20040513" />
+		<info name="serial" value="SLPS-03571~SLPS-03572"/>
+		<info name="release" value="20040513"/>
 		<info name="alt_title" value="ブラックマトリクス ゼロ ダブルオー 初回限定版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -39617,8 +39617,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Black Matrix Cross (Japan)</description>
 		<year>2000</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-02962~SLPS-02963 (NIPS-4011)" />
-		<info name="release" value="20001214" />
+		<info name="serial" value="SLPS-02962~SLPS-02963 (NIPS-4011)"/>
+		<info name="release" value="20001214"/>
 		<info name="alt_title" value="ブラックマトリクスクロス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -39643,8 +39643,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blade Arts - Tasogare no Miyako R'lyeh (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86602" />
-		<info name="release" value="20000928" />
+		<info name="serial" value="SLPM-86602"/>
+		<info name="release" value="20000928"/>
 		<info name="alt_title" value="ブレイドアーツ 黄昏の都ルルイエ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39664,8 +39664,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>BladeMaker (Japan)</description>
 		<year>1999</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-01795" />
-		<info name="release" value="19990701" />
+		<info name="serial" value="SLPS-01795"/>
+		<info name="release" value="19990701"/>
 		<info name="alt_title" value="ブレードメーカー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39685,8 +39685,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blam! -MachineHead (Japan)</description>
 		<year>1997</year>
 		<publisher>Virgin Interactive</publisher>
-		<info name="serial" value="SLPS-00798" />
-		<info name="release" value="19970523" />
+		<info name="serial" value="SLPS-00798"/>
+		<info name="release" value="19970523"/>
 		<info name="alt_title" value="ブラム！マシーンヘッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39707,8 +39707,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blend x Brand - Odekake Gousei RPG (Japan)</description>
 		<year>2000</year>
 		<publisher>Tonkin House</publisher>
-		<info name="serial" value="SLPS-02818" />
-		<info name="release" value="20000629" />
+		<info name="serial" value="SLPS-02818"/>
+		<info name="release" value="20000629"/>
 		<info name="alt_title" value="ブレンド×ブランド おでかけ合成RPG"/>
 		<info name="usage" value="Requires 15 free blocks on memory card to start (PocketStation)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -39729,8 +39729,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Block Kuzushi - Kowashite Help! (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Gallop</publisher>
-		<info name="serial" value="SLPS-03042" />
-		<info name="release" value="20001207" />
+		<info name="serial" value="SLPS-03042"/>
+		<info name="release" value="20001207"/>
 		<info name="alt_title" value="ブロックくずし こわしてHELP!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39750,8 +39750,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Block Kuzushi 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Marvelous Entertaiment</publisher>
-		<info name="serial" value="SLPS-02578" />
-		<info name="release" value="20000203" />
+		<info name="serial" value="SLPS-02578"/>
+		<info name="release" value="20000203"/>
 		<info name="alt_title" value="ブロックくずし2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39771,8 +39771,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blood Factory (Japan)</description>
 		<year>1996</year>
 		<publisher>Interplay</publisher>
-		<info name="serial" value="SLPS-00235" />
-		<info name="release" value="19960315" />
+		<info name="serial" value="SLPS-00235"/>
+		<info name="release" value="19960315"/>
 		<info name="alt_title" value="ブラッドファクトリー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39792,8 +39792,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>b.l.u.e. - Legend of Water (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01459" />
-		<info name="release" value="19980709" />
+		<info name="serial" value="SLPS-01459"/>
+		<info name="release" value="19980709"/>
 		<info name="alt_title" value="ブルー Legend of water"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39813,8 +39813,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blue Breaker Burst - Egao no Asuni (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01580" />
-		<info name="release" value="19980910" />
+		<info name="serial" value="SLPS-01580"/>
+		<info name="release" value="19980910"/>
 		<info name="alt_title" value="ブルーブレイカーバースト 笑顔の明日に"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39834,8 +39834,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Blue Marlin (Japan)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
-		<info name="serial" value="SLPS-02752" />
-		<info name="release" value="20000502" />
+		<info name="serial" value="SLPS-02752"/>
+		<info name="release" value="20000502"/>
 		<info name="alt_title" value="ザ・ブルーマーリン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39856,8 +39856,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - Append 3rd Mix Mini (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86156 (KICA7921)" />
-		<info name="release" value="19981127" />
+		<info name="serial" value="SLPM-86156 (KICA7921)"/>
+		<info name="release" value="19981127"/>
 		<info name="alt_title" value="ビートマニア サードミックスミニ"/>
 		<info name="usage" value="Data disc, use the disc change feature from a core Beatmania"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -39878,8 +39878,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - Append 5th Mix - Time to Get Down (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86322 (VX179-J1)" />
-		<info name="release" value="20000302" />
+		<info name="serial" value="SLPM-86322 (VX179-J1)"/>
+		<info name="release" value="20000302"/>
 		<info name="alt_title" value="ビートマニア アペンド フィフスミックス Time to get down"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39899,8 +39899,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania Append 6th Mix + Core Remix (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87012 (VX255-J1)" />
-		<info name="release" value="20020131" />
+		<info name="serial" value="SLPM-87012 (VX255-J1)"/>
+		<info name="release" value="20020131"/>
 		<info name="alt_title" value="ビートマニア シックスミックス＋コアリミックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39920,8 +39920,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - Best Hits (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86596 (VX195-J1)" />
-		<info name="release" value="20000727" />
+		<info name="serial" value="SLPM-86596 (VX195-J1)"/>
+		<info name="release" value="20000727"/>
 		<info name="alt_title" value="ビートマニア ベストヒッツ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39941,8 +39941,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - Append Club Mix (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86692 (VX225-J1)" />
-		<info name="release" value="20001221" />
+		<info name="serial" value="SLPM-86692 (VX225-J1)"/>
+		<info name="release" value="20001221"/>
 		<info name="alt_title" value="ビートマニア アペンド クラブミックス"/>
 		<info name="usage" value="Data disc, use the disc change feature from a core Beatmania"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -39963,8 +39963,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - featuring Dreams Come True (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86597 (VX198-J1)" />
-		<info name="release" value="20000727" />
+		<info name="serial" value="SLPM-86597 (VX198-J1)"/>
+		<info name="release" value="20000727"/>
 		<info name="alt_title" value="ビートマニア フィーチャリング ドリームズ・カム・トゥルー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39984,8 +39984,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania Append Gottamix 2 - Going Global (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86574 (VX197-J1)" />
-		<info name="release" value="20000907" />
+		<info name="serial" value="SLPM-86574 (VX197-J1)"/>
+		<info name="release" value="20000907"/>
 		<info name="alt_title" value="ビートマニア アペンド ゴッタミックス2～Going Global～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40005,8 +40005,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - The Sound of Tokyo! - Produced by Konishi Yasuharu (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86769 (VX238-J1)" />
-		<info name="release" value="20010329" />
+		<info name="serial" value="SLPM-86769 (VX238-J1)"/>
+		<info name="release" value="20010329"/>
 		<info name="alt_title" value="ビートマニア：ザ サウンド オブ トーキョー 小西康陽プロデュース"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40026,8 +40026,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blaze &amp; Blade - Busters (Japan)</description>
 		<year>1998</year>
 		<publisher>T&amp;E Soft</publisher>
-		<info name="serial" value="SLPS-01576" />
-		<info name="release" value="19980923" />
+		<info name="serial" value="SLPS-01576"/>
+		<info name="release" value="19980923"/>
 		<info name="alt_title" value="ブレイズ アンド ブレイド バスターズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40047,8 +40047,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blaze &amp; Blade - Eternal Quest (Japan)</description>
 		<year>1998</year>
 		<publisher>T&amp;E Soft</publisher>
-		<info name="serial" value="SLPS-01209" />
-		<info name="release" value="19980129" />
+		<info name="serial" value="SLPS-01209"/>
+		<info name="release" value="19980129"/>
 		<info name="alt_title" value="ブレイズ アンド ブレイド エターナルクエスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40069,8 +40069,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Breath of Fire III (Japan)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00990" />
-		<info name="release" value="19970911" />
+		<info name="serial" value="SLPS-00990"/>
+		<info name="release" value="19970911"/>
 		<info name="alt_title" value="ブレス オブ ファイアIII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40090,8 +40090,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Boku no Choro-Q (Japan)</description>
 		<year>2002</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPM-87024" />
-		<info name="release" value="20020307" />
+		<info name="serial" value="SLPM-87024"/>
+		<info name="release" value="20020307"/>
 		<info name="alt_title" value="ぼくのチョロQ こうつうルールをまもろう"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40111,8 +40111,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Boku wa Koukuu Kanseikan (Japan)</description>
 		<year>1999</year>
 		<publisher>Syscom</publisher>
-		<info name="serial" value="SLPS-02514" />
-		<info name="release" value="19991222" />
+		<info name="serial" value="SLPS-02514"/>
+		<info name="release" value="19991222"/>
 		<info name="alt_title" value="ぼくは航空管制官"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40132,8 +40132,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bonogurashi (Japan)</description>
 		<year>1996</year>
 		<publisher>Amuse</publisher>
-		<info name="serial" value="SLPS-00333" />
-		<info name="release" value="19960607" />
+		<info name="serial" value="SLPS-00333"/>
+		<info name="release" value="19960607"/>
 		<info name="alt_title" value="ぼのぐらし これで完璧でぃす ~ Bonogurashi - Kore de Kanpeki Disu (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40153,8 +40153,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Boundary Gate - Daughter of Kingdom (Japan)</description>
 		<year>1997</year>
 		<publisher>Pack-In-Soft</publisher>
-		<info name="serial" value="SLPS-00907" />
-		<info name="release" value="19970717" />
+		<info name="serial" value="SLPS-00907"/>
+		<info name="release" value="19970717"/>
 		<info name="alt_title" value="バウンダリーゲート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40174,8 +40174,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Brave Prove (Japan)</description>
 		<year>1998</year>
 		<publisher>Data West</publisher>
-		<info name="serial" value="SLPS-01316" />
-		<info name="release" value="19980416" />
+		<info name="serial" value="SLPS-01316"/>
+		<info name="release" value="19980416"/>
 		<info name="alt_title" value="ブレイヴ・プローヴ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40195,8 +40195,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shin Sedai Robot Senki - Brave Saga (Japan)</description>
 		<year>1998</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01756" />
-		<info name="release" value="19981217" />
+		<info name="serial" value="SLPS-01756"/>
+		<info name="release" value="19981217"/>
 		<info name="alt_title" value="新世代ロボット戦記 ブレイブサーガ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40219,8 +40219,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Brave Saga 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02580~SLPS-02581" />
-		<info name="release" value="20000502" />
+		<info name="serial" value="SLPS-02580~SLPS-02581"/>
+		<info name="release" value="20000502"/>
 		<info name="alt_title" value="ブレイブサーガ2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -40245,8 +40245,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Brave Sword (Japan)</description>
 		<year>2000</year>
 		<publisher>Sammy</publisher>
-		<info name="serial" value="SLPS-02889" />
-		<info name="release" value="20001019" />
+		<info name="serial" value="SLPS-02889"/>
+		<info name="release" value="20001019"/>
 		<info name="alt_title" value="ブレイブ・ソード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40266,8 +40266,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Burning Road (Japan)</description>
 		<year>1997</year>
 		<publisher>Vic Tokai</publisher>
-		<info name="serial" value="SLPS-00518" />
-		<info name="release" value="19970131" />
+		<info name="serial" value="SLPS-00518"/>
+		<info name="release" value="19970131"/>
 		<info name="alt_title" value="バーニング・ロード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40287,8 +40287,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Buckle Up! (Japan)</description>
 		<year>1998</year>
 		<publisher>Shangri-La</publisher>
-		<info name="serial" value="SLPS-01105" />
-		<info name="release" value="19980129" />
+		<info name="serial" value="SLPS-01105"/>
+		<info name="release" value="19980129"/>
 		<info name="alt_title" value="バックルアップ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40308,8 +40308,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bugi (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86133 (VX084-J1)" />
-		<info name="release" value="19981119" />
+		<info name="serial" value="SLPM-86133 (VX084-J1)"/>
+		<info name="release" value="19981119"/>
 		<info name="alt_title" value="武戯"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40329,8 +40329,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Burn Out (Japan, SuperLite 1500 Series)</description>
 		<year>2000</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86598" />
-		<info name="release" value="20000824" />
+		<info name="serial" value="SLPM-86598"/>
+		<info name="release" value="20000824"/>
 		<info name="alt_title" value="SuperLite1500シリーズ バーンアウト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40350,8 +40350,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Buttsubushi (Japan)</description>
 		<year>2001</year>
 		<publisher>Selen</publisher>
-		<info name="serial" value="SLPS-03162 (SLSA-0001)" />
-		<info name="release" value="20010315" />
+		<info name="serial" value="SLPS-03162 (SLSA-0001)"/>
+		<info name="release" value="20010315"/>
 		<info name="alt_title" value="ぶっつぶし"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40371,8 +40371,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>C1 Circuit (Japan)</description>
 		<year>1996</year>
 		<publisher>Invex</publisher>
-		<info name="serial" value="SLPS-00279" />
-		<info name="release" value="19961004" />
+		<info name="serial" value="SLPS-00279"/>
+		<info name="release" value="19961004"/>
 		<info name="alt_title" value="C1 サーキット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40392,8 +40392,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Calcolo! - Ochimo no Shooting (Japan)</description>
 		<year>1997</year>
 		<publisher>Clef Inventor</publisher>
-		<info name="serial" value="SLPS-01071" />
-		<info name="release" value="19971106" />
+		<info name="serial" value="SLPS-01071"/>
+		<info name="release" value="19971106"/>
 		<info name="alt_title" value="カルコロ おちものシューティング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40413,8 +40413,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Captain Commando (Japan)</description>
 		<year>1998</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01567" />
-		<info name="release" value="19980917" />
+		<info name="serial" value="SLPS-01567"/>
+		<info name="release" value="19980917"/>
 		<info name="alt_title" value="キャプテンコマンドー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40436,8 +40436,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Carnage Heart EZ - Easy Zapping (Japan)</description>
 		<year>1997</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-00919" />
-		<info name="release" value="19970724" />
+		<info name="serial" value="SLPS-00919"/>
+		<info name="release" value="19970724"/>
 		<info name="alt_title" value="カルネージハートEZ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40457,8 +40457,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Carom Shot 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Argent</publisher>
-		<info name="serial" value="SLPS-01486" />
-		<info name="release" value="19980730" />
+		<info name="serial" value="SLPS-01486"/>
+		<info name="release" value="19980730"/>
 		<info name="alt_title" value="キャロムショット2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40478,8 +40478,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Carton-kun (Japan)</description>
 		<year>2000</year>
 		<publisher>Irem</publisher>
-		<info name="serial" value="SLPS-02935" />
-		<info name="release" value="20000921" />
+		<info name="serial" value="SLPS-02935"/>
+		<info name="release" value="20000921"/>
 		<info name="alt_title" value="カートンくん"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40499,8 +40499,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Crazy Climber 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Nihon Bussan</publisher>
-		<info name="serial" value="SLPS-02582" />
-		<info name="release" value="20000203" />
+		<info name="serial" value="SLPS-02582"/>
+		<info name="release" value="20000203"/>
 		<info name="alt_title" value="クレイジー・クライマー2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40520,8 +40520,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arcade Hits - Crazy Climber (Japan, Major Wave Series)</description>
 		<year>2002</year>
 		<publisher>Hamster</publisher>
-		<info name="serial" value="SLPM-87067" />
-		<info name="release" value="20020523" />
+		<info name="serial" value="SLPM-87067"/>
+		<info name="release" value="20020523"/>
 		<info name="alt_title" value="アーケード・ヒッツ　～クレイジー・クライマー～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40541,8 +40541,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chaos Control (Japan)</description>
 		<year>1996</year>
 		<publisher>Virgin Interactive</publisher>
-		<info name="serial" value="SLPS-00168" />
-		<info name="release" value="19961004" />
+		<info name="serial" value="SLPS-00168"/>
+		<info name="release" value="19961004"/>
 		<info name="alt_title" value="カオス コントロール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40563,8 +40563,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chou Aniki - Kyuukyoku Muteki Ginga Saikyou Otoko (Japan)</description>
 		<year>1995</year>
 		<publisher>NCS</publisher>
-		<info name="serial" value="SLPS-00183" />
-		<info name="release" value="19951229" />
+		<info name="serial" value="SLPS-00183"/>
+		<info name="release" value="19951229"/>
 		<info name="alt_title" value="超兄貴 〜究極無敵銀河最強男〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40584,8 +40584,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chocolate Kiss (Japan)</description>
 		<year>2002</year>
 		<publisher>DigiCube</publisher>
-		<info name="serial" value="SLPS-03400" />
-		<info name="release" value="20020214" />
+		<info name="serial" value="SLPS-03400"/>
+		<info name="release" value="20020214"/>
 		<info name="alt_title" value="チョコレート♪キッス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40605,8 +40605,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Choro-Q (Japan)</description>
 		<year>1996</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-00242" />
-		<info name="release" value="19960322" />
+		<info name="serial" value="SLPS-00242"/>
+		<info name="release" value="19960322"/>
 		<info name="alt_title" value="チョロQ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40626,8 +40626,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Choro-Q Wonderful! (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02205" />
-		<info name="release" value="19990805" />
+		<info name="serial" value="SLPS-02205"/>
+		<info name="release" value="19990805"/>
 		<info name="alt_title" value="チョロQワンダフォー!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40647,8 +40647,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kuroi Hitomi no Noir - Cielgris Fantasm (Japan)</description>
 		<year>1999</year>
 		<publisher>Gust</publisher>
-		<info name="serial" value="SLPS-01450" />
-		<info name="release" value="19990701" />
+		<info name="serial" value="SLPS-01450"/>
+		<info name="release" value="19990701"/>
 		<info name="alt_title" value="黒い瞳のノア Cielgris Fantasm / Noir Yeux Noire (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40668,8 +40668,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Circuit Beat (Japan)</description>
 		<year>1996</year>
 		<publisher>Prism Arts</publisher>
-		<info name="serial" value="SLPS-00311" />
-		<info name="release" value="19960517" />
+		<info name="serial" value="SLPS-00311"/>
+		<info name="release" value="19960517"/>
 		<info name="alt_title" value="サーキットビード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40689,8 +40689,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chiisana Kyojin Microman (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01926" />
-		<info name="release" value="19990311" />
+		<info name="serial" value="SLPS-01926"/>
+		<info name="release" value="19990311"/>
 		<info name="alt_title" value="小さな巨人ミクロマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40710,8 +40710,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cleopatra's Fortune (Japan)</description>
 		<year>2001</year>
 		<publisher>Altron</publisher>
-		<info name="serial" value="SLPS-03187" />
-		<info name="release" value="20010517" />
+		<info name="serial" value="SLPS-03187"/>
+		<info name="release" value="20010517"/>
 		<info name="alt_title" value="クレオパトラ フォーチュン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40731,8 +40731,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Clock Tower - Ghost Head (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01290" />
-		<info name="release" value="19980312" />
+		<info name="serial" value="SLPS-01290"/>
+		<info name="release" value="19980312"/>
 		<info name="alt_title" value="クロックタワー ゴーストヘッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40752,8 +40752,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Click Manga - Dynamic Robot Taisen 1 (Japan)</description>
 		<year>1999</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-02131" />
-		<info name="release" value="19990930" />
+		<info name="serial" value="SLPS-02131"/>
+		<info name="release" value="19990930"/>
 		<info name="alt_title" value="クリックまんが ダイナミックロボット大戦1 出撃！驚異のロボット軍団！！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40773,8 +40773,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Click Manga - Dynamic Robot Taisen 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-02407" />
-		<info name="release" value="19991216" />
+		<info name="serial" value="SLPS-02407"/>
+		<info name="release" value="19991216"/>
 		<info name="alt_title" value="クリックまんが ダイナミックロボット大戦2 恐怖！悪魔族復活"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40794,8 +40794,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Click Manga - Click Nohi (Japan)</description>
 		<year>1999</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-02354" />
-		<info name="release" value="19991028" />
+		<info name="serial" value="SLPS-02354"/>
+		<info name="release" value="19991028"/>
 		<info name="alt_title" value="クリックまんが クリックのひ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40815,8 +40815,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Colorful Logic 3 - Fushigi na Henkei Logic (Japan)</description>
 		<year>2001</year>
 		<publisher>Altron</publisher>
-		<info name="serial" value="SLPS-03239" />
-		<info name="release" value="20010712" />
+		<info name="serial" value="SLPS-03239"/>
+		<info name="release" value="20010712"/>
 		<info name="alt_title" value="カラフルロジック3 不思議な変形ロジック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40836,8 +40836,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Community Pom (Japan)</description>
 		<year>1997</year>
 		<publisher>Fill-In Café</publisher>
-		<info name="serial" value="SLPS-00817" />
-		<info name="release" value="19971030" />
+		<info name="serial" value="SLPS-00817"/>
+		<info name="release" value="19971030"/>
 		<info name="alt_title" value="こみゅにてぃぽむ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40858,8 +40858,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Community Pom - Omoide o Dakishimete (Japan)</description>
 		<year>1999</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-02116" />
-		<info name="release" value="19990624" />
+		<info name="serial" value="SLPS-02116"/>
+		<info name="release" value="19990624"/>
 		<info name="alt_title" value="こみゅにてぃ ぽむ 想い出を抱きしめて"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40880,8 +40880,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Conveni Special - 3-tsu no Sekai o Dokusen Seyo (Japan)</description>
 		<year>1998</year>
 		<publisher>Ardink</publisher>
-		<info name="serial" value="SLPS-01301" />
-		<info name="release" value="19980312" />
+		<info name="serial" value="SLPS-01301"/>
+		<info name="release" value="19980312"/>
 		<info name="alt_title" value="ザ・コンビニ スペシャル ～3つの世界を独占せよ～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40901,8 +40901,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Honoo no Ryourinin - Cooking Fighter Tao (Japan)</description>
 		<year>1998</year>
 		<publisher>Nippon Ichi Software</publisher>
-		<info name="serial" value="SLPS-01382" />
-		<info name="release" value="19980521" />
+		<info name="serial" value="SLPS-01382"/>
+		<info name="release" value="19980521"/>
 		<info name="alt_title" value="炎の料理人 クッキングファイター 好"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40922,8 +40922,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cosmic Race (Japan)</description>
 		<year>1995</year>
 		<publisher>Neorex</publisher>
-		<info name="serial" value="SLPS-00009" />
-		<info name="release" value="19950120" />
+		<info name="serial" value="SLPS-00009"/>
+		<info name="release" value="19950120"/>
 		<info name="alt_title" value="コズミックレース"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40943,8 +40943,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cosmowarrior Zero (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86484 (TCPS10022)" />
-		<info name="release" value="20000518" />
+		<info name="serial" value="SLPM-86484 (TCPS10022)"/>
+		<info name="release" value="20000518"/>
 		<info name="alt_title" value="コスモウォーリアー零"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40965,8 +40965,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Märchen Adventure Cotton 100% (Japan, SuperLite 1500 Series)</description>
 		<year>2003</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-87211" />
-		<info name="release" value="20030327" />
+		<info name="serial" value="SLPM-87211"/>
+		<info name="release" value="20030327"/>
 		<info name="alt_title" value="SuperLite1500シリーズ メルヘンアドベンチャー コットン100％"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40986,8 +40986,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Crime Crackers 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10037" />
-		<info name="release" value="19971127" />
+		<info name="serial" value="SCPS-10037"/>
+		<info name="release" value="19971127"/>
 		<info name="alt_title" value="クライムクラッカーズ2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41007,8 +41007,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Croc Adventure (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86310" />
-		<info name="release" value="19990902" />
+		<info name="serial" value="SLPM-86310"/>
+		<info name="release" value="19990902"/>
 		<info name="alt_title" value="クロックアドベンチャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41029,8 +41029,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cross Tantei Monogatari 1 - Kouhen (Japan, Major Wave Series)</description>
 		<year>2000</year>
 		<publisher>WorkJam</publisher>
-		<info name="serial" value="SLPM-86639" />
-		<info name="release" value="20000928" />
+		<info name="serial" value="SLPM-86639"/>
+		<info name="release" value="20000928"/>
 		<info name="alt_title" value="クロス探偵物語1 〜後編〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41059,8 +41059,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>CRW - Counter Revolution War (Japan)</description>
 		<year>1996</year>
 		<publisher>Acclaim</publisher>
-		<info name="serial" value="SLPS-00220" />
-		<info name="release" value="19960830" />
+		<info name="serial" value="SLPS-00220"/>
+		<info name="release" value="19960830"/>
 		<info name="alt_title" value="CRW カウンター・レボリューション・ウォー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41080,8 +41080,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Captain Tsubasa - Aratanaru Densetsu Joshou (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87060 (VX260-J1)" />
-		<info name="release" value="20020516" />
+		<info name="serial" value="SLPM-87060 (VX260-J1)"/>
+		<info name="release" value="20020516"/>
 		<info name="alt_title" value="キャプテン翼 〜新たな伝説・序章〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41101,8 +41101,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Captain Tsubasa J - Get in the Tomorrow (Japan)</description>
 		<year>1996</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00310" />
-		<info name="release" value="19960503" />
+		<info name="serial" value="SLPS-00310"/>
+		<info name="release" value="19960503"/>
 		<info name="alt_title" value="キャプテン翼J ゲットインザトゥモロゥ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41122,8 +41122,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cu-On-Pa (Japan)</description>
 		<year>1997</year>
 		<publisher>T&amp;E Soft</publisher>
-		<info name="serial" value="SLPS-01026" />
-		<info name="release" value="19971009" />
+		<info name="serial" value="SLPS-01026"/>
+		<info name="release" value="19971009"/>
 		<info name="alt_title" value="クオンパ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41144,8 +41144,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Success</publisher>
 		<!-- unsure whether this is the same as the original SLPS-01864 release (19990204) or not -->
-		<info name="serial" value="SLPM-86580" />
-		<info name="release" value="20000928" />
+		<info name="serial" value="SLPM-86580"/>
+		<info name="release" value="20000928"/>
 		<info name="alt_title" value="SuperLite1500シリーズ サイバー大戦略 出撃！はるか隊"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41168,8 +41168,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cybernetic Empire (Japan)</description>
 		<year>1999</year>
 		<publisher>Telenet</publisher>
-		<info name="serial" value="SLPS-01912~SLPS-01913" />
-		<info name="release" value="19990805" />
+		<info name="serial" value="SLPS-01912~SLPS-01913"/>
+		<info name="release" value="19990805"/>
 		<info name="alt_title" value="サイバネティック・エンパイア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -41200,8 +41200,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cyber War (Japan)</description>
 		<year>1995</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-00055~SLPS-00057" />
-		<info name="release" value="19950721" />
+		<info name="serial" value="SLPS-00055~SLPS-00057"/>
+		<info name="release" value="19950721"/>
 		<info name="alt_title" value="サイバーウォー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -41231,8 +41231,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Daibouken Deluxe - Harukanaru Umi (Japan)</description>
 		<year>1997</year>
 		<publisher>Soft Office</publisher>
-		<info name="serial" value="SLPS-00813" />
-		<info name="release" value="19970428" />
+		<info name="serial" value="SLPS-00813"/>
+		<info name="release" value="19970428"/>
 		<info name="alt_title" value="大冒険デラックス 遥かなる海"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41252,8 +41252,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Daikoukai Jidai Gaiden (Japan)</description>
 		<year>1997</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01021" />
-		<info name="release" value="19971002" />
+		<info name="serial" value="SLPS-01021"/>
+		<info name="release" value="19971002"/>
 		<info name="alt_title" value="大航海時代外伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41273,8 +41273,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Daikoukai Jidai II (Japan)</description>
 		<year>1996</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00656" />
-		<info name="release" value="19961227" />
+		<info name="serial" value="SLPS-00656"/>
+		<info name="release" value="19961227"/>
 		<info name="alt_title" value="大航海時代II"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41294,8 +41294,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dakar '97 (Japan)</description>
 		<year>1997</year>
 		<publisher>Virgin Interactive</publisher>
-		<info name="serial" value="SLPS-00634" />
-		<info name="release" value="19970425" />
+		<info name="serial" value="SLPS-00634"/>
+		<info name="release" value="19970425"/>
 		<info name="alt_title" value="ダカール '97"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41321,8 +41321,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dancing Blade - Katteni Momotenshi! (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86100~SLPM-86102 (VX124-J1)" />
-		<info name="release" value="19980827" />
+		<info name="serial" value="SLPM-86100~SLPM-86102 (VX124-J1)"/>
+		<info name="release" value="19980827"/>
 		<info name="alt_title" value="ダンシングブレード かってに桃天使!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -41358,8 +41358,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dancing Blade - Katteni Momotenshi II - Tears of Eden (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86210~SLPM-86212 (VX129-J1)" />
-		<info name="release" value="19990318" />
+		<info name="serial" value="SLPM-86210~SLPM-86212 (VX129-J1)"/>
+		<info name="release" value="19990318"/>
 		<info name="alt_title" value="ダンシングブレード かってに桃天使II ～Tears of Eden～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -41390,7 +41390,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>KSS</publisher>
 		<info name="serial" value="SLPS-02609"/>
-		<info name="release" value="20000224" />
+		<info name="release" value="20000224"/>
 		<info name="alt_title" value="DANGAN〜弾丸〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41410,8 +41410,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Darkseed II (Japan)</description>
 		<year>1997</year>
 		<publisher>B-Factory</publisher>
-		<info name="serial" value="SLPS-00938" />
-		<info name="release" value="19970918" />
+		<info name="serial" value="SLPS-00938"/>
+		<info name="release" value="19970918"/>
 		<info name="alt_title" value="ダークシードII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41431,8 +41431,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dark Tales from the Lost Soul (Japan)</description>
 		<year>1999</year>
 		<publisher>Sammy</publisher>
-		<info name="serial" value="SLPS-02316" />
-		<info name="release" value="19991028" />
+		<info name="serial" value="SLPS-02316"/>
+		<info name="release" value="19991028"/>
 		<info name="alt_title" value="ダークテイルズ From The Lost Soul"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41452,8 +41452,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dynamite Boxing (Japan)</description>
 		<year>1998</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01387" />
-		<info name="release" value="19980521" />
+		<info name="serial" value="SLPS-01387"/>
+		<info name="release" value="19980521"/>
 		<info name="alt_title" value="ダイナマイト ボクシング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41474,8 +41474,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Ball Z - Idainaru Dragon Ball Densetsu (Japan)</description>
 		<year>1995</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00073" />
-		<info name="release" value="19950728" />
+		<info name="serial" value="SLPS-00073"/>
+		<info name="release" value="19950728"/>
 		<info name="alt_title" value="ドラゴンボールZ 偉大なるドラゴンボール伝説"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41495,8 +41495,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Destruction Derby 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SIPS-60012" />
-		<info name="release" value="19970221" />
+		<info name="serial" value="SIPS-60012"/>
+		<info name="release" value="19970221"/>
 		<info name="alt_title" value="デストラクション・ダービー2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41516,8 +41516,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dance Dance Revolution - 2nd Remix Append Club Version Vol. 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86399 (VX175-J1)" />
-		<info name="release" value="19991222" />
+		<info name="serial" value="SLPM-86399 (VX175-J1)"/>
+		<info name="release" value="19991222"/>
 		<info name="alt_title" value="ダンス ダンス レボリューション セカンドリミックス アペンド クラブバージョンvol.2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41538,8 +41538,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dance Dance Revolution - 5th Mix (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86897 (VX246-J1)" />
-		<info name="release" value="20010920" />
+		<info name="serial" value="SLPM-86897 (VX246-J1)"/>
+		<info name="release" value="20010920"/>
 		<info name="alt_title" value="ダンス ダンス レボリューション フィフスミックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41559,8 +41559,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dance Dance Revolution - Best Hits (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86693 (VX224-J1)" />
-		<info name="release" value="20001221" />
+		<info name="serial" value="SLPM-86693 (VX224-J1)"/>
+		<info name="release" value="20001221"/>
 		<info name="alt_title" value="ダンスダンスレボリューション ベストヒッツ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41580,8 +41580,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dance Dance Revolution - Extra Mix (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86831 (VX244-J1)" />
-		<info name="release" value="20010607" />
+		<info name="serial" value="SLPM-86831 (VX244-J1)"/>
+		<info name="release" value="20010607"/>
 		<info name="alt_title" value="ダンス ダンス レボリューション エクストラ ミックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41601,8 +41601,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Deadly Skies (Japan)</description>
 		<year>1997</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-01036" />
-		<info name="release" value="19971023" />
+		<info name="serial" value="SLPS-01036"/>
+		<info name="release" value="19971023"/>
 		<info name="alt_title" value="デッドリースカイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41622,8 +41622,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Death Wing (Japan)</description>
 		<year>1996</year>
 		<publisher>Cybertech Designs</publisher>
-		<info name="serial" value="SLPS-00489" />
-		<info name="release" value="19961025" />
+		<info name="serial" value="SLPS-00489"/>
+		<info name="release" value="19961025"/>
 		<info name="alt_title" value="デス・ウイング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41643,8 +41643,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Defeat Lightning (Japan)</description>
 		<year>1997</year>
 		<publisher>D Cruise</publisher>
-		<info name="serial" value="SLPS-00853" />
-		<info name="release" value="19970523" />
+		<info name="serial" value="SLPS-00853"/>
+		<info name="release" value="19970523"/>
 		<info name="alt_title" value="ディフィート・ライトニング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41664,8 +41664,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Densha Daisuki - Plarail ga Ippai (Japan)</description>
 		<year>1998</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-01753" />
-		<info name="release" value="19981223" />
+		<info name="serial" value="SLPS-01753"/>
+		<info name="release" value="19981223"/>
 		<info name="alt_title" value="電車だいすき プラレールがいっぱい (専用コントローラカバー付)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41685,8 +41685,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Densha de Go! Nagoya Railroad (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86424 (TCPS10015)" />
-		<info name="release" value="20000127" />
+		<info name="serial" value="SLPM-86424 (TCPS10015)"/>
+		<info name="release" value="20000127"/>
 		<info name="alt_title" value="電車でGO! 名古屋鉄道編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41707,8 +41707,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gear Fighter Dendoh (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03189" />
-		<info name="release" value="20010426" />
+		<info name="serial" value="SLPS-03189"/>
+		<info name="release" value="20010426"/>
 		<info name="alt_title" value="GEAR戦士 電童"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41728,8 +41728,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Denpa Shounenteki Game (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01287" />
-		<info name="release" value="19980402" />
+		<info name="serial" value="SLPS-01287"/>
+		<info name="release" value="19980402"/>
 		<info name="alt_title" value="電波少年的ゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41749,8 +41749,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Derby Jockey 2001 (Japan)</description>
 		<year>2001</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-03131" />
-		<info name="release" value="20010118" />
+		<info name="serial" value="SLPS-03131"/>
+		<info name="release" value="20010118"/>
 		<info name="alt_title" value="ダービージョッキー2001"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41770,8 +41770,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Descent (Japan)</description>
 		<year>1996</year>
 		<publisher>Interplay</publisher>
-		<info name="serial" value="SLPS-00212" />
-		<info name="release" value="19960126" />
+		<info name="serial" value="SLPS-00212"/>
+		<info name="release" value="19960126"/>
 		<info name="alt_title" value="ディセント"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41791,8 +41791,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Devicereign (Japan)</description>
 		<year>1999</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-01889" />
-		<info name="release" value="19990225" />
+		<info name="serial" value="SLPS-01889"/>
+		<info name="release" value="19990225"/>
 		<info name="alt_title" value="デバイスレイン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41815,8 +41815,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dezaemon Kids! (Japan)</description>
 		<year>1998</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-01503~SLPS-01504" />
-		<info name="release" value="19981022" />
+		<info name="serial" value="SLPS-01503~SLPS-01504"/>
+		<info name="release" value="19981022"/>
 		<info name="alt_title" value="デザエモンキッズ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -41842,8 +41842,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dezaemon Plus (Japan)</description>
 		<year>1996</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-00335" />
-		<info name="release" value="19960524" />
+		<info name="serial" value="SLPS-00335"/>
+		<info name="release" value="19960524"/>
 		<info name="alt_title" value="デザエモンプラス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41863,8 +41863,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dark Hunter - Ge Youma No Mori (Japan)</description>
 		<year>1997</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00789" />
-		<info name="release" value="19970530" />
+		<info name="serial" value="SLPS-00789"/>
+		<info name="release" value="19970530"/>
 		<info name="alt_title" value="ダークハンター (下) 妖魔の森"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41885,9 +41885,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Digical League (Japan)</description>
 		<year>1997</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques" />
-		<info name="serial" value="SLPM-86038" />
-		<info name="release" value="19970620" />
+		<info name="developer" value="Aques"/>
+		<info name="serial" value="SLPM-86038"/>
+		<info name="release" value="19970620"/>
 		<info name="alt_title" value="デジカルリーグ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41907,8 +41907,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kids Station - Digimon Park (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03248" />
-		<info name="release" value="20010726" />
+		<info name="serial" value="SLPS-03248"/>
+		<info name="release" value="20010726"/>
 		<info name="alt_title" value="キッズステーション デジモンパーク キッズステーションコントローラセット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41928,8 +41928,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Digimon Tamers - Battle Evolution (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03357" />
-		<info name="release" value="20011206" />
+		<info name="serial" value="SLPS-03357"/>
+		<info name="release" value="20011206"/>
 		<info name="alt_title" value="デジモンテイマーズ バトルエボリューション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41949,8 +41949,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Digimon World (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01797" />
-		<info name="release" value="19990128" />
+		<info name="serial" value="SLPS-01797"/>
+		<info name="release" value="19990128"/>
 		<info name="alt_title" value="デジモンワールド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41970,8 +41970,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Knight 4 (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00664" />
-		<info name="release" value="19970207" />
+		<info name="serial" value="SLPS-00664"/>
+		<info name="release" value="19970207"/>
 		<info name="alt_title" value="ドラゴンナイト4"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41991,8 +41991,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Knights Glorious (Japan)</description>
 		<year>1999</year>
 		<publisher>Pandora</publisher>
-		<info name="serial" value="SLPS-02391" />
-		<info name="release" value="19991118" />
+		<info name="serial" value="SLPS-02391"/>
+		<info name="release" value="19991118"/>
 		<info name="alt_title" value="PANDORA MAX SERIES Vol.1 ドラゴンナイツ・グロリアス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42012,8 +42012,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Docchi Mecha! (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10129" />
-		<info name="release" value="20000427" />
+		<info name="serial" value="SCPS-10129"/>
+		<info name="release" value="20000427"/>
 		<info name="alt_title" value="ドッチメチャ!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42033,8 +42033,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dodge de Ball! (Japan)</description>
 		<year>1998</year>
 		<publisher>Yumedia</publisher>
-		<info name="serial" value="SLPS-01362" />
-		<info name="release" value="19980514" />
+		<info name="serial" value="SLPS-01362"/>
+		<info name="release" value="19980514"/>
 		<info name="alt_title" value="ドッチ DE ボール！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42054,8 +42054,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Dog Master (Japan)</description>
 		<year>2003</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPM-87175" />
-		<info name="release" value="20030807" />
+		<info name="serial" value="SLPM-87175"/>
+		<info name="release" value="20030807"/>
 		<info name="alt_title" value="ザ・ドッグマスター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42075,8 +42075,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Doki Doki Shutter Chance - Koi no Puzzle o Kumitatete (Japan)</description>
 		<year>1997</year>
 		<publisher>Nippon Ichi Software</publisher>
-		<info name="serial" value="SLPS-01038" />
-		<info name="release" value="19971023" />
+		<info name="serial" value="SLPS-01038"/>
+		<info name="release" value="19971023"/>
 		<info name="alt_title" value="どきどきシャッターチャンス★ 〜恋のパズルを組み立てて〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42096,8 +42096,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dokomademo Aoku... (Japan, Limited Edition)</description>
 		<year>2002</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-03388" />
-		<info name="release" value="20020221" />
+		<info name="serial" value="SLPS-03388"/>
+		<info name="release" value="20020221"/>
 		<info name="alt_title" value="どこまでも青く…。 (初回限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42117,8 +42117,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Doukyuusei Mahjong (Japan)</description>
 		<year>1997</year>
 		<publisher>Yumedia</publisher>
-		<info name="serial" value="SLPS-00673" />
-		<info name="release" value="19970117" />
+		<info name="serial" value="SLPS-00673"/>
+		<info name="release" value="19970117"/>
 		<info name="alt_title" value="同級生麻雀"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42138,8 +42138,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Doukyuusei 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00691" />
-		<info name="release" value="19970807" />
+		<info name="serial" value="SLPS-00691"/>
+		<info name="release" value="19970807"/>
 		<info name="alt_title" value="同級生2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42159,8 +42159,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dolphin's Dream (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86122 (VX071-J1)" />
-		<info name="release" value="19980910" />
+		<info name="serial" value="SLPM-86122 (VX071-J1)"/>
+		<info name="release" value="19980910"/>
 		<info name="alt_title" value="ドルフィンズドリーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42180,8 +42180,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Domino-kun o Tomenaide. (Japan)</description>
 		<year>1998</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-01095" />
-		<info name="release" value="19980108" />
+		<info name="serial" value="SLPS-01095"/>
+		<info name="release" value="19980108"/>
 		<info name="alt_title" value="ドミノ君をとめないで。"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42201,8 +42201,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DonPachi (Japan)</description>
 		<year>1996</year>
 		<publisher>SPS</publisher>
-		<info name="serial" value="SLPS-00548 (PS-052)" />
-		<info name="release" value="19961018" />
+		<info name="serial" value="SLPS-00548 (PS-052)"/>
+		<info name="release" value="19961018"/>
 		<info name="alt_title" value="首領蜂"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42222,8 +42222,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Doraemon - Nobita to Fukkatsu no Hoshi (Japan)</description>
 		<year>1996</year>
 		<publisher>Epoch</publisher>
-		<info name="serial" value="SLPS-00233" />
-		<info name="release" value="19960216" />
+		<info name="serial" value="SLPS-00233"/>
+		<info name="release" value="19960216"/>
 		<info name="alt_title" value="ドラえもん のび太と復活の星"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42243,8 +42243,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Doraemon 2 - SOS! Otogi no Kuni (Japan)</description>
 		<year>1997</year>
 		<publisher>Epoch</publisher>
-		<info name="serial" value="SLPS-00628" />
-		<info name="release" value="19972021" />
+		<info name="serial" value="SLPS-00628"/>
+		<info name="release" value="19972021"/>
 		<info name="alt_title" value="ドラえもん2 SOS！おとぎの国"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42283,8 +42283,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Double Dragon (Japan)</description>
 		<year>1996</year>
 		<publisher>Technos Japan</publisher>
-		<info name="serial" value="SLPS-00191" />
-		<info name="release" value="19960426" />
+		<info name="serial" value="SLPS-00191"/>
+		<info name="release" value="19960426"/>
 		<info name="alt_title" value="ダブルドラゴン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42305,8 +42305,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Drive Tactics Break (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03470" />
-		<info name="release" value="20021003" />
+		<info name="serial" value="SLPS-03470"/>
+		<info name="release" value="20021003"/>
 		<info name="alt_title" value="ドラゴンドライブ タクティクスブレイク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42326,8 +42326,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Money (Japan)</description>
 		<year>1999</year>
 		<publisher>Micro Cabin</publisher>
-		<info name="serial" value="SLPS-02037" />
-		<info name="release" value="19990504" />
+		<info name="serial" value="SLPS-02037"/>
+		<info name="release" value="19990504"/>
 		<info name="alt_title" value="ドラゴンマネー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42347,8 +42347,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dr. Slump (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01934" />
-		<info name="release" value="19990318" />
+		<info name="serial" value="SLPS-01934"/>
+		<info name="release" value="19990318"/>
 		<info name="alt_title" value="ドクタースランプ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42368,8 +42368,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Drug Store - Matsumoto Kiyoshi de Okaimono! (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01516" />
-		<info name="release" value="19980806" />
+		<info name="serial" value="SLPS-01516"/>
+		<info name="release" value="19980806"/>
 		<info name="alt_title" value="ザ・ドラッグストア マツモトキヨシでお買いもの！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42389,8 +42389,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Druid - Yamie no Tsuisekisha (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01246" />
-		<info name="release" value="19980219" />
+		<info name="serial" value="SLPS-01246"/>
+		<info name="release" value="19980219"/>
 		<info name="alt_title" value="DRUID 闇への追跡者"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42410,8 +42410,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dancing Stage featuring Dreams Come True (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86505 (VX186-J1)" />
-		<info name="release" value="20000420" />
+		<info name="serial" value="SLPM-86505 (VX186-J1)"/>
+		<info name="release" value="20000420"/>
 		<info name="alt_title" value="ダンシングステージ フィーチャリング ドリームズ・カム・トゥルー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42443,8 +42443,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dancing Stage featuring TRUE KiSS DESTiNATiON (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86411 (VX174-J1)" />
-		<info name="release" value="19991209" />
+		<info name="serial" value="SLPM-86411 (VX174-J1)"/>
+		<info name="release" value="19991209"/>
 		<info name="alt_title" value="ダンシングステージ フィーチャリング トゥルー・キス・ディスティネーション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42464,8 +42464,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dynamite Soccer 2002 (Japan)</description>
 		<year>2002</year>
 		<publisher>A-Max</publisher>
-		<info name="serial" value="SLPS-03436" />
-		<info name="release" value="20020516" />
+		<info name="serial" value="SLPS-03436"/>
+		<info name="release" value="20020516"/>
 		<info name="alt_title" value="ダイナマイトサッカー2002"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42485,8 +42485,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dynamite Soccer 2004 Final (Japan)</description>
 		<year>2004</year>
 		<publisher>A-Max</publisher>
-		<info name="serial" value="SLPS-03575" />
-		<info name="release" value="20040415" />
+		<info name="serial" value="SLPS-03575"/>
+		<info name="release" value="20040415"/>
 		<info name="alt_title" value="ダイナマイトサッカー2004ファイナル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42506,8 +42506,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aura Battler Dunbine - Seisenshi Densetsu (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02390" />
-		<info name="release" value="20000304" />
+		<info name="serial" value="SLPS-02390"/>
+		<info name="release" value="20000304"/>
 		<info name="alt_title" value="聖戦士ダンバイン 聖戦士伝説 ~ Seisenshi Dunbine - Seisenshi Densetsu (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42530,8 +42530,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Valor (Japan)</description>
 		<year>1999</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-02190~SLPS-02191" />
-		<info name="release" value="19991202" />
+		<info name="serial" value="SLPS-02190~SLPS-02191"/>
+		<info name="release" value="19991202"/>
 		<info name="alt_title" value="ドラゴンヴァラー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -42556,8 +42556,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DX Jinsei Game IV - The Game of Life (Japan)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPM-86963" />
-		<info name="release" value="20011129" />
+		<info name="serial" value="SLPM-86963"/>
+		<info name="release" value="20011129"/>
 		<info name="alt_title" value="DX人生ゲームIV"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42577,8 +42577,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DX Jinsei Game V - The Game of Life (Japan)</description>
 		<year>2002</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPM-87187" />
-		<info name="release" value="20021205" />
+		<info name="serial" value="SLPM-87187"/>
+		<info name="release" value="20021205"/>
 		<info name="alt_title" value="DX人生ゲームV"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42598,8 +42598,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DX Monopoly (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02943" />
-		<info name="release" value="20001221" />
+		<info name="serial" value="SLPS-02943"/>
+		<info name="release" value="20001221"/>
 		<info name="alt_title" value="DXモノポリー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42619,8 +42619,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DX Okuman Chouja Game II - The Money Battle (Japan)</description>
 		<year>1998</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01586" />
-		<info name="release" value="19980923" />
+		<info name="serial" value="SLPS-01586"/>
+		<info name="release" value="19980923"/>
 		<info name="alt_title" value="DX億万長者ゲームII ザ・マネー・バトル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42640,8 +42640,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DX Shachou Game (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02105" />
-		<info name="release" value="19990708" />
+		<info name="serial" value="SLPS-02105"/>
+		<info name="release" value="19990708"/>
 		<info name="alt_title" value="DX社長ゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42661,8 +42661,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Eikan ha Kimini 4 (Japan)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-02173" />
-		<info name="release" value="19990805" />
+		<info name="serial" value="SLPS-02173"/>
+		<info name="release" value="19990805"/>
 		<info name="alt_title" value="栄冠は君に4"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42682,8 +42682,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Eisei Meijin (Japan)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPS-00090" />
-		<info name="release" value="19950908" />
+		<info name="serial" value="SLPS-00090"/>
+		<info name="release" value="19950908"/>
 		<info name="alt_title" value="永世名人"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42703,8 +42703,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>élan (Japan)</description>
 		<year>1999</year>
 		<publisher>Visco</publisher>
-		<info name="serial" value="SLPS-01925" />
-		<info name="release" value="19990401" />
+		<info name="serial" value="SLPS-01925"/>
+		<info name="release" value="19990401"/>
 		<info name="alt_title" value="エラン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42724,8 +42724,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>élan plus (Japan)</description>
 		<year>2000</year>
 		<publisher>Visco</publisher>
-		<info name="serial" value="SLPS-02759" />
-		<info name="release" value="20000511" />
+		<info name="serial" value="SLPS-02759"/>
+		<info name="release" value="20000511"/>
 		<info name="alt_title" value="エラン プラス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42745,8 +42745,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Elder Gate (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86494 (VX160-J1)" />
-		<info name="release" value="20000622" />
+		<info name="serial" value="SLPM-86494 (VX160-J1)"/>
+		<info name="release" value="20000622"/>
 		<info name="alt_title" value="エルダーゲート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42772,8 +42772,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Elf wo Karu Mono-tachi II (Japan)</description>
 		<year>1998</year>
 		<publisher>Altron</publisher>
-		<info name="serial" value="SLPS-01456~SLPS-01458" />
-		<info name="release" value="19980813" />
+		<info name="serial" value="SLPS-01456~SLPS-01458"/>
+		<info name="release" value="19980813"/>
 		<info name="alt_title" value="エルフを狩るモノたちII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -42803,8 +42803,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Emmyrea (Japan)</description>
 		<year>2001</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-03216" />
-		<info name="release" value="20010524" />
+		<info name="serial" value="SLPS-03216"/>
+		<info name="release" value="20010524"/>
 		<info name="alt_title" value="エミーリア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42824,8 +42824,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>End Sector (Japan)</description>
 		<year>1998</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-01584" />
-		<info name="release" value="19980923" />
+		<info name="serial" value="SLPS-01584"/>
+		<info name="release" value="19980923"/>
 		<info name="alt_title" value="エンドセクター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42845,8 +42845,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Engacho! (Japan)</description>
 		<year>1999</year>
 		<publisher>Nihon Application</publisher>
-		<info name="serial" value="SLPS-02263" />
-		<info name="release" value="19991118" />
+		<info name="serial" value="SLPS-02263"/>
+		<info name="release" value="19991118"/>
 		<info name="alt_title" value="えんがちょ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42869,8 +42869,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Enigma (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01351~SLPS-01352" />
-		<info name="release" value="19980402" />
+		<info name="serial" value="SLPS-01351~SLPS-01352"/>
+		<info name="release" value="19980402"/>
 		<info name="alt_title" value="エニグマ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -42895,8 +42895,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>EOS - Edge of Skyhigh (Japan)</description>
 		<year>1997</year>
 		<publisher>Micronet</publisher>
-		<info name="serial" value="SLPS-00820" />
-		<info name="release" value="19970703" />
+		<info name="serial" value="SLPS-00820"/>
+		<info name="release" value="19970703"/>
 		<info name="alt_title" value="―イオス― エッジ・オブ・スカイハイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42916,8 +42916,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Epica Stella (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01465" />
-		<info name="release" value="19980730" />
+		<info name="serial" value="SLPS-01465"/>
+		<info name="release" value="19980730"/>
 		<info name="alt_title" value="エピカ・ステラ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42937,8 +42937,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fuujin Ryouiki Eretzvaju (Japan)</description>
 		<year>1999</year>
 		<publisher>Yuke's</publisher>
-		<info name="serial" value="SLPS-01790" />
-		<info name="release" value="19990114" />
+		<info name="serial" value="SLPS-01790"/>
+		<info name="release" value="19990114"/>
 		<info name="alt_title" value="封神領域エルツヴァーユ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42958,8 +42958,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chiisana Oukoku Erutoria (Japan)</description>
 		<year>2000</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-02750" />
-		<info name="release" value="20000629" />
+		<info name="serial" value="SLPS-02750"/>
+		<info name="release" value="20000629"/>
 		<info name="alt_title" value="小さな王国エルトリア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42980,8 +42980,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Vision of Escaflowne (Japan, Limited Edition)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01014" />
-		<info name="release" value="19970925" />
+		<info name="serial" value="SLPS-01014"/>
+		<info name="release" value="19970925"/>
 		<info name="alt_title" value="天空のエスカフローネ限定版 Fortune BOX"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43001,8 +43001,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Weltorv Estleia (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01887" />
-		<info name="release" value="19990225" />
+		<info name="serial" value="SLPS-01887"/>
+		<info name="release" value="19990225"/>
 		<info name="alt_title" value="ウエルト オブ イストリア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43022,8 +43022,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yuukyuu no Eden - The Eternal Eden (Japan)</description>
 		<year>1999</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-01928" />
-		<info name="release" value="19990422" />
+		<info name="serial" value="SLPS-01928"/>
+		<info name="release" value="19990422"/>
 		<info name="alt_title" value="悠久のエデン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43049,8 +43049,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>EVE Zero (Japan)</description>
 		<year>2000</year>
 		<publisher>Game Village</publisher>
-		<info name="serial" value="SLPM-86478~SLPM-86480" />
-		<info name="release" value="20000330" />
+		<info name="serial" value="SLPM-86478~SLPM-86480"/>
+		<info name="release" value="20000330"/>
 		<info name="alt_title" value="イヴ ゼロ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -43080,8 +43080,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Evergreen Avenue (Japan)</description>
 		<year>2001</year>
 		<publisher>MediaWorks / Datam Polystar</publisher>
-		<info name="serial" value="SLPS-03278" />
-		<info name="release" value="20010913" />
+		<info name="serial" value="SLPS-03278"/>
+		<info name="release" value="20010913"/>
 		<info name="alt_title" value="エバーグリーン・アベニュー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43107,8 +43107,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>EVE - The Fatal Attraction (Japan)</description>
 		<year>2001</year>
 		<publisher>Game Village</publisher>
-		<info name="serial" value="SLPM-86826~SLPM-86828" />
-		<info name="release" value="20010927" />
+		<info name="serial" value="SLPM-86826~SLPM-86828"/>
+		<info name="release" value="20010927"/>
 		<info name="alt_title" value="イヴ・ザ・フェイタル・アトラクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -43138,8 +43138,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Exciting Bass (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86124 (VX099-J1)" />
-		<info name="release" value="19980923" />
+		<info name="serial" value="SLPM-86124 (VX099-J1)"/>
+		<info name="release" value="19980923"/>
 		<info name="alt_title" value="エキサイティングバス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43159,8 +43159,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Exciting Bass 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86295 (VX154-J1)" />
-		<info name="release" value="19990930" />
+		<info name="serial" value="SLPM-86295 (VX154-J1)"/>
+		<info name="release" value="19990930"/>
 		<info name="alt_title" value="エキサイティングバス2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43180,8 +43180,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Expert (Japan)</description>
 		<year>1996</year>
 		<publisher>Nihon Bussan</publisher>
-		<info name="serial" value="SLPS-00342" />
-		<info name="release" value="19960531" />
+		<info name="serial" value="SLPS-00342"/>
+		<info name="release" value="19960531"/>
 		<info name="alt_title" value="エキスパート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43201,8 +43201,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Family Diamond (Japan)</description>
 		<year>2002</year>
 		<publisher>Magnolia</publisher>
-		<info name="serial" value="SLPS-03348" />
-		<info name="release" value="20020124" />
+		<info name="serial" value="SLPS-03348"/>
+		<info name="release" value="20020124"/>
 		<info name="alt_title" value="ファミリーダイヤモンド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43222,8 +43222,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Family Restaurant - Shijou Saikyou no Menu (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01763" />
-		<info name="release" value="19981217" />
+		<info name="serial" value="SLPS-01763"/>
+		<info name="release" value="19981217"/>
 		<info name="alt_title" value="ザ・ファミレス〜史上最強のメニュー〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43243,8 +43243,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Farland Story - Yottsu no Fuuin (Japan)</description>
 		<year>1997</year>
 		<publisher>TGL</publisher>
-		<info name="serial" value="SLPS-00797" />
-		<info name="release" value="19971127" />
+		<info name="serial" value="SLPS-00797"/>
+		<info name="release" value="19971127"/>
 		<info name="alt_title" value="ファーランドストーリー〜四つの封印〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43264,8 +43264,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Farland Saga - Toki no Michishirube (Japan)</description>
 		<year>1999</year>
 		<publisher>TGL</publisher>
-		<info name="serial" value="SLPS-01903" />
-		<info name="release" value="19990428" />
+		<info name="serial" value="SLPS-01903"/>
+		<info name="release" value="19990428"/>
 		<info name="alt_title" value="ファーランドサーガ 時の道標"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43285,8 +43285,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Favorite Dear - Enkan no Monogatari (Japan)</description>
 		<year>2001</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-03286 (NIPS-4014)" />
-		<info name="release" value="20010927" />
+		<info name="serial" value="SLPS-03286 (NIPS-4014)"/>
+		<info name="release" value="20010927"/>
 		<info name="alt_title" value="フェィバリットディア −円環の物語−"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43306,8 +43306,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Favorite Dear - Junpaku no Yogenmono (Japan)</description>
 		<year>2000</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-02754 (NIPS-4008)" />
-		<info name="release" value="20001207" />
+		<info name="serial" value="SLPS-02754 (NIPS-4008)"/>
+		<info name="release" value="20001207"/>
 		<info name="alt_title" value="フェイバリットディア 純白の預言者 / Favorite Dear - The everlasting voices (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43327,8 +43327,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Formula Circus (Japan)</description>
 		<year>1997</year>
 		<publisher>Nichibutsu</publisher>
-		<info name="serial" value="SLPS-00358" />
-		<info name="release" value="19970502" />
+		<info name="serial" value="SLPS-00358"/>
+		<info name="release" value="19970502"/>
 		<info name="alt_title" value="フォーミュラ・サーカス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43348,8 +43348,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Feda 2 - White Surge - the Platoon (Japan)</description>
 		<year>1997</year>
 		<publisher>Yanoman Games</publisher>
-		<info name="serial" value="SLPS-00723" />
-		<info name="release" value="19970418" />
+		<info name="serial" value="SLPS-00723"/>
+		<info name="release" value="19970418"/>
 		<info name="alt_title" value="フェーダ2 ホワイト＝サージ ザ・プラトゥーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43369,8 +43369,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Final Fantasy (Japan)</description>
 		<year>2002</year>
 		<publisher>Squaresoft</publisher>
-		<info name="serial" value="SLPS-03430" />
-		<info name="release" value="20021031" />
+		<info name="serial" value="SLPS-03430"/>
+		<info name="release" value="20021031"/>
 		<info name="alt_title" value="ファイナルファンタジー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43390,8 +43390,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Final Fantasy II (Japan)</description>
 		<year>2002</year>
 		<publisher>Squaresoft</publisher>
-		<info name="serial" value="SLPS-03502" />
-		<info name="release" value="20021031" />
+		<info name="serial" value="SLPS-03502"/>
+		<info name="release" value="20021031"/>
 		<info name="alt_title" value="ファイナルファンタジーII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43411,8 +43411,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Formula Grand Prix 1997 - Team Unei Simulation 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-01154" />
-		<info name="release" value="19971225" />
+		<info name="serial" value="SLPS-01154"/>
+		<info name="release" value="19971225"/>
 		<info name="alt_title" value="フォーミュラグランプリ1997年版 チーム運営シミュレーション2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43432,8 +43432,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Forget me not - Palette (Japan)</description>
 		<year>2001</year>
 		<publisher>Enterbrain</publisher>
-		<info name="serial" value="SLPS-03191" />
-		<info name="release" value="20010426" />
+		<info name="serial" value="SLPS-03191"/>
+		<info name="release" value="20010426"/>
 		<info name="alt_title" value="フォーゲットミーノット －パレット－"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43453,8 +43453,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Final Doom (Japan)</description>
 		<year>1997</year>
 		<publisher>Soft Bank</publisher>
-		<info name="serial" value="SLPS-00727" />
-		<info name="release" value="19971002" />
+		<info name="serial" value="SLPS-00727"/>
+		<info name="release" value="19971002"/>
 		<info name="alt_title" value="ファイナルドゥーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43474,8 +43474,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Firemen 2 - Pete &amp; Danny (Japan)</description>
 		<year>1995</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-00148" />
-		<info name="release" value="19951222" />
+		<info name="serial" value="SLPS-00148"/>
+		<info name="release" value="19951222"/>
 		<info name="alt_title" value="ザ・ファイヤーメン2 ピート&amp;ダニー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43510,8 +43510,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fire Woman Matoigumi (Japan)</description>
 		<year>1998</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-01315" />
-		<info name="release" value="19980326" />
+		<info name="serial" value="SLPS-01315"/>
+		<info name="release" value="19980326"/>
 		<info name="alt_title" value="ファイアーウーマン纏組"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43531,8 +43531,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fish Eyes II (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-02383" />
-		<info name="release" value="20000127" />
+		<info name="serial" value="SLPS-02383"/>
+		<info name="release" value="20000127"/>
 		<info name="alt_title" value="フィッシュアイズII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43552,8 +43552,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fisher's Road (Japan)</description>
 		<year>1999</year>
 		<publisher>BPS</publisher>
-		<info name="serial" value="SLPS-01943" />
-		<info name="release" value="19990311" />
+		<info name="serial" value="SLPS-01943"/>
+		<info name="release" value="19990311"/>
 		<info name="alt_title" value="フィッシャーズロード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43573,8 +43573,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fist (Japan)</description>
 		<year>1996</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-00538" />
-		<info name="release" value="19961122" />
+		<info name="serial" value="SLPS-00538"/>
+		<info name="release" value="19961122"/>
 		<info name="alt_title" value="フィスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43594,8 +43594,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Formula Nippon '99 (Japan)</description>
 		<year>1999</year>
 		<publisher>TYO</publisher>
-		<info name="serial" value="SLPS-02259" />
-		<info name="release" value="19990909" />
+		<info name="serial" value="SLPS-02259"/>
+		<info name="release" value="19990909"/>
 		<info name="alt_title" value="フォーミュラ・ニッポン’99 レーシングドライバーになろう！ ~ Formula Nippon '99 - Racing Driver ni Narou! (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43615,8 +43615,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fox Junction (Japan)</description>
 		<year>1998</year>
 		<publisher>Trips</publisher>
-		<info name="serial" value="SLPS-01355" />
-		<info name="release" value="19980429" />
+		<info name="serial" value="SLPS-01355"/>
+		<info name="release" value="19980429"/>
 		<info name="alt_title" value="フォックスジャンクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43636,8 +43636,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>First Queen IV - Varcia Senki (Japan)</description>
 		<year>1996</year>
 		<publisher>KSK</publisher>
-		<info name="serial" value="SLPS-00604" />
-		<info name="release" value="19961206" />
+		<info name="serial" value="SLPS-00604"/>
+		<info name="release" value="19961206"/>
 		<info name="alt_title" value="ファーストクイーンIV ～バルシア戦記～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43658,8 +43658,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Media Entertainment</publisher>
 		<!-- unsure whether this is the same as the original SLPS-00985 release (19970925) or not -->
-		<info name="serial" value="SLPS-02655" />
-		<info name="release" value="20000323" />
+		<info name="serial" value="SLPS-02655"/>
+		<info name="release" value="20000323"/>
 		<info name="alt_title" value="Best of the Best フリートーク・スタジオ〜マリの気ままなおしゃべり〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43679,8 +43679,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arcade Hits - Frisky Tom (Japan, Major Wave Serie)</description>
 		<year>2002</year>
 		<publisher>Hamster</publisher>
-		<info name="serial" value="SLPM-87118" />
-		<info name="release" value="20020725" />
+		<info name="serial" value="SLPM-87118"/>
+		<info name="release" value="20020725"/>
 		<info name="alt_title" value="アーケード・ヒッツ　～フリスキー・トム～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43700,8 +43700,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Final Round (Japan)</description>
 		<year>1998</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-01266" />
-		<info name="release" value="19980312" />
+		<info name="serial" value="SLPS-01266"/>
+		<info name="release" value="19980312"/>
 		<info name="alt_title" value="ファイナルラウンド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43721,8 +43721,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fighters' Impact (Japan)</description>
 		<year>1997</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-00822" />
-		<info name="release" value="19970425" />
+		<info name="serial" value="SLPS-00822"/>
+		<info name="release" value="19970425"/>
 		<info name="alt_title" value="ファイターズ インパクト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43742,8 +43742,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fun! Fun! Pingu - *Youkoso! Nankyoku e* (Japan, Limited Edition)</description>
 		<year>1999</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-02306" />
-		<info name="release" value="19991118" />
+		<info name="serial" value="SLPS-02306"/>
+		<info name="release" value="19991118"/>
 		<info name="alt_title" value="ファン!ファン!ピングー *ようこそ!南極へ* (初回数量限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43763,8 +43763,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fushigi Keiji (Japan)</description>
 		<year>2000</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPM-86642" />
-		<info name="release" value="20001026" />
+		<info name="serial" value="SLPM-86642"/>
+		<info name="release" value="20001026"/>
 		<info name="alt_title" value="ふしぎ刑事 / Fushigi-Deka (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43784,8 +43784,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fuuraiki (Japan)</description>
 		<year>2001</year>
 		<publisher>FOG</publisher>
-		<info name="serial" value="SLPS-03094" />
-		<info name="release" value="20010118" />
+		<info name="serial" value="SLPS-03094"/>
+		<info name="release" value="20010118"/>
 		<info name="alt_title" value="風雨来記"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43833,8 +43833,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gaia Seed - Project Seed Trap (Japan)</description>
 		<year>1996</year>
 		<publisher>Techno Soleil</publisher>
-		<info name="serial" value="SLPS-00624" />
-		<info name="release" value="19961213" />
+		<info name="serial" value="SLPS-00624"/>
+		<info name="release" value="19961213"/>
 		<info name="alt_title" value="ガイアシード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43854,8 +43854,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gakkou de Atta Kowai Hanashi S (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00404" />
-		<info name="release" value="19960719" />
+		<info name="serial" value="SLPS-00404"/>
+		<info name="release" value="19960719"/>
 		<info name="alt_title" value="学校であった怖い話S"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43875,8 +43875,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gakkou no Kowai Uwasa - Hanako-san ga Kita!! (Japan)</description>
 		<year>1995</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00078" />
-		<info name="release" value="19950811" />
+		<info name="serial" value="SLPS-00078"/>
+		<info name="release" value="19950811"/>
 		<info name="alt_title" value="学校のコワイうわさ 花子さんがきた!!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43896,8 +43896,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gakkou wo Tsukurou!! 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01660" />
-		<info name="release" value="19981210" />
+		<info name="serial" value="SLPS-01660"/>
+		<info name="release" value="19981210"/>
 		<info name="alt_title" value="学校をつくろう!!2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43917,8 +43917,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gakkou wo Tsukurou!! Koushou Sensei Monogatari (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-02998" />
-		<info name="release" value="20001026" />
+		<info name="serial" value="SLPS-02998"/>
+		<info name="release" value="20001026"/>
 		<info name="alt_title" value="学校をつくろう!!校長先生物語"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43938,8 +43938,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hoshi no Oka Gakuen Monogatari - Gakuensai (Japan)</description>
 		<year>1998</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-01638" />
-		<info name="release" value="19981022" />
+		<info name="serial" value="SLPS-01638"/>
+		<info name="release" value="19981022"/>
 		<info name="alt_title" value="星の丘学園物語 学園祭"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43962,8 +43962,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Matsumoto Leiji - Story of Galaxy Express 999 (Japan)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-03220~SLPS-03221" />
-		<info name="release" value="20010628" />
+		<info name="serial" value="SLPS-03220~SLPS-03221"/>
+		<info name="release" value="20010628"/>
 		<info name="alt_title" value="松本零士999 〜Story of Galaxy Express999 〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -43989,8 +43989,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Galaxy Fight - Universal Warriors (Japan)</description>
 		<year>1996</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-00138" />
-		<info name="release" value="19960503" />
+		<info name="serial" value="SLPS-00138"/>
+		<info name="release" value="19960503"/>
 		<info name="alt_title" value="ギャラクシーファイト －ユニバーサル・ウォリアーズ－"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44010,8 +44010,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GALEOZ (Japan)</description>
 		<year>1996</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-00621" />
-		<info name="release" value="19961220" />
+		<info name="serial" value="SLPS-00621"/>
+		<info name="release" value="19961220"/>
 		<info name="alt_title" value="ΓΑΛΕΟΖ"/>
 		<info name="alt_title" value="ガレオス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -44032,8 +44032,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gambler Jikochuushinha Ippatsu Shoubu! (Japan)</description>
 		<year>2000</year>
 		<publisher>Game Arts</publisher>
-		<info name="serial" value="SLPS-02509" />
-		<info name="release" value="20000622" />
+		<info name="serial" value="SLPS-02509"/>
+		<info name="release" value="20000622"/>
 		<info name="alt_title" value="ぎゅわんぶらあ自己中心派"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44053,8 +44053,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Game Maker (Japan)</description>
 		<year>1998</year>
 		<publisher>Axela</publisher>
-		<info name="serial" value="SLPS-01583" />
-		<info name="release" value="19980923" />
+		<info name="serial" value="SLPS-01583"/>
+		<info name="release" value="19980923"/>
 		<info name="alt_title" value="ザ・ゲームメーカー 売れ売れ100万本げっとだぜ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44074,8 +44074,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gamera 2000 (Japan)</description>
 		<year>1997</year>
 		<publisher>Virgin Interactive</publisher>
-		<info name="serial" value="SLPS-00833" />
-		<info name="release" value="19970425" />
+		<info name="serial" value="SLPS-00833"/>
+		<info name="release" value="19970425"/>
 		<info name="alt_title" value="ガメラ2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44096,8 +44096,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GUNbare! Game Tengoku - The Game Paradise 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-01322" />
-		<info name="release" value="19980319" />
+		<info name="serial" value="SLPS-01322"/>
+		<info name="release" value="19980319"/>
 		<info name="alt_title" value="GUNばれ! ゲーム天国"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44117,8 +44117,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gamesoft wo Tsukurou - Let's Be a Super Game Creator (Japan)</description>
 		<year>1999</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-01607" />
-		<info name="release" value="19990128" />
+		<info name="serial" value="SLPS-01607"/>
+		<info name="release" value="19990128"/>
 		<info name="alt_title" value="ゲームソフトをつくろう"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44138,8 +44138,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gangway Monsters (Japan)</description>
 		<year>1998</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-01468" />
-		<info name="release" value="19981015" />
+		<info name="serial" value="SLPS-01468"/>
+		<info name="release" value="19981015"/>
 		<info name="alt_title" value="ギャングウェイ・モンスターズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44159,8 +44159,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yuusha-Ou GaoGaiGar - Blockaded Numbers (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01980" />
-		<info name="release" value="19990408" />
+		<info name="serial" value="SLPS-01980"/>
+		<info name="release" value="19990408"/>
 		<info name="alt_title" value="勇者王ガオガイガー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44180,8 +44180,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hyakujuu Sentai Gaoranger (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03353" />
-		<info name="release" value="20011129" />
+		<info name="serial" value="SLPS-03353"/>
+		<info name="release" value="20011129"/>
 		<info name="alt_title" value="百獣戦隊ガオレンジャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44201,8 +44201,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tactical Armor Custom Gasaraki (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02181" />
-		<info name="release" value="20000113" />
+		<info name="serial" value="SLPS-02181"/>
+		<info name="release" value="20000113"/>
 		<info name="alt_title" value="タクティカル アーマー カスタム ガサラキ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44225,8 +44225,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gate Keepers (Japan)</description>
 		<year>1999</year>
 		<publisher>Kadokawa Shoten</publisher>
-		<info name="serial" value="SLPS-02246~SLPS-02247" />
-		<info name="release" value="19991216" />
+		<info name="serial" value="SLPS-02246~SLPS-02247"/>
+		<info name="release" value="19991216"/>
 		<info name="alt_title" value="ゲートキーパーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -44263,8 +44263,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Great Battle VI (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00719" />
-		<info name="release" value="19970411" />
+		<info name="serial" value="SLPS-00719"/>
+		<info name="release" value="19970411"/>
 		<info name="alt_title" value="ザ・グレイトバトルVI"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44292,8 +44292,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GeGeGe no Kitarou (Japan)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00644" />
-		<info name="release" value="19970124" />
+		<info name="serial" value="SLPS-00644"/>
+		<info name="release" value="19970124"/>
 		<info name="alt_title" value="ゲゲゲの鬼太郎 / GeGeGe no Kitarou - Nonoi no Nikuto Katachi-tachi (Box?)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44313,8 +44313,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GeGeGe no Kitarou - Gyakushuu! Youkai Daikessen (Japan)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87286 (VX278-J1)" />
-		<info name="release" value="20031211" />
+		<info name="serial" value="SLPM-87286 (VX278-J1)"/>
+		<info name="release" value="20031211"/>
 		<info name="alt_title" value="ゲゲゲの鬼太郎 逆襲!妖魔大血戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44334,8 +44334,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Geki-Oh Shienryu (Japan)</description>
 		<year>1999</year>
 		<publisher>Warashi</publisher>
-		<info name="serial" value="SLPS-02056" />
-		<info name="release" value="19990520" />
+		<info name="serial" value="SLPS-02056"/>
+		<info name="release" value="19990520"/>
 		<info name="alt_title" value="撃王 紫炎龍"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44355,8 +44355,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aoki Ookami to Shiroki Mejika - Genchou Hishi (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01579" />
-		<info name="release" value="19980917" />
+		<info name="serial" value="SLPS-01579"/>
+		<info name="release" value="19980917"/>
 		<info name="alt_title" value="蒼き狼と白き牝鹿・元朝秘史"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44393,8 +44393,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Genei Tougi - Shadow Struggle (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00491" />
-		<info name="release" value="19960920" />
+		<info name="serial" value="SLPS-00491"/>
+		<info name="release" value="19960920"/>
 		<info name="alt_title" value="幻影闘技 SHADOW STRUGGLE"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44423,8 +44423,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>70's Robot Anime - Geppy-X - The Super Boosted Armor (Japan)</description>
 		<year>1999</year>
 		<publisher>Aroma</publisher>
-		<info name="serial" value="SLPS-01995~SLPS-01998" />
-		<info name="release" value="19990527" />
+		<info name="serial" value="SLPS-01995~SLPS-01998"/>
+		<info name="release" value="19990527"/>
 		<info name="alt_title" value="70年代風ロボットアニメ ゲッP-X"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -44459,8 +44459,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GetBackers Dakkanya (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86848 (VX240-J1)" />
-		<info name="release" value="20010726" />
+		<info name="serial" value="SLPM-86848 (VX240-J1)"/>
+		<info name="release" value="20010726"/>
 		<info name="alt_title" value="ゲットバッカーズ 奪還屋"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44480,8 +44480,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Guilty Gear (Japan)</description>
 		<year>1998</year>
 		<publisher>Arc System Works</publisher>
-		<info name="serial" value="SLPS-01357" />
-		<info name="release" value="19980514" />
+		<info name="serial" value="SLPS-01357"/>
+		<info name="release" value="19980514"/>
 		<info name="alt_title" value="ギルティ・ギア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44501,8 +44501,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ganbare Goemon - Ooedo Daikaiten (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86774 (VX239-J1)" />
-		<info name="release" value="20010329" />
+		<info name="serial" value="SLPM-86774 (VX239-J1)"/>
+		<info name="release" value="20010329"/>
 		<info name="alt_title" value="がんばれゴエモン 大江戸大回転"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44522,8 +44522,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ganbare Goemon - Uchuu Kaizoku Akogingu (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPS-00217 (VX011-J1)" />
-		<info name="release" value="19960322" />
+		<info name="serial" value="SLPS-00217 (VX011-J1)"/>
+		<info name="release" value="19960322"/>
 		<info name="alt_title" value="がんばれゴエモン〜宇宙海賊アコギング〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44543,8 +44543,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GI Jockey 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86413" />
-		<info name="release" value="20000203" />
+		<info name="serial" value="SLPM-86413"/>
+		<info name="release" value="20000203"/>
 		<info name="alt_title" value="ジーワン ジョッキー 2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44564,8 +44564,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ginga Eiyuu Densetsu (Japan)</description>
 		<year>1998</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-01358" />
-		<info name="release" value="19980528" />
+		<info name="serial" value="SLPS-01358"/>
+		<info name="release" value="19980528"/>
 		<info name="alt_title" value="银河英雄传说"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44585,8 +44585,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Glint Glitters (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86200 (VX226-J1)" />
-		<info name="release" value="19990729" />
+		<info name="serial" value="SLPM-86200 (VX226-J1)"/>
+		<info name="release" value="19990729"/>
 		<info name="alt_title" value="グリントグリッター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44606,8 +44606,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gallop Racer 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Tecmo</publisher>
-		<info name="serial" value="SLPS-02623" />
-		<info name="release" value="20000217" />
+		<info name="serial" value="SLPS-02623"/>
+		<info name="release" value="20000217"/>
 		<info name="alt_title" value="ギャロップレーサー2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44627,8 +44627,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gensou Maden Saiyuuki - Harukanaru Nishi e (Japan)</description>
 		<year>2002</year>
 		<publisher>J-Wing</publisher>
-		<info name="serial" value="SLPM-86986" />
-		<info name="release" value="20021226" />
+		<info name="serial" value="SLPM-86986"/>
+		<info name="release" value="20021226"/>
 		<info name="alt_title" value="幻想魔伝 最遊記 〜遙かなる西へ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44648,8 +44648,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Goemon - Shin Sedai Shuumei (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86997 (VX251-J1)" />
-		<info name="release" value="20011220" />
+		<info name="serial" value="SLPM-86997 (VX251-J1)"/>
+		<info name="release" value="20011220"/>
 		<info name="alt_title" value="ゴエモン 新世代襲名！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44669,8 +44669,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Goo! Goo! Soundy (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86250 (VX097-J1)" />
-		<info name="release" value="19990922" />
+		<info name="serial" value="SLPM-86250 (VX097-J1)"/>
+		<info name="release" value="19990922"/>
 		<info name="alt_title" value="グー！グー！サウンディ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44690,8 +44690,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Googootrops (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86148" />
-		<info name="release" value="19990128" />
+		<info name="serial" value="SLPM-86148"/>
+		<info name="release" value="19990128"/>
 		<info name="alt_title" value="グーグートロプス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44711,8 +44711,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gokuu Densetsu - Magic Beast Warriors (Japan)</description>
 		<year>1995</year>
 		<publisher>Allumer</publisher>
-		<info name="serial" value="SLPS-00048" />
-		<info name="release" value="19950526" />
+		<info name="serial" value="SLPS-00048"/>
+		<info name="release" value="19950526"/>
 		<info name="alt_title" value="悟空伝説 -Magic Beast Warriors-"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44732,8 +44732,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fuuun Gokuu Ninden (Japan)</description>
 		<year>1996</year>
 		<publisher>AiCOM</publisher>
-		<info name="serial" value="SLPS-00441" />
-		<info name="release" value="19960830" />
+		<info name="serial" value="SLPS-00441"/>
+		<info name="release" value="19960830"/>
 		<info name="alt_title" value="風雲悟空忍伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44772,8 +44772,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Goiken Muyou II (Japan)</description>
 		<year>1998</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-01542" />
-		<info name="release" value="19981029" />
+		<info name="serial" value="SLPS-01542"/>
+		<info name="release" value="19981029"/>
 		<info name="alt_title" value="御意见无用2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44793,8 +44793,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Golgo 13 - 1 - Karairu no Yabou (Japan)</description>
 		<year>1998</year>
 		<publisher>Daiki</publisher>
-		<info name="serial" value="SLPS-01712" />
-		<info name="release" value="19981126" />
+		<info name="serial" value="SLPS-01712"/>
+		<info name="release" value="19981126"/>
 		<info name="alt_title" value="ゴルゴ13 (1)カーライルの野望 D2MANGA"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44814,8 +44814,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Choujin Gakuen Gowcaizer (Japan)</description>
 		<year>1997</year>
 		<publisher>Urban Plant</publisher>
-		<info name="serial" value="SLPS-00527" />
-		<info name="release" value="19970717" />
+		<info name="serial" value="SLPS-00527"/>
+		<info name="release" value="19970717"/>
 		<info name="alt_title" value="超人学園GOWCAIZER"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44838,8 +44838,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>G-Police (Japan)</description>
 		<year>1998</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10065~SCPS-10066" />
-		<info name="release" value="19981119" />
+		<info name="serial" value="SCPS-10065~SCPS-10066"/>
+		<info name="release" value="19981119"/>
 		<info name="alt_title" value="ジーポリス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -44879,8 +44879,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chou-Kousoku Grandoll (Japan)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00935" />
-		<info name="release" value="19970724" />
+		<info name="serial" value="SLPS-00935"/>
+		<info name="release" value="19970724"/>
 		<info name="alt_title" value="超光速グランドール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44900,8 +44900,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gritz - The Pyramid Adventure (Japan)</description>
 		<year>1997</year>
 		<publisher>Sanyo</publisher>
-		<info name="serial" value="SLPS-00615" />
-		<info name="release" value="19970530" />
+		<info name="serial" value="SLPS-00615"/>
+		<info name="release" value="19970530"/>
 		<info name="alt_title" value="GRITZ ザ ピラミッドアドベンチャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44921,8 +44921,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Groove Jigoku V - Sweepstation Version (Japan)</description>
 		<year>1998</year>
 		<publisher>Kioon Sony Records</publisher>
-		<info name="serial" value="SLPS-01205" />
-		<info name="release" value="19980108" />
+		<info name="serial" value="SLPS-01205"/>
+		<info name="release" value="19980108"/>
 		<info name="alt_title" value="グルーヴ地獄V SweepStation Version"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44945,8 +44945,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Growlanser (Japan)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-02380~SLPS-02381" />
-		<info name="release" value="19991125" />
+		<info name="serial" value="SLPS-02380~SLPS-02381"/>
+		<info name="release" value="19991125"/>
 		<info name="alt_title" value="グローランサー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -44971,8 +44971,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Guitar Freaks Append 2nd Mix (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86446 (VX183-J1)" />
-		<info name="release" value="20000224" />
+		<info name="serial" value="SLPM-86446 (VX183-J1)"/>
+		<info name="release" value="20000224"/>
 		<info name="alt_title" value="ギターフリークス アペンド セカンドミックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44992,8 +44992,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gunbird (Japan)</description>
 		<year>1995</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-00157" />
-		<info name="release" value="19951215" />
+		<info name="serial" value="SLPS-00157"/>
+		<info name="release" value="19951215"/>
 		<info name="alt_title" value="ガンバード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45013,8 +45013,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gung-Ho Brigade (Japan)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-01902" />
-		<info name="release" value="20001019" />
+		<info name="serial" value="SLPS-01902"/>
+		<info name="release" value="20001019"/>
 		<info name="alt_title" value="ガンホーブリゲイド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45049,8 +45049,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kou Kidou Gensou - Gunparade March (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10136" />
-		<info name="release" value="20000928" />
+		<info name="serial" value="SCPS-10136"/>
+		<info name="release" value="20000928"/>
 		<info name="alt_title" value="高機動幻想 ガンパレード・マーチ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45075,8 +45075,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ridegear Guybrave II (Japan)</description>
 		<year>1998</year>
 		<publisher>Axela</publisher>
-		<info name="serial" value="SLPS-01643~SLPS-01644" />
-		<info name="release" value="19981029" />
+		<info name="serial" value="SLPS-01643~SLPS-01644"/>
+		<info name="release" value="19981029"/>
 		<info name="alt_title" value="雷弩機兵ガイブレイブII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -45101,9 +45101,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hai-Shin-2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques" />
-		<info name="serial" value="SLPM-86066" />
-		<info name="release" value="19980326" />
+		<info name="developer" value="Aques"/>
+		<info name="serial" value="SLPM-86066"/>
+		<info name="release" value="19980326"/>
 		<info name="alt_title" value="牌神2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45145,8 +45145,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hanabi Fantast (Japan)</description>
 		<year>1998</year>
 		<publisher>Magical</publisher>
-		<info name="serial" value="SLPS-01439" />
-		<info name="release" value="19980716" />
+		<info name="serial" value="SLPS-01439"/>
+		<info name="release" value="19980716"/>
 		<info name="alt_title" value="花火 FANTAST"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45166,8 +45166,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Happy Hotel (Japan)</description>
 		<year>1997</year>
 		<publisher>Tohoku Shinsha</publisher>
-		<info name="serial" value="SLPS-01110" />
-		<info name="release" value="19971127" />
+		<info name="serial" value="SLPS-01110"/>
+		<info name="release" value="19971127"/>
 		<info name="alt_title" value="ハッピーホテル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45187,8 +45187,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Happy Salvage (Japan)</description>
 		<year>2000</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-02821" />
-		<info name="release" value="20000831" />
+		<info name="serial" value="SLPS-02821"/>
+		<info name="release" value="20000831"/>
 		<info name="alt_title" value="ハッピィサルベージ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -45222,8 +45222,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hard Boiled (Japan)</description>
 		<year>1998</year>
 		<publisher>Sieg</publisher>
-		<info name="serial" value="SLPS-01484" />
-		<info name="release" value="19900730" />
+		<info name="serial" value="SLPS-01484"/>
+		<info name="release" value="19900730"/>
 		<info name="alt_title" value="ハードボイルド ～神経暦を破壊せよ～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45244,8 +45244,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ninpu Sentai Harikenger (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03493" />
-		<info name="release" value="20021128" />
+		<info name="serial" value="SLPS-03493"/>
+		<info name="release" value="20021128"/>
 		<info name="alt_title" value="忍風戦隊ハリケンジャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45265,8 +45265,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Harmful Park (Japan)</description>
 		<year>1997</year>
 		<publisher>Sky Think Systems</publisher>
-		<info name="serial" value="SLPS-00498" />
-		<info name="release" value="19970214" />
+		<info name="serial" value="SLPS-00498"/>
+		<info name="release" value="19970214"/>
 		<info name="alt_title" value="ハームフルパーク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45286,8 +45286,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Harukanaru Toki no Naka de - Banjou Yuugi (Japan, Premium Box)</description>
 		<year>2003</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-87241" />
-		<info name="release" value="20030626" />
+		<info name="serial" value="SLPM-87241"/>
+		<info name="release" value="20030626"/>
 		<info name="alt_title" value="遙かなる時空の中で 盤上遊戯 プレミアムBOX"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45307,8 +45307,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Harukanaru Toki no Naka de (Japan)</description>
 		<year>2000</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86466" />
-		<info name="release" value="20000406" />
+		<info name="serial" value="SLPM-86466"/>
+		<info name="release" value="20000406"/>
 		<info name="alt_title" value="遙かなる時空の中で"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45328,8 +45328,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hashiriya - Ookamitachi no Densetsu (Japan)</description>
 		<year>1997</year>
 		<publisher>Nichibutsu</publisher>
-		<info name="serial" value="SLPS-00704" />
-		<info name="release" value="19970418" />
+		<info name="serial" value="SLPS-00704"/>
+		<info name="release" value="19970418"/>
 		<info name="alt_title" value="走り屋 〜狼たちの伝説〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45349,8 +45349,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hatsukoi Valentine (Japan)</description>
 		<year>1997</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-00831" />
-		<info name="release" value="19970731" />
+		<info name="serial" value="SLPS-00831"/>
+		<info name="release" value="19970731"/>
 		<info name="alt_title" value="初恋ばれんたいん"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45370,8 +45370,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Haunted Junction - Seitokai Batch o Oe! (Japan)</description>
 		<year>1997</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-00668" />
-		<info name="release" value="19970117" />
+		<info name="serial" value="SLPS-00668"/>
+		<info name="release" value="19970117"/>
 		<info name="alt_title" value="ホーンテッドじゃんくしょん ～聖徒会バッジを追え！～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45391,8 +45391,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Heiwa Parlor! Pro Dolphin Ring Special (Japan)</description>
 		<year>2000</year>
 		<publisher>Nihon Telenet</publisher>
-		<info name="serial" value="SLPS-02689" />
-		<info name="release" value="20000330" />
+		<info name="serial" value="SLPS-02689"/>
+		<info name="release" value="20000330"/>
 		<info name="alt_title" value="平和パーラープロ ドルフィンリングスペシャルスペシャル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45412,8 +45412,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Heiwa Parlor! Pro Lupin Sansei Special (Japan)</description>
 		<year>2000</year>
 		<publisher>Nihon Telenet</publisher>
-		<info name="serial" value="SLPS-02541" />
-		<info name="release" value="20000113" />
+		<info name="serial" value="SLPS-02541"/>
+		<info name="release" value="20000113"/>
 		<info name="alt_title" value="平和パーラープロ ルパン三世スペシャル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45433,8 +45433,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Heiwa Otenki Studio (Japan)</description>
 		<year>2001</year>
 		<publisher>Aqua Rouge</publisher>
-		<info name="serial" value="SLPS-03178" />
-		<info name="release" value="20010329" />
+		<info name="serial" value="SLPS-03178"/>
+		<info name="release" value="20010329"/>
 		<info name="alt_title" value="THE 平和 〜お天気スタジオ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45454,8 +45454,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Heiwa Pachinko Graffiti Vol.1 (Japan)</description>
 		<year>1999</year>
 		<publisher>Aqua Rouge</publisher>
-		<info name="serial" value="SLPS-02374" />
-		<info name="release" value="19991209" />
+		<info name="serial" value="SLPS-02374"/>
+		<info name="release" value="19991209"/>
 		<info name="alt_title" value="平和パチンコグラフィティ Vol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45475,8 +45475,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Heiwa Parlor! Pro Tsunatori Monogatari Special (Japan)</description>
 		<year>2002</year>
 		<publisher>Nihon Telenet</publisher>
-		<info name="serial" value="SLPS-03370" />
-		<info name="release" value="20020307" />
+		<info name="serial" value="SLPS-03370"/>
+		<info name="release" value="20020307"/>
 		<info name="alt_title" value="平和パーラー！プロ つなとり 綱取物語スペシャル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45496,8 +45496,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hello Charlie!! (Japan)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86083" />
-		<info name="release" value="19980730" />
+		<info name="serial" value="SLPM-86083"/>
+		<info name="release" value="19980730"/>
 		<info name="alt_title" value="ハローチャーリー！！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45517,8 +45517,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hello Kitty's Cube De Cute (Japan)</description>
 		<year>1998</year>
 		<publisher>Culture Publishing</publisher>
-		<info name="serial" value="SLPS-01427" />
-		<info name="release" value="19980625" />
+		<info name="serial" value="SLPS-01427"/>
+		<info name="release" value="19980625"/>
 		<info name="alt_title" value="ハローキティのキューブでキュート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45569,8 +45569,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hello Kitty - White Present (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01766" />
-		<info name="release" value="19981217" />
+		<info name="serial" value="SLPS-01766"/>
+		<info name="release" value="19981217"/>
 		<info name="alt_title" value="ハローキティ ホワイトプレゼント"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45591,8 +45591,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Henry Explorers (Japan)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86021 (VX044-J1)" />
-		<info name="release" value="19970307" />
+		<info name="serial" value="SLPM-86021 (VX044-J1)"/>
+		<info name="release" value="19970307"/>
 		<info name="alt_title" value="ヘンリーエクスプローラーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45612,8 +45612,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hermie Hopperhead - Scrap Panic (Japan, Playstation the Best)</description>
 		<year>1996</year>
 		<publisher>Sony</publisher>
-		<info name="serial" value="SCPS-91016" />
-		<info name="release" value="19961206" />
+		<info name="serial" value="SCPS-91016"/>
+		<info name="release" value="19961206"/>
 		<info name="alt_title" value="ハーミィホッパーヘッド スクラップパニック (PlayStation the Best for Family)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45633,8 +45633,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Houma Hunter Lime - Special Collection Vol.1 (Japan)</description>
 		<year>1994</year>
 		<publisher>Asmik</publisher>
-		<info name="serial" value="SLPS-00020" />
-		<info name="release" value="19941222" />
+		<info name="serial" value="SLPS-00020"/>
+		<info name="release" value="19941222"/>
 		<info name="alt_title" value="宝魔ハンター・ライム スペシャルコレクションVol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45654,8 +45654,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hikari no Shima - Seven Lithographs in Shining Island (Japan)</description>
 		<year>1999</year>
 		<publisher>Affect</publisher>
-		<info name="serial" value="SLPS-02305" />
-		<info name="release" value="19991111" />
+		<info name="serial" value="SLPS-02305"/>
+		<info name="release" value="19991111"/>
 		<info name="alt_title" value="光の島"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45675,8 +45675,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hikaru no Go - Heian Gensou Ibunroku (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87059 (VX262-J1)" />
-		<info name="release" value="20020530" />
+		<info name="serial" value="SLPM-87059 (VX262-J1)"/>
+		<info name="release" value="20020530"/>
 		<info name="alt_title" value="ヒカルの碁 平安幻想異聞録"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45696,8 +45696,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hikaru no Go - Insei Choujou Kessen (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87199 (VX270-J1)" />
-		<info name="release" value="20021219" />
+		<info name="serial" value="SLPM-87199 (VX270-J1)"/>
+		<info name="release" value="20021219"/>
 		<info name="alt_title" value="ヒカルの碁 院生頂上決戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45723,8 +45723,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Himiko-Den (Japan)</description>
 		<year>1999</year>
 		<publisher>Hakuhodo</publisher>
-		<info name="serial" value="SLPS-01890~SLPS-01892" />
-		<info name="release" value="19990311" />
+		<info name="serial" value="SLPS-01890~SLPS-01892"/>
+		<info name="release" value="19990311"/>
 		<info name="alt_title" value="火魅子伝〜恋解〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -45754,8 +45754,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hissatsu Pachi-Slot Station 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-02355" />
-		<info name="release" value="19991028" />
+		<info name="serial" value="SLPS-02355"/>
+		<info name="release" value="19991028"/>
 		<info name="alt_title" value="必殺パチスロステーション2 爆登！常識破りの2タイプ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45775,8 +45775,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hissatsu Pachi-Slot Station 4 (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-02799" />
-		<info name="release" value="20000727" />
+		<info name="serial" value="SLPS-02799"/>
+		<info name="release" value="20000727"/>
 		<info name="alt_title" value="必殺パチスロステーション4 ニューバルR&amp;ホットロッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45796,8 +45796,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hissatsu Pachi-Slot Station 5 (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03030" />
-		<info name="release" value="20001116" />
+		<info name="serial" value="SLPS-03030"/>
+		<info name="release" value="20001116"/>
 		<info name="alt_title" value="必殺パチンコステーション5 インベーダー2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45817,8 +45817,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hissatsu Pachi-Slot Station SP (Japan)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-02494" />
-		<info name="release" value="19991216" />
+		<info name="serial" value="SLPS-02494"/>
+		<info name="release" value="19991216"/>
 		<info name="alt_title" value="必殺パチスロステーションSP 山佐★ベストチョイス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45838,8 +45838,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hit Back (Japan)</description>
 		<year>1999</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-01361" />
-		<info name="release" value="19990415" />
+		<info name="serial" value="SLPS-01361"/>
+		<info name="release" value="19990415"/>
 		<info name="alt_title" value="ひっとばっく"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45859,8 +45859,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hiza no Ue no Partner - Kitty On Your Lap (Japan)</description>
 		<year>1998</year>
 		<publisher>Culture Publishers</publisher>
-		<info name="serial" value="SLPS-01302" />
-		<info name="release" value="19980312" />
+		<info name="serial" value="SLPS-01302"/>
+		<info name="release" value="19980312"/>
 		<info name="alt_title" value="ひざの上の同居人 −KITTY ON YOUR LAP−"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45880,8 +45880,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hokuto no Ken (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00369" />
-		<info name="release" value="19960830" />
+		<info name="serial" value="SLPS-00369"/>
+		<info name="release" value="19960830"/>
 		<info name="alt_title" value="北斗の拳"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45904,7 +45904,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Bandai</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hokuto no ken - seikimatsu kyuuseishu densetsu (japan)" sha1="bd52aeec9c61c52b4e7a5391e1a4bd56fe453cdd" />
+				<disk name="hokuto no ken - seikimatsu kyuuseishu densetsu (japan)" sha1="bd52aeec9c61c52b4e7a5391e1a4bd56fe453cdd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -45919,8 +45919,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hooockey!! (Japan, SuperLite 1500 Series)</description>
 		<year>2000</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86488" />
-		<info name="release" value="20000525" />
+		<info name="serial" value="SLPM-86488"/>
+		<info name="release" value="20000525"/>
 		<info name="alt_title" value="SuperLite1500シリーズ ホッケー！！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45940,8 +45940,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hoshigami - Shizumiyuku Aoki Daichi (Japan)</description>
 		<year>2002</year>
 		<publisher>MaxFive</publisher>
-		<info name="serial" value="SLPS-02904" />
-		<info name="release" value="20020207" />
+		<info name="serial" value="SLPS-02904"/>
+		<info name="release" value="20020207"/>
 		<info name="alt_title" value="星神 〜沈みゆく蒼き大地〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45961,8 +45961,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>High School of Blitz (Japan)</description>
 		<year>1999</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-02351" />
-		<info name="release" value="19991125" />
+		<info name="serial" value="SLPS-02351"/>
+		<info name="release" value="19991125"/>
 		<info name="alt_title" value="ハイスクール オブ ブリッツ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45982,8 +45982,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Heaven's Gate (Japan)</description>
 		<year>1996</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-00667" />
-		<info name="release" value="19961213" />
+		<info name="serial" value="SLPS-00667"/>
+		<info name="release" value="19961213"/>
 		<info name="alt_title" value="ヘヴンズゲート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46003,8 +46003,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hunter X Hunter - Maboroshi no Greed Island (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86651 (VX214-J1)" />
-		<info name="release" value="20001026" />
+		<info name="serial" value="SLPM-86651 (VX214-J1)"/>
+		<info name="release" value="20001026"/>
 		<info name="alt_title" value="ハンター×ハンター 幻のグリードアイランド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46024,8 +46024,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hunter X Hunter - Ubawareta Aura Stone (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86895 (VX249-J1)" />
-		<info name="release" value="20010927" />
+		<info name="serial" value="SLPM-86895 (VX249-J1)"/>
+		<info name="release" value="20010927"/>
 		<info name="alt_title" value="Hハンター×ハンター 奪われたオーラストーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46045,8 +46045,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hyouryuu Ki - The Reportage Beyond the Sea (Japan)</description>
 		<year>1999</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-02358" />
-		<info name="release" value="19991028" />
+		<info name="serial" value="SLPS-02358"/>
+		<info name="release" value="19991028"/>
 		<info name="alt_title" value="漂流記"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46066,8 +46066,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hyper Crazy Climber (Japan)</description>
 		<year>1996</year>
 		<publisher>Nichibutsu</publisher>
-		<info name="serial" value="SLPS-00248" />
-		<info name="release" value="19960223" />
+		<info name="serial" value="SLPS-00248"/>
+		<info name="release" value="19960223"/>
 		<info name="alt_title" value="ハイパークレイジークライマー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46087,8 +46087,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hyper Securities 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01417" />
-		<info name="release" value="19980625" />
+		<info name="serial" value="SLPS-01417"/>
+		<info name="release" value="19980625"/>
 		<info name="alt_title" value="はいぱぁセキュリティーズ2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46108,8 +46108,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hyper Rally (Japan)</description>
 		<year>1996</year>
 		<publisher>Harvest One</publisher>
-		<info name="serial" value="SLPS-00462" />
-		<info name="release" value="19960830" />
+		<info name="serial" value="SLPS-00462"/>
+		<info name="release" value="19960830"/>
 		<info name="alt_title" value="ハイパーラリー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46129,8 +46129,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ichigeki - Hagane no Hito (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02199" />
-		<info name="release" value="19991102" />
+		<info name="serial" value="SLPS-02199"/>
+		<info name="release" value="19991102"/>
 		<info name="alt_title" value="一撃 鋼の人"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46150,8 +46150,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ide Yousuke no Mahjong Kyoshitsu (Japan)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-02272" />
-		<info name="release" value="19991202" />
+		<info name="serial" value="SLPS-02272"/>
+		<info name="release" value="19991202"/>
 		<info name="alt_title" value="井出洋介の麻雀教室"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46171,8 +46171,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Baseball Simulation - ID Pro Yakyuu (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86650 (VX189-J1)" />
-		<info name="release" value="20010125" />
+		<info name="serial" value="SLPM-86650 (VX189-J1)"/>
+		<info name="release" value="20010125"/>
 		<info name="alt_title" value="ベースボールシミュレーション IDプロ野球"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46192,8 +46192,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Minna Atsumore! Igo Kyoushitsu (Japan)</description>
 		<year>2003</year>
 		<publisher>I.Magic.</publisher>
-		<info name="serial" value="SLPS-03554" />
-		<info name="release" value="20031211" />
+		<info name="serial" value="SLPS-03554"/>
+		<info name="release" value="20031211"/>
 		<info name="alt_title" value="みんな集まれ!囲碁教室"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46213,8 +46213,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arcade Gears - Image Fight &amp; X-Multiply (Japan)</description>
 		<year>1998</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-01267" />
-		<info name="release" value="19980319" />
+		<info name="serial" value="SLPS-01267"/>
+		<info name="release" value="19980319"/>
 		<info name="alt_title" value="アーケードギアーズ イメージファイト&amp;X－マルチプライ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46234,8 +46234,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Inagawa Junji - Kyoufu no Yashiki (Japan)</description>
 		<year>1999</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPS-02142" />
-		<info name="release" value="19990701" />
+		<info name="serial" value="SLPS-02142"/>
+		<info name="release" value="19990701"/>
 		<info name="alt_title" value="稲川淳二 恐怖の屋敷"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46255,8 +46255,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Indy 500 (Japan)</description>
 		<year>1997</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-00860" />
-		<info name="release" value="19970523" />
+		<info name="serial" value="SLPS-00860"/>
+		<info name="release" value="19970523"/>
 		<info name="alt_title" value="インディ 500"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46276,8 +46276,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Inuyasha (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03374" />
-		<info name="release" value="20011227" />
+		<info name="serial" value="SLPS-03374"/>
+		<info name="release" value="20011227"/>
 		<info name="alt_title" value="犬夜叉"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46297,8 +46297,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Inuyasha - Sengoku Otogi Kassen (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03504" />
-		<info name="release" value="20021205" />
+		<info name="serial" value="SLPS-03504"/>
+		<info name="release" value="20021205"/>
 		<info name="alt_title" value="犬夜叉〜戦国お伽合戦〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46318,8 +46318,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ucchannanchan no Honoo no Challenger - Denryu Iraira-Bou Returns (Japan)</description>
 		<year>1998</year>
 		<publisher>Saurus</publisher>
-		<info name="serial" value="SLPS-01317" />
-		<info name="release" value="19980319" />
+		<info name="serial" value="SLPS-01317"/>
+		<info name="release" value="19980319"/>
 		<info name="alt_title" value="ウッチャンナンチャンの炎のチャレンジャー 電流イライラ棒リターンズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46339,8 +46339,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Irem Arcade Classics (Japan)</description>
 		<year>1996</year>
 		<publisher>I'Max</publisher>
-		<info name="serial" value="SLPS-00341" />
-		<info name="release" value="19960426" />
+		<info name="serial" value="SLPS-00341"/>
+		<info name="release" value="19960426"/>
 		<info name="alt_title" value="アイレム アーケード クラシックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46360,8 +46360,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Itadaki Street - Gorgeous King (Japan)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86120" />
-		<info name="release" value="19980923" />
+		<info name="serial" value="SLPM-86120"/>
+		<info name="release" value="19980923"/>
 		<info name="alt_title" value="いただきストリート ゴージャスキング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46384,8 +46384,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>JailBreaker (Japan)</description>
 		<year>1999</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-02076~SLPS-02077 (NIPS 4004)" />
-		<info name="release" value="19990603" />
+		<info name="serial" value="SLPS-02076~SLPS-02077 (NIPS 4004)"/>
+		<info name="release" value="19990603"/>
 		<info name="alt_title" value="ジェイルブレイカー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -46410,8 +46410,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Jaleco Collection Vol.1 (Japan)</description>
 		<year>2003</year>
 		<publisher>PCCW</publisher>
-		<info name="serial" value="SLPS-03562" />
-		<info name="release" value="20031023" />
+		<info name="serial" value="SLPS-03562"/>
+		<info name="release" value="20031023"/>
 		<info name="alt_title" value="ジャレココレクション Vol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46431,8 +46431,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Jellyfish - The Healing Friend (Japan)</description>
 		<year>2000</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPS-02892" />
-		<info name="release" value="20000928" />
+		<info name="serial" value="SLPS-02892"/>
+		<info name="release" value="20000928"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -46454,8 +46454,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shiritsu Justice Gakuen - Legion of Heroes (Japan)</description>
 		<year>1998</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01240~SLPS-01241" />
-		<info name="release" value="19980730" />
+		<info name="serial" value="SLPS-01240~SLPS-01241"/>
+		<info name="release" value="19980730"/>
 		<info name="alt_title" value="私立ジャスティス学園 〜リージョン オブ ヒーローズ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -46480,8 +46480,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shiritsu Justice Gakuen - Nekketsu Seishun Nikki 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-02120" />
-		<info name="release" value="19990624" />
+		<info name="serial" value="SLPS-02120"/>
+		<info name="release" value="19990624"/>
 		<info name="alt_title" value="私立ジャスティス学園－熱血青春日記2－"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46502,8 +46502,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Jigsaw World (Japan, Honkakuha de 1300Yen Series)</description>
 		<year>1999</year>
 		<publisher>Hect</publisher>
-		<info name="serial" value="SLPS-02251" />
-		<info name="release" value="19990914" />
+		<info name="serial" value="SLPS-02251"/>
+		<info name="release" value="19990914"/>
 		<info name="alt_title" value="本格派DE 1300円 ジグソーワールド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46540,8 +46540,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Jounetsu Nekketsu Athletes - Nakimushi Coach no Nikki (Japan)</description>
 		<year>1997</year>
 		<publisher>Asmik</publisher>
-		<info name="serial" value="SLPS-00936" />
-		<info name="release" value="19971009" />
+		<info name="serial" value="SLPS-00936"/>
+		<info name="release" value="19971009"/>
 		<info name="alt_title" value="情熱★熱血アスリーツ ～泣き虫コーチの日記～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46561,8 +46561,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Jungle Park (Japan)</description>
 		<year>1998</year>
 		<publisher>Digitalogue</publisher>
-		<info name="serial" value="SLPS-01086" />
-		<info name="release" value="19980226" />
+		<info name="serial" value="SLPS-01086"/>
+		<info name="release" value="19980226"/>
 		<info name="alt_title" value="ジャングルパーク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46599,8 +46599,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fighting Illusion - K-1 Grand Prix '98 (Japan)</description>
 		<year>1998</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-01696" />
-		<info name="release" value="19981126" />
+		<info name="serial" value="SLPS-01696"/>
+		<info name="release" value="19981126"/>
 		<info name="alt_title" value="ファイティング イリュージョン K-1グランプリ'98"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46620,8 +46620,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaeru no Ehon - Nakushita Kioku o Motomete (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-02332" />
-		<info name="release" value="19991021" />
+		<info name="serial" value="SLPS-02332"/>
+		<info name="release" value="19991021"/>
 		<info name="alt_title" value="かえるの絵本 なくした記憶を求めて"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46641,8 +46641,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kain the Vampire (Japan)</description>
 		<year>1997</year>
 		<publisher>BMG Japan</publisher>
-		<info name="serial" value="SLPS-00743" />
-		<info name="release" value="19970530" />
+		<info name="serial" value="SLPS-00743"/>
+		<info name="release" value="19970530"/>
 		<info name="alt_title" value="ケイン・ザ・バンパイア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46662,8 +46662,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaikan Phrase - Datenshi Kourin (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86438" />
-		<info name="release" value="20000224" />
+		<info name="serial" value="SLPM-86438"/>
+		<info name="release" value="20000224"/>
 		<info name="alt_title" value="快感フレーズ 堕天使降臨"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46683,8 +46683,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaitohranma Miyabi (Japan)</description>
 		<year>1999</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-01825" />
-		<info name="release" value="19990121" />
+		<info name="serial" value="SLPS-01825"/>
+		<info name="release" value="19990121"/>
 		<info name="alt_title" value="快刀乱麻 雅"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46704,8 +46704,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kakugo no Susume (Japan)</description>
 		<year>1997</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-00799" />
-		<info name="release" value="19970328" />
+		<info name="serial" value="SLPS-00799"/>
+		<info name="release" value="19970328"/>
 		<info name="alt_title" value="覚悟のススメ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46725,8 +46725,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kids Station - Kamen Rider Heroes (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03403" />
-		<info name="release" value="20020718" />
+		<info name="serial" value="SLPS-03403"/>
+		<info name="release" value="20020718"/>
 		<info name="alt_title" value="キッズステーション 仮面ライダーヒーローズ(ソフト単体版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46746,8 +46746,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kamen Rider Agito (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03344" />
-		<info name="release" value="20011129" />
+		<info name="serial" value="SLPS-03344"/>
+		<info name="release" value="20011129"/>
 		<info name="alt_title" value="仮面ライダーアギト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46846,8 +46846,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kamen Rider (Japan)</description>
 		<year>1998</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01570" />
-		<info name="release" value="19981001" />
+		<info name="serial" value="SLPS-01570"/>
+		<info name="release" value="19981001"/>
 		<info name="alt_title" value="仮面ライダー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46867,8 +46867,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kamen Rider Kuuga (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03090" />
-		<info name="release" value="20001221" />
+		<info name="serial" value="SLPS-03090"/>
+		<info name="release" value="20001221"/>
 		<info name="alt_title" value="仮面ライダークウガ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46888,8 +46888,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kamen Rider Ryuki (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03495" />
-		<info name="release" value="20021128" />
+		<info name="serial" value="SLPS-03495"/>
+		<info name="release" value="20021128"/>
 		<info name="alt_title" value="仮面ライダー龍騎"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46909,8 +46909,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kanako Enomoto - Junk Brain Diagnosis (Japan)</description>
 		<year>1999</year>
 		<publisher>Oracion</publisher>
-		<info name="serial" value="SLPS-01937" />
-		<info name="release" value="19990325" />
+		<info name="serial" value="SLPS-01937"/>
+		<info name="release" value="19990325"/>
 		<info name="alt_title" value="榎本加奈子のボケ診断ゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46930,8 +46930,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chou Hatsumei Boy Kanipan - Hirameki Wonderland (Japan)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86299 (TCPS10009)" />
-		<info name="release" value="19990930" />
+		<info name="serial" value="SLPM-86299 (TCPS10009)"/>
+		<info name="release" value="19990930"/>
 		<info name="alt_title" value="超発明BOYカニパン ヒラメキ☆ワンダーランド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46951,8 +46951,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kattobi Tune (Japan)</description>
 		<year>1998</year>
 		<publisher>Genki</publisher>
-		<info name="serial" value="SLPS-01253" />
-		<info name="release" value="19980423" />
+		<info name="serial" value="SLPS-01253"/>
+		<info name="release" value="19980423"/>
 		<info name="alt_title" value="かっとびチューン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46973,8 +46973,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaze no Notam - Notam of Wind (Japan)</description>
 		<year>1997</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-00912" />
-		<info name="release" value="19970911" />
+		<info name="serial" value="SLPS-00912"/>
+		<info name="release" value="19970911"/>
 		<info name="alt_title" value="風のノータム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46994,8 +46994,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Keiba Eight '98 Akifuyu (Japan)</description>
 		<year>1998</year>
 		<publisher>Shangri-La</publisher>
-		<info name="serial" value="SLPS-01640" />
-		<info name="release" value="19981022" />
+		<info name="serial" value="SLPS-01640"/>
+		<info name="release" value="19981022"/>
 		<info name="alt_title" value="競馬エイト'98秋冬"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47015,8 +47015,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Keiba Eight '98 Haru Natsu (Japan)</description>
 		<year>1998</year>
 		<publisher>Shangri-La</publisher>
-		<info name="serial" value="SLPS-01372" />
-		<info name="release" value="19980429" />
+		<info name="serial" value="SLPS-01372"/>
+		<info name="release" value="19980429"/>
 		<info name="alt_title" value="競馬エイト '98春夏"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47036,8 +47036,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Keiba Saishou no Housoku '95 (Japan)</description>
 		<year>1995</year>
 		<publisher>Copya System</publisher>
-		<info name="serial" value="SLPS-00063" />
-		<info name="release" value="19950623" />
+		<info name="serial" value="SLPS-00063"/>
+		<info name="release" value="19950623"/>
 		<info name="alt_title" value="競馬最勝の法則’95"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47058,8 +47058,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rami-Chan no Ooedo Surogoku - Keiou Yuugekitai Gaiden (Japan)</description>
 		<year>1998</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01546" />
-		<info name="release" value="19980917" />
+		<info name="serial" value="SLPS-01546"/>
+		<info name="release" value="19980917"/>
 		<info name="alt_title" value="蘭未ちゃんの大江戸すごろく 慶応遊撃隊外伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47079,8 +47079,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kenki Ippatsu! Crane Master ni Narou! (Japan)</description>
 		<year>2000</year>
 		<publisher>FAB Communication</publisher>
-		<info name="serial" value="SLPS-02831" />
-		<info name="release" value="20000803" />
+		<info name="serial" value="SLPS-02831"/>
+		<info name="release" value="20000803"/>
 		<info name="alt_title" value="けんき いっぱつ！クレーンマスターになろう！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47100,8 +47100,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kero Kero King (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
-		<info name="serial" value="SLPM-86621" />
-		<info name="release" value="20001102" />
+		<info name="serial" value="SLPM-86621"/>
+		<info name="release" value="20001102"/>
 		<info name="alt_title" value="ケロケロキング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47121,8 +47121,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Khamrai (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-02640" />
-		<info name="release" value="20001005" />
+		<info name="serial" value="SLPS-02640"/>
+		<info name="release" value="20001005"/>
 		<info name="alt_title" value="カムライー神来ー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47142,8 +47142,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Killer Bass (Japan)</description>
 		<year>2000</year>
 		<publisher>Magical</publisher>
-		<info name="serial" value="SLPS-02747" />
-		<info name="release" value="20000615" />
+		<info name="serial" value="SLPS-02747"/>
+		<info name="release" value="20000615"/>
 		<info name="alt_title" value="キラーバス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47166,8 +47166,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kindaichi Shounen no Jikenbo 3 - Seiryuu Densetsu Satsujin Jiken (Japan)</description>
 		<year>1999</year>
 		<publisher>Kodansha</publisher>
-		<info name="serial" value="SLPS-02223~SLPS-02224" />
-		<info name="release" value="19990805" />
+		<info name="serial" value="SLPS-02223~SLPS-02224"/>
+		<info name="release" value="19990805"/>
 		<info name="alt_title" value="金田一少年の事件簿3 青龍伝説殺人事件"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -47192,8 +47192,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>King of Bowling 2 - Professional-Hen (Japan)</description>
 		<year>1998</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-01541" />
-		<info name="release" value="19980827" />
+		<info name="serial" value="SLPS-01541"/>
+		<info name="release" value="19980827"/>
 		<info name="alt_title" value="キング オブ ボウリング2 プロフェッショナル編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47213,8 +47213,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hakaioh - King of Crusher (Japan)</description>
 		<year>1998</year>
 		<publisher>FAB Communications</publisher>
-		<info name="serial" value="SLPS-01677" />
-		<info name="release" value="19981112" />
+		<info name="serial" value="SLPS-01677"/>
+		<info name="release" value="19981112"/>
 		<info name="alt_title" value="破壊王 KING of CRUSHER"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47234,8 +47234,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Muscle Ranking - Kinniku Banzuke Vol.2 - Aratanaru Genkai e no Chousen! (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86457 (VX177-J1)" />
-		<info name="release" value="20000323" />
+		<info name="serial" value="SLPM-86457 (VX177-J1)"/>
+		<info name="release" value="20000323"/>
 		<info name="alt_title" value="筋肉番付VOL.2 ～新たなる限界への挑戦！～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47255,8 +47255,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kisya de Go! (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86449 (TCPS10020)" />
-		<info name="release" value="20000323" />
+		<info name="serial" value="SLPM-86449 (TCPS10020)"/>
+		<info name="release" value="20000323"/>
 		<info name="alt_title" value="汽車でGO!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47276,8 +47276,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kitchen Panic (Japan)</description>
 		<year>1998</year>
 		<publisher>Panther Software</publisher>
-		<info name="serial" value="SLPS-01395" />
-		<info name="release" value="19980528" />
+		<info name="serial" value="SLPS-01395"/>
+		<info name="release" value="19980528"/>
 		<info name="alt_title" value="キッチンぱにっく"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47297,8 +47297,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kochira Katsushikaku Kameari Kouenzen Hashutsujo - High Tech Building Shinkou Soshi Sakusen! no Ma (Japan)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00922" />
-		<info name="release" value="19970724" />
+		<info name="serial" value="SLPS-00922"/>
+		<info name="release" value="19970724"/>
 		<info name="alt_title" value="こちら葛飾区亀有公園前派出所 ハイテクビル侵攻阻止作戦！の巻"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47318,8 +47318,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Knight &amp; Baby (Japan)</description>
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
-		<info name="serial" value="SLPS-01531" />
-		<info name="release" value="19980923" />
+		<info name="serial" value="SLPS-01531"/>
+		<info name="release" value="19980923"/>
 		<info name="alt_title" value="ナイト&amp;ベイビー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47380,8 +47380,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The King of Fighters '95 (Japan)</description>
 		<year>1996</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPS-00351" />
-		<info name="release" value="19960628" />
+		<info name="serial" value="SLPS-00351"/>
+		<info name="release" value="19960628"/>
 		<info name="alt_title" value="ザ・キング・オブ・ファイターズ'95"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47441,8 +47441,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The King of Fighters '96 (Japan)</description>
 		<year>1997</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPS-00834" />
-		<info name="release" value="19970704" />
+		<info name="serial" value="SLPS-00834"/>
+		<info name="release" value="19970704"/>
 		<info name="alt_title" value="ザ・キング・オブ・ファイターズ'96"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47462,8 +47462,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The King of Fighters '98 - Dream Match Never Ends (Japan)</description>
 		<year>1999</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86201" />
-		<info name="release" value="19990325" />
+		<info name="serial" value="SLPM-86201"/>
+		<info name="release" value="19990325"/>
 		<info name="alt_title" value="ザ・キング・オブ・ファイターズ'98"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47484,8 +47484,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The King of Fighters '99 (Japan)</description>
 		<year>2000</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86462" />
-		<info name="release" value="20000323" />
+		<info name="serial" value="SLPM-86462"/>
+		<info name="release" value="20000323"/>
 		<info name="alt_title" value="ザ・キング・オブ・ファイターズ’99"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47508,8 +47508,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The King of Fighters Kyo (Japan)</description>
 		<year>1998</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86095" />
-		<info name="release" value="19980827" />
+		<info name="serial" value="SLPM-86095"/>
+		<info name="release" value="19980827"/>
 		<info name="alt_title" value="ザ・キング・オブ・ファイターズ 京"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47529,8 +47529,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kohni Shogun (Japan)</description>
 		<year>2000</year>
 		<publisher>ASK</publisher>
-		<info name="serial" value="SLPS-02955" />
-		<info name="release" value="20001026" />
+		<info name="serial" value="SLPS-02955"/>
+		<info name="release" value="20001026"/>
 		<info name="alt_title" value="高2→将軍"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47550,8 +47550,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kojin Kyouju - La Leçon Particulière (Japan)</description>
 		<year>1998</year>
 		<publisher>MyCom</publisher>
-		<info name="serial" value="SLPS-01354" />
-		<info name="release" value="19980409" />
+		<info name="serial" value="SLPS-01354"/>
+		<info name="release" value="19980409"/>
 		<info name="alt_title" value="個人教授"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47571,8 +47571,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Komotchi (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-03121" />
-		<info name="release" value="20010920" />
+		<info name="serial" value="SLPS-03121"/>
+		<info name="release" value="20010920"/>
 		<info name="alt_title" value="こもっち"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47592,8 +47592,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Konami 80's Arcade Gallery (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86228 (VX144-J1)" />
-		<info name="release" value="19990513" />
+		<info name="serial" value="SLPM-86228 (VX144-J1)"/>
+		<info name="release" value="19990513"/>
 		<info name="alt_title" value="コナミ80'sアーケードギャラリー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47613,8 +47613,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Korokoro Post Nin (Japan)</description>
 		<year>2002</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03479" />
-		<info name="release" value="20021017" />
+		<info name="serial" value="SLPS-03479"/>
+		<info name="release" value="20021017"/>
 		<info name="alt_title" value="コロコロポストニン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47634,8 +47634,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kouryuuki (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01338" />
-		<info name="release" value="19980326" />
+		<info name="serial" value="SLPS-01338"/>
+		<info name="release" value="19980326"/>
 		<info name="alt_title" value="項劉記"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47655,8 +47655,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kouklotheatro - Yuukyuu no Hitomi (Japan)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-02385" />
-		<info name="release" value="19991202" />
+		<info name="serial" value="SLPS-02385"/>
+		<info name="release" value="19991202"/>
 		<info name="alt_title" value="Κουκλοθεατρο 悠久の瞳"/>
 		<info name="alt_title" value="ククロセアトロ 悠久の瞳"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -47677,8 +47677,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Koyasai - A Sherd of Youthful Memories (Japan)</description>
 		<year>1999</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-01775" />
-		<info name="release" value="19990225" />
+		<info name="serial" value="SLPS-01775"/>
+		<info name="release" value="19990225"/>
 		<info name="alt_title" value="後夜祭"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47698,8 +47698,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kuubo Senki (Japan)</description>
 		<year>1999</year>
 		<publisher>Unbalance</publisher>
-		<info name="serial" value="SLPS-01854" />
-		<info name="release" value="19990204" />
+		<info name="serial" value="SLPS-01854"/>
+		<info name="release" value="19990204"/>
 		<info name="alt_title" value="空母戦記"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47719,8 +47719,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kunoichi Torimonocho (Japan)</description>
 		<year>1999</year>
 		<publisher>GMF</publisher>
-		<info name="serial" value="SLPS-01773" />
-		<info name="release" value="19990225" />
+		<info name="serial" value="SLPS-01773"/>
+		<info name="release" value="19990225"/>
 		<info name="alt_title" value="くのいち捕物帖"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47740,8 +47740,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kuro no Ken - Blade of the Darkness (Japan)</description>
 		<year>1997</year>
 		<publisher>CD Bros.</publisher>
-		<info name="serial" value="SLPS-01030" />
-		<info name="release" value="19971009" />
+		<info name="serial" value="SLPS-01030"/>
+		<info name="release" value="19971009"/>
 		<info name="alt_title" value="黒の剣"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47761,8 +47761,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ku-Ron Jo - Fukyuu Ban (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Rings</publisher>
-		<info name="serial" value="SLPS-03063" />
-		<info name="release" value="20001207" />
+		<info name="serial" value="SLPS-03063"/>
+		<info name="release" value="20001207"/>
 		<info name="alt_title" value="九龍城 普及版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47782,8 +47782,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kurumi Miracle (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00786" />
-		<info name="release" value="19970925" />
+		<info name="serial" value="SLPS-00786"/>
+		<info name="release" value="19970925"/>
 		<info name="alt_title" value="くるみミラクル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47830,8 +47830,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kururin Pa! (Japan)</description>
 		<year>1995</year>
 		<publisher>Sky Think System</publisher>
-		<info name="serial" value="SLPS-00066" />
-		<info name="release" value="19950707" />
+		<info name="serial" value="SLPS-00066"/>
+		<info name="release" value="19950707"/>
 		<info name="alt_title" value="くるりんPA！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47851,8 +47851,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kyorochan no Purikura Daisakusen (Japan)</description>
 		<year>1999</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-01692" />
-		<info name="release" value="19990211" />
+		<info name="serial" value="SLPS-01692"/>
+		<info name="release" value="19990211"/>
 		<info name="alt_title" value="キョロちゃんのプリクラ大作戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47872,8 +47872,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kyuin (Japan)</description>
 		<year>1996</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-00214 (100010)" />
-		<info name="release" value="19960531" />
+		<info name="serial" value="SLPS-00214 (100010)"/>
+		<info name="release" value="19960531"/>
 		<info name="alt_title" value="キュイーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47893,8 +47893,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lagnacure Legend (Japan)</description>
 		<year>2000</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-02832" />
-		<info name="release" value="20000706" />
+		<info name="serial" value="SLPS-02832"/>
+		<info name="release" value="20000706"/>
 		<info name="alt_title" value="ラグナキュール レジェンド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47914,8 +47914,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lagnacure (Japan)</description>
 		<year>1997</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-01009" />
-		<info name="release" value="19971002" />
+		<info name="serial" value="SLPS-01009"/>
+		<info name="release" value="19971002"/>
 		<info name="alt_title" value="ラグナキュール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47935,8 +47935,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lake Masters Pro - Nihon Juudan Kuro Masu Kikou (Japan)</description>
 		<year>1999</year>
 		<publisher>DaZZ</publisher>
-		<info name="serial" value="SLPS-02177 (PS-0012)" />
-		<info name="release" value="19990914" />
+		<info name="serial" value="SLPS-02177 (PS-0012)"/>
+		<info name="release" value="19990914"/>
 		<info name="alt_title" value="レイクマスターズPRO 日本全国縦断黒鱒紀行"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47956,8 +47956,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Langrisser I &amp; II (Japan)</description>
 		<year>1997</year>
 		<publisher>Masaya</publisher>
-		<info name="serial" value="SLPS-00897" />
-		<info name="release" value="19970731" />
+		<info name="serial" value="SLPS-00897"/>
+		<info name="release" value="19970731"/>
 		<info name="alt_title" value="ラングリッサーI&amp;II"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47985,8 +47985,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Langrisser IV &amp; V Final Edition (Japan)</description>
 		<year>1999</year>
 		<publisher>Masaya</publisher>
-		<info name="serial" value="SLPS-01818~SLPS-01819" />
-		<info name="release" value="19990128" />
+		<info name="serial" value="SLPS-01818~SLPS-01819"/>
+		<info name="release" value="19990128"/>
 		<info name="alt_title" value="ラングリッサーIV&amp;V ファイナル・エディション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -48011,8 +48011,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Libero Grande 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-02950" />
-		<info name="release" value="20000907" />
+		<info name="serial" value="SLPS-02950"/>
+		<info name="release" value="20000907"/>
 		<info name="alt_title" value="リベログランデ2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48041,8 +48041,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Legend of Dragoon (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10119~SCPS-10122" />
-		<info name="release" value="19991202" />
+		<info name="serial" value="SCPS-10119~SCPS-10122"/>
+		<info name="release" value="19991202"/>
 		<info name="alt_title" value="レジェンド オブ ドラグーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -48077,8 +48077,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lode Runner 2 (Japan, SuperLite 1500 Series)</description>
 		<year>2000</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86460" />
-		<info name="release" value="20000330" />
+		<info name="serial" value="SLPM-86460"/>
+		<info name="release" value="20000330"/>
 		<info name="alt_title" value="SuperLite1500シリーズ ロードランナー2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48098,8 +48098,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lode Runner Extra (Japan)</description>
 		<year>1997</year>
 		<publisher>Patra</publisher>
-		<info name="serial" value="SLPS-00641" />
-		<info name="release" value="19970110" />
+		<info name="serial" value="SLPS-00641"/>
+		<info name="release" value="19970110"/>
 		<info name="alt_title" value="ロードランナー・エクストラ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48122,8 +48122,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Little Princess +1 - Marl Oukoku no Ningyou Hime 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Nippon Ichi Software</publisher>
-		<info name="serial" value="SLPS-03012~SLPS-03013" />
-		<info name="release" value="20001026" />
+		<info name="serial" value="SLPS-03012~SLPS-03013"/>
+		<info name="release" value="20001026"/>
 		<info name="alt_title" value="リトルプリンセス＋1 マール王国の人形姫"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -48148,8 +48148,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Little Princess - Marl Oukoku no Ningyou Hime 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Nippon Ichi Software</publisher>
-		<info name="serial" value="SLPS-02376" />
-		<info name="release" value="19991125" />
+		<info name="serial" value="SLPS-02376"/>
+		<info name="release" value="19991125"/>
 		<info name="alt_title" value="リトルプリンセス マール王国の人形姫2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48169,8 +48169,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Linda³ Again (Japan)</description>
 		<year>1997</year>
 		<publisher>Sony</publisher>
-		<info name="serial" value="SCPS-10039" />
-		<info name="release" value="19970925" />
+		<info name="serial" value="SCPS-10039"/>
+		<info name="release" value="19970925"/>
 		<info name="alt_title" value="リンダキューブ アゲイン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48190,8 +48190,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ling Rise (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
-		<info name="serial" value="SLPS-01769" />
-		<info name="release" value="19991125" />
+		<info name="serial" value="SLPS-01769"/>
+		<info name="release" value="19991125"/>
 		<info name="alt_title" value="リングライズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48211,8 +48211,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lone Soldier (Japan)</description>
 		<year>1996</year>
 		<publisher>Virgin Interactive Entertainment</publisher>
-		<info name="serial" value="SLPS-00322" />
-		<info name="release" value="19961004" />
+		<info name="serial" value="SLPS-00322"/>
+		<info name="release" value="19961004"/>
 		<info name="alt_title" value="ローンソルジャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48232,8 +48232,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lord of Fist (Japan)</description>
 		<year>1999</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-02168" />
-		<info name="release" value="19990826" />
+		<info name="serial" value="SLPS-02168"/>
+		<info name="release" value="19990826"/>
 		<info name="alt_title" value="ロード・オブ・フィスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48253,8 +48253,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Love &amp; Destroy (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10124" />
-		<info name="release" value="19991216" />
+		<info name="serial" value="SCPS-10124"/>
+		<info name="release" value="19991216"/>
 		<info name="alt_title" value="ラブアンドデストロイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48288,8 +48288,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Love Love Truck (Japan)</description>
 		<year>1999</year>
 		<publisher>TYO</publisher>
-		<info name="serial" value="SLPS-02112" />
-		<info name="release" value="19990624" />
+		<info name="serial" value="SLPS-02112"/>
+		<info name="release" value="19990624"/>
 		<info name="alt_title" value="ラブラブトロッコ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48309,8 +48309,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>LSD - Dream Emulator (Japan, Limited Edition)</description>
 		<year>1998</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-01556" />
-		<info name="release" value="19981022" />
+		<info name="serial" value="SLPS-01556"/>
+		<info name="release" value="19981022"/>
 		<info name="alt_title" value="LSD 初回生産"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48336,8 +48336,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lucifer Ring (Japan)</description>
 		<year>1998</year>
 		<publisher>Toshiba EMI</publisher>
-		<info name="serial" value="SLPS-01784" />
-		<info name="release" value="19981223" />
+		<info name="serial" value="SLPS-01784"/>
+		<info name="release" value="19981223"/>
 		<info name="alt_title" value="ルシファー・リング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48363,8 +48363,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lunar 2 - Eternal Blue (Japan)</description>
 		<year>1999</year>
 		<publisher>Kadokawa Shoten</publisher>
-		<info name="serial" value="SLPS-02081~SLPS-02083" />
-		<info name="release" value="19990527" />
+		<info name="serial" value="SLPS-02081~SLPS-02083"/>
+		<info name="release" value="19990527"/>
 		<info name="alt_title" value="ルナ2 エターナルブルー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -48394,8 +48394,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lunar Wing - Toki o Koeta Seisen (Japan)</description>
 		<year>2001</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPM-86777" />
-		<info name="release" value="20010712" />
+		<info name="serial" value="SLPM-86777"/>
+		<info name="release" value="20010712"/>
 		<info name="alt_title" value="ルナ・ウイング 〜時を越えた聖戦〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48416,8 +48416,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lunatic Dawn III (Japan)</description>
 		<year>1998</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-01749" />
-		<info name="release" value="19981217" />
+		<info name="serial" value="SLPS-01749"/>
+		<info name="release" value="19981217"/>
 		<info name="alt_title" value="ルナティックドーンIII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48438,8 +48438,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lunatic Dawn Odyssey (Japan)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-02420" />
-		<info name="release" value="19991202" />
+		<info name="serial" value="SLPS-02420"/>
+		<info name="release" value="19991202"/>
 		<info name="alt_title" value="ルナティックドーン オデッセイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48459,8 +48459,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lup Salad - Lupupu Cube (Japan)</description>
 		<year>1996</year>
 		<publisher>Datam Polystar</publisher>
-		<info name="serial" value="SLPS-00416" />
-		<info name="release" value="19960830" />
+		<info name="serial" value="SLPS-00416"/>
+		<info name="release" value="19960830"/>
 		<info name="alt_title" value="ルプ☆さらだ るぷぷキューブ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48480,7 +48480,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chou Jikuu Yousai Macross - Ai Oboete Imasu ka (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<part name="cdrom" interface="psx_cdrom">
+		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
 				<disk name="chou jikuu yousai macross - ai oboete imasu ka (japan) (disc 1)" sha1="f231291ee425f4e6044f2711bb97d2357972d630"/>
 			</diskarea>
@@ -48559,8 +48559,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mad Panic Coaster (Japan)</description>
 		<year>1997</year>
 		<publisher>Hakuhodo</publisher>
-		<info name="serial" value="SLPS-00880" />
-		<info name="release" value="19971120" />
+		<info name="serial" value="SLPS-00880"/>
+		<info name="release" value="19971120"/>
 		<info name="alt_title" value="マッドパニックコースター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48591,8 +48591,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mad Stalker - Full Metal Force (Japan)</description>
 		<year>1997</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-00734" />
-		<info name="release" value="19970703" />
+		<info name="serial" value="SLPS-00734"/>
+		<info name="release" value="19970703"/>
 		<info name="alt_title" value="マッドストーカー フルメタルフォース"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48612,8 +48612,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Magical Drop F - Daibouken mo Rakujanai! (Japan)</description>
 		<year>1999</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-02337" />
-		<info name="release" value="19991021" />
+		<info name="serial" value="SLPS-02337"/>
+		<info name="release" value="19991021"/>
 		<info name="alt_title" value="マジカルドロップF"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48633,8 +48633,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Magical Medical (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86099 (VX081-J1)" />
-		<info name="release" value="19980910" />
+		<info name="serial" value="SLPM-86099 (VX081-J1)"/>
+		<info name="release" value="19980910"/>
 		<info name="alt_title" value="まじかるめでぃかる"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48654,8 +48654,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mahoutsukai ni Naru Houhou (Japan)</description>
 		<year>1999</year>
 		<publisher>TGL</publisher>
-		<info name="serial" value="SLPS-01754" />
-		<info name="release" value="19990218" />
+		<info name="serial" value="SLPS-01754"/>
+		<info name="release" value="19990218"/>
 		<info name="alt_title" value="魔法使いになる方法"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48675,8 +48675,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Majokko Daisakusen - Little Witching Mischiefs (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01850" />
-		<info name="release" value="19990204" />
+		<info name="serial" value="SLPS-01850"/>
+		<info name="release" value="19990204"/>
 		<info name="alt_title" value="魔女っ子 大作戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48725,8 +48725,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Makeruna! Makendo 2 (Japan)</description>
 		<year>1995</year>
 		<publisher>Datam Polystar</publisher>
-		<info name="serial" value="SLPS-00128" />
-		<info name="release" value="19951110" />
+		<info name="serial" value="SLPS-00128"/>
+		<info name="release" value="19951110"/>
 		<info name="alt_title" value="負けるな！魔剣道2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48746,8 +48746,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rikujou Boueitai Mao-chan (Japan, Deluxe Pack)</description>
 		<year>2003</year>
 		<publisher>Marvelous</publisher>
-		<info name="serial" value="SLPM-87198" />
-		<info name="release" value="20030123" />
+		<info name="serial" value="SLPM-87198"/>
+		<info name="release" value="20030123"/>
 		<info name="alt_title" value="陸上防衛隊まおちゃん DXパック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48767,8 +48767,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marionette Company (Japan)</description>
 		<year>1999</year>
 		<publisher>Micro Cabin</publisher>
-		<info name="serial" value="SLPS-02058" />
-		<info name="release" value="19990520" />
+		<info name="serial" value="SLPS-02058"/>
+		<info name="release" value="19990520"/>
 		<info name="alt_title" value="マリオネット カンパニー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48788,8 +48788,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marionette Company 2 Chu! (Japan)</description>
 		<year>2000</year>
 		<publisher>Micro Cabin</publisher>
-		<info name="serial" value="SLPS-02743" />
-		<info name="release" value="20000518" />
+		<info name="serial" value="SLPS-02743"/>
+		<info name="release" value="20000518"/>
 		<info name="alt_title" value="マリオネットカンパニー2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48809,8 +48809,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marl Jong!! (Japan, Limited Edition)</description>
 		<year>2003</year>
 		<publisher>Nippon Ichi Software</publisher>
-		<info name="serial" value="SLPS-03537" />
-		<info name="release" value="20030424" />
+		<info name="serial" value="SLPS-03537"/>
+		<info name="release" value="20030424"/>
 		<info name="alt_title" value="マールじゃん!! (限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48830,8 +48830,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Master's Fighter (Japan)</description>
 		<year>1997</year>
 		<publisher>Cinema Supply</publisher>
-		<info name="serial" value="SLPS-00722" />
-		<info name="release" value="19971120" />
+		<info name="serial" value="SLPS-00722"/>
+		<info name="release" value="19971120"/>
 		<info name="alt_title" value="ザ・マスターズファイター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48851,8 +48851,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Masumon Kids - The Another World of The Master of Monsters (Japan)</description>
 		<year>1998</year>
 		<publisher>Toshiba EMI</publisher>
-		<info name="serial" value="SLPS-01426" />
-		<info name="release" value="19980625" />
+		<info name="serial" value="SLPS-01426"/>
+		<info name="release" value="19980625"/>
 		<info name="alt_title" value="マスモンKIDS 〜The Another World Of The Master Of Monsters〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48872,8 +48872,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>MaxRacer (Japan)</description>
 		<year>1997</year>
 		<publisher>PD</publisher>
-		<info name="serial" value="SLPS-00795" />
-		<info name="release" value="19970418" />
+		<info name="serial" value="SLPS-00795"/>
+		<info name="release" value="19970418"/>
 		<info name="alt_title" value="マックスレーサー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48893,8 +48893,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Maze Heroes - Meikyuu Densetsu (Japan)</description>
 		<year>2002</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03490" />
-		<info name="release" value="20021128" />
+		<info name="serial" value="SLPS-03490"/>
+		<info name="release" value="20021128"/>
 		<info name="alt_title" value="メイズヒーローズ 〜迷宮伝説〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48914,8 +48914,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Meitantei Conan - Saikou no Aibou (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03425" />
-		<info name="release" value="20020425" />
+		<info name="serial" value="SLPS-03425"/>
+		<info name="release" value="20020425"/>
 		<info name="alt_title" value="名探偵コナン 最高の相棒"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48935,8 +48935,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Meitantei Conan - Trick Trick Vol.1 (Japan)</description>
 		<year>2003</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03548" />
-		<info name="release" value="20030417" />
+		<info name="serial" value="SLPS-03548"/>
+		<info name="release" value="20030417"/>
 		<info name="alt_title" value="名探偵コナン トリックトリック Vol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48959,8 +48959,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Medarot R - Parts Collection (Japan)</description>
 		<year>2000</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-02635" />
-		<info name="release" value="20000316" />
+		<info name="serial" value="SLPS-02635"/>
+		<info name="release" value="20000316"/>
 		<info name="alt_title" value="メダロットR・パーツコレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48984,8 +48984,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Medarot R (Japan)</description>
 		<year>1999</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-02414" />
-		<info name="release" value="19991125" />
+		<info name="serial" value="SLPS-02414"/>
+		<info name="release" value="19991125"/>
 		<info name="alt_title" value="メダロットR"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49005,8 +49005,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shinseiden Megaseed Fukkatsu-Hen (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00925" />
-		<info name="release" value="19970731" />
+		<info name="serial" value="SLPS-00925"/>
+		<info name="release" value="19970731"/>
 		<info name="alt_title" value="神聖伝メガシード 復活編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49026,8 +49026,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Megatudo 2096 (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00435" />
-		<info name="release" value="19961018" />
+		<info name="serial" value="SLPS-00435"/>
+		<info name="release" value="19961018"/>
 		<info name="alt_title" value="メガチュード2096"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49047,8 +49047,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ikuzawa Touru Kanshuu - Meisha Retsuden - Greatest 70's (Japan)</description>
 		<year>1997</year>
 		<publisher>Epoch</publisher>
-		<info name="serial" value="SLPS-01153" />
-		<info name="release" value="19971218" />
+		<info name="serial" value="SLPS-01153"/>
+		<info name="release" value="19971218"/>
 		<info name="alt_title" value="生沢 徹 監修 名車列伝 グレイテスト70's"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49071,8 +49071,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>MeltyLancer - The 3rd Planet (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86231~SLPM-86232 (VX126-J1)" />
-		<info name="release" value="19990617" />
+		<info name="serial" value="SLPM-86231~SLPM-86232 (VX126-J1)"/>
+		<info name="release" value="19990617"/>
 		<info name="alt_title" value="メルティランサーThe 3rd Planet"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -49097,8 +49097,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Menkyo o Torou (Japan)</description>
 		<year>2000</year>
 		<publisher>Twilight Express</publisher>
-		<info name="serial" value="SLPS-02685" />
-		<info name="release" value="20000525" />
+		<info name="serial" value="SLPS-02685"/>
+		<info name="release" value="20000525"/>
 		<info name="alt_title" value="免許をとろう"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49118,8 +49118,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Meremanoid (Japan)</description>
 		<year>1999</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-01664" />
-		<info name="release" value="19990805" />
+		<info name="serial" value="SLPS-01664"/>
+		<info name="release" value="19990805"/>
 		<info name="alt_title" value="マーメノイド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49145,8 +49145,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mermaid no Kisetsu - The Season of Mermaid (Japan)</description>
 		<year>2001</year>
 		<publisher>GameVillage</publisher>
-		<info name="serial" value="SLPM-86934~SLPM-86936" />
-		<info name="release" value="20011213" />
+		<info name="serial" value="SLPM-86934~SLPM-86936"/>
+		<info name="release" value="20011213"/>
 		<info name="alt_title" value="マーメイドの季節"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -49179,8 +49179,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Metal Angel 3 (Japan)</description>
 		<year>1997</year>
 		<publisher>Pack-in-Soft</publisher>
-		<info name="serial" value="SLPS-00867~SLPS-00868" />
-		<info name="release" value="19970613" />
+		<info name="serial" value="SLPS-00867~SLPS-00868"/>
+		<info name="release" value="19970613"/>
 		<info name="alt_title" value="メタルエンジェル3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -49205,8 +49205,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Metal Fist (Japan)</description>
 		<year>1998</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="SLPS-01164" />
-		<info name="release" value="19980115" />
+		<info name="serial" value="SLPS-01164"/>
+		<info name="release" value="19980115"/>
 		<info name="alt_title" value="メタルフィスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49226,8 +49226,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Himitsu Sentai Metamor V Deluxe (Japan, disc 1 only)</description>
 		<year>1998</year>
 		<publisher>Mycom</publisher>
-		<info name="serial" value="SLPS-01626" />
-		<info name="release" value="19981015" />
+		<info name="serial" value="SLPS-01626"/>
+		<info name="release" value="19981015"/>
 		<info name="alt_title" value="ひみつ戦隊メタモルVデラックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -49255,8 +49255,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Meta-Ph-List μ.χ.2297 (Japan)</description>
 		<year>1997</year>
 		<publisher>A.D.M</publisher>
-		<info name="serial" value="SLPS-00680~SLPS-00681" />
-		<info name="release" value="19970131" />
+		<info name="serial" value="SLPS-00680~SLPS-00681"/>
+		<info name="release" value="19970131"/>
 		<info name="alt_title" value="メタフリスト mu.chi.2297"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -49281,8 +49281,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mezase! Senkyuuou (Japan)</description>
 		<year>1996</year>
 		<publisher>Seibu Kaihatsu</publisher>
-		<info name="serial" value="SLPS-00313" />
-		<info name="release" value="19960419" />
+		<info name="serial" value="SLPS-00313"/>
+		<info name="release" value="19960419"/>
 		<info name="alt_title" value="めざせ！戦球王"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49302,8 +49302,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Monster Farm - Battle Card Professional (Japan)</description>
 		<year>2000</year>
 		<publisher>Tecmo</publisher>
-		<info name="serial" value="SLPS-02653" />
-		<info name="release" value="20000323" />
+		<info name="serial" value="SLPS-02653"/>
+		<info name="release" value="20000323"/>
 		<info name="alt_title" value="モンスターファーム バトルカード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49323,8 +49323,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Michinoku Hitou Koi Monogatari - Bishoujo Hanafuda Kikou (Japan)</description>
 		<year>1997</year>
 		<publisher>FOG</publisher>
-		<info name="serial" value="SLPS-00941" />
-		<info name="release" value="19970807" />
+		<info name="serial" value="SLPS-00941"/>
+		<info name="release" value="19970807"/>
 		<info name="alt_title" value="みちのく秘湯恋物語 美少女花札紀行"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49344,8 +49344,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Michinoku Hitou Koi Monogatari Kai (Japan)</description>
 		<year>1999</year>
 		<publisher>FOG</publisher>
-		<info name="serial" value="SLPS-02502" />
-		<info name="release" value="19991222" />
+		<info name="serial" value="SLPS-02502"/>
+		<info name="release" value="19991222"/>
 		<info name="alt_title" value="みちのく秘湯恋物語 kai"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49375,8 +49375,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Money Idol Exchanger (Japan)</description>
 		<year>1998</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-00963" />
-		<info name="release" value="19981105" />
+		<info name="serial" value="SLPS-00963"/>
+		<info name="release" value="19981105"/>
 		<info name="alt_title" value="マネーアイドル・エクスチェンジャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49396,8 +49396,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mini Moni. - Step Pyon Pyon Pyon (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87195 (VX272-J1)" />
-		<info name="release" value="20021212" />
+		<info name="serial" value="SLPM-87195 (VX272-J1)"/>
+		<info name="release" value="20021212"/>
 		<info name="alt_title" value="ミニモニ。ステップぴょんぴょんぴょん♪"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49417,8 +49417,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mini Moni. Shaker &amp; Tambourine! Dapyon! (Japan)</description>
 		<year>2002</year>
 		<publisher>Sega</publisher>
-		<info name="serial" value="SLPM-87132" />
-		<info name="release" value="20020919" />
+		<info name="serial" value="SLPM-87132"/>
+		<info name="release" value="20020919"/>
 		<info name="alt_title" value="ミニモニ。シャカっとタンバリン！だぴょん！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49438,8 +49438,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mini-Yonku Bakusou Kyoudai Let's &amp; Go!! - WGP Hyper Heat (Japan)</description>
 		<year>1997</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-01078" />
-		<info name="release" value="19971120" />
+		<info name="serial" value="SLPS-01078"/>
+		<info name="release" value="19971120"/>
 		<info name="alt_title" value="ミニ四駆 爆走兄弟 レッツ＆ゴー！！WGPハイパーヒート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49459,8 +49459,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Misaki Aggressive! (Japan)</description>
 		<year>1998</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-01474" />
-		<info name="release" value="19980723" />
+		<info name="serial" value="SLPS-01474"/>
+		<info name="release" value="19980723"/>
 		<info name="alt_title" value="みさきアグレッシヴ!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49480,8 +49480,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rock Climbing - Mitouhou e no Chousen - Alps-Hen (Japan)</description>
 		<year>1997</year>
 		<publisher>WENet</publisher>
-		<info name="serial" value="SLPS-00662 (WG0004)" />
-		<info name="release" value="19970724" />
+		<info name="serial" value="SLPS-00662 (WG0004)"/>
+		<info name="release" value="19970724"/>
 		<info name="alt_title" value="ロッククライミング 未踏峰への挑戦 アルプス編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49501,8 +49501,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mizzurna Falls (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01783" />
-		<info name="release" value="19981223" />
+		<info name="serial" value="SLPS-01783"/>
+		<info name="release" value="19981223"/>
 		<info name="alt_title" value="ミザーナフォールズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49522,8 +49522,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pro Mahjong Kiwame Plus (Japan)</description>
 		<year>1996</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-00402" />
-		<info name="release" value="19960830" />
+		<info name="serial" value="SLPS-00402"/>
+		<info name="release" value="19960830"/>
 		<info name="alt_title" value="プロ麻雀 極 プラス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49543,8 +49543,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pro Mahjong Kiwame Tengensenhen (Japan)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-02347" />
-		<info name="release" value="19991028" />
+		<info name="serial" value="SLPS-02347"/>
+		<info name="release" value="19991028"/>
 		<info name="alt_title" value="プロ麻雀 極 天元戦編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49564,8 +49564,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mahjong Yarouze! (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86173 (VX088-J1)" />
-		<info name="release" value="19990428" />
+		<info name="serial" value="SLPM-86173 (VX088-J1)"/>
+		<info name="release" value="19990428"/>
 		<info name="alt_title" value="麻雀やろうぜ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49585,8 +49585,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kosodate Quiz Motto My Angel (Japan)</description>
 		<year>1999</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-01885" />
-		<info name="release" value="19990325" />
+		<info name="serial" value="SLPS-01885"/>
+		<info name="release" value="19990325"/>
 		<info name="alt_title" value="子育てクイズ もっとマイエンジェル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49606,8 +49606,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Momotarou Densetsu (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01785" />
-		<info name="release" value="19981223" />
+		<info name="serial" value="SLPS-01785"/>
+		<info name="release" value="19981223"/>
 		<info name="alt_title" value="桃太郎伝説"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49627,8 +49627,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Momotarou Matsuri (Japan)</description>
 		<year>2001</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPM-86888" />
-		<info name="release" value="20010913" />
+		<info name="serial" value="SLPM-86888"/>
+		<info name="release" value="20010913"/>
 		<info name="alt_title" value="桃太郎まつり 石川六右衛門の巻"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49648,8 +49648,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Monster Collection - Kamen no Madoushi (Japan)</description>
 		<year>1999</year>
 		<publisher>Kadokawa Shoten</publisher>
-		<info name="serial" value="SLPS-02245" />
-		<info name="release" value="19991028" />
+		<info name="serial" value="SLPS-02245"/>
+		<info name="release" value="19991028"/>
 		<info name="alt_title" value="モンスター・コレクション 仮面の魔道士"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49669,8 +49669,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hole of the Legend Monster - Densetsu Kemono no Ana - Monster Complete World Ver.2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Idea Factory</publisher>
-		<info name="serial" value="SLPS-02297" />
-		<info name="release" value="19991028" />
+		<info name="serial" value="SLPS-02297"/>
+		<info name="release" value="19991028"/>
 		<info name="alt_title" value="伝説獣の穴 モンスターコンプリワールドVer.2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49690,8 +49690,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mouri Motonari - Chikai no Sanshi (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01285" />
-		<info name="release" value="19980226" />
+		<info name="serial" value="SLPS-01285"/>
+		<info name="release" value="19980226"/>
 		<info name="alt_title" value="毛利元就 誓いの三矢"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49711,8 +49711,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mori no Oukoku - Kingdom of Forest (Japan)</description>
 		<year>1999</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-01861" />
-		<info name="release" value="19991021" />
+		<info name="serial" value="SLPS-01861"/>
+		<info name="release" value="19991021"/>
 		<info name="alt_title" value="森の王国"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49732,8 +49732,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mr. Driller G (Japan)</description>
 		<year>2001</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-03336" />
-		<info name="release" value="20011122" />
+		<info name="serial" value="SLPS-03336"/>
+		<info name="release" value="20011122"/>
 		<info name="alt_title" value="ミスタードリラーグレート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49753,8 +49753,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marvel Super Heroes (Japan)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00763" />
-		<info name="release" value="19970925" />
+		<info name="serial" value="SLPS-00763"/>
+		<info name="release" value="19970925"/>
 		<info name="alt_title" value="マーヴル・スーパーヒーローズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49774,8 +49774,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marvel Super Heroes vs. Street Fighter - EX Edition (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01915" />
-		<info name="release" value="19990225" />
+		<info name="serial" value="SLPS-01915"/>
+		<info name="release" value="19990225"/>
 		<info name="alt_title" value="マーヴルスーパーヒーローズVSストリートファイター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49795,8 +49795,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Maestro Music (Japan, with Baton Stick)</description>
 		<year>2000</year>
 		<publisher>Global A</publisher>
-		<info name="serial" value="SLPM-86585" />
-		<info name="release" value="20000727" />
+		<info name="serial" value="SLPM-86585"/>
+		<info name="release" value="20000727"/>
 		<info name="alt_title" value="ザ・マエストロムジーク (バトンコントローラ同梱版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49816,8 +49816,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Maestro Music - Merry Christmas - Append Disc (Japan)</description>
 		<year>2000</year>
 		<publisher>Global A</publisher>
-		<info name="serial" value="SLPM-86684" />
-		<info name="release" value="20001207" />
+		<info name="serial" value="SLPM-86684"/>
+		<info name="release" value="20001207"/>
 		<info name="alt_title" value="ザ マエストロムジーク・メリークリスマス・アペンド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49837,8 +49837,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Konami Antiques - MSX Collection Vol.1 (Japan)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86052 (VX120-J1)" />
-		<info name="release" value="19971120" />
+		<info name="serial" value="SLPM-86052 (VX120-J1)"/>
+		<info name="release" value="19971120"/>
 		<info name="alt_title" value="コナミアンティークス MSXコレクション Vol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49858,8 +49858,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Konami Antiques - MSX Collection Vol.2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86062 (VX121-J1)" />
-		<info name="release" value="19980122" />
+		<info name="serial" value="SLPM-86062 (VX121-J1)"/>
+		<info name="release" value="19980122"/>
 		<info name="alt_title" value="コナミアンティークス MSXコレクション Vol.2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49879,8 +49879,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Magical Tetris Challenge featuring Mickey Mouse (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01786" />
-		<info name="release" value="19990318" />
+		<info name="serial" value="SLPS-01786"/>
+		<info name="release" value="19990318"/>
 		<info name="alt_title" value="マジカルテトリスチャレンジ フューチャリング ミッキー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49900,8 +49900,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yagami Hiroki no Game-Taste - Munasawagi no Yokan (Japan)</description>
 		<year>1999</year>
 		<publisher>Kodansha</publisher>
-		<info name="serial" value="SLPS-02064" />
-		<info name="release" value="19990520" />
+		<info name="serial" value="SLPS-02064"/>
+		<info name="release" value="19990520"/>
 		<info name="alt_title" value="胸騒ぎの予感　八神ひろきのGame-Taste"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49921,8 +49921,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marvel vs. Capcom - Clash of Super Heroes - EX Edition (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-02368" />
-		<info name="release" value="19991111" />
+		<info name="serial" value="SLPS-02368"/>
+		<info name="release" value="19991111"/>
 		<info name="alt_title" value="マーヴル VS. カプコン クラッシュオブスーパーヒーローズEXエディション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49942,8 +49942,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>My Home Dream 2 - Niwatsuki Ikkodate De, Ikou! (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor</publisher>
-		<info name="serial" value="SLPS-02470" />
-		<info name="release" value="19991202" />
+		<info name="serial" value="SLPS-02470"/>
+		<info name="release" value="19991202"/>
 		<info name="alt_title" value="マイホームドリーム2 庭つき一戸建てで、いこう！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49963,8 +49963,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mystic Ark - Maboroshi Gekijou (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86147" />
-		<info name="release" value="19990318" />
+		<info name="serial" value="SLPM-86147"/>
+		<info name="release" value="19990318"/>
 		<info name="alt_title" value="ミスティックアーク　まぼろし劇場"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49984,8 +49984,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Mystic Dragoons (Japan)</description>
 		<year>1999</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-02103" />
-		<info name="release" value="19990617" />
+		<info name="serial" value="SLPS-02103"/>
+		<info name="release" value="19990617"/>
 		<info name="alt_title" value="ミスティック・ドラグーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50005,8 +50005,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nage Libre - Rasen No Soukoku (Japan)</description>
 		<year>1997</year>
 		<publisher>Varie</publisher>
-		<info name="serial" value="SLPS-00692" />
-		<info name="release" value="19970228" />
+		<info name="serial" value="SLPS-00692"/>
+		<info name="release" value="19970228"/>
 		<info name="alt_title" value="ナージュ・リーブル 螺旋の相剋"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50026,8 +50026,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Najavu no Daibouken - My Favorite Namjatown (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPM-86601" />
-		<info name="release" value="20001013" />
+		<info name="serial" value="SLPM-86601"/>
+		<info name="release" value="20001013"/>
 		<info name="usage" value="Requires 15 free blocks on memory card to start (PocketStation)"/>
 		<info name="alt_title" value="ナジャブの大冒険 マイ・フェイバリット・ナンジャタウン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -50054,8 +50054,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nanatsu no Hikan (Japan)</description>
 		<year>1996</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00410~SLPS-00412" />
-		<info name="release" value="19960809" />
+		<info name="serial" value="SLPS-00410~SLPS-00412"/>
+		<info name="release" value="19960809"/>
 		<info name="alt_title" value="七つの秘館"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50085,8 +50085,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Naniwa no Akindo - Futte Nanbo no Saikoro Jinsei (Japan)</description>
 		<year>1997</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-00768" />
-		<info name="release" value="19970328" />
+		<info name="serial" value="SLPS-00768"/>
+		<info name="release" value="19970328"/>
 		<info name="alt_title" value="浪速の商人〜振ってナンボのサイコロ人生〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50106,8 +50106,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nankuro (Japan, SuperLite 1500 Series)</description>
 		<year>1999</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPS-02067" />
-		<info name="release" value="19990527" />
+		<info name="serial" value="SLPS-02067"/>
+		<info name="release" value="19990527"/>
 		<info name="alt_title" value="スーパーライト1500シリーズ ナンクロ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50127,8 +50127,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Natsuiro Kenjutsu Komachi (Japan, Limited Edition, disc 1 only)</description>
 		<year>2000</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-02665 (NIPS-4005)" />
-		<info name="release" value="20000316" />
+		<info name="serial" value="SLPS-02665 (NIPS-4005)"/>
+		<info name="release" value="20000316"/>
 		<info name="alt_title" value="夏色剣術小町 (初回限定生産版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50187,8 +50187,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Navit (Japan)</description>
 		<year>1998</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-01530" />
-		<info name="release" value="19980903" />
+		<info name="serial" value="SLPS-01530"/>
+		<info name="release" value="19980903"/>
 		<info name="alt_title" value="ナビット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50226,8 +50226,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arthur to Astaroth no Nazo Maikamura - Incredible Toons (Japan)</description>
 		<year>1996</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00363" />
-		<info name="release" value="19960830" />
+		<info name="serial" value="SLPS-00363"/>
+		<info name="release" value="19960830"/>
 		<info name="alt_title" value="アーサーとアスタロトの謎魔界村"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50247,8 +50247,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>NBA Power Dunkers 4 (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86176 (VX087-J1)" />
-		<info name="release" value="19990603" />
+		<info name="serial" value="SLPM-86176 (VX087-J1)"/>
+		<info name="release" value="19990603"/>
 		<info name="alt_title" value="NBAパワーダンカーズ4"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50268,8 +50268,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nemuru Mayu - Sleeping Cocoon (Japan)</description>
 		<year>2000</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-02597" />
-		<info name="release" value="20000323" />
+		<info name="serial" value="SLPS-02597"/>
+		<info name="release" value="20000323"/>
 		<info name="alt_title" value="眠ル繭"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50292,8 +50292,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Neorude (Japan)</description>
 		<year>1997</year>
 		<publisher>TechnoSoft</publisher>
-		<info name="serial" value="SLPS-00823~SLPS-00824" />
-		<info name="release" value="19970509" />
+		<info name="serial" value="SLPS-00823~SLPS-00824"/>
+		<info name="release" value="19970509"/>
 		<info name="alt_title" value="ネオリュード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50318,8 +50318,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Neorude 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>TechnoSoft</publisher>
-		<info name="serial" value="SLPS-01112" />
-		<info name="release" value="19971120" />
+		<info name="serial" value="SLPS-01112"/>
+		<info name="release" value="19971120"/>
 		<info name="alt_title" value="ネオリュード2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50339,8 +50339,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Next King - Koi no Sennen Oukoku (Japan)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00859" />
-		<info name="release" value="19970627" />
+		<info name="serial" value="SLPS-00859"/>
+		<info name="release" value="19970627"/>
 		<info name="alt_title" value="ネクストキング 恋の千年王国"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50360,8 +50360,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nichibutsu Arcade Classics (Japan)</description>
 		<year>1995</year>
 		<publisher>Nichibutsu</publisher>
-		<info name="serial" value="SLPS-00184" />
-		<info name="release" value="19951229" />
+		<info name="serial" value="SLPS-00184"/>
+		<info name="release" value="19951229"/>
 		<info name="alt_title" value="ニチブツアーケードクラシックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50381,8 +50381,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Night Raid (Japan)</description>
 		<year>2002</year>
 		<publisher>Takumi</publisher>
-		<info name="serial" value="SLPM-87048" />
-		<info name="release" value="20021010" />
+		<info name="serial" value="SLPM-87048"/>
+		<info name="release" value="20021010"/>
 		<info name="alt_title" value="ナイトレイド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50402,8 +50402,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nijiiro Dodgeball - Otometachi no Seishun (Japan)</description>
 		<year>2002</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPM-87039" />
-		<info name="release" value="20021212" />
+		<info name="serial" value="SLPM-87039"/>
+		<info name="release" value="20021212"/>
 		<info name="alt_title" value="虹色ドッジボール 乙女たちの青春"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50423,8 +50423,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ningyo no Rakuin (Japan)</description>
 		<year>2000</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-02854 (NIPS-4010)" />
-		<info name="release" value="20000803" />
+		<info name="serial" value="SLPS-02854 (NIPS-4010)"/>
+		<info name="release" value="20000803"/>
 		<info name="alt_title" value="人魚の烙印"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50444,8 +50444,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ninja Jajamaru-kun - Onigiri Ninpouchou (Japan)</description>
 		<year>1997</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-00494" />
-		<info name="release" value="19970221" />
+		<info name="serial" value="SLPS-00494"/>
+		<info name="release" value="19970221"/>
 		<info name="alt_title" value="忍者じゃじゃ丸くん 鬼斬忍法帖"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50465,8 +50465,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ninku (Japan)</description>
 		<year>1995</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-00172" />
-		<info name="release" value="19951222" />
+		<info name="serial" value="SLPS-00172"/>
+		<info name="release" value="19951222"/>
 		<info name="alt_title" value="NINKU－忍空－"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50486,8 +50486,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nobunaga no Yabou - Retsuupuden (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86300" />
-		<info name="release" value="19990909" />
+		<info name="serial" value="SLPM-86300"/>
+		<info name="release" value="19990909"/>
 		<info name="alt_title" value="信長の野望 烈風伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50513,8 +50513,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>NOëL 3 - Mission on the Line (Japan)</description>
 		<year>1999</year>
 		<publisher>Pioneer LDC</publisher>
-		<info name="serial" value="SLPS-01895~SLPS-01897" />
-		<info name="release" value="19990311" />
+		<info name="serial" value="SLPS-01895~SLPS-01897"/>
+		<info name="release" value="19990311"/>
 		<info name="alt_title" value="ノエル3 ミッション オン ザ ライン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50544,8 +50544,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Not Treasure Hunter (Japan)</description>
 		<year>1996</year>
 		<publisher>Acti-Art</publisher>
-		<info name="serial" value="SLPS-00274" />
-		<info name="release" value="19961220" />
+		<info name="serial" value="SLPS-00274"/>
+		<info name="release" value="19961220"/>
 		<info name="alt_title" value="ノット トレジャー ハンター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50568,8 +50568,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Novastorm (Japan)</description>
 		<year>1996</year>
 		<publisher>Victor Entertainment</publisher>
-		<info name="serial" value="SLPS-00314~SLPS-00315" />
-		<info name="release" value="19960301" />
+		<info name="serial" value="SLPS-00314~SLPS-00315"/>
+		<info name="release" value="19960301"/>
 		<info name="alt_title" value="ノバストーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50594,8 +50594,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Next Tetris (Japan)</description>
 		<year>1999</year>
 		<publisher>Bullet Proof</publisher>
-		<info name="serial" value="SLPS-01774" />
-		<info name="release" value="19990107" />
+		<info name="serial" value="SLPS-01774"/>
+		<info name="release" value="19990107"/>
 		<info name="alt_title" value="THE NEXT TETRIS"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50615,8 +50615,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Next Tetris - Deluxe DLX (Japan)</description>
 		<year>1999</year>
 		<publisher>BPS</publisher>
-		<info name="serial" value="SLPS-02507" />
-		<info name="release" value="19991216" />
+		<info name="serial" value="SLPS-02507"/>
+		<info name="release" value="19991216"/>
 		<info name="alt_title" value="ザ ネクスト テトリス デラックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50636,8 +50636,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nya Nyan ga Nyan - Light Fantasy Gaiden (Japan)</description>
 		<year>1999</year>
 		<publisher>Tonkin House</publisher>
-		<info name="serial" value="SLPS-02336" />
-		<info name="release" value="19991021" />
+		<info name="serial" value="SLPS-02336"/>
+		<info name="release" value="19991021"/>
 		<info name="alt_title" value="ライトファンタジー外伝 ニャニャンがニャン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50657,8 +50657,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Oasis Road (Japan)</description>
 		<year>1999</year>
 		<publisher>Idea Factory</publisher>
-		<info name="serial" value="SLPS-01899" />
-		<info name="release" value="19990225" />
+		<info name="serial" value="SLPS-01899"/>
+		<info name="release" value="19990225"/>
 		<info name="alt_title" value="オアシスロード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50678,8 +50678,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Oda Nobunaga Den (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01595" />
-		<info name="release" value="19980923" />
+		<info name="serial" value="SLPS-01595"/>
+		<info name="release" value="19980923"/>
 		<info name="alt_title" value="織田信長伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50699,8 +50699,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Odo Odo Oddity (Japan)</description>
 		<year>1997</year>
 		<publisher>I.D.C.</publisher>
-		<info name="serial" value="SLPS-00754" />
-		<info name="release" value="19970314" />
+		<info name="serial" value="SLPS-00754"/>
+		<info name="release" value="19970314"/>
 		<info name="alt_title" value="おどおどおっでぃ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50720,8 +50720,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ojamajo Doremi Dokka~n! Nijiiro Para-Dice (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03497" />
-		<info name="release" value="20021128" />
+		<info name="serial" value="SLPS-03497"/>
+		<info name="release" value="20021128"/>
 		<info name="alt_title" value="おジャ魔女どれみ ドッカーン! にじいろパラダイス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50744,8 +50744,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ojousama Express (Japan)</description>
 		<year>1998</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-01495~SLPS-01496" />
-		<info name="release" value="19980730" />
+		<info name="serial" value="SLPS-01495~SLPS-01496"/>
+		<info name="release" value="19980730"/>
 		<info name="alt_title" value="お嬢様特急"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50770,8 +50770,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Omiai Commando - Bakappuru ni Tsukkomi o (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86439" />
-		<info name="release" value="20000330" />
+		<info name="serial" value="SLPM-86439"/>
+		<info name="release" value="20000330"/>
 		<info name="alt_title" value="お見合いコマンドー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50791,8 +50791,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Omise de Tensyu (Japan)</description>
 		<year>1999</year>
 		<publisher>TechnoSoft</publisher>
-		<info name="serial" value="SLPS-01876" />
-		<info name="release" value="19990408" />
+		<info name="serial" value="SLPS-01876"/>
+		<info name="release" value="19990408"/>
 		<info name="alt_title" value="おみせde店主"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50812,8 +50812,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>One (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01812" />
-		<info name="release" value="19990325" />
+		<info name="serial" value="SLPS-01812"/>
+		<info name="release" value="19990325"/>
 		<info name="alt_title" value="ワン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50833,8 +50833,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ongaku Tsukuru Kanadeeru 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-00903" />
-		<info name="release" value="19980312" />
+		<info name="serial" value="SLPS-00903"/>
+		<info name="release" value="19980312"/>
 		<info name="alt_title" value="音楽ツクール かなで〜る2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50854,8 +50854,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ongaku Tsukuru 3 (Japan)</description>
 		<year>2001</year>
 		<publisher>EnterBrain</publisher>
-		<info name="serial" value="SLPS-03161" />
-		<info name="release" value="20010308" />
+		<info name="serial" value="SLPS-03161"/>
+		<info name="release" value="20010308"/>
 		<info name="alt_title" value="音楽ツクール3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50885,8 +50885,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Option Tuning Car Battle Spec-R (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
-		<info name="serial" value="SLPS-02587" />
-		<info name="release" value="20000511" />
+		<info name="serial" value="SLPS-02587"/>
+		<info name="release" value="20000511"/>
 		<info name="alt_title" value="オプション チューニングカーバトル スペックR"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50906,8 +50906,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ore no Ryouri (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10099" />
-		<info name="release" value="19990909" />
+		<info name="serial" value="SCPS-10099"/>
+		<info name="release" value="19990909"/>
 		<info name="alt_title" value="俺の料理"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50930,8 +50930,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sougaku Toshi - Osaka (Japan)</description>
 		<year>1999</year>
 		<publisher>King Records</publisher>
-		<info name="serial" value="SLPS-01722~SLPS-01723" />
-		<info name="release" value="19990311" />
+		<info name="serial" value="SLPS-01722~SLPS-01723"/>
+		<info name="release" value="19990311"/>
 		<info name="alt_title" value="奏楽都市 OSAKA"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50956,8 +50956,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Oshigotoshiki Jinsei Game - Mezase Shokugyou-oh (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-03056" />
-		<info name="release" value="20001214" />
+		<info name="serial" value="SLPS-03056"/>
+		<info name="release" value="20001214"/>
 		<info name="alt_title" value="お仕事式人生ゲーム めざせ職業王"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50977,8 +50977,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>One Two Smash - Tanoshii Tennis (Japan, Honkakuha de 1300Yen Series)</description>
 		<year>2000</year>
 		<publisher>Hect</publisher>
-		<info name="serial" value="SLPS-02585" />
-		<info name="release" value="20000224" />
+		<info name="serial" value="SLPS-02585"/>
+		<info name="release" value="20000224"/>
 		<info name="alt_title" value="本格派DE 1300円 ワン・ツー スマッシュ たのしいテニス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50998,8 +50998,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ouji-sama LV1 (Japan)</description>
 		<year>2002</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-03412" />
-		<info name="release" value="20020320" />
+		<info name="serial" value="SLPS-03412"/>
+		<info name="release" value="20020320"/>
 		<info name="alt_title" value="王子さまLV1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51019,8 +51019,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Oumagatoki (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-03235" />
-		<info name="release" value="20010809" />
+		<info name="serial" value="SLPS-03235"/>
+		<info name="release" value="20010809"/>
 		<info name="alt_title" value="逢魔が時"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51040,8 +51040,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Out Live - Be Eliminate Yesterday (Japan)</description>
 		<year>1997</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-00746" />
-		<info name="release" value="19970724" />
+		<info name="serial" value="SLPS-00746"/>
+		<info name="release" value="19970724"/>
 		<info name="alt_title" value="アウトライブ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51061,8 +51061,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Paca Paca Passion (Japan)</description>
 		<year>1999</year>
 		<publisher>Produce!</publisher>
-		<info name="serial" value="SLPS-02122" />
-		<info name="release" value="19990624" />
+		<info name="serial" value="SLPS-02122"/>
+		<info name="release" value="19990624"/>
 		<info name="alt_title" value="パカパカパッション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51082,8 +51082,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Paca Paca Passion 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Produce!</publisher>
-		<info name="serial" value="SLPS-02720" />
-		<info name="release" value="20000427" />
+		<info name="serial" value="SLPS-02720"/>
+		<info name="release" value="20000427"/>
 		<info name="alt_title" value="パカパカパッション2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51103,8 +51103,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Palm Town (Japan)</description>
 		<year>1999</year>
 		<publisher>MyCom</publisher>
-		<info name="serial" value="SLPS-01820" />
-		<info name="release" value="19990708" />
+		<info name="serial" value="SLPS-01820"/>
+		<info name="release" value="19990708"/>
 		<info name="alt_title" value="ぱーむたうん"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51125,8 +51125,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Panzer Bandit (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00899" />
-		<info name="release" value="19970807" />
+		<info name="serial" value="SLPS-00899"/>
+		<info name="release" value="19970807"/>
 		<info name="alt_title" value="パンツァーバンディット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51146,8 +51146,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Panzer Front bis. (Japan)</description>
 		<year>2001</year>
 		<publisher>Enterbrain</publisher>
-		<info name="serial" value="SLPS-03111" />
-		<info name="release" value="20010208" />
+		<info name="serial" value="SLPS-03111"/>
+		<info name="release" value="20010208"/>
 		<info name="alt_title" value="パンツァーフロントbis."/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51167,8 +51167,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shin Masoukishin - Panzer Warfare (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-02319" />
-		<info name="release" value="19991125" />
+		<info name="serial" value="SLPS-02319"/>
+		<info name="release" value="19991125"/>
 		<info name="alt_title" value="真・魔装機神"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51188,8 +51188,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaibutsu Para-Dice (Japan)</description>
 		<year>1997</year>
 		<publisher>Make Software</publisher>
-		<info name="serial" value="SLPS-00915" />
-		<info name="release" value="19970717" />
+		<info name="serial" value="SLPS-00915"/>
+		<info name="release" value="19970717"/>
 		<info name="alt_title" value="怪物パラ★ダイス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51209,8 +51209,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Paranoia Scape (Japan)</description>
 		<year>1998</year>
 		<publisher>Mathilda</publisher>
-		<info name="serial" value="SLPS-01375" />
-		<info name="release" value="19980528" />
+		<info name="serial" value="SLPS-01375"/>
+		<info name="release" value="19980528"/>
 		<info name="alt_title" value="パラノイアスケープ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51230,8 +51230,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Parlor! Pro Jr. Collection (Japan)</description>
 		<year>2000</year>
 		<publisher>Nihon Telenet</publisher>
-		<info name="serial" value="SLPS-02781" />
-		<info name="release" value="20000713" />
+		<info name="serial" value="SLPS-02781"/>
+		<info name="release" value="20000713"/>
 		<info name="alt_title" value="パーラー！プロ ジュニア コレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51251,8 +51251,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Paro Wars (Japan)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86016 (VX038-J1)" />
-		<info name="release" value="19970925" />
+		<info name="serial" value="SLPM-86016 (VX038-J1)"/>
+		<info name="release" value="19970925"/>
 		<info name="alt_title" value="パロウォーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51272,8 +51272,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kidou Keisatsu Patlabor - Mobile Police Patlabor - Game Edition (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02239" />
-		<info name="release" value="20001130" />
+		<info name="serial" value="SLPS-02239"/>
+		<info name="release" value="20001130"/>
 		<info name="alt_title" value="機動警察パトレイバー ゲームエディション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51293,8 +51293,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puzzle Bobble 3 DX (Japan)</description>
 		<year>1997</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-01065" />
-		<info name="release" value="19971106" />
+		<info name="serial" value="SLPS-01065"/>
+		<info name="release" value="19971106"/>
 		<info name="alt_title" value="パズルボブル3デラックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51314,8 +51314,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puzzle Bobble 4 (Japan)</description>
 		<year>1998</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-01492" />
-		<info name="release" value="19980806" />
+		<info name="serial" value="SLPS-01492"/>
+		<info name="release" value="19980806"/>
 		<info name="alt_title" value="パズルボブル4"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51335,8 +51335,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>PD Ultraman Invader (Japan)</description>
 		<year>1995</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00195" />
-		<info name="release" value="19951222" />
+		<info name="serial" value="SLPS-00195"/>
+		<info name="release" value="19951222"/>
 		<info name="alt_title" value="PDウルトラマンインベーダー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51363,8 +51363,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pepsiman (Japan)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-01762" />
-		<info name="release" value="19990304" />
+		<info name="serial" value="SLPS-01762"/>
+		<info name="release" value="19990304"/>
 		<info name="alt_title" value="ペプシマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51384,8 +51384,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pocket Fighter (Japan)</description>
 		<year>1998</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01360" />
-		<info name="release" value="19980611" />
+		<info name="serial" value="SLPS-01360"/>
+		<info name="release" value="19980611"/>
 		<info name="alt_title" value="ポケットファイター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51405,8 +51405,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pikinya! Excellent (Japan)</description>
 		<year>1998</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-01345" />
-		<info name="release" value="19980716" />
+		<info name="serial" value="SLPS-01345"/>
+		<info name="release" value="19980716"/>
 		<info name="alt_title" value="ピキーニャ エクセレンテ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51426,8 +51426,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pinball Fantasies Deluxe (Japan)</description>
 		<year>1996</year>
 		<publisher>VAP</publisher>
-		<info name="serial" value="SLPS-00482" />
-		<info name="release" value="19961025" />
+		<info name="serial" value="SLPS-00482"/>
+		<info name="release" value="19961025"/>
 		<info name="alt_title" value="ピンボール・ファンタジーズ・デラックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51447,8 +51447,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pitfall 3D - Beyond the Jungle (Japan)</description>
 		<year>1998</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01669" />
-		<info name="release" value="19981210" />
+		<info name="serial" value="SLPS-01669"/>
+		<info name="release" value="19981210"/>
 		<info name="alt_title" value="ピットフォール3D"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51468,8 +51468,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Planet Dob (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-02111" />
-		<info name="release" value="19991118" />
+		<info name="serial" value="SLPS-02111"/>
+		<info name="release" value="19991118"/>
 		<info name="alt_title" value="プラネット・ドブ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51489,8 +51489,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Planet Laika (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86264" />
-		<info name="release" value="19991021" />
+		<info name="serial" value="SLPM-86264"/>
+		<info name="release" value="19991021"/>
 		<info name="alt_title" value="プラネットライカ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51510,8 +51510,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pocket Digimon World (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02800" />
-		<info name="release" value="20000626" />
+		<info name="serial" value="SLPS-02800"/>
+		<info name="release" value="20000626"/>
 		<info name="alt_title" value="ポケットデジモンワールド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51531,8 +51531,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pocket Digimon World - Wind Battle Disc (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02992" />
-		<info name="release" value="20001026" />
+		<info name="serial" value="SLPS-02992"/>
+		<info name="release" value="20001026"/>
 		<info name="alt_title" value="ポケットデジモンワールド ウイングバトルディスク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51552,8 +51552,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pocket Digimon World - Cool &amp; Nature Battle Disc (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03146" />
-		<info name="release" value="20010222" />
+		<info name="serial" value="SLPS-03146"/>
+		<info name="release" value="20010222"/>
 		<info name="alt_title" value="ポケットデジモンワールド クール&amp;ネイチャー バトルディスク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51573,8 +51573,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pocket MuuMuu (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10076" />
-		<info name="release" value="19990204" />
+		<info name="serial" value="SCPS-10076"/>
+		<info name="release" value="19990204"/>
 		<info name="alt_title" value="ポケットムームー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51594,8 +51594,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Poitter's Point 2 - Sodom no Inbou (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86061 (VX091-J1)" />
-		<info name="release" value="19980709" />
+		<info name="serial" value="SLPM-86061 (VX091-J1)"/>
+		<info name="release" value="19980709"/>
 		<info name="alt_title" value="ポイッターズポイント2 ～ソドムの陰謀～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51615,8 +51615,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Policenauts - Private Collection (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPS-00228" />
-		<info name="release" value="19960209" />
+		<info name="serial" value="SLPS-00228"/>
+		<info name="release" value="19960209"/>
 		<info name="alt_title" value="ポリスノーツ プライベートコレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51636,8 +51636,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pop'n Music - Disney Tunes (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86670 (VX222-J1)" />
-		<info name="release" value="20001116" />
+		<info name="serial" value="SLPM-86670 (VX222-J1)"/>
+		<info name="release" value="20001116"/>
 		<info name="alt_title" value="ポップンミュージックディズニーチューンズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51657,8 +51657,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pop'n Pop (Japan)</description>
 		<year>1998</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-01636" />
-		<info name="release" value="19981022" />
+		<info name="serial" value="SLPS-01636"/>
+		<info name="release" value="19981022"/>
 		<info name="alt_title" value="ぽっぷんぽっぷ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51678,8 +51678,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pop'n Tanks! (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86146" />
-		<info name="release" value="19990729" />
+		<info name="serial" value="SLPM-86146"/>
+		<info name="release" value="19990729"/>
 		<info name="alt_title" value="ポップンタンクス！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51699,8 +51699,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Potestas (Japan)</description>
 		<year>1996</year>
 		<publisher>Nexus</publisher>
-		<info name="serial" value="SLPS-00324 (PS-0001)" />
-		<info name="release" value="19960412" />
+		<info name="serial" value="SLPS-00324 (PS-0001)"/>
+		<info name="release" value="19960412"/>
 		<info name="alt_title" value="ポテスタス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51720,8 +51720,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi Pachi Saga (Japan)</description>
 		<year>1996</year>
 		<publisher>TEN Institute</publisher>
-		<info name="serial" value="SLPS-00288" />
-		<info name="release" value="19960426" />
+		<info name="serial" value="SLPS-00288"/>
+		<info name="release" value="19960426"/>
 		<info name="alt_title" value="パチパチサーガ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51741,8 +51741,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Princess Maker - Go! Go! Princess (Japan)</description>
 		<year>1999</year>
 		<publisher>NineLives</publisher>
-		<info name="serial" value="SLPS-01505" />
-		<info name="release" value="19990121" />
+		<info name="serial" value="SLPS-01505"/>
+		<info name="release" value="19990121"/>
 		<info name="alt_title" value="プリンセスメーカー GO!GO!プリンセス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51762,8 +51762,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Prism Court (Japan)</description>
 		<year>1998</year>
 		<publisher>FPS</publisher>
-		<info name="serial" value="SLPS-01226" />
-		<info name="release" value="19980226" />
+		<info name="serial" value="SLPS-01226"/>
+		<info name="release" value="19980226"/>
 		<info name="alt_title" value="プリズムコート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51783,8 +51783,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Action Puzzle - Prism Land (Japan, Honkakuha de 1300Yen Series)</description>
 		<year>2000</year>
 		<publisher>HECT</publisher>
-		<info name="serial" value="SLPS-02586" />
-		<info name="release" value="20000224" />
+		<info name="serial" value="SLPS-02586"/>
+		<info name="release" value="20000224"/>
 		<info name="alt_title" value="本格派DE 1300円 アクションパズル プリズムランド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51804,8 +51804,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Prisoner (Japan)</description>
 		<year>1999</year>
 		<publisher>Mainichi</publisher>
-		<info name="serial" value="SLPS-02387" />
-		<info name="release" value="19991111" />
+		<info name="serial" value="SLPS-02387"/>
+		<info name="release" value="19991111"/>
 		<info name="alt_title" value="プリズナー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51838,8 +51838,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Aruze Oukoku 5 (Japan)</description>
 		<year>2001</year>
 		<publisher>Aruze</publisher>
-		<info name="serial" value="SLPS-03280" />
-		<info name="release" value="20011115" />
+		<info name="serial" value="SLPS-03280"/>
+		<info name="release" value="20011115"/>
 		<info name="alt_title" value="パチスロ アルゼ王国5"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51859,8 +51859,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou - Battle Knight &amp; Atlantis Doom (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03108" />
-		<info name="release" value="20001228" />
+		<info name="serial" value="SLPS-03108"/>
+		<info name="release" value="20001228"/>
 		<info name="alt_title" value="パチスロ帝王〜バトルナイト・アトランチスドーム〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51880,8 +51880,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou - Maker Suishou Manual 3 - I'm Angel White 2 &amp; I'm Angel Blue 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03130" />
-		<info name="release" value="20010426" />
+		<info name="serial" value="SLPS-03130"/>
+		<info name="release" value="20010426"/>
 		<info name="alt_title" value="パチスロ帝王 メーカー推奨マニュアル3 アイムエンジェル〜ホワイト2&amp;ブルー2〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51901,8 +51901,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou - Maker Suishou Manual 5 - Race Queen 2 &amp; Tomcat (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03245" />
-		<info name="release" value="20010830" />
+		<info name="serial" value="SLPS-03245"/>
+		<info name="release" value="20010830"/>
 		<info name="alt_title" value="パチスロ帝王 メーカー推奨マニュアル5 〜レースクイーン2・トムキャット〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51922,8 +51922,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou Maker Suishou Manual 6 - Takarabune (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03329" />
-		<info name="release" value="20011115" />
+		<info name="serial" value="SLPS-03329"/>
+		<info name="release" value="20011115"/>
 		<info name="alt_title" value="パチスロ帝王 メーカー推奨マニュアル6 宝船"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51943,8 +51943,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou - Maker Suishou Manual 7 - Trick Monster 2 (Japan)</description>
 		<year>2002</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03391" />
-		<info name="release" value="20020214" />
+		<info name="serial" value="SLPS-03391"/>
+		<info name="release" value="20020214"/>
 		<info name="alt_title" value="パチスロ帝王 メーカー推奨マニュアル7 トリックモンスター2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51964,8 +51964,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou Mini - Dr. A7 (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-02114" />
-		<info name="release" value="19990624" />
+		<info name="serial" value="SLPS-02114"/>
+		<info name="release" value="19990624"/>
 		<info name="alt_title" value="パチスロ帝王 ミニ ドクターエー7"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51985,8 +51985,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou 2 - Kagetsu &amp; 2 Pair &amp; Beaver X (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-02217" />
-		<info name="release" value="19990826" />
+		<info name="serial" value="SLPS-02217"/>
+		<info name="release" value="19990826"/>
 		<info name="alt_title" value="パチスロ帝王II 花月・ツーペア・マイマイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52006,8 +52006,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou 3 - Sea Master X &amp; Epsilon R &amp; Wai Wai Pulsar 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-02413" />
-		<info name="release" value="19991202" />
+		<info name="serial" value="SLPS-02413"/>
+		<info name="release" value="19991202"/>
 		<info name="alt_title" value="パチスロ帝王3～シーマスターX・イプシロンR・ワイワイパルサー2～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52027,8 +52027,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou 6 - Kung Fu Lady &amp; BangBang &amp; Prelude 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-02657" />
-		<info name="release" value="20000622" />
+		<info name="serial" value="SLPS-02657"/>
+		<info name="release" value="20000622"/>
 		<info name="alt_title" value="パチスロ帝王6 ～カンフーレディ・BANGBANG・プレリュード2～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52048,8 +52048,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou 7 - Maker Suishou Manual 1 - Beat the Dragon 2 &amp; Lupin Sansei &amp; Hot Rod Queen (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-02991" />
-		<info name="release" value="20001012" />
+		<info name="serial" value="SLPS-02991"/>
+		<info name="release" value="20001012"/>
 		<info name="alt_title" value="パチスロ帝王7 メーカー推奨マニュアル1 〜ビートザドラゴン2・ルパン三世・ホットロッドクイーン〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52069,8 +52069,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou - Twist &amp; Shimauta &amp; Nankoku Monogatari (Japan)</description>
 		<year>2002</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03442" />
-		<info name="release" value="20020620" />
+		<info name="serial" value="SLPS-03442"/>
+		<info name="release" value="20020620"/>
 		<info name="alt_title" value="パチスロ帝王〜Twist・島唄・南国物語〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52090,9 +52090,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Power Stakes (Japan)</description>
 		<year>1997</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques" />
-		<info name="serial" value="SLPM-86032" />
-		<info name="release" value="19970411" />
+		<info name="developer" value="Aques"/>
+		<info name="serial" value="SLPM-86032"/>
+		<info name="release" value="19970411"/>
 		<info name="alt_title" value="パワーステークス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52112,9 +52112,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Power Stakes Grade 1 (Japan)</description>
 		<year>1997</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques" />
-		<info name="serial" value="SLPM-86050" />
-		<info name="release" value="19971009" />
+		<info name="developer" value="Aques"/>
+		<info name="serial" value="SLPM-86050"/>
+		<info name="release" value="19971009"/>
 		<info name="alt_title" value="パワーステークス グレード1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52136,9 +52136,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pro Logic Mahjong Hai-Shin (Japan)</description>
 		<year>1997</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques" />
-		<info name="serial" value="SLPM-86018" />
-		<info name="release" value="19970131" />
+		<info name="developer" value="Aques"/>
+		<info name="serial" value="SLPM-86018"/>
+		<info name="release" value="19970131"/>
 		<info name="alt_title" value="プロロジック麻雀 牌神"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52158,8 +52158,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puchi Carat (Japan)</description>
 		<year>1998</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-01435" />
-		<info name="release" value="19980625" />
+		<info name="serial" value="SLPS-01435"/>
+		<info name="release" value="19980625"/>
 		<info name="alt_title" value="プチカラット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52179,8 +52179,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pukunpa - Joshikousei no Houkago... (Japan)</description>
 		<year>1996</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-00409" />
-		<info name="release" value="19960927" />
+		<info name="serial" value="SLPS-00409"/>
+		<info name="release" value="19960927"/>
 		<info name="alt_title" value="ぷくんパ 女子高生の放課後…"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52200,8 +52200,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puyo Puyo Box (Japan)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
-		<info name="serial" value="SLPS-03114" />
-		<info name="release" value="20001221" />
+		<info name="serial" value="SLPS-03114"/>
+		<info name="release" value="20001221"/>
 		<info name="alt_title" value="ぷよぷよBOX"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52221,8 +52221,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puyo Puyo 4 - Car-kun to Issho (Japan)</description>
 		<year>1999</year>
 		<publisher>Compile</publisher>
-		<info name="serial" value="SLPS-02412" />
-		<info name="release" value="19991216" />
+		<info name="serial" value="SLPS-02412"/>
+		<info name="release" value="19991216"/>
 		<info name="alt_title" value="ぷよぷよ〜ん カーくんといっしょ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52242,8 +52242,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puzzle Arena Toshinden (Japan)</description>
 		<year>1997</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-00879" />
-		<info name="release" value="19970620" />
+		<info name="serial" value="SLPS-00879"/>
+		<info name="release" value="19970620"/>
 		<info name="alt_title" value="パズルアリーナ闘神伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52263,8 +52263,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pro Wrestling Sengokuden - Hyper Tag Match (Japan)</description>
 		<year>1997</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-01006" />
-		<info name="release" value="19971023" />
+		<info name="serial" value="SLPS-01006"/>
+		<info name="release" value="19971023"/>
 		<info name="alt_title" value="プロレス戦国伝 〜HYPER TAG MATCH〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52284,8 +52284,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Power Shovel ni Norou!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86629 (TCPS10031)" />
-		<info name="release" value="20000921" />
+		<info name="serial" value="SLPM-86629 (TCPS10031)"/>
+		<info name="release" value="20000921"/>
 		<info name="alt_title" value="パワーショベルに乗ろう!!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52305,8 +52305,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Qix 2000 (Japan, SuperLite 1500 Series)</description>
 		<year>2000</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86659" />
-		<info name="release" value="20001026" />
+		<info name="serial" value="SLPM-86659"/>
+		<info name="release" value="20001026"/>
 		<info name="alt_title" value="SuperLite1500シリーズ クイックス2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52327,8 +52327,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Quantum Gate I - Akumu no Joshou (Japan)</description>
 		<year>1997</year>
 		<publisher>Gaga</publisher>
-		<info name="serial" value="SLPS-00399" />
-		<info name="release" value="19970606" />
+		<info name="serial" value="SLPS-00399"/>
+		<info name="release" value="19970606"/>
 		<info name="alt_title" value="クァンタム・ゲートI 〜悪夢の序章〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52348,8 +52348,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Quiz Charaokedon! Toei Tokusatsu Hero Part 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-02310" />
-		<info name="release" value="19991021" />
+		<info name="serial" value="SLPS-02310"/>
+		<info name="release" value="19991021"/>
 		<info name="alt_title" value="クイズキャラおけドン! 東映特撮ヒーローPART2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52369,8 +52369,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Quiz Darake no Jinsei Game - Un to Atama de Daifuugou!? (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02282" />
-		<info name="release" value="19990930" />
+		<info name="serial" value="SLPS-02282"/>
+		<info name="release" value="19990930"/>
 		<info name="alt_title" value="クイズだらけの人生ゲーム 運と頭で大富豪!?"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52390,8 +52390,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Quiz$Millionaire (Japan)</description>
 		<year>2001</year>
 		<publisher>Eidos</publisher>
-		<info name="serial" value="SLPS-03364" />
-		<info name="release" value="20011220" />
+		<info name="serial" value="SLPS-03364"/>
+		<info name="release" value="20011220"/>
 		<info name="alt_title" value="クイズ＄ミリオネア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52414,8 +52414,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Quo Vadis - Iberukatsu Seneki (Japan)</description>
 		<year>1997</year>
 		<publisher>Glams</publisher>
-		<info name="serial" value="SLPS-00733" />
-		<info name="release" value="19970418" />
+		<info name="serial" value="SLPS-00733"/>
+		<info name="release" value="19970418"/>
 		<info name="alt_title" value="クオバディス 〜イベルカーツ戦役〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52435,8 +52435,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Race Drivin' A Go! Go! (Japan)</description>
 		<year>1996</year>
 		<publisher>Time Warner</publisher>
-		<info name="serial" value="SLPS-00167" />
-		<info name="release" value="19960628" />
+		<info name="serial" value="SLPS-00167"/>
+		<info name="release" value="19960628"/>
 		<info name="alt_title" value="レースドライビン a ゴー！ゴー！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52456,8 +52456,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rakugaki Showtime (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86272" />
-		<info name="release" value="19990729" />
+		<info name="serial" value="SLPM-86272"/>
+		<info name="release" value="19990729"/>
 		<info name="alt_title" value="ラクガキショータイム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52477,8 +52477,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rally de Africa (Japan)</description>
 		<year>1998</year>
 		<publisher>Prism Arts</publisher>
-		<info name="serial" value="SLPS-01601" />
-		<info name="release" value="19980923" />
+		<info name="serial" value="SLPS-01601"/>
+		<info name="release" value="19980923"/>
 		<info name="alt_title" value="ラリー・デ・アフリカ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52498,8 +52498,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rally de Europe (Japan)</description>
 		<year>2000</year>
 		<publisher>Prism Arts</publisher>
-		<info name="serial" value="SLPS-02679" />
-		<info name="release" value="20000427" />
+		<info name="serial" value="SLPS-02679"/>
+		<info name="release" value="20000427"/>
 		<info name="alt_title" value="ラリー・デ・ヨーロッパ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52519,8 +52519,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chippoke Ralph no Daibouken - The Adventure of Little Ralph (Japan)</description>
 		<year>1999</year>
 		<publisher>New</publisher>
-		<info name="serial" value="SLPS-01853" />
-		<info name="release" value="19990603" />
+		<info name="serial" value="SLPS-01853"/>
+		<info name="release" value="19990603"/>
 		<info name="alt_title" value="ちっぽけラルフの大冒険"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52541,8 +52541,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ranma ½ - Battle Renaissance (Japan)</description>
 		<year>1996</year>
 		<publisher>Shogakukan</publisher>
-		<info name="serial" value="SLPS-00522" />
-		<info name="release" value="19961206" />
+		<info name="serial" value="SLPS-00522"/>
+		<info name="release" value="19961206"/>
 		<info name="alt_title" value="らんま1/2 バトルルネッサンス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52562,8 +52562,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaisoku Tenshi - The Rapid Angel (Japan)</description>
 		<year>1998</year>
 		<publisher>Techno Soleil</publisher>
-		<info name="serial" value="SLPS-01553" />
-		<info name="release" value="19980813" />
+		<info name="serial" value="SLPS-01553"/>
+		<info name="release" value="19980813"/>
 		<info name="alt_title" value="快速天使"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52584,8 +52584,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Groove Adventure Rave - Mikan no Hiseki (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87138 (VX265-J1)" />
-		<info name="release" value="20020829" />
+		<info name="serial" value="SLPM-87138 (VX265-J1)"/>
+		<info name="release" value="20020829"/>
 		<info name="alt_title" value="グルーヴアドベンチャーレイヴ　～未完の秘石～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52605,8 +52605,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Groove Adventure Rave - Yuukyuu no Kizuna (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87011 (VX253-J1)" />
-		<info name="release" value="20020131" />
+		<info name="serial" value="SLPM-87011 (VX253-J1)"/>
+		<info name="release" value="20020131"/>
 		<info name="alt_title" value="グルーブアドベンチャーレイヴ 悠久の絆"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52626,8 +52626,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rayman (Japan)</description>
 		<year>1995</year>
 		<publisher>Ubisoft</publisher>
-		<info name="serial" value="SLPS-00026" />
-		<info name="release" value="19950922" />
+		<info name="serial" value="SLPS-00026"/>
+		<info name="release" value="19950922"/>
 		<info name="alt_title" value="レイマン レイマンよ！エレクトゥーンを救え！~ Rayman - Rayman yo! Electroons o Sukue (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52647,8 +52647,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ray Tracers (Japan)</description>
 		<year>1997</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-00098" />
-		<info name="release" value="19970117" />
+		<info name="serial" value="SLPS-00098"/>
+		<info name="release" value="19970117"/>
 		<info name="alt_title" value="レイ・トレーサー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52671,8 +52671,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Real Bout Garou Densetsu Special - Dominated Mind (Japan, Limited Edition)</description>
 		<year>1998</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86090~SLPM-86091" />
-		<info name="release" value="19980625" />
+		<info name="serial" value="SLPM-86090~SLPM-86091"/>
+		<info name="release" value="19980625"/>
 		<info name="alt_title" value="リアルバウト餓狼伝説スペシャル ドミネイテッドマインド 限定版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -52697,8 +52697,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Recipro Heat 5000 (Japan)</description>
 		<year>1997</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-00744" />
-		<info name="release" value="19970731" />
+		<info name="serial" value="SLPS-00744"/>
+		<info name="release" value="19970731"/>
 		<info name="alt_title" value="レシプロヒート5000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52718,8 +52718,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ready Maid (Japan)</description>
 		<year>2002</year>
 		<publisher>Princess</publisher>
-		<info name="serial" value="SLPM-87157" />
-		<info name="release" value="20021024" />
+		<info name="serial" value="SLPM-87157"/>
+		<info name="release" value="20021024"/>
 		<info name="alt_title" value="れでぃ☆めいど"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52751,8 +52751,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Real Robots - Final Attack (Japan)</description>
 		<year>1998</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-01125" />
-		<info name="release" value="19980108" />
+		<info name="serial" value="SLPS-01125"/>
+		<info name="release" value="19980108"/>
 		<info name="alt_title" value="リアルロボッツ ファイナルアタック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52775,8 +52775,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Return to Zork (Japan)</description>
 		<year>1996</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00192~SLPS-00193" />
-		<info name="release" value="19960927" />
+		<info name="serial" value="SLPS-00192~SLPS-00193"/>
+		<info name="release" value="19960927"/>
 		<info name="alt_title" value="リターン・トゥ・ゾーク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -52801,8 +52801,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Riot Stars (Japan)</description>
 		<year>1997</year>
 		<publisher>Hect</publisher>
-		<info name="serial" value="SLPS-00829" />
-		<info name="release" value="19970502" />
+		<info name="serial" value="SLPS-00829"/>
+		<info name="release" value="19970502"/>
 		<info name="alt_title" value="ライアット・スターズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52822,8 +52822,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rise of Robots 2 - Resurrection (Japan)</description>
 		<year>1996</year>
 		<publisher>Acclaim</publisher>
-		<info name="serial" value="SLPS-00259" />
-		<info name="release" value="19960913" />
+		<info name="serial" value="SLPS-00259"/>
+		<info name="release" value="19960913"/>
 		<info name="alt_title" value="ライズ オブ ザ ロボット 2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52844,8 +52844,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rising Zan - The Samurai Gunman (Japan)</description>
 		<year>1999</year>
 		<publisher>UEP</publisher>
-		<info name="serial" value="SLPS-01691" />
-		<info name="release" value="19990325" />
+		<info name="serial" value="SLPS-01691"/>
+		<info name="release" value="19990325"/>
 		<info name="alt_title" value="ライジング ザン ザ・サムライガンマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52865,8 +52865,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Roommate - Inoue Ryoko (Japan)</description>
 		<year>1999</year>
 		<publisher>Datam Polystar</publisher>
-		<info name="serial" value="SLPS-02140" />
-		<info name="release" value="19990729" />
+		<info name="serial" value="SLPS-02140"/>
+		<info name="release" value="19990729"/>
 		<info name="alt_title" value="ルームメイト〜井上涼子〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52886,8 +52886,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Robin Lloyd no Daibouken (Japan)</description>
 		<year>2000</year>
 		<publisher>Gust</publisher>
-		<info name="serial" value="SLPS-02501" />
-		<info name="release" value="20000106" />
+		<info name="serial" value="SLPS-02501"/>
+		<info name="release" value="20000106"/>
 		<info name="alt_title" value="ロビン・ロイドの冒険"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52907,8 +52907,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Robot X Robot (Japan)</description>
 		<year>1999</year>
 		<publisher>Nemesys</publisher>
-		<info name="serial" value="SLPS-02331" />
-		<info name="release" value="19991014" />
+		<info name="serial" value="SLPS-02331"/>
+		<info name="release" value="19991014"/>
 		<info name="alt_title" value="ロボット×ロボット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52928,8 +52928,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Perfect Fishing - Rock Fishing (Japan)</description>
 		<year>2000</year>
 		<publisher>Seta</publisher>
-		<info name="serial" value="SLPS-02410" />
-		<info name="release" value="20000304" />
+		<info name="serial" value="SLPS-02410"/>
+		<info name="release" value="20000304"/>
 		<info name="alt_title" value="パーフェクトフィッシング 磯釣り"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52949,8 +52949,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Running High (Japan)</description>
 		<year>1997</year>
 		<publisher>REX Entertainment</publisher>
-		<info name="serial" value="SLPS-00751" />
-		<info name="release" value="19970425" />
+		<info name="serial" value="SLPS-00751"/>
+		<info name="release" value="19970425"/>
 		<info name="alt_title" value="ランニング・ハイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52970,8 +52970,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bishoujo Senshi Sailormoon Super S - Shin Shuyaku Soudatsusen (Japan, Genteiban)</description>
 		<year>1996</year>
 		<publisher>Angel</publisher>
-		<info name="serial" value="SLPS-00260" />
-		<info name="release" value="19960308" />
+		<info name="serial" value="SLPS-00260"/>
+		<info name="release" value="19960308"/>
 		<info name="alt_title" value="美少女戦士セーラームーンSuperS 真・主役争奪戦 限定版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52991,8 +52991,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kids Station - Bishoujo Senshi Sailormoon World - Chibiusa to Tanoshii Mainichi (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03318" />
-		<info name="release" value="20011129" />
+		<info name="serial" value="SLPS-03318"/>
+		<info name="release" value="20011129"/>
 		<info name="alt_title" value="キッズステーション 美少女戦士セーラームーンワールド ちびうさとたのしいまいにち"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53012,8 +53012,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sakkyoku Surundamon - Dance Remix (Japan)</description>
 		<year>2000</year>
 		<publisher>Ving</publisher>
-		<info name="serial" value="SLPS-02808" />
-		<info name="release" value="20000629" />
+		<info name="serial" value="SLPS-02808"/>
+		<info name="release" value="20000629"/>
 		<info name="alt_title" value="作曲するんだもん ダンスリミックス編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53033,8 +53033,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sakuma Shiki Jinsei Game (Japan)</description>
 		<year>1998</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01740" />
-		<info name="release" value="19981210" />
+		<info name="serial" value="SLPS-01740"/>
+		<info name="release" value="19981210"/>
 		<info name="alt_title" value="さくま式人生ゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53054,8 +53054,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Salary Man Champ - Tatakau Salary Man (Japan)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86820" />
-		<info name="release" value="20010531" />
+		<info name="serial" value="SLPM-86820"/>
+		<info name="release" value="20010531"/>
 		<info name="alt_title" value="サラリーマンチャンプ たたかうサラリーマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53075,8 +53075,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Salary Man Kintarou - The Game (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02806" />
-		<info name="release" value="20000622" />
+		<info name="serial" value="SLPS-02806"/>
+		<info name="release" value="20000622"/>
 		<info name="alt_title" value="サラリーマン金太郎 THE GAME"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53096,8 +53096,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Salary Man Settai Mahjong (Japan)</description>
 		<year>2001</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPS-03175" />
-		<info name="release" value="20010510" />
+		<info name="serial" value="SLPS-03175"/>
+		<info name="release" value="20010510"/>
 		<info name="alt_title" value="サラリーマン接待麻雀"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53117,8 +53117,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Samurai Deeper Kyo (Japan, Limited Edition)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03505" />
-		<info name="release" value="20021212" />
+		<info name="serial" value="SLPS-03505"/>
+		<info name="release" value="20021212"/>
 		<info name="alt_title" value="サムライディーパー キョウ (初回生産限定仕様)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53139,8 +53139,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Samurai Spirits - Zankurou Musouken (Japan, PlayStation the Best)</description>
 		<year>1997</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPS-91024" />
-		<info name="release" value="19970320" />
+		<info name="serial" value="SLPS-91024"/>
+		<info name="release" value="19970320"/>
 		<info name="alt_title" value="サムライスピリッツ 斬紅郎無双剣 PlayStation the Best"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53161,8 +53161,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Samurai Spirits - Kenkaku Yubinan Pack (Japan)</description>
 		<year>1998</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPS-00647" />
-		<info name="release" value="19980326" />
+		<info name="serial" value="SLPS-00647"/>
+		<info name="release" value="19980326"/>
 		<info name="alt_title" value="サムライスピリッツ 剣客指南パック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53185,8 +53185,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shinsetsu Samurai Spirits - Bushidou Retsuden (Japan)</description>
 		<year>1997</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPS-00814" />
-		<info name="release" value="19970627" />
+		<info name="serial" value="SLPS-00814"/>
+		<info name="release" value="19970627"/>
 		<info name="alt_title" value="真説サムライスピリッツ 武士道烈伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53206,8 +53206,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi - Eiketsuden (Japan)</description>
 		<year>1996</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00309" />
-		<info name="release" value="19960329" />
+		<info name="serial" value="SLPS-00309"/>
+		<info name="release" value="19960329"/>
 		<info name="alt_title" value="三國志英傑伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53227,8 +53227,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi - Koumeiden (Japan)</description>
 		<year>1997</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00688" />
-		<info name="release" value="19970214" />
+		<info name="serial" value="SLPS-00688"/>
+		<info name="release" value="19970214"/>
 		<info name="alt_title" value="三國志孔明伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53248,8 +53248,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi II (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01596" />
-		<info name="release" value="19980923" />
+		<info name="serial" value="SLPS-01596"/>
+		<info name="release" value="19980923"/>
 		<info name="alt_title" value="三國志II"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53269,8 +53269,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi III (Japan)</description>
 		<year>2001</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86747" />
-		<info name="release" value="20010222" />
+		<info name="serial" value="SLPM-86747"/>
+		<info name="release" value="20010222"/>
 		<info name="alt_title" value="三國志III"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53290,8 +53290,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi V (Asia)</description>
 		<year>1997?</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SCPS-45128" />
-		<info name="release" value="" />
+		<info name="serial" value="SCPS-45128"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value="三国志5"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53311,8 +53311,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi VI (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86129" />
-		<info name="release" value="19981008" />
+		<info name="serial" value="SLPM-86129"/>
+		<info name="release" value="19981008"/>
 		<info name="alt_title" value="三國志VI"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53332,8 +53332,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi Returns (Japan)</description>
 		<year>1997</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00474" />
-		<info name="release" value="19970320" />
+		<info name="serial" value="SLPS-00474"/>
+		<info name="release" value="19970320"/>
 		<info name="alt_title" value="三國志リターンズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53353,8 +53353,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sanyo Pachinko Paradise 2 - Umi Monogatari Special (Japan)</description>
 		<year>1999</year>
 		<publisher>Irem</publisher>
-		<info name="serial" value="SLPS-02389" />
-		<info name="release" value="19991118" />
+		<info name="serial" value="SLPS-02389"/>
+		<info name="release" value="19991118"/>
 		<info name="alt_title" value="三洋パチンコパラダイス2 海物語スペシャル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53383,8 +53383,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Super Adventure Rockman (Japan)</description>
 		<year>1998</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01051~SLPS-01053" />
-		<info name="release" value="19980625" />
+		<info name="serial" value="SLPS-01051~SLPS-01053"/>
+		<info name="release" value="19980625"/>
 		<info name="alt_title" value="スーパーアドベンチャーロックマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -53414,8 +53414,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SatelliTV (Japan)</description>
 		<year>1998</year>
 		<publisher>Nippon Ichi</publisher>
-		<info name="serial" value="SLPS-01203" />
-		<info name="release" value="19980108" />
+		<info name="serial" value="SLPS-01203"/>
+		<info name="release" value="19980108"/>
 		<info name="alt_title" value="サテライTV"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53435,8 +53435,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Satomi no Nazo (Japan)</description>
 		<year>1996</year>
 		<publisher>Sound Technology Japan</publisher>
-		<info name="serial" value="SLPS-00613" />
-		<info name="release" value="19961206" />
+		<info name="serial" value="SLPS-00613"/>
+		<info name="release" value="19961206"/>
 		<info name="alt_title" value="里見の謎"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53456,8 +53456,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Schrödinger no Neko - Die Katze von Schrödinger (Japan)</description>
 		<year>1997</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-00780" />
-		<info name="release" value="19970530" />
+		<info name="serial" value="SLPS-00780"/>
+		<info name="release" value="19970530"/>
 		<info name="alt_title" value="シュレディンガーの猫"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53477,8 +53477,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.02 - Afro Ken - The Puzzle (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03307" />
-		<info name="release" value="20011025" />
+		<info name="serial" value="SLPS-03307"/>
+		<info name="release" value="20011025"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.02 アフロ犬 THE パズル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53498,8 +53498,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.03 - Kamen Rider - The Bike Race (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03308" />
-		<info name="release" value="20011025" />
+		<info name="serial" value="SLPS-03308"/>
+		<info name="release" value="20011025"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.03 仮面ライダー THE バイクレース"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53519,8 +53519,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.04 - Jarinko Chie - The Hanafuda (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03350" />
-		<info name="release" value="20011129" />
+		<info name="serial" value="SLPS-03350"/>
+		<info name="release" value="20011129"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.04 じゃりン子チエ THE 花札"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53540,8 +53540,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series vol.05 - Highschool Kimengumi - The Table Hockey (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03362" />
-		<info name="release" value="20011220" />
+		<info name="serial" value="SLPS-03362"/>
+		<info name="release" value="20011220"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.05 ハイスクール奇面組 THE テーブルホッケー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53561,8 +53561,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.06 - Dokonjou Gaeru - The Mahjong (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03363" />
-		<info name="release" value="20020124" />
+		<info name="serial" value="SLPS-03363"/>
+		<info name="release" value="20020124"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.06 ど根性ガエル THE 麻雀"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53582,8 +53582,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series vol.07 - Ikkyuu-san - The Quiz (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03418" />
-		<info name="release" value="20020328" />
+		<info name="serial" value="SLPS-03418"/>
+		<info name="release" value="20020328"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.07 一休さん THE クイズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53603,8 +53603,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.09 - Tsuri Kichi Sanpei - The Tsuri (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03445" />
-		<info name="release" value="20020627" />
+		<info name="serial" value="SLPS-03445"/>
+		<info name="release" value="20020627"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.09 釣りキチ三平 THE 釣り"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53624,8 +53624,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.10 - Sakigake!! Otojo Juku - The Dodgeball (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03457" />
-		<info name="release" value="20020829" />
+		<info name="serial" value="SLPS-03457"/>
+		<info name="release" value="20020829"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.10 魁!!男塾 THE 怒馳暴流"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53645,8 +53645,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.12 - Kidou Butouden G Gundam - The Battle (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03471" />
-		<info name="release" value="20021010" />
+		<info name="serial" value="SLPS-03471"/>
+		<info name="release" value="20021010"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ VOL.12 機動武闘伝Gガンダム THE バトル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53666,8 +53666,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series vol.13 - Kidou Senki Gundam W - The Battle (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03472" />
-		<info name="release" value="20021010" />
+		<info name="serial" value="SLPS-03472"/>
+		<info name="release" value="20021010"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ VOL.13 新機動戦記ガンダムW THE バトル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53687,8 +53687,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.14 - Nante Tantei Idol - The Jigsaw Puzzle (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03473" />
-		<info name="release" value="20021010" />
+		<info name="serial" value="SLPS-03473"/>
+		<info name="release" value="20021010"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.14 なんてっ探偵アイドル THE ジグソーパズル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53708,8 +53708,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series vol.15 - Cyborg 009 - The Block Kuzushi (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03474" />
-		<info name="release" value="20021010" />
+		<info name="serial" value="SLPS-03474"/>
+		<info name="release" value="20021010"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.15 サイボーグ009 THE ブロックくずし"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53729,8 +53729,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.16 - Ganba no Bouken - The Puzzle Action (Japan)</description>
 		<year>2003</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03546" />
-		<info name="release" value="20030403" />
+		<info name="serial" value="SLPS-03546"/>
+		<info name="release" value="20030403"/>
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.16 ガンバの冒険 THE パズルアクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53750,8 +53750,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SD Gundam G Generation-F.I.F (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03195" />
-		<info name="release" value="20010502" />
+		<info name="serial" value="SLPS-03195"/>
+		<info name="release" value="20010502"/>
 		<info name="alt_title" value="SDガンダム ジージェネレーション・エフイフ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53777,8 +53777,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SD Gundam G - Generation-0 (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02200~SLPS-02202" />
-		<info name="release" value="19990812" />
+		<info name="serial" value="SLPS-02200~SLPS-02202"/>
+		<info name="release" value="19990812"/>
 		<info name="alt_title" value="SDガンダム ジージェネレーション・ゼロ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -53817,8 +53817,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SD Gundam G Generation-F (Japan, Limited Edition)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02900~SLPS-02902" />
-		<info name="release" value="20000803" />
+		<info name="serial" value="SLPS-02900~SLPS-02902"/>
+		<info name="release" value="20000803"/>
 		<info name="alt_title" value="SDガンダム ジージェネレーション・エフ (限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -53848,8 +53848,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SD Gundam Eiyuu Den Daikessen!! - Kishi vs. Musha (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03145" />
-		<info name="release" value="20010301" />
+		<info name="serial" value="SLPS-03145"/>
+		<info name="release" value="20010301"/>
 		<info name="alt_title" value="SDガンダム英雄伝 大決戦!!騎士VS武者"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53869,8 +53869,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SeaBass Fishing 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-00992" />
-		<info name="release" value="19970925" />
+		<info name="serial" value="SLPS-00992"/>
+		<info name="release" value="19970925"/>
 		<info name="alt_title" value="シーバス・フィッシング2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53890,8 +53890,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Seikai no Monshou (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02323" />
-		<info name="release" value="20000525" />
+		<info name="serial" value="SLPS-02323"/>
+		<info name="release" value="20000525"/>
 		<info name="alt_title" value="星界の紋章"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53911,8 +53911,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Seirei Shoukan - Princess of Darkness (Japan)</description>
 		<year>1998</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-01271" />
-		<info name="release" value="19980625" />
+		<info name="serial" value="SLPS-01271"/>
+		<info name="release" value="19980625"/>
 		<info name="alt_title" value="精霊召喚 〜プリンセス オブ ダークネス〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53932,8 +53932,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sengoku Mugen (Japan)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-03151" />
-		<info name="release" value="20010531" />
+		<info name="serial" value="SLPS-03151"/>
+		<info name="release" value="20010531"/>
 		<info name="alt_title" value="戦国夢幻"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53953,8 +53953,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Senkai Taisen - TV Animation Senkaiden Houshin Engi Yori (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02736" />
-		<info name="release" value="20000629" />
+		<info name="serial" value="SLPS-02736"/>
+		<info name="release" value="20000629"/>
 		<info name="alt_title" value="仙界大戦 〜TVアニメーション仙界伝封神演義より〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53974,8 +53974,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Senryaku Shidan - Tora! Tora! Tora! Rikusen-hen (Japan)</description>
 		<year>2000</year>
 		<publisher>DaZZ</publisher>
-		<info name="serial" value="SLPS-02631 (PS-0014)" />
-		<info name="release" value="20000224" />
+		<info name="serial" value="SLPS-02631 (PS-0014)"/>
+		<info name="release" value="20000224"/>
 		<info name="alt_title" value="戦略師団 トラ!トラ!トラ! 陸戦編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53995,8 +53995,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sentimental Graffiti (Japan)</description>
 		<year>2001</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-03184 (NIPS-4013)" />
-		<info name="release" value="20010329" />
+		<info name="serial" value="SLPS-03184 (NIPS-4013)"/>
+		<info name="release" value="20010329"/>
 		<info name="alt_title" value="センチメンタルグラフティ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54016,8 +54016,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sentou Kokka Kai - Improved (Japan)</description>
 		<year>1997</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10034" />
-		<info name="release" value="19970411" />
+		<info name="serial" value="SCPS-10034"/>
+		<info name="release" value="19970411"/>
 		<info name="alt_title" value="戦闘国家－改－ インプルーブド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54037,8 +54037,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Super Football Champ (Japan)</description>
 		<year>1996</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-00569" />
-		<info name="release" value="19961129" />
+		<info name="serial" value="SLPS-00569"/>
+		<info name="release" value="19961129"/>
 		<info name="alt_title" value="スーパーフットボールチャンプ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54133,8 +54133,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Street Fighter Collection (Japan)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00800~SLPS-00801" />
-		<info name="release" value="19971023" />
+		<info name="serial" value="SLPS-00800~SLPS-00801"/>
+		<info name="release" value="19971023"/>
 		<info name="alt_title" value="ストリートファイターコレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -54159,8 +54159,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shachou Eiyuuden - The Eagle Shooting Heroes (Asia)</description>
 		<year>2000?</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-45510" />
-		<info name="release" value="" />
+		<info name="serial" value="SCPS-45510"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value="射雕英雄传"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54181,8 +54181,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shiibas 1-2-3 - Destiny! Unmei o Kaeru Mono! (Japan)</description>
 		<year>2000</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-01893" />
-		<info name="release" value="20000106" />
+		<info name="serial" value="SLPS-01893"/>
+		<info name="release" value="20000106"/>
 		<info name="alt_title" value="シーバス 1－2－3 ～DESTINY！運命を変える者！～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54202,8 +54202,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shin Megami Tensei (Japan)</description>
 		<year>2001</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-03170" />
-		<info name="release" value="20010531" />
+		<info name="serial" value="SLPS-03170"/>
+		<info name="release" value="20010531"/>
 		<info name="alt_title" value="真・女神転生"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54223,8 +54223,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Shinri Game (Japan)</description>
 		<year>1996</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPS-00169" />
-		<info name="release" value="19960426" />
+		<info name="serial" value="SLPS-00169"/>
+		<info name="release" value="19960426"/>
 		<info name="alt_title" value="ザ・心理ゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54244,8 +54244,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shin SD Sengokuden - Kidou Musha Taisen (Japan, Limited Edition)</description>
 		<year>1996</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00576" />
-		<info name="release" value="19961220" />
+		<info name="serial" value="SLPS-00576"/>
+		<info name="release" value="19961220"/>
 		<info name="alt_title" value="新SD戦国伝 機動武者大戦(限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54265,8 +54265,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Hello Kitty vol.01 - Hello Kitty Bowling (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86866" />
-		<info name="release" value="20010830" />
+		<info name="serial" value="SLPM-86866"/>
+		<info name="release" value="20010830"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ ハローキティ Vol.01 Hello Kitty ボウリング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54286,8 +54286,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Hello Kitty Vol.02 - Hello Kitty Illust Puzzle (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86867" />
-		<info name="release" value="20010830" />
+		<info name="serial" value="SLPM-86867"/>
+		<info name="release" value="20010830"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ ハローキティ Vol.02 Hello Kitty イラストパズル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54307,8 +54307,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Hello Kitty vol.03 - Hello Kitty Block Kuzushi (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86911" />
-		<info name="release" value="20011025" />
+		<info name="serial" value="SLPM-86911"/>
+		<info name="release" value="20011025"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ ハローキティ Vol.03 Hello Kitty ブロックくずし"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54328,8 +54328,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Hello Kitty Vol.04 - Hello Kitty Trump (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86910" />
-		<info name="release" value="20011025" />
+		<info name="serial" value="SLPM-86910"/>
+		<info name="release" value="20011025"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ ハローキティ Vol.04 Hello Kitty トランプ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54349,8 +54349,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kato Hifumi Kudan - Shogi Club (Japan, Honkakuha de 1300Yen Series)</description>
 		<year>1999</year>
 		<publisher>Hect</publisher>
-		<info name="serial" value="SLPS-02078" />
-		<info name="release" value="19990527" />
+		<info name="serial" value="SLPS-02078"/>
+		<info name="release" value="19990527"/>
 		<info name="alt_title" value="本格派DE 1300円 加藤一二三 九段 将棋倶楽部"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54370,8 +54370,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shouryuu Sangoku Engi (Japan)</description>
 		<year>1996</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-00253" />
-		<info name="release" value="19960216" />
+		<info name="serial" value="SLPS-00253"/>
+		<info name="release" value="19960216"/>
 		<info name="alt_title" value="昇龍三国演義"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54411,8 +54411,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shura no Mon (Japan)</description>
 		<year>1998</year>
 		<publisher>Kodansha</publisher>
-		<info name="serial" value="SLPS-01202" />
-		<info name="release" value="19980402" />
+		<info name="serial" value="SLPS-01202"/>
+		<info name="release" value="19980402"/>
 		<info name="alt_title" value="修羅の門"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54432,8 +54432,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Side Pocket 3 - 3D Polygon Billiard Game (Japan)</description>
 		<year>1998</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-01079" />
-		<info name="release" value="19980416" />
+		<info name="serial" value="SLPS-01079"/>
+		<info name="release" value="19980416"/>
 		<info name="alt_title" value="サイドポケット3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54453,8 +54453,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sidewinder (Japan)</description>
 		<year>1996</year>
 		<publisher>Asmik</publisher>
-		<info name="serial" value="SLPS-00156" />
-		<info name="release" value="19960126" />
+		<info name="serial" value="SLPS-00156"/>
+		<info name="release" value="19960126"/>
 		<info name="alt_title" value="サイドワインダー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54474,8 +54474,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Silent Möbius - Genei no Datenshi (Japan, disc 1 only)</description>
 		<year>1998</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01803" />
-		<info name="release" value="19981223" />
+		<info name="serial" value="SLPS-01803"/>
+		<info name="release" value="19981223"/>
 		<info name="alt_title" value="サイレントメビウス 幻影の堕天使"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -54500,8 +54500,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Silhouette Mirage - Reprogrammed Hope (Japan)</description>
 		<year>1998</year>
 		<publisher>ESP</publisher>
-		<info name="serial" value="SLPS-01449" />
-		<info name="release" value="19980723" />
+		<info name="serial" value="SLPS-01449"/>
+		<info name="release" value="19980723"/>
 		<info name="alt_title" value="シルエットミラージュ リプログラムドホープ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54521,8 +54521,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Silhouette Stories (Japan)</description>
 		<year>1996</year>
 		<publisher>Kaneko</publisher>
-		<info name="serial" value="SLPS-00374" />
-		<info name="release" value="19960927" />
+		<info name="serial" value="SLPS-00374"/>
+		<info name="release" value="19960927"/>
 		<info name="alt_title" value="シルエット☆ストーリィズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54542,8 +54542,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simulation Zoo - Sekaiichi no Doubutsuen o Tsukurou (Japan)</description>
 		<year>1996</year>
 		<publisher>SoftBank</publisher>
-		<info name="serial" value="SLPS-00458" />
-		<info name="release" value="19961129" />
+		<info name="serial" value="SLPS-00458"/>
+		<info name="release" value="19961129"/>
 		<info name="alt_title" value="シミュレーションズー 世界一の動物園をつくろう"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54563,8 +54563,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sister Princess - Pure Stories (Japan)</description>
 		<year>2001</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-03360" />
-		<info name="release" value="20011223" />
+		<info name="serial" value="SLPS-03360"/>
+		<info name="release" value="20011223"/>
 		<info name="alt_title" value="シスター・プリンセス 〜ピュア・ストーリーズ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54584,8 +54584,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.01 - Norikae Annai -2000 Edition- (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPS-02842" />
-		<info name="release" value="20000914" />
+		<info name="serial" value="SLPS-02842"/>
+		<info name="release" value="20000914"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.01 乗換案内〜2000年版〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54605,8 +54605,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.03 - Seimei Handan (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPS-02841" />
-		<info name="release" value="20000824" />
+		<info name="serial" value="SLPS-02841"/>
+		<info name="release" value="20000824"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.03 姓名判断"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54626,8 +54626,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.04 - Ryouri (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPS-02839" />
-		<info name="release" value="20000824" />
+		<info name="serial" value="SLPS-02839"/>
+		<info name="release" value="20000824"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.04 料理〜定番料理レシピ集〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54647,8 +54647,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.05 - Kusuri no Jiten - Pill Book 2001 Edition (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86706" />
-		<info name="release" value="20010118" />
+		<info name="serial" value="SLPM-86706"/>
+		<info name="release" value="20010118"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.05 薬の事典〜ピルブック2001年版〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54668,8 +54668,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.06 - Cocktail no Recipe (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86707" />
-		<info name="release" value="20010118" />
+		<info name="serial" value="SLPM-86707"/>
+		<info name="release" value="20010118"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.06 カクテルのレシピ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54689,8 +54689,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.07 - Tanoshiku Manabu Unten Menkyo (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86797" />
-		<info name="release" value="20010502" />
+		<info name="serial" value="SLPM-86797"/>
+		<info name="release" value="20010502"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.07 楽しく学ぶ運転免許"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54710,8 +54710,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.08 - 1-Jikan de Wakaru Kabushiki Toushi (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86708" />
-		<info name="release" value="20010726" />
+		<info name="serial" value="SLPM-86708"/>
+		<info name="release" value="20010726"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.08 1時間でわかる株式投資"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54731,8 +54731,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.09 - Watashi Style no Aromatherapy (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86843" />
-		<info name="release" value="20010726" />
+		<info name="serial" value="SLPM-86843"/>
+		<info name="release" value="20010726"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.09 わたしスタイルのアロマセラピー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54752,8 +54752,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.10 - Tarot Uranai (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86913" />
-		<info name="release" value="20011025" />
+		<info name="serial" value="SLPM-86913"/>
+		<info name="release" value="20011025"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.10 タロット占い"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54773,13 +54773,13 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.11 - Katei de Dekiru Tsubo Shiatsu (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86968" />
-		<info name="release" value="20011213" />
+		<info name="serial" value="SLPM-86968"/>
+		<info name="release" value="20011213"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.11 家庭でできるツボ指圧"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="simple 1500 jitsuyou series vol.11 - katei de dekiru tsubo shiatsu (japan) [slpm-86968]" sha1="6328c634cd08e9fef0d3a3f39ca4a288e660c1e9" status="baddump"/>
+				<disk name="simple 1500 jitsuyou series vol.11 - katei de dekiru tsubo shiatsu (japan) [slpm-86968]" sha1="99e83ee7ce9f67b40ad512bde5167964e6539bbd" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>
@@ -54794,8 +54794,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.12 - Katei no Igaku (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86969" />
-		<info name="release" value="20011213" />
+		<info name="serial" value="SLPM-86969"/>
+		<info name="release" value="20011213"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.12 家庭の医学"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54815,8 +54815,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.13 - Shinri Game - Soreike X Kokoroji (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87016" />
-		<info name="release" value="20020214" />
+		<info name="serial" value="SLPM-87016"/>
+		<info name="release" value="20020214"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.13 心理ゲーム 〜それいけ×ココロジー ココロのウソの摩訶不思議〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54836,8 +54836,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.14 - Kurashi no Manner (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87022" />
-		<info name="release" value="20020214" />
+		<info name="serial" value="SLPM-87022"/>
+		<info name="release" value="20020214"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.14 暮らしのマナー 〜冠婚葬祭編〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54857,8 +54857,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.15 - Inu no Kaikata - Sekai no Inu Catalog (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87051" />
-		<info name="release" value="20020418" />
+		<info name="serial" value="SLPM-87051"/>
+		<info name="release" value="20020418"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.15 犬の飼い方 〜世界の犬カタログ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54878,8 +54878,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.16 - Neko no Kaikata - Sekai no Neko Catalog (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87052" />
-		<info name="release" value="20020418" />
+		<info name="serial" value="SLPM-87052"/>
+		<info name="release" value="20020418"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.16 猫の飼い方 〜世界の猫カタログ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54899,8 +54899,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.17 - Planetarium (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87049" />
-		<info name="release" value="20020418" />
+		<info name="serial" value="SLPM-87049"/>
+		<info name="release" value="20020418"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.17 THE プラネタリウム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54920,8 +54920,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.18 - Kanji Quiz - Kanji Keitei ni Challenge (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87072" />
-		<info name="release" value="20020523" />
+		<info name="serial" value="SLPM-87072"/>
+		<info name="release" value="20020523"/>
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.18 THE 漢字クイズ 〜漢字検定にチャレンジ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54941,8 +54941,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Slap Happy Rhythm Busters (Japan)</description>
 		<year>2000</year>
 		<publisher>ASK</publisher>
-		<info name="serial" value="SLPS-02789" />
-		<info name="release" value="20000629" />
+		<info name="serial" value="SLPS-02789"/>
+		<info name="release" value="20000629"/>
 		<info name="alt_title" value="スラップ ハッピー リズム バスターズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54963,9 +54963,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Super Live Stadium (Japan)</description>
 		<year>1998</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques" />
-		<info name="serial" value="SLPM-86019" />
-		<info name="release" value="19980101" />
+		<info name="developer" value="Aques"/>
+		<info name="serial" value="SLPM-86019"/>
+		<info name="release" value="19980101"/>
 		<info name="alt_title" value="スーパーライブスタジアム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54985,8 +54985,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kids Station - Motto! Oja Majo Dorami - MAHO-dou Smile Party (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03247" />
-		<info name="release" value="20010726" />
+		<info name="serial" value="SLPS-03247"/>
+		<info name="release" value="20010726"/>
 		<info name="alt_title" value="キッズステーション も〜っと！おジャ魔女どれみ MAHO堂スマイルパーテ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55006,8 +55006,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Snatcher (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPS-00154" />
-		<info name="release" value="19960216" />
+		<info name="serial" value="SLPS-00154"/>
+		<info name="release" value="19960216"/>
 		<info name="alt_title" value="スナッチャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55027,8 +55027,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>S.Q. - Sound Qube (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01309" />
-		<info name="release" value="19980312" />
+		<info name="serial" value="SLPS-01309"/>
+		<info name="release" value="19980312"/>
 		<info name="alt_title" value="S.Q. サウンドキューブ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55048,8 +55048,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Snobow Kids Plus (Japan)</description>
 		<year>1999</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-01823" />
-		<info name="release" value="19990121" />
+		<info name="serial" value="SLPS-01823"/>
+		<info name="release" value="19990121"/>
 		<info name="alt_title" value="スノボキッズプラス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55100,8 +55100,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Soukyugurentai - Oubushustugeki (Japan)</description>
 		<year>1997</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-01172" />
-		<info name="release" value="19971225" />
+		<info name="serial" value="SLPS-01172"/>
+		<info name="release" value="19971225"/>
 		<info name="alt_title" value="蒼穹紅蓮隊 黄武出撃"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55121,8 +55121,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gakuen Sentai Solblast (Japan)</description>
 		<year>1999</year>
 		<publisher>Creative Heads</publisher>
-		<info name="serial" value="SLPS-01852" />
-		<info name="release" value="19990204" />
+		<info name="serial" value="SLPS-01852"/>
+		<info name="release" value="19990204"/>
 		<info name="alt_title" value="学園戦隊ソルブラスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55145,8 +55145,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sonata (Japan)</description>
 		<year>1999</year>
 		<publisher>T&amp;E Soft</publisher>
-		<info name="serial" value="SLPS-01843~SLPS-01844" />
-		<info name="release" value="19990304" />
+		<info name="serial" value="SLPS-01843~SLPS-01844"/>
+		<info name="release" value="19990304"/>
 		<info name="alt_title" value="ソナタ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -55171,8 +55171,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sotsugyou Crossworld (Japan)</description>
 		<year>1996</year>
 		<publisher>Hearty Robin</publisher>
-		<info name="serial" value="SLPS-00273" />
-		<info name="release" value="19960628" />
+		<info name="serial" value="SLPS-00273"/>
+		<info name="release" value="19960628"/>
 		<info name="alt_title" value="卒業クロスワールド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55192,8 +55192,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Space Invaders X (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86419 (TCPS10014)" />
-		<info name="release" value="20000217" />
+		<info name="serial" value="SLPM-86419 (TCPS10014)"/>
+		<info name="release" value="20000217"/>
 		<info name="alt_title" value="スペースインベーダーX"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55213,8 +55213,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Spectral Blade (Japan)</description>
 		<year>1999</year>
 		<publisher>Idea Factory</publisher>
-		<info name="serial" value="SLPS-02526" />
-		<info name="release" value="19991222" />
+		<info name="serial" value="SLPS-02526"/>
+		<info name="release" value="19991222"/>
 		<info name="alt_title" value="スペクトラルブレイド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55234,8 +55234,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Speed King (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86013 (VX025-J1)" />
-		<info name="release" value="19961213" />
+		<info name="serial" value="SLPM-86013 (VX025-J1)"/>
+		<info name="release" value="19961213"/>
 		<info name="alt_title" value="スピードキング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55255,8 +55255,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Speed Power Gunbike (Japan)</description>
 		<year>1998</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-01066" />
-		<info name="release" value="19980423" />
+		<info name="serial" value="SLPS-01066"/>
+		<info name="release" value="19980423"/>
 		<info name="alt_title" value="可変走攻 ガンバイク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55276,8 +55276,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Spider-Man (Japan)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86739" />
-		<info name="release" value="20010426" />
+		<info name="serial" value="SLPM-86739"/>
+		<info name="release" value="20010426"/>
 		<info name="alt_title" value="スパイダーマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55297,7 +55297,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen alpha (japan) (v1.1)" sha1="55891934c6f643bad499999e441d019c9a14f478" />
+				<disk name="super robot taisen alpha (japan) (v1.1)" sha1="55891934c6f643bad499999e441d019c9a14f478"/>
 			</diskarea>
 		</part>
 	</software>
@@ -55312,7 +55312,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen alpha gaiden - premium edition (japan)" sha1="6d1c0aadeb797702d8de68b1d96b0c62ae84cf77" />
+				<disk name="super robot taisen alpha gaiden - premium edition (japan)" sha1="6d1c0aadeb797702d8de68b1d96b0c62ae84cf77"/>
 			</diskarea>
 		</part>
 	</software>
@@ -55327,7 +55327,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen alpha gaiden - shokai genteiban (japan)" sha1="104390ee61a56baf4902f45a945cb588d3b7c795" />
+				<disk name="super robot taisen alpha gaiden - shokai genteiban (japan)" sha1="104390ee61a56baf4902f45a945cb588d3b7c795"/>
 			</diskarea>
 		</part>
 	</software>
@@ -55345,7 +55345,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen - complete box (japan) (disc 1)" sha1="624cc4b224cb211199095a6c2daad947c9d4c6de" />
+				<disk name="super robot taisen - complete box (japan) (disc 1)" sha1="624cc4b224cb211199095a6c2daad947c9d4c6de"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -55366,7 +55366,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen f (japan)" sha1="3b86350787d8d9512e276f646a6ef7d8fe2191d4" />
+				<disk name="super robot taisen f (japan)" sha1="3b86350787d8d9512e276f646a6ef7d8fe2191d4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -55382,7 +55382,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen f kanketsuhen (japan)" sha1="f2587e200ebb55eee1dcd7092b2e745102d5db3a" />
+				<disk name="super robot taisen f kanketsuhen (japan)" sha1="f2587e200ebb55eee1dcd7092b2e745102d5db3a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -55397,8 +55397,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.37 - The Illustration Puzzle &amp; Slide Puzzle (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPS-02958" />
-		<info name="release" value="20000914" />
+		<info name="serial" value="SLPS-02958"/>
+		<info name="release" value="20000914"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.37 THE イラストパズル&amp;スライドパズル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55418,8 +55418,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.51 - The Jigsaw Puzzle (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86700" />
-		<info name="release" value="20001228" />
+		<info name="serial" value="SLPM-86700"/>
+		<info name="release" value="20001228"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.51 THE ジグソーパズル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55439,8 +55439,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.63 - The Gun Shooting 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86816" />
-		<info name="release" value="20010531" />
+		<info name="serial" value="SLPM-86816"/>
+		<info name="release" value="20010531"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.63 THE ガンシューティング2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55460,8 +55460,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.67 - The Soccer - Dynamite Soccer 1500 (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86864" />
-		<info name="release" value="20010809" />
+		<info name="serial" value="SLPM-86864"/>
+		<info name="release" value="20010809"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.67 THE サッカー 〜ダイナマイトサッカー1500〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55481,8 +55481,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.71 - The Ren'ai Simulation 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86870" />
-		<info name="release" value="20010830" />
+		<info name="serial" value="SLPM-86870"/>
+		<info name="release" value="20010830"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.71 THE 恋愛シミュレーション2 〜ふれあい〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55502,8 +55502,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.72 - The Beach Volley (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86871" />
-		<info name="release" value="20010830" />
+		<info name="serial" value="SLPM-86871"/>
+		<info name="release" value="20010830"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.72 THE ビーチバレー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55524,8 +55524,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.73 - The Invaders - Space Invaders 1500 (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86900" />
-		<info name="release" value="20010927" />
+		<info name="serial" value="SLPM-86900"/>
+		<info name="release" value="20010927"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.73 THE インベーダー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55545,8 +55545,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.76 - The Dodgeball (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86914" />
-		<info name="release" value="20011025" />
+		<info name="serial" value="SLPM-86914"/>
+		<info name="release" value="20011025"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.76 THE ドッヂボール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55566,8 +55566,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.83 - The Wakeboard - BursTrick Wake Boarding!! (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86998" />
-		<info name="release" value="20011220" />
+		<info name="serial" value="SLPM-86998"/>
+		<info name="release" value="20011220"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.83 THE ウェイクボード～バーストリック ウェイクボーディング！！～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55587,8 +55587,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.85 - The Sengoku Bushou - Tenka Touitsu no Yabou (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87008" />
-		<info name="release" value="20020130" />
+		<info name="serial" value="SLPM-87008"/>
+		<info name="release" value="20020130"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.85 THE 戦国武将 〜天下統一の野望〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55608,8 +55608,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.88 - The Gal Mahjong - Love Songs - Idol wa High Rate (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87023" />
-		<info name="release" value="20020328" />
+		<info name="serial" value="SLPM-87023"/>
+		<info name="release" value="20020328"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.88 THE ギャル麻雀 〜LoveSongs アイドルはハイレ〜ト〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55629,8 +55629,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.89 - The Power Shovel - Power Shovel ni Norou! (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87035" />
-		<info name="release" value="20020328" />
+		<info name="serial" value="SLPM-87035"/>
+		<info name="release" value="20020328"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.89 THE パワーショベル 〜パワーショベルに乗ろう!!〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55650,8 +55650,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.90 - The Sensha (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87044" />
-		<info name="release" value="20020328" />
+		<info name="serial" value="SLPM-87044"/>
+		<info name="release" value="20020328"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.90 THE 戦車"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55671,8 +55671,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.93 - The Puzzle Bobble 4 (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87057" />
-		<info name="release" value="20020425" />
+		<info name="serial" value="SLPM-87057"/>
+		<info name="release" value="20020425"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.93 THE パズルボブル 〜パズルボブル4〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55692,8 +55692,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.97 - The Squash (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87088" />
-		<info name="release" value="20020627" />
+		<info name="serial" value="SLPM-87088"/>
+		<info name="release" value="20020627"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.97 THE スカッシュ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55713,8 +55713,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.99 - The Kendo - Ken no Hanamichi (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87140" />
-		<info name="release" value="20020829" />
+		<info name="serial" value="SLPM-87140"/>
+		<info name="release" value="20020829"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.99 THE 剣道 〜剣の花道〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55734,8 +55734,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.101 - The Sentou (Japan)</description>
 		<year>2003</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87142" />
-		<info name="release" value="20030130" />
+		<info name="serial" value="SLPM-87142"/>
+		<info name="release" value="20030130"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.101 THE 銭湯"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55755,8 +55755,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.102 - The Densha Untensha - Densha de Go! - Nagoya Tetsudou-hen (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87144" />
-		<info name="release" value="20020829" />
+		<info name="serial" value="SLPM-87144"/>
+		<info name="release" value="20020829"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.102 THE 電車運転手〜電車でGO!名古屋鉄道編〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55776,8 +55776,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.103 - The Ganso Densha Utenshi - Densha De Go! (Japan)</description>
 		<year>2003</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87212" />
-		<info name="release" value="20030130" />
+		<info name="serial" value="SLPM-87212"/>
+		<info name="release" value="20030130"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.103 THE 元祖電車運転士〜電車でGO!〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55819,8 +55819,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.104 - The Pink Panther - Pinkadelic Pursuit (Japan)</description>
 		<year>2003</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87215" />
-		<info name="release" value="20030227" />
+		<info name="serial" value="SLPM-87215"/>
+		<info name="release" value="20030227"/>
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.104 THE ピンクパンサー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55856,8 +55856,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Stahlfeder - Tetsukou Hikuudan (Japan)</description>
 		<year>1996</year>
 		<publisher>Santos</publisher>
-		<info name="serial" value="SLPS-00162" />
-		<info name="release" value="19960126" />
+		<info name="serial" value="SLPS-00162"/>
+		<info name="release" value="19960126"/>
 		<info name="alt_title" value="シュタールフェーダー 〜鉄甲飛空団〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55877,8 +55877,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Startling Odyssey 1 - Blue Evolution (Japan)</description>
 		<year>1999</year>
 		<publisher>RayForce</publisher>
-		<info name="serial" value="SLPS-02043" />
-		<info name="release" value="19990715" />
+		<info name="serial" value="SLPS-02043"/>
+		<info name="release" value="19990715"/>
 		<info name="alt_title" value="スタートリング・オデッセイ1 ブルーエヴォリューション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55898,8 +55898,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kotetsu Reiki - Steel Dom (Japan)</description>
 		<year>1996</year>
 		<publisher>TecnoSoft</publisher>
-		<info name="serial" value="SLPS-00431" />
-		<info name="release" value="19960830" />
+		<info name="serial" value="SLPS-00431"/>
+		<info name="release" value="19960830"/>
 		<info name="alt_title" value="鋼鉄霊域 (スティールダム)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55919,8 +55919,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shin Theme Park (Japan)</description>
 		<year>1997</year>
 		<publisher>Electronic Arts Victor</publisher>
-		<info name="serial" value="SLPS-00810" />
-		<info name="release" value="19970411" />
+		<info name="serial" value="SLPS-00810"/>
+		<info name="release" value="19970411"/>
 		<info name="alt_title" value="新テーマパーク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55940,8 +55940,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Suchie-Pai Adventure - Doki Doki Nightmare (Japan, disc 2 only)</description>
 		<year>1998</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-01265" />
-		<info name="release" value="19980409" />
+		<info name="serial" value="SLPS-01265"/>
+		<info name="release" value="19980409"/>
 		<info name="alt_title" value="スーチーパイアドベンチャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<!--
@@ -55974,8 +55974,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Idol Janshi Suchie-Pai II Limited (Japan)</description>
 		<year>1996</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-00290~SLPS-00292" />
-		<info name="release" value="19960920" />
+		<info name="serial" value="SLPS-00290~SLPS-00292"/>
+		<info name="release" value="19960920"/>
 		<info name="alt_title" value="アイドル雀士スーチーパイII リミテッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56005,8 +56005,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Idol Janshi Suchie-Pai Limited (Japan)</description>
 		<year>1995</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-00029" />
-		<info name="release" value="19950324" />
+		<info name="serial" value="SLPS-00029"/>
+		<info name="release" value="19950324"/>
 		<info name="alt_title" value="アイドル雀士スーチーパイ リミテッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56053,8 +56053,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Suiko Enbu - Outlaws of the Lost Dynasty (Japan)</description>
 		<year>1996</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-00137" />
-		<info name="release" value="19960126" />
+		<info name="serial" value="SLPS-00137"/>
+		<info name="release" value="19960126"/>
 		<info name="alt_title" value="水滸演武"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56074,8 +56074,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.1 - Ikki &amp; Super Arabian (Japan)</description>
 		<year>2001</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03135" />
-		<info name="release" value="20011004" />
+		<info name="serial" value="SLPS-03135"/>
+		<info name="release" value="20011004"/>
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフト Vol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56095,8 +56095,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.2 - Route-16 Turbo &amp; Atlantis no Nazo (Japan)</description>
 		<year>2001</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03181" />
-		<info name="release" value="20011206" />
+		<info name="serial" value="SLPS-03181"/>
+		<info name="release" value="20011206"/>
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフトVOL.2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56116,8 +56116,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.3 - Madoola no Tsubasa &amp; Toukaidou Gojuusan Tsugi (Japan)</description>
 		<year>2001</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03366" />
-		<info name="release" value="20011227" />
+		<info name="serial" value="SLPS-03366"/>
+		<info name="release" value="20011227"/>
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフトVOL.3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56137,8 +56137,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.4 - Chou Wakusei Senki Metafight &amp; Ripple Island (Japan)</description>
 		<year>2002</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03382" />
-		<info name="release" value="20020214" />
+		<info name="serial" value="SLPS-03382"/>
+		<info name="release" value="20020214"/>
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフト VOL.4"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56158,8 +56158,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.5 - Raf World &amp; Hebereke (Japan)</description>
 		<year>2002</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03397" />
-		<info name="release" value="20020328" />
+		<info name="serial" value="SLPS-03397"/>
+		<info name="release" value="20020328"/>
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフト VOL.5"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56179,8 +56179,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.6 - Battle Formula &amp; Gimmick! (Japan)</description>
 		<year>2002</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03486" />
-		<info name="release" value="20021121" />
+		<info name="serial" value="SLPS-03486"/>
+		<info name="release" value="20021121"/>
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフトVOL.6"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56200,8 +56200,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tactics Ogre - Let Us Cling Together (Japan)</description>
 		<year>1997</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-00767" />
-		<info name="release" value="19970925" />
+		<info name="serial" value="SLPS-00767"/>
+		<info name="release" value="19970925"/>
 		<info name="alt_title" value="タクティクス・オウガ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56222,8 +56222,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tatsunoko Fight (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02939" />
-		<info name="release" value="20001005" />
+		<info name="serial" value="SLPS-02939"/>
+		<info name="release" value="20001005"/>
 		<info name="alt_title" value="タツノコファイト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56243,8 +56243,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tenant Wars (Japan)</description>
 		<year>1998</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-01243" />
-		<info name="release" value="19980211" />
+		<info name="serial" value="SLPS-01243"/>
+		<info name="release" value="19980211"/>
 		<info name="alt_title" value="テナントウォーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56267,8 +56267,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tenchi Muyou! Toukou Muyou (Japan)</description>
 		<year>1996</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-00451~SLPS-00452" />
-		<info name="release" value="19960913" />
+		<info name="serial" value="SLPS-00451~SLPS-00452"/>
+		<info name="release" value="19960913"/>
 		<info name="alt_title" value="天地無用！〜登校無用〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56293,8 +56293,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tenchi wo Kurau II - Sekiheki no Tatakai (Japan)</description>
 		<year>1996</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00203" />
-		<info name="release" value="19960322" />
+		<info name="serial" value="SLPS-00203"/>
+		<info name="release" value="19960322"/>
 		<info name="alt_title" value="天地を喰らうII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56314,8 +56314,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ten Made Jack - Odoroki Manenoki Daitoubou!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86368" />
-		<info name="release" value="20000323" />
+		<info name="serial" value="SLPM-86368"/>
+		<info name="release" value="20000323"/>
 		<info name="alt_title" value="天までジャック オドロキマメノキ大逃亡！！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56335,8 +56335,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tennis Arena (Japan)</description>
 		<year>1998</year>
 		<publisher>Ubi Soft</publisher>
-		<info name="serial" value="SLPS-01303" />
-		<info name="release" value="19980319" />
+		<info name="serial" value="SLPS-01303"/>
+		<info name="release" value="19980319"/>
 		<info name="alt_title" value="テニス・アリーナ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56356,8 +56356,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tensen Nyannyan - Gekijou-ban (Japan)</description>
 		<year>1998</year>
 		<publisher>Time Point</publisher>
-		<info name="serial" value="SLPS-01278" />
-		<info name="release" value="19980226" />
+		<info name="serial" value="SLPS-01278"/>
+		<info name="release" value="19980226"/>
 		<info name="alt_title" value="天仙娘々〜劇場版〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56377,8 +56377,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Oukyuu no Hihou - Tension (Japan)</description>
 		<year>1996</year>
 		<publisher>VAP</publisher>
-		<info name="serial" value="SLPS-00438" />
-		<info name="release" value="19960927" />
+		<info name="serial" value="SLPS-00438"/>
+		<info name="release" value="19960927"/>
 		<info name="alt_title" value="王宮の秘宝 テンション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56398,8 +56398,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tetris X (Japan)</description>
 		<year>1996</year>
 		<publisher>BPS</publisher>
-		<info name="serial" value="SLPS-00321" />
-		<info name="release" value="19960329" />
+		<info name="serial" value="SLPS-00321"/>
+		<info name="release" value="19960329"/>
 		<info name="alt_title" value="テトリス X"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56419,8 +56419,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Thunder Force V - Perfect System (Japan)</description>
 		<year>1998</year>
 		<publisher>TechnoSoft</publisher>
-		<info name="serial" value="SLPS-01406" />
-		<info name="release" value="19980521" />
+		<info name="serial" value="SLPS-01406"/>
+		<info name="release" value="19980521"/>
 		<info name="alt_title" value="サンダー・フォースＶ　～パーフェクト・システム～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56440,8 +56440,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>TFX - Tactical Fighter Experiment (Japan)</description>
 		<year>1996</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-00511" />
-		<info name="release" value="19961129" />
+		<info name="serial" value="SLPS-00511"/>
+		<info name="release" value="19961129"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -56469,8 +56469,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Time Gal &amp; Ninja Hayate (Japan)</description>
 		<year>1996</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-00383~SLPS-00384" />
-		<info name="release" value="19960705" />
+		<info name="serial" value="SLPS-00383~SLPS-00384"/>
+		<info name="release" value="19960705"/>
 		<info name="alt_title" value="タイムギャル&amp;忍者ハヤテ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56497,8 +56497,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>That's QT (Japan)</description>
 		<year>2000</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86340" />
-		<info name="release" value="20010127" />
+		<info name="serial" value="SLPM-86340"/>
+		<info name="release" value="20010127"/>
 		<info name="alt_title" value="ザッツキューティ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56518,8 +56518,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Theme Hospital (Japan)</description>
 		<year>1998</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="SLPS-01405" />
-		<info name="release" value="19980618" />
+		<info name="serial" value="SLPS-01405"/>
+		<info name="release" value="19980618"/>
 		<info name="alt_title" value="テーマホスピタル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56539,8 +56539,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tiny Bullets (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10130" />
-		<info name="release" value="20000413" />
+		<info name="serial" value="SCPS-10130"/>
+		<info name="release" value="20000413"/>
 		<info name="alt_title" value="タイニーバレット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56560,8 +56560,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tantei Jinguuji Saburou - Early Collection (Japan)</description>
 		<year>1999</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-02157" />
-		<info name="release" value="19990805" />
+		<info name="serial" value="SLPS-02157"/>
+		<info name="release" value="19990805"/>
 		<info name="alt_title" value="探偵神宮寺三郎 アーリーコレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56581,8 +56581,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tantei Jinguuji Saburou - Mikan no Rupo (Japan, Popular Edition)</description>
 		<year>2000</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-03016" />
-		<info name="release" value="20001214" />
+		<info name="serial" value="SLPS-03016"/>
+		<info name="release" value="20001214"/>
 		<info name="alt_title" value="普及版1,500円シリーズ 探偵神宮寺三郎 未完のルポ 普及版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56602,8 +56602,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tantei Jinguuji Saburou - Tomoshibi ga Kienumani (Japan)</description>
 		<year>1999</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-02427" />
-		<info name="release" value="19991125" />
+		<info name="serial" value="SLPS-02427"/>
+		<info name="release" value="19991125"/>
 		<info name="alt_title" value="探偵 神宮寺三郎 灯火が消えぬ間に"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56623,8 +56623,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tantei Jinguuji Saburou - Yume no Owari ni (Japan)</description>
 		<year>1998</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-01356" />
-		<info name="release" value="19980423" />
+		<info name="serial" value="SLPS-01356"/>
+		<info name="release" value="19980423"/>
 		<info name="alt_title" value="探偵 神宮寺三郎 夢の終わりに"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56644,8 +56644,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>T kara Hajimaru Monogatari (Japan)</description>
 		<year>1998</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-01350" />
-		<info name="release" value="19980604" />
+		<info name="serial" value="SLPS-01350"/>
+		<info name="release" value="19980604"/>
 		<info name="alt_title" value="Tから始まる物語"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56668,8 +56668,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Toukidenshou - Angel Eyes (Japan)</description>
 		<year>1997</year>
 		<publisher>Tecmo</publisher>
-		<info name="serial" value="SLPS-01168" />
-		<info name="release" value="19971211" />
+		<info name="serial" value="SLPS-01168"/>
+		<info name="release" value="19971211"/>
 		<info name="alt_title" value="闘姫伝承 エンジェルアイズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56689,8 +56689,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial Taisen Puzzle-Dama (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86005 (VX036-J1)" />
-		<info name="release" value="19960927" />
+		<info name="serial" value="SLPM-86005 (VX036-J1)"/>
+		<info name="release" value="19960927"/>
 		<info name="alt_title" value="ときめきメモリアル対戦ぱずるだま"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56710,8 +56710,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 EVS Append Disc 1 (Kotoko - Miyuki - Kaedeko) (Japan)</description>
 		<year>2000</year>
 		<publisher>Aspect</publisher>
-		<info name="serial" value="SLPM-80527" />
-		<info name="release" value="" />
+		<info name="serial" value="SLPM-80527"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value=""/>
 		<info name="usage" value="This disc contains additional EVS tracks for Tokimeki Memorial 2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -56732,15 +56732,14 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 EVS Append Disc 2 (Homura - Akane - Kaori) (Japan)</description>
 		<year>2000</year>
 		<publisher>Aspect</publisher>
-		<info name="serial" value="SLPM-80544" />
-		<info name="release" value="" />
+		<info name="serial" value="SLPM-80544"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value=""/>
 		<info name="usage" value="This disc contains additional EVS tracks for Tokimeki Memorial 2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tokimeki memorial 2 emotional voice system (vol.2 - homura-akane-kaori) (japan) [slpm-80544]" sha1="a14c4bd793988821bc164c28cb07aa7c5b777c70" status="baddump"
-/>
+				<disk name="tokimeki memorial 2 emotional voice system (vol.2 - homura-akane-kaori) (japan) [slpm-80544]" sha1="a14c4bd793988821bc164c28cb07aa7c5b777c70" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>
@@ -56755,15 +56754,14 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 EVS Append Disc 3 (Miho - Mei - Sumire) (Japan)</description>
 		<year>2000</year>
 		<publisher>Enterbrain</publisher>
-		<info name="serial" value="SLPM-80550" />
-		<info name="release" value="" />
+		<info name="serial" value="SLPM-80550"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value=""/>
 		<info name="usage" value="This disc contains additional EVS tracks for Tokimeki Memorial 2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tokimeki memorial 2 emotional voice system (vol.3 - miho-mei-sumire) (japan) [slpm-80550]" sha1="f1da5b225d32d08e35d762f0e473dc12212190e5" status="baddump"
-/>
+				<disk name="tokimeki memorial 2 emotional voice system (vol.3 - miho-mei-sumire) (japan) [slpm-80550]" sha1="f1da5b225d32d08e35d762f0e473dc12212190e5" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>
@@ -56781,8 +56779,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 Substories Vol.1 - Dancing Summer Vacation (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86549~SLPM-86550 (VX200-J1)" />
-		<info name="release" value="20000928" />
+		<info name="serial" value="SLPM-86549~SLPM-86550 (VX200-J1)"/>
+		<info name="release" value="20000928"/>
 		<info name="alt_title" value="ときめきメモリアル2 サブストーリーズ 〜Dancing Summer Vacation〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56810,8 +56808,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 Substories Vol.2 - Leaping School Festival (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86775~SLPM-86776 (VX232-J1)" />
-		<info name="release" value="20010329" />
+		<info name="serial" value="SLPM-86775~SLPM-86776 (VX232-J1)"/>
+		<info name="release" value="20010329"/>
 		<info name="alt_title" value="ときめきメモリアル2 サブストーリーズ 〜Leaping School Festival〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56839,8 +56837,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 Substories Vol.3 - Memories Ringing On (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86881~SLPM-86882 (VX247-J1)" />
-		<info name="release" value="20010830" />
+		<info name="serial" value="SLPM-86881~SLPM-86882 (VX247-J1)"/>
+		<info name="release" value="20010830"/>
 		<info name="alt_title" value="ときめきメモリアル2 サブストーリーズ 〜Memories Ringing On〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56865,8 +56863,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tenshi no Shippo (Japan)</description>
 		<year>2003</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03531" />
-		<info name="release" value="20030227" />
+		<info name="serial" value="SLPS-03531"/>
+		<info name="release" value="20030227"/>
 		<info name="alt_title" value="天使のしっぽ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56886,8 +56884,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tales of Fandom Vol.1 (Japan, Cless Version)</description>
 		<year>2002</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-03375" />
-		<info name="release" value="20020131" />
+		<info name="serial" value="SLPS-03375"/>
+		<info name="release" value="20020131"/>
 		<info name="alt_title" value="テイルズオブファンダム Vol.1 (クレス・ルーティー・ファラバージョン)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56910,8 +56908,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>To Heart (Japan)</description>
 		<year>1999</year>
 		<publisher>Aqua Plus</publisher>
-		<info name="serial" value="SLPS-01919~SLPS-01920" />
-		<info name="release" value="19990325" />
+		<info name="serial" value="SLPS-01919~SLPS-01920"/>
+		<info name="release" value="19990325"/>
 		<info name="alt_title" value="トゥハート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56961,8 +56959,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Toaplan Shooting Battle 1 (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00436" />
-		<info name="release" value="19960830" />
+		<info name="serial" value="SLPS-00436"/>
+		<info name="release" value="19960830"/>
 		<info name="alt_title" value="東亜プラン シューティングバトル1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56982,8 +56980,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>TOCA Touring Car Championship (Japan)</description>
 		<year>1998</year>
 		<publisher>Upstar</publisher>
-		<info name="serial" value="SLPS-01410" />
-		<info name="release" value="19980618" />
+		<info name="serial" value="SLPS-01410"/>
+		<info name="release" value="19980618"/>
 		<info name="alt_title" value="トカ ツーリングカーチャンピオンシップ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57003,8 +57001,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial Drama Series Vol.1 - Nijiiro No Seishun (Japan, Konami the Best)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86360 (VX069-J2)" />
-		<info name="release" value="19991125" />
+		<info name="serial" value="SLPM-86360 (VX069-J2)"/>
+		<info name="release" value="19991125"/>
 		<info name="alt_title" value="タイトル ときめきメモリアル　ドラマシリーズVol.1　虹色の青春（ベスト）"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57030,8 +57028,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokyo Majin Gakuen Gehouchou (Japan)</description>
 		<year>2002</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-03333~SLPS-03335" />
-		<info name="release" value="20020124" />
+		<info name="serial" value="SLPS-03333~SLPS-03335"/>
+		<info name="release" value="20020124"/>
 		<info name="alt_title" value="東京魔人学園外法帖"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -57061,8 +57059,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gekitotsu Toma L'Arc - Tomarunner vs. L'Arc~en~Ciel (Japan)</description>
 		<year>2000</year>
 		<publisher>Sony</publisher>
-		<info name="serial" value="SCPS-10134" />
-		<info name="release" value="20000719" />
+		<info name="serial" value="SCPS-10134"/>
+		<info name="release" value="20000719"/>
 		<info name="alt_title" value="激突トマラルク トマランナー vs ラルク アン シエル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57082,8 +57080,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gekisou Tomarunner (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10087" />
-		<info name="release" value="19990722" />
+		<info name="serial" value="SCPS-10087"/>
+		<info name="release" value="19990722"/>
 		<info name="alt_title" value="激走トマランナー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57103,8 +57101,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ore! Tomba (Japan)</description>
 		<year>1997</year>
 		<publisher>Whoopee Camp</publisher>
-		<info name="serial" value="SLPS-01144" />
-		<info name="release" value="19971225" />
+		<info name="serial" value="SLPS-01144"/>
+		<info name="release" value="19971225"/>
 		<info name="alt_title" value="オレっ！トンバ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57124,8 +57122,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tomba! The Wild Adventures (Japan)</description>
 		<year>1999</year>
 		<publisher>Whoopee Camp</publisher>
-		<info name="serial" value="SLPS-02350" />
-		<info name="release" value="19991028" />
+		<info name="serial" value="SLPS-02350"/>
+		<info name="release" value="19991028"/>
 		<info name="alt_title" value="トンバ！ ザ・ワイルドアドベンチャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57145,8 +57143,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tomica Town o Tsukurou! (Japan)</description>
 		<year>1999</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-01935" />
-		<info name="release" value="19990311" />
+		<info name="serial" value="SLPS-01935"/>
+		<info name="release" value="19990311"/>
 		<info name="alt_title" value="トミカタウンをつくろう!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57167,8 +57165,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>ToPoLo (Japan)</description>
 		<year>1996</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-00620" />
-		<info name="release" value="19961206" />
+		<info name="serial" value="SLPS-00620"/>
+		<info name="release" value="19961206"/>
 		<info name="alt_title" value="トポロ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57188,8 +57186,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Toshinden Card Quest (Japan)</description>
 		<year>1998</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01113" />
-		<info name="release" value="19980402" />
+		<info name="serial" value="SLPS-01113"/>
+		<info name="release" value="19980402"/>
 		<info name="alt_title" value="闘神伝 カードクエスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57209,8 +57207,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Touge Max G (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-02361" />
-		<info name="release" value="20000113" />
+		<info name="serial" value="SLPS-02361"/>
+		<info name="release" value="20000113"/>
 		<info name="alt_title" value="峠マックスG"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57231,7 +57229,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Toyota Netz Racing (Japan)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPM-80429" />
+		<info name="serial" value="SLPM-80429"/>
 		<info name="alt_title" value="ソフト ネッツ・レーシング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57251,8 +57249,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Toys Dream (Japan)</description>
 		<year>1998</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-01704" />
-		<info name="release" value="19981126" />
+		<info name="serial" value="SLPS-01704"/>
+		<info name="release" value="19981126"/>
 		<info name="alt_title" value="トイズドリーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57272,8 +57270,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tripuzz (Japan)</description>
 		<year>1997</year>
 		<publisher>Santos</publisher>
-		<info name="serial" value="SLPS-00911" />
-		<info name="release" value="19971030" />
+		<info name="serial" value="SLPS-00911"/>
+		<info name="release" value="19971030"/>
 		<info name="alt_title" value="トリパズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57293,8 +57291,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Trump Shiyouyo! (Japan)</description>
 		<year>1998</year>
 		<publisher>Bottom Up</publisher>
-		<info name="serial" value="SLPS-01440" />
-		<info name="release" value="19981015" />
+		<info name="serial" value="SLPS-01440"/>
+		<info name="release" value="19981015"/>
 		<info name="alt_title" value="トランプしようよ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57314,8 +57312,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tsun Tsun Kumi 2 - Moji Moji Bakkun (Japan)</description>
 		<year>1998</year>
 		<publisher>Kodansha</publisher>
-		<info name="serial" value="SLPS-01694" />
-		<info name="release" value="19981119" />
+		<info name="serial" value="SLPS-01694"/>
+		<info name="release" value="19981119"/>
 		<info name="alt_title" value="つんつん組2 ～もじもじぱっくん～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57335,8 +57333,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tsun Tsun Kumi 3 - Kanji Vader (Japan)</description>
 		<year>1999</year>
 		<publisher>Kodansha</publisher>
-		<info name="serial" value="SLPS-01839" />
-		<info name="release" value="19990128" />
+		<info name="serial" value="SLPS-01839"/>
+		<info name="release" value="19990128"/>
 		<info name="alt_title" value="つんつん組3 〜もじもじぱっくん〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57356,8 +57354,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tsuri Baka Nisshi (Japan)</description>
 		<year>1996</year>
 		<publisher>Shogakukan</publisher>
-		<info name="serial" value="SLPS-00440" />
-		<info name="release" value="19960913" />
+		<info name="serial" value="SLPS-00440"/>
+		<info name="release" value="19960913"/>
 		<info name="alt_title" value="釣りバカ日誌"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57377,8 +57375,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Twinbee Taisen Puzzle-Dama (Japan)</description>
 		<year>1994</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPS-00015" />
-		<info name="release" value="19941209" />
+		<info name="serial" value="SLPS-00015"/>
+		<info name="release" value="19941209"/>
 		<info name="alt_title" value="ツインビー対戦ぱずるだま"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57398,8 +57396,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>TwinBee RPG (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86077 (VX060-J1)" />
-		<info name="release" value="19980402" />
+		<info name="serial" value="SLPM-86077 (VX060-J1)"/>
+		<info name="release" value="19980402"/>
 		<info name="alt_title" value="ツインビーRPG"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57419,8 +57417,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Twin Goddesses (Japan)</description>
 		<year>1994</year>
 		<publisher>PolyGram</publisher>
-		<info name="serial" value="SLPS-00018" />
-		<info name="release" value="19941222" />
+		<info name="serial" value="SLPS-00018"/>
+		<info name="release" value="19941222"/>
 		<info name="alt_title" value="ツイン・ゴッデス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57440,8 +57438,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Twins Story - Kimi ni Tsutaetakute... (Japan)</description>
 		<year>1999</year>
 		<publisher>Panther</publisher>
-		<info name="serial" value="SLPS-02126" />
-		<info name="release" value="19990624" />
+		<info name="serial" value="SLPS-02126"/>
+		<info name="release" value="19990624"/>
 		<info name="alt_title" value="ツインズストーリー きみにつたえたくて…"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57463,8 +57461,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Two-Tenkaku (Japan)</description>
 		<year>1995</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-00131" />
-		<info name="release" value="19951229" />
+		<info name="serial" value="SLPS-00131"/>
+		<info name="release" value="19951229"/>
 		<info name="alt_title" value="通天閣"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57484,8 +57482,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>UFO - A Day in the Life (Japan)</description>
 		<year>1999</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-02032" />
-		<info name="release" value="19990624" />
+		<info name="serial" value="SLPS-02032"/>
+		<info name="release" value="19990624"/>
 		<info name="alt_title" value="UFO ～A day in the life～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57505,8 +57503,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ugetsu Kitan (Japan)</description>
 		<year>1996</year>
 		<publisher>Tonkin House</publisher>
-		<info name="serial" value="SLPS-00391" />
-		<info name="release" value="19960705" />
+		<info name="serial" value="SLPS-00391"/>
+		<info name="release" value="19960705"/>
 		<info name="alt_title" value="雨月奇譚 〜うげつきたん〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57526,8 +57524,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>UkiUki Tsuri Tengoku - Uogami Densetsu wo Oe (Japan)</description>
 		<year>2000</year>
 		<publisher>Teichiku</publisher>
-		<info name="serial" value="SLPS-02579" />
-		<info name="release" value="20000217" />
+		<info name="serial" value="SLPS-02579"/>
+		<info name="release" value="20000217"/>
 		<info name="alt_title" value="ウキウキ釣り天国〜魚神伝説を追え〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57547,8 +57545,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ultima Underworld - The Stygian Abyss (Japan)</description>
 		<year>1997</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="SLPS-00742" />
-		<info name="release" value="19970314" />
+		<info name="serial" value="SLPS-00742"/>
+		<info name="release" value="19970314"/>
 		<info name="alt_title" value="ウルティマ アンダーワールド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57595,8 +57593,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ultraman Tiga &amp; Ultraman Dyna Fighting Evolution - New Generations (Japan)</description>
 		<year>1998</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01455" />
-		<info name="release" value="19980716" />
+		<info name="serial" value="SLPS-01455"/>
+		<info name="release" value="19980716"/>
 		<info name="alt_title" value="ウルトラマンティガ&amp;ダイナ 新たなる二つの光"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57616,8 +57614,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ultraman Zearth (Japan)</description>
 		<year>1996</year>
 		<publisher>Tohoku Shinsha</publisher>
-		<info name="serial" value="SLPS-00652" />
-		<info name="release" value="19961220" />
+		<info name="serial" value="SLPS-00652"/>
+		<info name="release" value="19961220"/>
 		<info name="alt_title" value="ウルトラマンゼアス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57637,8 +57635,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bokujyou Keieiteki Board Game Umapoly (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86403 (VX167-J1)" />
-		<info name="release" value="19991225" />
+		<info name="serial" value="SLPM-86403 (VX167-J1)"/>
+		<info name="release" value="19991225"/>
 		<info name="alt_title" value="牧場経営的ボードゲーム うまぽりぃ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57658,8 +57656,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Umi no Nushi Tsuri - Takarajimi ni Mukatte (Japan)</description>
 		<year>1999</year>
 		<publisher>Pack-in-Soft</publisher>
-		<info name="serial" value="SLPS-02172" />
-		<info name="release" value="19990722" />
+		<info name="serial" value="SLPS-02172"/>
+		<info name="release" value="19990722"/>
 		<info name="alt_title" value="海のぬし釣り−宝島に向かって−"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57680,8 +57678,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Umihara Kawase Shun - Second Edition (Japan, Maruan Series 1)</description>
 		<year>2000</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-02549" />
-		<info name="release" value="20000120" />
+		<info name="serial" value="SLPS-02549"/>
+		<info name="release" value="20000120"/>
 		<info name="alt_title" value="マル安シリーズ1 海腹川背・旬 〜セカンドエディション〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57704,8 +57702,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Taiho Shichauzo! - You're Under Arrest (Japan)</description>
 		<year>2001</year>
 		<publisher>Pioneer</publisher>
-		<info name="serial" value="SLPM-86782~SLPM-86783" />
-		<info name="release" value="20010329" />
+		<info name="serial" value="SLPM-86782~SLPM-86783"/>
+		<info name="release" value="20010329"/>
 		<info name="alt_title" value="逮捕しちゃうぞ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -57730,8 +57728,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ungra Walker (Japan)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-87055" />
-		<info name="release" value="20020606" />
+		<info name="serial" value="SLPM-87055"/>
+		<info name="release" value="20020606"/>
 		<info name="alt_title" value="アングラウォーカー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57751,8 +57749,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Urawaza Mahjong - Korette Tenhoutte Yatsukai (Japan)</description>
 		<year>2000</year>
 		<publisher>Spike</publisher>
-		<info name="serial" value="SLPS-02807" />
-		<info name="release" value="20000629" />
+		<info name="serial" value="SLPS-02807"/>
+		<info name="release" value="20000629"/>
 		<info name="alt_title" value="裏技麻雀〜これって天和ってやつかい〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57772,8 +57770,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Assault Suits Valken 2 - Juusou Kihei Valken 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Masaya</publisher>
-		<info name="serial" value="SLPS-00854" />
-		<info name="release" value="19990729" />
+		<info name="serial" value="SLPS-00854"/>
+		<info name="release" value="19990729"/>
 		<info name="alt_title" value="重装機兵ヴァルケン2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57794,8 +57792,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Vampir Kyuuketsuki Densetsu (Japan)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-01932" />
-		<info name="release" value="19990304" />
+		<info name="serial" value="SLPS-01932"/>
+		<info name="release" value="19990304"/>
 		<info name="alt_title" value="ヴァンピール 吸血鬼伝説"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57815,8 +57813,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Vehicle Cavalier (Japan)</description>
 		<year>1996</year>
 		<publisher>Vanguard Works</publisher>
-		<info name="serial" value="SLPS-00232" />
-		<info name="release" value="19960216" />
+		<info name="serial" value="SLPS-00232"/>
+		<info name="release" value="19960216"/>
 		<info name="alt_title" value="ヴィーグル・キャヴァリアー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57836,8 +57834,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Vermin Kids (Japan)</description>
 		<year>1996</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="SLPS-00558" />
-		<info name="release" value="19961101" />
+		<info name="serial" value="SLPS-00558"/>
+		<info name="release" value="19961101"/>
 		<info name="alt_title" value="バーミン・キッズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57857,8 +57855,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Virtual Hiryuu no Ken (Japan)</description>
 		<year>1997</year>
 		<publisher>Culture Brain</publisher>
-		<info name="serial" value="SLPS-00338" />
-		<info name="release" value="19970717" />
+		<info name="serial" value="SLPS-00338"/>
+		<info name="release" value="19970717"/>
 		<info name="alt_title" value="バーチャル飛龍の拳"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57878,8 +57876,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Victory Zone - Real Pachinko Simulator (Japan)</description>
 		<year>1995</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10002" />
-		<info name="release" value="19950331" />
+		<info name="serial" value="SCPS-10002"/>
+		<info name="release" value="19950331"/>
 		<info name="alt_title" value="ヴィクトリーゾーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57899,8 +57897,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Virus - The Battle Field (Japan)</description>
 		<year>1999</year>
 		<publisher>PolyGram</publisher>
-		<info name="serial" value="SLPS-02008" />
-		<info name="release" value="19990408" />
+		<info name="serial" value="SLPS-02008"/>
+		<info name="release" value="19990408"/>
 		<info name="alt_title" value="ウイルス －ザ バトルフィールド－"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57920,8 +57918,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Virtual Kyoutei '98 (Japan)</description>
 		<year>1998</year>
 		<publisher>Nihon Bussan</publisher>
-		<info name="serial" value="SLPS-01396" />
-		<info name="release" value="19980702" />
+		<info name="serial" value="SLPS-01396"/>
+		<info name="release" value="19980702"/>
 		<info name="alt_title" value="バーチャル競艇 '98"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57941,8 +57939,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Volfoss (Japan)</description>
 		<year>2001</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-03140" />
-		<info name="release" value="20010222" />
+		<info name="serial" value="SLPS-03140"/>
+		<info name="release" value="20010222"/>
 		<info name="alt_title" value="ボルフォス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57962,8 +57960,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Soukou Kihei Votoms - Lightning Slash (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01961" />
-		<info name="release" value="19990318" />
+		<info name="serial" value="SLPS-01961"/>
+		<info name="release" value="19990318"/>
 		<info name="alt_title" value="装甲騎兵ボトムズ ライトニングスラッシュ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57983,8 +57981,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Olympia Yamasa - Virtua Pachi-Slot II - Jissen! Bishoujo Kouryaku Hou (Japan)</description>
 		<year>1997</year>
 		<publisher>Map Japan</publisher>
-		<info name="serial" value="SLPS-00714" />
-		<info name="release" value="19970418" />
+		<info name="serial" value="SLPS-00714"/>
+		<info name="release" value="19970418"/>
 		<info name="alt_title" value="オリンピア・山佐 バーチャパチスロII〜必勝美少女攻略法〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58004,8 +58002,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Virtual Pro Wrestling (Japan)</description>
 		<year>1996</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-00449" />
-		<info name="release" value="19960913" />
+		<info name="serial" value="SLPS-00449"/>
+		<info name="release" value="19960913"/>
 		<info name="alt_title" value="バーチャルプロレスリング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58025,8 +58023,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Victory Spike (Japan)</description>
 		<year>1996</year>
 		<publisher>Imagineer</publisher>
-		<info name="serial" value="SLPS-00372" />
-		<info name="release" value="19960607" />
+		<info name="serial" value="SLPS-00372"/>
+		<info name="release" value="19960607"/>
 		<info name="alt_title" value="ヴィクトリー・スパイク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58046,8 +58044,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>V-Tennis 2 (Japan)</description>
 		<year>1996</year>
 		<publisher>Tonkin House</publisher>
-		<info name="serial" value="SLPS-00469" />
-		<info name="release" value="19961129" />
+		<info name="serial" value="SLPS-00469"/>
+		<info name="release" value="19961129"/>
 		<info name="alt_title" value="Vテニス2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58067,8 +58065,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chiki Chiki Machine Mou Race - Wacky Races (Japan)</description>
 		<year>2001</year>
 		<publisher>Infogrames Hudson</publisher>
-		<info name="serial" value="SLPM-86845" />
-		<info name="release" value="20010726" />
+		<info name="serial" value="SLPM-86845"/>
+		<info name="release" value="20010726"/>
 		<info name="alt_title" value="ドタバタ爆笑レースゲーム チキチキマシン猛レース"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58088,8 +58086,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wagamama Fairy Mirumo de Pon! - Mirumo no Mahou Gakkou Monogatari (Japan)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87220 (VX275-J1)" />
-		<info name="release" value="20030320" />
+		<info name="serial" value="SLPM-87220 (VX275-J1)"/>
+		<info name="release" value="20030320"/>
 		<info name="alt_title" value="わがままフェアリーミルモでポン! ミルモの魔法学校ものがたり"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58112,8 +58110,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wangan Trial (Japan)</description>
 		<year>1998</year>
 		<publisher>Pack-in-Soft</publisher>
-		<info name="serial" value="SLPS-01213~SLPS-01214" />
-		<info name="release" value="19980307" />
+		<info name="serial" value="SLPS-01213~SLPS-01214"/>
+		<info name="release" value="19980307"/>
 		<info name="alt_title" value="湾岸トライアル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -58138,8 +58136,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Warera Mitsubayashi Tankentai!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-02658" />
-		<info name="release" value="20000420" />
+		<info name="serial" value="SLPS-02658"/>
+		<info name="release" value="20000420"/>
 		<info name="alt_title" value="われら密林探検隊!!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58159,8 +58157,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Water Summer (Japan, Limited Edition)</description>
 		<year>2002</year>
 		<publisher>Princess Soft</publisher>
-		<info name="serial" value="SLPM-87085" />
-		<info name="release" value="20020718" />
+		<info name="serial" value="SLPM-87085"/>
+		<info name="release" value="20020718"/>
 		<info name="alt_title" value="ウォーターサマー (初回限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58180,8 +58178,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wedding Peach - Doki Doki Oironaoshi Fashion Daisakusen (Japan)</description>
 		<year>1996</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-00368" />
-		<info name="release" value="19960927" />
+		<info name="serial" value="SLPS-00368"/>
+		<info name="release" value="19960927"/>
 		<info name="alt_title" value="ウェディングピーチ ドキドキお色直し"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58201,8 +58199,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Welcome House (Japan)</description>
 		<year>1996</year>
 		<publisher>Gust</publisher>
-		<info name="serial" value="SLPS-00190" />
-		<info name="release" value="19960223" />
+		<info name="serial" value="SLPS-00190"/>
+		<info name="release" value="19960223"/>
 		<info name="alt_title" value="ウエルカムハウス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58222,8 +58220,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>White Diamond (Japan)</description>
 		<year>1999</year>
 		<publisher>Escot</publisher>
-		<info name="serial" value="SLPS-02352" />
-		<info name="release" value="19991125" />
+		<info name="serial" value="SLPS-02352"/>
+		<info name="release" value="19991125"/>
 		<info name="alt_title" value="ホワイトダイアモンド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58243,8 +58241,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wing Over (Japan)</description>
 		<year>1997</year>
 		<publisher>Pack-In Soft</publisher>
-		<info name="serial" value="SLPS-00598" />
-		<info name="release" value="19970221" />
+		<info name="serial" value="SLPS-00598"/>
+		<info name="release" value="19970221"/>
 		<info name="alt_title" value="ウイングオーバー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58264,8 +58262,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wizard's Harmony R (Japan)</description>
 		<year>1998</year>
 		<publisher>Arc System Works</publisher>
-		<info name="serial" value="SLPS-01716" />
-		<info name="release" value="19981126" />
+		<info name="serial" value="SLPS-01716"/>
+		<info name="release" value="19981126"/>
 		<info name="alt_title" value="ウィザーズハーモニーR"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58286,8 +58284,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>World League Soccer - Challenge Nippon! (Japan, Family Price 1500)</description>
 		<year>2000</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-02687" />
-		<info name="release" value="20000330" />
+		<info name="serial" value="SLPS-02687"/>
+		<info name="release" value="20000330"/>
 		<info name="alt_title" value="ワールドリーグサッカー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58309,8 +58307,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wolf Fang Kuuga 2001 (Japan)</description>
 		<year>1996</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-00254" />
-		<info name="release" value="19960510" />
+		<info name="serial" value="SLPS-00254"/>
+		<info name="release" value="19960510"/>
 		<info name="alt_title" value="ウルフファング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58330,8 +58328,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wonder B-Cruise - Dogiborn Daisakusen (Japan)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-02322" />
-		<info name="release" value="19991007" />
+		<info name="serial" value="SLPS-02322"/>
+		<info name="release" value="19991007"/>
 		<info name="alt_title" value="わんダービークルズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58351,8 +58349,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arcade Gears - Wonder 3 (Japan)</description>
 		<year>1998</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-00927" />
-		<info name="release" value="19980402" />
+		<info name="serial" value="SLPS-00927"/>
+		<info name="release" value="19980402"/>
 		<info name="alt_title" value="ワンダー3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58372,8 +58370,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wonder Trek (Japan)</description>
 		<year>1998</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10072" />
-		<info name="release" value="19981210" />
+		<info name="serial" value="SCPS-10072"/>
+		<info name="release" value="19981210"/>
 		<info name="alt_title" value="ワンダートレック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58394,8 +58392,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hiroki Matsukata Presents - World Fishing (Japan, BPS The Choice)</description>
 		<year>1999</year>
 		<publisher>BPS</publisher>
-		<info name="serial" value="SLPS-02041" />
-		<info name="release" value="19990428" />
+		<info name="serial" value="SLPS-02041"/>
+		<info name="release" value="19990428"/>
 		<info name="alt_title" value="BPS ザ・チョイス 松方弘樹のワールドフィッシング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58415,8 +58413,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>World Pro Tennis '98 (Japan)</description>
 		<year>1998</year>
 		<publisher>I.Magic</publisher>
-		<info name="serial" value="SLPS-01379" />
-		<info name="release" value="19980806" />
+		<info name="serial" value="SLPS-01379"/>
+		<info name="release" value="19980806"/>
 		<info name="alt_title" value="ワールドプロテニス98"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58436,8 +58434,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>WWF Wrestlemania - The Arcade Game (Japan)</description>
 		<year>1996</year>
 		<publisher>Acclaim</publisher>
-		<info name="serial" value="SLPS-00223" />
-		<info name="release" value="19960126" />
+		<info name="serial" value="SLPS-00223"/>
+		<info name="release" value="19960126"/>
 		<info name="alt_title" value="レッスルマニア・ジ・アーケードゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58468,8 +58466,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>X2 - No Relief (Japan)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00766" />
-		<info name="release" value="19970821" />
+		<info name="serial" value="SLPS-00766"/>
+		<info name="release" value="19970821"/>
 		<info name="alt_title" value="エックス2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58489,8 +58487,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Extra Bright (Japan)</description>
 		<year>1996</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-00625" />
-		<info name="release" value="19961206" />
+		<info name="serial" value="SLPS-00625"/>
+		<info name="release" value="19961206"/>
 		<info name="alt_title" value="エクストラブライト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58510,8 +58508,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>X. Racing (Japan)</description>
 		<year>1998</year>
 		<publisher>Nichibutsu</publisher>
-		<info name="serial" value="SLPS-01063" />
-		<info name="release" value="19980211" />
+		<info name="serial" value="SLPS-01063"/>
+		<info name="release" value="19980211"/>
 		<info name="alt_title" value="エックス・レーシング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58532,8 +58530,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>TV Animation X - Unmei no Tatakai (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03459" />
-		<info name="release" value="20020822" />
+		<info name="serial" value="SLPS-03459"/>
+		<info name="release" value="20020822"/>
 		<info name="alt_title" value="TV Animation X〜運命の選択〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58553,8 +58551,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yakiniku Bugyou (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03209" />
-		<info name="release" value="20010524" />
+		<info name="serial" value="SLPS-03209"/>
+		<info name="release" value="20010524"/>
 		<info name="alt_title" value="焼肉奉行"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58574,8 +58572,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yakitori Musume - Sugo Ude Hanjouki (Japan)</description>
 		<year>2002</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03435" />
-		<info name="release" value="20020509" />
+		<info name="serial" value="SLPS-03435"/>
+		<info name="release" value="20020509"/>
 		<info name="alt_title" value="やきとり娘〜スゴ腕繁盛記〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58604,8 +58602,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yamagata Digital Museum (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
-		<info name="serial" value="SLPS-02393~SLPS-02396" />
-		<info name="release" value="19991118" />
+		<info name="serial" value="SLPS-02393~SLPS-02396"/>
+		<info name="release" value="19991118"/>
 		<info name="alt_title" value="デジタルミュージアム ヒロ・ヤマガタ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -58648,8 +58646,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Youkai Hana Asobi (Japan)</description>
 		<year>2001</year>
 		<publisher>Unbalance</publisher>
-		<info name="serial" value="SLPM-86857" />
-		<info name="release" value="20010809" />
+		<info name="serial" value="SLPM-86857"/>
+		<info name="release" value="20010809"/>
 		<info name="alt_title" value="妖怪花あそび"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58669,8 +58667,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yoshimoto Muchicco Daikessen - Minami no Umi no Gorongo Shima (Japan)</description>
 		<year>1999</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-02308" />
-		<info name="release" value="19990930" />
+		<info name="serial" value="SLPS-02308"/>
+		<info name="release" value="19990930"/>
 		<info name="alt_title" value="ヨシモト ムチッ子大決戦 ～南の海のゴロンゴ島～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58690,8 +58688,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yuugen Kaisha Chikyuu Boueitai - Guard of Earth Organization (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Rings</publisher>
-		<info name="serial" value="SLPS-02024" />
-		<info name="release" value="19990428" />
+		<info name="serial" value="SLPS-02024"/>
+		<info name="release" value="19990428"/>
 		<info name="alt_title" value="有限会社 地球防衛隊"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58711,8 +58709,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yu-Gi-Oh! - Monster Capsule Breed &amp; Battle (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86096 (VX210-J1)" />
-		<info name="release" value="19980723" />
+		<info name="serial" value="SLPM-86096 (VX210-J1)"/>
+		<info name="release" value="19980723"/>
 		<info name="alt_title" value="遊戯王 モンスターカプセル ブリード&amp;バトル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58732,8 +58730,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yukinko Burning (Japan)</description>
 		<year>2002</year>
 		<publisher>Princess Soft</publisher>
-		<info name="serial" value="SLPM-87013" />
-		<info name="release" value="20020131" />
+		<info name="serial" value="SLPM-87013"/>
+		<info name="release" value="20020131"/>
 		<info name="alt_title" value="ゆきんこ☆ばぁにんぐ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58753,8 +58751,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yume Iroiro - Yumemigaoka Gakuen Koutou Gakkou Dai 33-Kisei (Japan)</description>
 		<year>1998</year>
 		<publisher>Feathered</publisher>
-		<info name="serial" value="SLPS-01401" />
-		<info name="release" value="19980730" />
+		<info name="serial" value="SLPS-01401"/>
+		<info name="release" value="19980730"/>
 		<info name="alt_title" value="夢☆色いろ 夢美が丘学園高等学校第33期生"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58774,8 +58772,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yume no Tsubasa (Japan)</description>
 		<year>2000</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-02954" />
-		<info name="release" value="20000928" />
+		<info name="serial" value="SLPS-02954"/>
+		<info name="release" value="20000928"/>
 		<info name="alt_title" value="夢のつばさ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58795,8 +58793,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ginga Ojousama Densetsu Yuna - Final Edition (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01451" />
-		<info name="release" value="19980625" />
+		<info name="serial" value="SLPS-01451"/>
+		<info name="release" value="19980625"/>
 		<info name="alt_title" value="銀河お嬢様伝説ユナ ファイナル・エディション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58816,8 +58814,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yuuyami Douri Tankentai (Japan)</description>
 		<year>1999</year>
 		<publisher>Spike</publisher>
-		<info name="serial" value="SLPS-02274" />
-		<info name="release" value="19991007" />
+		<info name="serial" value="SLPS-02274"/>
+		<info name="release" value="19991007"/>
 		<info name="alt_title" value="夕闇通り探検隊"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58837,8 +58835,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zap! Snowboarding Trix '98 (Japan)</description>
 		<year>1997</year>
 		<publisher>Pony Canyon</publisher>
-		<info name="serial" value="SLPS-00909" />
-		<info name="release" value="19971225" />
+		<info name="serial" value="SLPS-00909"/>
+		<info name="release" value="19971225"/>
 		<info name="alt_title" value="ザップ！ スノーボーディング・トリックス'98"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58858,8 +58856,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zeiramzone (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00575" />
-		<info name="release" value="19961213" />
+		<info name="serial" value="SLPS-00575"/>
+		<info name="release" value="19961213"/>
 		<info name="alt_title" value="ゼイラムゾーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58879,8 +58877,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zeitgeist (Japan)</description>
 		<year>1995</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-00034" />
-		<info name="release" value="19950825" />
+		<info name="serial" value="SLPS-00034"/>
+		<info name="release" value="19950825"/>
 		<info name="alt_title" value="ツァイトガイスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58900,8 +58898,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zero4 Champ DooZy-J (Japan)</description>
 		<year>1997</year>
 		<publisher>Media Rings</publisher>
-		<info name="serial" value="SLPS-00755" />
-		<info name="release" value="19970620" />
+		<info name="serial" value="SLPS-00755"/>
+		<info name="release" value="19970620"/>
 		<info name="alt_title" value="ゼロヨンチャンプ ドゥーヅィ・ジェイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58921,7 +58919,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kidou Senshi Z-Gundam (Japan, demo)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPM-80139" />
+		<info name="serial" value="SLPM-80139"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -58940,8 +58938,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zig Zag Ball (Japan)</description>
 		<year>1998</year>
 		<publisher>Upstar</publisher>
-		<info name="serial" value="SLPS-01483" />
-		<info name="release" value="19981210" />
+		<info name="serial" value="SLPS-01483"/>
+		<info name="release" value="19981210"/>
 		<info name="alt_title" value="ジグザグボール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58961,8 +58959,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zipangujima - Unmei wa Saikoro ga Kimeru! (Japan)</description>
 		<year>1999</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-02260" />
-		<info name="release" value="19991007" />
+		<info name="serial" value="SLPS-02260"/>
+		<info name="release" value="19991007"/>
 		<info name="alt_title" value="じぱんぐ島 〜運命はサイコロが決める!?〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58983,8 +58981,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zen-Nihon Joshi Pro Wrestling - Joou Densetsu Yume no Taikousen (Japan)</description>
 		<year>1998</year>
 		<publisher>TEN</publisher>
-		<info name="serial" value="SLPS-01475" />
-		<info name="release" value="19980723" />
+		<info name="serial" value="SLPS-01475"/>
+		<info name="release" value="19980723"/>
 		<info name="alt_title" value="全日本女子プロレス 女王伝説 夢の対抗戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59004,8 +59002,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zen-Nihon Pro Wrestling - Ouja no Kon (Japan)</description>
 		<year>1999</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01849" />
-		<info name="release" value="19990408" />
+		<info name="serial" value="SLPS-01849"/>
+		<info name="release" value="19990408"/>
 		<info name="alt_title" value="全日本プロレス 王者の魂"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59025,8 +59023,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zoids - Teikoku vs Kyouwakoku - Meka Seitai no Idenshi (Japan)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-02982" />
-		<info name="release" value="20001122" />
+		<info name="serial" value="SLPS-02982"/>
+		<info name="release" value="20001122"/>
 		<info name="alt_title" value="ゾイド帝国vs共和国 メカ生体の遺伝子 / Zoids - ZENEBUS VS HERIC (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59046,8 +59044,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zoids 2 - Helic Kyouwakoku vs Guylos Teikoku (Japan)</description>
 		<year>2002</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-03389" />
-		<info name="release" value="20020221" />
+		<info name="serial" value="SLPS-03389"/>
+		<info name="release" value="20020221"/>
 		<info name="alt_title" value="ゾイド2 ヘリック共和国 VS ガイロス帝国 / Zoids 2 - HERIC VS GUYLOS"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59067,8 +59065,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zoids - Battle Card Game - Seihou Tairiku Senki (Japan)</description>
 		<year>2001</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-03255" />
-		<info name="release" value="20010726" />
+		<info name="serial" value="SLPS-03255"/>
+		<info name="release" value="20010726"/>
 		<info name="alt_title" value="ゾイドバトルカードゲーム 西方大陸戦記"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59097,8 +59095,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zoku Hatsukoi Monogatari - Shuugaku Ryokou (Japan)</description>
 		<year>1998</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-01326~SLPS-01329" />
-		<info name="release" value="19980326" />
+		<info name="serial" value="SLPS-01326~SLPS-01329"/>
+		<info name="release" value="19980326"/>
 		<info name="alt_title" value="続 初恋物語 〜修学旅行〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -59133,8 +59131,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zork I - The Great Underground Empire (Japan)</description>
 		<year>1996</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-00271" />
-		<info name="release" value="19960315" />
+		<info name="serial" value="SLPS-00271"/>
+		<info name="release" value="19960315"/>
 		<info name="alt_title" value="ゾーク・ワン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59156,8 +59154,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zutto Issho - With Me Everytime... (Japan, Major Wave Series)</description>
 		<year>2000</year>
 		<publisher>Hamster</publisher>
-		<info name="serial" value="SLPM-86523" />
-		<info name="release" value="20000525" />
+		<info name="serial" value="SLPM-86523"/>
+		<info name="release" value="20000525"/>
 		<info name="alt_title" value="Major Waveシリーズ ずっといっしょ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59177,8 +59175,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>ZXE-D - Legend of Plasmatlite (Japan)</description>
 		<year>1996</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00424" />
-		<info name="release" value="19961220" />
+		<info name="serial" value="SLPS-00424"/>
+		<info name="release" value="19961220"/>
 		<info name="alt_title" value="ゼクシード レジェンド・オブ・プラズマトライト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59201,8 +59199,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Final Fantasy Extra Collection (Japan)</description>
 		<year>199?</year>
 		<publisher>Squaresoft</publisher>
-		<info name="serial" value="SLPM-80073" />
-		<info name="release" value="" />
+		<info name="serial" value="SLPM-80073"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value="ファイナルファンタジー　エクストラコレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59222,8 +59220,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Squaresoft Memory Card Data CD (Japan)</description>
 		<year>199?</year>
 		<publisher>Squaresoft</publisher>
-		<info name="serial" value="SLPM-80556" />
-		<info name="release" value="" />
+		<info name="serial" value="SLPM-80556"/>
+		<info name="release" value=""/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -59242,8 +59240,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lalala PlayStation Trial Disk 1998 Summer (Japan, demo)</description>
 		<year>199?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="serial" value="PAPX-90052" />
-		<info name="release" value="" />
+		<info name="serial" value="PAPX-90052"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value="ラララ　プレイステーション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59263,8 +59261,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Armored Core (Japan, demo)</description>
 		<year>1997</year>
 		<publisher>From Software</publisher>
-		<info name="serial" value="SLPM-80118" />
-		<info name="release" value="" />
+		<info name="serial" value="SLPM-80118"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value="装甲核心 - 体验版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59284,8 +59282,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Clock Tower 2 (Japan, Taikenban)</description>
 		<year>1996</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPM-80063" />
-		<info name="release" value="" />
+		<info name="serial" value="SLPM-80063"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value="クロックタワー2体験版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59305,8 +59303,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Granstream Denki (Japan, demo)</description>
 		<year>1997</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="PCPX-96087" />
-		<info name="release" value="" />
+		<info name="serial" value="PCPX-96087"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value="グランストリーム伝紀 体験版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59326,8 +59324,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Koudelka (Japan, demo)</description>
 		<year>199?</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-80490" />
-		<info name="release" value="" />
+		<info name="serial" value="SLPM-80490"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value="KOUDELKA クーデルカ 体験版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59347,8 +59345,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Legaia Densetsu (Japan, demo)</description>
 		<year>1998</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="PAPX-90055" />
-		<info name="release" value="" />
+		<info name="serial" value="PAPX-90055"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value="レガイア伝説"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59368,8 +59366,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rescue Shot Bubibo &amp; BioHazard - Gun Survivor (Japan, demo)</description>
 		<year>200?</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SLPM-80522" />
-		<info name="release" value="" />
+		<info name="serial" value="SLPM-80522"/>
+		<info name="release" value=""/>
 		<info name="alt_title" value="レスキューショットブービーぼー&amp;バイオハザードガンサバイバー ガンコン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59389,7 +59387,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Square's Preview 5 (Japan, Seiken Densetsu Demo)</description>
 		<year>1999</year>
 		<publisher>Squaresoft</publisher>
-		<info name="serial" value="SCPS-45417" />
+		<info name="serial" value="SCPS-45417"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -59408,8 +59406,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tamamayu Monogatari - Dennou Bijutsukan (Japan, demo)</description>
 		<year>199?</year>
 		<publisher>Genki</publisher>
-		<info name="serial" value="SLPM-80325" />
-		<info name="release" value="" />
+		<info name="serial" value="SLPM-80325"/>
+		<info name="release" value=""/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -59443,7 +59441,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-01564"/>
-		<info name="release" value="19990701" />
+		<info name="release" value="19990701"/>
 		<info name="barcode" value="7 11719 78752 5"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59460,7 +59458,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1996</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCED-00273 (9636229)"/>
-		<info name="release" value="199610xx" />
+		<info name="release" value="199610xx"/>
 		<info name="ring_code" value="DADC AUSTRIA   A0100197331-0101   15, DADC AUSTRIA   A0100197331-0101   35"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59492,7 +59490,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02812 (9184829)"/>
-		<info name="release" value="200009xx" />
+		<info name="release" value="200009xx"/>
 		<info name="ring_code" value="Sony DADC   A0100327637-0102   13 (Disc 1), Sony DADC   A0100327637-0202   23 (Disc 2)"/>
 		<info name="barcode" value="7 11719 18442 3, 7 11719 18432 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59517,7 +59515,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02834, SCES-02834-P"/>
-		<info name="release" value="200012xx" />
+		<info name="release" value="200012xx"/>
 		<info name="barcode" value="7 11719 23282 7, 7 11719 28422 2, 7 11719 28472 7"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59592,7 +59590,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Microïds</publisher>
 		<info name="serial" value="SLES-02757"/>
-		<info name="release" value="20000206" />
+		<info name="release" value="20000206"/>
 		<info name="ring_code" value="Sony DADC   A0100320928-0102   45 (Disc 1), Sony DADC   A0100320928-0202   15 (Disc 2)"/>
 		<info name="barcode" value="3 342185 276601"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59616,7 +59614,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Infogrames Europe</publisher>
 		<info name="serial" value="SLES-02993#, SLES-02993-P"/>
-		<info name="release" value="20001117" />
+		<info name="release" value="20001117"/>
 		<info name="ring_code" value="Sony DADC   A0100343709-0102   65 (Disc 1), Sony DADC   A0100343709-0202   33 (Disc 2)"/>
 		<info name="barcode" value="3 546430 012703, 3 546430 021552"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59923,7 +59921,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02146"/>
-		<info name="release" value="20000419" />
+		<info name="release" value="20000419"/>
 		<info name="ring_code" value="Sony DADC   A0100316368-0101   13"/>
 		<info name="barcode" value="7 11719 16572 9, 7 11719 16612 2"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59940,7 +59938,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-03119, SLES-03119-P"/>
-		<info name="release" value="20000929" />
+		<info name="release" value="20000929"/>
 		<info name="ring_code" value="Sony DADC   A0100333924-0101   33"/>
 		<info name="barcode" value="5 030930 025366, 5 030945 029045"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59958,7 +59956,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02080 ANZ-P, SLES-02080"/>
-		<info name="release" value="19991001" />
+		<info name="release" value="19991001"/>
 		<info name="ring_code" value="DADC   A0100288304-0104   15, Sony DADC   A0100288304-0104   45 (Disc 1), DADC   A0100288304-0204   15, Sony DADC   A0100288304-0204   65 (Disc 2), DADC   A0100288304-0304   25, Sony DADC   A0100288304-0304   85 (Disc 3), DADC   A0100288304-0404   15 (Disc 4)"/>
 		<info name="barcode" value="7 11719 19392 0, 7 11719 85842 3, 7 11719 85902 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59993,7 +59991,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Front Mission 3 (Europe, prototype 20000616)</description>
 		<year>2000</year>
 		<publisher>Square Europe</publisher>
-		<info name="release" value="20000616" />
+		<info name="release" value="20000616"/>
 		<info name="ring_code" value="R012-3848-2968"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60009,7 +60007,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02543"/>
-		<info name="release" value="20000420" />
+		<info name="release" value="20000420"/>
 		<info name="barcode" value="7 11719 16332 9, 7 11719 16402 9"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60025,7 +60023,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1998</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-00984, SCES-00984#"/>
-		<info name="release" value="19980505" />
+		<info name="release" value="19980505"/>
 		<info name="ring_code" value="DADC   A0100242488-0101   35, DADC   A0100242488-0101   45, DADC AUSTRIA   A0100242488-0101   25"/>
 		<info name="barcode" value="7 11719 72352 3, 7 11719 72392 9, 7 11719 74232 6, 7 11719 74252 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60042,7 +60040,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02380"/>
-		<info name="release" value="20000128" />
+		<info name="release" value="20000128"/>
 		<info name="ring_code" value="DADC   A0100306121-0102   15, DADC   A0100306121-0102   25 (Disc 1), DADC   A0100306121-0202   15, DADC   A0100306121-0202   25, DADC   A0100306121-0202   35 (Disc 2)"/>
 		<info name="barcode" value="7 11719 22012 1, 7 11719 22192 0, 7 11719 87822 3, 7 11719 87832 2, 7 11719 87842 1"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60066,7 +60064,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="SLES-01404#"/>
-		<info name="release" value="199910xx" />
+		<info name="release" value="199910xx"/>
 		<info name="ring_code" value="DADC   A0100294705-0101   15"/>
 		<info name="barcode" value="5 026555 190206, 5 026555 190794"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60084,7 +60082,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Infogrames Europe</publisher>
 		<info name="serial" value="SLES-01362 (0006672), SLES-01362#"/>
-		<info name="release" value="19991126" />
+		<info name="release" value="19991126"/>
 		<info name="ring_code" value="DADC   A0100300873-0101   15"/>
 		<info name="barcode" value="3 546430 011850, 3 546430 013830, 5 013156 900518, 5 013156 900563"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60101,7 +60099,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-03124, SLES-03124/P"/>
-		<info name="release" value="20001201" />
+		<info name="release" value="20001201"/>
 		<info name="ring_code" value="Sony DADC   A0100343956-0101   15"/>
 		<info name="barcode" value="5 030930 024659, 5 030930 028152, 5 030935 024654 >"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60118,7 +60116,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SLES-01370"/>
-		<info name="release" value="19990226" />
+		<info name="release" value="19990226"/>
 		<info name="ring_code" value="DADC   A0100267025-0102   15, DADC   A0100267025-0102   35 (Disc 1), DADC   A0100267025-0202   25, Sony DADC   A0100267025-0202   55 (Disc 2)"/>
 		<info name="barcode" value="4 012927 020067, 4 988602 749786"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60142,7 +60140,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Konami of Europe</publisher>
 		<info name="serial" value="SLES-02136"/>
-		<info name="release" value="199910xx" />
+		<info name="release" value="199910xx"/>
 		<info name="barcode" value="4 988602 676297"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60158,7 +60156,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>The Codemasters Software Company</publisher>
 		<info name="serial" value="SLES-00016#"/>
-		<info name="release" value="199703xx" />
+		<info name="release" value="199703xx"/>
 		<info name="barcode" value="5 024866 241532, 5 024866 241563"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60174,7 +60172,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-00469"/>
-		<info name="release" value="19971103" />
+		<info name="release" value="19971103"/>
 		<info name="ring_code" value="DADC AUSTRIA   A0100228657-0101   25, DADC AUSTRIA   A0100228657-0101   35"/>
 		<info name="barcode" value="5 030930 013257 >, 5 030935 013252 >"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60191,7 +60189,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="SCES-03037"/>
-		<info name="release" value="200011xx" />
+		<info name="release" value="200011xx"/>
 		<info name="ring_code" value="Sony DADC   A0100333381-0101   15"/>
 		<info name="barcode" value="7 11719 19482 8"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60208,7 +60206,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1998</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="SLES-01356"/>
-		<info name="release" value="199811xx" />
+		<info name="release" value="199811xx"/>
 		<info name="ring_code" value="DADC   A0100261573-0101   15"/>
 		<info name="barcode" value="5 024866 240504, 5 024866 240511, 5 024866 240542"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60225,7 +60223,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-00658"/>
-		<info name="release" value="199705xx" />
+		<info name="release" value="199705xx"/>
 		<info name="barcode" value="5 030945 012634"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60241,7 +60239,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1998</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-01154"/>
-		<info name="release" value="199804xx" />
+		<info name="release" value="199804xx"/>
 		<info name="barcode" value="5 030930 022723"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60273,7 +60271,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>GT Interactive Software Europe / Infogrames</publisher>
 		<info name="serial" value="SLES-00664, SLES-00664#"/>
-		<info name="release" value="199709xx" />
+		<info name="release" value="199709xx"/>
 		<info name="ring_code" value="DADC   A0100225498-0101   15, DADC   A0100225498-0101   35"/>
 		<info name="barcode" value="3 546430 010112 >, 5 029988 004676 >"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60306,7 +60304,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-00886#"/>
-		<info name="release" value="19971101" />
+		<info name="release" value="19971101"/>
 		<info name="barcode" value="7 11719 73022 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60338,7 +60336,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-00409, SCES-00409#"/>
-		<info name="release" value="19970701" />
+		<info name="release" value="19970701"/>
 		<info name="ring_code" value="DADC AUSTRIA   A0100212393-0101   15, DADC AUSTRIA   A0100212393-0101   25, DADC AUSTRIA   A0100212393-0101   35"/>
 		<info name="barcode" value="7 11719 18722 6, 7 11719 18732 5, 7 11719 65932 7, 7 11719 65942 6, 7 11719 71082 0"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60388,7 +60386,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="SCES-02569 (9169024)"/>
-		<info name="release" value="20000407" />
+		<info name="release" value="20000407"/>
 		<info name="ring_code" value="Sony DADC   A0100318110-0101   13, KODAK CD-R 74 9920 2404 1100"/>
 		<info name="barcode" value="7 11719 16832 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60405,7 +60403,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1996</year>
 		<publisher>Virgin Interactive Entertainment (Europe)</publisher>
 		<info name="serial" value="SLES-00200"/>
-		<info name="release" value="199608xx" />
+		<info name="release" value="199608xx"/>
 		<info name="barcode" value="5 028587 083846"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60452,7 +60450,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Konami Digital Entertainment</publisher>
 		<info name="serial" value="SLES-01514, SLES-01514 - P"/>
-		<info name="release" value="199908xx" />
+		<info name="release" value="199908xx"/>
 		<info name="ring_code" value="DADC   A0100284653-0101   15, Sony DADC   A0100284653-0101   63"/>
 		<info name="barcode" value="4 988602 068597, 4 988602 555660"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60501,7 +60499,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1998</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-01438 (9750925)"/>
-		<info name="release" value="19981001" />
+		<info name="release" value="19981001"/>
 		<info name="ring_code" value="DADC AUSTRIA   A0100257302-0101   15, DADC AUSTRIA   A0100257302-0101   35, Sony DADC   A0100257302-0101   75"/>
 		<info name="barcode" value="7 11719 75022 2, 7 11719 75072 7, 7 11719 88542 9, 7 11719 88972 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60519,7 +60517,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2001</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02835"/>
-		<info name="release" value="20011210" /> <!-- Rev. 1 -->
+		<info name="release" value="20011210"/> <!-- Rev. 1 -->
 		<info name="ring_code" value="Sony DADC   A0100342055-0101   15"/>
 		<info name="barcode" value="7 11719 283621, 7 11719 28392 8"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60583,7 +60581,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1998</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-00627"/>
-		<info name="release" value="199802xx" />
+		<info name="release" value="199802xx"/>
 		<info name="barcode" value="5 030930 022747"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60617,7 +60615,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>The Codemasters Software Company</publisher>
 		<info name="serial" value="SLES-02572, SLES-02572/P"/>
-		<info name="release" value="20000825" />
+		<info name="release" value="20000825"/>
 		<info name="barcode" value="5 024866 241297, 5 024866 241310, 5 024866 242256"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60633,7 +60631,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Eidos Interactive</publisher>
 		<info name="serial" value="SLES-02238, SLES-02238/ANZ"/>
-		<info name="release" value="199911xx" />
+		<info name="release" value="199911xx"/>
 		<info name="barcode" value="5 032921 008488"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60666,7 +60664,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2001</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="SLES-02534"/>
-		<info name="release" value="20010331" />
+		<info name="release" value="20010331"/>
 		<info name="ring_code" value="Sony DADC   A0100355439-0101   23"/>
 		<info name="barcode" value="3 455192 121212, 3 455192 121236"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60683,7 +60681,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-02253"/>
-		<info name="release" value="19991216" />
+		<info name="release" value="19991216"/>
 		<info name="barcode" value="5 030930 021191"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60721,7 +60719,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Firebugs (Europe)</description>
 		<year>2002</year>
 		<publisher>Sony</publisher>
-		<info name="serial" value="SCES-03884" />
+		<info name="serial" value="SCES-03884"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -60740,7 +60738,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Terracon (Europe)</description>
 		<year>2000</year>
 		<publisher>Sony</publisher>
-		<info name="serial" value="SCES-02836" />
+		<info name="serial" value="SCES-02836"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -60808,7 +60806,7 @@ A few comments on these:
 		<publisher>&lt;pirate&gt;</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ddrdmp" sha1="914d1980a4a46574adfedac1e3335ac2738ae5c1" />
+				<disk name="ddrdmp" sha1="914d1980a4a46574adfedac1e3335ac2738ae5c1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -60817,7 +60815,7 @@ A few comments on these:
 <!-- Prototype discs -->
 
 	<!-- boot OK -->
-	<software name="bublbob2" >
+	<software name="bublbob2">
 		<!--
 		Original images
 		<rom name="bb2.bin" size="62620864" crc="1c2c9f63" sha1="2d9cf9e34057c93fe1d40940428c463a7224444e"/>
@@ -60845,22 +60843,22 @@ A few comments on these:
 		<description>Baldur's Gate (USA, prototype)</description>
 		<year>19??</year>
 		<publisher>Interplay</publisher>
-		<info name="serial" value="SLUS-01037" />
+		<info name="serial" value="SLUS-01037"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="baldur's gate - disc 1" sha1="abe5d1c7f466150937c44802e559020ba479d941" />
+				<disk name="baldur's gate - disc 1" sha1="abe5d1c7f466150937c44802e559020ba479d941"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="baldur's gate - disc 2" sha1="42db8585e1c0b68fbfb9274adaf0db8717427b28" />
+				<disk name="baldur's gate - disc 2" sha1="42db8585e1c0b68fbfb9274adaf0db8717427b28"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="baldur's gate - disc 3" sha1="a59f863f0304bb457ed6aaa4f7e9797f233ee91b" />
+				<disk name="baldur's gate - disc 3" sha1="a59f863f0304bb457ed6aaa4f7e9797f233ee91b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -60875,7 +60873,7 @@ A few comments on these:
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="biohazard - 1995 - 08 - 04 - sample" sha1="de2b4d723709dd262553065849c9000807d1e4cc" />
+				<disk name="biohazard - 1995 - 08 - 04 - sample" sha1="de2b4d723709dd262553065849c9000807d1e4cc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -60890,7 +60888,7 @@ A few comments on these:
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="biohazard - 1995 - 10 - 04 - sample" sha1="7c1e9f60c045fcf984c91dbaad7421d73a8aec73" />
+				<disk name="biohazard - 1995 - 10 - 04 - sample" sha1="7c1e9f60c045fcf984c91dbaad7421d73a8aec73"/>
 			</diskarea>
 		</part>
 	</software>
@@ -60905,7 +60903,7 @@ A few comments on these:
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bio hazard (j) (sample 1996.01.31) [slps-00222]" sha1="e73192b6a3f573b4b04e9dd4ba90275d9d978b7a" />
+				<disk name="bio hazard (j) (sample 1996.01.31) [slps-00222]" sha1="e73192b6a3f573b4b04e9dd4ba90275d9d978b7a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -60921,7 +60919,7 @@ A few comments on these:
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="biohazard-2-beta" sha1="2b7148b98f05498329e7bf2ced2a9ce44f3d4e9a" />
+				<disk name="biohazard-2-beta" sha1="2b7148b98f05498329e7bf2ced2a9ce44f3d4e9a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -60936,7 +60934,7 @@ A few comments on these:
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="biohazard 2 (beta 2)" sha1="6297f31f083406884e03a1f52fd9db577e017fd8" />
+				<disk name="biohazard 2 (beta 2)" sha1="6297f31f083406884e03a1f52fd9db577e017fd8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -60966,7 +60964,7 @@ A few comments on these:
 		<publisher>Radical</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="breakneck" sha1="bc1e3088bb29c95681b59489d16e6cbb15171279" />
+				<disk name="breakneck" sha1="bc1e3088bb29c95681b59489d16e6cbb15171279"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61013,7 +61011,7 @@ A few comments on these:
 		<publisher>Sony Computer Entertainment America</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="crash" sha1="8272aa46a2a959d2ffd54f281301a38bd1b2fbad" />
+				<disk name="crash" sha1="8272aa46a2a959d2ffd54f281301a38bd1b2fbad"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61086,7 +61084,7 @@ A few comments on these:
 		<publisher>Midway</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="deuce (usa, prototype)" sha1="76911bb495fd3ff66e0e764eba1f1f7aa9aca8d2" />
+				<disk name="deuce (usa, prototype)" sha1="76911bb495fd3ff66e0e764eba1f1f7aa9aca8d2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61101,7 +61099,7 @@ A few comments on these:
 		<publisher>Electronic Arts</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="diablo" sha1="00fe192c6ac3496c76e7f4f8af157b949073dda8" />
+				<disk name="diablo" sha1="00fe192c6ac3496c76e7f4f8af157b949073dda8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61130,7 +61128,7 @@ A few comments on these:
 		<publisher>GT Interactive</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ttk" sha1="4531bb227e2444fbc10ee53807c71a309637c55e" status="baddump" />
+				<disk name="ttk" sha1="4531bb227e2444fbc10ee53807c71a309637c55e" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61145,7 +61143,7 @@ A few comments on these:
 		<publisher>Psygnosis</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slus-01419" sha1="b8df7f15e32150e703780951fd7ccb6914c75c06" />
+				<disk name="slus-01419" sha1="b8df7f15e32150e703780951fd7ccb6914c75c06"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61191,7 +61189,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Eidos</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legacy of kain - soul reaver (usa, prototype 19990628)" sha1="d0df73cdbfc9ef35076f13f9996593f2e8f50130" />
+				<disk name="legacy of kain - soul reaver (usa, prototype 19990628)" sha1="d0df73cdbfc9ef35076f13f9996593f2e8f50130"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61207,7 +61205,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Eidos</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legacy of kain - soul reaver (usa, prototype 19990512)" sha1="0255d212fba97680a57c7235d172940978d6c8d2" />
+				<disk name="legacy of kain - soul reaver (usa, prototype 19990512)" sha1="0255d212fba97680a57c7235d172940978d6c8d2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61222,7 +61220,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Electronic Arts</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="madden96" sha1="74c6c4e4cc13a8f4a12e26d5444ad6f829e50342" />
+				<disk name="madden96" sha1="74c6c4e4cc13a8f4a12e26d5444ad6f829e50342"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61253,10 +61251,10 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<description>Metal Gear Solid (pilot disk)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-80254" />
+		<info name="serial" value="SLPM-80254"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slpm-80254" sha1="304e7e9b7182d8f30315cd589abe41d18a19c55c" />
+				<disk name="slpm-80254" sha1="304e7e9b7182d8f30315cd589abe41d18a19c55c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61287,7 +61285,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Atlus</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="persona2xus" sha1="63910ca0f84d97496c5f4498e7a8d70299b14d64" />
+				<disk name="persona2xus" sha1="63910ca0f84d97496c5f4498e7a8d70299b14d64"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61317,7 +61315,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rockman 8 beta v1" sha1="ef22ee21d0ab15b69c64d951e69099c5e46e189a" />
+				<disk name="rockman 8 beta v1" sha1="ef22ee21d0ab15b69c64d951e69099c5e46e189a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61332,7 +61330,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rockman 8 beta 1" sha1="fa1b3e5cac9463866f51e5f67e5321bc532b5a2b" />
+				<disk name="rockman 8 beta 1" sha1="fa1b3e5cac9463866f51e5f67e5321bc532b5a2b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61347,7 +61345,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rockman 8 beta 2" sha1="ee3149d9579cdf1ad7b32d2ab9103e9f9353e732" />
+				<disk name="rockman 8 beta 2" sha1="ee3149d9579cdf1ad7b32d2ab9103e9f9353e732"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61359,10 +61357,10 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<description>Rockman Dash (Capcom Friendly Club demo)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPM-80158" />
+		<info name="serial" value="SLPM-80158"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slpm-80158" sha1="e62186095e824961557607c78a35229217ae8ebf" />
+				<disk name="slpm-80158" sha1="e62186095e824961557607c78a35229217ae8ebf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61377,7 +61375,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rockman_x6" sha1="0ff73049e29de65b67f7bc682a9354ecbe5c8ede" />
+				<disk name="rockman_x6" sha1="0ff73049e29de65b67f7bc682a9354ecbe5c8ede"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61392,7 +61390,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Konami</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="silent1" sha1="95a9401a0f0aaa1b6a1e27324651ed8f67690eb7" />
+				<disk name="silent1" sha1="95a9401a0f0aaa1b6a1e27324651ed8f67690eb7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61407,7 +61405,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Acclaim</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spirit master (u) (prototype)" sha1="891a5584995be8c319c7422fa5cca1da60afebc8" />
+				<disk name="spirit master (u) (prototype)" sha1="891a5584995be8c319c7422fa5cca1da60afebc8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61423,7 +61421,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Accolade</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="starcon" sha1="cae7074b0498bc489d668a30a7bc94b541d10036" />
+				<disk name="starcon" sha1="cae7074b0498bc489d668a30a7bc94b541d10036"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61455,7 +61453,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<info name="serial" value="SLUS-00752?"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="thrill kill" sha1="09721bf343ee69f13b7ed86cc92beb0be94db04a" />
+				<disk name="thrill kill" sha1="09721bf343ee69f13b7ed86cc92beb0be94db04a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61485,7 +61483,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Core Design</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider (beta)(07-22-1996)" sha1="8efa97244b2b7744dde94c68497d370f9bf7c999" />
+				<disk name="tomb raider (beta)(07-22-1996)" sha1="8efa97244b2b7744dde94c68497d370f9bf7c999"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61502,7 +61500,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Core Design</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider ii (usa, prototype)" sha1="62036de387e8715afdbe30c3ba6c12aa1121cfeb" />
+				<disk name="tomb raider ii (usa, prototype)" sha1="62036de387e8715afdbe30c3ba6c12aa1121cfeb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61517,7 +61515,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Activision</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tony hawk's pro skater (usa) [beta]" sha1="f326e476b44f3d011efd65197df633b446f77101" />
+				<disk name="tony hawk's pro skater (usa) [beta]" sha1="f326e476b44f3d011efd65197df633b446f77101"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61531,7 +61529,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Head Games</publisher>   <!-- Head Games were actually the developer, but I was unable to dig any info about actual publishing deals -->
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="torc - legend of the ogre crown (prototype)" sha1="fd93d28c7a64f047d6e9d40fb8333fc74a43b887" />
+				<disk name="torc - legend of the ogre crown (prototype)" sha1="fd93d28c7a64f047d6e9d40fb8333fc74a43b887"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61578,7 +61576,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>THQ</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf smackdown (beta)" sha1="7aa0bc14fc4d33f785d0a9c911e8f177e737ad78" />
+				<disk name="wwf smackdown (beta)" sha1="7aa0bc14fc4d33f785d0a9c911e8f177e737ad78"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61594,7 +61592,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<description>Resident Evil 2 (Europe, preview, CD Consoles No.38)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLED-00977" />
+		<info name="serial" value="SLED-00977"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sled-00977" sha1="e4b02905f0032c4f834cddd45e8c4ba3f12150a3"/>
@@ -61610,10 +61608,10 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<description>Resident Evil 3 (Europe, demo)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLED-02541" />
+		<info name="serial" value="SLED-02541"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sled-02541" sha1="6bad1e2c7c6541ba21333ef9e7076d910088ce87" />
+				<disk name="sled-02541" sha1="6bad1e2c7c6541ba21333ef9e7076d910088ce87"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61628,7 +61626,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Data West</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bountyarms" sha1="5543cc67b3e56de44ed2edf5faea7b8c002e9269" />
+				<disk name="bountyarms" sha1="5543cc67b3e56de44ed2edf5faea7b8c002e9269"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61646,7 +61644,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Konami</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sotn e3 demo" sha1="c3f5a41ee4722660ce9a708c22990bf9656d5949" />
+				<disk name="sotn e3 demo" sha1="c3f5a41ee4722660ce9a708c22990bf9656d5949"/>
 			</diskarea>
 		</part>
 	</software>
@@ -61691,7 +61689,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<description>Silent Hill (USA, trade demo)</description>
 		<year>1999</year>
 		<publisher>Konami of America</publisher>
-		<info name="serial" value="SLUS-80707" />
+		<info name="serial" value="SLUS-80707"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
 				<disk name="slus-80707" sha1="3dc02338a4a00a5a9fb1e89308a7ec75854efec5"/>
@@ -61710,7 +61708,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>SCEI</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tr1" sha1="a42bca9a943f660a6c080a38a2c8082109c78e79" />
+				<disk name="tr1" sha1="a42bca9a943f660a6c080a38a2c8082109c78e79"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/psx.xml
+++ b/hash/psx.xml
@@ -43,7 +43,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="007 racing (usa)" sha1="b0d5e1641367d45c6f187c5c6249371c95636e5a"/>
+				<disk name="007 racing (usa)" sha1="c0fffd6939c403a0b7a179b472ae768c06c05c26"/>
 			</diskarea>
 		</part>
 	</software>
@@ -62,7 +62,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="007 - tomorrow never dies (usa)" sha1="f48f0e79572be7d676341fb9f6cb0ccb5a31e0d9"/>
+				<disk name="007 - tomorrow never dies (usa)" sha1="603abd8d718ddb72cf34a0d8eece062c03463dc5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -79,7 +79,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="007 - the world is not enough (usa)" sha1="d79f4b8ce9db7c5dacd841e7d7ebbb306f88de70"/>
+				<disk name="007 - the world is not enough (usa)" sha1="3af01c1f0a584751d161dc2c102639cd8c892ea9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -208,7 +208,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ten pin alley (usa)" sha1="9e54d18bdeeaac86a91d57e223271e0e4cadd6e1"/>
+				<disk name="ten pin alley (usa)" sha1="efa45b20a81d2d285bea24dddf87b1c758a8beb7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -313,7 +313,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="3d lemmings (usa)" sha1="ce0fe62049e1f2567b7e4e66f209d97713fb54d8"/>
+				<disk name="3d lemmings (usa)" sha1="4801d11a8fc06628bc972bfb5a9d5b411fe15101"/>
 			</diskarea>
 		</part>
 	</software>
@@ -359,7 +359,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="3xtreme (usa)" sha1="dbc36461c1491be04b9b41cdb43f5aacc5b8d219"/>
+				<disk name="3xtreme (usa)" sha1="a0678bbf322f512072f7a78f072fdbab6555559b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -402,7 +402,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fifth element, the (usa)" sha1="bf56ec6d782ed3df91a1d3a113bad7f0fca715b6"/>
+				<disk name="fifth element, the (usa)" sha1="edf59f00c16acfcb4f8e7f44e4c72c6ab44aaa5d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -419,7 +419,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="oddworld - abe's oddysee (usa) (v1.1)" sha1="15418f0f1bd9bb64e7c491e964eaff90ead7ff61"/>
+				<disk name="oddworld - abe's oddysee (usa) (v1.1)" sha1="fdf0041ff97101b468fe943c8461b906466add02"/>
 			</diskarea>
 		</part>
 	</software>
@@ -455,12 +455,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="oddworld - abe's exoddus (usa) (disc 1)" sha1="361b3a54f0716ab523f5ea3569df623f8cdc9872"/>
+				<disk name="oddworld - abe's exoddus (usa) (disc 1)" sha1="660edf4bddb298beff44964951af74b3443dc2bd"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="oddworld - abe's exoddus (usa) (disc 2)" sha1="36e619c28dafd7e4baed28a8d56ffebe93584de7"/>
+				<disk name="oddworld - abe's exoddus (usa) (disc 2)" sha1="5b806ee562fd9cd719a6cc47e0fd0b1353068c2f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -754,7 +754,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alien resurrection (usa)" sha1="a5c6b0c879e523ac7b19c209ac9c06eaf1ab3a01"/>
+				<disk name="alien resurrection (usa)" sha1="79de3fd8c2541398a4f26f7a81a617946fd1cbfa"/>
 			</diskarea>
 		</part>
 	</software>
@@ -796,7 +796,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alien trilogy (usa)" sha1="34268b5750155db04b9dd25991d98f428ae5fa68"/>
+				<disk name="alien trilogy (usa)" sha1="29b7f1384cef58ec2404a1aa53a30da71f2fa0fb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -879,7 +879,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alundra (usa) (v1.1)" sha1="cdfaed8c651dcb09d971bfc9d05f1daaf94d2df3"/>
+				<disk name="alundra (usa) (v1.1)" sha1="bdc6a648003469505ee47c7fa83b1b07a6aa2ea9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -896,7 +896,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alundra 2 - a new legend begins (usa)" sha1="16111c51d568e112f9e57c24da60a6e68347a58c"/>
+				<disk name="alundra 2 - a new legend begins (usa)" sha1="c0e152d67a02dd91e44660ae81099803d2ec0a11"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1035,7 +1035,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="army men - sarge's heroes (usa)" sha1="489c92c1eb6e6ad3ae4c952e38e0541d2ff90b0e"/>
+				<disk name="army men - sarge's heroes (usa)" sha1="b958c6c0f674d5c6508d204d1f913bee61dbab95"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1162,7 +1162,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ape escape (usa)" sha1="07f05352164077ea5726c3c89e00522bee8261ad"/>
+				<disk name="ape escape (usa)" sha1="11b04950f4300f0a44e3197cf6d57a34cc30f17c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1520,7 +1520,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="armorines - project s.w.a.r.m. (usa)" sha1="b88c2e6abc4f56ab17d3ea245d0c55aede617e5a"/>
+				<disk name="armorines - project s.w.a.r.m. (usa)" sha1="af534a5d5825174d58619669d748f97cf3902087"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1557,7 +1557,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="army men 3d (usa)" sha1="a2e29ff020e5db89de055a9fbed0812658b5acd1"/>
+				<disk name="army men 3d (usa)" sha1="66a85dfac355ba06fc9544eb36d240f3f07b7f8d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1592,7 +1592,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all-star baseball 97 featuring frank thomas (usa)" sha1="f821a4a160e0c958495c9c2d1d8978fee21c3dc2"/>
+				<disk name="all-star baseball 97 featuring frank thomas (usa)" sha1="e5891c4ef7dac37e97ce94c700f9fc1dcc9fb231"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1609,7 +1609,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all-star slammin' d-ball (usa)" sha1="ee0142e2f218cc38d24d0ab027e8ca8e4d953755"/>
+				<disk name="all-star slammin' d-ball (usa)" sha1="38d356d59ab2fa8cd6d7058afbe405e1b7338b5b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1633,7 +1633,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all star racing 2 (usa)" sha1="6b51229aadc6fcab51636481a3ec77579e22b22e"/>
+				<disk name="all star racing 2 (usa)" sha1="67d2403c1008244af761546bfdcee1e98b9a082c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1656,7 +1656,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all star racing (usa)" sha1="9a89181fe3c5bd9004f0a7525e7f844cc7616085"/>
+				<disk name="all star racing (usa)" sha1="0509a19e098bf71024d82703745b2c2cc2e50413"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1722,7 +1722,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="asteroids (usa)" sha1="04aea1e4423a4f1353288dd63e6911265feccf55"/>
+				<disk name="asteroids (usa)" sha1="e59d3a8fa874f6c01dde1905b63c8e60bd363b20"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1757,7 +1757,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's atlantis - the lost empire (usa)" sha1="9d4a654e3aff0e5c4527cbc4133db64be43b186b"/>
+				<disk name="disney's atlantis - the lost empire (usa)" sha1="b3f6094a44c22f50589ab7eaa3abee23d5190ac2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1988,7 +1988,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="baldies (usa)" sha1="b249bd2371cbcd4406ad9de138468b229b01469c"/>
+				<disk name="baldies (usa)" sha1="5f6075436bef2bd6c939b27bcdc666b775889d24"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2067,7 +2067,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ballistic (usa)" sha1="df2cf0f292b34d36045d3274b77a2b07879f85e4"/>
+				<disk name="ballistic (usa)" sha1="91ec8debbdc2b725eca16533fc73af5d7e1131dc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2098,7 +2098,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bust-a-move 2 - arcade edition (usa)" sha1="67a76852d1c4a729692011aca8f5a798c8ba049b"/>
+				<disk name="bust-a-move 2 - arcade edition (usa)" sha1="b1ff7f7289e80a8660de51792d27a843a6e37e3e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2137,7 +2137,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bust-a-move 4 (usa)" sha1="7354ae16e8bcaa39f1204b5372790ce8d60309b6"/>
+				<disk name="bust-a-move 4 (usa)" sha1="5fae962b40cfd65c71af587ad5f9bc7cd3f866c0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2173,7 +2173,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bust-a-move '99 (usa)" sha1="c7873febe1bb6a7cac45c0075a7e8d159e8dbc6c"/>
+				<disk name="bust-a-move '99 (usa)" sha1="33abb06e575e8b8369dd69e1156347bf22b7938c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2341,7 +2341,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="batman forever - the arcade game (usa)" sha1="88393684ae19946abfa096c2e56f53098c5cfa35"/>
+				<disk name="batman forever - the arcade game (usa)" sha1="5406a0cdb0849a48b318d44f8c7c773612c1a60d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2455,7 +2455,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bushido blade 2 (usa)" sha1="7f0603b6cc467b42156405465b270d8284fe1d50"/>
+				<disk name="bushido blade 2 (usa)" sha1="5d35481b47b07e51cb7011b48d505fa10e30b16f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2532,7 +2532,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="buster bros. collection (usa)" sha1="aec44fbab4d775ad54de562f2f36317848fad19b"/>
+				<disk name="buster bros. collection (usa)" sha1="f27b8779c8bdeba79c05f2964b27883d4e40402b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2740,7 +2740,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="frank thomas big hurt baseball (usa)" sha1="f558c913841efcc8f0089535603159222e16f264"/>
+				<disk name="frank thomas big hurt baseball (usa)" sha1="0f976975a6c425dc66381ae571b92bb3854c4c52"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2808,7 +2808,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bio f.r.e.a.k.s. (usa)" sha1="cbbef6452d8fefffc41b51476ef0f06a6e1cda90"/>
+				<disk name="bio f.r.e.a.k.s. (usa)" sha1="cdd4839e9276971f5d5206b6e183ea0ea18dfa70"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2876,7 +2876,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="black dawn (usa)" sha1="54eb6a39008efe1fbc3f9926b841517b28f95ec5"/>
+				<disk name="black dawn (usa)" sha1="c293e3a618769b28d3c0f6a45125809959178b62"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3072,7 +3072,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl blitz 2000 (usa)" sha1="8ee063c43415f1ffade34d0e5dd7d67ef466acf7"/>
+				<disk name="nfl blitz 2000 (usa)" sha1="57c5607b92a9842b4efb87b7fc663461928af4b9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3256,7 +3256,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="breath of fire iii (usa)" sha1="979b329df58855cd1cb2f60793abec33367409e7"/>
+				<disk name="breath of fire iii (usa)" sha1="b9cf8ac6c5b364898c28be663cc94134d2a6482a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3362,7 +3362,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bomberman - party edition (usa)" sha1="89f5e21e602e72dfee3fc3f930bbc2f7a89864c8"/>
+				<disk name="bomberman - party edition (usa)" sha1="9e8373fbd06c8752c3d47d8f6b5e305fbb98d32a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3379,7 +3379,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bomberman world (usa)" sha1="529e4527fa3b086e8860c84c70e3886dd20e5863"/>
+				<disk name="bomberman world (usa)" sha1="16b36158a7454cf6872a05c98f9c89dd539f302d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3942,7 +3942,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battlesport (usa)" sha1="a3026e6bd0555d065b5a5f01b2e94d070932d0c9"/>
+				<disk name="battlesport (usa)" sha1="ac7e9492b92ecbf78bc585ca489311efae331973"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3994,7 +3994,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bubble bobble also featuring rainbow islands (usa)" sha1="c43ba72269ba09a2311c112cf2f0889db327ce28"/>
+				<disk name="bubble bobble also featuring rainbow islands (usa)" sha1="1561fd3ea3e4b1426087c0d6d87003faef4d752f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4495,7 +4495,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="centipede (usa)" sha1="0f8b6ee552a0ae5ea36a342a513bdba477cd43b0"/>
+				<disk name="centipede (usa)" sha1="ee59aa0b53f4c6e964b33a6ff660dd267a39a354"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4653,7 +4653,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="chocobo racing (usa)" sha1="d64c6737893dec45980c2088e1a528ce20d00dac"/>
+				<disk name="chocobo racing (usa)" sha1="784566dd126798f9963c05a744ded12d390332ed"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4733,7 +4733,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cleopatra's fortune (usa)" sha1="3c8c19b3ab98d2098ffd168be7af0c75c2cb7057"/>
+				<disk name="cleopatra's fortune (usa)" sha1="109e3b9958e6dd7cc7251ff4faafb07034d4eff5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4997,7 +4997,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="college slam (usa)" sha1="0c315070fc9e6be87a1994618fc9a3bfe2ecbbdf"/>
+				<disk name="college slam (usa)" sha1="8e6d3a869461f9de6a2760ffbc314a3e5cbd9937"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5073,7 +5073,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="c - the contra adventure (usa)" sha1="681c9d33763a59fd1a65185d80b687ce24587e2c"/>
+				<disk name="c - the contra adventure (usa)" sha1="077cf80003bc72c6801cf8c95b6a98d3105a9d93"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5101,7 +5101,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="contra - legacy of war (usa)" sha1="9403c380d5f391c8c0adb18fe238cc6a2c5d3999"/>
+				<disk name="contra - legacy of war (usa)" sha1="2d251c9aeb30adead8bf9bb2c0d4e094d9b6969e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5155,7 +5155,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool boarders 2 (usa)" sha1="bdd071c0046fb44067b0d7282597b4ac8f5b4929"/>
+				<disk name="cool boarders 2 (usa)" sha1="990a6cac9659a572a1b73acfa7ee7d3ad60b4195"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5189,7 +5189,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool boarders 4 (usa)" sha1="b47be79d214644ef36c212ede129c09ef357be52"/>
+				<disk name="cool boarders 4 (usa)" sha1="3fbb6e924df7206cc07a75fa276e97007a9cf118"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5219,7 +5219,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool boarders (usa)" sha1="4a7db4f12f28fe2a2af805394ba96de0ef0a5a94"/>
+				<disk name="cool boarders (usa)" sha1="b0923041fcdac9288d73e571fd21e6240ccb34bf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5417,7 +5417,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="crash bandicoot (usa)" sha1="11ab0c2c674fe9bebc62927c8308cee6d6a1dff3"/>
+				<disk name="crash bandicoot (usa)" sha1="73c7cd894227a54a36a165c746371cc63283103b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5434,7 +5434,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="crash bandicoot 2 - cortex strikes back (usa)" sha1="2edb8097887880020387c168ff2bb04354b1ddf9"/>
+				<disk name="crash bandicoot 2 - cortex strikes back (usa)" sha1="3ff7ccb1b38a9f172f0a96b7c780913401c28b03"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5451,7 +5451,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="crash bandicoot - warped (usa)" sha1="1fc5f8aaf5def00ed131f6424483fe88991d920c"/>
+				<disk name="crash bandicoot - warped (usa)" sha1="80e68dbd89ea40ed6f09d7bdfe2ccc0fe46d766e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5486,7 +5486,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cardinal syn (usa)" sha1="0a5b77436723f66abc8ac7b7cbaf748bb0b0d044"/>
+				<disk name="cardinal syn (usa)" sha1="bbd9e3af8c886460fc8c4907f93ef4b5bc6cb868"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5740,7 +5740,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ctr - crash team racing (usa)" sha1="6ac9869bd696ed7ce6d3b734f774bdb82047ef3d"/>
+				<disk name="ctr - crash team racing (usa)" sha1="d9d5c97d9bc453c4b6339a3635f8d53353ffa7b2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5757,7 +5757,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy chronicles - chrono trigger (usa) (v1.1)" sha1="968de200edd4fc4e809105618a41696c0b0354c0"/>
+				<disk name="final fantasy chronicles - chrono trigger (usa) (v1.1)" sha1="3c76fb48973021b9b7b3f53efd6ff97d1d8a666e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5815,7 +5815,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="castlevania chronicles (usa)" sha1="7d39bbd905910eb1d31ae395c3a79224f725b82e"/>
+				<disk name="castlevania chronicles (usa)" sha1="545ee61ce191dd672056897988a8c9d9286497ea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5832,7 +5832,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="capcom vs. snk pro (usa)" sha1="d42a868cb769371d994ed903016a82a48715e065"/>
+				<disk name="capcom vs. snk pro (usa)" sha1="1df7e28ccb8ea8249d26e85c9bf6bb89c1797700"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5853,12 +5853,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colony wars (usa) (disc 1)" sha1="87a35925848ca127c53828bc738bfca668ebe7c1"/>
+				<disk name="colony wars (usa) (disc 1)" sha1="7c558a7f13d3c9a4d3e5e9d20ee0382bcf3c305c"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colony wars (usa) (disc 2)" sha1="97dfd9daf9be05574b4107ac74d12123e3f70114"/>
+				<disk name="colony wars (usa) (disc 2)" sha1="bd2c07643b93647fba705678411d83d42fd0af6f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5893,7 +5893,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colony wars - vengeance (usa)" sha1="c80c017209ab38cfe12192526e564a784b9d9cd7"/>
+				<disk name="colony wars - vengeance (usa)" sha1="2de0f44070c24e6df4cda0c32b24e635c4517082"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6076,17 +6076,17 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="d (usa) (disc 1)" sha1="59bfa30b9cd0cf6d467ffaaab4a5ac572dae5a62"/>
+				<disk name="d (usa) (disc 1)" sha1="ce5b1b1ac03c6623766ca310ecd1858f2287ea88"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="d (usa) (disc 2)" sha1="343ba13b3651b4e3038e97c494f8ae5aaca41f41"/>
+				<disk name="d (usa) (disc 2)" sha1="b5c259490f06acce90b935a7f4afc3acd28104fb"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="d (usa) (disc 3)" sha1="fca47f407610dfef163a36af2f15095d91d87683"/>
+				<disk name="d (usa) (disc 3)" sha1="14e5ac2aea74b93d34d472530bdbfeec66239aa0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6218,7 +6218,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="destruction derby (usa)" sha1="e45355a420d1ace0501f2f404b6b8b38db328c1c"/>
+				<disk name="destruction derby (usa)" sha1="b3e00cae226deb4f9061388ffb24196b8dc3dba0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6282,7 +6282,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="destruction derby raw (usa)" sha1="a360f3543e19c57c161b18bdd6bc420833d14667"/>
+				<disk name="destruction derby raw (usa)" sha1="3f0db6b6eef98b845c61f4f6f9f8bddd22b2a70c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6571,7 +6571,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragonheart - fire &amp; steel (usa)" sha1="f699e517400360896eb6662d1547a0cd1f38ca56"/>
+				<disk name="dragonheart - fire &amp; steel (usa)" sha1="7a463d7c50661e210aed0e971158fd64d1e3c7f4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6606,7 +6606,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="diablo (usa) (en,fr,de,sv)" sha1="98f6d32fd9318ea9c7e2177b9bc264b978a19412"/>
+				<disk name="diablo (usa) (en,fr,de,sv)" sha1="e45913154e69d68b73e81ec44abbb6bb2f37c274"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6623,7 +6623,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="die hard trilogy 2 - viva las vegas (usa)" sha1="db2f22501c2ad26eb9d80e0857956c588e717323"/>
+				<disk name="die hard trilogy 2 - viva las vegas (usa)" sha1="f9f23d720ab04990149d0a1c28d873d6ff8c9473"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6660,7 +6660,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="die hard trilogy (usa) (v1.1)" sha1="8c2819931074e83032d3290a74882be06c504dd9"/>
+				<disk name="die hard trilogy (usa) (v1.1)" sha1="015f4b16dcef0c0d2bd9fc0d119f27f97a32f7ac"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6800,7 +6800,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dino crisis (usa) (v1.1)" sha1="bcf33257cde0d08678f6880c264c1388cc1a73c8"/>
+				<disk name="dino crisis (usa) (v1.1)" sha1="d5bd911a9185dd137040bc43726f8d2248c7dd4c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6836,7 +6836,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dino crisis 2 (usa)" sha1="866ba69cfde3b56960078849dcb18c84c16d9c16"/>
+				<disk name="dino crisis 2 (usa)" sha1="7d9ac5ee241bc94ac64893893bbb4c82ebba250f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6889,7 +6889,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="discworld ii - mortality bytes (usa)" sha1="7b2297b7bd6a2bf37bf7eb6d97b942563987bb67"/>
+				<disk name="discworld ii - mortality bytes (usa)" sha1="43448cc290f1f53288b0501b7196bbd49d7fd7cb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7071,7 +7071,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="doom (usa)" sha1="dc8481ece400c356eba83373a2b77e5afae7f74f"/>
+				<disk name="doom (usa)" sha1="1fe56d1e220712bdc2681bb55f2e90b457cc593b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7170,7 +7170,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="driver - you are the wheelman (usa) (v1.1)" sha1="14fbbd4d4fa8111d0bba35bd1644366854395fe2"/>
+				<disk name="driver - you are the wheelman (usa) (v1.1)" sha1="608728b6e7e3e584535b5c39c2c0aee35be35510"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7189,12 +7189,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="driver 2 (usa) (disc 1) (v1.1)" sha1="6f14915496207e5694914acea4e4d9b4c83f2639"/>
+				<disk name="driver 2 (usa) (disc 1) (v1.1)" sha1="5a6c7c8177bd826a3b6e6fbb565e0c3002aa3855"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="driver 2 (usa) (disc 2) (v1.1)" sha1="d02381334ab2b96e92bc489bc51929dff57de86f"/>
+				<disk name="driver 2 (usa) (disc 2) (v1.1)" sha1="c5014e627310d3d719e04801a1b035844a7c0ee9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7333,7 +7333,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="darkstalkers - the night warriors (usa)" sha1="05abd2adc8fce631ec887b73e1974111160e9326"/>
+				<disk name="darkstalkers - the night warriors (usa)" sha1="9156b564c4cec38716e3bc204e80480c93dd974d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7350,7 +7350,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="darkstalkers 3 (usa)" sha1="1706692ada422550d4ea86637a5294afe0fae1d0"/>
+				<disk name="darkstalkers 3 (usa)" sha1="8e629c928e68454516571f8b4913f585b822b9a8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7413,7 +7413,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="duke nukem - time to kill (usa)" sha1="023db69cc8c8adc0b9c51c0aa22c7aca4e130bab"/>
+				<disk name="duke nukem - time to kill (usa)" sha1="33949530e9826e1078fe06adf1f69ba2e53953de"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7657,7 +7657,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ecw hardcore revolution (usa)" sha1="490d497f6d164f5965cfd1ca13c2327fce110112"/>
+				<disk name="ecw hardcore revolution (usa)" sha1="59284d988e456fb0ea191c0f43311f67eb443cfb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7710,7 +7710,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="einhaender (usa)" sha1="5de113ab0543445a0c6033e887c807620f8ff1f9"/>
+				<disk name="einhaender (usa)" sha1="dd2ba34301ace8399abb7a70b756b5f7f10ebf68"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8227,7 +8227,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="formula 1 98 (usa) (en,fr,de,es,it,fi)" sha1="fde45c916538081833a24abd5cb739d83884d733"/>
+				<disk name="formula 1 98 (usa) (en,fr,de,es,it,fi)" sha1="5b8407c8c5a16a302cf945dc8280a1c0b0291d49"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8245,7 +8245,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="formula 1 championship edition (usa) (en,fr,de,es,it)" sha1="affc201e03129bdf22b13e0b23c525e98bd1170d"/>
+				<disk name="formula 1 championship edition (usa) (en,fr,de,es,it)" sha1="f912bc68926779b42b0c7bbd9870ca0166ffef84"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8360,7 +8360,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="family card games fun pack (usa)" sha1="88e9487308500d1d2d6735bf603ae26f3c2a5e46"/>
+				<disk name="family card games fun pack (usa)" sha1="c4027956a0643350d71f621d268d37250aeeb1e9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8455,7 +8455,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fatal fury - wild ambition (usa)" sha1="dfda7b8134200fe49eb181736c88c93bf667d384"/>
+				<disk name="fatal fury - wild ambition (usa)" sha1="35cc9c62f2511ce4fc06e34d4d2a619addb3b90b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8637,7 +8637,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy chronicles - final fantasy iv (usa) (v1.1)" sha1="13c2db5ca21481ae16436fbe270e296a03371b8b"/>
+				<disk name="final fantasy chronicles - final fantasy iv (usa) (v1.1)" sha1="96a91cb6b297d0f0f601c56167bffbcb9ad0f7af"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8671,7 +8671,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy anthology - final fantasy v (usa) (v1.1)" sha1="561aa73f27b7bbe6d85cfc899aa544cba86c9ac1"/>
+				<disk name="final fantasy anthology - final fantasy v (usa) (v1.1)" sha1="9e82d3d6c8441fabea47dd652a6ea5196f2ef438"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8705,7 +8705,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy anthology - final fantasy vi (usa) (v1.1)" sha1="4fdce0a4c9aeda24839be92fbd52ec0b1c126ec8"/>
+				<disk name="final fantasy anthology - final fantasy vi (usa) (v1.1)" sha1="249bc9af1de0e75bbd7c30e1fb7b935103ff23c2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8743,17 +8743,17 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy vii (usa) (disc 1)" sha1="f53774b1c71a120cdb77d271e00c7bd54b928ca0"/>
+				<disk name="final fantasy vii (usa) (disc 1)" sha1="b5665fbb2895d0e4fa010e5e15d68c15ceac3688"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy vii (usa) (disc 2)" sha1="487a1a6c5d4feff03fb370f149d89e2d19986e26"/>
+				<disk name="final fantasy vii (usa) (disc 2)" sha1="ca80cb0c94936bef091364ef9060a675914a80bd"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy vii (usa) (disc 3)" sha1="9364f48f6f381ddc9d954c534951f686ac65f255"/>
+				<disk name="final fantasy vii (usa) (disc 3)" sha1="87223b2d6c54c4e8d5891d8ae485264cbb887d3c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8776,22 +8776,22 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 1)" sha1="998c8ff53258bc62ae4d9349aff763f954783295"/>
+				<disk name="final fantasy viii (usa) (disc 1)" sha1="4b589aed4dfdf9ec75c3351ed81d367ea2dd0e7f"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 2)" sha1="2f9bfa1b5f56bc62b70be6a6c66c27576d585593"/>
+				<disk name="final fantasy viii (usa) (disc 2)" sha1="4ca6918c519fc8505d637bc5b20e263eb57961c3"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 3)" sha1="11094511c2c764c12c2632802161f7c594a724fe"/>
+				<disk name="final fantasy viii (usa) (disc 3)" sha1="cd5b06dfa24506866694dfc1e0d799e958723045"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 4)" sha1="c4eadb3360a54f7c71756c7a4f5115aa538856f7"/>
+				<disk name="final fantasy viii (usa) (disc 4)" sha1="2e53f99d622be145cdaecd5fbb7d9e43440232d2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8814,22 +8814,22 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 1) (v1.1)" sha1="6cc195d41e08d485d957beb51e222f0c275a662c"/>
+				<disk name="final fantasy ix (usa) (disc 1) (v1.1)" sha1="aa95b490a84e95c18d8ac127ea6ab98ebe3d8d7f"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 2) (v1.1)" sha1="f0d7f01f7278ca3625d1654ee80526688a6731a1"/>
+				<disk name="final fantasy ix (usa) (disc 2) (v1.1)" sha1="3c7c71f6e0d37b31e26a2955d9f1f3ae3d61e95c"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 3) (v1.1)" sha1="2744357291b4ccc6527732f638eff5a0fcf4c9cc"/>
+				<disk name="final fantasy ix (usa) (disc 3) (v1.1)" sha1="66dd04783469215b1074552a222239da2ae21665"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 4) (v1.1)" sha1="308f3e7519293212f75fe7110c269fbcbe23e18e"/>
+				<disk name="final fantasy ix (usa) (disc 4) (v1.1)" sha1="ef8760c71d408d7492f8269f28ef9f5dbce02cef"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8884,7 +8884,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy tactics (usa)" sha1="f061d8a0e42a0f976b82bbdc4ae3a7b36d96f6a8"/>
+				<disk name="final fantasy tactics (usa)" sha1="f44672cbf59ac08e0ce5f7473ee9a0e352c6f061"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9048,7 +9048,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy origins (usa) (v1.1)" sha1="60ecf85c194d5aa096e39fff6d8300fdc818bb24"/>
+				<disk name="final fantasy origins (usa) (v1.1)" sha1="833a6bf605ab741b2258312874c9955de2086586"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9224,7 +9224,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fifa soccer 97 (usa)" sha1="173828198c0a07bf9c74216bd89bbaf5759655b1"/>
+				<disk name="fifa soccer 97 (usa)" sha1="a3944ff8ddd5fcd46ea6a914dbb087114c229fea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9316,7 +9316,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final doom (usa)" sha1="61b6eeefb1159b4c3a60b53e443c2d34d0c1ea37"/>
+				<disk name="final doom (usa)" sha1="569c9d342e6cad12cc7000a74141a006aa1aeaf3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9440,7 +9440,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="forsaken (usa)" sha1="29a6f5cd68d957569d91cd1a86f07e1b1afe4ce3"/>
+				<disk name="forsaken (usa)" sha1="8dd5e8d46f0367ab5bf9f6bf464b9bf0bd14d689"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9542,7 +9542,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="freestyle boardin' '99 (usa)" sha1="a114a132941abbe27b3a1172fd75a1e83ff500fc"/>
+				<disk name="freestyle boardin' '99 (usa)" sha1="7a6a4a694f6a744e9abe40de6dd28f3c55740c87"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9560,7 +9560,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="freestyle motocross - mcgrath vs. pastrana (usa)" sha1="2e8b9ccd2086b427193c8a5de9c4e14b1f8b9548"/>
+				<disk name="freestyle motocross - mcgrath vs. pastrana (usa)" sha1="6363a81040545fe3998909117f6fa9d579466adb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9578,7 +9578,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="frogger (usa)" sha1="dd9ef6dbde1c90923cf5c9078022f322b0f7ab07"/>
+				<disk name="frogger (usa)" sha1="fa22e611dba522775cac04e0412fbdb6b68b67f9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9681,7 +9681,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="galaga - destination earth (usa)" sha1="3a00321afb1228bf007f5d6b870e6f6c898843fc"/>
+				<disk name="galaga - destination earth (usa)" sha1="d4ac318914aaef6295985322b53e9b199feb8e66"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9729,7 +9729,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gauntlet legends (usa)" sha1="7e0f39f5e3fca397d679924836b18914a7989d57"/>
+				<disk name="gauntlet legends (usa)" sha1="9b924cd15c05f01bdd0b1a7090ae039dabf35938"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9764,7 +9764,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="g. darius (usa)" sha1="7c5e7cb9f9313f56b32ee3161a907a5bc6aaac41"/>
+				<disk name="g. darius (usa)" sha1="17aec6a72ea6a0f8dd41cc5c36cafafe8fd06b50"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9787,7 +9787,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gekido - urban fighters (usa)" sha1="99a03064684e94bd96ccedcf6258f18dd633181c"/>
+				<disk name="gekido - urban fighters (usa)" sha1="ebcdd5d5989ab745adbb2d817d42291cded54ef1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9804,7 +9804,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gekioh - shooting king (usa)" sha1="59b58f25ac0dbeadfd7d78aaa6ed7d993f2b18ed"/>
+				<disk name="gekioh - shooting king (usa)" sha1="d4c4b5956475322cfeb5e55a073ba1c70a2b00e9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9821,7 +9821,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gex (usa)" sha1="497f50122c31968587750a2ce69edfdfc10ae02e"/>
+				<disk name="gex (usa)" sha1="ec0f32b9f76e0bc6febe489f3e4903dc1c2e7e15"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9855,7 +9855,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gex 3 - deep cover gecko (usa)" sha1="9c12acdd9a223ed05086fc87f912c5f5df1c811e"/>
+				<disk name="gex 3 - deep cover gecko (usa)" sha1="631ce1a305a6a220b98bbb2b6d67eb6b15583411"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9911,7 +9911,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="guilty gear (usa) (v1.0)" sha1="42d1118faa2dac97d7c0a7daa6a64bda2973b570"/>
+				<disk name="guilty gear (usa) (v1.0)" sha1="b57095a1daf1ee30cbb3c9507aa501a7bf5617ca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9928,7 +9928,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ghost in the shell (usa)" sha1="c8403397712d75541a9a789a2f52e9696310be52"/>
+				<disk name="ghost in the shell (usa)" sha1="4910b272fc7edbe9da836b78a7db8acce4a4d9c0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10350,7 +10350,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gran turismo (usa) (v1.1)" sha1="cea9169f54157b01bbbdb530ebeee8b85a39c3f4"/>
+				<disk name="gran turismo (usa) (v1.1)" sha1="0f6bb343c0fc919de6b6e6076b6e5d97c27663e9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10388,7 +10388,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Arcade Mode"/>
 			<diskarea name="cdrom">
-				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="a30b84274435e2cac3b5232980d7217977e46c85"/>
+				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="67e07f8dcd580ccdf1745bc25520772fec5bb0d3"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -10415,7 +10415,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Arcade Mode"/>
 			<diskarea name="cdrom">
-				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="a30b84274435e2cac3b5232980d7217977e46c85"/>
+				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="e5c8728d348125aaadc5a51ce3692026f2138aa7"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -10511,7 +10511,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="grand theft auto 2 (usa)" sha1="87627fbb043f13c63392799cb327a503da9ab14f"/>
+				<disk name="grand theft auto 2 (usa)" sha1="3a4ee881dc53edc2c3c822182d742007e6e9356f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10543,7 +10543,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="grand theft auto - mission pack 1 - london 1969 (usa)" sha1="c7387613ee8abbabbc0d2549a538f0b0957a36d5"/>
+				<disk name="grand theft auto - mission pack 1 - london 1969 (usa)" sha1="1b62bc051314f36924a53885282e2332d2001816"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10610,7 +10610,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gubble (usa)" sha1="8a581696e5cbbf10f709d10002f1d263dac4a3b1"/>
+				<disk name="gubble (usa)" sha1="6780bdcd0cd766439c9b6bc3d9a832278bea4708"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10628,7 +10628,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gundam battle assault 2 (usa)" sha1="b7f2b3a9aef64706d20bfe17016fc9b82c6e8c29"/>
+				<disk name="gundam battle assault 2 (usa)" sha1="595fb715a6aaae0faa4adaedd482901c7303dde3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10665,7 +10665,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gundam battle assault (usa)" sha1="ece9d43daddd1a8a6c020cb18df9e2045ae1a5d2"/>
+				<disk name="gundam battle assault (usa)" sha1="08d96a6d7aa3fbeacf72d7ceb63575b80caedd70"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10826,7 +10826,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hbo boxing (usa)" sha1="96fe53a1b8adc1cf54eb0f4f154f1dcdbf24e763"/>
+				<disk name="hbo boxing (usa)" sha1="16462ae80de1c16041ca0128b6ec2c3761c48297"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11101,7 +11101,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hogs of war (usa)" sha1="cbae32df37fa854c0bea209f61940a41455a1a93"/>
+				<disk name="hogs of war (usa)" sha1="85899ca70527dbe81f2a6eaf5edbcd5ca871481f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11261,7 +11261,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hot wheels - extreme racing (usa)" sha1="5d4eeee81caabb3f1b977bee341d93bd56c7648d"/>
+				<disk name="hot wheels - extreme racing (usa)" sha1="f1fdaf5004f2b8046127e01c7ae852fe6dfb387e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11359,7 +11359,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hydro thunder (usa)" sha1="286b84560da424c10dd1391ce7f3cd49ff1048f8"/>
+				<disk name="hydro thunder (usa)" sha1="50a8b79a2c251b050f2a49760f5aa9b2950a5dc0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11415,7 +11415,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="impact racing (usa)" sha1="969605d72e0fb880c1dc5448a3ab09ef82076915"/>
+				<disk name="impact racing (usa)" sha1="821fba81b854ad8ec15c6e8644475ffeb3650bcc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11451,7 +11451,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="independence day (usa)" sha1="0c8222154bb994fcc615f9c39b73622d560f9804"/>
+				<disk name="independence day (usa)" sha1="dab6552233247e1ad05c656066f2dddec9ef7a76"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11497,7 +11497,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="in the hunt (usa)" sha1="ee934ab08575bc4d361046fdeace43fb32f57b76"/>
+				<disk name="in the hunt (usa)" sha1="e721dd560cc07498943e4b9959e324729e65a760"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11617,7 +11617,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="advanced dungeons &amp; dragons - iron &amp; blood - warriors of ravenloft (usa)" sha1="18245fa03c7b3e9ebadb1f4ddaa9a022c49ba58e"/>
+				<disk name="advanced dungeons &amp; dragons - iron &amp; blood - warriors of ravenloft (usa)" sha1="17801ddab215bcc26034feb352967b41cdc95d40"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11655,7 +11655,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="iron man &amp; x-o manowar in heavy metal (usa)" sha1="8d2aa21eedc311c45dfc6d074a54e5e3638adf3f"/>
+				<disk name="iron man &amp; x-o manowar in heavy metal (usa)" sha1="7e65d61c52f08b39933f57978710888153a475e0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11689,7 +11689,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="irritating stick (usa)" sha1="3c832ebbddb7bea03214de8ad8a79c081e516cf7"/>
+				<disk name="irritating stick (usa)" sha1="9289c8dabe05a5b590aea9a82a32324b8895525c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11790,7 +11790,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="international track &amp; field (usa)" sha1="de74c844ed802c43af60db60c652b03c53444588"/>
+				<disk name="international track &amp; field (usa)" sha1="dc937024fdeed3b294b1c3baae36bd6edebb65b9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11858,7 +11858,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="johnny bazookatone (usa)" sha1="e455f2d675034ce47d24feebe55cdd3e42ca70fd"/>
+				<disk name="johnny bazookatone (usa)" sha1="419614f7156fa21dd6996edba658546d9c6e219a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11892,7 +11892,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="judge dredd (usa)" sha1="4c139c872708cbf01506dddbabb1233c5e9271ef"/>
+				<disk name="judge dredd (usa)" sha1="cc74396b0e1b24feb5366f704029dab76c88b4fd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12020,7 +12020,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet moto 2 - championship edition (usa)" sha1="c7f10dc476869c636aa0826d03927e3f13332a3e"/>
+				<disk name="jet moto 2 - championship edition (usa)" sha1="b42cb27c9047e3a205ac705f103b84d9a9bb82bc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12050,7 +12050,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet moto (usa)" sha1="69496c1d35ac44334eb92121b3057b679c16d76c"/>
+				<disk name="jet moto (usa)" sha1="251e9d825407a0ca917c8dac11344b0f95698d29"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12100,7 +12100,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet moto 3 (usa)" sha1="c2540cd8102c7e5df1080565678cb62b0b36eac5"/>
+				<disk name="jet moto 3 (usa)" sha1="9b41ae93feb09afc8e876653209794f97ad09c70"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12198,7 +12198,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jojo's bizarre adventure (usa)" sha1="847680c54853a9bb551b848214f61a993f60ab55"/>
+				<disk name="jojo's bizarre adventure (usa)" sha1="1a535aab9dd8a47280f8ee71bce3a33ea2dd68c8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12297,7 +12297,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jupiter strike (usa)" sha1="c5e4aebe9edaf950e4303cccf88e334ff4ea4cb5"/>
+				<disk name="jupiter strike (usa)" sha1="db3044e8afc055ec72a6d6034d8a2a276ae75f92"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12382,7 +12382,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="k-1 grand prix (usa)" sha1="be79f2fabda5f7b7898ce19672170f3d4cd3535b"/>
+				<disk name="k-1 grand prix (usa)" sha1="a1262560ed86589598e03e50b3f8e372833a327f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12414,7 +12414,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="k-1 revenge (usa)" sha1="8f6e555cf4be7d60495b484fd0d51b56a9a41fe8"/>
+				<disk name="k-1 revenge (usa)" sha1="2ca9009bf2df2ce939a73bb4e837e16f0959fb99"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12448,7 +12448,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="blood omen - legacy of kain (usa)" sha1="86db9d235c28087c5d43d60e4816c3fd384a036b"/>
+				<disk name="blood omen - legacy of kain (usa)" sha1="b9d465144c3b42c1fa09e1a59c48d8992021aef9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12465,7 +12465,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legacy of kain - soul reaver (usa)" sha1="b66a08f5059e90203b62fe6c839c2e2a2aa03bfc"/>
+				<disk name="legacy of kain - soul reaver (usa)" sha1="7151e18c9833410a3b2d72602903f2968142042d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12633,7 +12633,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="killing zone (usa)" sha1="96347fadf418e31f762e2d2667dad71434a1fd74"/>
+				<disk name="killing zone (usa)" sha1="cf7c9338c633a29d841fd0327b5877c9fbbcee49"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12666,7 +12666,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kingsley's adventure (usa)" sha1="d9ff5035cdbfbb6c04a2a6f60cabdbcf9ea0a83d"/>
+				<disk name="kingsley's adventure (usa)" sha1="34e26047072db3fc7092c1ad0a825803f631bfe7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12683,7 +12683,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king's field ii (usa)" sha1="c343c9a6c44fa505cf35a9437c670009eddcd017"/>
+				<disk name="king's field ii (usa)" sha1="f43928ccc08fa097a775e1b8f777c8b32c3c1dff"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12700,7 +12700,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king's field (usa)" sha1="660f25acc3dab1352ef4d60d81d9541c11043d45"/>
+				<disk name="king's field (usa)" sha1="b41a6c67cab617b266e637eb10ef36ad54518b8b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12792,7 +12792,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king of fighters '95, the (usa)" sha1="559180dd465fc4333a920f74f586ad70735827e8"/>
+				<disk name="king of fighters '95, the (usa)" sha1="fb4f2e9bd9f855d851caed63240473bd41e38556"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12810,7 +12810,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king of fighters '99, the (usa)" sha1="953d566b5786bc1ed2726f93b0cdd5b3c2b8b5d8"/>
+				<disk name="king of fighters '99, the (usa)" sha1="280100c9b4613597f4ee0f89482c47dd078f00db"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13083,22 +13083,22 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 1)" sha1="dbab4b64e4f3b582486bb9d3e44149c691f3032d"/>
+				<disk name="legend of dragoon, the (usa) (disc 1)" sha1="e094a24456ffcdfaff840835f0759e1f86c88201"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 2)" sha1="f7a98165bcf919bcb721f50eaf4beb9f845160fb"/>
+				<disk name="legend of dragoon, the (usa) (disc 2)" sha1="ac8f2803d8fb0c7f43f356c86121a7b6fd2ede96"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 3)" sha1="05a4297cbb8c9accb6b4c40d3afd045fb68e74f0"/>
+				<disk name="legend of dragoon, the (usa) (disc 3)" sha1="f18594fcc92fd8925293459bab3f56beb0b15205"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 4)" sha1="7db94128cd99568980fe369620d10946d8aa401b"/>
+				<disk name="legend of dragoon, the (usa) (disc 4)" sha1="f1d1535770b6f15a75a90742bfde56d6b9ae378d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13147,7 +13147,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lode runner (usa)" sha1="a92cd56b8d7e0f554e5da6fe6c2e8cb49c00cf8f"/>
+				<disk name="lode runner (usa)" sha1="ce3155f60b6f0d5b349ebb3273c99f055cf4a3f6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13315,7 +13315,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's the lion king ii - simba's mighty adventure (usa)" sha1="b21b7e2ba91deb94a610d809ee89ba08c8f828c5"/>
+				<disk name="disney's the lion king ii - simba's mighty adventure (usa)" sha1="b14db1fa5383a32fb69089e43a5eb1436c9b4a17"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13361,7 +13361,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="loaded (usa) (en,fr)" sha1="fbc93540a150af582ff241fc9d49c0c1d8a11784"/>
+				<disk name="loaded (usa) (en,fr)" sha1="727bafe2c941a53ce7c52380aade32369017c664"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13419,7 +13419,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="looney tunes racing (usa) (en,fr,es)" sha1="79ebf67729f24b78cf13eedb736950171301f181"/>
+				<disk name="looney tunes racing (usa) (en,fr,es)" sha1="72032b1794885cdeae3301b3805da4f4f501e98b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13538,12 +13538,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar - silver star story complete (usa) (disc 1)" sha1="eb1fb6c49ffec47ac2b7bf26d7621d9bf90d2010"/>
+				<disk name="lunar - silver star story complete (usa) (disc 1)" sha1="51cfe14a5449efe6b6d4097d4b46d6e9e3623424"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar - silver star story complete (usa) (disc 2)" sha1="0461da91ed7dcbabe2f61444126951840b213ae6"/>
+				<disk name="lunar - silver star story complete (usa) (disc 2)" sha1="f664aa20deee48210e7a76c312f53d580b2d2985"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
@@ -13571,17 +13571,17 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar 2 - eternal blue complete (usa) (disc 1)" sha1="1ce47e3775e83b13d8c50662319dacb5e89d9743"/>
+				<disk name="lunar 2 - eternal blue complete (usa) (disc 1)" sha1="897a4777fa5cfbdd792982dd52f6ea9a5d053d9e"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar 2 - eternal blue complete (usa) (disc 2)" sha1="0172a2f6b924da9ab0d2caa12e1ddbce3f628678"/>
+				<disk name="lunar 2 - eternal blue complete (usa) (disc 2)" sha1="79ebabbce45631d667c4e3692f8b6195ec5dc16d"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar 2 - eternal blue complete (usa) (disc 3)" sha1="0e91e547f38869d91b86ee027c2c822083d2e840"/>
+				<disk name="lunar 2 - eternal blue complete (usa) (disc 3)" sha1="084395e85478b80230bf2d3fb67184970e2f7a65"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
@@ -13605,7 +13605,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="south park - chef's luv shack (usa)" sha1="3d143af6327f81e3d2a9b21429c69ffc10355f17"/>
+				<disk name="south park - chef's luv shack (usa)" sha1="7b9d8f83135f476983315718e9b1c77bc24dcb1e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13662,7 +13662,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="machine hunter (usa)" sha1="e4d2df64b8d1d0864f0173156f3502ee1f85edc2"/>
+				<disk name="machine hunter (usa)" sha1="383552eb1286d39f1ce409059b29700d59fa0926"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13798,7 +13798,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="madden nfl 98 (usa)" sha1="7124e21295dc612add3d8c7555e4bca2c2670bf5"/>
+				<disk name="madden nfl 98 (usa)" sha1="02c50904e0d3f20f154266c95f4acaee57263788"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13889,7 +13889,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="magic - the gathering - battlemage (usa)" sha1="3bcd8f733bb5ab8cd3726a9d59a51574d148bdea"/>
+				<disk name="magic - the gathering - battlemage (usa)" sha1="be87a3319fab8418b1d548e7787514f9d0a77cd6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14065,7 +14065,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colin mcrae rally (usa)" sha1="0765845afa78dc8a1572823294780b1765791667"/>
+				<disk name="colin mcrae rally (usa)" sha1="279449a95bf0b7fbd1215ed1dd4f2d8abfcc63fb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14083,7 +14083,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colin mcrae rally 2.0 (usa) (en,fr,es)" sha1="a451bc1214db4b0c0fe9aada8e9798f9fab44272"/>
+				<disk name="colin mcrae rally 2.0 (usa) (en,fr,es)" sha1="3974bfd4be890617807e3bfbfa78bf92030d323a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14210,7 +14210,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man 8 (usa)" sha1="355eb773d9f468cfa2a9ed36b7878f3814f0d263"/>
+				<disk name="mega man 8 (usa)" sha1="e4e71e460de78f5a571f46fb2e1f5b940c9477c3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14227,7 +14227,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x4 (usa)" sha1="35dc1d61ad36b70177107e20d257325790a3f347"/>
+				<disk name="mega man x4 (usa)" sha1="ad336c1d3481030735d7c10c434c564ec7b1d68d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14244,7 +14244,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x5 (usa)" sha1="077c266a0b9245def631058d1ea83e919cdbec9f"/>
+				<disk name="mega man x5 (usa)" sha1="c9c6246beb5b6bd6ae45498db2b8026ade8522f0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14261,7 +14261,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x6 (usa) (v1.1)" sha1="0c6435369163895a333e0df446844b1ae87d58be"/>
+				<disk name="mega man x6 (usa) (v1.1)" sha1="278c3ce12bafea06148777ebfc168d73ec62ddc1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14278,7 +14278,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x6 (usa) (v1.0)" sha1="0718095e485314c49914c274158b947d5199d21c"/>
+				<disk name="mega man x6 (usa) (v1.0)" sha1="576a04c12f3e635e3b48ebafcf7d1e1295ce07dc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14338,12 +14338,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal gear solid (usa) (disc 1) (v1.0)" sha1="ca11d3f7172718401b4a529e35aedcb5f6e0a6d9"/>
+				<disk name="metal gear solid (usa) (disc 1) (v1.0)" sha1="23c8ef7a30624c517271a9280ed85c9995ece418"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal gear solid (usa) (disc 2) (v1.0)" sha1="3f3560a2986639e33d2844239a8847945fca2cc1"/>
+				<disk name="metal gear solid (usa) (disc 2) (v1.0)" sha1="370361be299494ed7876fa80572870f52afa0a73"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14360,7 +14360,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal gear solid - vr missions (usa)" sha1="3b7ece83bd06c5802d7025b801c0f8d16b135d5f"/>
+				<disk name="metal gear solid - vr missions (usa)" sha1="19b873b051acc323a0b6b3bb98ddb2c10cac58a1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14377,7 +14377,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="medal of honor (usa)" sha1="56fbf554551f0f92c3e9795208a943d40dcf1706"/>
+				<disk name="medal of honor (usa)" sha1="f155640f176acd8638e38578a9d2ab9bc9087ea3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14394,7 +14394,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="medal of honor - underground (usa)" sha1="3bdad42aa0dfa1430ded815378764f3de5aec1ac"/>
+				<disk name="medal of honor - underground (usa)" sha1="c49f2fa8c648d5f7055ce1057c415050286ff8ba"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14449,7 +14449,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="foxkids.com - micro maniacs racing (usa)" sha1="60cc762c02dc1124439ac4306ba464878031c544"/>
+				<disk name="foxkids.com - micro maniacs racing (usa)" sha1="937f7b96e2f8098ab109e5eb971d3a649e1793a8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14468,7 +14468,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="micro machines v3 (usa)" sha1="30fba5a4fdc0ea1249fda0a4fb746202af4a4dfb"/>
+				<disk name="micro machines v3 (usa)" sha1="d0c9cf70cafaf2025f31c2404c1553f5dca672c3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14539,7 +14539,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="missile command (usa)" sha1="38179e41ea89de49e7c16908115b192a3258da90"/>
+				<disk name="missile command (usa)" sha1="1163e909b3a83421e7a7672c780c8f27ce4c1283"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14651,7 +14651,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat 3 (usa)" sha1="4d34f61a4555ab7ca047212b1101c89fb77f6cc5"/>
+				<disk name="mortal kombat 3 (usa)" sha1="60a313d72beefa8b19cb838623983ccc8b634c6c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14668,7 +14668,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat 4 (usa)" sha1="3eca48bcc496ea0d22648787d7e5e78c4930ce12"/>
+				<disk name="mortal kombat 4 (usa)" sha1="64b679e01f6984d689fa18aa5a51c6da0300d482"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14685,7 +14685,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat - special forces (usa)" sha1="e9919c72ccef3a0e8877fbe5f940e83d47bbfcda"/>
+				<disk name="mortal kombat - special forces (usa)" sha1="5e307fb758331fdee0a2d740c051bf6f98af3ae3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14731,7 +14731,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat trilogy (usa) (v1.1)" sha1="9713a08222b02d12f503c2296d28c215e9b07e91"/>
+				<disk name="mortal kombat trilogy (usa) (v1.1)" sha1="bb7ce7deff58cd2573b531b2d3e69ea73ba93631"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14964,7 +14964,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mobile light force (usa)" sha1="9316dad634ed08f3ad2cf3d242300973d8490632"/>
+				<disk name="mobile light force (usa)" sha1="f37e1d8593bb0714b16730ea341a592f27d1ddcb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14982,7 +14982,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man legends (usa)" sha1="594f3159b3a7b1392826197343059205732fed6b"/>
+				<disk name="mega man legends (usa)" sha1="77aab55210eac8354aa7c698ddf3476afccf356b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15000,7 +15000,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man legends 2 (usa)" sha1="8d1592a30125ad666ec5a1f1eaaafc209f06df6e"/>
+				<disk name="mega man legends 2 (usa)" sha1="183034a51563b69164b5cfc7995af86e9c37fed9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15208,7 +15208,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="monopoly (usa)" sha1="89d9a4e39b7532eb62cf18d37a44cd7758f19e22"/>
+				<disk name="monopoly (usa)" sha1="87b78ac3034312cc57dd94a86751064c93bf5ab2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15390,7 +15390,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="moto racer world tour (usa)" sha1="2dfef2f8f61302432df5711d8b7d2de87ee4b843"/>
+				<disk name="moto racer world tour (usa)" sha1="d75f1e4c85d6123cab908e484784a4dabe2ca5a4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15481,7 +15481,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="monster rancher battle card - episode ii (usa)" sha1="411ae96c5383b8f62d8e59893507f53218ef7667"/>
+				<disk name="monster rancher battle card - episode ii (usa)" sha1="91c00f8384f6f57c56f8e8b8b534b781a943b413"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15626,7 +15626,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="marvel super heroes (usa)" sha1="2e43e577c2ed880442e54d0d4976ba1ef75ae206"/>
+				<disk name="marvel super heroes (usa)" sha1="81592bf673c4dbe866cf7daad06b6965f370563d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15660,7 +15660,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal slug x (usa)" sha1="fcb065838e146998c3608b6d77d5a464cf1daea4"/>
+				<disk name="metal slug x (usa)" sha1="bc7953f15bd7b9d2154741b043d6c7dde73f444e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15683,7 +15683,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ms. pac-man maze madness (usa) (v1.1)" sha1="45fe7713732f29b177c7abb3e5b41adbda1b4e38"/>
+				<disk name="ms. pac-man maze madness (usa) (v1.1)" sha1="321629602dd4368a3aad449c3e75125a59ff40c0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15938,7 +15938,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="marvel vs. capcom - clash of super heroes (usa)" sha1="90e936d55824b807e9e956e62b00b086e680c9de"/>
+				<disk name="marvel vs. capcom - clash of super heroes (usa)" sha1="7d558cd1650bf313d8a1a5678b592180e2110f8c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16043,7 +16043,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nagano winter olympics '98 (usa)" sha1="0b986f1fe8805c5198ac936bbd6c7095fd36f01f"/>
+				<disk name="nagano winter olympics '98 (usa)" sha1="96e0e908a22d53cd60e9a1862371a5902b61fcbd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16069,7 +16069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="namco museum vol. 1 (usa) (v1.1)" sha1="50a37d173a660cfa9a05d2d07c7b25dc52c34755"/>
+				<disk name="namco museum vol. 1 (usa) (v1.1)" sha1="af19f724d9b57041b6ed0ab11f5977279ff85f3b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16213,7 +16213,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nanotek warrior (usa)" sha1="21f9021c62593b759d565ef5309cce39713b6ba6"/>
+				<disk name="nanotek warrior (usa)" sha1="4badc333c2390a7ebcd32d12aa31ed6912b12119"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16356,7 +16356,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nascar racing (usa)" sha1="3a109011c05a550085b4b2f86157b4fa29661042"/>
+				<disk name="nascar racing (usa)" sha1="21465648f2b7c6352650d13d48fb8740f57b451f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16496,7 +16496,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nba basketball 2000 (usa)" sha1="9caf6613ada46e2f3ae32779e8727f05826b1c24"/>
+				<disk name="nba basketball 2000 (usa)" sha1="5107f34115b589a0894d5038849b27c9f1cdc8df"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16594,7 +16594,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nba jam - tournament edition (usa)" sha1="840ac0e924c16224739bb6439a91952bb0fada12"/>
+				<disk name="nba jam - tournament edition (usa)" sha1="370523bd8a770b55a3a38be5b195ad9397f911e2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17363,7 +17363,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nightmare creatures (usa)" sha1="f2389e82bc41b3afc1ad12b43795e350b717f7c1"/>
+				<disk name="nightmare creatures (usa)" sha1="8592a07f87df446601902a137d69075dde4cf206"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17631,7 +17631,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl quarterback club 97 (usa)" sha1="580836aa0eaac13a581a98c67df8c23017b13c5a"/>
+				<disk name="nfl quarterback club 97 (usa)" sha1="bd689204eba515256d945f45b295bc23541b5480"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17701,7 +17701,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed ii (usa)" sha1="4771b65e81100ac28307b22f719cda2b7709df7c"/>
+				<disk name="need for speed ii (usa)" sha1="54d978f44c97fe927ce5a28d673a34600e1d619d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17735,7 +17735,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - high stakes (usa)" sha1="be8caf7a7eaa4e9999e78c3b8c84c9985e663fb5"/>
+				<disk name="need for speed - high stakes (usa)" sha1="7f231d785984b12ef6d67c77ffc91d6a60d54e0b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17766,7 +17766,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - porsche unleashed (usa)" sha1="3a5ba01e5c10a6e55945af093531119cd8a08b33"/>
+				<disk name="need for speed - porsche unleashed (usa)" sha1="6efeccdc5918c8d131afdfc53783ae5380c1fcc2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17852,7 +17852,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl open ice - 2 on 2 challenge (usa)" sha1="ba6fa14d4337bd030c681f6be920294b35a053fb"/>
+				<disk name="nhl open ice - 2 on 2 challenge (usa)" sha1="ba639897d02c043ae0db9369402930f8d73f948f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17877,7 +17877,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl 97 (usa)" sha1="5d488298c1e49531cd6e329fd51052e67c750550"/>
+				<disk name="nhl 97 (usa)" sha1="f2e1a333096d48d58ee5a4f47b71264d0648564f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17929,7 +17929,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl breakaway 98 (usa)" sha1="f241ed941b2fb1b7fe78cf842f779f0e1981746c"/>
+				<disk name="nhl breakaway 98 (usa)" sha1="ca21c54f8ed8a10913690a8b20ffe0fe98c144a0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17947,7 +17947,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl championship 2000 (usa)" sha1="e279abecb164f2cab5dcc2d430a0575315d91471"/>
+				<disk name="nhl championship 2000 (usa)" sha1="08343902480229df1175ff93c8776f49c172e0df"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18218,12 +18218,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="novastorm (usa) (disc 1)" sha1="b03235765aae4d84497f9c885d980139ca8e4410"/>
+				<disk name="novastorm (usa) (disc 1)" sha1="56b2709a371ddf8dc249d95453e9f80795b65333"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="novastorm (usa) (disc 2)" sha1="67221f49410f43cbbb6b55f706a5b5703cd4a670"/>
+				<disk name="novastorm (usa) (disc 2)" sha1="73329a95c40ad19e5a8e795a557de8a0d7b5460e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18268,7 +18268,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="next tetris, the (usa)" sha1="e4c71550fe89b90771c1aea8c276713eed06ca69"/>
+				<disk name="next tetris, the (usa)" sha1="7c9c36b4342b110eb0877f219f17adda181d0379"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18286,7 +18286,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="o.d.t. (usa)" sha1="ee356e30a34462ce35f15c7a1775fa2c64d5ab70"/>
+				<disk name="o.d.t. (usa)" sha1="10597fb61fc7b614fb1c5a6665114a0b4fab45d6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18386,7 +18386,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="olympic summer games (usa)" sha1="e0d8b762e01314cd2029921b7e4b53cbef438dc1"/>
+				<disk name="olympic summer games (usa)" sha1="d5bdc9a83a2bda1475adb3312ccf30ee5593a6e3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18497,7 +18497,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pac-man world (usa)" sha1="18dd91e41a5a39b6185d1f1ecdbc45d711bbb074"/>
+				<disk name="pac-man world (usa)" sha1="c17bfd790a0b71a711ed64b8ea91469be6569479"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18531,7 +18531,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pandemonium (usa)" sha1="40c7499febe8ccf3d62e81bac6876c128d845bca"/>
+				<disk name="pandemonium (usa)" sha1="01a0f5957cffc9c59d3b8196827e64116eaeea98"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18548,7 +18548,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="parappa the rapper (usa) (en,fr,de,es,it)" sha1="91a64f0ecf079964d5d8df0939157e8b53a9a2ff"/>
+				<disk name="parappa the rapper (usa) (en,fr,de,es,it)" sha1="a0228849bf77c2b59830bfc2c5a62cc88a8bb984"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18734,7 +18734,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pocket fighter (usa)" sha1="d859aefd472ebf7446e966ddcd6f003b8875d557"/>
+				<disk name="pocket fighter (usa)" sha1="e4709a85ed8e1b461295fa0a8585636fc44e2cca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18802,7 +18802,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pga tour 98 (usa)" sha1="8e6b6e5c474d11f08e738ea128f0aeaded9b0a09"/>
+				<disk name="pga tour 98 (usa)" sha1="4868ce46755c35c26962ecf50e36429fef1d831c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18819,7 +18819,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tiger woods 99 pga tour golf (usa) (v1.1)" sha1="7292af853c21299fe5b145e59d7395db0bc307ca"/>
+				<disk name="tiger woods 99 pga tour golf (usa) (v1.1)" sha1="aecc7ccfad0de21e55648a08a8da404e38704b3d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18870,7 +18870,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="philosoma (usa)" sha1="8ade448fec4d5dc2843067b584d0bc5031d61f1b"/>
+				<disk name="philosoma (usa)" sha1="2a8f5a57b6cb60179487eec66133f77e5e068b4d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18927,7 +18927,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pink panther - pinkadelic pursuit (usa)" sha1="d7244b9c1765858cacfdde9fdbcd9085c914599c"/>
+				<disk name="pink panther - pinkadelic pursuit (usa)" sha1="a90123d9053f7f5adfa6ef957f43bb4b06687a12"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18944,7 +18944,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pinobee (usa)" sha1="7c64c4dc449df84ef7af7a77342d8e89388ba10a"/>
+				<disk name="pinobee (usa)" sha1="6f366d9bea7d7f8d69da6ab6224e2eda766687c5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19028,7 +19028,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pitball (usa)" sha1="9d537ff80666fe7aa88ce91d0c32ac4ddd8340d1"/>
+				<disk name="pitball (usa)" sha1="6fe84ef777ca355d118e25b45f5f54f973a5cda3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19045,7 +19045,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pitfall 3d - beyond the jungle (usa)" sha1="9e2d24b34db59a19465087cd4888612d17114606"/>
+				<disk name="pitfall 3d - beyond the jungle (usa)" sha1="2ce1320196672709ae3719bfab10f183b306042b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19468,7 +19468,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro pinball - big race usa (usa)" sha1="42816c090226ef0d7942cfae336845b7120bf365"/>
+				<disk name="pro pinball - big race usa (usa)" sha1="082793fafe243b5d65882f9403a7b2bf10f44040"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19506,7 +19506,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro pinball - fantastic journey (usa)" sha1="b408150fb52b95e1e8eb85e2c6a609d0d11f0812"/>
+				<disk name="pro pinball - fantastic journey (usa)" sha1="83f8747f57ed1139eae35fcd1e531c812a5fb6f7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19556,7 +19556,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro pinball - timeshock (usa)" sha1="b167931677dc208d460f5a4ab4adf0efb8d82cfb"/>
+				<disk name="pro pinball - timeshock (usa)" sha1="ded80f6e94df5dfb0e04988078ad9aa9ab3603b8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19688,7 +19688,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="professional underground league of pain (usa)" sha1="383514e0d2311965243a141c5a5f18f23bb12ff4"/>
+				<disk name="professional underground league of pain (usa)" sha1="8f1933b0221455b27479ebe00d218ea865cb51a2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19893,7 +19893,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="point blank 3 (usa)" sha1="0c45fddde3c36091881c1302ecd39175eef88af3"/>
+				<disk name="point blank 3 (usa)" sha1="2817ab2414f3867454006f095f564d443994d3f0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20017,7 +20017,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="power shovel (usa)" sha1="b6dc87df1c42c65ab3785c8cd5158b128d71fcd3"/>
+				<disk name="power shovel (usa)" sha1="13936d1357e23408fb584e4b2f8f2a258fa04c15"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20034,7 +20034,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="q-bert (usa)" sha1="133c93ffd5af5241212ba5cad24172fa4f9cfee8"/>
+				<disk name="q-bert (usa)" sha1="fe1441d93e56657c6bc83d4fb036e85e241f606f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20069,7 +20069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="quake ii (usa)" sha1="42fd8eafadd029bc27887c9852a4aeb989283830"/>
+				<disk name="quake ii (usa)" sha1="5009e8ea4cdb4c24acf19db8d3190cf25c316d06"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20191,7 +20191,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="raiden project, the (usa)" sha1="cb1e4fae25d42e70fcb3eec5e1c1afcbdc5c2af3"/>
+				<disk name="raiden project, the (usa)" sha1="66d3217fe26ce9aa08023c20b098c365ffa90b0e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20287,7 +20287,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tom clancy's rainbow six (usa)" sha1="fe52e58df1cfffbae7bb25fa603662b87b84170c"/>
+				<disk name="tom clancy's rainbow six (usa)" sha1="2d30f33cd7c770bffa4b923ed8b5dbb0745dadf3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20415,7 +20415,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rascal (usa)" sha1="3c702834316424e1349c36c9757c56c9b758e9eb"/>
+				<disk name="rascal (usa)" sha1="8544b494fa90845e5fd25d3b4f873385e8609262"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20534,7 +20534,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rayman (usa)" sha1="bb97094982d27a44815198a57c7aedcaaab74e42"/>
+				<disk name="rayman (usa)" sha1="07f8272430ee6ec9d0707fef1667f0e4ebb5b23b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20552,7 +20552,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rayman 2 - the great escape (usa) (en,fr,es)" sha1="0060a539f78fdfe27a9e15b25c50bdb0a8957df7"/>
+				<disk name="rayman 2 - the great escape (usa) (en,fr,es)" sha1="580332fd7023842653c212cabd99421ad89dcb8c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20597,7 +20597,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rayman rush (usa)" sha1="d0cf85a4b454baaf9eb3ea3c9234fda9fcda05f0"/>
+				<disk name="rayman rush (usa)" sha1="dcf04b288d2c52ee0afb3068a393fdc6c28fd85c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20614,7 +20614,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="raystorm (usa)" sha1="c24a45839799dc4292e78faf79207e0e0bff6d37"/>
+				<disk name="raystorm (usa)" sha1="a1105f7e11b421df63d5c0586b1fd58a63077fd7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20674,7 +20674,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rc de go (usa)" sha1="6d5bd7305164593f1f1a085e3e517965a3e557a6"/>
+				<disk name="rc de go (usa)" sha1="d30a3a92467d1b32f969a63fa55567bdcc19fd12"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20743,7 +20743,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rc revenge (usa)" sha1="a0deb3cb7f06968d04b287dcea519bb5d2397165"/>
+				<disk name="rc revenge (usa)" sha1="1083fc28192252a2838db6dd46a576e53cfbf307"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20991,12 +20991,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 (usa) (disc 1)" sha1="7322b79e6d4d539d115388b0ce367af5f3df2a69"/>
+				<disk name="resident evil 2 (usa) (disc 1)" sha1="c0365d8e731a288fe91e48d530d613277984a7be"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 (usa) (disc 2)" sha1="646c4f732a16149a98756d27211ee4190c50fa3b"/>
+				<disk name="resident evil 2 (usa) (disc 2)" sha1="d31bc0f576bdde73fb5e5300645b4a88df01309a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21017,12 +21017,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 - dual shock ver. (usa) (disc 1) (leon)" sha1="163470a70ad2bf13a668665547dde90968efab8c"/>
+				<disk name="resident evil 2 - dual shock ver. (usa) (disc 1) (leon)" sha1="38c5a6c7c5cc25c4838f4b5e80f9fb0eb884ae55"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 - dual shock ver. (usa) (disc 2) (claire)" sha1="b84c429ddb5cbe366cc747e0a79f7f6e70a88f34"/>
+				<disk name="resident evil 2 - dual shock ver. (usa) (disc 2) (claire)" sha1="9c7a90f0566982068c69ae581b041ba5dde3baed"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21039,7 +21039,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 3 - nemesis (usa)" sha1="297ccfe24c4935f0869d6ba89d0e46fd9887773a"/>
+				<disk name="resident evil 3 - nemesis (usa)" sha1="e5c6cf477eb7bc69ea59ab1f464ef97446813548"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21074,7 +21074,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil - director's cut - dual shock ver. (usa)" sha1="bb90fb489cfb2182541d725b30c09621f32676e8"/>
+				<disk name="resident evil - director's cut - dual shock ver. (usa)" sha1="9ecd4c66e3ccd142a95a35b000e05546fab048b8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21091,7 +21091,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil - survivor (usa)" sha1="b5fa1bfc4a8932c9828eb30312daa9236fdd4bf5"/>
+				<disk name="resident evil - survivor (usa)" sha1="2a9eb069ef468dada08eb4415117289efaa491db"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21110,7 +21110,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="re-volt (usa)" sha1="70dea533f66ef91de0e37078eaed57d24f41226c"/>
+				<disk name="re-volt (usa)" sha1="76ff6ff0c3692626268e270a6707eb58a3786c26"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21191,7 +21191,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ridge racer (usa)" sha1="d8db80f9bea0310181454001d9305dbbd3123a55"/>
+				<disk name="ridge racer (usa)" sha1="8ac66ea834865a693bb2e437b8aedb9cd1256649"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21334,7 +21334,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="road rash (usa)" sha1="89336b0c8e5f90ce9ad5d9e6405a9ea81a5a99a7"/>
+				<disk name="road rash (usa)" sha1="0ad49eb687923de7363db773d57fad78bc5ceb31"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21359,7 +21359,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="roadsters (usa)" sha1="b5405e343a91f3e9522fe0c52efd5fe84398efd1"/>
+				<disk name="roadsters (usa)" sha1="870193bf83cb6ab12ca9c07bc19a9306d35f48ca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21389,7 +21389,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rock 'em sock 'em robots arena (usa)" sha1="a29a309b78a1c04e83a4837fff290d00eb390873"/>
+				<disk name="rock 'em sock 'em robots arena (usa)" sha1="0be803228de8c56dc37538af0434232081e4ddb1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21519,7 +21519,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rollcage stage ii (usa)" sha1="fdc91b071c77f3b374417c9413dfc88ab7d4da78"/>
+				<disk name="rollcage stage ii (usa)" sha1="508f6e5bf1321077b0936c7f9d25fc4c024c2f84"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21551,7 +21551,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rollcage (usa)" sha1="0a00e8466df9b31dbbbea0cec63254adc28eef65"/>
+				<disk name="rollcage (usa)" sha1="7799fdd199249cd3ada436656e0dc583845a8b9a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21668,7 +21668,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="r4 - ridge racer type 4 (usa)" sha1="5bf4db632745058203d3e622c559aadc9728c86e"/>
+				<disk name="r4 - ridge racer type 4 (usa)" sha1="f637a55052d40c054ea10b724e639658ab334617"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -21691,7 +21691,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="road rash 3d (usa)" sha1="6df63908f9c58acb6eacbe3ab86f1163a4724cd9"/>
+				<disk name="road rash 3d (usa)" sha1="34494c7346d55449a601ee2ebaffb497a0ef1061"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21744,7 +21744,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ridge racer revolution (usa)" sha1="567ed38059cb168a998ac535d592c283df3cdd48"/>
+				<disk name="ridge racer revolution (usa)" sha1="a5a87bf9383964e427e0785c84ee8a706e6e717f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21865,7 +21865,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="r-type delta (usa)" sha1="fd3cb15de17a3a917edd0edbc8e8d550cedbdf7b"/>
+				<disk name="r-type delta (usa)" sha1="aa58dfc96d015dae777f5c4bdef088bfcec50a64"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22069,7 +22069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rush hour (usa)" sha1="3a0d7c90676561f96c293055b92539f0a99503db"/>
+				<disk name="rush hour (usa)" sha1="cea81724f4684b8ef4d130a03d9c07c530bce5ee"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22092,7 +22092,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Arcade Disc"/>
 			<diskarea name="cdrom">
-				<disk name="rival schools - united by fate (usa) (disc 1) (arcade disc)" sha1="b22ced7cd2756472c021643bea839e88e24a0df2"/>
+				<disk name="rival schools - united by fate (usa) (disc 1) (arcade disc)" sha1="fb05951b30b08366d3f0f14370a98569bdfa4bdf"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -22132,7 +22132,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strikers 1945 (usa)" sha1="208b4b5701241daec9800bba33aa387576c7aa67"/>
+				<disk name="strikers 1945 (usa)" sha1="c46e5e4327047045802c714bb7e47777f4aa47f5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22344,7 +22344,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="samurai shodown iii - blades of blood (usa)" sha1="ec39b0de944008cfb464b339ffb219682890e7a6"/>
+				<disk name="samurai shodown iii - blades of blood (usa)" sha1="e4621a82a82f93253c29a7536e3ffa5030bbaeaf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22361,7 +22361,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="samurai shodown - warriors rage (usa)" sha1="5c406bc0e7e9306edd0a801864f43bb66e038d6d"/>
+				<disk name="samurai shodown - warriors rage (usa)" sha1="9ac2ddb993c8810740fd08ce4d4580ea231057b0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22395,7 +22395,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super bubble pop (usa)" sha1="86f5077178ba9ac862da42697a592c921a9f5b9a"/>
+				<disk name="super bubble pop (usa)" sha1="82185ff124636de2447919e348600b8a1079e36d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22484,7 +22484,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="scrabble (usa)" sha1="3f7d0a812be4e9ce6312f1adb39163ff641c0dfd"/>
+				<disk name="scrabble (usa)" sha1="4030820874124b74fc1535c6a39954c80d08008d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22556,7 +22556,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sentient (usa)" sha1="28e6a7d9f9de0247f3cbc9688de335f722711361"/>
+				<disk name="sentient (usa)" sha1="d140a7e2fe184ed72ea07fb881a500cffbc17a11"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22640,7 +22640,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter alpha - warriors' dreams (usa)" sha1="ae3168c4f6097e6fa7083411f76ba94d95d2037d"/>
+				<disk name="street fighter alpha - warriors' dreams (usa)" sha1="711afd8cc92d07f4d10462192cf48d202d9ab3d7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22658,7 +22658,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter alpha 2 (usa)" sha1="0bf01b34786c097489bcdaae0c84f07cc4a3ccc2"/>
+				<disk name="street fighter alpha 2 (usa)" sha1="a1c39448d2013c764eba9596e7857208ccb3ce27"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22676,7 +22676,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter alpha 3 (usa)" sha1="0f9efd002a0653925734af77d4d1fd38a0bed869"/>
+				<disk name="street fighter alpha 3 (usa)" sha1="950830b7b0ad50f58c300506d4b0484dd09e946c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22771,13 +22771,13 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Super Street Fighter II &amp; Super Street Fighter II Turbo"/>
 			<diskarea name="cdrom">
-				<disk name="street fighter collection (usa) (disc 1) (v1.1)" sha1="9eaab12a032b7e9d6a05f342752f1de8fe4d27b3"/>
+				<disk name="street fighter collection (usa) (disc 1) (v1.1)" sha1="15099186368611834f61ce1471b626e2b6071b2e"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<feature name="part_id" value="Super Street Fighter Alpha 2 Gold"/>
 			<diskarea name="cdrom">
-				<disk name="street fighter collection (usa) (disc 2) (v1.1)" sha1="b42293238b6b2dd5ebc9dc990bdc08ab6e6ec8c4"/>
+				<disk name="street fighter collection (usa) (disc 2) (v1.1)" sha1="56530bdbc1a3547a51695486be9865434a56a0fb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22899,7 +22899,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter collection 2 (usa)" sha1="56e122837fda765c8515dbd738faa316670538ed"/>
+				<disk name="street fighter collection 2 (usa)" sha1="0e64662c3c641d193fed1bffebb5a5a9e35e3b40"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22916,7 +22916,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter ex2 plus (usa)" sha1="2a4e2e8bd97b6b647068ba895d36527ef5432899"/>
+				<disk name="street fighter ex2 plus (usa)" sha1="7412bc70b906f05e50994ff80899dfb18073771b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22933,7 +22933,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter ex plus alpha (usa)" sha1="383b2a669ece1407d41cf2386e943e6257eaea57"/>
+				<disk name="street fighter ex plus alpha (usa)" sha1="9d9f2d5ad38ad742abb7c7ea3b80e03068a6084b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22979,7 +22979,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter - the movie (usa)" sha1="086d63873dea95a64c706202c1eb998f8c6904b7"/>
+				<disk name="street fighter - the movie (usa)" sha1="3a96da37e19cc988aff750d03705cf2f0457ad3a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23036,7 +23036,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="shadow man (usa)" sha1="485f80a243bff3a4bafa6015d931b3ff6bf78be8"/>
+				<disk name="shadow man (usa)" sha1="70718577aa4bb03dd1006c33094837859f6dee19"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23325,7 +23325,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="silent hill (usa)" sha1="ea7a7503593012e9e726c4549c193f956510ffee"/>
+				<disk name="silent hill (usa)" sha1="fd460847a57795d2368b6b1a2784fa077cffb37f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23421,7 +23421,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="simpsons wrestling, the (usa)" sha1="c4af5e47f91ab14aab2359a3a4826bd2c88342ec"/>
+				<disk name="simpsons wrestling, the (usa)" sha1="2901283291baa7f1e3e3d9bdc4adce514bd4215d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23523,7 +23523,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slam 'n jam '96 featuring magic &amp; kareem (usa)" sha1="d026e97d9bb15470718df2151bba33208ff9fe07"/>
+				<disk name="slam 'n jam '96 featuring magic &amp; kareem (usa)" sha1="1a91ab0f827b68509db476ed24314412de38e05f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23601,7 +23601,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slots (usa)" sha1="43b08f17ed50f7ca259f33903012b1609e140c62"/>
+				<disk name="slots (usa)" sha1="b93ee66bcb99189a3cc594736f94902bdd4233e0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23715,7 +23715,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="smurfs, the (usa) (en,fr,es)" sha1="9a12b993132ec4bb762e7949b1451b851bbdcc3f"/>
+				<disk name="smurfs, the (usa) (en,fr,es)" sha1="c2b14925b21eb5fb34a78ec885249950ff535239"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23758,7 +23758,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="snowboarding (usa)" sha1="15dcedb3041bc9fea57aabad56ee0b9188cc5f50"/>
+				<disk name="snowboarding (usa)" sha1="0a9b080ab657b422d6214939b3e7f83a77c7f860"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23855,7 +23855,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="castlevania - symphony of the night (usa)" sha1="37b2cdcaa49bf773406a6d886a2d5ba8f835cf76"/>
+				<disk name="castlevania - symphony of the night (usa)" sha1="5239b5c6c2f2da5f1d9356670fa614f31e4e3075"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23872,7 +23872,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="soul blade (usa) (v1.1)" sha1="4c8f306c713b7f1820a758f0e02e6410aaa57bed"/>
+				<disk name="soul blade (usa) (v1.1)" sha1="a66be2ea6ade0326bb40e75ffd949fef0e93d1d5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23924,7 +23924,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="south park (usa)" sha1="283070618ece8b9692baabc8f47735df1a779984"/>
+				<disk name="south park (usa)" sha1="cfa1847f45a5435157506def8e8bc437420cf745"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23942,7 +23942,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space invaders (usa)" sha1="aa41f19e38d7ffdf451b587433811bc6b4cb3857"/>
+				<disk name="space invaders (usa)" sha1="b3aa1b3e2f509e44d5f840cc2d9fa2aa8bceba82"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23960,7 +23960,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space jam (usa)" sha1="398d676f0aef38c079c53214bd8e9ff603478e62"/>
+				<disk name="space jam (usa)" sha1="24934636c63dbb820e6716e60aaecc283486636d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23977,7 +23977,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space shot (usa)" sha1="ab678f726c6841c2d657820a256f97fd59ed1427"/>
+				<disk name="space shot (usa)" sha1="79446aef0301e34210284080ad3208bdfb6cd265"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24069,7 +24069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="south park rally (usa)" sha1="dd9351c50f964035ad4d0d932d98970dcb2ba176"/>
+				<disk name="south park rally (usa)" sha1="ca945cf19c22bebd043ec005bb90e8f765b67c04"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24303,7 +24303,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super puzzle fighter ii turbo (usa)" sha1="23fdf03ffd002de06b2b6366a93d552c00798d45"/>
+				<disk name="super puzzle fighter ii turbo (usa)" sha1="8e42b8bcdfc295bd7cd90bf554f4f30efb36129a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24338,7 +24338,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spider - the video game (usa)" sha1="4f04f45cec47033616a45b0acc7550654030fff0"/>
+				<disk name="spider - the video game (usa)" sha1="e332ae9c41bf4385964db272c7ec003e21155421"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24355,7 +24355,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spider-man (usa)" sha1="66c09444240ddf96f194d2d2e63b42a2af77bc37"/>
+				<disk name="spider-man (usa)" sha1="196e5fb8bc1a96db65107abd338593198a207fae"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24483,7 +24483,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spyro the dragon (usa)" sha1="ab729c36603444bfde190542f0b42e9262eebeaa"/>
+				<disk name="spyro the dragon (usa)" sha1="1a861139d485f7fcfc3cfd839a4db5bdd95267f9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24500,7 +24500,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spyro 2 - ripto's rage (usa)" sha1="4df448b9cfe122821ac8f812f76891209f31d4fe"/>
+				<disk name="spyro 2 - ripto's rage (usa)" sha1="b31b6dfd9d16cb90b6cfcd9a5ea71663a4132d26"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24517,7 +24517,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spyro - year of the dragon (usa) (v1.1)" sha1="85fa6a1688326cb194d3423f3ddd4381712f2065"/>
+				<disk name="spyro - year of the dragon (usa) (v1.1)" sha1="ca1593703cb4c7a746f03b7f29ca9e788631de3a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24564,7 +24564,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street racer (usa)" sha1="67fdc6df29b2ab81d2bcc84d521af9c577b57f38"/>
+				<disk name="street racer (usa)" sha1="3653b9818f7aa8dc2c1f94fe0dd9530816de2949"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24628,7 +24628,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sports superbike 2 (usa)" sha1="3c3ff1484bd50d2d13e2ece3a86ab63995529647"/>
+				<disk name="sports superbike 2 (usa)" sha1="a119ec81e05090feab67521b45e107a4cb8c0620"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24765,7 +24765,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star gladiator - episode i - final crusade (usa)" sha1="ef090bb9a672649d6088c960405c3514a2e376c1"/>
+				<disk name="star gladiator - episode i - final crusade (usa)" sha1="cd617da2869cb015112634c449433c10c002933b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24901,7 +24901,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="streak hoverboard racing (usa)" sha1="ca792dbf94f57729390973a09f7fb5900932d34c"/>
+				<disk name="streak hoverboard racing (usa)" sha1="438af526e14d22d4d191ba48b8ff4ad3b3557a3c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24937,7 +24937,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strider (usa)" sha1="fa9e3f112aa7ecd854edb5ab2200e476c807453f"/>
+				<disk name="strider (usa)" sha1="250c17d0565edb1fede48aff809b3a80f5020f34"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24956,7 +24956,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strider 2 (usa)" sha1="5bae061e35040cae34914d40e4e51eb2b515f736"/>
+				<disk name="strider 2 (usa)" sha1="9d36dbde94c02d9209139ebea7497ad62a1ce969"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24975,7 +24975,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="striker 96 (usa)" sha1="b405a370a8f800edd0d5d1d6a5e25b3826132e5b"/>
+				<disk name="striker 96 (usa)" sha1="2b43bad6cdc0b3f754b41683c0b7c17f32ddd895"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25102,7 +25102,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat mythologies - sub-zero (usa)" sha1="d67cc625011a58b0abccbf864bcd7d2027d1bea7"/>
+				<disk name="mortal kombat mythologies - sub-zero (usa)" sha1="f1e1d9e2f54ba89b3da6a94a01c326dc20ade137"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25119,7 +25119,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="suikoden (usa) (v1.1)" sha1="55eeefa1a0afd329e85747d4afe6b038793c9919"/>
+				<disk name="suikoden (usa) (v1.1)" sha1="cdeb30e8cf297186a84eacfa523ce8204f5f604e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25136,7 +25136,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="suikoden (usa) (v1.0)" sha1="a969814a8fe8d2c7c7033192fc490045b3c1485d"/>
+				<disk name="suikoden (usa) (v1.0)" sha1="f949b37c1109d8650d8c4dcdc062c0d8e9c29440"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25153,7 +25153,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="suikoden ii (usa)" sha1="a47dbce42efb9dc0e2f2d0835d3534774e33dd6d"/>
+				<disk name="suikoden ii (usa)" sha1="37bd1800d6afdfb49d7fa5d33a361a4d9ab5925d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25214,7 +25214,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="swagman (usa)" sha1="ca6e3eda048cfc1135d794db0636b0cae9884684"/>
+				<disk name="swagman (usa)" sha1="cc4169335d7ba136153f77bda5a41292fe1b5003"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25276,7 +25276,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star wars - episode i - the phantom menace (usa)" sha1="8ab36c9e46e6bec0e27c611c2890fbfbeb0eeb31"/>
+				<disk name="star wars - episode i - the phantom menace (usa)" sha1="3b5e805896f8222b563e3ebc9c2ffd903a1c9894"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25536,7 +25536,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tail concerto (usa)" sha1="b3adcc6c634b5a8c7a24f9bcc649bba7d4a00848"/>
+				<disk name="tail concerto (usa)" sha1="e06ac367c9f1b2d408caa6c6748c60fdf892c765"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25598,7 +25598,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's tarzan (usa) (v1.1)" sha1="f2779268217aaacb3aa0fa18ea92e154a0d3e47a"/>
+				<disk name="disney's tarzan (usa) (v1.1)" sha1="cbc0f2b3cdddc73356662a5b5b45a037b1e23cde"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25616,7 +25616,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's tarzan (usa) (v1.0)" sha1="a9f0b4f770dbe12dfece2822f525852e0bc1f0b1"/>
+				<disk name="disney's tarzan (usa) (v1.0)" sha1="c4ddc339825d8398f9efaa1cc1962708be6faf87"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25766,7 +25766,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="team buddies (usa)" sha1="3f155d0e980d4ed84630b279da94af78cb339563"/>
+				<disk name="team buddies (usa)" sha1="0803b39feabeecdb224f54e4e1e8f59e3ca49f64"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25919,7 +25919,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tekken (usa)" sha1="b2d2c32c3ab3c597b7017c1d1f7cb7d69496ba17"/>
+				<disk name="tekken (usa)" sha1="cb5cd46bf8c7d5e1d34d4aa25ec54ce9a4632e46"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25938,7 +25938,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tekken 2 (usa) (v1.1)" sha1="ce046321efa2d377c0b241f725fd6f9fbac660ea"/>
+				<disk name="tekken 2 (usa) (v1.1)" sha1="2d3c614e5278f9189b6fdc803fe1b942ec97c442"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25976,7 +25976,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tekken 3 (usa)" sha1="e1537fb7c60ee4e39743847ffadfa33c94912652"/>
+				<disk name="tekken 3 (usa)" sha1="319ec7377eb0c3ef0b6049e440937d26ae743290"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26082,7 +26082,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tennis (usa)" sha1="000a5de8072f21f168f8663429673cd33acea5bf"/>
+				<disk name="tennis (usa)" sha1="213ea8a9a04f09cfb0154b1f3807e743b1b7abbc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26222,7 +26222,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tetris plus (usa)" sha1="d8d67a9c6eb5246fdc2e5ebb9233a429bbbd9b4f"/>
+				<disk name="tetris plus (usa)" sha1="26f26fc78fb2c507c9a72fdcdc2ed1910dcbc039"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26239,7 +26239,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="thunder force v - perfect system (usa)" sha1="0c01c35c0b08f87763277581abd19d2f082b6c29"/>
+				<disk name="thunder force v - perfect system (usa)" sha1="17658f39053eaed1028a1a470f59388553fd2ded"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26328,7 +26328,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tony hawk's pro skater (usa)" sha1="7a6b07b327d77cd27ebe161a3a64d149ebd19e3e"/>
+				<disk name="tony hawk's pro skater (usa)" sha1="b94afb759d5c2f289f5d4ec910b3d92c79316c0c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26345,7 +26345,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tony hawk's pro skater 2 (usa)" sha1="1069052c61fe99be3e938b98887355170ac91318"/>
+				<disk name="tony hawk's pro skater 2 (usa)" sha1="76ca2e86180f977c596a53c7257914f338e6a0de"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26379,7 +26379,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tony hawk's pro skater 4 (usa)" sha1="694bed9d4d9cd260d393b67b2825eb01e32c5eb1"/>
+				<disk name="tony hawk's pro skater 4 (usa)" sha1="1cf3955bb1a3e41343dc027985f1d615b8e9c9d6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26600,7 +26600,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tiny tank (usa)" sha1="87d08ea463c0096f7ca154e92805429d4f52bf5e"/>
+				<disk name="tiny tank (usa)" sha1="e61cd0f24d0afc8846e978e4e5a61d35ca99ffa6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26824,7 +26824,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomba (usa)" sha1="e543a25583ef211010dd6736b88c43f8b4132931"/>
+				<disk name="tomba (usa)" sha1="50d87fb5646c60fe419b56a53c20f112806f068b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26842,7 +26842,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomba 2 - the evil swine return (usa)" sha1="34859016049661e1083391e9015f73f67a919f24"/>
+				<disk name="tomba 2 - the evil swine return (usa)" sha1="21b5620e342529ea2dbd68ca47da5399eff71199"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26973,7 +26973,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle arena toshinden (usa)" sha1="c216b34a840255677fb7fd10bdaa60c5edf863f5"/>
+				<disk name="battle arena toshinden (usa)" sha1="64e5b9f4443b4770668d26c46a8d711017e5f41b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27007,7 +27007,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle arena toshinden 2 (usa)" sha1="2dbd6c7312e3c1edf1baaeea5e1ab1bac598a125"/>
+				<disk name="battle arena toshinden 2 (usa)" sha1="aca3e7f7da0527e3c94e43ab9650461b91fc0c87"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27025,7 +27025,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle arena toshinden 3 (usa) (en,ja)" sha1="bcc2a1583b44c4d087d94cb9a3bd152726b29884"/>
+				<disk name="battle arena toshinden 3 (usa) (en,ja)" sha1="03d70fde6dde4439b573c2272b8ad930960f3ae1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27110,7 +27110,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="triple play baseball (usa)" sha1="81f7c10f296db0136d5c749601270f6d36fc112f"/>
+				<disk name="triple play baseball (usa)" sha1="67642c3ab9777501904d3843f77d9e1a38bea64c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27310,7 +27310,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider (usa) (v1.6)" sha1="697842403e9a7e5f662d8d5a56b40480742fe3ac"/>
+				<disk name="tomb raider (usa) (v1.6)" sha1="294b08736f01ca7528a191ed5ee50f849b40dbff"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27387,7 +27387,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider ii - starring lara croft (usa) (v1.3)" sha1="459ef793bc4b451997c87054b6925afa5f4358d7"/>
+				<disk name="tomb raider ii - starring lara croft (usa) (v1.3)" sha1="bdf8850b894577ec723b82da59d3c53f40893236"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27635,7 +27635,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider iii - adventures of lara croft (usa) (v1.2)" sha1="0a883e2f47003f50b2b9793159d30421668bb2c6"/>
+				<disk name="tomb raider iii - adventures of lara croft (usa) (v1.2)" sha1="42badae97c44239c7bf61bb8bc1e35beb025a207"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27686,7 +27686,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider - the last revelation (usa) (v1.1)" sha1="53cd52f5f77979b2547d49db33fc554589733774"/>
+				<disk name="tomb raider - the last revelation (usa) (v1.1)" sha1="26761d10c047676960391d97bb1ce48498689bf0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28272,7 +28272,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="misadventures of tron bonne, the (usa)" sha1="0695a8d71036b2c3d15440aea80d7d722c26ad56"/>
+				<disk name="misadventures of tron bonne, the (usa)" sha1="7e4316ac95ae0f9d26b9b99820d283d318c276a3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28338,7 +28338,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="true pinball (usa)" sha1="87a1463306ed777635daf00b70f09212203a61bc"/>
+				<disk name="true pinball (usa)" sha1="a747481095f7860138e405c418e8ff32069e77c1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28499,7 +28499,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal - small brawl (usa)" sha1="7f4d093f996f2e1e6ceb1d8b13477aadedc47155"/>
+				<disk name="twisted metal - small brawl (usa)" sha1="4589bbc09de5f537f0809895fe32d69c26106678"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28527,7 +28527,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal 2 (usa)" sha1="ea300893c05cbf43ef4fba616112c542627e6016"/>
+				<disk name="twisted metal 2 (usa)" sha1="ed75cb9b039ce559118bdf624685e221e6dbf906"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28580,7 +28580,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal iii (usa) (v1.1)" sha1="0300b5d0bac4c7a24e541b5a9f83979b79cb1dbf"/>
+				<disk name="twisted metal iii (usa) (v1.1)" sha1="5339b19b908e44f34310a6a1ecbc60817665b8ca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28672,7 +28672,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal 4 (usa)" sha1="b6ea4d26c0172bce93825f483699b55988bad28a"/>
+				<disk name="twisted metal 4 (usa)" sha1="3420fe8dbb4b1718f971afffb790ac7e8f4fa1d3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28697,7 +28697,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal (usa)" sha1="b02c5da714570a23ac2f9a55d5a938dce5fd2d6b"/>
+				<disk name="twisted metal (usa)" sha1="67269637d563ed2ffafd842be8908b068548bc2b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28792,7 +28792,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ultimate brain games (usa)" sha1="a46038894503a5864a1b8ea23661553677789fdf"/>
+				<disk name="ultimate brain games (usa)" sha1="ef1229098eb2ee7ee9d0b4c84625b3875b8c8a0c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28913,7 +28913,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vagrant story (usa)" sha1="f70f1bce87e8c7a84953c4d7271cfb2f3622bb4a"/>
+				<disk name="vagrant story (usa)" sha1="d200433ef70d5a859fb49736dbcfea5cb030ba19"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29029,7 +29029,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vanishing point (usa)" sha1="5ded96e4907f70541f68088e2026d6786e5ed931"/>
+				<disk name="vanishing point (usa)" sha1="ac1adde7e60f76502636afa478308f728a830f08"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29063,7 +29063,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vegas games 2000 (usa)" sha1="950f66e7efae1a84aa6a1edeb4d7084c0d55153f"/>
+				<disk name="vegas games 2000 (usa)" sha1="f94739301a9352bb0b3f52a99393ef3b6ace448e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29099,7 +29099,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="viewpoint (usa)" sha1="2019a0a7f0cf294e9f93c5ef7d72243500f1aac2"/>
+				<disk name="viewpoint (usa)" sha1="495e5408ce67261120f5128d9ddb3c1e27320821"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29312,7 +29312,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - v-rally (usa)" sha1="02cb03c751ea2d22b065a6588649b6e5d25cd2d1"/>
+				<disk name="need for speed - v-rally (usa)" sha1="ea312ed2010a224acf94675342d5aeeb48214427"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29336,7 +29336,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - v-rally 2 (usa)" sha1="a0c2e8b268c5ce33a98ef66652fe7a9a16fa376c"/>
+				<disk name="need for speed - v-rally 2 (usa)" sha1="e4eb2e42ddd69a0e591c008adcb06b9c49260dc5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29446,7 +29446,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vr sports powerboat racing (usa)" sha1="5d5db014fbb80d764ea4583867880b0ac125281e"/>
+				<disk name="vr sports powerboat racing (usa)" sha1="922b7edf37558c03d93dd6e093177ceff1ad378d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29500,7 +29500,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="v-tennis (usa)" sha1="7f9f873b2462d06e13b96435483f0e25ec993587"/>
+				<disk name="v-tennis (usa)" sha1="d4f4d0548ce5014736b3cb842b7feaeafcb9ea99"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29517,7 +29517,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="warcraft ii - the dark saga (usa) (en,fr,de,es,it)" sha1="b33a8b1bd8a007725138b840e6baa386efd881b6"/>
+				<disk name="warcraft ii - the dark saga (usa) (en,fr,de,es,it)" sha1="0cbccd6e495156337aafd0b5d2ca21d287d8ad03"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29588,7 +29588,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="warhawk - the red mercury missions (usa)" sha1="27a6349c15269d5b5ea1cec65fdc6d598cdaf981"/>
+				<disk name="warhawk - the red mercury missions (usa)" sha1="7d0fbd0a88465353f4880746212726786e5bfdc3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29810,7 +29810,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="world destruction league - thunder tanks (usa)" sha1="2ab20dffff5961a1293b1ea77b50545b76c5d158"/>
+				<disk name="world destruction league - thunder tanks (usa)" sha1="e2834f6a373579793b1cbe475e11b8074aee9540"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29957,7 +29957,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="who wants to be a millionaire - 3rd edition (usa)" sha1="8905733e730fd883cc8ef73731e17c98c4cc1ef6"/>
+				<disk name="who wants to be a millionaire - 3rd edition (usa)" sha1="2bd8d522484e153d83ba40d4af29ff970e905cf5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30444,7 +30444,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf attitude (usa)" sha1="99705956be9321648758a86fa8921f3678649511"/>
+				<disk name="wwf attitude (usa)" sha1="b268502bd345e64ec78abf064fa7282cd879061c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30462,7 +30462,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf in your house (usa) (v1.1)" sha1="7f9ee48b66b97c00f825a252abb5e133f6f52a6b"/>
+				<disk name="wwf in your house (usa) (v1.1)" sha1="797f8d3655a02cdf231e973b662343580337e232"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30497,7 +30497,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf wrestlemania - the arcade game (usa)" sha1="887df77fc1b3d73c906f04b6509c1ab710fbb9bb"/>
+				<disk name="wwf wrestlemania - the arcade game (usa)" sha1="9b2b6d1d6d2793a321ece7409ae9a76e77db4ff4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30531,7 +30531,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf smackdown (usa)" sha1="188a1e58141544712ef6dc9e75ebbbe26831b40c"/>
+				<disk name="wwf smackdown (usa)" sha1="9fb74cc0699ee1a11ee3e2838ec7885636ef7862"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30549,7 +30549,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf war zone (usa) (v1.1)" sha1="17e6c6470688d54e5ec008fe085187afbcaec52c"/>
+				<disk name="wwf war zone (usa) (v1.1)" sha1="fbe408d78500a5441e280e7aaa59f11500c050fb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30680,12 +30680,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="xenogears (usa) (disc 1)" sha1="2b3ce2abb86c1ef68c4aa5baa54a95887f95015d"/>
+				<disk name="xenogears (usa) (disc 1)" sha1="64a49e3b3bcd14ef74f363d5a5ccf366e283d790"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="xenogears (usa) (disc 2)" sha1="bbb7eaea1bace092a96691ba604ba5c906d3da93"/>
+				<disk name="xenogears (usa) (disc 2)" sha1="918b8d1b36037e47ba87c9504f53f83d151dadc3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30702,7 +30702,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="xevious 3d-g+ (usa)" sha1="168b85cd3561c918ddb443fef133e2c13ae77519"/>
+				<disk name="xevious 3d-g+ (usa)" sha1="a8ab9950c8b627f67ac0b33731741f089d08f604"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30775,7 +30775,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men - children of the atom (usa)" sha1="da09e144894978fc306eff0e4a4ddcc74de88b38"/>
+				<disk name="x-men - children of the atom (usa)" sha1="db53105be644f4e24440b3e98bf8971feeb69d52"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30803,7 +30803,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men - mutant academy (usa)" sha1="5829f1227cca671c1bc29b820ee97932449730ad"/>
+				<disk name="x-men - mutant academy (usa)" sha1="f278224ff06ea10c46abe85145ab124b043ff000"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30832,7 +30832,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men - mutant academy 2 (usa)" sha1="c80819e5a50d971a3ff7c38650b4757aec5c015c"/>
+				<disk name="x-men - mutant academy 2 (usa)" sha1="7e021fc6b42cdfe18b8572e2d271182d3aa04e04"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30849,7 +30849,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men vs. street fighter (usa)" sha1="a5de42525daba6420653b835e01ea99d8e6b8799"/>
+				<disk name="x-men vs. street fighter (usa)" sha1="05be871ffb7e54985689a10a31638c1324cae3f7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -48480,7 +48480,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chou Jikuu Yousai Macross - Ai Oboete Imasu ka (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<part name="cdrom" interface="psx_cdrom">
+		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
 				<disk name="chou jikuu yousai macross - ai oboete imasu ka (japan) (disc 1)" sha1="f231291ee425f4e6044f2711bb97d2357972d630"/>
 			</diskarea>
@@ -54779,7 +54779,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="simple 1500 jitsuyou series vol.11 - katei de dekiru tsubo shiatsu (japan) [slpm-86968]" sha1="6328c634cd08e9fef0d3a3f39ca4a288e660c1e9" status="baddump"/>
+				<disk name="simple 1500 jitsuyou series vol.11 - katei de dekiru tsubo shiatsu (japan) [slpm-86968]" sha1="99e83ee7ce9f67b40ad512bde5167964e6539bbd" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>
@@ -56739,8 +56739,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tokimeki memorial 2 emotional voice system (vol.2 - homura-akane-kaori) (japan) [slpm-80544]" sha1="a14c4bd793988821bc164c28cb07aa7c5b777c70" status="baddump"
-/>
+				<disk name="tokimeki memorial 2 emotional voice system (vol.2 - homura-akane-kaori) (japan) [slpm-80544]" sha1="a14c4bd793988821bc164c28cb07aa7c5b777c70" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>
@@ -56762,8 +56761,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tokimeki memorial 2 emotional voice system (vol.3 - miho-mei-sumire) (japan) [slpm-80550]" sha1="f1da5b225d32d08e35d762f0e473dc12212190e5" status="baddump"
-/>
+				<disk name="tokimeki memorial 2 emotional voice system (vol.3 - miho-mei-sumire) (japan) [slpm-80550]" sha1="f1da5b225d32d08e35d762f0e473dc12212190e5" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>

--- a/hash/psx.xml
+++ b/hash/psx.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
@@ -62,7 +62,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="007 - tomorrow never dies (usa)" sha1="603abd8d718ddb72cf34a0d8eece062c03463dc5"/>
+				<disk name="007 - tomorrow never dies (usa)" sha1="f48f0e79572be7d676341fb9f6cb0ccb5a31e0d9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -79,7 +79,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="007 - the world is not enough (usa)" sha1="3af01c1f0a584751d161dc2c102639cd8c892ea9"/>
+				<disk name="007 - the world is not enough (usa)" sha1="d79f4b8ce9db7c5dacd841e7d7ebbb306f88de70"/>
 			</diskarea>
 		</part>
 	</software>
@@ -208,7 +208,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ten pin alley (usa)" sha1="efa45b20a81d2d285bea24dddf87b1c758a8beb7"/>
+				<disk name="ten pin alley (usa)" sha1="9e54d18bdeeaac86a91d57e223271e0e4cadd6e1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -313,7 +313,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="3d lemmings (usa)" sha1="4801d11a8fc06628bc972bfb5a9d5b411fe15101"/>
+				<disk name="3d lemmings (usa)" sha1="ce0fe62049e1f2567b7e4e66f209d97713fb54d8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -359,7 +359,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="3xtreme (usa)" sha1="a0678bbf322f512072f7a78f072fdbab6555559b"/>
+				<disk name="3xtreme (usa)" sha1="dbc36461c1491be04b9b41cdb43f5aacc5b8d219"/>
 			</diskarea>
 		</part>
 	</software>
@@ -402,7 +402,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fifth element, the (usa)" sha1="edf59f00c16acfcb4f8e7f44e4c72c6ab44aaa5d"/>
+				<disk name="fifth element, the (usa)" sha1="bf56ec6d782ed3df91a1d3a113bad7f0fca715b6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -419,7 +419,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="oddworld - abe's oddysee (usa) (v1.1)" sha1="fdf0041ff97101b468fe943c8461b906466add02"/>
+				<disk name="oddworld - abe's oddysee (usa) (v1.1)" sha1="15418f0f1bd9bb64e7c491e964eaff90ead7ff61"/>
 			</diskarea>
 		</part>
 	</software>
@@ -455,12 +455,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="oddworld - abe's exoddus (usa) (disc 1)" sha1="660edf4bddb298beff44964951af74b3443dc2bd"/>
+				<disk name="oddworld - abe's exoddus (usa) (disc 1)" sha1="361b3a54f0716ab523f5ea3569df623f8cdc9872"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="oddworld - abe's exoddus (usa) (disc 2)" sha1="5b806ee562fd9cd719a6cc47e0fd0b1353068c2f"/>
+				<disk name="oddworld - abe's exoddus (usa) (disc 2)" sha1="36e619c28dafd7e4baed28a8d56ffebe93584de7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -754,7 +754,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alien resurrection (usa)" sha1="79de3fd8c2541398a4f26f7a81a617946fd1cbfa"/>
+				<disk name="alien resurrection (usa)" sha1="a5c6b0c879e523ac7b19c209ac9c06eaf1ab3a01"/>
 			</diskarea>
 		</part>
 	</software>
@@ -796,7 +796,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alien trilogy (usa)" sha1="29b7f1384cef58ec2404a1aa53a30da71f2fa0fb"/>
+				<disk name="alien trilogy (usa)" sha1="34268b5750155db04b9dd25991d98f428ae5fa68"/>
 			</diskarea>
 		</part>
 	</software>
@@ -879,7 +879,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alundra (usa) (v1.1)" sha1="bdc6a648003469505ee47c7fa83b1b07a6aa2ea9"/>
+				<disk name="alundra (usa) (v1.1)" sha1="cdfaed8c651dcb09d971bfc9d05f1daaf94d2df3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -896,7 +896,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alundra 2 - a new legend begins (usa)" sha1="c0e152d67a02dd91e44660ae81099803d2ec0a11"/>
+				<disk name="alundra 2 - a new legend begins (usa)" sha1="16111c51d568e112f9e57c24da60a6e68347a58c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1035,7 +1035,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="army men - sarge's heroes (usa)" sha1="b958c6c0f674d5c6508d204d1f913bee61dbab95"/>
+				<disk name="army men - sarge's heroes (usa)" sha1="489c92c1eb6e6ad3ae4c952e38e0541d2ff90b0e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1162,7 +1162,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ape escape (usa)" sha1="11b04950f4300f0a44e3197cf6d57a34cc30f17c"/>
+				<disk name="ape escape (usa)" sha1="07f05352164077ea5726c3c89e00522bee8261ad"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1520,7 +1520,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="armorines - project s.w.a.r.m. (usa)" sha1="af534a5d5825174d58619669d748f97cf3902087"/>
+				<disk name="armorines - project s.w.a.r.m. (usa)" sha1="b88c2e6abc4f56ab17d3ea245d0c55aede617e5a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1557,7 +1557,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="army men 3d (usa)" sha1="66a85dfac355ba06fc9544eb36d240f3f07b7f8d"/>
+				<disk name="army men 3d (usa)" sha1="a2e29ff020e5db89de055a9fbed0812658b5acd1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1592,7 +1592,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all-star baseball 97 featuring frank thomas (usa)" sha1="e5891c4ef7dac37e97ce94c700f9fc1dcc9fb231"/>
+				<disk name="all-star baseball 97 featuring frank thomas (usa)" sha1="f821a4a160e0c958495c9c2d1d8978fee21c3dc2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1609,7 +1609,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all-star slammin' d-ball (usa)" sha1="38d356d59ab2fa8cd6d7058afbe405e1b7338b5b"/>
+				<disk name="all-star slammin' d-ball (usa)" sha1="ee0142e2f218cc38d24d0ab027e8ca8e4d953755"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1633,7 +1633,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all star racing 2 (usa)" sha1="67d2403c1008244af761546bfdcee1e98b9a082c"/>
+				<disk name="all star racing 2 (usa)" sha1="6b51229aadc6fcab51636481a3ec77579e22b22e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1656,7 +1656,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="all star racing (usa)" sha1="0509a19e098bf71024d82703745b2c2cc2e50413"/>
+				<disk name="all star racing (usa)" sha1="9a89181fe3c5bd9004f0a7525e7f844cc7616085"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1722,7 +1722,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="asteroids (usa)" sha1="e59d3a8fa874f6c01dde1905b63c8e60bd363b20"/>
+				<disk name="asteroids (usa)" sha1="04aea1e4423a4f1353288dd63e6911265feccf55"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1757,7 +1757,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's atlantis - the lost empire (usa)" sha1="b3f6094a44c22f50589ab7eaa3abee23d5190ac2"/>
+				<disk name="disney's atlantis - the lost empire (usa)" sha1="9d4a654e3aff0e5c4527cbc4133db64be43b186b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1988,7 +1988,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="baldies (usa)" sha1="5f6075436bef2bd6c939b27bcdc666b775889d24"/>
+				<disk name="baldies (usa)" sha1="b249bd2371cbcd4406ad9de138468b229b01469c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2067,7 +2067,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ballistic (usa)" sha1="91ec8debbdc2b725eca16533fc73af5d7e1131dc"/>
+				<disk name="ballistic (usa)" sha1="df2cf0f292b34d36045d3274b77a2b07879f85e4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2098,7 +2098,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bust-a-move 2 - arcade edition (usa)" sha1="b1ff7f7289e80a8660de51792d27a843a6e37e3e"/>
+				<disk name="bust-a-move 2 - arcade edition (usa)" sha1="67a76852d1c4a729692011aca8f5a798c8ba049b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2137,7 +2137,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bust-a-move 4 (usa)" sha1="5fae962b40cfd65c71af587ad5f9bc7cd3f866c0"/>
+				<disk name="bust-a-move 4 (usa)" sha1="7354ae16e8bcaa39f1204b5372790ce8d60309b6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2173,7 +2173,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bust-a-move '99 (usa)" sha1="33abb06e575e8b8369dd69e1156347bf22b7938c"/>
+				<disk name="bust-a-move '99 (usa)" sha1="c7873febe1bb6a7cac45c0075a7e8d159e8dbc6c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2341,7 +2341,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="batman forever - the arcade game (usa)" sha1="5406a0cdb0849a48b318d44f8c7c773612c1a60d"/>
+				<disk name="batman forever - the arcade game (usa)" sha1="88393684ae19946abfa096c2e56f53098c5cfa35"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2455,7 +2455,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bushido blade 2 (usa)" sha1="5d35481b47b07e51cb7011b48d505fa10e30b16f"/>
+				<disk name="bushido blade 2 (usa)" sha1="7f0603b6cc467b42156405465b270d8284fe1d50"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2532,7 +2532,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="buster bros. collection (usa)" sha1="f27b8779c8bdeba79c05f2964b27883d4e40402b"/>
+				<disk name="buster bros. collection (usa)" sha1="aec44fbab4d775ad54de562f2f36317848fad19b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2740,7 +2740,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="frank thomas big hurt baseball (usa)" sha1="0f976975a6c425dc66381ae571b92bb3854c4c52"/>
+				<disk name="frank thomas big hurt baseball (usa)" sha1="f558c913841efcc8f0089535603159222e16f264"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2808,7 +2808,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bio f.r.e.a.k.s. (usa)" sha1="cdd4839e9276971f5d5206b6e183ea0ea18dfa70"/>
+				<disk name="bio f.r.e.a.k.s. (usa)" sha1="cbbef6452d8fefffc41b51476ef0f06a6e1cda90"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2876,7 +2876,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="black dawn (usa)" sha1="c293e3a618769b28d3c0f6a45125809959178b62"/>
+				<disk name="black dawn (usa)" sha1="54eb6a39008efe1fbc3f9926b841517b28f95ec5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3072,7 +3072,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl blitz 2000 (usa)" sha1="57c5607b92a9842b4efb87b7fc663461928af4b9"/>
+				<disk name="nfl blitz 2000 (usa)" sha1="8ee063c43415f1ffade34d0e5dd7d67ef466acf7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3256,7 +3256,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="breath of fire iii (usa)" sha1="b9cf8ac6c5b364898c28be663cc94134d2a6482a"/>
+				<disk name="breath of fire iii (usa)" sha1="979b329df58855cd1cb2f60793abec33367409e7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3362,7 +3362,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bomberman - party edition (usa)" sha1="9e8373fbd06c8752c3d47d8f6b5e305fbb98d32a"/>
+				<disk name="bomberman - party edition (usa)" sha1="89f5e21e602e72dfee3fc3f930bbc2f7a89864c8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3379,7 +3379,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bomberman world (usa)" sha1="16b36158a7454cf6872a05c98f9c89dd539f302d"/>
+				<disk name="bomberman world (usa)" sha1="529e4527fa3b086e8860c84c70e3886dd20e5863"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3942,7 +3942,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battlesport (usa)" sha1="ac7e9492b92ecbf78bc585ca489311efae331973"/>
+				<disk name="battlesport (usa)" sha1="a3026e6bd0555d065b5a5f01b2e94d070932d0c9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3994,7 +3994,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bubble bobble also featuring rainbow islands (usa)" sha1="1561fd3ea3e4b1426087c0d6d87003faef4d752f"/>
+				<disk name="bubble bobble also featuring rainbow islands (usa)" sha1="c43ba72269ba09a2311c112cf2f0889db327ce28"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4495,7 +4495,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="centipede (usa)" sha1="ee59aa0b53f4c6e964b33a6ff660dd267a39a354"/>
+				<disk name="centipede (usa)" sha1="0f8b6ee552a0ae5ea36a342a513bdba477cd43b0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4653,7 +4653,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="chocobo racing (usa)" sha1="784566dd126798f9963c05a744ded12d390332ed"/>
+				<disk name="chocobo racing (usa)" sha1="d64c6737893dec45980c2088e1a528ce20d00dac"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4733,7 +4733,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cleopatra's fortune (usa)" sha1="109e3b9958e6dd7cc7251ff4faafb07034d4eff5"/>
+				<disk name="cleopatra's fortune (usa)" sha1="3c8c19b3ab98d2098ffd168be7af0c75c2cb7057"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4997,7 +4997,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="college slam (usa)" sha1="8e6d3a869461f9de6a2760ffbc314a3e5cbd9937"/>
+				<disk name="college slam (usa)" sha1="0c315070fc9e6be87a1994618fc9a3bfe2ecbbdf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5073,7 +5073,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="c - the contra adventure (usa)" sha1="077cf80003bc72c6801cf8c95b6a98d3105a9d93"/>
+				<disk name="c - the contra adventure (usa)" sha1="681c9d33763a59fd1a65185d80b687ce24587e2c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5101,7 +5101,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="contra - legacy of war (usa)" sha1="2d251c9aeb30adead8bf9bb2c0d4e094d9b6969e"/>
+				<disk name="contra - legacy of war (usa)" sha1="9403c380d5f391c8c0adb18fe238cc6a2c5d3999"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5155,7 +5155,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool boarders 2 (usa)" sha1="990a6cac9659a572a1b73acfa7ee7d3ad60b4195"/>
+				<disk name="cool boarders 2 (usa)" sha1="bdd071c0046fb44067b0d7282597b4ac8f5b4929"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5189,7 +5189,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool boarders 4 (usa)" sha1="3fbb6e924df7206cc07a75fa276e97007a9cf118"/>
+				<disk name="cool boarders 4 (usa)" sha1="b47be79d214644ef36c212ede129c09ef357be52"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5219,7 +5219,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cool boarders (usa)" sha1="b0923041fcdac9288d73e571fd21e6240ccb34bf"/>
+				<disk name="cool boarders (usa)" sha1="4a7db4f12f28fe2a2af805394ba96de0ef0a5a94"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5417,7 +5417,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="crash bandicoot (usa)" sha1="73c7cd894227a54a36a165c746371cc63283103b"/>
+				<disk name="crash bandicoot (usa)" sha1="11ab0c2c674fe9bebc62927c8308cee6d6a1dff3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5434,7 +5434,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="crash bandicoot 2 - cortex strikes back (usa)" sha1="3ff7ccb1b38a9f172f0a96b7c780913401c28b03"/>
+				<disk name="crash bandicoot 2 - cortex strikes back (usa)" sha1="2edb8097887880020387c168ff2bb04354b1ddf9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5451,7 +5451,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="crash bandicoot - warped (usa)" sha1="80e68dbd89ea40ed6f09d7bdfe2ccc0fe46d766e"/>
+				<disk name="crash bandicoot - warped (usa)" sha1="1fc5f8aaf5def00ed131f6424483fe88991d920c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5486,7 +5486,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cardinal syn (usa)" sha1="bbd9e3af8c886460fc8c4907f93ef4b5bc6cb868"/>
+				<disk name="cardinal syn (usa)" sha1="0a5b77436723f66abc8ac7b7cbaf748bb0b0d044"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5740,7 +5740,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ctr - crash team racing (usa)" sha1="d9d5c97d9bc453c4b6339a3635f8d53353ffa7b2"/>
+				<disk name="ctr - crash team racing (usa)" sha1="6ac9869bd696ed7ce6d3b734f774bdb82047ef3d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5757,7 +5757,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy chronicles - chrono trigger (usa) (v1.1)" sha1="3c76fb48973021b9b7b3f53efd6ff97d1d8a666e"/>
+				<disk name="final fantasy chronicles - chrono trigger (usa) (v1.1)" sha1="968de200edd4fc4e809105618a41696c0b0354c0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5815,7 +5815,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="castlevania chronicles (usa)" sha1="545ee61ce191dd672056897988a8c9d9286497ea"/>
+				<disk name="castlevania chronicles (usa)" sha1="7d39bbd905910eb1d31ae395c3a79224f725b82e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5832,7 +5832,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="capcom vs. snk pro (usa)" sha1="1df7e28ccb8ea8249d26e85c9bf6bb89c1797700"/>
+				<disk name="capcom vs. snk pro (usa)" sha1="d42a868cb769371d994ed903016a82a48715e065"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5853,12 +5853,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colony wars (usa) (disc 1)" sha1="7c558a7f13d3c9a4d3e5e9d20ee0382bcf3c305c"/>
+				<disk name="colony wars (usa) (disc 1)" sha1="87a35925848ca127c53828bc738bfca668ebe7c1"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colony wars (usa) (disc 2)" sha1="bd2c07643b93647fba705678411d83d42fd0af6f"/>
+				<disk name="colony wars (usa) (disc 2)" sha1="97dfd9daf9be05574b4107ac74d12123e3f70114"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5893,7 +5893,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colony wars - vengeance (usa)" sha1="2de0f44070c24e6df4cda0c32b24e635c4517082"/>
+				<disk name="colony wars - vengeance (usa)" sha1="c80c017209ab38cfe12192526e564a784b9d9cd7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6076,17 +6076,17 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="d (usa) (disc 1)" sha1="ce5b1b1ac03c6623766ca310ecd1858f2287ea88"/>
+				<disk name="d (usa) (disc 1)" sha1="59bfa30b9cd0cf6d467ffaaab4a5ac572dae5a62"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="d (usa) (disc 2)" sha1="b5c259490f06acce90b935a7f4afc3acd28104fb"/>
+				<disk name="d (usa) (disc 2)" sha1="343ba13b3651b4e3038e97c494f8ae5aaca41f41"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="d (usa) (disc 3)" sha1="14e5ac2aea74b93d34d472530bdbfeec66239aa0"/>
+				<disk name="d (usa) (disc 3)" sha1="fca47f407610dfef163a36af2f15095d91d87683"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6218,7 +6218,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="destruction derby (usa)" sha1="b3e00cae226deb4f9061388ffb24196b8dc3dba0"/>
+				<disk name="destruction derby (usa)" sha1="e45355a420d1ace0501f2f404b6b8b38db328c1c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6282,7 +6282,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="destruction derby raw (usa)" sha1="3f0db6b6eef98b845c61f4f6f9f8bddd22b2a70c"/>
+				<disk name="destruction derby raw (usa)" sha1="a360f3543e19c57c161b18bdd6bc420833d14667"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6571,7 +6571,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragonheart - fire &amp; steel (usa)" sha1="7a463d7c50661e210aed0e971158fd64d1e3c7f4"/>
+				<disk name="dragonheart - fire &amp; steel (usa)" sha1="f699e517400360896eb6662d1547a0cd1f38ca56"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6606,7 +6606,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="diablo (usa) (en,fr,de,sv)" sha1="e45913154e69d68b73e81ec44abbb6bb2f37c274"/>
+				<disk name="diablo (usa) (en,fr,de,sv)" sha1="98f6d32fd9318ea9c7e2177b9bc264b978a19412"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6623,7 +6623,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="die hard trilogy 2 - viva las vegas (usa)" sha1="f9f23d720ab04990149d0a1c28d873d6ff8c9473"/>
+				<disk name="die hard trilogy 2 - viva las vegas (usa)" sha1="db2f22501c2ad26eb9d80e0857956c588e717323"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6660,7 +6660,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="die hard trilogy (usa) (v1.1)" sha1="015f4b16dcef0c0d2bd9fc0d119f27f97a32f7ac"/>
+				<disk name="die hard trilogy (usa) (v1.1)" sha1="8c2819931074e83032d3290a74882be06c504dd9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6800,7 +6800,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dino crisis (usa) (v1.1)" sha1="d5bd911a9185dd137040bc43726f8d2248c7dd4c"/>
+				<disk name="dino crisis (usa) (v1.1)" sha1="bcf33257cde0d08678f6880c264c1388cc1a73c8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6836,7 +6836,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dino crisis 2 (usa)" sha1="7d9ac5ee241bc94ac64893893bbb4c82ebba250f"/>
+				<disk name="dino crisis 2 (usa)" sha1="866ba69cfde3b56960078849dcb18c84c16d9c16"/>
 			</diskarea>
 		</part>
 	</software>
@@ -6889,7 +6889,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="discworld ii - mortality bytes (usa)" sha1="43448cc290f1f53288b0501b7196bbd49d7fd7cb"/>
+				<disk name="discworld ii - mortality bytes (usa)" sha1="7b2297b7bd6a2bf37bf7eb6d97b942563987bb67"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7071,7 +7071,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="doom (usa)" sha1="1fe56d1e220712bdc2681bb55f2e90b457cc593b"/>
+				<disk name="doom (usa)" sha1="dc8481ece400c356eba83373a2b77e5afae7f74f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7170,7 +7170,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="driver - you are the wheelman (usa) (v1.1)" sha1="608728b6e7e3e584535b5c39c2c0aee35be35510"/>
+				<disk name="driver - you are the wheelman (usa) (v1.1)" sha1="14fbbd4d4fa8111d0bba35bd1644366854395fe2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7189,12 +7189,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="driver 2 (usa) (disc 1) (v1.1)" sha1="5a6c7c8177bd826a3b6e6fbb565e0c3002aa3855"/>
+				<disk name="driver 2 (usa) (disc 1) (v1.1)" sha1="6f14915496207e5694914acea4e4d9b4c83f2639"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="driver 2 (usa) (disc 2) (v1.1)" sha1="c5014e627310d3d719e04801a1b035844a7c0ee9"/>
+				<disk name="driver 2 (usa) (disc 2) (v1.1)" sha1="d02381334ab2b96e92bc489bc51929dff57de86f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7333,7 +7333,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="darkstalkers - the night warriors (usa)" sha1="9156b564c4cec38716e3bc204e80480c93dd974d"/>
+				<disk name="darkstalkers - the night warriors (usa)" sha1="05abd2adc8fce631ec887b73e1974111160e9326"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7350,7 +7350,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="darkstalkers 3 (usa)" sha1="8e629c928e68454516571f8b4913f585b822b9a8"/>
+				<disk name="darkstalkers 3 (usa)" sha1="1706692ada422550d4ea86637a5294afe0fae1d0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7413,7 +7413,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="duke nukem - time to kill (usa)" sha1="33949530e9826e1078fe06adf1f69ba2e53953de"/>
+				<disk name="duke nukem - time to kill (usa)" sha1="023db69cc8c8adc0b9c51c0aa22c7aca4e130bab"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7657,7 +7657,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ecw hardcore revolution (usa)" sha1="59284d988e456fb0ea191c0f43311f67eb443cfb"/>
+				<disk name="ecw hardcore revolution (usa)" sha1="490d497f6d164f5965cfd1ca13c2327fce110112"/>
 			</diskarea>
 		</part>
 	</software>
@@ -7710,7 +7710,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="einhaender (usa)" sha1="dd2ba34301ace8399abb7a70b756b5f7f10ebf68"/>
+				<disk name="einhaender (usa)" sha1="5de113ab0543445a0c6033e887c807620f8ff1f9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8227,7 +8227,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="formula 1 98 (usa) (en,fr,de,es,it,fi)" sha1="5b8407c8c5a16a302cf945dc8280a1c0b0291d49"/>
+				<disk name="formula 1 98 (usa) (en,fr,de,es,it,fi)" sha1="fde45c916538081833a24abd5cb739d83884d733"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8245,7 +8245,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="formula 1 championship edition (usa) (en,fr,de,es,it)" sha1="f912bc68926779b42b0c7bbd9870ca0166ffef84"/>
+				<disk name="formula 1 championship edition (usa) (en,fr,de,es,it)" sha1="affc201e03129bdf22b13e0b23c525e98bd1170d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8360,7 +8360,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="family card games fun pack (usa)" sha1="c4027956a0643350d71f621d268d37250aeeb1e9"/>
+				<disk name="family card games fun pack (usa)" sha1="88e9487308500d1d2d6735bf603ae26f3c2a5e46"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8455,7 +8455,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fatal fury - wild ambition (usa)" sha1="35cc9c62f2511ce4fc06e34d4d2a619addb3b90b"/>
+				<disk name="fatal fury - wild ambition (usa)" sha1="dfda7b8134200fe49eb181736c88c93bf667d384"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8637,7 +8637,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy chronicles - final fantasy iv (usa) (v1.1)" sha1="96a91cb6b297d0f0f601c56167bffbcb9ad0f7af"/>
+				<disk name="final fantasy chronicles - final fantasy iv (usa) (v1.1)" sha1="13c2db5ca21481ae16436fbe270e296a03371b8b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8671,7 +8671,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy anthology - final fantasy v (usa) (v1.1)" sha1="9e82d3d6c8441fabea47dd652a6ea5196f2ef438"/>
+				<disk name="final fantasy anthology - final fantasy v (usa) (v1.1)" sha1="561aa73f27b7bbe6d85cfc899aa544cba86c9ac1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8705,7 +8705,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy anthology - final fantasy vi (usa) (v1.1)" sha1="249bc9af1de0e75bbd7c30e1fb7b935103ff23c2"/>
+				<disk name="final fantasy anthology - final fantasy vi (usa) (v1.1)" sha1="4fdce0a4c9aeda24839be92fbd52ec0b1c126ec8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8743,17 +8743,17 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy vii (usa) (disc 1)" sha1="b5665fbb2895d0e4fa010e5e15d68c15ceac3688"/>
+				<disk name="final fantasy vii (usa) (disc 1)" sha1="f53774b1c71a120cdb77d271e00c7bd54b928ca0"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy vii (usa) (disc 2)" sha1="ca80cb0c94936bef091364ef9060a675914a80bd"/>
+				<disk name="final fantasy vii (usa) (disc 2)" sha1="487a1a6c5d4feff03fb370f149d89e2d19986e26"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy vii (usa) (disc 3)" sha1="87223b2d6c54c4e8d5891d8ae485264cbb887d3c"/>
+				<disk name="final fantasy vii (usa) (disc 3)" sha1="9364f48f6f381ddc9d954c534951f686ac65f255"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8776,22 +8776,22 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 1)" sha1="4b589aed4dfdf9ec75c3351ed81d367ea2dd0e7f"/>
+				<disk name="final fantasy viii (usa) (disc 1)" sha1="998c8ff53258bc62ae4d9349aff763f954783295"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 2)" sha1="4ca6918c519fc8505d637bc5b20e263eb57961c3"/>
+				<disk name="final fantasy viii (usa) (disc 2)" sha1="2f9bfa1b5f56bc62b70be6a6c66c27576d585593"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 3)" sha1="cd5b06dfa24506866694dfc1e0d799e958723045"/>
+				<disk name="final fantasy viii (usa) (disc 3)" sha1="11094511c2c764c12c2632802161f7c594a724fe"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy viii (usa) (disc 4)" sha1="2e53f99d622be145cdaecd5fbb7d9e43440232d2"/>
+				<disk name="final fantasy viii (usa) (disc 4)" sha1="c4eadb3360a54f7c71756c7a4f5115aa538856f7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8814,22 +8814,22 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 1) (v1.1)" sha1="aa95b490a84e95c18d8ac127ea6ab98ebe3d8d7f"/>
+				<disk name="final fantasy ix (usa) (disc 1) (v1.1)" sha1="6cc195d41e08d485d957beb51e222f0c275a662c"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 2) (v1.1)" sha1="3c7c71f6e0d37b31e26a2955d9f1f3ae3d61e95c"/>
+				<disk name="final fantasy ix (usa) (disc 2) (v1.1)" sha1="f0d7f01f7278ca3625d1654ee80526688a6731a1"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 3) (v1.1)" sha1="66dd04783469215b1074552a222239da2ae21665"/>
+				<disk name="final fantasy ix (usa) (disc 3) (v1.1)" sha1="2744357291b4ccc6527732f638eff5a0fcf4c9cc"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy ix (usa) (disc 4) (v1.1)" sha1="ef8760c71d408d7492f8269f28ef9f5dbce02cef"/>
+				<disk name="final fantasy ix (usa) (disc 4) (v1.1)" sha1="308f3e7519293212f75fe7110c269fbcbe23e18e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -8884,7 +8884,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy tactics (usa)" sha1="f44672cbf59ac08e0ce5f7473ee9a0e352c6f061"/>
+				<disk name="final fantasy tactics (usa)" sha1="f061d8a0e42a0f976b82bbdc4ae3a7b36d96f6a8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9048,7 +9048,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fantasy origins (usa) (v1.1)" sha1="833a6bf605ab741b2258312874c9955de2086586"/>
+				<disk name="final fantasy origins (usa) (v1.1)" sha1="60ecf85c194d5aa096e39fff6d8300fdc818bb24"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9224,7 +9224,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fifa soccer 97 (usa)" sha1="a3944ff8ddd5fcd46ea6a914dbb087114c229fea"/>
+				<disk name="fifa soccer 97 (usa)" sha1="173828198c0a07bf9c74216bd89bbaf5759655b1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9316,7 +9316,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final doom (usa)" sha1="569c9d342e6cad12cc7000a74141a006aa1aeaf3"/>
+				<disk name="final doom (usa)" sha1="61b6eeefb1159b4c3a60b53e443c2d34d0c1ea37"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9440,7 +9440,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="forsaken (usa)" sha1="8dd5e8d46f0367ab5bf9f6bf464b9bf0bd14d689"/>
+				<disk name="forsaken (usa)" sha1="29a6f5cd68d957569d91cd1a86f07e1b1afe4ce3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9542,7 +9542,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="freestyle boardin' '99 (usa)" sha1="7a6a4a694f6a744e9abe40de6dd28f3c55740c87"/>
+				<disk name="freestyle boardin' '99 (usa)" sha1="a114a132941abbe27b3a1172fd75a1e83ff500fc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9560,7 +9560,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="freestyle motocross - mcgrath vs. pastrana (usa)" sha1="6363a81040545fe3998909117f6fa9d579466adb"/>
+				<disk name="freestyle motocross - mcgrath vs. pastrana (usa)" sha1="2e8b9ccd2086b427193c8a5de9c4e14b1f8b9548"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9578,7 +9578,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="frogger (usa)" sha1="fa22e611dba522775cac04e0412fbdb6b68b67f9"/>
+				<disk name="frogger (usa)" sha1="dd9ef6dbde1c90923cf5c9078022f322b0f7ab07"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9681,7 +9681,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="galaga - destination earth (usa)" sha1="d4ac318914aaef6295985322b53e9b199feb8e66"/>
+				<disk name="galaga - destination earth (usa)" sha1="3a00321afb1228bf007f5d6b870e6f6c898843fc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9729,7 +9729,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gauntlet legends (usa)" sha1="9b924cd15c05f01bdd0b1a7090ae039dabf35938"/>
+				<disk name="gauntlet legends (usa)" sha1="7e0f39f5e3fca397d679924836b18914a7989d57"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9764,7 +9764,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="g. darius (usa)" sha1="17aec6a72ea6a0f8dd41cc5c36cafafe8fd06b50"/>
+				<disk name="g. darius (usa)" sha1="7c5e7cb9f9313f56b32ee3161a907a5bc6aaac41"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9787,7 +9787,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gekido - urban fighters (usa)" sha1="ebcdd5d5989ab745adbb2d817d42291cded54ef1"/>
+				<disk name="gekido - urban fighters (usa)" sha1="99a03064684e94bd96ccedcf6258f18dd633181c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9804,7 +9804,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gekioh - shooting king (usa)" sha1="d4c4b5956475322cfeb5e55a073ba1c70a2b00e9"/>
+				<disk name="gekioh - shooting king (usa)" sha1="59b58f25ac0dbeadfd7d78aaa6ed7d993f2b18ed"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9821,7 +9821,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gex (usa)" sha1="ec0f32b9f76e0bc6febe489f3e4903dc1c2e7e15"/>
+				<disk name="gex (usa)" sha1="497f50122c31968587750a2ce69edfdfc10ae02e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9855,7 +9855,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gex 3 - deep cover gecko (usa)" sha1="631ce1a305a6a220b98bbb2b6d67eb6b15583411"/>
+				<disk name="gex 3 - deep cover gecko (usa)" sha1="9c12acdd9a223ed05086fc87f912c5f5df1c811e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9911,7 +9911,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="guilty gear (usa) (v1.0)" sha1="b57095a1daf1ee30cbb3c9507aa501a7bf5617ca"/>
+				<disk name="guilty gear (usa) (v1.0)" sha1="42d1118faa2dac97d7c0a7daa6a64bda2973b570"/>
 			</diskarea>
 		</part>
 	</software>
@@ -9928,7 +9928,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ghost in the shell (usa)" sha1="4910b272fc7edbe9da836b78a7db8acce4a4d9c0"/>
+				<disk name="ghost in the shell (usa)" sha1="c8403397712d75541a9a789a2f52e9696310be52"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10350,7 +10350,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gran turismo (usa) (v1.1)" sha1="0f6bb343c0fc919de6b6e6076b6e5d97c27663e9"/>
+				<disk name="gran turismo (usa) (v1.1)" sha1="cea9169f54157b01bbbdb530ebeee8b85a39c3f4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10388,7 +10388,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Arcade Mode"/>
 			<diskarea name="cdrom">
-				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="67e07f8dcd580ccdf1745bc25520772fec5bb0d3"/>
+				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="a30b84274435e2cac3b5232980d7217977e46c85"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -10415,7 +10415,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Arcade Mode"/>
 			<diskarea name="cdrom">
-				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="e5c8728d348125aaadc5a51ce3692026f2138aa7"/>
+				<disk name="gran turismo 2 (usa) (arcade mode) (v1.1)" sha1="a30b84274435e2cac3b5232980d7217977e46c85"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -10511,7 +10511,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="grand theft auto 2 (usa)" sha1="3a4ee881dc53edc2c3c822182d742007e6e9356f"/>
+				<disk name="grand theft auto 2 (usa)" sha1="87627fbb043f13c63392799cb327a503da9ab14f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10543,7 +10543,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="grand theft auto - mission pack 1 - london 1969 (usa)" sha1="1b62bc051314f36924a53885282e2332d2001816"/>
+				<disk name="grand theft auto - mission pack 1 - london 1969 (usa)" sha1="c7387613ee8abbabbc0d2549a538f0b0957a36d5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10610,7 +10610,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gubble (usa)" sha1="6780bdcd0cd766439c9b6bc3d9a832278bea4708"/>
+				<disk name="gubble (usa)" sha1="8a581696e5cbbf10f709d10002f1d263dac4a3b1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10628,7 +10628,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gundam battle assault 2 (usa)" sha1="595fb715a6aaae0faa4adaedd482901c7303dde3"/>
+				<disk name="gundam battle assault 2 (usa)" sha1="b7f2b3a9aef64706d20bfe17016fc9b82c6e8c29"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10665,7 +10665,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gundam battle assault (usa)" sha1="08d96a6d7aa3fbeacf72d7ceb63575b80caedd70"/>
+				<disk name="gundam battle assault (usa)" sha1="ece9d43daddd1a8a6c020cb18df9e2045ae1a5d2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10826,7 +10826,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hbo boxing (usa)" sha1="16462ae80de1c16041ca0128b6ec2c3761c48297"/>
+				<disk name="hbo boxing (usa)" sha1="96fe53a1b8adc1cf54eb0f4f154f1dcdbf24e763"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11101,7 +11101,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hogs of war (usa)" sha1="85899ca70527dbe81f2a6eaf5edbcd5ca871481f"/>
+				<disk name="hogs of war (usa)" sha1="cbae32df37fa854c0bea209f61940a41455a1a93"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11261,7 +11261,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hot wheels - extreme racing (usa)" sha1="f1fdaf5004f2b8046127e01c7ae852fe6dfb387e"/>
+				<disk name="hot wheels - extreme racing (usa)" sha1="5d4eeee81caabb3f1b977bee341d93bd56c7648d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11359,7 +11359,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hydro thunder (usa)" sha1="50a8b79a2c251b050f2a49760f5aa9b2950a5dc0"/>
+				<disk name="hydro thunder (usa)" sha1="286b84560da424c10dd1391ce7f3cd49ff1048f8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11415,7 +11415,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="impact racing (usa)" sha1="821fba81b854ad8ec15c6e8644475ffeb3650bcc"/>
+				<disk name="impact racing (usa)" sha1="969605d72e0fb880c1dc5448a3ab09ef82076915"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11451,7 +11451,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="independence day (usa)" sha1="dab6552233247e1ad05c656066f2dddec9ef7a76"/>
+				<disk name="independence day (usa)" sha1="0c8222154bb994fcc615f9c39b73622d560f9804"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11497,7 +11497,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="in the hunt (usa)" sha1="e721dd560cc07498943e4b9959e324729e65a760"/>
+				<disk name="in the hunt (usa)" sha1="ee934ab08575bc4d361046fdeace43fb32f57b76"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11617,7 +11617,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="advanced dungeons &amp; dragons - iron &amp; blood - warriors of ravenloft (usa)" sha1="17801ddab215bcc26034feb352967b41cdc95d40"/>
+				<disk name="advanced dungeons &amp; dragons - iron &amp; blood - warriors of ravenloft (usa)" sha1="18245fa03c7b3e9ebadb1f4ddaa9a022c49ba58e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11655,7 +11655,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="iron man &amp; x-o manowar in heavy metal (usa)" sha1="7e65d61c52f08b39933f57978710888153a475e0"/>
+				<disk name="iron man &amp; x-o manowar in heavy metal (usa)" sha1="8d2aa21eedc311c45dfc6d074a54e5e3638adf3f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11689,7 +11689,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="irritating stick (usa)" sha1="9289c8dabe05a5b590aea9a82a32324b8895525c"/>
+				<disk name="irritating stick (usa)" sha1="3c832ebbddb7bea03214de8ad8a79c081e516cf7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11790,7 +11790,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="international track &amp; field (usa)" sha1="dc937024fdeed3b294b1c3baae36bd6edebb65b9"/>
+				<disk name="international track &amp; field (usa)" sha1="de74c844ed802c43af60db60c652b03c53444588"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11858,7 +11858,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="johnny bazookatone (usa)" sha1="419614f7156fa21dd6996edba658546d9c6e219a"/>
+				<disk name="johnny bazookatone (usa)" sha1="e455f2d675034ce47d24feebe55cdd3e42ca70fd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -11892,7 +11892,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="judge dredd (usa)" sha1="cc74396b0e1b24feb5366f704029dab76c88b4fd"/>
+				<disk name="judge dredd (usa)" sha1="4c139c872708cbf01506dddbabb1233c5e9271ef"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12020,7 +12020,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet moto 2 - championship edition (usa)" sha1="b42cb27c9047e3a205ac705f103b84d9a9bb82bc"/>
+				<disk name="jet moto 2 - championship edition (usa)" sha1="c7f10dc476869c636aa0826d03927e3f13332a3e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12050,7 +12050,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet moto (usa)" sha1="251e9d825407a0ca917c8dac11344b0f95698d29"/>
+				<disk name="jet moto (usa)" sha1="69496c1d35ac44334eb92121b3057b679c16d76c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12100,7 +12100,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jet moto 3 (usa)" sha1="9b41ae93feb09afc8e876653209794f97ad09c70"/>
+				<disk name="jet moto 3 (usa)" sha1="c2540cd8102c7e5df1080565678cb62b0b36eac5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12198,7 +12198,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jojo's bizarre adventure (usa)" sha1="1a535aab9dd8a47280f8ee71bce3a33ea2dd68c8"/>
+				<disk name="jojo's bizarre adventure (usa)" sha1="847680c54853a9bb551b848214f61a993f60ab55"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12297,7 +12297,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jupiter strike (usa)" sha1="db3044e8afc055ec72a6d6034d8a2a276ae75f92"/>
+				<disk name="jupiter strike (usa)" sha1="c5e4aebe9edaf950e4303cccf88e334ff4ea4cb5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12382,7 +12382,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="k-1 grand prix (usa)" sha1="a1262560ed86589598e03e50b3f8e372833a327f"/>
+				<disk name="k-1 grand prix (usa)" sha1="be79f2fabda5f7b7898ce19672170f3d4cd3535b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12414,7 +12414,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="k-1 revenge (usa)" sha1="2ca9009bf2df2ce939a73bb4e837e16f0959fb99"/>
+				<disk name="k-1 revenge (usa)" sha1="8f6e555cf4be7d60495b484fd0d51b56a9a41fe8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12448,7 +12448,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="blood omen - legacy of kain (usa)" sha1="b9d465144c3b42c1fa09e1a59c48d8992021aef9"/>
+				<disk name="blood omen - legacy of kain (usa)" sha1="86db9d235c28087c5d43d60e4816c3fd384a036b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12465,7 +12465,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legacy of kain - soul reaver (usa)" sha1="7151e18c9833410a3b2d72602903f2968142042d"/>
+				<disk name="legacy of kain - soul reaver (usa)" sha1="b66a08f5059e90203b62fe6c839c2e2a2aa03bfc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12633,7 +12633,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="killing zone (usa)" sha1="cf7c9338c633a29d841fd0327b5877c9fbbcee49"/>
+				<disk name="killing zone (usa)" sha1="96347fadf418e31f762e2d2667dad71434a1fd74"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12666,7 +12666,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kingsley's adventure (usa)" sha1="34e26047072db3fc7092c1ad0a825803f631bfe7"/>
+				<disk name="kingsley's adventure (usa)" sha1="d9ff5035cdbfbb6c04a2a6f60cabdbcf9ea0a83d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12683,7 +12683,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king's field ii (usa)" sha1="f43928ccc08fa097a775e1b8f777c8b32c3c1dff"/>
+				<disk name="king's field ii (usa)" sha1="c343c9a6c44fa505cf35a9437c670009eddcd017"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12700,7 +12700,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king's field (usa)" sha1="b41a6c67cab617b266e637eb10ef36ad54518b8b"/>
+				<disk name="king's field (usa)" sha1="660f25acc3dab1352ef4d60d81d9541c11043d45"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12792,7 +12792,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king of fighters '95, the (usa)" sha1="fb4f2e9bd9f855d851caed63240473bd41e38556"/>
+				<disk name="king of fighters '95, the (usa)" sha1="559180dd465fc4333a920f74f586ad70735827e8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -12810,7 +12810,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king of fighters '99, the (usa)" sha1="280100c9b4613597f4ee0f89482c47dd078f00db"/>
+				<disk name="king of fighters '99, the (usa)" sha1="953d566b5786bc1ed2726f93b0cdd5b3c2b8b5d8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13083,22 +13083,22 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 1)" sha1="e094a24456ffcdfaff840835f0759e1f86c88201"/>
+				<disk name="legend of dragoon, the (usa) (disc 1)" sha1="dbab4b64e4f3b582486bb9d3e44149c691f3032d"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 2)" sha1="ac8f2803d8fb0c7f43f356c86121a7b6fd2ede96"/>
+				<disk name="legend of dragoon, the (usa) (disc 2)" sha1="f7a98165bcf919bcb721f50eaf4beb9f845160fb"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 3)" sha1="f18594fcc92fd8925293459bab3f56beb0b15205"/>
+				<disk name="legend of dragoon, the (usa) (disc 3)" sha1="05a4297cbb8c9accb6b4c40d3afd045fb68e74f0"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legend of dragoon, the (usa) (disc 4)" sha1="f1d1535770b6f15a75a90742bfde56d6b9ae378d"/>
+				<disk name="legend of dragoon, the (usa) (disc 4)" sha1="7db94128cd99568980fe369620d10946d8aa401b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13147,7 +13147,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lode runner (usa)" sha1="ce3155f60b6f0d5b349ebb3273c99f055cf4a3f6"/>
+				<disk name="lode runner (usa)" sha1="a92cd56b8d7e0f554e5da6fe6c2e8cb49c00cf8f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13315,7 +13315,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's the lion king ii - simba's mighty adventure (usa)" sha1="b14db1fa5383a32fb69089e43a5eb1436c9b4a17"/>
+				<disk name="disney's the lion king ii - simba's mighty adventure (usa)" sha1="b21b7e2ba91deb94a610d809ee89ba08c8f828c5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13361,7 +13361,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="loaded (usa) (en,fr)" sha1="727bafe2c941a53ce7c52380aade32369017c664"/>
+				<disk name="loaded (usa) (en,fr)" sha1="fbc93540a150af582ff241fc9d49c0c1d8a11784"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13419,7 +13419,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="looney tunes racing (usa) (en,fr,es)" sha1="72032b1794885cdeae3301b3805da4f4f501e98b"/>
+				<disk name="looney tunes racing (usa) (en,fr,es)" sha1="79ebf67729f24b78cf13eedb736950171301f181"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13538,12 +13538,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar - silver star story complete (usa) (disc 1)" sha1="51cfe14a5449efe6b6d4097d4b46d6e9e3623424"/>
+				<disk name="lunar - silver star story complete (usa) (disc 1)" sha1="eb1fb6c49ffec47ac2b7bf26d7621d9bf90d2010"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar - silver star story complete (usa) (disc 2)" sha1="f664aa20deee48210e7a76c312f53d580b2d2985"/>
+				<disk name="lunar - silver star story complete (usa) (disc 2)" sha1="0461da91ed7dcbabe2f61444126951840b213ae6"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
@@ -13571,17 +13571,17 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar 2 - eternal blue complete (usa) (disc 1)" sha1="897a4777fa5cfbdd792982dd52f6ea9a5d053d9e"/>
+				<disk name="lunar 2 - eternal blue complete (usa) (disc 1)" sha1="1ce47e3775e83b13d8c50662319dacb5e89d9743"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar 2 - eternal blue complete (usa) (disc 2)" sha1="79ebabbce45631d667c4e3692f8b6195ec5dc16d"/>
+				<disk name="lunar 2 - eternal blue complete (usa) (disc 2)" sha1="0172a2f6b924da9ab0d2caa12e1ddbce3f628678"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar 2 - eternal blue complete (usa) (disc 3)" sha1="084395e85478b80230bf2d3fb67184970e2f7a65"/>
+				<disk name="lunar 2 - eternal blue complete (usa) (disc 3)" sha1="0e91e547f38869d91b86ee027c2c822083d2e840"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="psx_cdrom">
@@ -13605,7 +13605,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="south park - chef's luv shack (usa)" sha1="7b9d8f83135f476983315718e9b1c77bc24dcb1e"/>
+				<disk name="south park - chef's luv shack (usa)" sha1="3d143af6327f81e3d2a9b21429c69ffc10355f17"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13662,7 +13662,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="machine hunter (usa)" sha1="383552eb1286d39f1ce409059b29700d59fa0926"/>
+				<disk name="machine hunter (usa)" sha1="e4d2df64b8d1d0864f0173156f3502ee1f85edc2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13798,7 +13798,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="madden nfl 98 (usa)" sha1="02c50904e0d3f20f154266c95f4acaee57263788"/>
+				<disk name="madden nfl 98 (usa)" sha1="7124e21295dc612add3d8c7555e4bca2c2670bf5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -13889,7 +13889,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="magic - the gathering - battlemage (usa)" sha1="be87a3319fab8418b1d548e7787514f9d0a77cd6"/>
+				<disk name="magic - the gathering - battlemage (usa)" sha1="3bcd8f733bb5ab8cd3726a9d59a51574d148bdea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14065,7 +14065,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colin mcrae rally (usa)" sha1="279449a95bf0b7fbd1215ed1dd4f2d8abfcc63fb"/>
+				<disk name="colin mcrae rally (usa)" sha1="0765845afa78dc8a1572823294780b1765791667"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14083,7 +14083,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="colin mcrae rally 2.0 (usa) (en,fr,es)" sha1="3974bfd4be890617807e3bfbfa78bf92030d323a"/>
+				<disk name="colin mcrae rally 2.0 (usa) (en,fr,es)" sha1="a451bc1214db4b0c0fe9aada8e9798f9fab44272"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14210,7 +14210,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man 8 (usa)" sha1="e4e71e460de78f5a571f46fb2e1f5b940c9477c3"/>
+				<disk name="mega man 8 (usa)" sha1="355eb773d9f468cfa2a9ed36b7878f3814f0d263"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14227,7 +14227,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x4 (usa)" sha1="ad336c1d3481030735d7c10c434c564ec7b1d68d"/>
+				<disk name="mega man x4 (usa)" sha1="35dc1d61ad36b70177107e20d257325790a3f347"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14244,7 +14244,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x5 (usa)" sha1="c9c6246beb5b6bd6ae45498db2b8026ade8522f0"/>
+				<disk name="mega man x5 (usa)" sha1="077c266a0b9245def631058d1ea83e919cdbec9f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14261,7 +14261,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x6 (usa) (v1.1)" sha1="278c3ce12bafea06148777ebfc168d73ec62ddc1"/>
+				<disk name="mega man x6 (usa) (v1.1)" sha1="0c6435369163895a333e0df446844b1ae87d58be"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14278,7 +14278,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man x6 (usa) (v1.0)" sha1="576a04c12f3e635e3b48ebafcf7d1e1295ce07dc"/>
+				<disk name="mega man x6 (usa) (v1.0)" sha1="0718095e485314c49914c274158b947d5199d21c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14338,12 +14338,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal gear solid (usa) (disc 1) (v1.0)" sha1="23c8ef7a30624c517271a9280ed85c9995ece418"/>
+				<disk name="metal gear solid (usa) (disc 1) (v1.0)" sha1="ca11d3f7172718401b4a529e35aedcb5f6e0a6d9"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal gear solid (usa) (disc 2) (v1.0)" sha1="370361be299494ed7876fa80572870f52afa0a73"/>
+				<disk name="metal gear solid (usa) (disc 2) (v1.0)" sha1="3f3560a2986639e33d2844239a8847945fca2cc1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14360,7 +14360,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal gear solid - vr missions (usa)" sha1="19b873b051acc323a0b6b3bb98ddb2c10cac58a1"/>
+				<disk name="metal gear solid - vr missions (usa)" sha1="3b7ece83bd06c5802d7025b801c0f8d16b135d5f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14377,7 +14377,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="medal of honor (usa)" sha1="f155640f176acd8638e38578a9d2ab9bc9087ea3"/>
+				<disk name="medal of honor (usa)" sha1="56fbf554551f0f92c3e9795208a943d40dcf1706"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14394,7 +14394,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="medal of honor - underground (usa)" sha1="c49f2fa8c648d5f7055ce1057c415050286ff8ba"/>
+				<disk name="medal of honor - underground (usa)" sha1="3bdad42aa0dfa1430ded815378764f3de5aec1ac"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14449,7 +14449,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="foxkids.com - micro maniacs racing (usa)" sha1="937f7b96e2f8098ab109e5eb971d3a649e1793a8"/>
+				<disk name="foxkids.com - micro maniacs racing (usa)" sha1="60cc762c02dc1124439ac4306ba464878031c544"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14468,7 +14468,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="micro machines v3 (usa)" sha1="d0c9cf70cafaf2025f31c2404c1553f5dca672c3"/>
+				<disk name="micro machines v3 (usa)" sha1="30fba5a4fdc0ea1249fda0a4fb746202af4a4dfb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14539,7 +14539,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="missile command (usa)" sha1="1163e909b3a83421e7a7672c780c8f27ce4c1283"/>
+				<disk name="missile command (usa)" sha1="38179e41ea89de49e7c16908115b192a3258da90"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14651,7 +14651,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat 3 (usa)" sha1="60a313d72beefa8b19cb838623983ccc8b634c6c"/>
+				<disk name="mortal kombat 3 (usa)" sha1="4d34f61a4555ab7ca047212b1101c89fb77f6cc5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14668,7 +14668,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat 4 (usa)" sha1="64b679e01f6984d689fa18aa5a51c6da0300d482"/>
+				<disk name="mortal kombat 4 (usa)" sha1="3eca48bcc496ea0d22648787d7e5e78c4930ce12"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14685,7 +14685,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat - special forces (usa)" sha1="5e307fb758331fdee0a2d740c051bf6f98af3ae3"/>
+				<disk name="mortal kombat - special forces (usa)" sha1="e9919c72ccef3a0e8877fbe5f940e83d47bbfcda"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14731,7 +14731,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat trilogy (usa) (v1.1)" sha1="bb7ce7deff58cd2573b531b2d3e69ea73ba93631"/>
+				<disk name="mortal kombat trilogy (usa) (v1.1)" sha1="9713a08222b02d12f503c2296d28c215e9b07e91"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14964,7 +14964,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mobile light force (usa)" sha1="f37e1d8593bb0714b16730ea341a592f27d1ddcb"/>
+				<disk name="mobile light force (usa)" sha1="9316dad634ed08f3ad2cf3d242300973d8490632"/>
 			</diskarea>
 		</part>
 	</software>
@@ -14982,7 +14982,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man legends (usa)" sha1="77aab55210eac8354aa7c698ddf3476afccf356b"/>
+				<disk name="mega man legends (usa)" sha1="594f3159b3a7b1392826197343059205732fed6b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15000,7 +15000,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega man legends 2 (usa)" sha1="183034a51563b69164b5cfc7995af86e9c37fed9"/>
+				<disk name="mega man legends 2 (usa)" sha1="8d1592a30125ad666ec5a1f1eaaafc209f06df6e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15208,7 +15208,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="monopoly (usa)" sha1="87b78ac3034312cc57dd94a86751064c93bf5ab2"/>
+				<disk name="monopoly (usa)" sha1="89d9a4e39b7532eb62cf18d37a44cd7758f19e22"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15390,7 +15390,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="moto racer world tour (usa)" sha1="d75f1e4c85d6123cab908e484784a4dabe2ca5a4"/>
+				<disk name="moto racer world tour (usa)" sha1="2dfef2f8f61302432df5711d8b7d2de87ee4b843"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15481,7 +15481,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="monster rancher battle card - episode ii (usa)" sha1="91c00f8384f6f57c56f8e8b8b534b781a943b413"/>
+				<disk name="monster rancher battle card - episode ii (usa)" sha1="411ae96c5383b8f62d8e59893507f53218ef7667"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15626,7 +15626,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="marvel super heroes (usa)" sha1="81592bf673c4dbe866cf7daad06b6965f370563d"/>
+				<disk name="marvel super heroes (usa)" sha1="2e43e577c2ed880442e54d0d4976ba1ef75ae206"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15660,7 +15660,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal slug x (usa)" sha1="bc7953f15bd7b9d2154741b043d6c7dde73f444e"/>
+				<disk name="metal slug x (usa)" sha1="fcb065838e146998c3608b6d77d5a464cf1daea4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15683,7 +15683,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ms. pac-man maze madness (usa) (v1.1)" sha1="321629602dd4368a3aad449c3e75125a59ff40c0"/>
+				<disk name="ms. pac-man maze madness (usa) (v1.1)" sha1="45fe7713732f29b177c7abb3e5b41adbda1b4e38"/>
 			</diskarea>
 		</part>
 	</software>
@@ -15938,7 +15938,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="marvel vs. capcom - clash of super heroes (usa)" sha1="7d558cd1650bf313d8a1a5678b592180e2110f8c"/>
+				<disk name="marvel vs. capcom - clash of super heroes (usa)" sha1="90e936d55824b807e9e956e62b00b086e680c9de"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16043,7 +16043,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nagano winter olympics '98 (usa)" sha1="96e0e908a22d53cd60e9a1862371a5902b61fcbd"/>
+				<disk name="nagano winter olympics '98 (usa)" sha1="0b986f1fe8805c5198ac936bbd6c7095fd36f01f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16069,7 +16069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="namco museum vol. 1 (usa) (v1.1)" sha1="af19f724d9b57041b6ed0ab11f5977279ff85f3b"/>
+				<disk name="namco museum vol. 1 (usa) (v1.1)" sha1="50a37d173a660cfa9a05d2d07c7b25dc52c34755"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16213,7 +16213,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nanotek warrior (usa)" sha1="4badc333c2390a7ebcd32d12aa31ed6912b12119"/>
+				<disk name="nanotek warrior (usa)" sha1="21f9021c62593b759d565ef5309cce39713b6ba6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16356,7 +16356,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nascar racing (usa)" sha1="21465648f2b7c6352650d13d48fb8740f57b451f"/>
+				<disk name="nascar racing (usa)" sha1="3a109011c05a550085b4b2f86157b4fa29661042"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16496,7 +16496,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nba basketball 2000 (usa)" sha1="5107f34115b589a0894d5038849b27c9f1cdc8df"/>
+				<disk name="nba basketball 2000 (usa)" sha1="9caf6613ada46e2f3ae32779e8727f05826b1c24"/>
 			</diskarea>
 		</part>
 	</software>
@@ -16594,7 +16594,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nba jam - tournament edition (usa)" sha1="370523bd8a770b55a3a38be5b195ad9397f911e2"/>
+				<disk name="nba jam - tournament edition (usa)" sha1="840ac0e924c16224739bb6439a91952bb0fada12"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17363,7 +17363,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nightmare creatures (usa)" sha1="8592a07f87df446601902a137d69075dde4cf206"/>
+				<disk name="nightmare creatures (usa)" sha1="f2389e82bc41b3afc1ad12b43795e350b717f7c1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17631,7 +17631,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl quarterback club 97 (usa)" sha1="bd689204eba515256d945f45b295bc23541b5480"/>
+				<disk name="nfl quarterback club 97 (usa)" sha1="580836aa0eaac13a581a98c67df8c23017b13c5a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17701,7 +17701,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed ii (usa)" sha1="54d978f44c97fe927ce5a28d673a34600e1d619d"/>
+				<disk name="need for speed ii (usa)" sha1="4771b65e81100ac28307b22f719cda2b7709df7c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17735,7 +17735,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - high stakes (usa)" sha1="7f231d785984b12ef6d67c77ffc91d6a60d54e0b"/>
+				<disk name="need for speed - high stakes (usa)" sha1="be8caf7a7eaa4e9999e78c3b8c84c9985e663fb5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17766,7 +17766,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - porsche unleashed (usa)" sha1="6efeccdc5918c8d131afdfc53783ae5380c1fcc2"/>
+				<disk name="need for speed - porsche unleashed (usa)" sha1="3a5ba01e5c10a6e55945af093531119cd8a08b33"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17852,7 +17852,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl open ice - 2 on 2 challenge (usa)" sha1="ba639897d02c043ae0db9369402930f8d73f948f"/>
+				<disk name="nhl open ice - 2 on 2 challenge (usa)" sha1="ba6fa14d4337bd030c681f6be920294b35a053fb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17877,7 +17877,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl 97 (usa)" sha1="f2e1a333096d48d58ee5a4f47b71264d0648564f"/>
+				<disk name="nhl 97 (usa)" sha1="5d488298c1e49531cd6e329fd51052e67c750550"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17929,7 +17929,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl breakaway 98 (usa)" sha1="ca21c54f8ed8a10913690a8b20ffe0fe98c144a0"/>
+				<disk name="nhl breakaway 98 (usa)" sha1="f241ed941b2fb1b7fe78cf842f779f0e1981746c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -17947,7 +17947,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl championship 2000 (usa)" sha1="08343902480229df1175ff93c8776f49c172e0df"/>
+				<disk name="nhl championship 2000 (usa)" sha1="e279abecb164f2cab5dcc2d430a0575315d91471"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18218,12 +18218,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="novastorm (usa) (disc 1)" sha1="56b2709a371ddf8dc249d95453e9f80795b65333"/>
+				<disk name="novastorm (usa) (disc 1)" sha1="b03235765aae4d84497f9c885d980139ca8e4410"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="novastorm (usa) (disc 2)" sha1="73329a95c40ad19e5a8e795a557de8a0d7b5460e"/>
+				<disk name="novastorm (usa) (disc 2)" sha1="67221f49410f43cbbb6b55f706a5b5703cd4a670"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18268,7 +18268,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="next tetris, the (usa)" sha1="7c9c36b4342b110eb0877f219f17adda181d0379"/>
+				<disk name="next tetris, the (usa)" sha1="e4c71550fe89b90771c1aea8c276713eed06ca69"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18286,7 +18286,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="o.d.t. (usa)" sha1="10597fb61fc7b614fb1c5a6665114a0b4fab45d6"/>
+				<disk name="o.d.t. (usa)" sha1="ee356e30a34462ce35f15c7a1775fa2c64d5ab70"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18386,7 +18386,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="olympic summer games (usa)" sha1="d5bdc9a83a2bda1475adb3312ccf30ee5593a6e3"/>
+				<disk name="olympic summer games (usa)" sha1="e0d8b762e01314cd2029921b7e4b53cbef438dc1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18497,7 +18497,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pac-man world (usa)" sha1="c17bfd790a0b71a711ed64b8ea91469be6569479"/>
+				<disk name="pac-man world (usa)" sha1="18dd91e41a5a39b6185d1f1ecdbc45d711bbb074"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18531,7 +18531,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pandemonium (usa)" sha1="01a0f5957cffc9c59d3b8196827e64116eaeea98"/>
+				<disk name="pandemonium (usa)" sha1="40c7499febe8ccf3d62e81bac6876c128d845bca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18548,7 +18548,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="parappa the rapper (usa) (en,fr,de,es,it)" sha1="a0228849bf77c2b59830bfc2c5a62cc88a8bb984"/>
+				<disk name="parappa the rapper (usa) (en,fr,de,es,it)" sha1="91a64f0ecf079964d5d8df0939157e8b53a9a2ff"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18734,7 +18734,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pocket fighter (usa)" sha1="e4709a85ed8e1b461295fa0a8585636fc44e2cca"/>
+				<disk name="pocket fighter (usa)" sha1="d859aefd472ebf7446e966ddcd6f003b8875d557"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18802,7 +18802,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pga tour 98 (usa)" sha1="4868ce46755c35c26962ecf50e36429fef1d831c"/>
+				<disk name="pga tour 98 (usa)" sha1="8e6b6e5c474d11f08e738ea128f0aeaded9b0a09"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18819,7 +18819,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tiger woods 99 pga tour golf (usa) (v1.1)" sha1="aecc7ccfad0de21e55648a08a8da404e38704b3d"/>
+				<disk name="tiger woods 99 pga tour golf (usa) (v1.1)" sha1="7292af853c21299fe5b145e59d7395db0bc307ca"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18870,7 +18870,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="philosoma (usa)" sha1="2a8f5a57b6cb60179487eec66133f77e5e068b4d"/>
+				<disk name="philosoma (usa)" sha1="8ade448fec4d5dc2843067b584d0bc5031d61f1b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18927,7 +18927,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pink panther - pinkadelic pursuit (usa)" sha1="a90123d9053f7f5adfa6ef957f43bb4b06687a12"/>
+				<disk name="pink panther - pinkadelic pursuit (usa)" sha1="d7244b9c1765858cacfdde9fdbcd9085c914599c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -18944,7 +18944,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pinobee (usa)" sha1="6f366d9bea7d7f8d69da6ab6224e2eda766687c5"/>
+				<disk name="pinobee (usa)" sha1="7c64c4dc449df84ef7af7a77342d8e89388ba10a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19028,7 +19028,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pitball (usa)" sha1="6fe84ef777ca355d118e25b45f5f54f973a5cda3"/>
+				<disk name="pitball (usa)" sha1="9d537ff80666fe7aa88ce91d0c32ac4ddd8340d1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19045,7 +19045,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pitfall 3d - beyond the jungle (usa)" sha1="2ce1320196672709ae3719bfab10f183b306042b"/>
+				<disk name="pitfall 3d - beyond the jungle (usa)" sha1="9e2d24b34db59a19465087cd4888612d17114606"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19468,7 +19468,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro pinball - big race usa (usa)" sha1="082793fafe243b5d65882f9403a7b2bf10f44040"/>
+				<disk name="pro pinball - big race usa (usa)" sha1="42816c090226ef0d7942cfae336845b7120bf365"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19506,7 +19506,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro pinball - fantastic journey (usa)" sha1="83f8747f57ed1139eae35fcd1e531c812a5fb6f7"/>
+				<disk name="pro pinball - fantastic journey (usa)" sha1="b408150fb52b95e1e8eb85e2c6a609d0d11f0812"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19556,7 +19556,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro pinball - timeshock (usa)" sha1="ded80f6e94df5dfb0e04988078ad9aa9ab3603b8"/>
+				<disk name="pro pinball - timeshock (usa)" sha1="b167931677dc208d460f5a4ab4adf0efb8d82cfb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19688,7 +19688,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="professional underground league of pain (usa)" sha1="8f1933b0221455b27479ebe00d218ea865cb51a2"/>
+				<disk name="professional underground league of pain (usa)" sha1="383514e0d2311965243a141c5a5f18f23bb12ff4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -19893,7 +19893,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="point blank 3 (usa)" sha1="2817ab2414f3867454006f095f564d443994d3f0"/>
+				<disk name="point blank 3 (usa)" sha1="0c45fddde3c36091881c1302ecd39175eef88af3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20017,7 +20017,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="power shovel (usa)" sha1="13936d1357e23408fb584e4b2f8f2a258fa04c15"/>
+				<disk name="power shovel (usa)" sha1="b6dc87df1c42c65ab3785c8cd5158b128d71fcd3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20034,7 +20034,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="q-bert (usa)" sha1="fe1441d93e56657c6bc83d4fb036e85e241f606f"/>
+				<disk name="q-bert (usa)" sha1="133c93ffd5af5241212ba5cad24172fa4f9cfee8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20069,7 +20069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="quake ii (usa)" sha1="5009e8ea4cdb4c24acf19db8d3190cf25c316d06"/>
+				<disk name="quake ii (usa)" sha1="42fd8eafadd029bc27887c9852a4aeb989283830"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20191,7 +20191,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="raiden project, the (usa)" sha1="66d3217fe26ce9aa08023c20b098c365ffa90b0e"/>
+				<disk name="raiden project, the (usa)" sha1="cb1e4fae25d42e70fcb3eec5e1c1afcbdc5c2af3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20287,7 +20287,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tom clancy's rainbow six (usa)" sha1="2d30f33cd7c770bffa4b923ed8b5dbb0745dadf3"/>
+				<disk name="tom clancy's rainbow six (usa)" sha1="fe52e58df1cfffbae7bb25fa603662b87b84170c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20415,7 +20415,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rascal (usa)" sha1="8544b494fa90845e5fd25d3b4f873385e8609262"/>
+				<disk name="rascal (usa)" sha1="3c702834316424e1349c36c9757c56c9b758e9eb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20534,7 +20534,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rayman (usa)" sha1="07f8272430ee6ec9d0707fef1667f0e4ebb5b23b"/>
+				<disk name="rayman (usa)" sha1="bb97094982d27a44815198a57c7aedcaaab74e42"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20552,7 +20552,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rayman 2 - the great escape (usa) (en,fr,es)" sha1="580332fd7023842653c212cabd99421ad89dcb8c"/>
+				<disk name="rayman 2 - the great escape (usa) (en,fr,es)" sha1="0060a539f78fdfe27a9e15b25c50bdb0a8957df7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20597,7 +20597,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rayman rush (usa)" sha1="dcf04b288d2c52ee0afb3068a393fdc6c28fd85c"/>
+				<disk name="rayman rush (usa)" sha1="d0cf85a4b454baaf9eb3ea3c9234fda9fcda05f0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20614,7 +20614,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="raystorm (usa)" sha1="a1105f7e11b421df63d5c0586b1fd58a63077fd7"/>
+				<disk name="raystorm (usa)" sha1="c24a45839799dc4292e78faf79207e0e0bff6d37"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20674,7 +20674,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rc de go (usa)" sha1="d30a3a92467d1b32f969a63fa55567bdcc19fd12"/>
+				<disk name="rc de go (usa)" sha1="6d5bd7305164593f1f1a085e3e517965a3e557a6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20743,7 +20743,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rc revenge (usa)" sha1="1083fc28192252a2838db6dd46a576e53cfbf307"/>
+				<disk name="rc revenge (usa)" sha1="a0deb3cb7f06968d04b287dcea519bb5d2397165"/>
 			</diskarea>
 		</part>
 	</software>
@@ -20991,12 +20991,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 (usa) (disc 1)" sha1="c0365d8e731a288fe91e48d530d613277984a7be"/>
+				<disk name="resident evil 2 (usa) (disc 1)" sha1="7322b79e6d4d539d115388b0ce367af5f3df2a69"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 (usa) (disc 2)" sha1="d31bc0f576bdde73fb5e5300645b4a88df01309a"/>
+				<disk name="resident evil 2 (usa) (disc 2)" sha1="646c4f732a16149a98756d27211ee4190c50fa3b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21017,12 +21017,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 - dual shock ver. (usa) (disc 1) (leon)" sha1="38c5a6c7c5cc25c4838f4b5e80f9fb0eb884ae55"/>
+				<disk name="resident evil 2 - dual shock ver. (usa) (disc 1) (leon)" sha1="163470a70ad2bf13a668665547dde90968efab8c"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 2 - dual shock ver. (usa) (disc 2) (claire)" sha1="9c7a90f0566982068c69ae581b041ba5dde3baed"/>
+				<disk name="resident evil 2 - dual shock ver. (usa) (disc 2) (claire)" sha1="b84c429ddb5cbe366cc747e0a79f7f6e70a88f34"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21039,7 +21039,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil 3 - nemesis (usa)" sha1="e5c6cf477eb7bc69ea59ab1f464ef97446813548"/>
+				<disk name="resident evil 3 - nemesis (usa)" sha1="297ccfe24c4935f0869d6ba89d0e46fd9887773a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21074,7 +21074,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil - director's cut - dual shock ver. (usa)" sha1="9ecd4c66e3ccd142a95a35b000e05546fab048b8"/>
+				<disk name="resident evil - director's cut - dual shock ver. (usa)" sha1="bb90fb489cfb2182541d725b30c09621f32676e8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21091,7 +21091,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="resident evil - survivor (usa)" sha1="2a9eb069ef468dada08eb4415117289efaa491db"/>
+				<disk name="resident evil - survivor (usa)" sha1="b5fa1bfc4a8932c9828eb30312daa9236fdd4bf5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21110,7 +21110,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="re-volt (usa)" sha1="76ff6ff0c3692626268e270a6707eb58a3786c26"/>
+				<disk name="re-volt (usa)" sha1="70dea533f66ef91de0e37078eaed57d24f41226c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21191,7 +21191,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ridge racer (usa)" sha1="8ac66ea834865a693bb2e437b8aedb9cd1256649"/>
+				<disk name="ridge racer (usa)" sha1="d8db80f9bea0310181454001d9305dbbd3123a55"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21334,7 +21334,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="road rash (usa)" sha1="0ad49eb687923de7363db773d57fad78bc5ceb31"/>
+				<disk name="road rash (usa)" sha1="89336b0c8e5f90ce9ad5d9e6405a9ea81a5a99a7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21359,7 +21359,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="roadsters (usa)" sha1="870193bf83cb6ab12ca9c07bc19a9306d35f48ca"/>
+				<disk name="roadsters (usa)" sha1="b5405e343a91f3e9522fe0c52efd5fe84398efd1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21389,7 +21389,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rock 'em sock 'em robots arena (usa)" sha1="0be803228de8c56dc37538af0434232081e4ddb1"/>
+				<disk name="rock 'em sock 'em robots arena (usa)" sha1="a29a309b78a1c04e83a4837fff290d00eb390873"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21519,7 +21519,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rollcage stage ii (usa)" sha1="508f6e5bf1321077b0936c7f9d25fc4c024c2f84"/>
+				<disk name="rollcage stage ii (usa)" sha1="fdc91b071c77f3b374417c9413dfc88ab7d4da78"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21551,7 +21551,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rollcage (usa)" sha1="7799fdd199249cd3ada436656e0dc583845a8b9a"/>
+				<disk name="rollcage (usa)" sha1="0a00e8466df9b31dbbbea0cec63254adc28eef65"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21668,7 +21668,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="r4 - ridge racer type 4 (usa)" sha1="f637a55052d40c054ea10b724e639658ab334617"/>
+				<disk name="r4 - ridge racer type 4 (usa)" sha1="5bf4db632745058203d3e622c559aadc9728c86e"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -21691,7 +21691,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="road rash 3d (usa)" sha1="34494c7346d55449a601ee2ebaffb497a0ef1061"/>
+				<disk name="road rash 3d (usa)" sha1="6df63908f9c58acb6eacbe3ab86f1163a4724cd9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21744,7 +21744,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ridge racer revolution (usa)" sha1="a5a87bf9383964e427e0785c84ee8a706e6e717f"/>
+				<disk name="ridge racer revolution (usa)" sha1="567ed38059cb168a998ac535d592c283df3cdd48"/>
 			</diskarea>
 		</part>
 	</software>
@@ -21865,7 +21865,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="r-type delta (usa)" sha1="aa58dfc96d015dae777f5c4bdef088bfcec50a64"/>
+				<disk name="r-type delta (usa)" sha1="fd3cb15de17a3a917edd0edbc8e8d550cedbdf7b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22069,7 +22069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rush hour (usa)" sha1="cea81724f4684b8ef4d130a03d9c07c530bce5ee"/>
+				<disk name="rush hour (usa)" sha1="3a0d7c90676561f96c293055b92539f0a99503db"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22092,7 +22092,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Arcade Disc"/>
 			<diskarea name="cdrom">
-				<disk name="rival schools - united by fate (usa) (disc 1) (arcade disc)" sha1="fb05951b30b08366d3f0f14370a98569bdfa4bdf"/>
+				<disk name="rival schools - united by fate (usa) (disc 1) (arcade disc)" sha1="b22ced7cd2756472c021643bea839e88e24a0df2"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -22132,7 +22132,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strikers 1945 (usa)" sha1="c46e5e4327047045802c714bb7e47777f4aa47f5"/>
+				<disk name="strikers 1945 (usa)" sha1="208b4b5701241daec9800bba33aa387576c7aa67"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22344,7 +22344,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="samurai shodown iii - blades of blood (usa)" sha1="e4621a82a82f93253c29a7536e3ffa5030bbaeaf"/>
+				<disk name="samurai shodown iii - blades of blood (usa)" sha1="ec39b0de944008cfb464b339ffb219682890e7a6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22361,7 +22361,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="samurai shodown - warriors rage (usa)" sha1="9ac2ddb993c8810740fd08ce4d4580ea231057b0"/>
+				<disk name="samurai shodown - warriors rage (usa)" sha1="5c406bc0e7e9306edd0a801864f43bb66e038d6d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22395,7 +22395,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super bubble pop (usa)" sha1="82185ff124636de2447919e348600b8a1079e36d"/>
+				<disk name="super bubble pop (usa)" sha1="86f5077178ba9ac862da42697a592c921a9f5b9a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22484,7 +22484,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="scrabble (usa)" sha1="4030820874124b74fc1535c6a39954c80d08008d"/>
+				<disk name="scrabble (usa)" sha1="3f7d0a812be4e9ce6312f1adb39163ff641c0dfd"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22556,7 +22556,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sentient (usa)" sha1="d140a7e2fe184ed72ea07fb881a500cffbc17a11"/>
+				<disk name="sentient (usa)" sha1="28e6a7d9f9de0247f3cbc9688de335f722711361"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22640,7 +22640,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter alpha - warriors' dreams (usa)" sha1="711afd8cc92d07f4d10462192cf48d202d9ab3d7"/>
+				<disk name="street fighter alpha - warriors' dreams (usa)" sha1="ae3168c4f6097e6fa7083411f76ba94d95d2037d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22658,7 +22658,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter alpha 2 (usa)" sha1="a1c39448d2013c764eba9596e7857208ccb3ce27"/>
+				<disk name="street fighter alpha 2 (usa)" sha1="0bf01b34786c097489bcdaae0c84f07cc4a3ccc2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22676,7 +22676,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter alpha 3 (usa)" sha1="950830b7b0ad50f58c300506d4b0484dd09e946c"/>
+				<disk name="street fighter alpha 3 (usa)" sha1="0f9efd002a0653925734af77d4d1fd38a0bed869"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22771,13 +22771,13 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<part name="cdrom1" interface="psx_cdrom">
 			<feature name="part_id" value="Super Street Fighter II &amp; Super Street Fighter II Turbo"/>
 			<diskarea name="cdrom">
-				<disk name="street fighter collection (usa) (disc 1) (v1.1)" sha1="15099186368611834f61ce1471b626e2b6071b2e"/>
+				<disk name="street fighter collection (usa) (disc 1) (v1.1)" sha1="9eaab12a032b7e9d6a05f342752f1de8fe4d27b3"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<feature name="part_id" value="Super Street Fighter Alpha 2 Gold"/>
 			<diskarea name="cdrom">
-				<disk name="street fighter collection (usa) (disc 2) (v1.1)" sha1="56530bdbc1a3547a51695486be9865434a56a0fb"/>
+				<disk name="street fighter collection (usa) (disc 2) (v1.1)" sha1="b42293238b6b2dd5ebc9dc990bdc08ab6e6ec8c4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22899,7 +22899,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter collection 2 (usa)" sha1="0e64662c3c641d193fed1bffebb5a5a9e35e3b40"/>
+				<disk name="street fighter collection 2 (usa)" sha1="56e122837fda765c8515dbd738faa316670538ed"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22916,7 +22916,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter ex2 plus (usa)" sha1="7412bc70b906f05e50994ff80899dfb18073771b"/>
+				<disk name="street fighter ex2 plus (usa)" sha1="2a4e2e8bd97b6b647068ba895d36527ef5432899"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22933,7 +22933,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter ex plus alpha (usa)" sha1="9d9f2d5ad38ad742abb7c7ea3b80e03068a6084b"/>
+				<disk name="street fighter ex plus alpha (usa)" sha1="383b2a669ece1407d41cf2386e943e6257eaea57"/>
 			</diskarea>
 		</part>
 	</software>
@@ -22979,7 +22979,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street fighter - the movie (usa)" sha1="3a96da37e19cc988aff750d03705cf2f0457ad3a"/>
+				<disk name="street fighter - the movie (usa)" sha1="086d63873dea95a64c706202c1eb998f8c6904b7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23036,7 +23036,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="shadow man (usa)" sha1="70718577aa4bb03dd1006c33094837859f6dee19"/>
+				<disk name="shadow man (usa)" sha1="485f80a243bff3a4bafa6015d931b3ff6bf78be8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23325,7 +23325,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="silent hill (usa)" sha1="fd460847a57795d2368b6b1a2784fa077cffb37f"/>
+				<disk name="silent hill (usa)" sha1="ea7a7503593012e9e726c4549c193f956510ffee"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23421,7 +23421,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="simpsons wrestling, the (usa)" sha1="2901283291baa7f1e3e3d9bdc4adce514bd4215d"/>
+				<disk name="simpsons wrestling, the (usa)" sha1="c4af5e47f91ab14aab2359a3a4826bd2c88342ec"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23523,7 +23523,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slam 'n jam '96 featuring magic &amp; kareem (usa)" sha1="1a91ab0f827b68509db476ed24314412de38e05f"/>
+				<disk name="slam 'n jam '96 featuring magic &amp; kareem (usa)" sha1="d026e97d9bb15470718df2151bba33208ff9fe07"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23601,7 +23601,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slots (usa)" sha1="b93ee66bcb99189a3cc594736f94902bdd4233e0"/>
+				<disk name="slots (usa)" sha1="43b08f17ed50f7ca259f33903012b1609e140c62"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23715,7 +23715,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="smurfs, the (usa) (en,fr,es)" sha1="c2b14925b21eb5fb34a78ec885249950ff535239"/>
+				<disk name="smurfs, the (usa) (en,fr,es)" sha1="9a12b993132ec4bb762e7949b1451b851bbdcc3f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23758,7 +23758,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="snowboarding (usa)" sha1="0a9b080ab657b422d6214939b3e7f83a77c7f860"/>
+				<disk name="snowboarding (usa)" sha1="15dcedb3041bc9fea57aabad56ee0b9188cc5f50"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23855,7 +23855,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="castlevania - symphony of the night (usa)" sha1="5239b5c6c2f2da5f1d9356670fa614f31e4e3075"/>
+				<disk name="castlevania - symphony of the night (usa)" sha1="37b2cdcaa49bf773406a6d886a2d5ba8f835cf76"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23872,7 +23872,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="soul blade (usa) (v1.1)" sha1="a66be2ea6ade0326bb40e75ffd949fef0e93d1d5"/>
+				<disk name="soul blade (usa) (v1.1)" sha1="4c8f306c713b7f1820a758f0e02e6410aaa57bed"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23924,7 +23924,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="south park (usa)" sha1="cfa1847f45a5435157506def8e8bc437420cf745"/>
+				<disk name="south park (usa)" sha1="283070618ece8b9692baabc8f47735df1a779984"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23942,7 +23942,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space invaders (usa)" sha1="b3aa1b3e2f509e44d5f840cc2d9fa2aa8bceba82"/>
+				<disk name="space invaders (usa)" sha1="aa41f19e38d7ffdf451b587433811bc6b4cb3857"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23960,7 +23960,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space jam (usa)" sha1="24934636c63dbb820e6716e60aaecc283486636d"/>
+				<disk name="space jam (usa)" sha1="398d676f0aef38c079c53214bd8e9ff603478e62"/>
 			</diskarea>
 		</part>
 	</software>
@@ -23977,7 +23977,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space shot (usa)" sha1="79446aef0301e34210284080ad3208bdfb6cd265"/>
+				<disk name="space shot (usa)" sha1="ab678f726c6841c2d657820a256f97fd59ed1427"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24069,7 +24069,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="south park rally (usa)" sha1="ca945cf19c22bebd043ec005bb90e8f765b67c04"/>
+				<disk name="south park rally (usa)" sha1="dd9351c50f964035ad4d0d932d98970dcb2ba176"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24303,7 +24303,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super puzzle fighter ii turbo (usa)" sha1="8e42b8bcdfc295bd7cd90bf554f4f30efb36129a"/>
+				<disk name="super puzzle fighter ii turbo (usa)" sha1="23fdf03ffd002de06b2b6366a93d552c00798d45"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24338,7 +24338,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spider - the video game (usa)" sha1="e332ae9c41bf4385964db272c7ec003e21155421"/>
+				<disk name="spider - the video game (usa)" sha1="4f04f45cec47033616a45b0acc7550654030fff0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24355,7 +24355,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spider-man (usa)" sha1="196e5fb8bc1a96db65107abd338593198a207fae"/>
+				<disk name="spider-man (usa)" sha1="66c09444240ddf96f194d2d2e63b42a2af77bc37"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24483,7 +24483,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spyro the dragon (usa)" sha1="1a861139d485f7fcfc3cfd839a4db5bdd95267f9"/>
+				<disk name="spyro the dragon (usa)" sha1="ab729c36603444bfde190542f0b42e9262eebeaa"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24500,7 +24500,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spyro 2 - ripto's rage (usa)" sha1="b31b6dfd9d16cb90b6cfcd9a5ea71663a4132d26"/>
+				<disk name="spyro 2 - ripto's rage (usa)" sha1="4df448b9cfe122821ac8f812f76891209f31d4fe"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24517,7 +24517,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spyro - year of the dragon (usa) (v1.1)" sha1="ca1593703cb4c7a746f03b7f29ca9e788631de3a"/>
+				<disk name="spyro - year of the dragon (usa) (v1.1)" sha1="85fa6a1688326cb194d3423f3ddd4381712f2065"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24564,7 +24564,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="street racer (usa)" sha1="3653b9818f7aa8dc2c1f94fe0dd9530816de2949"/>
+				<disk name="street racer (usa)" sha1="67fdc6df29b2ab81d2bcc84d521af9c577b57f38"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24628,7 +24628,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sports superbike 2 (usa)" sha1="a119ec81e05090feab67521b45e107a4cb8c0620"/>
+				<disk name="sports superbike 2 (usa)" sha1="3c3ff1484bd50d2d13e2ece3a86ab63995529647"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24765,7 +24765,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star gladiator - episode i - final crusade (usa)" sha1="cd617da2869cb015112634c449433c10c002933b"/>
+				<disk name="star gladiator - episode i - final crusade (usa)" sha1="ef090bb9a672649d6088c960405c3514a2e376c1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24901,7 +24901,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="streak hoverboard racing (usa)" sha1="438af526e14d22d4d191ba48b8ff4ad3b3557a3c"/>
+				<disk name="streak hoverboard racing (usa)" sha1="ca792dbf94f57729390973a09f7fb5900932d34c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24937,7 +24937,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strider (usa)" sha1="250c17d0565edb1fede48aff809b3a80f5020f34"/>
+				<disk name="strider (usa)" sha1="fa9e3f112aa7ecd854edb5ab2200e476c807453f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24956,7 +24956,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strider 2 (usa)" sha1="9d36dbde94c02d9209139ebea7497ad62a1ce969"/>
+				<disk name="strider 2 (usa)" sha1="5bae061e35040cae34914d40e4e51eb2b515f736"/>
 			</diskarea>
 		</part>
 	</software>
@@ -24975,7 +24975,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="striker 96 (usa)" sha1="2b43bad6cdc0b3f754b41683c0b7c17f32ddd895"/>
+				<disk name="striker 96 (usa)" sha1="b405a370a8f800edd0d5d1d6a5e25b3826132e5b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25102,7 +25102,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat mythologies - sub-zero (usa)" sha1="f1e1d9e2f54ba89b3da6a94a01c326dc20ade137"/>
+				<disk name="mortal kombat mythologies - sub-zero (usa)" sha1="d67cc625011a58b0abccbf864bcd7d2027d1bea7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25119,7 +25119,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="suikoden (usa) (v1.1)" sha1="cdeb30e8cf297186a84eacfa523ce8204f5f604e"/>
+				<disk name="suikoden (usa) (v1.1)" sha1="55eeefa1a0afd329e85747d4afe6b038793c9919"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25136,7 +25136,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="suikoden (usa) (v1.0)" sha1="f949b37c1109d8650d8c4dcdc062c0d8e9c29440"/>
+				<disk name="suikoden (usa) (v1.0)" sha1="a969814a8fe8d2c7c7033192fc490045b3c1485d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25153,7 +25153,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="suikoden ii (usa)" sha1="37bd1800d6afdfb49d7fa5d33a361a4d9ab5925d"/>
+				<disk name="suikoden ii (usa)" sha1="a47dbce42efb9dc0e2f2d0835d3534774e33dd6d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25214,7 +25214,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="swagman (usa)" sha1="cc4169335d7ba136153f77bda5a41292fe1b5003"/>
+				<disk name="swagman (usa)" sha1="ca6e3eda048cfc1135d794db0636b0cae9884684"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25276,7 +25276,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star wars - episode i - the phantom menace (usa)" sha1="3b5e805896f8222b563e3ebc9c2ffd903a1c9894"/>
+				<disk name="star wars - episode i - the phantom menace (usa)" sha1="8ab36c9e46e6bec0e27c611c2890fbfbeb0eeb31"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25536,7 +25536,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tail concerto (usa)" sha1="e06ac367c9f1b2d408caa6c6748c60fdf892c765"/>
+				<disk name="tail concerto (usa)" sha1="b3adcc6c634b5a8c7a24f9bcc649bba7d4a00848"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25598,7 +25598,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's tarzan (usa) (v1.1)" sha1="cbc0f2b3cdddc73356662a5b5b45a037b1e23cde"/>
+				<disk name="disney's tarzan (usa) (v1.1)" sha1="f2779268217aaacb3aa0fa18ea92e154a0d3e47a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25616,7 +25616,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="disney's tarzan (usa) (v1.0)" sha1="c4ddc339825d8398f9efaa1cc1962708be6faf87"/>
+				<disk name="disney's tarzan (usa) (v1.0)" sha1="a9f0b4f770dbe12dfece2822f525852e0bc1f0b1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25766,7 +25766,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="team buddies (usa)" sha1="0803b39feabeecdb224f54e4e1e8f59e3ca49f64"/>
+				<disk name="team buddies (usa)" sha1="3f155d0e980d4ed84630b279da94af78cb339563"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25919,7 +25919,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tekken (usa)" sha1="cb5cd46bf8c7d5e1d34d4aa25ec54ce9a4632e46"/>
+				<disk name="tekken (usa)" sha1="b2d2c32c3ab3c597b7017c1d1f7cb7d69496ba17"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25938,7 +25938,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tekken 2 (usa) (v1.1)" sha1="2d3c614e5278f9189b6fdc803fe1b942ec97c442"/>
+				<disk name="tekken 2 (usa) (v1.1)" sha1="ce046321efa2d377c0b241f725fd6f9fbac660ea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -25976,7 +25976,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tekken 3 (usa)" sha1="319ec7377eb0c3ef0b6049e440937d26ae743290"/>
+				<disk name="tekken 3 (usa)" sha1="e1537fb7c60ee4e39743847ffadfa33c94912652"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26082,7 +26082,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tennis (usa)" sha1="213ea8a9a04f09cfb0154b1f3807e743b1b7abbc"/>
+				<disk name="tennis (usa)" sha1="000a5de8072f21f168f8663429673cd33acea5bf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26222,7 +26222,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tetris plus (usa)" sha1="26f26fc78fb2c507c9a72fdcdc2ed1910dcbc039"/>
+				<disk name="tetris plus (usa)" sha1="d8d67a9c6eb5246fdc2e5ebb9233a429bbbd9b4f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26239,7 +26239,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="thunder force v - perfect system (usa)" sha1="17658f39053eaed1028a1a470f59388553fd2ded"/>
+				<disk name="thunder force v - perfect system (usa)" sha1="0c01c35c0b08f87763277581abd19d2f082b6c29"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26328,7 +26328,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tony hawk's pro skater (usa)" sha1="b94afb759d5c2f289f5d4ec910b3d92c79316c0c"/>
+				<disk name="tony hawk's pro skater (usa)" sha1="7a6b07b327d77cd27ebe161a3a64d149ebd19e3e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26345,7 +26345,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tony hawk's pro skater 2 (usa)" sha1="76ca2e86180f977c596a53c7257914f338e6a0de"/>
+				<disk name="tony hawk's pro skater 2 (usa)" sha1="1069052c61fe99be3e938b98887355170ac91318"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26379,7 +26379,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tony hawk's pro skater 4 (usa)" sha1="1cf3955bb1a3e41343dc027985f1d615b8e9c9d6"/>
+				<disk name="tony hawk's pro skater 4 (usa)" sha1="694bed9d4d9cd260d393b67b2825eb01e32c5eb1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26600,7 +26600,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tiny tank (usa)" sha1="e61cd0f24d0afc8846e978e4e5a61d35ca99ffa6"/>
+				<disk name="tiny tank (usa)" sha1="87d08ea463c0096f7ca154e92805429d4f52bf5e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26824,7 +26824,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomba (usa)" sha1="50d87fb5646c60fe419b56a53c20f112806f068b"/>
+				<disk name="tomba (usa)" sha1="e543a25583ef211010dd6736b88c43f8b4132931"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26842,7 +26842,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomba 2 - the evil swine return (usa)" sha1="21b5620e342529ea2dbd68ca47da5399eff71199"/>
+				<disk name="tomba 2 - the evil swine return (usa)" sha1="34859016049661e1083391e9015f73f67a919f24"/>
 			</diskarea>
 		</part>
 	</software>
@@ -26973,7 +26973,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle arena toshinden (usa)" sha1="64e5b9f4443b4770668d26c46a8d711017e5f41b"/>
+				<disk name="battle arena toshinden (usa)" sha1="c216b34a840255677fb7fd10bdaa60c5edf863f5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27007,7 +27007,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle arena toshinden 2 (usa)" sha1="aca3e7f7da0527e3c94e43ab9650461b91fc0c87"/>
+				<disk name="battle arena toshinden 2 (usa)" sha1="2dbd6c7312e3c1edf1baaeea5e1ab1bac598a125"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27025,7 +27025,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battle arena toshinden 3 (usa) (en,ja)" sha1="03d70fde6dde4439b573c2272b8ad930960f3ae1"/>
+				<disk name="battle arena toshinden 3 (usa) (en,ja)" sha1="bcc2a1583b44c4d087d94cb9a3bd152726b29884"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27110,7 +27110,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="triple play baseball (usa)" sha1="67642c3ab9777501904d3843f77d9e1a38bea64c"/>
+				<disk name="triple play baseball (usa)" sha1="81f7c10f296db0136d5c749601270f6d36fc112f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27310,7 +27310,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider (usa) (v1.6)" sha1="294b08736f01ca7528a191ed5ee50f849b40dbff"/>
+				<disk name="tomb raider (usa) (v1.6)" sha1="697842403e9a7e5f662d8d5a56b40480742fe3ac"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27387,7 +27387,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider ii - starring lara croft (usa) (v1.3)" sha1="bdf8850b894577ec723b82da59d3c53f40893236"/>
+				<disk name="tomb raider ii - starring lara croft (usa) (v1.3)" sha1="459ef793bc4b451997c87054b6925afa5f4358d7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27635,7 +27635,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider iii - adventures of lara croft (usa) (v1.2)" sha1="42badae97c44239c7bf61bb8bc1e35beb025a207"/>
+				<disk name="tomb raider iii - adventures of lara croft (usa) (v1.2)" sha1="0a883e2f47003f50b2b9793159d30421668bb2c6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27686,7 +27686,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider - the last revelation (usa) (v1.1)" sha1="26761d10c047676960391d97bb1ce48498689bf0"/>
+				<disk name="tomb raider - the last revelation (usa) (v1.1)" sha1="53cd52f5f77979b2547d49db33fc554589733774"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28272,7 +28272,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="misadventures of tron bonne, the (usa)" sha1="7e4316ac95ae0f9d26b9b99820d283d318c276a3"/>
+				<disk name="misadventures of tron bonne, the (usa)" sha1="0695a8d71036b2c3d15440aea80d7d722c26ad56"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28338,7 +28338,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="true pinball (usa)" sha1="a747481095f7860138e405c418e8ff32069e77c1"/>
+				<disk name="true pinball (usa)" sha1="87a1463306ed777635daf00b70f09212203a61bc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28499,7 +28499,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal - small brawl (usa)" sha1="4589bbc09de5f537f0809895fe32d69c26106678"/>
+				<disk name="twisted metal - small brawl (usa)" sha1="7f4d093f996f2e1e6ceb1d8b13477aadedc47155"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28527,7 +28527,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal 2 (usa)" sha1="ed75cb9b039ce559118bdf624685e221e6dbf906"/>
+				<disk name="twisted metal 2 (usa)" sha1="ea300893c05cbf43ef4fba616112c542627e6016"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28580,7 +28580,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal iii (usa) (v1.1)" sha1="5339b19b908e44f34310a6a1ecbc60817665b8ca"/>
+				<disk name="twisted metal iii (usa) (v1.1)" sha1="0300b5d0bac4c7a24e541b5a9f83979b79cb1dbf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28672,7 +28672,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal 4 (usa)" sha1="3420fe8dbb4b1718f971afffb790ac7e8f4fa1d3"/>
+				<disk name="twisted metal 4 (usa)" sha1="b6ea4d26c0172bce93825f483699b55988bad28a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28697,7 +28697,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="twisted metal (usa)" sha1="67269637d563ed2ffafd842be8908b068548bc2b"/>
+				<disk name="twisted metal (usa)" sha1="b02c5da714570a23ac2f9a55d5a938dce5fd2d6b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28792,7 +28792,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ultimate brain games (usa)" sha1="ef1229098eb2ee7ee9d0b4c84625b3875b8c8a0c"/>
+				<disk name="ultimate brain games (usa)" sha1="a46038894503a5864a1b8ea23661553677789fdf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -28913,7 +28913,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vagrant story (usa)" sha1="d200433ef70d5a859fb49736dbcfea5cb030ba19"/>
+				<disk name="vagrant story (usa)" sha1="f70f1bce87e8c7a84953c4d7271cfb2f3622bb4a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29029,7 +29029,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vanishing point (usa)" sha1="ac1adde7e60f76502636afa478308f728a830f08"/>
+				<disk name="vanishing point (usa)" sha1="5ded96e4907f70541f68088e2026d6786e5ed931"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29063,7 +29063,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vegas games 2000 (usa)" sha1="f94739301a9352bb0b3f52a99393ef3b6ace448e"/>
+				<disk name="vegas games 2000 (usa)" sha1="950f66e7efae1a84aa6a1edeb4d7084c0d55153f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29099,7 +29099,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="viewpoint (usa)" sha1="495e5408ce67261120f5128d9ddb3c1e27320821"/>
+				<disk name="viewpoint (usa)" sha1="2019a0a7f0cf294e9f93c5ef7d72243500f1aac2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29312,7 +29312,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - v-rally (usa)" sha1="ea312ed2010a224acf94675342d5aeeb48214427"/>
+				<disk name="need for speed - v-rally (usa)" sha1="02cb03c751ea2d22b065a6588649b6e5d25cd2d1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29336,7 +29336,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="need for speed - v-rally 2 (usa)" sha1="e4eb2e42ddd69a0e591c008adcb06b9c49260dc5"/>
+				<disk name="need for speed - v-rally 2 (usa)" sha1="a0c2e8b268c5ce33a98ef66652fe7a9a16fa376c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29446,7 +29446,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vr sports powerboat racing (usa)" sha1="922b7edf37558c03d93dd6e093177ceff1ad378d"/>
+				<disk name="vr sports powerboat racing (usa)" sha1="5d5db014fbb80d764ea4583867880b0ac125281e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29500,7 +29500,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="v-tennis (usa)" sha1="d4f4d0548ce5014736b3cb842b7feaeafcb9ea99"/>
+				<disk name="v-tennis (usa)" sha1="7f9f873b2462d06e13b96435483f0e25ec993587"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29517,7 +29517,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="warcraft ii - the dark saga (usa) (en,fr,de,es,it)" sha1="0cbccd6e495156337aafd0b5d2ca21d287d8ad03"/>
+				<disk name="warcraft ii - the dark saga (usa) (en,fr,de,es,it)" sha1="b33a8b1bd8a007725138b840e6baa386efd881b6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29588,7 +29588,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="warhawk - the red mercury missions (usa)" sha1="7d0fbd0a88465353f4880746212726786e5bfdc3"/>
+				<disk name="warhawk - the red mercury missions (usa)" sha1="27a6349c15269d5b5ea1cec65fdc6d598cdaf981"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29810,7 +29810,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="world destruction league - thunder tanks (usa)" sha1="e2834f6a373579793b1cbe475e11b8074aee9540"/>
+				<disk name="world destruction league - thunder tanks (usa)" sha1="2ab20dffff5961a1293b1ea77b50545b76c5d158"/>
 			</diskarea>
 		</part>
 	</software>
@@ -29957,7 +29957,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="who wants to be a millionaire - 3rd edition (usa)" sha1="2bd8d522484e153d83ba40d4af29ff970e905cf5"/>
+				<disk name="who wants to be a millionaire - 3rd edition (usa)" sha1="8905733e730fd883cc8ef73731e17c98c4cc1ef6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30444,7 +30444,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf attitude (usa)" sha1="b268502bd345e64ec78abf064fa7282cd879061c"/>
+				<disk name="wwf attitude (usa)" sha1="99705956be9321648758a86fa8921f3678649511"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30462,7 +30462,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf in your house (usa) (v1.1)" sha1="797f8d3655a02cdf231e973b662343580337e232"/>
+				<disk name="wwf in your house (usa) (v1.1)" sha1="7f9ee48b66b97c00f825a252abb5e133f6f52a6b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30497,7 +30497,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf wrestlemania - the arcade game (usa)" sha1="9b2b6d1d6d2793a321ece7409ae9a76e77db4ff4"/>
+				<disk name="wwf wrestlemania - the arcade game (usa)" sha1="887df77fc1b3d73c906f04b6509c1ab710fbb9bb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30531,7 +30531,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf smackdown (usa)" sha1="9fb74cc0699ee1a11ee3e2838ec7885636ef7862"/>
+				<disk name="wwf smackdown (usa)" sha1="188a1e58141544712ef6dc9e75ebbbe26831b40c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30549,7 +30549,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf war zone (usa) (v1.1)" sha1="fbe408d78500a5441e280e7aaa59f11500c050fb"/>
+				<disk name="wwf war zone (usa) (v1.1)" sha1="17e6c6470688d54e5ec008fe085187afbcaec52c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30680,12 +30680,12 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="xenogears (usa) (disc 1)" sha1="64a49e3b3bcd14ef74f363d5a5ccf366e283d790"/>
+				<disk name="xenogears (usa) (disc 1)" sha1="2b3ce2abb86c1ef68c4aa5baa54a95887f95015d"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="xenogears (usa) (disc 2)" sha1="918b8d1b36037e47ba87c9504f53f83d151dadc3"/>
+				<disk name="xenogears (usa) (disc 2)" sha1="bbb7eaea1bace092a96691ba604ba5c906d3da93"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30702,7 +30702,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="xevious 3d-g+ (usa)" sha1="a8ab9950c8b627f67ac0b33731741f089d08f604"/>
+				<disk name="xevious 3d-g+ (usa)" sha1="168b85cd3561c918ddb443fef133e2c13ae77519"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30775,7 +30775,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men - children of the atom (usa)" sha1="db53105be644f4e24440b3e98bf8971feeb69d52"/>
+				<disk name="x-men - children of the atom (usa)" sha1="da09e144894978fc306eff0e4a4ddcc74de88b38"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30803,7 +30803,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men - mutant academy (usa)" sha1="f278224ff06ea10c46abe85145ab124b043ff000"/>
+				<disk name="x-men - mutant academy (usa)" sha1="5829f1227cca671c1bc29b820ee97932449730ad"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30832,7 +30832,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men - mutant academy 2 (usa)" sha1="7e021fc6b42cdfe18b8572e2d271182d3aa04e04"/>
+				<disk name="x-men - mutant academy 2 (usa)" sha1="c80819e5a50d971a3ff7c38650b4757aec5c015c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -30849,7 +30849,7 @@ For an overview of US PS1 discs that have not been dumped and added to redump's 
 		<sharedfeat name="compatibility" value="NTSC-U"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="x-men vs. street fighter (usa)" sha1="05be871ffb7e54985689a10a31638c1324cae3f7"/>
+				<disk name="x-men vs. street fighter (usa)" sha1="a5de42525daba6420653b835e01ea99d8e6b8799"/>
 			</diskarea>
 		</part>
 	</software>
@@ -37182,8 +37182,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Creature Shock (Japan)</description>
 		<year>1996</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-00120~SLPS-00121"/>
-		<info name="release" value="19960823"/>
+		<info name="serial" value="SLPS-00120~SLPS-00121" />
+		<info name="release" value="19960823" />
 		<info name="alt_title" value="クリーチャーショック"/>
 		<info name="ring_code" value="SLPS-00120   1 (Disc 1), SLPS-00121   1 (Disc 2)"/>
 		<info name="barcode" value="4 961082 300081"/>
@@ -37208,7 +37208,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1996</year>
 		<publisher>Sony Computer Entertainment</publisher>
 		<info name="serial" value="SCPS 18003"/>
-		<info name="release" value="19961206"/>
+		<info name="release" value="19961206" />
 		<info name="barcode" value="4 948872 180030"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37229,7 +37229,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2003</year>
 		<publisher>Square Enix</publisher>
 		<info name="serial" value="SLPM-87317"/>
-		<info name="release" value="20031023"/>
+		<info name="release" value="20031023" />
 		<info name="alt_title" value="フロントミッション ザ・ファースト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37250,7 +37250,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1996</year>
 		<publisher>Harvest One</publisher>
 		<info name="serial" value="SLPS-00348"/>
-		<info name="release" value="19961011"/>
+		<info name="release" value="19961011" />
 		<info name="alt_title" value="リーディングジョッキーハイブリッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37267,7 +37267,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Hudson</publisher>
 		<info name="serial" value="SLPS-01866"/>
 		<info name="alt_title" value="Piとメール"/>
-		<info name="release" value="19990211"/>
+		<info name="release" value="19990211" />
 		<info name="barcode" value="4 988607 050252"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37287,8 +37287,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Raiden DX (Japan, Major Wave Series)</description>
 		<year>2000</year>
 		<publisher>Hamster</publisher>
-		<info name="serial" value="SLPM-86656"/>
-		<info name="release" value="20001026"/>
+		<info name="serial" value="SLPM-86656" />
+		<info name="release" value="20001026" />
 		<info name="alt_title" value="雷電ディー・エックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37308,8 +37308,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Raiden DX (Japan)</description>
 		<year>1997</year>
 		<publisher>Nihon System</publisher>
-		<info name="serial" value="SLPS-00728"/>
-		<info name="release" value="19970411"/>
+		<info name="serial" value="SLPS-00728" />
+		<info name="release" value="19970411" />
 		<info name="alt_title" value="雷電DX"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37328,8 +37328,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Raiden Project (Japan)</description>
 		<year>1995</year>
 		<publisher>Nihon System</publisher>
-		<info name="serial" value="SLPS-00013, SLPS-91002 (Playstation the Best)"/>
-		<info name="release" value="19950127, 19960712 (Playstation the Best)"/>
+		<info name="serial" value="SLPS-00013, SLPS-91002 (Playstation the Best)" />
+		<info name="release" value="19950127, 19960712 (Playstation the Best)" />
 		<info name="alt_title" value="雷電プロジェクト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37346,7 +37346,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Sony Computer Entertainment</publisher>
 		<info name="serial" value="SCPS 10015, SCPS 91008"/>
 		<info name="alt_title" value="戦闘国家 AIR LAND BATTLE"/>
-		<info name="release" value="19951201"/>
+		<info name="release" value="19951201" />
 		<info name="barcode" value="4 948872 100151, 4 948872 910088"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37367,7 +37367,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="SLPM-86344 (TCPS10011)"/>
-		<info name="release" value="19991111"/>
+		<info name="release" value="19991111" />
 		<info name="alt_title" value="サイドバイサイドスペシャル２０００"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37384,7 +37384,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Yutaka</publisher>
 		<info name="serial" value="SLPS 00596 (104017-0052421-9800), SLPS 00740 (104017-0051785-5800)"/>
 		<info name="alt_title" value="聖刻1092 操兵伝"/>
-		<info name="release" value="19971106"/>
+		<info name="release" value="19971106" />
 		<info name="barcode" value="4 974229 517853, 4 974229 524219"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37405,7 +37405,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>Riverhill Soft</publisher>
 		<info name="serial" value="SLPS-01037, SLPS-91086 (Playstation the Best)"/>
-		<info name="release" value="19971023, 19980806 (Playstation the Best)"/>
+		<info name="release" value="19971023, 19980806 (Playstation the Best)" />
 		<info name="alt_title" value="ワールド・ネバーランド ～オルルド王国物語～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37474,8 +37474,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>007 - Tomorrow Never Dies (Japan)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts Square</publisher>
-		<info name="serial" value="SLPS-02604"/>
-		<info name="release" value="20000210"/>
+		<info name="serial" value="SLPS-02604" />
+		<info name="release" value="20000210" />
 		<info name="alt_title" value="００７　～トゥモロー・ネバー・ダイ～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37509,8 +37509,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>10101 - "Will" the Starship (Japan)</description>
 		<year>1997</year>
 		<publisher>Sound Technology Japan</publisher>
-		<info name="serial" value="SLPS-01054"/>
-		<info name="release" value="19971106"/>
+		<info name="serial" value="SLPS-01054" />
+		<info name="release" value="19971106" />
 		<info name="alt_title" value="10101 スターシップ・ウィル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37530,8 +37530,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>19-ji 03-pun Ueno Hatsu Yakou Ressha (Japan)</description>
 		<year>1999</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPS-01865"/>
-		<info name="release" value="19990304"/>
+		<info name="serial" value="SLPS-01865" />
+		<info name="release" value="19990304" />
 		<info name="alt_title" value="19時03分　上野発夜光列車"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37551,8 +37551,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>1-on-1 - Single Basketball (Japan)</description>
 		<year>1998</year>
 		<publisher>Jorudan</publisher>
-		<info name="serial" value="SLPS-01706"/>
-		<info name="release" value="19981126"/>
+		<info name="serial" value="SLPS-01706" />
+		<info name="release" value="19981126" />
 		<info name="alt_title" value="ワン オン ワン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37575,8 +37575,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>First Kiss Monogatari (Japan)</description>
 		<year>1998</year>
 		<publisher>HuneX</publisher>
-		<info name="serial" value="SLPS-01708~SLPS-01709"/>
-		<info name="release" value="19981126"/>
+		<info name="serial" value="SLPS-01708~SLPS-01709" />
+		<info name="release" value="19981126" />
 		<info name="alt_title" value="ファーストKiss☆物語"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -37601,8 +37601,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>20 Seiki Striker Retsuden - The 20th Century's Real Strikers (Japan)</description>
 		<year>2000</year>
 		<publisher>DaZZ</publisher>
-		<info name="serial" value="SLPS-02348 (PS-0014)"/>
-		<info name="release" value="20000210"/>
+		<info name="serial" value="SLPS-02348 (PS-0014)" />
+		<info name="release" value="20000210" />
 		<info name="alt_title" value="20世紀ストライカー列伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37622,8 +37622,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Abe a GoGo (Japan)</description>
 		<year>1997</year>
 		<publisher>GameBank</publisher>
-		<info name="serial" value="SLPS-01118"/>
-		<info name="release" value="19971211"/>
+		<info name="serial" value="SLPS-01118" />
+		<info name="release" value="19971211" />
 		<info name="alt_title" value="エイブ・ア・ゴーゴー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37643,8 +37643,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Acid (Japan)</description>
 		<year>1999</year>
 		<publisher>Taki</publisher>
-		<info name="serial" value="SLPS-02119"/>
-		<info name="release" value="19990708"/>
+		<info name="serial" value="SLPS-02119" />
+		<info name="release" value="19990708" />
 		<info name="alt_title" value="アシッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37667,8 +37667,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aconcagua (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10131~SCPS-10132"/>
-		<info name="release" value="20000601"/>
+		<info name="serial" value="SCPS-10131~SCPS-10132" />
+		<info name="release" value="20000601" />
 		<info name="alt_title" value="アコンカグア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -37694,8 +37694,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ad Lib Ouji ...to Fuyukai na Nakamatachi!? (Japan)</description>
 		<year>2002</year>
 		<publisher>Nihon Telenet</publisher>
-		<info name="serial" value="SLPS-03510"/>
-		<info name="release" value="20021219"/>
+		<info name="serial" value="SLPS-03510" />
+		<info name="release" value="20021219" />
 		<info name="alt_title" value="アドリブ王子 …と不愉快な仲間達!?"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37716,8 +37716,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Advan Racing (Japan)</description>
 		<year>1998</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-01689"/>
-		<info name="release" value="19981119"/>
+		<info name="serial" value="SLPS-01689" />
+		<info name="release" value="19981119" />
 		<info name="alt_title" value="アドバン・レーシング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37737,8 +37737,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Afraid Gear Another (Japan)</description>
 		<year>2001</year>
 		<publisher>Office Create</publisher>
-		<info name="serial" value="SLPM-86834"/>
-		<info name="release" value="20010614"/>
+		<info name="serial" value="SLPM-86834" />
+		<info name="release" value="20010614" />
 		<info name="alt_title" value="アフレイドギア・アナザ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37768,8 +37768,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Afraid Gear (Japan)</description>
 		<year>1998</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-00995"/>
-		<info name="release" value="19981029"/>
+		<info name="serial" value="SLPS-00995" />
+		<info name="release" value="19981029" />
 		<info name="alt_title" value="アフレイドギア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37816,8 +37816,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Airgrave (Japan)</description>
 		<year>1996</year>
 		<publisher>Santos</publisher>
-		<info name="serial" value="SLPS-00559"/>
-		<info name="release" value="19961129"/>
+		<info name="serial" value="SLPS-00559" />
+		<info name="release" value="19961129" />
 		<info name="alt_title" value="エア・グレイヴ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37837,8 +37837,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Airs (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01916"/>
-		<info name="release" value="19990325"/>
+		<info name="serial" value="SLPS-01916" />
+		<info name="release" value="19990325" />
 		<info name="alt_title" value="エアーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37880,8 +37880,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aitakute... Your Smiles in My Heart (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86254~SLPM-86257 (VX058-J1)"/>
-		<info name="release" value="20000316"/>
+		<info name="serial" value="SLPM-86254~SLPM-86257 (VX058-J1)" />
+		<info name="release" value="20000316" />
 		<info name="alt_title" value="あいたくて・・・your smiles in my heart"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -37916,8 +37916,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aizouban Houshin Engi (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86209"/>
-		<info name="release" value="19990401"/>
+		<info name="serial" value="SLPM-86209" />
+		<info name="release" value="19990401" />
 		<info name="alt_title" value="愛蔵版 封神演義"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37937,8 +37937,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Akagawa Jirou Majo-tachi no Nemuri - Fukkatsu Matsuri (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01863"/>
-		<info name="release" value="19990415"/>
+		<info name="serial" value="SLPS-01863" />
+		<info name="release" value="19990415" />
 		<info name="alt_title" value="赤川次郎 魔女たちの眠り ―復活祭―"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37958,8 +37958,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Akagawa Jirou - Yasoukyoku 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-03213"/>
-		<info name="release" value="20010614"/>
+		<info name="serial" value="SLPS-03213" />
+		<info name="release" value="20010614" />
 		<info name="alt_title" value="赤川次郎 夜想曲2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -37979,8 +37979,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pop de Cute na Shinri Test - Alabama (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPS-02961"/>
-		<info name="release" value="20000921"/>
+		<info name="serial" value="SLPS-02961" />
+		<info name="release" value="20000921" />
 		<info name="alt_title" value="ポップでキュートな心理テスト アラバマ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38001,8 +38001,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Albalea no Otome - Uruwashi no Seishikitachi (Japan)</description>
 		<year>1998</year>
 		<publisher>Masaya</publisher>
-		<info name="serial" value="SLPS-01578"/>
-		<info name="release" value="19981008"/>
+		<info name="serial" value="SLPS-01578" />
+		<info name="release" value="19981008" />
 		<info name="alt_title" value="アルバレアの乙女 麗しの聖騎士たち"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38022,8 +38022,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Alice in Cyberland (Japan)</description>
 		<year>1996</year>
 		<publisher>Glams</publisher>
-		<info name="serial" value="SLPS-00636"/>
-		<info name="release" value="19961220"/>
+		<info name="serial" value="SLPS-00636" />
+		<info name="release" value="19961220" />
 		<info name="alt_title" value="ありす イン サイバーランド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38049,8 +38049,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Alive (Japan)</description>
 		<year>1998</year>
 		<publisher>General Entertainment</publisher>
-		<info name="serial" value="SLPS-01527~SLPS-01529"/>
-		<info name="release" value="19980806"/>
+		<info name="serial" value="SLPS-01527~SLPS-01529" />
+		<info name="release" value="19980806" />
 		<info name="alt_title" value="アライブ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38080,8 +38080,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gensou no Altemis - Actress School Mystery Adventure (Japan)</description>
 		<year>2000</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-02563"/>
-		<info name="release" value="20000127"/>
+		<info name="serial" value="SLPS-02563" />
+		<info name="release" value="20000127" />
 		<info name="alt_title" value="幻想のアルテミス〜Actress School Mystery Adventure〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38101,8 +38101,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Alundra 2 - Mashinka no Nazo (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10115"/>
-		<info name="release" value="19991118"/>
+		<info name="serial" value="SCPS-10115" />
+		<info name="release" value="19991118" />
 		<info name="alt_title" value="アランドラ2 魔進化の謎"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38124,8 +38124,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Another Memories (Japan)</description>
 		<year>1998</year>
 		<publisher>Hearty Robin</publisher>
-		<info name="serial" value="SLPS-01431"/>
-		<info name="release" value="19980618"/>
+		<info name="serial" value="SLPS-01431" />
+		<info name="release" value="19980618" />
 		<info name="alt_title" value="アナザー メモリーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38145,8 +38145,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>A Nanjarin (Japan)</description>
 		<year>1998</year>
 		<publisher>To One</publisher>
-		<info name="serial" value="SLPS-01424"/>
-		<info name="release" value="19980611"/>
+		<info name="serial" value="SLPS-01424" />
+		<info name="release" value="19980611" />
 		<info name="alt_title" value="あっナンジャリン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38169,8 +38169,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ancient Roman - Power of the Dark Side (Japan)</description>
 		<year>1998</year>
 		<publisher>Nihon Systems</publisher>
-		<info name="serial" value="SLPS-01108~SLPS-01109"/>
-		<info name="release" value="19980423"/>
+		<info name="serial" value="SLPS-01108~SLPS-01109" />
+		<info name="release" value="19980423" />
 		<info name="alt_title" value="アンシャントロマン パワー・オブ・ダークサイド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38195,8 +38195,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angelique Duet (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01337"/>
-		<info name="release" value="19980730"/>
+		<info name="serial" value="SLPS-01337" />
+		<info name="release" value="19980730" />
 		<info name="alt_title" value="アンジェリーク デュエット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38218,8 +38218,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angel Blade (Japan)</description>
 		<year>1997</year>
 		<publisher>On DiMand</publisher>
-		<info name="serial" value="SLPS-00894"/>
-		<info name="release" value="19970703"/>
+		<info name="serial" value="SLPS-00894" />
+		<info name="release" value="19970703" />
 		<info name="alt_title" value="エンジェル・ブレード Neo Tokyo Guardians ~ Angel Blade - Neo Tokyo Guardians (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38240,8 +38240,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angel Graffiti - Anata e no Profile (Japan)</description>
 		<year>1996</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-00163"/>
-		<info name="release" value="19960726"/>
+		<info name="serial" value="SLPS-00163" />
+		<info name="release" value="19960726" />
 		<info name="alt_title" value="エンジェルグラフィティ あなたへのプロフィール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38261,8 +38261,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angolmois '99 (Japan, SuperLite 1500 Series)</description>
 		<year>1999</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86278"/>
-		<info name="release" value="19990826"/>
+		<info name="serial" value="SLPM-86278" />
+		<info name="release" value="19990826" />
 		<info name="alt_title" value="SuperLite 1500 シリーズ アンゴルモア99"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38284,8 +38284,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angelique Special (Japan)</description>
 		<year>1996</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00320"/>
-		<info name="release" value="19960329"/>
+		<info name="serial" value="SLPS-00320" />
+		<info name="release" value="19960329" />
 		<info name="alt_title" value="アンジェリークスペシャル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38305,8 +38305,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angelique Special 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00805"/>
-		<info name="release" value="19970411"/>
+		<info name="serial" value="SLPS-00805" />
+		<info name="release" value="19970411" />
 		<info name="alt_title" value="アンジェリークスペシャル2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38326,8 +38326,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Angelique Tenkuu no Requiem (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86165"/>
-		<info name="release" value="19990204"/>
+		<info name="serial" value="SLPM-86165" />
+		<info name="release" value="19990204" />
 		<info name="alt_title" value="アンジェリーク 天空の鎮魂歌"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38350,8 +38350,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ayakashi Ninden Kunoichiban (Japan)</description>
 		<year>1997</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-00946~SLPS-00947"/>
-		<info name="release" value="19970925"/>
+		<info name="serial" value="SLPS-00946~SLPS-00947" />
+		<info name="release" value="19970925" />
 		<info name="alt_title" value="あやかし忍伝 くの一番"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38376,8 +38376,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kids Station - Soreike! Anpanman 2 - Anpanman to Daibouken! (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03197"/>
-		<info name="release" value="20010726"/>
+		<info name="serial" value="SLPS-03197" />
+		<info name="release" value="20010726" />
 		<info name="alt_title" value="キッズステーション それいけ！アンパンマン2 アンパンマンとだいぼうけん！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38400,8 +38400,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ao no Roku-gou - Antarctica (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02940~SLPS-02941"/>
-		<info name="release" value="20000928"/>
+		<info name="serial" value="SLPS-02940~SLPS-02941" />
+		<info name="release" value="20000928" />
 		<info name="alt_title" value="青の6号 アンタクティカ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38426,8 +38426,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ao Zora to Nakama Tachi - Yume No Bouken (Japan)</description>
 		<year>2003</year>
 		<publisher>MTO</publisher>
-		<info name="serial" value="SLPS-03564"/>
-		<info name="release" value="20031113"/>
+		<info name="serial" value="SLPS-03564" />
+		<info name="release" value="20031113" />
 		<info name="alt_title" value="アオ・ゾーラと仲間たち 夢の冒険プラス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38447,8 +38447,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Saru! Get You! (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10091"/>
-		<info name="release" value="19990604"/>
+		<info name="serial" value="SCPS-10091" />
+		<info name="release" value="19990604" />
 		<info name="alt_title" value="サルゲッチュ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38469,8 +38469,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aquanaut no Kyuujitsu 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-02141"/>
-		<info name="release" value="19990701"/>
+		<info name="serial" value="SLPS-02141" />
+		<info name="release" value="19990701" />
 		<info name="alt_title" value="アクアノートの休日2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38490,8 +38490,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aqua Paradise - Boku no Suizokukan (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-03095"/>
-		<info name="release" value="20001228"/>
+		<info name="serial" value="SLPS-03095" />
+		<info name="release" value="20001228" />
 		<info name="alt_title" value="アクアパラダイス ぼくの水族館"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38513,8 +38513,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aquarian Age - Tokyo Wars (Japan)</description>
 		<year>2000</year>
 		<publisher>ESP Software</publisher>
-		<info name="serial" value="SLPS-02731"/>
-		<info name="release" value="20000525"/>
+		<info name="serial" value="SLPS-02731" />
+		<info name="release" value="20000525" />
 		<info name="alt_title" value="アクエリアン・エイジ　～東京・ウォーズ～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38542,8 +38542,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>A5 - A Ressha de Ikou 5 (Japan, Playstation the Best)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-91124 (Playstation the Best)"/>
-		<info name="release" value="19990325"/>
+		<info name="serial" value="SLPS-91124 (Playstation the Best)" />
+		<info name="release" value="19990325" />
 		<info name="alt_title" value="A5 A列車で行こう5"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38569,8 +38569,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>A Ressha de Ikou Z - Mezase! Tairiku Oudan (Japan)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-02050"/>
-		<info name="release" value="19990504"/>
+		<info name="serial" value="SLPS-02050" />
+		<info name="release" value="19990504" />
 		<info name="alt_title" value="A列車で行こうZ 目指せ！大陸横断"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38592,8 +38592,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arkana Senki Ludo (Japan)</description>
 		<year>1998</year>
 		<publisher>Pai</publisher>
-		<info name="serial" value="SLPS-01438"/>
-		<info name="release" value="19980709"/>
+		<info name="serial" value="SLPS-01438" />
+		<info name="release" value="19980709" />
 		<info name="alt_title" value="アルカナ戦記ルド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38613,8 +38613,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arkanoid R 2000 (Japan)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86262 (TCPS10006)"/>
-		<info name="release" value="19990701"/>
+		<info name="serial" value="SLPM-86262 (TCPS10006)" />
+		<info name="release" value="19990701" />
 		<info name="alt_title" value="アルカノイドリターンズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38634,8 +38634,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Armed Fighter (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-01598"/>
-		<info name="release" value="19990304"/>
+		<info name="serial" value="SLPS-01598" />
+		<info name="release" value="19990304" />
 		<info name="alt_title" value="アームド・ファイター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38655,8 +38655,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Agent Armstrong - Himitsu Shirei Daisakusen (Japan)</description>
 		<year>1997</year>
 		<publisher>WENet</publisher>
-		<info name="serial" value="SLPS-01073 (WG 0005)"/>
-		<info name="release" value="19971204"/>
+		<info name="serial" value="SLPS-01073 (WG 0005)" />
+		<info name="release" value="19971204" />
 		<info name="alt_title" value="エージェントアームストロング 秘密司令大作戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38676,8 +38676,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Art Camion - Geijutsuden (Japan, re-release 2002)</description>
 		<year>2002</year>
 		<publisher>TYO</publisher>
-		<info name="serial" value="SLPM-87186"/>
-		<info name="release" value="20021202"/>
+		<info name="serial" value="SLPM-87186" />
+		<info name="release" value="20021202" />
 		<info name="alt_title" value="アートカミオン 芸術伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38697,8 +38697,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Art Camion - Geijutsuden (Japan)</description>
 		<year>1999</year>
 		<publisher>TYO</publisher>
-		<info name="serial" value="SLPS-02405"/>
-		<info name="release" value="19991216"/>
+		<info name="serial" value="SLPS-02405" />
+		<info name="release" value="19991216" />
 		<info name="alt_title" value="アートカミオン 芸術伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38721,8 +38721,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Astronoka (Japan)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86088~SLPM-86089"/>
-		<info name="release" value="19980827"/>
+		<info name="serial" value="SLPM-86088~SLPM-86089" />
+		<info name="release" value="19980827" />
 		<info name="alt_title" value="アストロノーカ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38748,8 +38748,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Asuka 120% Burning Fest. Excellent (Japan)</description>
 		<year>1997</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-00849"/>
-		<info name="release" value="19970509"/>
+		<info name="serial" value="SLPS-00849" />
+		<info name="release" value="19970509" />
 		<info name="alt_title" value="あすか120%エクセレント BURNING Fest. EXCELLENT"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38770,8 +38770,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Asuka 120% Burning Fest. Final (Japan)</description>
 		<year>1999</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-02074"/>
-		<info name="release" value="19990527"/>
+		<info name="serial" value="SLPS-02074" />
+		<info name="release" value="19990527" />
 		<info name="alt_title" value="あすか120%ファイナル BURNING Fest."/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38815,8 +38815,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Asuka 120% Burning Fest. Special (Japan)</description>
 		<year>1996</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-00231"/>
-		<info name="release" value="19960329"/>
+		<info name="serial" value="SLPS-00231" />
+		<info name="release" value="19960329" />
 		<info name="alt_title" value="あすか120％ スペシャル BURNING Fest."/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38868,8 +38868,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Asuncia - Matsue no Jubaku (Japan, XING Maru-yasu Series)</description>
 		<year>2000</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-03075"/>
-		<info name="release" value="20001207"/>
+		<info name="serial" value="SLPS-03075" />
+		<info name="release" value="20001207" />
 		<info name="alt_title" value="アサンシア ～魔杖の呪縛～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38897,8 +38897,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Athena - Awakening from the Ordinary Life (Japan, Koei the Best)</description>
 		<year>1999</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86185~SLPM-86187"/>
-		<info name="release" value="19990311"/>
+		<info name="serial" value="SLPM-86185~SLPM-86187" />
+		<info name="release" value="19990311" />
 		<info name="alt_title" value="アテナ ~Awakening from the ordinary life~"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -38948,8 +38948,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Advanced V.G. (Japan)</description>
 		<year>1996</year>
 		<publisher>TGL</publisher>
-		<info name="serial" value="SLPS-00208"/>
-		<info name="release" value="19960419"/>
+		<info name="serial" value="SLPS-00208" />
+		<info name="release" value="19960419" />
 		<info name="alt_title" value="アドヴァンスト ヴァリアブル・ジオ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -38973,8 +38973,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Advanced V.G. 2 (Japan, SuperLite 1500 Series)</description>
 		<year>2003</year>
 		<publisher>TGL</publisher>
-		<info name="serial" value="SLPM-87226"/>
-		<info name="release" value="20030227"/>
+		<info name="serial" value="SLPM-87226" />
+		<info name="release" value="20030227" />
 		<info name="alt_title" value="SuperLite1500シリーズ アドヴァンスト ヴァリアブル・ジオ2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39001,8 +39001,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Azito (Japan)</description>
 		<year>1997</year>
 		<publisher>Astec21</publisher>
-		<info name="serial" value="SLPS-00683"/>
-		<info name="release" value="19970228"/>
+		<info name="serial" value="SLPS-00683" />
+		<info name="release" value="19970228" />
 		<info name="alt_title" value="アジト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39023,8 +39023,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Azito 3 (Japan)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-02496"/>
-		<info name="release" value="20000217"/>
+		<info name="serial" value="SLPS-02496" />
+		<info name="release" value="20000217" />
 		<info name="alt_title" value="アジト3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39044,8 +39044,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Azumanga Donjara Daiou (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03424"/>
-		<info name="release" value="20020418"/>
+		<info name="serial" value="SLPS-03424" />
+		<info name="release" value="20020418" />
 		<info name="alt_title" value="あずまんがドンジャラ大王"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39071,8 +39071,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>BackGuiner - Yomigaeru Yuusha-tachi - Hishou-hen 'Uragiri no Senjou' (Japan)</description>
 		<year>1998</year>
 		<publisher>Ving</publisher>
-		<info name="serial" value="SLPS-01446~SLPS-01448"/>
-		<info name="release" value="19980625"/>
+		<info name="serial" value="SLPS-01446~SLPS-01448" />
+		<info name="release" value="19980625" />
 		<info name="alt_title" value="バックガイナー よみがえる勇者たち 飛翔編「うらぎりの戦場」"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -39102,8 +39102,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bakuretsu Hunter - Mahjong Special (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00541"/>
-		<info name="release" value="19961025"/>
+		<info name="serial" value="SLPS-00541" />
+		<info name="release" value="19961025" />
 		<info name="alt_title" value="爆れつハンター まあじゃんすぺしゃる"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39123,8 +39123,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Uchuu Goushou-den - Bakuretsu Akindo (Japan)</description>
 		<year>1996</year>
 		<publisher>Astec21</publisher>
-		<info name="serial" value="SLPS-00236"/>
-		<info name="release" value="19960322"/>
+		<info name="serial" value="SLPS-00236" />
+		<info name="release" value="19960322" />
 		<info name="alt_title" value="爆裂商人 宇宙豪商伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39145,8 +39145,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bakumatsu Roman - Gekka no Kenshi (Japan)</description>
 		<year>1999</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86118"/>
-		<info name="release" value="19990225"/>
+		<info name="serial" value="SLPM-86118" />
+		<info name="release" value="19990225" />
 		<info name="alt_title" value="幕末浪漫 月華の剣士"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39166,8 +39166,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bakuryu (Japan)</description>
 		<year>2000</year>
 		<publisher>Fujimic</publisher>
-		<info name="serial" value="SLPS-02429"/>
-		<info name="release" value="20000914"/>
+		<info name="serial" value="SLPS-02429" />
+		<info name="release" value="20000914" />
 		<info name="alt_title" value="爆流"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39187,8 +39187,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Barbapapa (Japan)</description>
 		<year>2001</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03301"/>
-		<info name="release" value="20011004"/>
+		<info name="serial" value="SLPS-03301" />
+		<info name="release" value="20011004" />
 		<info name="alt_title" value="バーバパパ (キッズステーションコントローラセット) [Kid Station Controller Set Package]"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39208,8 +39208,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bardysh (Japan)</description>
 		<year>1999</year>
 		<publisher>Imadio</publisher>
-		<info name="serial" value="SLPS-02187"/>
-		<info name="release" value="19990722"/>
+		<info name="serial" value="SLPS-02187" />
+		<info name="release" value="19990722" />
 		<info name="alt_title" value="バルディッシュ 〜クロムフォードの住人たち〜 ~ Bardysh - Kromeford no Juunin-tachi (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39229,8 +39229,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Baroque Syndrome (Japan)</description>
 		<year>2000</year>
 		<publisher>Sting</publisher>
-		<info name="serial" value="SLPM-86540"/>
-		<info name="release" value="20000727"/>
+		<info name="serial" value="SLPM-86540" />
+		<info name="release" value="20000727" />
 		<info name="alt_title" value="バロック▲シンドローム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39250,8 +39250,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Baroque - Yuganda Mousou (Japan)</description>
 		<year>1999</year>
 		<publisher>Sting</publisher>
-		<info name="serial" value="SLPM-86341"/>
-		<info name="release" value="19991028"/>
+		<info name="serial" value="SLPM-86341" />
+		<info name="release" value="19991028" />
 		<info name="alt_title" value="バロック 歪んだ妄想"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39271,8 +39271,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fishing Freaks - BassRise (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01931"/>
-		<info name="release" value="19990325"/>
+		<info name="serial" value="SLPS-01931" />
+		<info name="release" value="19990325" />
 		<info name="alt_title" value="フィッシングフリーク バスライズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39294,8 +39294,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Battle Master (Japan, Major Wave Series)</description>
 		<year>2000</year>
 		<publisher>Hamster</publisher>
-		<info name="serial" value="SLPM-86519"/>
-		<info name="release" value="20000427"/>
+		<info name="serial" value="SLPM-86519" />
+		<info name="release" value="20000427" />
 		<info name="alt_title" value="バトルマスター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39315,8 +39315,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Battle "Sugoroku" - The Hunter - A.R.0062 (Japan, SuperLite 1500 Series)</description>
 		<year>1999</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86400"/>
-		<info name="release" value="19991222"/>
+		<info name="serial" value="SLPM-86400" />
+		<info name="release" value="19991222" />
 		<info name="alt_title" value="SuperLite 1500シリーズ バトルすごろく ハンター A.R.0062"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39336,8 +39336,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bealphareth (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10138"/>
-		<info name="release" value="20000928"/>
+		<info name="serial" value="SCPS-10138" />
+		<info name="release" value="20000928" />
 		<info name="alt_title" value="ベアルファレス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39357,8 +39357,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beat Planet Music (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-18013"/>
-		<info name="release" value="20000120"/>
+		<info name="serial" value="SCPS-18013" />
+		<info name="release" value="20000120" />
 		<info name="alt_title" value="ビートプラネットミュージック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39378,8 +39378,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>MTV's Beavis and Butt-Head in Virtual Stupidity (Japan)</description>
 		<year>1998</year>
 		<publisher>B-Factory</publisher>
-		<info name="serial" value="SLPS-01219"/>
-		<info name="release" value="19980129"/>
+		<info name="serial" value="SLPS-01219" />
+		<info name="release" value="19980129" />
 		<info name="alt_title" value="ビーバス&amp;バットヘッド ヴァーチャル・アホ症候群 ~ MTV's Beavis and Butt-Head - Virtual Aho Shoukougun (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39400,8 +39400,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Susume! Kaizoku - Be Pirates! (Japan)</description>
 		<year>1998</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-01737"/>
-		<info name="release" value="19981203"/>
+		<info name="serial" value="SLPS-01737" />
+		<info name="release" value="19981203" />
 		<info name="alt_title" value="進め! 海賊"/>
 		<info name="usage" value="Requires 3 blocks to save on PocketStation"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -39437,8 +39437,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Soukou Kihei Votoms Gaiden - Ao no Kishi Berserga Monogatari (Japan)</description>
 		<year>1997</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-00982"/>
-		<info name="release" value="19971030"/>
+		<info name="serial" value="SLPS-00982" />
+		<info name="release" value="19971030" />
 		<info name="alt_title" value="装甲騎兵ボトムズ外伝 青の騎士 ベルゼルガ物語"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39458,8 +39458,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bass Fisherman - Texas (Japan)</description>
 		<year>1998</year>
 		<publisher>Sammy</publisher>
-		<info name="serial" value="SLPS-01304"/>
-		<info name="release" value="19980611"/>
+		<info name="serial" value="SLPS-01304" />
+		<info name="release" value="19980611" />
 		<info name="alt_title" value="バスフィッシャーマン TEXAS"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39480,8 +39480,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bishi Bashi Special (Japan, Konami the Best)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86825 (VX096-J2)"/>
-		<info name="release" value="20010927"/>
+		<info name="serial" value="SLPM-86825 (VX096-J2)" />
+		<info name="release" value="20010927" />
 		<info name="alt_title" value="ビシバシスペシャル (コナミ ザ・ベスト)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39501,8 +39501,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bishi Bashi Special 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86267 (VX149-J1)"/>
-		<info name="release" value="19990902"/>
+		<info name="serial" value="SLPM-86267 (VX149-J1)" />
+		<info name="release" value="19990902" />
 		<info name="alt_title" value="ビシバシスペシャル2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39522,8 +39522,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bishi Bashi Special 3 - Step Champ (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86539 (VX182-J1)"/>
-		<info name="release" value="20000629"/>
+		<info name="serial" value="SLPM-86539 (VX182-J1)" />
+		<info name="release" value="20000629" />
 		<info name="alt_title" value="ビシバシスペシャル3 〜ステップチャンプ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39543,8 +39543,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Break Volley (Japan)</description>
 		<year>1999</year>
 		<publisher>Aqua Rouge</publisher>
-		<info name="serial" value="SLPS-02375"/>
-		<info name="release" value="19991102"/>
+		<info name="serial" value="SLPS-02375" />
+		<info name="release" value="19991102" />
 		<info name="alt_title" value="ブレイクバレー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39564,8 +39564,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Black Jack vs. Matsuda Jun (Japan)</description>
 		<year>2000</year>
 		<publisher>Pony Canyon</publisher>
-		<info name="serial" value="SLPS-01983"/>
-		<info name="release" value="20000810"/>
+		<info name="serial" value="SLPS-01983" />
+		<info name="release" value="20000810" />
 		<info name="alt_title" value="ブラックジャック VS 松田純"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39588,8 +39588,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Black Matrix Zero OO (Japan, Shokai Genteiban)</description>
 		<year>2004</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-03571~SLPS-03572"/>
-		<info name="release" value="20040513"/>
+		<info name="serial" value="SLPS-03571~SLPS-03572" />
+		<info name="release" value="20040513" />
 		<info name="alt_title" value="ブラックマトリクス ゼロ ダブルオー 初回限定版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -39617,8 +39617,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Black Matrix Cross (Japan)</description>
 		<year>2000</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-02962~SLPS-02963 (NIPS-4011)"/>
-		<info name="release" value="20001214"/>
+		<info name="serial" value="SLPS-02962~SLPS-02963 (NIPS-4011)" />
+		<info name="release" value="20001214" />
 		<info name="alt_title" value="ブラックマトリクスクロス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -39643,8 +39643,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blade Arts - Tasogare no Miyako R'lyeh (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86602"/>
-		<info name="release" value="20000928"/>
+		<info name="serial" value="SLPM-86602" />
+		<info name="release" value="20000928" />
 		<info name="alt_title" value="ブレイドアーツ 黄昏の都ルルイエ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39664,8 +39664,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>BladeMaker (Japan)</description>
 		<year>1999</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-01795"/>
-		<info name="release" value="19990701"/>
+		<info name="serial" value="SLPS-01795" />
+		<info name="release" value="19990701" />
 		<info name="alt_title" value="ブレードメーカー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39685,8 +39685,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blam! -MachineHead (Japan)</description>
 		<year>1997</year>
 		<publisher>Virgin Interactive</publisher>
-		<info name="serial" value="SLPS-00798"/>
-		<info name="release" value="19970523"/>
+		<info name="serial" value="SLPS-00798" />
+		<info name="release" value="19970523" />
 		<info name="alt_title" value="ブラム！マシーンヘッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39707,8 +39707,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blend x Brand - Odekake Gousei RPG (Japan)</description>
 		<year>2000</year>
 		<publisher>Tonkin House</publisher>
-		<info name="serial" value="SLPS-02818"/>
-		<info name="release" value="20000629"/>
+		<info name="serial" value="SLPS-02818" />
+		<info name="release" value="20000629" />
 		<info name="alt_title" value="ブレンド×ブランド おでかけ合成RPG"/>
 		<info name="usage" value="Requires 15 free blocks on memory card to start (PocketStation)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -39729,8 +39729,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Block Kuzushi - Kowashite Help! (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Gallop</publisher>
-		<info name="serial" value="SLPS-03042"/>
-		<info name="release" value="20001207"/>
+		<info name="serial" value="SLPS-03042" />
+		<info name="release" value="20001207" />
 		<info name="alt_title" value="ブロックくずし こわしてHELP!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39750,8 +39750,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Block Kuzushi 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Marvelous Entertaiment</publisher>
-		<info name="serial" value="SLPS-02578"/>
-		<info name="release" value="20000203"/>
+		<info name="serial" value="SLPS-02578" />
+		<info name="release" value="20000203" />
 		<info name="alt_title" value="ブロックくずし2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39771,8 +39771,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blood Factory (Japan)</description>
 		<year>1996</year>
 		<publisher>Interplay</publisher>
-		<info name="serial" value="SLPS-00235"/>
-		<info name="release" value="19960315"/>
+		<info name="serial" value="SLPS-00235" />
+		<info name="release" value="19960315" />
 		<info name="alt_title" value="ブラッドファクトリー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39792,8 +39792,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>b.l.u.e. - Legend of Water (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01459"/>
-		<info name="release" value="19980709"/>
+		<info name="serial" value="SLPS-01459" />
+		<info name="release" value="19980709" />
 		<info name="alt_title" value="ブルー Legend of water"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39813,8 +39813,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blue Breaker Burst - Egao no Asuni (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01580"/>
-		<info name="release" value="19980910"/>
+		<info name="serial" value="SLPS-01580" />
+		<info name="release" value="19980910" />
 		<info name="alt_title" value="ブルーブレイカーバースト 笑顔の明日に"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39834,8 +39834,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Blue Marlin (Japan)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
-		<info name="serial" value="SLPS-02752"/>
-		<info name="release" value="20000502"/>
+		<info name="serial" value="SLPS-02752" />
+		<info name="release" value="20000502" />
 		<info name="alt_title" value="ザ・ブルーマーリン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39856,8 +39856,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - Append 3rd Mix Mini (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86156 (KICA7921)"/>
-		<info name="release" value="19981127"/>
+		<info name="serial" value="SLPM-86156 (KICA7921)" />
+		<info name="release" value="19981127" />
 		<info name="alt_title" value="ビートマニア サードミックスミニ"/>
 		<info name="usage" value="Data disc, use the disc change feature from a core Beatmania"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -39878,8 +39878,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - Append 5th Mix - Time to Get Down (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86322 (VX179-J1)"/>
-		<info name="release" value="20000302"/>
+		<info name="serial" value="SLPM-86322 (VX179-J1)" />
+		<info name="release" value="20000302" />
 		<info name="alt_title" value="ビートマニア アペンド フィフスミックス Time to get down"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39899,8 +39899,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania Append 6th Mix + Core Remix (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87012 (VX255-J1)"/>
-		<info name="release" value="20020131"/>
+		<info name="serial" value="SLPM-87012 (VX255-J1)" />
+		<info name="release" value="20020131" />
 		<info name="alt_title" value="ビートマニア シックスミックス＋コアリミックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39920,8 +39920,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - Best Hits (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86596 (VX195-J1)"/>
-		<info name="release" value="20000727"/>
+		<info name="serial" value="SLPM-86596 (VX195-J1)" />
+		<info name="release" value="20000727" />
 		<info name="alt_title" value="ビートマニア ベストヒッツ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39941,8 +39941,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - Append Club Mix (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86692 (VX225-J1)"/>
-		<info name="release" value="20001221"/>
+		<info name="serial" value="SLPM-86692 (VX225-J1)" />
+		<info name="release" value="20001221" />
 		<info name="alt_title" value="ビートマニア アペンド クラブミックス"/>
 		<info name="usage" value="Data disc, use the disc change feature from a core Beatmania"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -39963,8 +39963,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - featuring Dreams Come True (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86597 (VX198-J1)"/>
-		<info name="release" value="20000727"/>
+		<info name="serial" value="SLPM-86597 (VX198-J1)" />
+		<info name="release" value="20000727" />
 		<info name="alt_title" value="ビートマニア フィーチャリング ドリームズ・カム・トゥルー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -39984,8 +39984,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania Append Gottamix 2 - Going Global (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86574 (VX197-J1)"/>
-		<info name="release" value="20000907"/>
+		<info name="serial" value="SLPM-86574 (VX197-J1)" />
+		<info name="release" value="20000907" />
 		<info name="alt_title" value="ビートマニア アペンド ゴッタミックス2～Going Global～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40005,8 +40005,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Beatmania - The Sound of Tokyo! - Produced by Konishi Yasuharu (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86769 (VX238-J1)"/>
-		<info name="release" value="20010329"/>
+		<info name="serial" value="SLPM-86769 (VX238-J1)" />
+		<info name="release" value="20010329" />
 		<info name="alt_title" value="ビートマニア：ザ サウンド オブ トーキョー 小西康陽プロデュース"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40026,8 +40026,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blaze &amp; Blade - Busters (Japan)</description>
 		<year>1998</year>
 		<publisher>T&amp;E Soft</publisher>
-		<info name="serial" value="SLPS-01576"/>
-		<info name="release" value="19980923"/>
+		<info name="serial" value="SLPS-01576" />
+		<info name="release" value="19980923" />
 		<info name="alt_title" value="ブレイズ アンド ブレイド バスターズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40047,8 +40047,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Blaze &amp; Blade - Eternal Quest (Japan)</description>
 		<year>1998</year>
 		<publisher>T&amp;E Soft</publisher>
-		<info name="serial" value="SLPS-01209"/>
-		<info name="release" value="19980129"/>
+		<info name="serial" value="SLPS-01209" />
+		<info name="release" value="19980129" />
 		<info name="alt_title" value="ブレイズ アンド ブレイド エターナルクエスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40069,8 +40069,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Breath of Fire III (Japan)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00990"/>
-		<info name="release" value="19970911"/>
+		<info name="serial" value="SLPS-00990" />
+		<info name="release" value="19970911" />
 		<info name="alt_title" value="ブレス オブ ファイアIII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40090,8 +40090,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Boku no Choro-Q (Japan)</description>
 		<year>2002</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPM-87024"/>
-		<info name="release" value="20020307"/>
+		<info name="serial" value="SLPM-87024" />
+		<info name="release" value="20020307" />
 		<info name="alt_title" value="ぼくのチョロQ こうつうルールをまもろう"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40111,8 +40111,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Boku wa Koukuu Kanseikan (Japan)</description>
 		<year>1999</year>
 		<publisher>Syscom</publisher>
-		<info name="serial" value="SLPS-02514"/>
-		<info name="release" value="19991222"/>
+		<info name="serial" value="SLPS-02514" />
+		<info name="release" value="19991222" />
 		<info name="alt_title" value="ぼくは航空管制官"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40132,8 +40132,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bonogurashi (Japan)</description>
 		<year>1996</year>
 		<publisher>Amuse</publisher>
-		<info name="serial" value="SLPS-00333"/>
-		<info name="release" value="19960607"/>
+		<info name="serial" value="SLPS-00333" />
+		<info name="release" value="19960607" />
 		<info name="alt_title" value="ぼのぐらし これで完璧でぃす ~ Bonogurashi - Kore de Kanpeki Disu (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40153,8 +40153,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Boundary Gate - Daughter of Kingdom (Japan)</description>
 		<year>1997</year>
 		<publisher>Pack-In-Soft</publisher>
-		<info name="serial" value="SLPS-00907"/>
-		<info name="release" value="19970717"/>
+		<info name="serial" value="SLPS-00907" />
+		<info name="release" value="19970717" />
 		<info name="alt_title" value="バウンダリーゲート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40174,8 +40174,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Brave Prove (Japan)</description>
 		<year>1998</year>
 		<publisher>Data West</publisher>
-		<info name="serial" value="SLPS-01316"/>
-		<info name="release" value="19980416"/>
+		<info name="serial" value="SLPS-01316" />
+		<info name="release" value="19980416" />
 		<info name="alt_title" value="ブレイヴ・プローヴ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40195,8 +40195,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shin Sedai Robot Senki - Brave Saga (Japan)</description>
 		<year>1998</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01756"/>
-		<info name="release" value="19981217"/>
+		<info name="serial" value="SLPS-01756" />
+		<info name="release" value="19981217" />
 		<info name="alt_title" value="新世代ロボット戦記 ブレイブサーガ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40219,8 +40219,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Brave Saga 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02580~SLPS-02581"/>
-		<info name="release" value="20000502"/>
+		<info name="serial" value="SLPS-02580~SLPS-02581" />
+		<info name="release" value="20000502" />
 		<info name="alt_title" value="ブレイブサーガ2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -40245,8 +40245,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Brave Sword (Japan)</description>
 		<year>2000</year>
 		<publisher>Sammy</publisher>
-		<info name="serial" value="SLPS-02889"/>
-		<info name="release" value="20001019"/>
+		<info name="serial" value="SLPS-02889" />
+		<info name="release" value="20001019" />
 		<info name="alt_title" value="ブレイブ・ソード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40266,8 +40266,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Burning Road (Japan)</description>
 		<year>1997</year>
 		<publisher>Vic Tokai</publisher>
-		<info name="serial" value="SLPS-00518"/>
-		<info name="release" value="19970131"/>
+		<info name="serial" value="SLPS-00518" />
+		<info name="release" value="19970131" />
 		<info name="alt_title" value="バーニング・ロード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40287,8 +40287,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Buckle Up! (Japan)</description>
 		<year>1998</year>
 		<publisher>Shangri-La</publisher>
-		<info name="serial" value="SLPS-01105"/>
-		<info name="release" value="19980129"/>
+		<info name="serial" value="SLPS-01105" />
+		<info name="release" value="19980129" />
 		<info name="alt_title" value="バックルアップ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40308,8 +40308,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bugi (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86133 (VX084-J1)"/>
-		<info name="release" value="19981119"/>
+		<info name="serial" value="SLPM-86133 (VX084-J1)" />
+		<info name="release" value="19981119" />
 		<info name="alt_title" value="武戯"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40329,8 +40329,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Burn Out (Japan, SuperLite 1500 Series)</description>
 		<year>2000</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86598"/>
-		<info name="release" value="20000824"/>
+		<info name="serial" value="SLPM-86598" />
+		<info name="release" value="20000824" />
 		<info name="alt_title" value="SuperLite1500シリーズ バーンアウト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40350,8 +40350,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Buttsubushi (Japan)</description>
 		<year>2001</year>
 		<publisher>Selen</publisher>
-		<info name="serial" value="SLPS-03162 (SLSA-0001)"/>
-		<info name="release" value="20010315"/>
+		<info name="serial" value="SLPS-03162 (SLSA-0001)" />
+		<info name="release" value="20010315" />
 		<info name="alt_title" value="ぶっつぶし"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40371,8 +40371,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>C1 Circuit (Japan)</description>
 		<year>1996</year>
 		<publisher>Invex</publisher>
-		<info name="serial" value="SLPS-00279"/>
-		<info name="release" value="19961004"/>
+		<info name="serial" value="SLPS-00279" />
+		<info name="release" value="19961004" />
 		<info name="alt_title" value="C1 サーキット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40392,8 +40392,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Calcolo! - Ochimo no Shooting (Japan)</description>
 		<year>1997</year>
 		<publisher>Clef Inventor</publisher>
-		<info name="serial" value="SLPS-01071"/>
-		<info name="release" value="19971106"/>
+		<info name="serial" value="SLPS-01071" />
+		<info name="release" value="19971106" />
 		<info name="alt_title" value="カルコロ おちものシューティング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40413,8 +40413,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Captain Commando (Japan)</description>
 		<year>1998</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01567"/>
-		<info name="release" value="19980917"/>
+		<info name="serial" value="SLPS-01567" />
+		<info name="release" value="19980917" />
 		<info name="alt_title" value="キャプテンコマンドー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40436,8 +40436,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Carnage Heart EZ - Easy Zapping (Japan)</description>
 		<year>1997</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-00919"/>
-		<info name="release" value="19970724"/>
+		<info name="serial" value="SLPS-00919" />
+		<info name="release" value="19970724" />
 		<info name="alt_title" value="カルネージハートEZ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40457,8 +40457,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Carom Shot 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Argent</publisher>
-		<info name="serial" value="SLPS-01486"/>
-		<info name="release" value="19980730"/>
+		<info name="serial" value="SLPS-01486" />
+		<info name="release" value="19980730" />
 		<info name="alt_title" value="キャロムショット2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40478,8 +40478,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Carton-kun (Japan)</description>
 		<year>2000</year>
 		<publisher>Irem</publisher>
-		<info name="serial" value="SLPS-02935"/>
-		<info name="release" value="20000921"/>
+		<info name="serial" value="SLPS-02935" />
+		<info name="release" value="20000921" />
 		<info name="alt_title" value="カートンくん"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40499,8 +40499,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Crazy Climber 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Nihon Bussan</publisher>
-		<info name="serial" value="SLPS-02582"/>
-		<info name="release" value="20000203"/>
+		<info name="serial" value="SLPS-02582" />
+		<info name="release" value="20000203" />
 		<info name="alt_title" value="クレイジー・クライマー2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40520,8 +40520,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arcade Hits - Crazy Climber (Japan, Major Wave Series)</description>
 		<year>2002</year>
 		<publisher>Hamster</publisher>
-		<info name="serial" value="SLPM-87067"/>
-		<info name="release" value="20020523"/>
+		<info name="serial" value="SLPM-87067" />
+		<info name="release" value="20020523" />
 		<info name="alt_title" value="アーケード・ヒッツ　～クレイジー・クライマー～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40541,8 +40541,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chaos Control (Japan)</description>
 		<year>1996</year>
 		<publisher>Virgin Interactive</publisher>
-		<info name="serial" value="SLPS-00168"/>
-		<info name="release" value="19961004"/>
+		<info name="serial" value="SLPS-00168" />
+		<info name="release" value="19961004" />
 		<info name="alt_title" value="カオス コントロール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40563,8 +40563,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chou Aniki - Kyuukyoku Muteki Ginga Saikyou Otoko (Japan)</description>
 		<year>1995</year>
 		<publisher>NCS</publisher>
-		<info name="serial" value="SLPS-00183"/>
-		<info name="release" value="19951229"/>
+		<info name="serial" value="SLPS-00183" />
+		<info name="release" value="19951229" />
 		<info name="alt_title" value="超兄貴 〜究極無敵銀河最強男〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40584,8 +40584,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chocolate Kiss (Japan)</description>
 		<year>2002</year>
 		<publisher>DigiCube</publisher>
-		<info name="serial" value="SLPS-03400"/>
-		<info name="release" value="20020214"/>
+		<info name="serial" value="SLPS-03400" />
+		<info name="release" value="20020214" />
 		<info name="alt_title" value="チョコレート♪キッス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40605,8 +40605,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Choro-Q (Japan)</description>
 		<year>1996</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-00242"/>
-		<info name="release" value="19960322"/>
+		<info name="serial" value="SLPS-00242" />
+		<info name="release" value="19960322" />
 		<info name="alt_title" value="チョロQ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40626,8 +40626,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Choro-Q Wonderful! (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02205"/>
-		<info name="release" value="19990805"/>
+		<info name="serial" value="SLPS-02205" />
+		<info name="release" value="19990805" />
 		<info name="alt_title" value="チョロQワンダフォー!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40647,8 +40647,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kuroi Hitomi no Noir - Cielgris Fantasm (Japan)</description>
 		<year>1999</year>
 		<publisher>Gust</publisher>
-		<info name="serial" value="SLPS-01450"/>
-		<info name="release" value="19990701"/>
+		<info name="serial" value="SLPS-01450" />
+		<info name="release" value="19990701" />
 		<info name="alt_title" value="黒い瞳のノア Cielgris Fantasm / Noir Yeux Noire (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40668,8 +40668,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Circuit Beat (Japan)</description>
 		<year>1996</year>
 		<publisher>Prism Arts</publisher>
-		<info name="serial" value="SLPS-00311"/>
-		<info name="release" value="19960517"/>
+		<info name="serial" value="SLPS-00311" />
+		<info name="release" value="19960517" />
 		<info name="alt_title" value="サーキットビード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40689,8 +40689,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chiisana Kyojin Microman (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01926"/>
-		<info name="release" value="19990311"/>
+		<info name="serial" value="SLPS-01926" />
+		<info name="release" value="19990311" />
 		<info name="alt_title" value="小さな巨人ミクロマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40710,8 +40710,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cleopatra's Fortune (Japan)</description>
 		<year>2001</year>
 		<publisher>Altron</publisher>
-		<info name="serial" value="SLPS-03187"/>
-		<info name="release" value="20010517"/>
+		<info name="serial" value="SLPS-03187" />
+		<info name="release" value="20010517" />
 		<info name="alt_title" value="クレオパトラ フォーチュン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40731,8 +40731,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Clock Tower - Ghost Head (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01290"/>
-		<info name="release" value="19980312"/>
+		<info name="serial" value="SLPS-01290" />
+		<info name="release" value="19980312" />
 		<info name="alt_title" value="クロックタワー ゴーストヘッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40752,8 +40752,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Click Manga - Dynamic Robot Taisen 1 (Japan)</description>
 		<year>1999</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-02131"/>
-		<info name="release" value="19990930"/>
+		<info name="serial" value="SLPS-02131" />
+		<info name="release" value="19990930" />
 		<info name="alt_title" value="クリックまんが ダイナミックロボット大戦1 出撃！驚異のロボット軍団！！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40773,8 +40773,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Click Manga - Dynamic Robot Taisen 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-02407"/>
-		<info name="release" value="19991216"/>
+		<info name="serial" value="SLPS-02407" />
+		<info name="release" value="19991216" />
 		<info name="alt_title" value="クリックまんが ダイナミックロボット大戦2 恐怖！悪魔族復活"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40794,8 +40794,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Click Manga - Click Nohi (Japan)</description>
 		<year>1999</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-02354"/>
-		<info name="release" value="19991028"/>
+		<info name="serial" value="SLPS-02354" />
+		<info name="release" value="19991028" />
 		<info name="alt_title" value="クリックまんが クリックのひ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40815,8 +40815,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Colorful Logic 3 - Fushigi na Henkei Logic (Japan)</description>
 		<year>2001</year>
 		<publisher>Altron</publisher>
-		<info name="serial" value="SLPS-03239"/>
-		<info name="release" value="20010712"/>
+		<info name="serial" value="SLPS-03239" />
+		<info name="release" value="20010712" />
 		<info name="alt_title" value="カラフルロジック3 不思議な変形ロジック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40836,8 +40836,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Community Pom (Japan)</description>
 		<year>1997</year>
 		<publisher>Fill-In Café</publisher>
-		<info name="serial" value="SLPS-00817"/>
-		<info name="release" value="19971030"/>
+		<info name="serial" value="SLPS-00817" />
+		<info name="release" value="19971030" />
 		<info name="alt_title" value="こみゅにてぃぽむ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40858,8 +40858,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Community Pom - Omoide o Dakishimete (Japan)</description>
 		<year>1999</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-02116"/>
-		<info name="release" value="19990624"/>
+		<info name="serial" value="SLPS-02116" />
+		<info name="release" value="19990624" />
 		<info name="alt_title" value="こみゅにてぃ ぽむ 想い出を抱きしめて"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40880,8 +40880,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Conveni Special - 3-tsu no Sekai o Dokusen Seyo (Japan)</description>
 		<year>1998</year>
 		<publisher>Ardink</publisher>
-		<info name="serial" value="SLPS-01301"/>
-		<info name="release" value="19980312"/>
+		<info name="serial" value="SLPS-01301" />
+		<info name="release" value="19980312" />
 		<info name="alt_title" value="ザ・コンビニ スペシャル ～3つの世界を独占せよ～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40901,8 +40901,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Honoo no Ryourinin - Cooking Fighter Tao (Japan)</description>
 		<year>1998</year>
 		<publisher>Nippon Ichi Software</publisher>
-		<info name="serial" value="SLPS-01382"/>
-		<info name="release" value="19980521"/>
+		<info name="serial" value="SLPS-01382" />
+		<info name="release" value="19980521" />
 		<info name="alt_title" value="炎の料理人 クッキングファイター 好"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40922,8 +40922,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cosmic Race (Japan)</description>
 		<year>1995</year>
 		<publisher>Neorex</publisher>
-		<info name="serial" value="SLPS-00009"/>
-		<info name="release" value="19950120"/>
+		<info name="serial" value="SLPS-00009" />
+		<info name="release" value="19950120" />
 		<info name="alt_title" value="コズミックレース"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40943,8 +40943,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cosmowarrior Zero (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86484 (TCPS10022)"/>
-		<info name="release" value="20000518"/>
+		<info name="serial" value="SLPM-86484 (TCPS10022)" />
+		<info name="release" value="20000518" />
 		<info name="alt_title" value="コスモウォーリアー零"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40965,8 +40965,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Märchen Adventure Cotton 100% (Japan, SuperLite 1500 Series)</description>
 		<year>2003</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-87211"/>
-		<info name="release" value="20030327"/>
+		<info name="serial" value="SLPM-87211" />
+		<info name="release" value="20030327" />
 		<info name="alt_title" value="SuperLite1500シリーズ メルヘンアドベンチャー コットン100％"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -40986,8 +40986,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Crime Crackers 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10037"/>
-		<info name="release" value="19971127"/>
+		<info name="serial" value="SCPS-10037" />
+		<info name="release" value="19971127" />
 		<info name="alt_title" value="クライムクラッカーズ2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41007,8 +41007,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Croc Adventure (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86310"/>
-		<info name="release" value="19990902"/>
+		<info name="serial" value="SLPM-86310" />
+		<info name="release" value="19990902" />
 		<info name="alt_title" value="クロックアドベンチャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41029,8 +41029,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cross Tantei Monogatari 1 - Kouhen (Japan, Major Wave Series)</description>
 		<year>2000</year>
 		<publisher>WorkJam</publisher>
-		<info name="serial" value="SLPM-86639"/>
-		<info name="release" value="20000928"/>
+		<info name="serial" value="SLPM-86639" />
+		<info name="release" value="20000928" />
 		<info name="alt_title" value="クロス探偵物語1 〜後編〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41059,8 +41059,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>CRW - Counter Revolution War (Japan)</description>
 		<year>1996</year>
 		<publisher>Acclaim</publisher>
-		<info name="serial" value="SLPS-00220"/>
-		<info name="release" value="19960830"/>
+		<info name="serial" value="SLPS-00220" />
+		<info name="release" value="19960830" />
 		<info name="alt_title" value="CRW カウンター・レボリューション・ウォー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41080,8 +41080,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Captain Tsubasa - Aratanaru Densetsu Joshou (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87060 (VX260-J1)"/>
-		<info name="release" value="20020516"/>
+		<info name="serial" value="SLPM-87060 (VX260-J1)" />
+		<info name="release" value="20020516" />
 		<info name="alt_title" value="キャプテン翼 〜新たな伝説・序章〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41101,8 +41101,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Captain Tsubasa J - Get in the Tomorrow (Japan)</description>
 		<year>1996</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00310"/>
-		<info name="release" value="19960503"/>
+		<info name="serial" value="SLPS-00310" />
+		<info name="release" value="19960503" />
 		<info name="alt_title" value="キャプテン翼J ゲットインザトゥモロゥ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41122,8 +41122,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cu-On-Pa (Japan)</description>
 		<year>1997</year>
 		<publisher>T&amp;E Soft</publisher>
-		<info name="serial" value="SLPS-01026"/>
-		<info name="release" value="19971009"/>
+		<info name="serial" value="SLPS-01026" />
+		<info name="release" value="19971009" />
 		<info name="alt_title" value="クオンパ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41144,8 +41144,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Success</publisher>
 		<!-- unsure whether this is the same as the original SLPS-01864 release (19990204) or not -->
-		<info name="serial" value="SLPM-86580"/>
-		<info name="release" value="20000928"/>
+		<info name="serial" value="SLPM-86580" />
+		<info name="release" value="20000928" />
 		<info name="alt_title" value="SuperLite1500シリーズ サイバー大戦略 出撃！はるか隊"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41168,8 +41168,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cybernetic Empire (Japan)</description>
 		<year>1999</year>
 		<publisher>Telenet</publisher>
-		<info name="serial" value="SLPS-01912~SLPS-01913"/>
-		<info name="release" value="19990805"/>
+		<info name="serial" value="SLPS-01912~SLPS-01913" />
+		<info name="release" value="19990805" />
 		<info name="alt_title" value="サイバネティック・エンパイア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -41200,8 +41200,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Cyber War (Japan)</description>
 		<year>1995</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-00055~SLPS-00057"/>
-		<info name="release" value="19950721"/>
+		<info name="serial" value="SLPS-00055~SLPS-00057" />
+		<info name="release" value="19950721" />
 		<info name="alt_title" value="サイバーウォー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -41231,8 +41231,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Daibouken Deluxe - Harukanaru Umi (Japan)</description>
 		<year>1997</year>
 		<publisher>Soft Office</publisher>
-		<info name="serial" value="SLPS-00813"/>
-		<info name="release" value="19970428"/>
+		<info name="serial" value="SLPS-00813" />
+		<info name="release" value="19970428" />
 		<info name="alt_title" value="大冒険デラックス 遥かなる海"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41252,8 +41252,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Daikoukai Jidai Gaiden (Japan)</description>
 		<year>1997</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01021"/>
-		<info name="release" value="19971002"/>
+		<info name="serial" value="SLPS-01021" />
+		<info name="release" value="19971002" />
 		<info name="alt_title" value="大航海時代外伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41273,8 +41273,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Daikoukai Jidai II (Japan)</description>
 		<year>1996</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00656"/>
-		<info name="release" value="19961227"/>
+		<info name="serial" value="SLPS-00656" />
+		<info name="release" value="19961227" />
 		<info name="alt_title" value="大航海時代II"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41294,8 +41294,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dakar '97 (Japan)</description>
 		<year>1997</year>
 		<publisher>Virgin Interactive</publisher>
-		<info name="serial" value="SLPS-00634"/>
-		<info name="release" value="19970425"/>
+		<info name="serial" value="SLPS-00634" />
+		<info name="release" value="19970425" />
 		<info name="alt_title" value="ダカール '97"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41321,8 +41321,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dancing Blade - Katteni Momotenshi! (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86100~SLPM-86102 (VX124-J1)"/>
-		<info name="release" value="19980827"/>
+		<info name="serial" value="SLPM-86100~SLPM-86102 (VX124-J1)" />
+		<info name="release" value="19980827" />
 		<info name="alt_title" value="ダンシングブレード かってに桃天使!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -41358,8 +41358,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dancing Blade - Katteni Momotenshi II - Tears of Eden (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86210~SLPM-86212 (VX129-J1)"/>
-		<info name="release" value="19990318"/>
+		<info name="serial" value="SLPM-86210~SLPM-86212 (VX129-J1)" />
+		<info name="release" value="19990318" />
 		<info name="alt_title" value="ダンシングブレード かってに桃天使II ～Tears of Eden～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -41390,7 +41390,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>KSS</publisher>
 		<info name="serial" value="SLPS-02609"/>
-		<info name="release" value="20000224"/>
+		<info name="release" value="20000224" />
 		<info name="alt_title" value="DANGAN〜弾丸〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41410,8 +41410,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Darkseed II (Japan)</description>
 		<year>1997</year>
 		<publisher>B-Factory</publisher>
-		<info name="serial" value="SLPS-00938"/>
-		<info name="release" value="19970918"/>
+		<info name="serial" value="SLPS-00938" />
+		<info name="release" value="19970918" />
 		<info name="alt_title" value="ダークシードII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41431,8 +41431,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dark Tales from the Lost Soul (Japan)</description>
 		<year>1999</year>
 		<publisher>Sammy</publisher>
-		<info name="serial" value="SLPS-02316"/>
-		<info name="release" value="19991028"/>
+		<info name="serial" value="SLPS-02316" />
+		<info name="release" value="19991028" />
 		<info name="alt_title" value="ダークテイルズ From The Lost Soul"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41452,8 +41452,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dynamite Boxing (Japan)</description>
 		<year>1998</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01387"/>
-		<info name="release" value="19980521"/>
+		<info name="serial" value="SLPS-01387" />
+		<info name="release" value="19980521" />
 		<info name="alt_title" value="ダイナマイト ボクシング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41474,8 +41474,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Ball Z - Idainaru Dragon Ball Densetsu (Japan)</description>
 		<year>1995</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00073"/>
-		<info name="release" value="19950728"/>
+		<info name="serial" value="SLPS-00073" />
+		<info name="release" value="19950728" />
 		<info name="alt_title" value="ドラゴンボールZ 偉大なるドラゴンボール伝説"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41495,8 +41495,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Destruction Derby 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SIPS-60012"/>
-		<info name="release" value="19970221"/>
+		<info name="serial" value="SIPS-60012" />
+		<info name="release" value="19970221" />
 		<info name="alt_title" value="デストラクション・ダービー2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41516,8 +41516,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dance Dance Revolution - 2nd Remix Append Club Version Vol. 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86399 (VX175-J1)"/>
-		<info name="release" value="19991222"/>
+		<info name="serial" value="SLPM-86399 (VX175-J1)" />
+		<info name="release" value="19991222" />
 		<info name="alt_title" value="ダンス ダンス レボリューション セカンドリミックス アペンド クラブバージョンvol.2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41538,8 +41538,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dance Dance Revolution - 5th Mix (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86897 (VX246-J1)"/>
-		<info name="release" value="20010920"/>
+		<info name="serial" value="SLPM-86897 (VX246-J1)" />
+		<info name="release" value="20010920" />
 		<info name="alt_title" value="ダンス ダンス レボリューション フィフスミックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41559,8 +41559,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dance Dance Revolution - Best Hits (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86693 (VX224-J1)"/>
-		<info name="release" value="20001221"/>
+		<info name="serial" value="SLPM-86693 (VX224-J1)" />
+		<info name="release" value="20001221" />
 		<info name="alt_title" value="ダンスダンスレボリューション ベストヒッツ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41580,8 +41580,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dance Dance Revolution - Extra Mix (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86831 (VX244-J1)"/>
-		<info name="release" value="20010607"/>
+		<info name="serial" value="SLPM-86831 (VX244-J1)" />
+		<info name="release" value="20010607" />
 		<info name="alt_title" value="ダンス ダンス レボリューション エクストラ ミックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41601,8 +41601,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Deadly Skies (Japan)</description>
 		<year>1997</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-01036"/>
-		<info name="release" value="19971023"/>
+		<info name="serial" value="SLPS-01036" />
+		<info name="release" value="19971023" />
 		<info name="alt_title" value="デッドリースカイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41622,8 +41622,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Death Wing (Japan)</description>
 		<year>1996</year>
 		<publisher>Cybertech Designs</publisher>
-		<info name="serial" value="SLPS-00489"/>
-		<info name="release" value="19961025"/>
+		<info name="serial" value="SLPS-00489" />
+		<info name="release" value="19961025" />
 		<info name="alt_title" value="デス・ウイング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41643,8 +41643,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Defeat Lightning (Japan)</description>
 		<year>1997</year>
 		<publisher>D Cruise</publisher>
-		<info name="serial" value="SLPS-00853"/>
-		<info name="release" value="19970523"/>
+		<info name="serial" value="SLPS-00853" />
+		<info name="release" value="19970523" />
 		<info name="alt_title" value="ディフィート・ライトニング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41664,8 +41664,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Densha Daisuki - Plarail ga Ippai (Japan)</description>
 		<year>1998</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-01753"/>
-		<info name="release" value="19981223"/>
+		<info name="serial" value="SLPS-01753" />
+		<info name="release" value="19981223" />
 		<info name="alt_title" value="電車だいすき プラレールがいっぱい (専用コントローラカバー付)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41685,8 +41685,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Densha de Go! Nagoya Railroad (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86424 (TCPS10015)"/>
-		<info name="release" value="20000127"/>
+		<info name="serial" value="SLPM-86424 (TCPS10015)" />
+		<info name="release" value="20000127" />
 		<info name="alt_title" value="電車でGO! 名古屋鉄道編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41707,8 +41707,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gear Fighter Dendoh (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03189"/>
-		<info name="release" value="20010426"/>
+		<info name="serial" value="SLPS-03189" />
+		<info name="release" value="20010426" />
 		<info name="alt_title" value="GEAR戦士 電童"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41728,8 +41728,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Denpa Shounenteki Game (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01287"/>
-		<info name="release" value="19980402"/>
+		<info name="serial" value="SLPS-01287" />
+		<info name="release" value="19980402" />
 		<info name="alt_title" value="電波少年的ゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41749,8 +41749,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Derby Jockey 2001 (Japan)</description>
 		<year>2001</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-03131"/>
-		<info name="release" value="20010118"/>
+		<info name="serial" value="SLPS-03131" />
+		<info name="release" value="20010118" />
 		<info name="alt_title" value="ダービージョッキー2001"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41770,8 +41770,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Descent (Japan)</description>
 		<year>1996</year>
 		<publisher>Interplay</publisher>
-		<info name="serial" value="SLPS-00212"/>
-		<info name="release" value="19960126"/>
+		<info name="serial" value="SLPS-00212" />
+		<info name="release" value="19960126" />
 		<info name="alt_title" value="ディセント"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41791,8 +41791,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Devicereign (Japan)</description>
 		<year>1999</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-01889"/>
-		<info name="release" value="19990225"/>
+		<info name="serial" value="SLPS-01889" />
+		<info name="release" value="19990225" />
 		<info name="alt_title" value="デバイスレイン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41815,8 +41815,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dezaemon Kids! (Japan)</description>
 		<year>1998</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-01503~SLPS-01504"/>
-		<info name="release" value="19981022"/>
+		<info name="serial" value="SLPS-01503~SLPS-01504" />
+		<info name="release" value="19981022" />
 		<info name="alt_title" value="デザエモンキッズ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -41842,8 +41842,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dezaemon Plus (Japan)</description>
 		<year>1996</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-00335"/>
-		<info name="release" value="19960524"/>
+		<info name="serial" value="SLPS-00335" />
+		<info name="release" value="19960524" />
 		<info name="alt_title" value="デザエモンプラス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41863,8 +41863,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dark Hunter - Ge Youma No Mori (Japan)</description>
 		<year>1997</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00789"/>
-		<info name="release" value="19970530"/>
+		<info name="serial" value="SLPS-00789" />
+		<info name="release" value="19970530" />
 		<info name="alt_title" value="ダークハンター (下) 妖魔の森"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41885,9 +41885,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Digical League (Japan)</description>
 		<year>1997</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques"/>
-		<info name="serial" value="SLPM-86038"/>
-		<info name="release" value="19970620"/>
+		<info name="developer" value="Aques" />
+		<info name="serial" value="SLPM-86038" />
+		<info name="release" value="19970620" />
 		<info name="alt_title" value="デジカルリーグ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41907,8 +41907,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kids Station - Digimon Park (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03248"/>
-		<info name="release" value="20010726"/>
+		<info name="serial" value="SLPS-03248" />
+		<info name="release" value="20010726" />
 		<info name="alt_title" value="キッズステーション デジモンパーク キッズステーションコントローラセット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41928,8 +41928,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Digimon Tamers - Battle Evolution (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03357"/>
-		<info name="release" value="20011206"/>
+		<info name="serial" value="SLPS-03357" />
+		<info name="release" value="20011206" />
 		<info name="alt_title" value="デジモンテイマーズ バトルエボリューション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41949,8 +41949,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Digimon World (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01797"/>
-		<info name="release" value="19990128"/>
+		<info name="serial" value="SLPS-01797" />
+		<info name="release" value="19990128" />
 		<info name="alt_title" value="デジモンワールド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41970,8 +41970,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Knight 4 (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00664"/>
-		<info name="release" value="19970207"/>
+		<info name="serial" value="SLPS-00664" />
+		<info name="release" value="19970207" />
 		<info name="alt_title" value="ドラゴンナイト4"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -41991,8 +41991,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Knights Glorious (Japan)</description>
 		<year>1999</year>
 		<publisher>Pandora</publisher>
-		<info name="serial" value="SLPS-02391"/>
-		<info name="release" value="19991118"/>
+		<info name="serial" value="SLPS-02391" />
+		<info name="release" value="19991118" />
 		<info name="alt_title" value="PANDORA MAX SERIES Vol.1 ドラゴンナイツ・グロリアス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42012,8 +42012,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Docchi Mecha! (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10129"/>
-		<info name="release" value="20000427"/>
+		<info name="serial" value="SCPS-10129" />
+		<info name="release" value="20000427" />
 		<info name="alt_title" value="ドッチメチャ!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42033,8 +42033,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dodge de Ball! (Japan)</description>
 		<year>1998</year>
 		<publisher>Yumedia</publisher>
-		<info name="serial" value="SLPS-01362"/>
-		<info name="release" value="19980514"/>
+		<info name="serial" value="SLPS-01362" />
+		<info name="release" value="19980514" />
 		<info name="alt_title" value="ドッチ DE ボール！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42054,8 +42054,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Dog Master (Japan)</description>
 		<year>2003</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPM-87175"/>
-		<info name="release" value="20030807"/>
+		<info name="serial" value="SLPM-87175" />
+		<info name="release" value="20030807" />
 		<info name="alt_title" value="ザ・ドッグマスター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42075,8 +42075,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Doki Doki Shutter Chance - Koi no Puzzle o Kumitatete (Japan)</description>
 		<year>1997</year>
 		<publisher>Nippon Ichi Software</publisher>
-		<info name="serial" value="SLPS-01038"/>
-		<info name="release" value="19971023"/>
+		<info name="serial" value="SLPS-01038" />
+		<info name="release" value="19971023" />
 		<info name="alt_title" value="どきどきシャッターチャンス★ 〜恋のパズルを組み立てて〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42096,8 +42096,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dokomademo Aoku... (Japan, Limited Edition)</description>
 		<year>2002</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-03388"/>
-		<info name="release" value="20020221"/>
+		<info name="serial" value="SLPS-03388" />
+		<info name="release" value="20020221" />
 		<info name="alt_title" value="どこまでも青く…。 (初回限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42117,8 +42117,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Doukyuusei Mahjong (Japan)</description>
 		<year>1997</year>
 		<publisher>Yumedia</publisher>
-		<info name="serial" value="SLPS-00673"/>
-		<info name="release" value="19970117"/>
+		<info name="serial" value="SLPS-00673" />
+		<info name="release" value="19970117" />
 		<info name="alt_title" value="同級生麻雀"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42138,8 +42138,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Doukyuusei 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00691"/>
-		<info name="release" value="19970807"/>
+		<info name="serial" value="SLPS-00691" />
+		<info name="release" value="19970807" />
 		<info name="alt_title" value="同級生2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42159,8 +42159,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dolphin's Dream (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86122 (VX071-J1)"/>
-		<info name="release" value="19980910"/>
+		<info name="serial" value="SLPM-86122 (VX071-J1)" />
+		<info name="release" value="19980910" />
 		<info name="alt_title" value="ドルフィンズドリーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42180,8 +42180,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Domino-kun o Tomenaide. (Japan)</description>
 		<year>1998</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-01095"/>
-		<info name="release" value="19980108"/>
+		<info name="serial" value="SLPS-01095" />
+		<info name="release" value="19980108" />
 		<info name="alt_title" value="ドミノ君をとめないで。"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42201,8 +42201,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DonPachi (Japan)</description>
 		<year>1996</year>
 		<publisher>SPS</publisher>
-		<info name="serial" value="SLPS-00548 (PS-052)"/>
-		<info name="release" value="19961018"/>
+		<info name="serial" value="SLPS-00548 (PS-052)" />
+		<info name="release" value="19961018" />
 		<info name="alt_title" value="首領蜂"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42222,8 +42222,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Doraemon - Nobita to Fukkatsu no Hoshi (Japan)</description>
 		<year>1996</year>
 		<publisher>Epoch</publisher>
-		<info name="serial" value="SLPS-00233"/>
-		<info name="release" value="19960216"/>
+		<info name="serial" value="SLPS-00233" />
+		<info name="release" value="19960216" />
 		<info name="alt_title" value="ドラえもん のび太と復活の星"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42243,8 +42243,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Doraemon 2 - SOS! Otogi no Kuni (Japan)</description>
 		<year>1997</year>
 		<publisher>Epoch</publisher>
-		<info name="serial" value="SLPS-00628"/>
-		<info name="release" value="19972021"/>
+		<info name="serial" value="SLPS-00628" />
+		<info name="release" value="19972021" />
 		<info name="alt_title" value="ドラえもん2 SOS！おとぎの国"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42283,8 +42283,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Double Dragon (Japan)</description>
 		<year>1996</year>
 		<publisher>Technos Japan</publisher>
-		<info name="serial" value="SLPS-00191"/>
-		<info name="release" value="19960426"/>
+		<info name="serial" value="SLPS-00191" />
+		<info name="release" value="19960426" />
 		<info name="alt_title" value="ダブルドラゴン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42305,8 +42305,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Drive Tactics Break (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03470"/>
-		<info name="release" value="20021003"/>
+		<info name="serial" value="SLPS-03470" />
+		<info name="release" value="20021003" />
 		<info name="alt_title" value="ドラゴンドライブ タクティクスブレイク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42326,8 +42326,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Money (Japan)</description>
 		<year>1999</year>
 		<publisher>Micro Cabin</publisher>
-		<info name="serial" value="SLPS-02037"/>
-		<info name="release" value="19990504"/>
+		<info name="serial" value="SLPS-02037" />
+		<info name="release" value="19990504" />
 		<info name="alt_title" value="ドラゴンマネー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42347,8 +42347,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dr. Slump (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01934"/>
-		<info name="release" value="19990318"/>
+		<info name="serial" value="SLPS-01934" />
+		<info name="release" value="19990318" />
 		<info name="alt_title" value="ドクタースランプ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42368,8 +42368,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Drug Store - Matsumoto Kiyoshi de Okaimono! (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01516"/>
-		<info name="release" value="19980806"/>
+		<info name="serial" value="SLPS-01516" />
+		<info name="release" value="19980806" />
 		<info name="alt_title" value="ザ・ドラッグストア マツモトキヨシでお買いもの！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42389,8 +42389,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Druid - Yamie no Tsuisekisha (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01246"/>
-		<info name="release" value="19980219"/>
+		<info name="serial" value="SLPS-01246" />
+		<info name="release" value="19980219" />
 		<info name="alt_title" value="DRUID 闇への追跡者"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42410,8 +42410,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dancing Stage featuring Dreams Come True (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86505 (VX186-J1)"/>
-		<info name="release" value="20000420"/>
+		<info name="serial" value="SLPM-86505 (VX186-J1)" />
+		<info name="release" value="20000420" />
 		<info name="alt_title" value="ダンシングステージ フィーチャリング ドリームズ・カム・トゥルー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42443,8 +42443,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dancing Stage featuring TRUE KiSS DESTiNATiON (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86411 (VX174-J1)"/>
-		<info name="release" value="19991209"/>
+		<info name="serial" value="SLPM-86411 (VX174-J1)" />
+		<info name="release" value="19991209" />
 		<info name="alt_title" value="ダンシングステージ フィーチャリング トゥルー・キス・ディスティネーション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42464,8 +42464,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dynamite Soccer 2002 (Japan)</description>
 		<year>2002</year>
 		<publisher>A-Max</publisher>
-		<info name="serial" value="SLPS-03436"/>
-		<info name="release" value="20020516"/>
+		<info name="serial" value="SLPS-03436" />
+		<info name="release" value="20020516" />
 		<info name="alt_title" value="ダイナマイトサッカー2002"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42485,8 +42485,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dynamite Soccer 2004 Final (Japan)</description>
 		<year>2004</year>
 		<publisher>A-Max</publisher>
-		<info name="serial" value="SLPS-03575"/>
-		<info name="release" value="20040415"/>
+		<info name="serial" value="SLPS-03575" />
+		<info name="release" value="20040415" />
 		<info name="alt_title" value="ダイナマイトサッカー2004ファイナル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42506,8 +42506,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aura Battler Dunbine - Seisenshi Densetsu (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02390"/>
-		<info name="release" value="20000304"/>
+		<info name="serial" value="SLPS-02390" />
+		<info name="release" value="20000304" />
 		<info name="alt_title" value="聖戦士ダンバイン 聖戦士伝説 ~ Seisenshi Dunbine - Seisenshi Densetsu (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42530,8 +42530,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Dragon Valor (Japan)</description>
 		<year>1999</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-02190~SLPS-02191"/>
-		<info name="release" value="19991202"/>
+		<info name="serial" value="SLPS-02190~SLPS-02191" />
+		<info name="release" value="19991202" />
 		<info name="alt_title" value="ドラゴンヴァラー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -42556,8 +42556,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DX Jinsei Game IV - The Game of Life (Japan)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPM-86963"/>
-		<info name="release" value="20011129"/>
+		<info name="serial" value="SLPM-86963" />
+		<info name="release" value="20011129" />
 		<info name="alt_title" value="DX人生ゲームIV"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42577,8 +42577,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DX Jinsei Game V - The Game of Life (Japan)</description>
 		<year>2002</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPM-87187"/>
-		<info name="release" value="20021205"/>
+		<info name="serial" value="SLPM-87187" />
+		<info name="release" value="20021205" />
 		<info name="alt_title" value="DX人生ゲームV"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42598,8 +42598,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DX Monopoly (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02943"/>
-		<info name="release" value="20001221"/>
+		<info name="serial" value="SLPS-02943" />
+		<info name="release" value="20001221" />
 		<info name="alt_title" value="DXモノポリー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42619,8 +42619,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DX Okuman Chouja Game II - The Money Battle (Japan)</description>
 		<year>1998</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01586"/>
-		<info name="release" value="19980923"/>
+		<info name="serial" value="SLPS-01586" />
+		<info name="release" value="19980923" />
 		<info name="alt_title" value="DX億万長者ゲームII ザ・マネー・バトル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42640,8 +42640,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>DX Shachou Game (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02105"/>
-		<info name="release" value="19990708"/>
+		<info name="serial" value="SLPS-02105" />
+		<info name="release" value="19990708" />
 		<info name="alt_title" value="DX社長ゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42661,8 +42661,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Eikan ha Kimini 4 (Japan)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-02173"/>
-		<info name="release" value="19990805"/>
+		<info name="serial" value="SLPS-02173" />
+		<info name="release" value="19990805" />
 		<info name="alt_title" value="栄冠は君に4"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42682,8 +42682,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Eisei Meijin (Japan)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPS-00090"/>
-		<info name="release" value="19950908"/>
+		<info name="serial" value="SLPS-00090" />
+		<info name="release" value="19950908" />
 		<info name="alt_title" value="永世名人"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42703,8 +42703,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>élan (Japan)</description>
 		<year>1999</year>
 		<publisher>Visco</publisher>
-		<info name="serial" value="SLPS-01925"/>
-		<info name="release" value="19990401"/>
+		<info name="serial" value="SLPS-01925" />
+		<info name="release" value="19990401" />
 		<info name="alt_title" value="エラン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42724,8 +42724,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>élan plus (Japan)</description>
 		<year>2000</year>
 		<publisher>Visco</publisher>
-		<info name="serial" value="SLPS-02759"/>
-		<info name="release" value="20000511"/>
+		<info name="serial" value="SLPS-02759" />
+		<info name="release" value="20000511" />
 		<info name="alt_title" value="エラン プラス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42745,8 +42745,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Elder Gate (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86494 (VX160-J1)"/>
-		<info name="release" value="20000622"/>
+		<info name="serial" value="SLPM-86494 (VX160-J1)" />
+		<info name="release" value="20000622" />
 		<info name="alt_title" value="エルダーゲート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42772,8 +42772,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Elf wo Karu Mono-tachi II (Japan)</description>
 		<year>1998</year>
 		<publisher>Altron</publisher>
-		<info name="serial" value="SLPS-01456~SLPS-01458"/>
-		<info name="release" value="19980813"/>
+		<info name="serial" value="SLPS-01456~SLPS-01458" />
+		<info name="release" value="19980813" />
 		<info name="alt_title" value="エルフを狩るモノたちII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -42803,8 +42803,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Emmyrea (Japan)</description>
 		<year>2001</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-03216"/>
-		<info name="release" value="20010524"/>
+		<info name="serial" value="SLPS-03216" />
+		<info name="release" value="20010524" />
 		<info name="alt_title" value="エミーリア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42824,8 +42824,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>End Sector (Japan)</description>
 		<year>1998</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-01584"/>
-		<info name="release" value="19980923"/>
+		<info name="serial" value="SLPS-01584" />
+		<info name="release" value="19980923" />
 		<info name="alt_title" value="エンドセクター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42845,8 +42845,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Engacho! (Japan)</description>
 		<year>1999</year>
 		<publisher>Nihon Application</publisher>
-		<info name="serial" value="SLPS-02263"/>
-		<info name="release" value="19991118"/>
+		<info name="serial" value="SLPS-02263" />
+		<info name="release" value="19991118" />
 		<info name="alt_title" value="えんがちょ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42869,8 +42869,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Enigma (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01351~SLPS-01352"/>
-		<info name="release" value="19980402"/>
+		<info name="serial" value="SLPS-01351~SLPS-01352" />
+		<info name="release" value="19980402" />
 		<info name="alt_title" value="エニグマ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -42895,8 +42895,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>EOS - Edge of Skyhigh (Japan)</description>
 		<year>1997</year>
 		<publisher>Micronet</publisher>
-		<info name="serial" value="SLPS-00820"/>
-		<info name="release" value="19970703"/>
+		<info name="serial" value="SLPS-00820" />
+		<info name="release" value="19970703" />
 		<info name="alt_title" value="―イオス― エッジ・オブ・スカイハイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42916,8 +42916,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Epica Stella (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01465"/>
-		<info name="release" value="19980730"/>
+		<info name="serial" value="SLPS-01465" />
+		<info name="release" value="19980730" />
 		<info name="alt_title" value="エピカ・ステラ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42937,8 +42937,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fuujin Ryouiki Eretzvaju (Japan)</description>
 		<year>1999</year>
 		<publisher>Yuke's</publisher>
-		<info name="serial" value="SLPS-01790"/>
-		<info name="release" value="19990114"/>
+		<info name="serial" value="SLPS-01790" />
+		<info name="release" value="19990114" />
 		<info name="alt_title" value="封神領域エルツヴァーユ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42958,8 +42958,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chiisana Oukoku Erutoria (Japan)</description>
 		<year>2000</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-02750"/>
-		<info name="release" value="20000629"/>
+		<info name="serial" value="SLPS-02750" />
+		<info name="release" value="20000629" />
 		<info name="alt_title" value="小さな王国エルトリア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -42980,8 +42980,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Vision of Escaflowne (Japan, Limited Edition)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01014"/>
-		<info name="release" value="19970925"/>
+		<info name="serial" value="SLPS-01014" />
+		<info name="release" value="19970925" />
 		<info name="alt_title" value="天空のエスカフローネ限定版 Fortune BOX"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43001,8 +43001,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Weltorv Estleia (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01887"/>
-		<info name="release" value="19990225"/>
+		<info name="serial" value="SLPS-01887" />
+		<info name="release" value="19990225" />
 		<info name="alt_title" value="ウエルト オブ イストリア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43022,8 +43022,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yuukyuu no Eden - The Eternal Eden (Japan)</description>
 		<year>1999</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-01928"/>
-		<info name="release" value="19990422"/>
+		<info name="serial" value="SLPS-01928" />
+		<info name="release" value="19990422" />
 		<info name="alt_title" value="悠久のエデン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43049,8 +43049,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>EVE Zero (Japan)</description>
 		<year>2000</year>
 		<publisher>Game Village</publisher>
-		<info name="serial" value="SLPM-86478~SLPM-86480"/>
-		<info name="release" value="20000330"/>
+		<info name="serial" value="SLPM-86478~SLPM-86480" />
+		<info name="release" value="20000330" />
 		<info name="alt_title" value="イヴ ゼロ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -43080,8 +43080,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Evergreen Avenue (Japan)</description>
 		<year>2001</year>
 		<publisher>MediaWorks / Datam Polystar</publisher>
-		<info name="serial" value="SLPS-03278"/>
-		<info name="release" value="20010913"/>
+		<info name="serial" value="SLPS-03278" />
+		<info name="release" value="20010913" />
 		<info name="alt_title" value="エバーグリーン・アベニュー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43107,8 +43107,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>EVE - The Fatal Attraction (Japan)</description>
 		<year>2001</year>
 		<publisher>Game Village</publisher>
-		<info name="serial" value="SLPM-86826~SLPM-86828"/>
-		<info name="release" value="20010927"/>
+		<info name="serial" value="SLPM-86826~SLPM-86828" />
+		<info name="release" value="20010927" />
 		<info name="alt_title" value="イヴ・ザ・フェイタル・アトラクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -43138,8 +43138,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Exciting Bass (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86124 (VX099-J1)"/>
-		<info name="release" value="19980923"/>
+		<info name="serial" value="SLPM-86124 (VX099-J1)" />
+		<info name="release" value="19980923" />
 		<info name="alt_title" value="エキサイティングバス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43159,8 +43159,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Exciting Bass 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86295 (VX154-J1)"/>
-		<info name="release" value="19990930"/>
+		<info name="serial" value="SLPM-86295 (VX154-J1)" />
+		<info name="release" value="19990930" />
 		<info name="alt_title" value="エキサイティングバス2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43180,8 +43180,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Expert (Japan)</description>
 		<year>1996</year>
 		<publisher>Nihon Bussan</publisher>
-		<info name="serial" value="SLPS-00342"/>
-		<info name="release" value="19960531"/>
+		<info name="serial" value="SLPS-00342" />
+		<info name="release" value="19960531" />
 		<info name="alt_title" value="エキスパート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43201,8 +43201,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Family Diamond (Japan)</description>
 		<year>2002</year>
 		<publisher>Magnolia</publisher>
-		<info name="serial" value="SLPS-03348"/>
-		<info name="release" value="20020124"/>
+		<info name="serial" value="SLPS-03348" />
+		<info name="release" value="20020124" />
 		<info name="alt_title" value="ファミリーダイヤモンド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43222,8 +43222,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Family Restaurant - Shijou Saikyou no Menu (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01763"/>
-		<info name="release" value="19981217"/>
+		<info name="serial" value="SLPS-01763" />
+		<info name="release" value="19981217" />
 		<info name="alt_title" value="ザ・ファミレス〜史上最強のメニュー〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43243,8 +43243,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Farland Story - Yottsu no Fuuin (Japan)</description>
 		<year>1997</year>
 		<publisher>TGL</publisher>
-		<info name="serial" value="SLPS-00797"/>
-		<info name="release" value="19971127"/>
+		<info name="serial" value="SLPS-00797" />
+		<info name="release" value="19971127" />
 		<info name="alt_title" value="ファーランドストーリー〜四つの封印〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43264,8 +43264,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Farland Saga - Toki no Michishirube (Japan)</description>
 		<year>1999</year>
 		<publisher>TGL</publisher>
-		<info name="serial" value="SLPS-01903"/>
-		<info name="release" value="19990428"/>
+		<info name="serial" value="SLPS-01903" />
+		<info name="release" value="19990428" />
 		<info name="alt_title" value="ファーランドサーガ 時の道標"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43285,8 +43285,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Favorite Dear - Enkan no Monogatari (Japan)</description>
 		<year>2001</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-03286 (NIPS-4014)"/>
-		<info name="release" value="20010927"/>
+		<info name="serial" value="SLPS-03286 (NIPS-4014)" />
+		<info name="release" value="20010927" />
 		<info name="alt_title" value="フェィバリットディア −円環の物語−"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43306,8 +43306,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Favorite Dear - Junpaku no Yogenmono (Japan)</description>
 		<year>2000</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-02754 (NIPS-4008)"/>
-		<info name="release" value="20001207"/>
+		<info name="serial" value="SLPS-02754 (NIPS-4008)" />
+		<info name="release" value="20001207" />
 		<info name="alt_title" value="フェイバリットディア 純白の預言者 / Favorite Dear - The everlasting voices (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43327,8 +43327,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Formula Circus (Japan)</description>
 		<year>1997</year>
 		<publisher>Nichibutsu</publisher>
-		<info name="serial" value="SLPS-00358"/>
-		<info name="release" value="19970502"/>
+		<info name="serial" value="SLPS-00358" />
+		<info name="release" value="19970502" />
 		<info name="alt_title" value="フォーミュラ・サーカス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43348,8 +43348,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Feda 2 - White Surge - the Platoon (Japan)</description>
 		<year>1997</year>
 		<publisher>Yanoman Games</publisher>
-		<info name="serial" value="SLPS-00723"/>
-		<info name="release" value="19970418"/>
+		<info name="serial" value="SLPS-00723" />
+		<info name="release" value="19970418" />
 		<info name="alt_title" value="フェーダ2 ホワイト＝サージ ザ・プラトゥーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43369,8 +43369,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Final Fantasy (Japan)</description>
 		<year>2002</year>
 		<publisher>Squaresoft</publisher>
-		<info name="serial" value="SLPS-03430"/>
-		<info name="release" value="20021031"/>
+		<info name="serial" value="SLPS-03430" />
+		<info name="release" value="20021031" />
 		<info name="alt_title" value="ファイナルファンタジー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43390,8 +43390,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Final Fantasy II (Japan)</description>
 		<year>2002</year>
 		<publisher>Squaresoft</publisher>
-		<info name="serial" value="SLPS-03502"/>
-		<info name="release" value="20021031"/>
+		<info name="serial" value="SLPS-03502" />
+		<info name="release" value="20021031" />
 		<info name="alt_title" value="ファイナルファンタジーII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43411,8 +43411,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Formula Grand Prix 1997 - Team Unei Simulation 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-01154"/>
-		<info name="release" value="19971225"/>
+		<info name="serial" value="SLPS-01154" />
+		<info name="release" value="19971225" />
 		<info name="alt_title" value="フォーミュラグランプリ1997年版 チーム運営シミュレーション2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43432,8 +43432,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Forget me not - Palette (Japan)</description>
 		<year>2001</year>
 		<publisher>Enterbrain</publisher>
-		<info name="serial" value="SLPS-03191"/>
-		<info name="release" value="20010426"/>
+		<info name="serial" value="SLPS-03191" />
+		<info name="release" value="20010426" />
 		<info name="alt_title" value="フォーゲットミーノット －パレット－"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43453,8 +43453,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Final Doom (Japan)</description>
 		<year>1997</year>
 		<publisher>Soft Bank</publisher>
-		<info name="serial" value="SLPS-00727"/>
-		<info name="release" value="19971002"/>
+		<info name="serial" value="SLPS-00727" />
+		<info name="release" value="19971002" />
 		<info name="alt_title" value="ファイナルドゥーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43474,8 +43474,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Firemen 2 - Pete &amp; Danny (Japan)</description>
 		<year>1995</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-00148"/>
-		<info name="release" value="19951222"/>
+		<info name="serial" value="SLPS-00148" />
+		<info name="release" value="19951222" />
 		<info name="alt_title" value="ザ・ファイヤーメン2 ピート&amp;ダニー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43510,8 +43510,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fire Woman Matoigumi (Japan)</description>
 		<year>1998</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-01315"/>
-		<info name="release" value="19980326"/>
+		<info name="serial" value="SLPS-01315" />
+		<info name="release" value="19980326" />
 		<info name="alt_title" value="ファイアーウーマン纏組"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43531,8 +43531,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fish Eyes II (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-02383"/>
-		<info name="release" value="20000127"/>
+		<info name="serial" value="SLPS-02383" />
+		<info name="release" value="20000127" />
 		<info name="alt_title" value="フィッシュアイズII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43552,8 +43552,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fisher's Road (Japan)</description>
 		<year>1999</year>
 		<publisher>BPS</publisher>
-		<info name="serial" value="SLPS-01943"/>
-		<info name="release" value="19990311"/>
+		<info name="serial" value="SLPS-01943" />
+		<info name="release" value="19990311" />
 		<info name="alt_title" value="フィッシャーズロード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43573,8 +43573,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fist (Japan)</description>
 		<year>1996</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-00538"/>
-		<info name="release" value="19961122"/>
+		<info name="serial" value="SLPS-00538" />
+		<info name="release" value="19961122" />
 		<info name="alt_title" value="フィスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43594,8 +43594,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Formula Nippon '99 (Japan)</description>
 		<year>1999</year>
 		<publisher>TYO</publisher>
-		<info name="serial" value="SLPS-02259"/>
-		<info name="release" value="19990909"/>
+		<info name="serial" value="SLPS-02259" />
+		<info name="release" value="19990909" />
 		<info name="alt_title" value="フォーミュラ・ニッポン’99 レーシングドライバーになろう！ ~ Formula Nippon '99 - Racing Driver ni Narou! (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43615,8 +43615,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fox Junction (Japan)</description>
 		<year>1998</year>
 		<publisher>Trips</publisher>
-		<info name="serial" value="SLPS-01355"/>
-		<info name="release" value="19980429"/>
+		<info name="serial" value="SLPS-01355" />
+		<info name="release" value="19980429" />
 		<info name="alt_title" value="フォックスジャンクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43636,8 +43636,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>First Queen IV - Varcia Senki (Japan)</description>
 		<year>1996</year>
 		<publisher>KSK</publisher>
-		<info name="serial" value="SLPS-00604"/>
-		<info name="release" value="19961206"/>
+		<info name="serial" value="SLPS-00604" />
+		<info name="release" value="19961206" />
 		<info name="alt_title" value="ファーストクイーンIV ～バルシア戦記～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43658,8 +43658,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Media Entertainment</publisher>
 		<!-- unsure whether this is the same as the original SLPS-00985 release (19970925) or not -->
-		<info name="serial" value="SLPS-02655"/>
-		<info name="release" value="20000323"/>
+		<info name="serial" value="SLPS-02655" />
+		<info name="release" value="20000323" />
 		<info name="alt_title" value="Best of the Best フリートーク・スタジオ〜マリの気ままなおしゃべり〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43679,8 +43679,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arcade Hits - Frisky Tom (Japan, Major Wave Serie)</description>
 		<year>2002</year>
 		<publisher>Hamster</publisher>
-		<info name="serial" value="SLPM-87118"/>
-		<info name="release" value="20020725"/>
+		<info name="serial" value="SLPM-87118" />
+		<info name="release" value="20020725" />
 		<info name="alt_title" value="アーケード・ヒッツ　～フリスキー・トム～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43700,8 +43700,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Final Round (Japan)</description>
 		<year>1998</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-01266"/>
-		<info name="release" value="19980312"/>
+		<info name="serial" value="SLPS-01266" />
+		<info name="release" value="19980312" />
 		<info name="alt_title" value="ファイナルラウンド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43721,8 +43721,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fighters' Impact (Japan)</description>
 		<year>1997</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-00822"/>
-		<info name="release" value="19970425"/>
+		<info name="serial" value="SLPS-00822" />
+		<info name="release" value="19970425" />
 		<info name="alt_title" value="ファイターズ インパクト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43742,8 +43742,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fun! Fun! Pingu - *Youkoso! Nankyoku e* (Japan, Limited Edition)</description>
 		<year>1999</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-02306"/>
-		<info name="release" value="19991118"/>
+		<info name="serial" value="SLPS-02306" />
+		<info name="release" value="19991118" />
 		<info name="alt_title" value="ファン!ファン!ピングー *ようこそ!南極へ* (初回数量限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43763,8 +43763,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fushigi Keiji (Japan)</description>
 		<year>2000</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPM-86642"/>
-		<info name="release" value="20001026"/>
+		<info name="serial" value="SLPM-86642" />
+		<info name="release" value="20001026" />
 		<info name="alt_title" value="ふしぎ刑事 / Fushigi-Deka (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43784,8 +43784,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fuuraiki (Japan)</description>
 		<year>2001</year>
 		<publisher>FOG</publisher>
-		<info name="serial" value="SLPS-03094"/>
-		<info name="release" value="20010118"/>
+		<info name="serial" value="SLPS-03094" />
+		<info name="release" value="20010118" />
 		<info name="alt_title" value="風雨来記"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43833,8 +43833,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gaia Seed - Project Seed Trap (Japan)</description>
 		<year>1996</year>
 		<publisher>Techno Soleil</publisher>
-		<info name="serial" value="SLPS-00624"/>
-		<info name="release" value="19961213"/>
+		<info name="serial" value="SLPS-00624" />
+		<info name="release" value="19961213" />
 		<info name="alt_title" value="ガイアシード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43854,8 +43854,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gakkou de Atta Kowai Hanashi S (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00404"/>
-		<info name="release" value="19960719"/>
+		<info name="serial" value="SLPS-00404" />
+		<info name="release" value="19960719" />
 		<info name="alt_title" value="学校であった怖い話S"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43875,8 +43875,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gakkou no Kowai Uwasa - Hanako-san ga Kita!! (Japan)</description>
 		<year>1995</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00078"/>
-		<info name="release" value="19950811"/>
+		<info name="serial" value="SLPS-00078" />
+		<info name="release" value="19950811" />
 		<info name="alt_title" value="学校のコワイうわさ 花子さんがきた!!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43896,8 +43896,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gakkou wo Tsukurou!! 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01660"/>
-		<info name="release" value="19981210"/>
+		<info name="serial" value="SLPS-01660" />
+		<info name="release" value="19981210" />
 		<info name="alt_title" value="学校をつくろう!!2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43917,8 +43917,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gakkou wo Tsukurou!! Koushou Sensei Monogatari (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-02998"/>
-		<info name="release" value="20001026"/>
+		<info name="serial" value="SLPS-02998" />
+		<info name="release" value="20001026" />
 		<info name="alt_title" value="学校をつくろう!!校長先生物語"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43938,8 +43938,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hoshi no Oka Gakuen Monogatari - Gakuensai (Japan)</description>
 		<year>1998</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-01638"/>
-		<info name="release" value="19981022"/>
+		<info name="serial" value="SLPS-01638" />
+		<info name="release" value="19981022" />
 		<info name="alt_title" value="星の丘学園物語 学園祭"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -43962,8 +43962,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Matsumoto Leiji - Story of Galaxy Express 999 (Japan)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-03220~SLPS-03221"/>
-		<info name="release" value="20010628"/>
+		<info name="serial" value="SLPS-03220~SLPS-03221" />
+		<info name="release" value="20010628" />
 		<info name="alt_title" value="松本零士999 〜Story of Galaxy Express999 〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -43989,8 +43989,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Galaxy Fight - Universal Warriors (Japan)</description>
 		<year>1996</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-00138"/>
-		<info name="release" value="19960503"/>
+		<info name="serial" value="SLPS-00138" />
+		<info name="release" value="19960503" />
 		<info name="alt_title" value="ギャラクシーファイト －ユニバーサル・ウォリアーズ－"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44010,8 +44010,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GALEOZ (Japan)</description>
 		<year>1996</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-00621"/>
-		<info name="release" value="19961220"/>
+		<info name="serial" value="SLPS-00621" />
+		<info name="release" value="19961220" />
 		<info name="alt_title" value="ΓΑΛΕΟΖ"/>
 		<info name="alt_title" value="ガレオス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -44032,8 +44032,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gambler Jikochuushinha Ippatsu Shoubu! (Japan)</description>
 		<year>2000</year>
 		<publisher>Game Arts</publisher>
-		<info name="serial" value="SLPS-02509"/>
-		<info name="release" value="20000622"/>
+		<info name="serial" value="SLPS-02509" />
+		<info name="release" value="20000622" />
 		<info name="alt_title" value="ぎゅわんぶらあ自己中心派"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44053,8 +44053,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Game Maker (Japan)</description>
 		<year>1998</year>
 		<publisher>Axela</publisher>
-		<info name="serial" value="SLPS-01583"/>
-		<info name="release" value="19980923"/>
+		<info name="serial" value="SLPS-01583" />
+		<info name="release" value="19980923" />
 		<info name="alt_title" value="ザ・ゲームメーカー 売れ売れ100万本げっとだぜ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44074,8 +44074,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gamera 2000 (Japan)</description>
 		<year>1997</year>
 		<publisher>Virgin Interactive</publisher>
-		<info name="serial" value="SLPS-00833"/>
-		<info name="release" value="19970425"/>
+		<info name="serial" value="SLPS-00833" />
+		<info name="release" value="19970425" />
 		<info name="alt_title" value="ガメラ2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44096,8 +44096,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GUNbare! Game Tengoku - The Game Paradise 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-01322"/>
-		<info name="release" value="19980319"/>
+		<info name="serial" value="SLPS-01322" />
+		<info name="release" value="19980319" />
 		<info name="alt_title" value="GUNばれ! ゲーム天国"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44117,8 +44117,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gamesoft wo Tsukurou - Let's Be a Super Game Creator (Japan)</description>
 		<year>1999</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-01607"/>
-		<info name="release" value="19990128"/>
+		<info name="serial" value="SLPS-01607" />
+		<info name="release" value="19990128" />
 		<info name="alt_title" value="ゲームソフトをつくろう"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44138,8 +44138,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gangway Monsters (Japan)</description>
 		<year>1998</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-01468"/>
-		<info name="release" value="19981015"/>
+		<info name="serial" value="SLPS-01468" />
+		<info name="release" value="19981015" />
 		<info name="alt_title" value="ギャングウェイ・モンスターズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44159,8 +44159,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yuusha-Ou GaoGaiGar - Blockaded Numbers (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01980"/>
-		<info name="release" value="19990408"/>
+		<info name="serial" value="SLPS-01980" />
+		<info name="release" value="19990408" />
 		<info name="alt_title" value="勇者王ガオガイガー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44180,8 +44180,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hyakujuu Sentai Gaoranger (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03353"/>
-		<info name="release" value="20011129"/>
+		<info name="serial" value="SLPS-03353" />
+		<info name="release" value="20011129" />
 		<info name="alt_title" value="百獣戦隊ガオレンジャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44201,8 +44201,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tactical Armor Custom Gasaraki (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02181"/>
-		<info name="release" value="20000113"/>
+		<info name="serial" value="SLPS-02181" />
+		<info name="release" value="20000113" />
 		<info name="alt_title" value="タクティカル アーマー カスタム ガサラキ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44225,8 +44225,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gate Keepers (Japan)</description>
 		<year>1999</year>
 		<publisher>Kadokawa Shoten</publisher>
-		<info name="serial" value="SLPS-02246~SLPS-02247"/>
-		<info name="release" value="19991216"/>
+		<info name="serial" value="SLPS-02246~SLPS-02247" />
+		<info name="release" value="19991216" />
 		<info name="alt_title" value="ゲートキーパーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -44263,8 +44263,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Great Battle VI (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00719"/>
-		<info name="release" value="19970411"/>
+		<info name="serial" value="SLPS-00719" />
+		<info name="release" value="19970411" />
 		<info name="alt_title" value="ザ・グレイトバトルVI"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44292,8 +44292,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GeGeGe no Kitarou (Japan)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00644"/>
-		<info name="release" value="19970124"/>
+		<info name="serial" value="SLPS-00644" />
+		<info name="release" value="19970124" />
 		<info name="alt_title" value="ゲゲゲの鬼太郎 / GeGeGe no Kitarou - Nonoi no Nikuto Katachi-tachi (Box?)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44313,8 +44313,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GeGeGe no Kitarou - Gyakushuu! Youkai Daikessen (Japan)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87286 (VX278-J1)"/>
-		<info name="release" value="20031211"/>
+		<info name="serial" value="SLPM-87286 (VX278-J1)" />
+		<info name="release" value="20031211" />
 		<info name="alt_title" value="ゲゲゲの鬼太郎 逆襲!妖魔大血戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44334,8 +44334,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Geki-Oh Shienryu (Japan)</description>
 		<year>1999</year>
 		<publisher>Warashi</publisher>
-		<info name="serial" value="SLPS-02056"/>
-		<info name="release" value="19990520"/>
+		<info name="serial" value="SLPS-02056" />
+		<info name="release" value="19990520" />
 		<info name="alt_title" value="撃王 紫炎龍"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44355,8 +44355,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Aoki Ookami to Shiroki Mejika - Genchou Hishi (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01579"/>
-		<info name="release" value="19980917"/>
+		<info name="serial" value="SLPS-01579" />
+		<info name="release" value="19980917" />
 		<info name="alt_title" value="蒼き狼と白き牝鹿・元朝秘史"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44393,8 +44393,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Genei Tougi - Shadow Struggle (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00491"/>
-		<info name="release" value="19960920"/>
+		<info name="serial" value="SLPS-00491" />
+		<info name="release" value="19960920" />
 		<info name="alt_title" value="幻影闘技 SHADOW STRUGGLE"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44423,8 +44423,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>70's Robot Anime - Geppy-X - The Super Boosted Armor (Japan)</description>
 		<year>1999</year>
 		<publisher>Aroma</publisher>
-		<info name="serial" value="SLPS-01995~SLPS-01998"/>
-		<info name="release" value="19990527"/>
+		<info name="serial" value="SLPS-01995~SLPS-01998" />
+		<info name="release" value="19990527" />
 		<info name="alt_title" value="70年代風ロボットアニメ ゲッP-X"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -44459,8 +44459,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GetBackers Dakkanya (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86848 (VX240-J1)"/>
-		<info name="release" value="20010726"/>
+		<info name="serial" value="SLPM-86848 (VX240-J1)" />
+		<info name="release" value="20010726" />
 		<info name="alt_title" value="ゲットバッカーズ 奪還屋"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44480,8 +44480,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Guilty Gear (Japan)</description>
 		<year>1998</year>
 		<publisher>Arc System Works</publisher>
-		<info name="serial" value="SLPS-01357"/>
-		<info name="release" value="19980514"/>
+		<info name="serial" value="SLPS-01357" />
+		<info name="release" value="19980514" />
 		<info name="alt_title" value="ギルティ・ギア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44501,8 +44501,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ganbare Goemon - Ooedo Daikaiten (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86774 (VX239-J1)"/>
-		<info name="release" value="20010329"/>
+		<info name="serial" value="SLPM-86774 (VX239-J1)" />
+		<info name="release" value="20010329" />
 		<info name="alt_title" value="がんばれゴエモン 大江戸大回転"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44522,8 +44522,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ganbare Goemon - Uchuu Kaizoku Akogingu (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPS-00217 (VX011-J1)"/>
-		<info name="release" value="19960322"/>
+		<info name="serial" value="SLPS-00217 (VX011-J1)" />
+		<info name="release" value="19960322" />
 		<info name="alt_title" value="がんばれゴエモン〜宇宙海賊アコギング〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44543,8 +44543,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>GI Jockey 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86413"/>
-		<info name="release" value="20000203"/>
+		<info name="serial" value="SLPM-86413" />
+		<info name="release" value="20000203" />
 		<info name="alt_title" value="ジーワン ジョッキー 2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44564,8 +44564,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ginga Eiyuu Densetsu (Japan)</description>
 		<year>1998</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-01358"/>
-		<info name="release" value="19980528"/>
+		<info name="serial" value="SLPS-01358" />
+		<info name="release" value="19980528" />
 		<info name="alt_title" value="银河英雄传说"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44585,8 +44585,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Glint Glitters (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86200 (VX226-J1)"/>
-		<info name="release" value="19990729"/>
+		<info name="serial" value="SLPM-86200 (VX226-J1)" />
+		<info name="release" value="19990729" />
 		<info name="alt_title" value="グリントグリッター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44606,8 +44606,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gallop Racer 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Tecmo</publisher>
-		<info name="serial" value="SLPS-02623"/>
-		<info name="release" value="20000217"/>
+		<info name="serial" value="SLPS-02623" />
+		<info name="release" value="20000217" />
 		<info name="alt_title" value="ギャロップレーサー2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44627,8 +44627,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gensou Maden Saiyuuki - Harukanaru Nishi e (Japan)</description>
 		<year>2002</year>
 		<publisher>J-Wing</publisher>
-		<info name="serial" value="SLPM-86986"/>
-		<info name="release" value="20021226"/>
+		<info name="serial" value="SLPM-86986" />
+		<info name="release" value="20021226" />
 		<info name="alt_title" value="幻想魔伝 最遊記 〜遙かなる西へ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44648,8 +44648,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Goemon - Shin Sedai Shuumei (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86997 (VX251-J1)"/>
-		<info name="release" value="20011220"/>
+		<info name="serial" value="SLPM-86997 (VX251-J1)" />
+		<info name="release" value="20011220" />
 		<info name="alt_title" value="ゴエモン 新世代襲名！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44669,8 +44669,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Goo! Goo! Soundy (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86250 (VX097-J1)"/>
-		<info name="release" value="19990922"/>
+		<info name="serial" value="SLPM-86250 (VX097-J1)" />
+		<info name="release" value="19990922" />
 		<info name="alt_title" value="グー！グー！サウンディ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44690,8 +44690,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Googootrops (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86148"/>
-		<info name="release" value="19990128"/>
+		<info name="serial" value="SLPM-86148" />
+		<info name="release" value="19990128" />
 		<info name="alt_title" value="グーグートロプス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44711,8 +44711,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gokuu Densetsu - Magic Beast Warriors (Japan)</description>
 		<year>1995</year>
 		<publisher>Allumer</publisher>
-		<info name="serial" value="SLPS-00048"/>
-		<info name="release" value="19950526"/>
+		<info name="serial" value="SLPS-00048" />
+		<info name="release" value="19950526" />
 		<info name="alt_title" value="悟空伝説 -Magic Beast Warriors-"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44732,8 +44732,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fuuun Gokuu Ninden (Japan)</description>
 		<year>1996</year>
 		<publisher>AiCOM</publisher>
-		<info name="serial" value="SLPS-00441"/>
-		<info name="release" value="19960830"/>
+		<info name="serial" value="SLPS-00441" />
+		<info name="release" value="19960830" />
 		<info name="alt_title" value="風雲悟空忍伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44772,8 +44772,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Goiken Muyou II (Japan)</description>
 		<year>1998</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-01542"/>
-		<info name="release" value="19981029"/>
+		<info name="serial" value="SLPS-01542" />
+		<info name="release" value="19981029" />
 		<info name="alt_title" value="御意见无用2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44793,8 +44793,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Golgo 13 - 1 - Karairu no Yabou (Japan)</description>
 		<year>1998</year>
 		<publisher>Daiki</publisher>
-		<info name="serial" value="SLPS-01712"/>
-		<info name="release" value="19981126"/>
+		<info name="serial" value="SLPS-01712" />
+		<info name="release" value="19981126" />
 		<info name="alt_title" value="ゴルゴ13 (1)カーライルの野望 D2MANGA"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44814,8 +44814,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Choujin Gakuen Gowcaizer (Japan)</description>
 		<year>1997</year>
 		<publisher>Urban Plant</publisher>
-		<info name="serial" value="SLPS-00527"/>
-		<info name="release" value="19970717"/>
+		<info name="serial" value="SLPS-00527" />
+		<info name="release" value="19970717" />
 		<info name="alt_title" value="超人学園GOWCAIZER"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44838,8 +44838,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>G-Police (Japan)</description>
 		<year>1998</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10065~SCPS-10066"/>
-		<info name="release" value="19981119"/>
+		<info name="serial" value="SCPS-10065~SCPS-10066" />
+		<info name="release" value="19981119" />
 		<info name="alt_title" value="ジーポリス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -44879,8 +44879,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chou-Kousoku Grandoll (Japan)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00935"/>
-		<info name="release" value="19970724"/>
+		<info name="serial" value="SLPS-00935" />
+		<info name="release" value="19970724" />
 		<info name="alt_title" value="超光速グランドール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44900,8 +44900,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gritz - The Pyramid Adventure (Japan)</description>
 		<year>1997</year>
 		<publisher>Sanyo</publisher>
-		<info name="serial" value="SLPS-00615"/>
-		<info name="release" value="19970530"/>
+		<info name="serial" value="SLPS-00615" />
+		<info name="release" value="19970530" />
 		<info name="alt_title" value="GRITZ ザ ピラミッドアドベンチャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44921,8 +44921,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Groove Jigoku V - Sweepstation Version (Japan)</description>
 		<year>1998</year>
 		<publisher>Kioon Sony Records</publisher>
-		<info name="serial" value="SLPS-01205"/>
-		<info name="release" value="19980108"/>
+		<info name="serial" value="SLPS-01205" />
+		<info name="release" value="19980108" />
 		<info name="alt_title" value="グルーヴ地獄V SweepStation Version"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44945,8 +44945,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Growlanser (Japan)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-02380~SLPS-02381"/>
-		<info name="release" value="19991125"/>
+		<info name="serial" value="SLPS-02380~SLPS-02381" />
+		<info name="release" value="19991125" />
 		<info name="alt_title" value="グローランサー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -44971,8 +44971,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Guitar Freaks Append 2nd Mix (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86446 (VX183-J1)"/>
-		<info name="release" value="20000224"/>
+		<info name="serial" value="SLPM-86446 (VX183-J1)" />
+		<info name="release" value="20000224" />
 		<info name="alt_title" value="ギターフリークス アペンド セカンドミックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -44992,8 +44992,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gunbird (Japan)</description>
 		<year>1995</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-00157"/>
-		<info name="release" value="19951215"/>
+		<info name="serial" value="SLPS-00157" />
+		<info name="release" value="19951215" />
 		<info name="alt_title" value="ガンバード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45013,8 +45013,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gung-Ho Brigade (Japan)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-01902"/>
-		<info name="release" value="20001019"/>
+		<info name="serial" value="SLPS-01902" />
+		<info name="release" value="20001019" />
 		<info name="alt_title" value="ガンホーブリゲイド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45049,8 +45049,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kou Kidou Gensou - Gunparade March (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10136"/>
-		<info name="release" value="20000928"/>
+		<info name="serial" value="SCPS-10136" />
+		<info name="release" value="20000928" />
 		<info name="alt_title" value="高機動幻想 ガンパレード・マーチ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45075,8 +45075,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ridegear Guybrave II (Japan)</description>
 		<year>1998</year>
 		<publisher>Axela</publisher>
-		<info name="serial" value="SLPS-01643~SLPS-01644"/>
-		<info name="release" value="19981029"/>
+		<info name="serial" value="SLPS-01643~SLPS-01644" />
+		<info name="release" value="19981029" />
 		<info name="alt_title" value="雷弩機兵ガイブレイブII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -45101,9 +45101,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hai-Shin-2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques"/>
-		<info name="serial" value="SLPM-86066"/>
-		<info name="release" value="19980326"/>
+		<info name="developer" value="Aques" />
+		<info name="serial" value="SLPM-86066" />
+		<info name="release" value="19980326" />
 		<info name="alt_title" value="牌神2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45145,8 +45145,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hanabi Fantast (Japan)</description>
 		<year>1998</year>
 		<publisher>Magical</publisher>
-		<info name="serial" value="SLPS-01439"/>
-		<info name="release" value="19980716"/>
+		<info name="serial" value="SLPS-01439" />
+		<info name="release" value="19980716" />
 		<info name="alt_title" value="花火 FANTAST"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45166,8 +45166,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Happy Hotel (Japan)</description>
 		<year>1997</year>
 		<publisher>Tohoku Shinsha</publisher>
-		<info name="serial" value="SLPS-01110"/>
-		<info name="release" value="19971127"/>
+		<info name="serial" value="SLPS-01110" />
+		<info name="release" value="19971127" />
 		<info name="alt_title" value="ハッピーホテル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45187,8 +45187,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Happy Salvage (Japan)</description>
 		<year>2000</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-02821"/>
-		<info name="release" value="20000831"/>
+		<info name="serial" value="SLPS-02821" />
+		<info name="release" value="20000831" />
 		<info name="alt_title" value="ハッピィサルベージ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -45222,8 +45222,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hard Boiled (Japan)</description>
 		<year>1998</year>
 		<publisher>Sieg</publisher>
-		<info name="serial" value="SLPS-01484"/>
-		<info name="release" value="19900730"/>
+		<info name="serial" value="SLPS-01484" />
+		<info name="release" value="19900730" />
 		<info name="alt_title" value="ハードボイルド ～神経暦を破壊せよ～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45244,8 +45244,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ninpu Sentai Harikenger (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03493"/>
-		<info name="release" value="20021128"/>
+		<info name="serial" value="SLPS-03493" />
+		<info name="release" value="20021128" />
 		<info name="alt_title" value="忍風戦隊ハリケンジャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45265,8 +45265,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Harmful Park (Japan)</description>
 		<year>1997</year>
 		<publisher>Sky Think Systems</publisher>
-		<info name="serial" value="SLPS-00498"/>
-		<info name="release" value="19970214"/>
+		<info name="serial" value="SLPS-00498" />
+		<info name="release" value="19970214" />
 		<info name="alt_title" value="ハームフルパーク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45286,8 +45286,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Harukanaru Toki no Naka de - Banjou Yuugi (Japan, Premium Box)</description>
 		<year>2003</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-87241"/>
-		<info name="release" value="20030626"/>
+		<info name="serial" value="SLPM-87241" />
+		<info name="release" value="20030626" />
 		<info name="alt_title" value="遙かなる時空の中で 盤上遊戯 プレミアムBOX"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45307,8 +45307,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Harukanaru Toki no Naka de (Japan)</description>
 		<year>2000</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86466"/>
-		<info name="release" value="20000406"/>
+		<info name="serial" value="SLPM-86466" />
+		<info name="release" value="20000406" />
 		<info name="alt_title" value="遙かなる時空の中で"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45328,8 +45328,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hashiriya - Ookamitachi no Densetsu (Japan)</description>
 		<year>1997</year>
 		<publisher>Nichibutsu</publisher>
-		<info name="serial" value="SLPS-00704"/>
-		<info name="release" value="19970418"/>
+		<info name="serial" value="SLPS-00704" />
+		<info name="release" value="19970418" />
 		<info name="alt_title" value="走り屋 〜狼たちの伝説〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45349,8 +45349,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hatsukoi Valentine (Japan)</description>
 		<year>1997</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-00831"/>
-		<info name="release" value="19970731"/>
+		<info name="serial" value="SLPS-00831" />
+		<info name="release" value="19970731" />
 		<info name="alt_title" value="初恋ばれんたいん"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45370,8 +45370,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Haunted Junction - Seitokai Batch o Oe! (Japan)</description>
 		<year>1997</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-00668"/>
-		<info name="release" value="19970117"/>
+		<info name="serial" value="SLPS-00668" />
+		<info name="release" value="19970117" />
 		<info name="alt_title" value="ホーンテッドじゃんくしょん ～聖徒会バッジを追え！～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45391,8 +45391,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Heiwa Parlor! Pro Dolphin Ring Special (Japan)</description>
 		<year>2000</year>
 		<publisher>Nihon Telenet</publisher>
-		<info name="serial" value="SLPS-02689"/>
-		<info name="release" value="20000330"/>
+		<info name="serial" value="SLPS-02689" />
+		<info name="release" value="20000330" />
 		<info name="alt_title" value="平和パーラープロ ドルフィンリングスペシャルスペシャル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45412,8 +45412,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Heiwa Parlor! Pro Lupin Sansei Special (Japan)</description>
 		<year>2000</year>
 		<publisher>Nihon Telenet</publisher>
-		<info name="serial" value="SLPS-02541"/>
-		<info name="release" value="20000113"/>
+		<info name="serial" value="SLPS-02541" />
+		<info name="release" value="20000113" />
 		<info name="alt_title" value="平和パーラープロ ルパン三世スペシャル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45433,8 +45433,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Heiwa Otenki Studio (Japan)</description>
 		<year>2001</year>
 		<publisher>Aqua Rouge</publisher>
-		<info name="serial" value="SLPS-03178"/>
-		<info name="release" value="20010329"/>
+		<info name="serial" value="SLPS-03178" />
+		<info name="release" value="20010329" />
 		<info name="alt_title" value="THE 平和 〜お天気スタジオ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45454,8 +45454,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Heiwa Pachinko Graffiti Vol.1 (Japan)</description>
 		<year>1999</year>
 		<publisher>Aqua Rouge</publisher>
-		<info name="serial" value="SLPS-02374"/>
-		<info name="release" value="19991209"/>
+		<info name="serial" value="SLPS-02374" />
+		<info name="release" value="19991209" />
 		<info name="alt_title" value="平和パチンコグラフィティ Vol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45475,8 +45475,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Heiwa Parlor! Pro Tsunatori Monogatari Special (Japan)</description>
 		<year>2002</year>
 		<publisher>Nihon Telenet</publisher>
-		<info name="serial" value="SLPS-03370"/>
-		<info name="release" value="20020307"/>
+		<info name="serial" value="SLPS-03370" />
+		<info name="release" value="20020307" />
 		<info name="alt_title" value="平和パーラー！プロ つなとり 綱取物語スペシャル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45496,8 +45496,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hello Charlie!! (Japan)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86083"/>
-		<info name="release" value="19980730"/>
+		<info name="serial" value="SLPM-86083" />
+		<info name="release" value="19980730" />
 		<info name="alt_title" value="ハローチャーリー！！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45517,8 +45517,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hello Kitty's Cube De Cute (Japan)</description>
 		<year>1998</year>
 		<publisher>Culture Publishing</publisher>
-		<info name="serial" value="SLPS-01427"/>
-		<info name="release" value="19980625"/>
+		<info name="serial" value="SLPS-01427" />
+		<info name="release" value="19980625" />
 		<info name="alt_title" value="ハローキティのキューブでキュート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45569,8 +45569,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hello Kitty - White Present (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01766"/>
-		<info name="release" value="19981217"/>
+		<info name="serial" value="SLPS-01766" />
+		<info name="release" value="19981217" />
 		<info name="alt_title" value="ハローキティ ホワイトプレゼント"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45591,8 +45591,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Henry Explorers (Japan)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86021 (VX044-J1)"/>
-		<info name="release" value="19970307"/>
+		<info name="serial" value="SLPM-86021 (VX044-J1)" />
+		<info name="release" value="19970307" />
 		<info name="alt_title" value="ヘンリーエクスプローラーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45612,8 +45612,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hermie Hopperhead - Scrap Panic (Japan, Playstation the Best)</description>
 		<year>1996</year>
 		<publisher>Sony</publisher>
-		<info name="serial" value="SCPS-91016"/>
-		<info name="release" value="19961206"/>
+		<info name="serial" value="SCPS-91016" />
+		<info name="release" value="19961206" />
 		<info name="alt_title" value="ハーミィホッパーヘッド スクラップパニック (PlayStation the Best for Family)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45633,8 +45633,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Houma Hunter Lime - Special Collection Vol.1 (Japan)</description>
 		<year>1994</year>
 		<publisher>Asmik</publisher>
-		<info name="serial" value="SLPS-00020"/>
-		<info name="release" value="19941222"/>
+		<info name="serial" value="SLPS-00020" />
+		<info name="release" value="19941222" />
 		<info name="alt_title" value="宝魔ハンター・ライム スペシャルコレクションVol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45654,8 +45654,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hikari no Shima - Seven Lithographs in Shining Island (Japan)</description>
 		<year>1999</year>
 		<publisher>Affect</publisher>
-		<info name="serial" value="SLPS-02305"/>
-		<info name="release" value="19991111"/>
+		<info name="serial" value="SLPS-02305" />
+		<info name="release" value="19991111" />
 		<info name="alt_title" value="光の島"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45675,8 +45675,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hikaru no Go - Heian Gensou Ibunroku (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87059 (VX262-J1)"/>
-		<info name="release" value="20020530"/>
+		<info name="serial" value="SLPM-87059 (VX262-J1)" />
+		<info name="release" value="20020530" />
 		<info name="alt_title" value="ヒカルの碁 平安幻想異聞録"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45696,8 +45696,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hikaru no Go - Insei Choujou Kessen (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87199 (VX270-J1)"/>
-		<info name="release" value="20021219"/>
+		<info name="serial" value="SLPM-87199 (VX270-J1)" />
+		<info name="release" value="20021219" />
 		<info name="alt_title" value="ヒカルの碁 院生頂上決戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45723,8 +45723,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Himiko-Den (Japan)</description>
 		<year>1999</year>
 		<publisher>Hakuhodo</publisher>
-		<info name="serial" value="SLPS-01890~SLPS-01892"/>
-		<info name="release" value="19990311"/>
+		<info name="serial" value="SLPS-01890~SLPS-01892" />
+		<info name="release" value="19990311" />
 		<info name="alt_title" value="火魅子伝〜恋解〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -45754,8 +45754,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hissatsu Pachi-Slot Station 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-02355"/>
-		<info name="release" value="19991028"/>
+		<info name="serial" value="SLPS-02355" />
+		<info name="release" value="19991028" />
 		<info name="alt_title" value="必殺パチスロステーション2 爆登！常識破りの2タイプ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45775,8 +45775,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hissatsu Pachi-Slot Station 4 (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-02799"/>
-		<info name="release" value="20000727"/>
+		<info name="serial" value="SLPS-02799" />
+		<info name="release" value="20000727" />
 		<info name="alt_title" value="必殺パチスロステーション4 ニューバルR&amp;ホットロッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45796,8 +45796,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hissatsu Pachi-Slot Station 5 (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03030"/>
-		<info name="release" value="20001116"/>
+		<info name="serial" value="SLPS-03030" />
+		<info name="release" value="20001116" />
 		<info name="alt_title" value="必殺パチンコステーション5 インベーダー2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45817,8 +45817,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hissatsu Pachi-Slot Station SP (Japan)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-02494"/>
-		<info name="release" value="19991216"/>
+		<info name="serial" value="SLPS-02494" />
+		<info name="release" value="19991216" />
 		<info name="alt_title" value="必殺パチスロステーションSP 山佐★ベストチョイス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45838,8 +45838,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hit Back (Japan)</description>
 		<year>1999</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-01361"/>
-		<info name="release" value="19990415"/>
+		<info name="serial" value="SLPS-01361" />
+		<info name="release" value="19990415" />
 		<info name="alt_title" value="ひっとばっく"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45859,8 +45859,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hiza no Ue no Partner - Kitty On Your Lap (Japan)</description>
 		<year>1998</year>
 		<publisher>Culture Publishers</publisher>
-		<info name="serial" value="SLPS-01302"/>
-		<info name="release" value="19980312"/>
+		<info name="serial" value="SLPS-01302" />
+		<info name="release" value="19980312" />
 		<info name="alt_title" value="ひざの上の同居人 −KITTY ON YOUR LAP−"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45880,8 +45880,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hokuto no Ken (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00369"/>
-		<info name="release" value="19960830"/>
+		<info name="serial" value="SLPS-00369" />
+		<info name="release" value="19960830" />
 		<info name="alt_title" value="北斗の拳"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45904,7 +45904,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Bandai</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hokuto no ken - seikimatsu kyuuseishu densetsu (japan)" sha1="bd52aeec9c61c52b4e7a5391e1a4bd56fe453cdd"/>
+				<disk name="hokuto no ken - seikimatsu kyuuseishu densetsu (japan)" sha1="bd52aeec9c61c52b4e7a5391e1a4bd56fe453cdd" />
 			</diskarea>
 		</part>
 	</software>
@@ -45919,8 +45919,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hooockey!! (Japan, SuperLite 1500 Series)</description>
 		<year>2000</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86488"/>
-		<info name="release" value="20000525"/>
+		<info name="serial" value="SLPM-86488" />
+		<info name="release" value="20000525" />
 		<info name="alt_title" value="SuperLite1500シリーズ ホッケー！！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45940,8 +45940,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hoshigami - Shizumiyuku Aoki Daichi (Japan)</description>
 		<year>2002</year>
 		<publisher>MaxFive</publisher>
-		<info name="serial" value="SLPS-02904"/>
-		<info name="release" value="20020207"/>
+		<info name="serial" value="SLPS-02904" />
+		<info name="release" value="20020207" />
 		<info name="alt_title" value="星神 〜沈みゆく蒼き大地〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45961,8 +45961,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>High School of Blitz (Japan)</description>
 		<year>1999</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-02351"/>
-		<info name="release" value="19991125"/>
+		<info name="serial" value="SLPS-02351" />
+		<info name="release" value="19991125" />
 		<info name="alt_title" value="ハイスクール オブ ブリッツ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -45982,8 +45982,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Heaven's Gate (Japan)</description>
 		<year>1996</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-00667"/>
-		<info name="release" value="19961213"/>
+		<info name="serial" value="SLPS-00667" />
+		<info name="release" value="19961213" />
 		<info name="alt_title" value="ヘヴンズゲート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46003,8 +46003,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hunter X Hunter - Maboroshi no Greed Island (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86651 (VX214-J1)"/>
-		<info name="release" value="20001026"/>
+		<info name="serial" value="SLPM-86651 (VX214-J1)" />
+		<info name="release" value="20001026" />
 		<info name="alt_title" value="ハンター×ハンター 幻のグリードアイランド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46024,8 +46024,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hunter X Hunter - Ubawareta Aura Stone (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86895 (VX249-J1)"/>
-		<info name="release" value="20010927"/>
+		<info name="serial" value="SLPM-86895 (VX249-J1)" />
+		<info name="release" value="20010927" />
 		<info name="alt_title" value="Hハンター×ハンター 奪われたオーラストーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46045,8 +46045,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hyouryuu Ki - The Reportage Beyond the Sea (Japan)</description>
 		<year>1999</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-02358"/>
-		<info name="release" value="19991028"/>
+		<info name="serial" value="SLPS-02358" />
+		<info name="release" value="19991028" />
 		<info name="alt_title" value="漂流記"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46066,8 +46066,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hyper Crazy Climber (Japan)</description>
 		<year>1996</year>
 		<publisher>Nichibutsu</publisher>
-		<info name="serial" value="SLPS-00248"/>
-		<info name="release" value="19960223"/>
+		<info name="serial" value="SLPS-00248" />
+		<info name="release" value="19960223" />
 		<info name="alt_title" value="ハイパークレイジークライマー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46087,8 +46087,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hyper Securities 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01417"/>
-		<info name="release" value="19980625"/>
+		<info name="serial" value="SLPS-01417" />
+		<info name="release" value="19980625" />
 		<info name="alt_title" value="はいぱぁセキュリティーズ2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46108,8 +46108,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hyper Rally (Japan)</description>
 		<year>1996</year>
 		<publisher>Harvest One</publisher>
-		<info name="serial" value="SLPS-00462"/>
-		<info name="release" value="19960830"/>
+		<info name="serial" value="SLPS-00462" />
+		<info name="release" value="19960830" />
 		<info name="alt_title" value="ハイパーラリー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46129,8 +46129,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ichigeki - Hagane no Hito (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02199"/>
-		<info name="release" value="19991102"/>
+		<info name="serial" value="SLPS-02199" />
+		<info name="release" value="19991102" />
 		<info name="alt_title" value="一撃 鋼の人"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46150,8 +46150,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ide Yousuke no Mahjong Kyoshitsu (Japan)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-02272"/>
-		<info name="release" value="19991202"/>
+		<info name="serial" value="SLPS-02272" />
+		<info name="release" value="19991202" />
 		<info name="alt_title" value="井出洋介の麻雀教室"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46171,8 +46171,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Baseball Simulation - ID Pro Yakyuu (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86650 (VX189-J1)"/>
-		<info name="release" value="20010125"/>
+		<info name="serial" value="SLPM-86650 (VX189-J1)" />
+		<info name="release" value="20010125" />
 		<info name="alt_title" value="ベースボールシミュレーション IDプロ野球"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46192,8 +46192,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Minna Atsumore! Igo Kyoushitsu (Japan)</description>
 		<year>2003</year>
 		<publisher>I.Magic.</publisher>
-		<info name="serial" value="SLPS-03554"/>
-		<info name="release" value="20031211"/>
+		<info name="serial" value="SLPS-03554" />
+		<info name="release" value="20031211" />
 		<info name="alt_title" value="みんな集まれ!囲碁教室"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46213,8 +46213,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arcade Gears - Image Fight &amp; X-Multiply (Japan)</description>
 		<year>1998</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-01267"/>
-		<info name="release" value="19980319"/>
+		<info name="serial" value="SLPS-01267" />
+		<info name="release" value="19980319" />
 		<info name="alt_title" value="アーケードギアーズ イメージファイト&amp;X－マルチプライ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46234,8 +46234,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Inagawa Junji - Kyoufu no Yashiki (Japan)</description>
 		<year>1999</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPS-02142"/>
-		<info name="release" value="19990701"/>
+		<info name="serial" value="SLPS-02142" />
+		<info name="release" value="19990701" />
 		<info name="alt_title" value="稲川淳二 恐怖の屋敷"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46255,8 +46255,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Indy 500 (Japan)</description>
 		<year>1997</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-00860"/>
-		<info name="release" value="19970523"/>
+		<info name="serial" value="SLPS-00860" />
+		<info name="release" value="19970523" />
 		<info name="alt_title" value="インディ 500"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46276,8 +46276,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Inuyasha (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03374"/>
-		<info name="release" value="20011227"/>
+		<info name="serial" value="SLPS-03374" />
+		<info name="release" value="20011227" />
 		<info name="alt_title" value="犬夜叉"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46297,8 +46297,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Inuyasha - Sengoku Otogi Kassen (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03504"/>
-		<info name="release" value="20021205"/>
+		<info name="serial" value="SLPS-03504" />
+		<info name="release" value="20021205" />
 		<info name="alt_title" value="犬夜叉〜戦国お伽合戦〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46318,8 +46318,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ucchannanchan no Honoo no Challenger - Denryu Iraira-Bou Returns (Japan)</description>
 		<year>1998</year>
 		<publisher>Saurus</publisher>
-		<info name="serial" value="SLPS-01317"/>
-		<info name="release" value="19980319"/>
+		<info name="serial" value="SLPS-01317" />
+		<info name="release" value="19980319" />
 		<info name="alt_title" value="ウッチャンナンチャンの炎のチャレンジャー 電流イライラ棒リターンズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46339,8 +46339,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Irem Arcade Classics (Japan)</description>
 		<year>1996</year>
 		<publisher>I'Max</publisher>
-		<info name="serial" value="SLPS-00341"/>
-		<info name="release" value="19960426"/>
+		<info name="serial" value="SLPS-00341" />
+		<info name="release" value="19960426" />
 		<info name="alt_title" value="アイレム アーケード クラシックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46360,8 +46360,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Itadaki Street - Gorgeous King (Japan)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86120"/>
-		<info name="release" value="19980923"/>
+		<info name="serial" value="SLPM-86120" />
+		<info name="release" value="19980923" />
 		<info name="alt_title" value="いただきストリート ゴージャスキング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46384,8 +46384,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>JailBreaker (Japan)</description>
 		<year>1999</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-02076~SLPS-02077 (NIPS 4004)"/>
-		<info name="release" value="19990603"/>
+		<info name="serial" value="SLPS-02076~SLPS-02077 (NIPS 4004)" />
+		<info name="release" value="19990603" />
 		<info name="alt_title" value="ジェイルブレイカー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -46410,8 +46410,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Jaleco Collection Vol.1 (Japan)</description>
 		<year>2003</year>
 		<publisher>PCCW</publisher>
-		<info name="serial" value="SLPS-03562"/>
-		<info name="release" value="20031023"/>
+		<info name="serial" value="SLPS-03562" />
+		<info name="release" value="20031023" />
 		<info name="alt_title" value="ジャレココレクション Vol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46431,8 +46431,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Jellyfish - The Healing Friend (Japan)</description>
 		<year>2000</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPS-02892"/>
-		<info name="release" value="20000928"/>
+		<info name="serial" value="SLPS-02892" />
+		<info name="release" value="20000928" />
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -46454,8 +46454,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shiritsu Justice Gakuen - Legion of Heroes (Japan)</description>
 		<year>1998</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01240~SLPS-01241"/>
-		<info name="release" value="19980730"/>
+		<info name="serial" value="SLPS-01240~SLPS-01241" />
+		<info name="release" value="19980730" />
 		<info name="alt_title" value="私立ジャスティス学園 〜リージョン オブ ヒーローズ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -46480,8 +46480,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shiritsu Justice Gakuen - Nekketsu Seishun Nikki 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-02120"/>
-		<info name="release" value="19990624"/>
+		<info name="serial" value="SLPS-02120" />
+		<info name="release" value="19990624" />
 		<info name="alt_title" value="私立ジャスティス学園－熱血青春日記2－"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46502,8 +46502,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Jigsaw World (Japan, Honkakuha de 1300Yen Series)</description>
 		<year>1999</year>
 		<publisher>Hect</publisher>
-		<info name="serial" value="SLPS-02251"/>
-		<info name="release" value="19990914"/>
+		<info name="serial" value="SLPS-02251" />
+		<info name="release" value="19990914" />
 		<info name="alt_title" value="本格派DE 1300円 ジグソーワールド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46540,8 +46540,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Jounetsu Nekketsu Athletes - Nakimushi Coach no Nikki (Japan)</description>
 		<year>1997</year>
 		<publisher>Asmik</publisher>
-		<info name="serial" value="SLPS-00936"/>
-		<info name="release" value="19971009"/>
+		<info name="serial" value="SLPS-00936" />
+		<info name="release" value="19971009" />
 		<info name="alt_title" value="情熱★熱血アスリーツ ～泣き虫コーチの日記～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46561,8 +46561,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Jungle Park (Japan)</description>
 		<year>1998</year>
 		<publisher>Digitalogue</publisher>
-		<info name="serial" value="SLPS-01086"/>
-		<info name="release" value="19980226"/>
+		<info name="serial" value="SLPS-01086" />
+		<info name="release" value="19980226" />
 		<info name="alt_title" value="ジャングルパーク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46599,8 +46599,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Fighting Illusion - K-1 Grand Prix '98 (Japan)</description>
 		<year>1998</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-01696"/>
-		<info name="release" value="19981126"/>
+		<info name="serial" value="SLPS-01696" />
+		<info name="release" value="19981126" />
 		<info name="alt_title" value="ファイティング イリュージョン K-1グランプリ'98"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46620,8 +46620,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaeru no Ehon - Nakushita Kioku o Motomete (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-02332"/>
-		<info name="release" value="19991021"/>
+		<info name="serial" value="SLPS-02332" />
+		<info name="release" value="19991021" />
 		<info name="alt_title" value="かえるの絵本 なくした記憶を求めて"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46641,8 +46641,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kain the Vampire (Japan)</description>
 		<year>1997</year>
 		<publisher>BMG Japan</publisher>
-		<info name="serial" value="SLPS-00743"/>
-		<info name="release" value="19970530"/>
+		<info name="serial" value="SLPS-00743" />
+		<info name="release" value="19970530" />
 		<info name="alt_title" value="ケイン・ザ・バンパイア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46662,8 +46662,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaikan Phrase - Datenshi Kourin (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86438"/>
-		<info name="release" value="20000224"/>
+		<info name="serial" value="SLPM-86438" />
+		<info name="release" value="20000224" />
 		<info name="alt_title" value="快感フレーズ 堕天使降臨"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46683,8 +46683,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaitohranma Miyabi (Japan)</description>
 		<year>1999</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-01825"/>
-		<info name="release" value="19990121"/>
+		<info name="serial" value="SLPS-01825" />
+		<info name="release" value="19990121" />
 		<info name="alt_title" value="快刀乱麻 雅"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46704,8 +46704,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kakugo no Susume (Japan)</description>
 		<year>1997</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-00799"/>
-		<info name="release" value="19970328"/>
+		<info name="serial" value="SLPS-00799" />
+		<info name="release" value="19970328" />
 		<info name="alt_title" value="覚悟のススメ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46725,8 +46725,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kids Station - Kamen Rider Heroes (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03403"/>
-		<info name="release" value="20020718"/>
+		<info name="serial" value="SLPS-03403" />
+		<info name="release" value="20020718" />
 		<info name="alt_title" value="キッズステーション 仮面ライダーヒーローズ(ソフト単体版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46746,8 +46746,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kamen Rider Agito (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03344"/>
-		<info name="release" value="20011129"/>
+		<info name="serial" value="SLPS-03344" />
+		<info name="release" value="20011129" />
 		<info name="alt_title" value="仮面ライダーアギト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46846,8 +46846,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kamen Rider (Japan)</description>
 		<year>1998</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01570"/>
-		<info name="release" value="19981001"/>
+		<info name="serial" value="SLPS-01570" />
+		<info name="release" value="19981001" />
 		<info name="alt_title" value="仮面ライダー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46867,8 +46867,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kamen Rider Kuuga (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03090"/>
-		<info name="release" value="20001221"/>
+		<info name="serial" value="SLPS-03090" />
+		<info name="release" value="20001221" />
 		<info name="alt_title" value="仮面ライダークウガ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46888,8 +46888,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kamen Rider Ryuki (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03495"/>
-		<info name="release" value="20021128"/>
+		<info name="serial" value="SLPS-03495" />
+		<info name="release" value="20021128" />
 		<info name="alt_title" value="仮面ライダー龍騎"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46909,8 +46909,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kanako Enomoto - Junk Brain Diagnosis (Japan)</description>
 		<year>1999</year>
 		<publisher>Oracion</publisher>
-		<info name="serial" value="SLPS-01937"/>
-		<info name="release" value="19990325"/>
+		<info name="serial" value="SLPS-01937" />
+		<info name="release" value="19990325" />
 		<info name="alt_title" value="榎本加奈子のボケ診断ゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46930,8 +46930,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chou Hatsumei Boy Kanipan - Hirameki Wonderland (Japan)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86299 (TCPS10009)"/>
-		<info name="release" value="19990930"/>
+		<info name="serial" value="SLPM-86299 (TCPS10009)" />
+		<info name="release" value="19990930" />
 		<info name="alt_title" value="超発明BOYカニパン ヒラメキ☆ワンダーランド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46951,8 +46951,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kattobi Tune (Japan)</description>
 		<year>1998</year>
 		<publisher>Genki</publisher>
-		<info name="serial" value="SLPS-01253"/>
-		<info name="release" value="19980423"/>
+		<info name="serial" value="SLPS-01253" />
+		<info name="release" value="19980423" />
 		<info name="alt_title" value="かっとびチューン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46973,8 +46973,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaze no Notam - Notam of Wind (Japan)</description>
 		<year>1997</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-00912"/>
-		<info name="release" value="19970911"/>
+		<info name="serial" value="SLPS-00912" />
+		<info name="release" value="19970911" />
 		<info name="alt_title" value="風のノータム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -46994,8 +46994,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Keiba Eight '98 Akifuyu (Japan)</description>
 		<year>1998</year>
 		<publisher>Shangri-La</publisher>
-		<info name="serial" value="SLPS-01640"/>
-		<info name="release" value="19981022"/>
+		<info name="serial" value="SLPS-01640" />
+		<info name="release" value="19981022" />
 		<info name="alt_title" value="競馬エイト'98秋冬"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47015,8 +47015,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Keiba Eight '98 Haru Natsu (Japan)</description>
 		<year>1998</year>
 		<publisher>Shangri-La</publisher>
-		<info name="serial" value="SLPS-01372"/>
-		<info name="release" value="19980429"/>
+		<info name="serial" value="SLPS-01372" />
+		<info name="release" value="19980429" />
 		<info name="alt_title" value="競馬エイト '98春夏"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47036,8 +47036,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Keiba Saishou no Housoku '95 (Japan)</description>
 		<year>1995</year>
 		<publisher>Copya System</publisher>
-		<info name="serial" value="SLPS-00063"/>
-		<info name="release" value="19950623"/>
+		<info name="serial" value="SLPS-00063" />
+		<info name="release" value="19950623" />
 		<info name="alt_title" value="競馬最勝の法則’95"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47058,8 +47058,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rami-Chan no Ooedo Surogoku - Keiou Yuugekitai Gaiden (Japan)</description>
 		<year>1998</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01546"/>
-		<info name="release" value="19980917"/>
+		<info name="serial" value="SLPS-01546" />
+		<info name="release" value="19980917" />
 		<info name="alt_title" value="蘭未ちゃんの大江戸すごろく 慶応遊撃隊外伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47079,8 +47079,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kenki Ippatsu! Crane Master ni Narou! (Japan)</description>
 		<year>2000</year>
 		<publisher>FAB Communication</publisher>
-		<info name="serial" value="SLPS-02831"/>
-		<info name="release" value="20000803"/>
+		<info name="serial" value="SLPS-02831" />
+		<info name="release" value="20000803" />
 		<info name="alt_title" value="けんき いっぱつ！クレーンマスターになろう！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47100,8 +47100,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kero Kero King (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
-		<info name="serial" value="SLPM-86621"/>
-		<info name="release" value="20001102"/>
+		<info name="serial" value="SLPM-86621" />
+		<info name="release" value="20001102" />
 		<info name="alt_title" value="ケロケロキング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47121,8 +47121,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Khamrai (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-02640"/>
-		<info name="release" value="20001005"/>
+		<info name="serial" value="SLPS-02640" />
+		<info name="release" value="20001005" />
 		<info name="alt_title" value="カムライー神来ー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47142,8 +47142,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Killer Bass (Japan)</description>
 		<year>2000</year>
 		<publisher>Magical</publisher>
-		<info name="serial" value="SLPS-02747"/>
-		<info name="release" value="20000615"/>
+		<info name="serial" value="SLPS-02747" />
+		<info name="release" value="20000615" />
 		<info name="alt_title" value="キラーバス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47166,8 +47166,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kindaichi Shounen no Jikenbo 3 - Seiryuu Densetsu Satsujin Jiken (Japan)</description>
 		<year>1999</year>
 		<publisher>Kodansha</publisher>
-		<info name="serial" value="SLPS-02223~SLPS-02224"/>
-		<info name="release" value="19990805"/>
+		<info name="serial" value="SLPS-02223~SLPS-02224" />
+		<info name="release" value="19990805" />
 		<info name="alt_title" value="金田一少年の事件簿3 青龍伝説殺人事件"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -47192,8 +47192,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>King of Bowling 2 - Professional-Hen (Japan)</description>
 		<year>1998</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-01541"/>
-		<info name="release" value="19980827"/>
+		<info name="serial" value="SLPS-01541" />
+		<info name="release" value="19980827" />
 		<info name="alt_title" value="キング オブ ボウリング2 プロフェッショナル編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47213,8 +47213,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hakaioh - King of Crusher (Japan)</description>
 		<year>1998</year>
 		<publisher>FAB Communications</publisher>
-		<info name="serial" value="SLPS-01677"/>
-		<info name="release" value="19981112"/>
+		<info name="serial" value="SLPS-01677" />
+		<info name="release" value="19981112" />
 		<info name="alt_title" value="破壊王 KING of CRUSHER"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47234,8 +47234,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Muscle Ranking - Kinniku Banzuke Vol.2 - Aratanaru Genkai e no Chousen! (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86457 (VX177-J1)"/>
-		<info name="release" value="20000323"/>
+		<info name="serial" value="SLPM-86457 (VX177-J1)" />
+		<info name="release" value="20000323" />
 		<info name="alt_title" value="筋肉番付VOL.2 ～新たなる限界への挑戦！～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47255,8 +47255,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kisya de Go! (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86449 (TCPS10020)"/>
-		<info name="release" value="20000323"/>
+		<info name="serial" value="SLPM-86449 (TCPS10020)" />
+		<info name="release" value="20000323" />
 		<info name="alt_title" value="汽車でGO!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47276,8 +47276,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kitchen Panic (Japan)</description>
 		<year>1998</year>
 		<publisher>Panther Software</publisher>
-		<info name="serial" value="SLPS-01395"/>
-		<info name="release" value="19980528"/>
+		<info name="serial" value="SLPS-01395" />
+		<info name="release" value="19980528" />
 		<info name="alt_title" value="キッチンぱにっく"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47297,8 +47297,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kochira Katsushikaku Kameari Kouenzen Hashutsujo - High Tech Building Shinkou Soshi Sakusen! no Ma (Japan)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00922"/>
-		<info name="release" value="19970724"/>
+		<info name="serial" value="SLPS-00922" />
+		<info name="release" value="19970724" />
 		<info name="alt_title" value="こちら葛飾区亀有公園前派出所 ハイテクビル侵攻阻止作戦！の巻"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47318,8 +47318,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Knight &amp; Baby (Japan)</description>
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
-		<info name="serial" value="SLPS-01531"/>
-		<info name="release" value="19980923"/>
+		<info name="serial" value="SLPS-01531" />
+		<info name="release" value="19980923" />
 		<info name="alt_title" value="ナイト&amp;ベイビー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47380,8 +47380,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The King of Fighters '95 (Japan)</description>
 		<year>1996</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPS-00351"/>
-		<info name="release" value="19960628"/>
+		<info name="serial" value="SLPS-00351" />
+		<info name="release" value="19960628" />
 		<info name="alt_title" value="ザ・キング・オブ・ファイターズ'95"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47441,8 +47441,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The King of Fighters '96 (Japan)</description>
 		<year>1997</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPS-00834"/>
-		<info name="release" value="19970704"/>
+		<info name="serial" value="SLPS-00834" />
+		<info name="release" value="19970704" />
 		<info name="alt_title" value="ザ・キング・オブ・ファイターズ'96"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47462,8 +47462,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The King of Fighters '98 - Dream Match Never Ends (Japan)</description>
 		<year>1999</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86201"/>
-		<info name="release" value="19990325"/>
+		<info name="serial" value="SLPM-86201" />
+		<info name="release" value="19990325" />
 		<info name="alt_title" value="ザ・キング・オブ・ファイターズ'98"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47484,8 +47484,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The King of Fighters '99 (Japan)</description>
 		<year>2000</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86462"/>
-		<info name="release" value="20000323"/>
+		<info name="serial" value="SLPM-86462" />
+		<info name="release" value="20000323" />
 		<info name="alt_title" value="ザ・キング・オブ・ファイターズ’99"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47508,8 +47508,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The King of Fighters Kyo (Japan)</description>
 		<year>1998</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86095"/>
-		<info name="release" value="19980827"/>
+		<info name="serial" value="SLPM-86095" />
+		<info name="release" value="19980827" />
 		<info name="alt_title" value="ザ・キング・オブ・ファイターズ 京"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47529,8 +47529,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kohni Shogun (Japan)</description>
 		<year>2000</year>
 		<publisher>ASK</publisher>
-		<info name="serial" value="SLPS-02955"/>
-		<info name="release" value="20001026"/>
+		<info name="serial" value="SLPS-02955" />
+		<info name="release" value="20001026" />
 		<info name="alt_title" value="高2→将軍"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47550,8 +47550,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kojin Kyouju - La Leçon Particulière (Japan)</description>
 		<year>1998</year>
 		<publisher>MyCom</publisher>
-		<info name="serial" value="SLPS-01354"/>
-		<info name="release" value="19980409"/>
+		<info name="serial" value="SLPS-01354" />
+		<info name="release" value="19980409" />
 		<info name="alt_title" value="個人教授"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47571,8 +47571,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Komotchi (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-03121"/>
-		<info name="release" value="20010920"/>
+		<info name="serial" value="SLPS-03121" />
+		<info name="release" value="20010920" />
 		<info name="alt_title" value="こもっち"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47592,8 +47592,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Konami 80's Arcade Gallery (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86228 (VX144-J1)"/>
-		<info name="release" value="19990513"/>
+		<info name="serial" value="SLPM-86228 (VX144-J1)" />
+		<info name="release" value="19990513" />
 		<info name="alt_title" value="コナミ80'sアーケードギャラリー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47613,8 +47613,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Korokoro Post Nin (Japan)</description>
 		<year>2002</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03479"/>
-		<info name="release" value="20021017"/>
+		<info name="serial" value="SLPS-03479" />
+		<info name="release" value="20021017" />
 		<info name="alt_title" value="コロコロポストニン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47634,8 +47634,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kouryuuki (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01338"/>
-		<info name="release" value="19980326"/>
+		<info name="serial" value="SLPS-01338" />
+		<info name="release" value="19980326" />
 		<info name="alt_title" value="項劉記"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47655,8 +47655,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kouklotheatro - Yuukyuu no Hitomi (Japan)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-02385"/>
-		<info name="release" value="19991202"/>
+		<info name="serial" value="SLPS-02385" />
+		<info name="release" value="19991202" />
 		<info name="alt_title" value="Κουκλοθεατρο 悠久の瞳"/>
 		<info name="alt_title" value="ククロセアトロ 悠久の瞳"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -47677,8 +47677,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Koyasai - A Sherd of Youthful Memories (Japan)</description>
 		<year>1999</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-01775"/>
-		<info name="release" value="19990225"/>
+		<info name="serial" value="SLPS-01775" />
+		<info name="release" value="19990225" />
 		<info name="alt_title" value="後夜祭"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47698,8 +47698,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kuubo Senki (Japan)</description>
 		<year>1999</year>
 		<publisher>Unbalance</publisher>
-		<info name="serial" value="SLPS-01854"/>
-		<info name="release" value="19990204"/>
+		<info name="serial" value="SLPS-01854" />
+		<info name="release" value="19990204" />
 		<info name="alt_title" value="空母戦記"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47719,8 +47719,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kunoichi Torimonocho (Japan)</description>
 		<year>1999</year>
 		<publisher>GMF</publisher>
-		<info name="serial" value="SLPS-01773"/>
-		<info name="release" value="19990225"/>
+		<info name="serial" value="SLPS-01773" />
+		<info name="release" value="19990225" />
 		<info name="alt_title" value="くのいち捕物帖"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47740,8 +47740,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kuro no Ken - Blade of the Darkness (Japan)</description>
 		<year>1997</year>
 		<publisher>CD Bros.</publisher>
-		<info name="serial" value="SLPS-01030"/>
-		<info name="release" value="19971009"/>
+		<info name="serial" value="SLPS-01030" />
+		<info name="release" value="19971009" />
 		<info name="alt_title" value="黒の剣"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47761,8 +47761,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ku-Ron Jo - Fukyuu Ban (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Rings</publisher>
-		<info name="serial" value="SLPS-03063"/>
-		<info name="release" value="20001207"/>
+		<info name="serial" value="SLPS-03063" />
+		<info name="release" value="20001207" />
 		<info name="alt_title" value="九龍城 普及版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47782,8 +47782,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kurumi Miracle (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00786"/>
-		<info name="release" value="19970925"/>
+		<info name="serial" value="SLPS-00786" />
+		<info name="release" value="19970925" />
 		<info name="alt_title" value="くるみミラクル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47830,8 +47830,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kururin Pa! (Japan)</description>
 		<year>1995</year>
 		<publisher>Sky Think System</publisher>
-		<info name="serial" value="SLPS-00066"/>
-		<info name="release" value="19950707"/>
+		<info name="serial" value="SLPS-00066" />
+		<info name="release" value="19950707" />
 		<info name="alt_title" value="くるりんPA！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47851,8 +47851,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kyorochan no Purikura Daisakusen (Japan)</description>
 		<year>1999</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-01692"/>
-		<info name="release" value="19990211"/>
+		<info name="serial" value="SLPS-01692" />
+		<info name="release" value="19990211" />
 		<info name="alt_title" value="キョロちゃんのプリクラ大作戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47872,8 +47872,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kyuin (Japan)</description>
 		<year>1996</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-00214 (100010)"/>
-		<info name="release" value="19960531"/>
+		<info name="serial" value="SLPS-00214 (100010)" />
+		<info name="release" value="19960531" />
 		<info name="alt_title" value="キュイーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47893,8 +47893,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lagnacure Legend (Japan)</description>
 		<year>2000</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-02832"/>
-		<info name="release" value="20000706"/>
+		<info name="serial" value="SLPS-02832" />
+		<info name="release" value="20000706" />
 		<info name="alt_title" value="ラグナキュール レジェンド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47914,8 +47914,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lagnacure (Japan)</description>
 		<year>1997</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-01009"/>
-		<info name="release" value="19971002"/>
+		<info name="serial" value="SLPS-01009" />
+		<info name="release" value="19971002" />
 		<info name="alt_title" value="ラグナキュール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47935,8 +47935,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lake Masters Pro - Nihon Juudan Kuro Masu Kikou (Japan)</description>
 		<year>1999</year>
 		<publisher>DaZZ</publisher>
-		<info name="serial" value="SLPS-02177 (PS-0012)"/>
-		<info name="release" value="19990914"/>
+		<info name="serial" value="SLPS-02177 (PS-0012)" />
+		<info name="release" value="19990914" />
 		<info name="alt_title" value="レイクマスターズPRO 日本全国縦断黒鱒紀行"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47956,8 +47956,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Langrisser I &amp; II (Japan)</description>
 		<year>1997</year>
 		<publisher>Masaya</publisher>
-		<info name="serial" value="SLPS-00897"/>
-		<info name="release" value="19970731"/>
+		<info name="serial" value="SLPS-00897" />
+		<info name="release" value="19970731" />
 		<info name="alt_title" value="ラングリッサーI&amp;II"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -47985,8 +47985,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Langrisser IV &amp; V Final Edition (Japan)</description>
 		<year>1999</year>
 		<publisher>Masaya</publisher>
-		<info name="serial" value="SLPS-01818~SLPS-01819"/>
-		<info name="release" value="19990128"/>
+		<info name="serial" value="SLPS-01818~SLPS-01819" />
+		<info name="release" value="19990128" />
 		<info name="alt_title" value="ラングリッサーIV&amp;V ファイナル・エディション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -48011,8 +48011,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Libero Grande 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-02950"/>
-		<info name="release" value="20000907"/>
+		<info name="serial" value="SLPS-02950" />
+		<info name="release" value="20000907" />
 		<info name="alt_title" value="リベログランデ2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48041,8 +48041,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Legend of Dragoon (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10119~SCPS-10122"/>
-		<info name="release" value="19991202"/>
+		<info name="serial" value="SCPS-10119~SCPS-10122" />
+		<info name="release" value="19991202" />
 		<info name="alt_title" value="レジェンド オブ ドラグーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -48077,8 +48077,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lode Runner 2 (Japan, SuperLite 1500 Series)</description>
 		<year>2000</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86460"/>
-		<info name="release" value="20000330"/>
+		<info name="serial" value="SLPM-86460" />
+		<info name="release" value="20000330" />
 		<info name="alt_title" value="SuperLite1500シリーズ ロードランナー2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48098,8 +48098,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lode Runner Extra (Japan)</description>
 		<year>1997</year>
 		<publisher>Patra</publisher>
-		<info name="serial" value="SLPS-00641"/>
-		<info name="release" value="19970110"/>
+		<info name="serial" value="SLPS-00641" />
+		<info name="release" value="19970110" />
 		<info name="alt_title" value="ロードランナー・エクストラ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48122,8 +48122,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Little Princess +1 - Marl Oukoku no Ningyou Hime 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Nippon Ichi Software</publisher>
-		<info name="serial" value="SLPS-03012~SLPS-03013"/>
-		<info name="release" value="20001026"/>
+		<info name="serial" value="SLPS-03012~SLPS-03013" />
+		<info name="release" value="20001026" />
 		<info name="alt_title" value="リトルプリンセス＋1 マール王国の人形姫"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -48148,8 +48148,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Little Princess - Marl Oukoku no Ningyou Hime 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Nippon Ichi Software</publisher>
-		<info name="serial" value="SLPS-02376"/>
-		<info name="release" value="19991125"/>
+		<info name="serial" value="SLPS-02376" />
+		<info name="release" value="19991125" />
 		<info name="alt_title" value="リトルプリンセス マール王国の人形姫2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48169,8 +48169,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Linda³ Again (Japan)</description>
 		<year>1997</year>
 		<publisher>Sony</publisher>
-		<info name="serial" value="SCPS-10039"/>
-		<info name="release" value="19970925"/>
+		<info name="serial" value="SCPS-10039" />
+		<info name="release" value="19970925" />
 		<info name="alt_title" value="リンダキューブ アゲイン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48190,8 +48190,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ling Rise (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
-		<info name="serial" value="SLPS-01769"/>
-		<info name="release" value="19991125"/>
+		<info name="serial" value="SLPS-01769" />
+		<info name="release" value="19991125" />
 		<info name="alt_title" value="リングライズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48211,8 +48211,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lone Soldier (Japan)</description>
 		<year>1996</year>
 		<publisher>Virgin Interactive Entertainment</publisher>
-		<info name="serial" value="SLPS-00322"/>
-		<info name="release" value="19961004"/>
+		<info name="serial" value="SLPS-00322" />
+		<info name="release" value="19961004" />
 		<info name="alt_title" value="ローンソルジャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48232,8 +48232,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lord of Fist (Japan)</description>
 		<year>1999</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-02168"/>
-		<info name="release" value="19990826"/>
+		<info name="serial" value="SLPS-02168" />
+		<info name="release" value="19990826" />
 		<info name="alt_title" value="ロード・オブ・フィスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48253,8 +48253,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Love &amp; Destroy (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10124"/>
-		<info name="release" value="19991216"/>
+		<info name="serial" value="SCPS-10124" />
+		<info name="release" value="19991216" />
 		<info name="alt_title" value="ラブアンドデストロイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48288,8 +48288,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Love Love Truck (Japan)</description>
 		<year>1999</year>
 		<publisher>TYO</publisher>
-		<info name="serial" value="SLPS-02112"/>
-		<info name="release" value="19990624"/>
+		<info name="serial" value="SLPS-02112" />
+		<info name="release" value="19990624" />
 		<info name="alt_title" value="ラブラブトロッコ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48309,8 +48309,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>LSD - Dream Emulator (Japan, Limited Edition)</description>
 		<year>1998</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-01556"/>
-		<info name="release" value="19981022"/>
+		<info name="serial" value="SLPS-01556" />
+		<info name="release" value="19981022" />
 		<info name="alt_title" value="LSD 初回生産"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48336,8 +48336,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lucifer Ring (Japan)</description>
 		<year>1998</year>
 		<publisher>Toshiba EMI</publisher>
-		<info name="serial" value="SLPS-01784"/>
-		<info name="release" value="19981223"/>
+		<info name="serial" value="SLPS-01784" />
+		<info name="release" value="19981223" />
 		<info name="alt_title" value="ルシファー・リング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48363,8 +48363,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lunar 2 - Eternal Blue (Japan)</description>
 		<year>1999</year>
 		<publisher>Kadokawa Shoten</publisher>
-		<info name="serial" value="SLPS-02081~SLPS-02083"/>
-		<info name="release" value="19990527"/>
+		<info name="serial" value="SLPS-02081~SLPS-02083" />
+		<info name="release" value="19990527" />
 		<info name="alt_title" value="ルナ2 エターナルブルー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -48394,8 +48394,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lunar Wing - Toki o Koeta Seisen (Japan)</description>
 		<year>2001</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPM-86777"/>
-		<info name="release" value="20010712"/>
+		<info name="serial" value="SLPM-86777" />
+		<info name="release" value="20010712" />
 		<info name="alt_title" value="ルナ・ウイング 〜時を越えた聖戦〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48416,8 +48416,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lunatic Dawn III (Japan)</description>
 		<year>1998</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-01749"/>
-		<info name="release" value="19981217"/>
+		<info name="serial" value="SLPS-01749" />
+		<info name="release" value="19981217" />
 		<info name="alt_title" value="ルナティックドーンIII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48438,8 +48438,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lunatic Dawn Odyssey (Japan)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-02420"/>
-		<info name="release" value="19991202"/>
+		<info name="serial" value="SLPS-02420" />
+		<info name="release" value="19991202" />
 		<info name="alt_title" value="ルナティックドーン オデッセイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48459,8 +48459,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lup Salad - Lupupu Cube (Japan)</description>
 		<year>1996</year>
 		<publisher>Datam Polystar</publisher>
-		<info name="serial" value="SLPS-00416"/>
-		<info name="release" value="19960830"/>
+		<info name="serial" value="SLPS-00416" />
+		<info name="release" value="19960830" />
 		<info name="alt_title" value="ルプ☆さらだ るぷぷキューブ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48480,7 +48480,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chou Jikuu Yousai Macross - Ai Oboete Imasu ka (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<part name="cdrom1" interface="psx_cdrom">
+		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
 				<disk name="chou jikuu yousai macross - ai oboete imasu ka (japan) (disc 1)" sha1="f231291ee425f4e6044f2711bb97d2357972d630"/>
 			</diskarea>
@@ -48559,8 +48559,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mad Panic Coaster (Japan)</description>
 		<year>1997</year>
 		<publisher>Hakuhodo</publisher>
-		<info name="serial" value="SLPS-00880"/>
-		<info name="release" value="19971120"/>
+		<info name="serial" value="SLPS-00880" />
+		<info name="release" value="19971120" />
 		<info name="alt_title" value="マッドパニックコースター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48591,8 +48591,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mad Stalker - Full Metal Force (Japan)</description>
 		<year>1997</year>
 		<publisher>Family Soft</publisher>
-		<info name="serial" value="SLPS-00734"/>
-		<info name="release" value="19970703"/>
+		<info name="serial" value="SLPS-00734" />
+		<info name="release" value="19970703" />
 		<info name="alt_title" value="マッドストーカー フルメタルフォース"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48612,8 +48612,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Magical Drop F - Daibouken mo Rakujanai! (Japan)</description>
 		<year>1999</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-02337"/>
-		<info name="release" value="19991021"/>
+		<info name="serial" value="SLPS-02337" />
+		<info name="release" value="19991021" />
 		<info name="alt_title" value="マジカルドロップF"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48633,8 +48633,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Magical Medical (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86099 (VX081-J1)"/>
-		<info name="release" value="19980910"/>
+		<info name="serial" value="SLPM-86099 (VX081-J1)" />
+		<info name="release" value="19980910" />
 		<info name="alt_title" value="まじかるめでぃかる"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48654,8 +48654,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mahoutsukai ni Naru Houhou (Japan)</description>
 		<year>1999</year>
 		<publisher>TGL</publisher>
-		<info name="serial" value="SLPS-01754"/>
-		<info name="release" value="19990218"/>
+		<info name="serial" value="SLPS-01754" />
+		<info name="release" value="19990218" />
 		<info name="alt_title" value="魔法使いになる方法"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48675,8 +48675,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Majokko Daisakusen - Little Witching Mischiefs (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01850"/>
-		<info name="release" value="19990204"/>
+		<info name="serial" value="SLPS-01850" />
+		<info name="release" value="19990204" />
 		<info name="alt_title" value="魔女っ子 大作戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48725,8 +48725,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Makeruna! Makendo 2 (Japan)</description>
 		<year>1995</year>
 		<publisher>Datam Polystar</publisher>
-		<info name="serial" value="SLPS-00128"/>
-		<info name="release" value="19951110"/>
+		<info name="serial" value="SLPS-00128" />
+		<info name="release" value="19951110" />
 		<info name="alt_title" value="負けるな！魔剣道2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48746,8 +48746,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rikujou Boueitai Mao-chan (Japan, Deluxe Pack)</description>
 		<year>2003</year>
 		<publisher>Marvelous</publisher>
-		<info name="serial" value="SLPM-87198"/>
-		<info name="release" value="20030123"/>
+		<info name="serial" value="SLPM-87198" />
+		<info name="release" value="20030123" />
 		<info name="alt_title" value="陸上防衛隊まおちゃん DXパック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48767,8 +48767,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marionette Company (Japan)</description>
 		<year>1999</year>
 		<publisher>Micro Cabin</publisher>
-		<info name="serial" value="SLPS-02058"/>
-		<info name="release" value="19990520"/>
+		<info name="serial" value="SLPS-02058" />
+		<info name="release" value="19990520" />
 		<info name="alt_title" value="マリオネット カンパニー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48788,8 +48788,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marionette Company 2 Chu! (Japan)</description>
 		<year>2000</year>
 		<publisher>Micro Cabin</publisher>
-		<info name="serial" value="SLPS-02743"/>
-		<info name="release" value="20000518"/>
+		<info name="serial" value="SLPS-02743" />
+		<info name="release" value="20000518" />
 		<info name="alt_title" value="マリオネットカンパニー2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48809,8 +48809,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marl Jong!! (Japan, Limited Edition)</description>
 		<year>2003</year>
 		<publisher>Nippon Ichi Software</publisher>
-		<info name="serial" value="SLPS-03537"/>
-		<info name="release" value="20030424"/>
+		<info name="serial" value="SLPS-03537" />
+		<info name="release" value="20030424" />
 		<info name="alt_title" value="マールじゃん!! (限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48830,8 +48830,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Master's Fighter (Japan)</description>
 		<year>1997</year>
 		<publisher>Cinema Supply</publisher>
-		<info name="serial" value="SLPS-00722"/>
-		<info name="release" value="19971120"/>
+		<info name="serial" value="SLPS-00722" />
+		<info name="release" value="19971120" />
 		<info name="alt_title" value="ザ・マスターズファイター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48851,8 +48851,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Masumon Kids - The Another World of The Master of Monsters (Japan)</description>
 		<year>1998</year>
 		<publisher>Toshiba EMI</publisher>
-		<info name="serial" value="SLPS-01426"/>
-		<info name="release" value="19980625"/>
+		<info name="serial" value="SLPS-01426" />
+		<info name="release" value="19980625" />
 		<info name="alt_title" value="マスモンKIDS 〜The Another World Of The Master Of Monsters〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48872,8 +48872,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>MaxRacer (Japan)</description>
 		<year>1997</year>
 		<publisher>PD</publisher>
-		<info name="serial" value="SLPS-00795"/>
-		<info name="release" value="19970418"/>
+		<info name="serial" value="SLPS-00795" />
+		<info name="release" value="19970418" />
 		<info name="alt_title" value="マックスレーサー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48893,8 +48893,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Maze Heroes - Meikyuu Densetsu (Japan)</description>
 		<year>2002</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03490"/>
-		<info name="release" value="20021128"/>
+		<info name="serial" value="SLPS-03490" />
+		<info name="release" value="20021128" />
 		<info name="alt_title" value="メイズヒーローズ 〜迷宮伝説〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48914,8 +48914,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Meitantei Conan - Saikou no Aibou (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03425"/>
-		<info name="release" value="20020425"/>
+		<info name="serial" value="SLPS-03425" />
+		<info name="release" value="20020425" />
 		<info name="alt_title" value="名探偵コナン 最高の相棒"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48935,8 +48935,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Meitantei Conan - Trick Trick Vol.1 (Japan)</description>
 		<year>2003</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03548"/>
-		<info name="release" value="20030417"/>
+		<info name="serial" value="SLPS-03548" />
+		<info name="release" value="20030417" />
 		<info name="alt_title" value="名探偵コナン トリックトリック Vol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48959,8 +48959,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Medarot R - Parts Collection (Japan)</description>
 		<year>2000</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-02635"/>
-		<info name="release" value="20000316"/>
+		<info name="serial" value="SLPS-02635" />
+		<info name="release" value="20000316" />
 		<info name="alt_title" value="メダロットR・パーツコレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -48984,8 +48984,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Medarot R (Japan)</description>
 		<year>1999</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-02414"/>
-		<info name="release" value="19991125"/>
+		<info name="serial" value="SLPS-02414" />
+		<info name="release" value="19991125" />
 		<info name="alt_title" value="メダロットR"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49005,8 +49005,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shinseiden Megaseed Fukkatsu-Hen (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00925"/>
-		<info name="release" value="19970731"/>
+		<info name="serial" value="SLPS-00925" />
+		<info name="release" value="19970731" />
 		<info name="alt_title" value="神聖伝メガシード 復活編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49026,8 +49026,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Megatudo 2096 (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00435"/>
-		<info name="release" value="19961018"/>
+		<info name="serial" value="SLPS-00435" />
+		<info name="release" value="19961018" />
 		<info name="alt_title" value="メガチュード2096"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49047,8 +49047,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ikuzawa Touru Kanshuu - Meisha Retsuden - Greatest 70's (Japan)</description>
 		<year>1997</year>
 		<publisher>Epoch</publisher>
-		<info name="serial" value="SLPS-01153"/>
-		<info name="release" value="19971218"/>
+		<info name="serial" value="SLPS-01153" />
+		<info name="release" value="19971218" />
 		<info name="alt_title" value="生沢 徹 監修 名車列伝 グレイテスト70's"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49071,8 +49071,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>MeltyLancer - The 3rd Planet (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86231~SLPM-86232 (VX126-J1)"/>
-		<info name="release" value="19990617"/>
+		<info name="serial" value="SLPM-86231~SLPM-86232 (VX126-J1)" />
+		<info name="release" value="19990617" />
 		<info name="alt_title" value="メルティランサーThe 3rd Planet"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -49097,8 +49097,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Menkyo o Torou (Japan)</description>
 		<year>2000</year>
 		<publisher>Twilight Express</publisher>
-		<info name="serial" value="SLPS-02685"/>
-		<info name="release" value="20000525"/>
+		<info name="serial" value="SLPS-02685" />
+		<info name="release" value="20000525" />
 		<info name="alt_title" value="免許をとろう"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49118,8 +49118,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Meremanoid (Japan)</description>
 		<year>1999</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-01664"/>
-		<info name="release" value="19990805"/>
+		<info name="serial" value="SLPS-01664" />
+		<info name="release" value="19990805" />
 		<info name="alt_title" value="マーメノイド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49145,8 +49145,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mermaid no Kisetsu - The Season of Mermaid (Japan)</description>
 		<year>2001</year>
 		<publisher>GameVillage</publisher>
-		<info name="serial" value="SLPM-86934~SLPM-86936"/>
-		<info name="release" value="20011213"/>
+		<info name="serial" value="SLPM-86934~SLPM-86936" />
+		<info name="release" value="20011213" />
 		<info name="alt_title" value="マーメイドの季節"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -49179,8 +49179,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Metal Angel 3 (Japan)</description>
 		<year>1997</year>
 		<publisher>Pack-in-Soft</publisher>
-		<info name="serial" value="SLPS-00867~SLPS-00868"/>
-		<info name="release" value="19970613"/>
+		<info name="serial" value="SLPS-00867~SLPS-00868" />
+		<info name="release" value="19970613" />
 		<info name="alt_title" value="メタルエンジェル3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -49205,8 +49205,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Metal Fist (Japan)</description>
 		<year>1998</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="SLPS-01164"/>
-		<info name="release" value="19980115"/>
+		<info name="serial" value="SLPS-01164" />
+		<info name="release" value="19980115" />
 		<info name="alt_title" value="メタルフィスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49226,8 +49226,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Himitsu Sentai Metamor V Deluxe (Japan, disc 1 only)</description>
 		<year>1998</year>
 		<publisher>Mycom</publisher>
-		<info name="serial" value="SLPS-01626"/>
-		<info name="release" value="19981015"/>
+		<info name="serial" value="SLPS-01626" />
+		<info name="release" value="19981015" />
 		<info name="alt_title" value="ひみつ戦隊メタモルVデラックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -49255,8 +49255,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Meta-Ph-List μ.χ.2297 (Japan)</description>
 		<year>1997</year>
 		<publisher>A.D.M</publisher>
-		<info name="serial" value="SLPS-00680~SLPS-00681"/>
-		<info name="release" value="19970131"/>
+		<info name="serial" value="SLPS-00680~SLPS-00681" />
+		<info name="release" value="19970131" />
 		<info name="alt_title" value="メタフリスト mu.chi.2297"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -49281,8 +49281,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mezase! Senkyuuou (Japan)</description>
 		<year>1996</year>
 		<publisher>Seibu Kaihatsu</publisher>
-		<info name="serial" value="SLPS-00313"/>
-		<info name="release" value="19960419"/>
+		<info name="serial" value="SLPS-00313" />
+		<info name="release" value="19960419" />
 		<info name="alt_title" value="めざせ！戦球王"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49302,8 +49302,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Monster Farm - Battle Card Professional (Japan)</description>
 		<year>2000</year>
 		<publisher>Tecmo</publisher>
-		<info name="serial" value="SLPS-02653"/>
-		<info name="release" value="20000323"/>
+		<info name="serial" value="SLPS-02653" />
+		<info name="release" value="20000323" />
 		<info name="alt_title" value="モンスターファーム バトルカード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49323,8 +49323,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Michinoku Hitou Koi Monogatari - Bishoujo Hanafuda Kikou (Japan)</description>
 		<year>1997</year>
 		<publisher>FOG</publisher>
-		<info name="serial" value="SLPS-00941"/>
-		<info name="release" value="19970807"/>
+		<info name="serial" value="SLPS-00941" />
+		<info name="release" value="19970807" />
 		<info name="alt_title" value="みちのく秘湯恋物語 美少女花札紀行"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49344,8 +49344,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Michinoku Hitou Koi Monogatari Kai (Japan)</description>
 		<year>1999</year>
 		<publisher>FOG</publisher>
-		<info name="serial" value="SLPS-02502"/>
-		<info name="release" value="19991222"/>
+		<info name="serial" value="SLPS-02502" />
+		<info name="release" value="19991222" />
 		<info name="alt_title" value="みちのく秘湯恋物語 kai"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49375,8 +49375,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Money Idol Exchanger (Japan)</description>
 		<year>1998</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-00963"/>
-		<info name="release" value="19981105"/>
+		<info name="serial" value="SLPS-00963" />
+		<info name="release" value="19981105" />
 		<info name="alt_title" value="マネーアイドル・エクスチェンジャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49396,8 +49396,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mini Moni. - Step Pyon Pyon Pyon (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87195 (VX272-J1)"/>
-		<info name="release" value="20021212"/>
+		<info name="serial" value="SLPM-87195 (VX272-J1)" />
+		<info name="release" value="20021212" />
 		<info name="alt_title" value="ミニモニ。ステップぴょんぴょんぴょん♪"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49417,8 +49417,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mini Moni. Shaker &amp; Tambourine! Dapyon! (Japan)</description>
 		<year>2002</year>
 		<publisher>Sega</publisher>
-		<info name="serial" value="SLPM-87132"/>
-		<info name="release" value="20020919"/>
+		<info name="serial" value="SLPM-87132" />
+		<info name="release" value="20020919" />
 		<info name="alt_title" value="ミニモニ。シャカっとタンバリン！だぴょん！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49438,8 +49438,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mini-Yonku Bakusou Kyoudai Let's &amp; Go!! - WGP Hyper Heat (Japan)</description>
 		<year>1997</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-01078"/>
-		<info name="release" value="19971120"/>
+		<info name="serial" value="SLPS-01078" />
+		<info name="release" value="19971120" />
 		<info name="alt_title" value="ミニ四駆 爆走兄弟 レッツ＆ゴー！！WGPハイパーヒート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49459,8 +49459,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Misaki Aggressive! (Japan)</description>
 		<year>1998</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-01474"/>
-		<info name="release" value="19980723"/>
+		<info name="serial" value="SLPS-01474" />
+		<info name="release" value="19980723" />
 		<info name="alt_title" value="みさきアグレッシヴ!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49480,8 +49480,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rock Climbing - Mitouhou e no Chousen - Alps-Hen (Japan)</description>
 		<year>1997</year>
 		<publisher>WENet</publisher>
-		<info name="serial" value="SLPS-00662 (WG0004)"/>
-		<info name="release" value="19970724"/>
+		<info name="serial" value="SLPS-00662 (WG0004)" />
+		<info name="release" value="19970724" />
 		<info name="alt_title" value="ロッククライミング 未踏峰への挑戦 アルプス編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49501,8 +49501,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mizzurna Falls (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01783"/>
-		<info name="release" value="19981223"/>
+		<info name="serial" value="SLPS-01783" />
+		<info name="release" value="19981223" />
 		<info name="alt_title" value="ミザーナフォールズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49522,8 +49522,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pro Mahjong Kiwame Plus (Japan)</description>
 		<year>1996</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-00402"/>
-		<info name="release" value="19960830"/>
+		<info name="serial" value="SLPS-00402" />
+		<info name="release" value="19960830" />
 		<info name="alt_title" value="プロ麻雀 極 プラス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49543,8 +49543,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pro Mahjong Kiwame Tengensenhen (Japan)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-02347"/>
-		<info name="release" value="19991028"/>
+		<info name="serial" value="SLPS-02347" />
+		<info name="release" value="19991028" />
 		<info name="alt_title" value="プロ麻雀 極 天元戦編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49564,8 +49564,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mahjong Yarouze! (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86173 (VX088-J1)"/>
-		<info name="release" value="19990428"/>
+		<info name="serial" value="SLPM-86173 (VX088-J1)" />
+		<info name="release" value="19990428" />
 		<info name="alt_title" value="麻雀やろうぜ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49585,8 +49585,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kosodate Quiz Motto My Angel (Japan)</description>
 		<year>1999</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-01885"/>
-		<info name="release" value="19990325"/>
+		<info name="serial" value="SLPS-01885" />
+		<info name="release" value="19990325" />
 		<info name="alt_title" value="子育てクイズ もっとマイエンジェル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49606,8 +49606,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Momotarou Densetsu (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01785"/>
-		<info name="release" value="19981223"/>
+		<info name="serial" value="SLPS-01785" />
+		<info name="release" value="19981223" />
 		<info name="alt_title" value="桃太郎伝説"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49627,8 +49627,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Momotarou Matsuri (Japan)</description>
 		<year>2001</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPM-86888"/>
-		<info name="release" value="20010913"/>
+		<info name="serial" value="SLPM-86888" />
+		<info name="release" value="20010913" />
 		<info name="alt_title" value="桃太郎まつり 石川六右衛門の巻"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49648,8 +49648,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Monster Collection - Kamen no Madoushi (Japan)</description>
 		<year>1999</year>
 		<publisher>Kadokawa Shoten</publisher>
-		<info name="serial" value="SLPS-02245"/>
-		<info name="release" value="19991028"/>
+		<info name="serial" value="SLPS-02245" />
+		<info name="release" value="19991028" />
 		<info name="alt_title" value="モンスター・コレクション 仮面の魔道士"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49669,8 +49669,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hole of the Legend Monster - Densetsu Kemono no Ana - Monster Complete World Ver.2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Idea Factory</publisher>
-		<info name="serial" value="SLPS-02297"/>
-		<info name="release" value="19991028"/>
+		<info name="serial" value="SLPS-02297" />
+		<info name="release" value="19991028" />
 		<info name="alt_title" value="伝説獣の穴 モンスターコンプリワールドVer.2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49690,8 +49690,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mouri Motonari - Chikai no Sanshi (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01285"/>
-		<info name="release" value="19980226"/>
+		<info name="serial" value="SLPS-01285" />
+		<info name="release" value="19980226" />
 		<info name="alt_title" value="毛利元就 誓いの三矢"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49711,8 +49711,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mori no Oukoku - Kingdom of Forest (Japan)</description>
 		<year>1999</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-01861"/>
-		<info name="release" value="19991021"/>
+		<info name="serial" value="SLPS-01861" />
+		<info name="release" value="19991021" />
 		<info name="alt_title" value="森の王国"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49732,8 +49732,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mr. Driller G (Japan)</description>
 		<year>2001</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-03336"/>
-		<info name="release" value="20011122"/>
+		<info name="serial" value="SLPS-03336" />
+		<info name="release" value="20011122" />
 		<info name="alt_title" value="ミスタードリラーグレート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49753,8 +49753,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marvel Super Heroes (Japan)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00763"/>
-		<info name="release" value="19970925"/>
+		<info name="serial" value="SLPS-00763" />
+		<info name="release" value="19970925" />
 		<info name="alt_title" value="マーヴル・スーパーヒーローズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49774,8 +49774,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marvel Super Heroes vs. Street Fighter - EX Edition (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01915"/>
-		<info name="release" value="19990225"/>
+		<info name="serial" value="SLPS-01915" />
+		<info name="release" value="19990225" />
 		<info name="alt_title" value="マーヴルスーパーヒーローズVSストリートファイター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49795,8 +49795,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Maestro Music (Japan, with Baton Stick)</description>
 		<year>2000</year>
 		<publisher>Global A</publisher>
-		<info name="serial" value="SLPM-86585"/>
-		<info name="release" value="20000727"/>
+		<info name="serial" value="SLPM-86585" />
+		<info name="release" value="20000727" />
 		<info name="alt_title" value="ザ・マエストロムジーク (バトンコントローラ同梱版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49816,8 +49816,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Maestro Music - Merry Christmas - Append Disc (Japan)</description>
 		<year>2000</year>
 		<publisher>Global A</publisher>
-		<info name="serial" value="SLPM-86684"/>
-		<info name="release" value="20001207"/>
+		<info name="serial" value="SLPM-86684" />
+		<info name="release" value="20001207" />
 		<info name="alt_title" value="ザ マエストロムジーク・メリークリスマス・アペンド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49837,8 +49837,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Konami Antiques - MSX Collection Vol.1 (Japan)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86052 (VX120-J1)"/>
-		<info name="release" value="19971120"/>
+		<info name="serial" value="SLPM-86052 (VX120-J1)" />
+		<info name="release" value="19971120" />
 		<info name="alt_title" value="コナミアンティークス MSXコレクション Vol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49858,8 +49858,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Konami Antiques - MSX Collection Vol.2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86062 (VX121-J1)"/>
-		<info name="release" value="19980122"/>
+		<info name="serial" value="SLPM-86062 (VX121-J1)" />
+		<info name="release" value="19980122" />
 		<info name="alt_title" value="コナミアンティークス MSXコレクション Vol.2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49879,8 +49879,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Magical Tetris Challenge featuring Mickey Mouse (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01786"/>
-		<info name="release" value="19990318"/>
+		<info name="serial" value="SLPS-01786" />
+		<info name="release" value="19990318" />
 		<info name="alt_title" value="マジカルテトリスチャレンジ フューチャリング ミッキー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49900,8 +49900,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yagami Hiroki no Game-Taste - Munasawagi no Yokan (Japan)</description>
 		<year>1999</year>
 		<publisher>Kodansha</publisher>
-		<info name="serial" value="SLPS-02064"/>
-		<info name="release" value="19990520"/>
+		<info name="serial" value="SLPS-02064" />
+		<info name="release" value="19990520" />
 		<info name="alt_title" value="胸騒ぎの予感　八神ひろきのGame-Taste"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49921,8 +49921,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Marvel vs. Capcom - Clash of Super Heroes - EX Edition (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-02368"/>
-		<info name="release" value="19991111"/>
+		<info name="serial" value="SLPS-02368" />
+		<info name="release" value="19991111" />
 		<info name="alt_title" value="マーヴル VS. カプコン クラッシュオブスーパーヒーローズEXエディション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49942,8 +49942,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>My Home Dream 2 - Niwatsuki Ikkodate De, Ikou! (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor</publisher>
-		<info name="serial" value="SLPS-02470"/>
-		<info name="release" value="19991202"/>
+		<info name="serial" value="SLPS-02470" />
+		<info name="release" value="19991202" />
 		<info name="alt_title" value="マイホームドリーム2 庭つき一戸建てで、いこう！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49963,8 +49963,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Mystic Ark - Maboroshi Gekijou (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86147"/>
-		<info name="release" value="19990318"/>
+		<info name="serial" value="SLPM-86147" />
+		<info name="release" value="19990318" />
 		<info name="alt_title" value="ミスティックアーク　まぼろし劇場"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -49984,8 +49984,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Mystic Dragoons (Japan)</description>
 		<year>1999</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-02103"/>
-		<info name="release" value="19990617"/>
+		<info name="serial" value="SLPS-02103" />
+		<info name="release" value="19990617" />
 		<info name="alt_title" value="ミスティック・ドラグーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50005,8 +50005,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nage Libre - Rasen No Soukoku (Japan)</description>
 		<year>1997</year>
 		<publisher>Varie</publisher>
-		<info name="serial" value="SLPS-00692"/>
-		<info name="release" value="19970228"/>
+		<info name="serial" value="SLPS-00692" />
+		<info name="release" value="19970228" />
 		<info name="alt_title" value="ナージュ・リーブル 螺旋の相剋"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50026,8 +50026,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Najavu no Daibouken - My Favorite Namjatown (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPM-86601"/>
-		<info name="release" value="20001013"/>
+		<info name="serial" value="SLPM-86601" />
+		<info name="release" value="20001013" />
 		<info name="usage" value="Requires 15 free blocks on memory card to start (PocketStation)"/>
 		<info name="alt_title" value="ナジャブの大冒険 マイ・フェイバリット・ナンジャタウン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -50054,8 +50054,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nanatsu no Hikan (Japan)</description>
 		<year>1996</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00410~SLPS-00412"/>
-		<info name="release" value="19960809"/>
+		<info name="serial" value="SLPS-00410~SLPS-00412" />
+		<info name="release" value="19960809" />
 		<info name="alt_title" value="七つの秘館"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50085,8 +50085,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Naniwa no Akindo - Futte Nanbo no Saikoro Jinsei (Japan)</description>
 		<year>1997</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-00768"/>
-		<info name="release" value="19970328"/>
+		<info name="serial" value="SLPS-00768" />
+		<info name="release" value="19970328" />
 		<info name="alt_title" value="浪速の商人〜振ってナンボのサイコロ人生〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50106,8 +50106,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nankuro (Japan, SuperLite 1500 Series)</description>
 		<year>1999</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPS-02067"/>
-		<info name="release" value="19990527"/>
+		<info name="serial" value="SLPS-02067" />
+		<info name="release" value="19990527" />
 		<info name="alt_title" value="スーパーライト1500シリーズ ナンクロ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50127,8 +50127,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Natsuiro Kenjutsu Komachi (Japan, Limited Edition, disc 1 only)</description>
 		<year>2000</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-02665 (NIPS-4005)"/>
-		<info name="release" value="20000316"/>
+		<info name="serial" value="SLPS-02665 (NIPS-4005)" />
+		<info name="release" value="20000316" />
 		<info name="alt_title" value="夏色剣術小町 (初回限定生産版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50187,8 +50187,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Navit (Japan)</description>
 		<year>1998</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-01530"/>
-		<info name="release" value="19980903"/>
+		<info name="serial" value="SLPS-01530" />
+		<info name="release" value="19980903" />
 		<info name="alt_title" value="ナビット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50226,8 +50226,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arthur to Astaroth no Nazo Maikamura - Incredible Toons (Japan)</description>
 		<year>1996</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00363"/>
-		<info name="release" value="19960830"/>
+		<info name="serial" value="SLPS-00363" />
+		<info name="release" value="19960830" />
 		<info name="alt_title" value="アーサーとアスタロトの謎魔界村"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50247,8 +50247,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>NBA Power Dunkers 4 (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86176 (VX087-J1)"/>
-		<info name="release" value="19990603"/>
+		<info name="serial" value="SLPM-86176 (VX087-J1)" />
+		<info name="release" value="19990603" />
 		<info name="alt_title" value="NBAパワーダンカーズ4"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50268,8 +50268,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nemuru Mayu - Sleeping Cocoon (Japan)</description>
 		<year>2000</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-02597"/>
-		<info name="release" value="20000323"/>
+		<info name="serial" value="SLPS-02597" />
+		<info name="release" value="20000323" />
 		<info name="alt_title" value="眠ル繭"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50292,8 +50292,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Neorude (Japan)</description>
 		<year>1997</year>
 		<publisher>TechnoSoft</publisher>
-		<info name="serial" value="SLPS-00823~SLPS-00824"/>
-		<info name="release" value="19970509"/>
+		<info name="serial" value="SLPS-00823~SLPS-00824" />
+		<info name="release" value="19970509" />
 		<info name="alt_title" value="ネオリュード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50318,8 +50318,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Neorude 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>TechnoSoft</publisher>
-		<info name="serial" value="SLPS-01112"/>
-		<info name="release" value="19971120"/>
+		<info name="serial" value="SLPS-01112" />
+		<info name="release" value="19971120" />
 		<info name="alt_title" value="ネオリュード2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50339,8 +50339,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Next King - Koi no Sennen Oukoku (Japan)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00859"/>
-		<info name="release" value="19970627"/>
+		<info name="serial" value="SLPS-00859" />
+		<info name="release" value="19970627" />
 		<info name="alt_title" value="ネクストキング 恋の千年王国"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50360,8 +50360,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nichibutsu Arcade Classics (Japan)</description>
 		<year>1995</year>
 		<publisher>Nichibutsu</publisher>
-		<info name="serial" value="SLPS-00184"/>
-		<info name="release" value="19951229"/>
+		<info name="serial" value="SLPS-00184" />
+		<info name="release" value="19951229" />
 		<info name="alt_title" value="ニチブツアーケードクラシックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50381,8 +50381,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Night Raid (Japan)</description>
 		<year>2002</year>
 		<publisher>Takumi</publisher>
-		<info name="serial" value="SLPM-87048"/>
-		<info name="release" value="20021010"/>
+		<info name="serial" value="SLPM-87048" />
+		<info name="release" value="20021010" />
 		<info name="alt_title" value="ナイトレイド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50402,8 +50402,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nijiiro Dodgeball - Otometachi no Seishun (Japan)</description>
 		<year>2002</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPM-87039"/>
-		<info name="release" value="20021212"/>
+		<info name="serial" value="SLPM-87039" />
+		<info name="release" value="20021212" />
 		<info name="alt_title" value="虹色ドッジボール 乙女たちの青春"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50423,8 +50423,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ningyo no Rakuin (Japan)</description>
 		<year>2000</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-02854 (NIPS-4010)"/>
-		<info name="release" value="20000803"/>
+		<info name="serial" value="SLPS-02854 (NIPS-4010)" />
+		<info name="release" value="20000803" />
 		<info name="alt_title" value="人魚の烙印"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50444,8 +50444,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ninja Jajamaru-kun - Onigiri Ninpouchou (Japan)</description>
 		<year>1997</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-00494"/>
-		<info name="release" value="19970221"/>
+		<info name="serial" value="SLPS-00494" />
+		<info name="release" value="19970221" />
 		<info name="alt_title" value="忍者じゃじゃ丸くん 鬼斬忍法帖"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50465,8 +50465,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ninku (Japan)</description>
 		<year>1995</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-00172"/>
-		<info name="release" value="19951222"/>
+		<info name="serial" value="SLPS-00172" />
+		<info name="release" value="19951222" />
 		<info name="alt_title" value="NINKU－忍空－"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50486,8 +50486,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nobunaga no Yabou - Retsuupuden (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86300"/>
-		<info name="release" value="19990909"/>
+		<info name="serial" value="SLPM-86300" />
+		<info name="release" value="19990909" />
 		<info name="alt_title" value="信長の野望 烈風伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50513,8 +50513,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>NOëL 3 - Mission on the Line (Japan)</description>
 		<year>1999</year>
 		<publisher>Pioneer LDC</publisher>
-		<info name="serial" value="SLPS-01895~SLPS-01897"/>
-		<info name="release" value="19990311"/>
+		<info name="serial" value="SLPS-01895~SLPS-01897" />
+		<info name="release" value="19990311" />
 		<info name="alt_title" value="ノエル3 ミッション オン ザ ライン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50544,8 +50544,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Not Treasure Hunter (Japan)</description>
 		<year>1996</year>
 		<publisher>Acti-Art</publisher>
-		<info name="serial" value="SLPS-00274"/>
-		<info name="release" value="19961220"/>
+		<info name="serial" value="SLPS-00274" />
+		<info name="release" value="19961220" />
 		<info name="alt_title" value="ノット トレジャー ハンター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50568,8 +50568,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Novastorm (Japan)</description>
 		<year>1996</year>
 		<publisher>Victor Entertainment</publisher>
-		<info name="serial" value="SLPS-00314~SLPS-00315"/>
-		<info name="release" value="19960301"/>
+		<info name="serial" value="SLPS-00314~SLPS-00315" />
+		<info name="release" value="19960301" />
 		<info name="alt_title" value="ノバストーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50594,8 +50594,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Next Tetris (Japan)</description>
 		<year>1999</year>
 		<publisher>Bullet Proof</publisher>
-		<info name="serial" value="SLPS-01774"/>
-		<info name="release" value="19990107"/>
+		<info name="serial" value="SLPS-01774" />
+		<info name="release" value="19990107" />
 		<info name="alt_title" value="THE NEXT TETRIS"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50615,8 +50615,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Next Tetris - Deluxe DLX (Japan)</description>
 		<year>1999</year>
 		<publisher>BPS</publisher>
-		<info name="serial" value="SLPS-02507"/>
-		<info name="release" value="19991216"/>
+		<info name="serial" value="SLPS-02507" />
+		<info name="release" value="19991216" />
 		<info name="alt_title" value="ザ ネクスト テトリス デラックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50636,8 +50636,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Nya Nyan ga Nyan - Light Fantasy Gaiden (Japan)</description>
 		<year>1999</year>
 		<publisher>Tonkin House</publisher>
-		<info name="serial" value="SLPS-02336"/>
-		<info name="release" value="19991021"/>
+		<info name="serial" value="SLPS-02336" />
+		<info name="release" value="19991021" />
 		<info name="alt_title" value="ライトファンタジー外伝 ニャニャンがニャン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50657,8 +50657,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Oasis Road (Japan)</description>
 		<year>1999</year>
 		<publisher>Idea Factory</publisher>
-		<info name="serial" value="SLPS-01899"/>
-		<info name="release" value="19990225"/>
+		<info name="serial" value="SLPS-01899" />
+		<info name="release" value="19990225" />
 		<info name="alt_title" value="オアシスロード"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50678,8 +50678,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Oda Nobunaga Den (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01595"/>
-		<info name="release" value="19980923"/>
+		<info name="serial" value="SLPS-01595" />
+		<info name="release" value="19980923" />
 		<info name="alt_title" value="織田信長伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50699,8 +50699,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Odo Odo Oddity (Japan)</description>
 		<year>1997</year>
 		<publisher>I.D.C.</publisher>
-		<info name="serial" value="SLPS-00754"/>
-		<info name="release" value="19970314"/>
+		<info name="serial" value="SLPS-00754" />
+		<info name="release" value="19970314" />
 		<info name="alt_title" value="おどおどおっでぃ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50720,8 +50720,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ojamajo Doremi Dokka~n! Nijiiro Para-Dice (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03497"/>
-		<info name="release" value="20021128"/>
+		<info name="serial" value="SLPS-03497" />
+		<info name="release" value="20021128" />
 		<info name="alt_title" value="おジャ魔女どれみ ドッカーン! にじいろパラダイス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50744,8 +50744,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ojousama Express (Japan)</description>
 		<year>1998</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-01495~SLPS-01496"/>
-		<info name="release" value="19980730"/>
+		<info name="serial" value="SLPS-01495~SLPS-01496" />
+		<info name="release" value="19980730" />
 		<info name="alt_title" value="お嬢様特急"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50770,8 +50770,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Omiai Commando - Bakappuru ni Tsukkomi o (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86439"/>
-		<info name="release" value="20000330"/>
+		<info name="serial" value="SLPM-86439" />
+		<info name="release" value="20000330" />
 		<info name="alt_title" value="お見合いコマンドー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50791,8 +50791,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Omise de Tensyu (Japan)</description>
 		<year>1999</year>
 		<publisher>TechnoSoft</publisher>
-		<info name="serial" value="SLPS-01876"/>
-		<info name="release" value="19990408"/>
+		<info name="serial" value="SLPS-01876" />
+		<info name="release" value="19990408" />
 		<info name="alt_title" value="おみせde店主"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50812,8 +50812,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>One (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01812"/>
-		<info name="release" value="19990325"/>
+		<info name="serial" value="SLPS-01812" />
+		<info name="release" value="19990325" />
 		<info name="alt_title" value="ワン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50833,8 +50833,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ongaku Tsukuru Kanadeeru 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-00903"/>
-		<info name="release" value="19980312"/>
+		<info name="serial" value="SLPS-00903" />
+		<info name="release" value="19980312" />
 		<info name="alt_title" value="音楽ツクール かなで〜る2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50854,8 +50854,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ongaku Tsukuru 3 (Japan)</description>
 		<year>2001</year>
 		<publisher>EnterBrain</publisher>
-		<info name="serial" value="SLPS-03161"/>
-		<info name="release" value="20010308"/>
+		<info name="serial" value="SLPS-03161" />
+		<info name="release" value="20010308" />
 		<info name="alt_title" value="音楽ツクール3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50885,8 +50885,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Option Tuning Car Battle Spec-R (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
-		<info name="serial" value="SLPS-02587"/>
-		<info name="release" value="20000511"/>
+		<info name="serial" value="SLPS-02587" />
+		<info name="release" value="20000511" />
 		<info name="alt_title" value="オプション チューニングカーバトル スペックR"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50906,8 +50906,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ore no Ryouri (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10099"/>
-		<info name="release" value="19990909"/>
+		<info name="serial" value="SCPS-10099" />
+		<info name="release" value="19990909" />
 		<info name="alt_title" value="俺の料理"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50930,8 +50930,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sougaku Toshi - Osaka (Japan)</description>
 		<year>1999</year>
 		<publisher>King Records</publisher>
-		<info name="serial" value="SLPS-01722~SLPS-01723"/>
-		<info name="release" value="19990311"/>
+		<info name="serial" value="SLPS-01722~SLPS-01723" />
+		<info name="release" value="19990311" />
 		<info name="alt_title" value="奏楽都市 OSAKA"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -50956,8 +50956,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Oshigotoshiki Jinsei Game - Mezase Shokugyou-oh (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-03056"/>
-		<info name="release" value="20001214"/>
+		<info name="serial" value="SLPS-03056" />
+		<info name="release" value="20001214" />
 		<info name="alt_title" value="お仕事式人生ゲーム めざせ職業王"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50977,8 +50977,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>One Two Smash - Tanoshii Tennis (Japan, Honkakuha de 1300Yen Series)</description>
 		<year>2000</year>
 		<publisher>Hect</publisher>
-		<info name="serial" value="SLPS-02585"/>
-		<info name="release" value="20000224"/>
+		<info name="serial" value="SLPS-02585" />
+		<info name="release" value="20000224" />
 		<info name="alt_title" value="本格派DE 1300円 ワン・ツー スマッシュ たのしいテニス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -50998,8 +50998,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ouji-sama LV1 (Japan)</description>
 		<year>2002</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-03412"/>
-		<info name="release" value="20020320"/>
+		<info name="serial" value="SLPS-03412" />
+		<info name="release" value="20020320" />
 		<info name="alt_title" value="王子さまLV1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51019,8 +51019,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Oumagatoki (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-03235"/>
-		<info name="release" value="20010809"/>
+		<info name="serial" value="SLPS-03235" />
+		<info name="release" value="20010809" />
 		<info name="alt_title" value="逢魔が時"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51040,8 +51040,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Out Live - Be Eliminate Yesterday (Japan)</description>
 		<year>1997</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-00746"/>
-		<info name="release" value="19970724"/>
+		<info name="serial" value="SLPS-00746" />
+		<info name="release" value="19970724" />
 		<info name="alt_title" value="アウトライブ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51061,8 +51061,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Paca Paca Passion (Japan)</description>
 		<year>1999</year>
 		<publisher>Produce!</publisher>
-		<info name="serial" value="SLPS-02122"/>
-		<info name="release" value="19990624"/>
+		<info name="serial" value="SLPS-02122" />
+		<info name="release" value="19990624" />
 		<info name="alt_title" value="パカパカパッション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51082,8 +51082,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Paca Paca Passion 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Produce!</publisher>
-		<info name="serial" value="SLPS-02720"/>
-		<info name="release" value="20000427"/>
+		<info name="serial" value="SLPS-02720" />
+		<info name="release" value="20000427" />
 		<info name="alt_title" value="パカパカパッション2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51103,8 +51103,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Palm Town (Japan)</description>
 		<year>1999</year>
 		<publisher>MyCom</publisher>
-		<info name="serial" value="SLPS-01820"/>
-		<info name="release" value="19990708"/>
+		<info name="serial" value="SLPS-01820" />
+		<info name="release" value="19990708" />
 		<info name="alt_title" value="ぱーむたうん"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51125,8 +51125,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Panzer Bandit (Japan)</description>
 		<year>1997</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00899"/>
-		<info name="release" value="19970807"/>
+		<info name="serial" value="SLPS-00899" />
+		<info name="release" value="19970807" />
 		<info name="alt_title" value="パンツァーバンディット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51146,8 +51146,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Panzer Front bis. (Japan)</description>
 		<year>2001</year>
 		<publisher>Enterbrain</publisher>
-		<info name="serial" value="SLPS-03111"/>
-		<info name="release" value="20010208"/>
+		<info name="serial" value="SLPS-03111" />
+		<info name="release" value="20010208" />
 		<info name="alt_title" value="パンツァーフロントbis."/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51167,8 +51167,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shin Masoukishin - Panzer Warfare (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-02319"/>
-		<info name="release" value="19991125"/>
+		<info name="serial" value="SLPS-02319" />
+		<info name="release" value="19991125" />
 		<info name="alt_title" value="真・魔装機神"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51188,8 +51188,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaibutsu Para-Dice (Japan)</description>
 		<year>1997</year>
 		<publisher>Make Software</publisher>
-		<info name="serial" value="SLPS-00915"/>
-		<info name="release" value="19970717"/>
+		<info name="serial" value="SLPS-00915" />
+		<info name="release" value="19970717" />
 		<info name="alt_title" value="怪物パラ★ダイス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51209,8 +51209,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Paranoia Scape (Japan)</description>
 		<year>1998</year>
 		<publisher>Mathilda</publisher>
-		<info name="serial" value="SLPS-01375"/>
-		<info name="release" value="19980528"/>
+		<info name="serial" value="SLPS-01375" />
+		<info name="release" value="19980528" />
 		<info name="alt_title" value="パラノイアスケープ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51230,8 +51230,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Parlor! Pro Jr. Collection (Japan)</description>
 		<year>2000</year>
 		<publisher>Nihon Telenet</publisher>
-		<info name="serial" value="SLPS-02781"/>
-		<info name="release" value="20000713"/>
+		<info name="serial" value="SLPS-02781" />
+		<info name="release" value="20000713" />
 		<info name="alt_title" value="パーラー！プロ ジュニア コレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51251,8 +51251,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Paro Wars (Japan)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86016 (VX038-J1)"/>
-		<info name="release" value="19970925"/>
+		<info name="serial" value="SLPM-86016 (VX038-J1)" />
+		<info name="release" value="19970925" />
 		<info name="alt_title" value="パロウォーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51272,8 +51272,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kidou Keisatsu Patlabor - Mobile Police Patlabor - Game Edition (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02239"/>
-		<info name="release" value="20001130"/>
+		<info name="serial" value="SLPS-02239" />
+		<info name="release" value="20001130" />
 		<info name="alt_title" value="機動警察パトレイバー ゲームエディション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51293,8 +51293,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puzzle Bobble 3 DX (Japan)</description>
 		<year>1997</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-01065"/>
-		<info name="release" value="19971106"/>
+		<info name="serial" value="SLPS-01065" />
+		<info name="release" value="19971106" />
 		<info name="alt_title" value="パズルボブル3デラックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51314,8 +51314,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puzzle Bobble 4 (Japan)</description>
 		<year>1998</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-01492"/>
-		<info name="release" value="19980806"/>
+		<info name="serial" value="SLPS-01492" />
+		<info name="release" value="19980806" />
 		<info name="alt_title" value="パズルボブル4"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51335,8 +51335,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>PD Ultraman Invader (Japan)</description>
 		<year>1995</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00195"/>
-		<info name="release" value="19951222"/>
+		<info name="serial" value="SLPS-00195" />
+		<info name="release" value="19951222" />
 		<info name="alt_title" value="PDウルトラマンインベーダー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51363,8 +51363,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pepsiman (Japan)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-01762"/>
-		<info name="release" value="19990304"/>
+		<info name="serial" value="SLPS-01762" />
+		<info name="release" value="19990304" />
 		<info name="alt_title" value="ペプシマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51384,8 +51384,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pocket Fighter (Japan)</description>
 		<year>1998</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01360"/>
-		<info name="release" value="19980611"/>
+		<info name="serial" value="SLPS-01360" />
+		<info name="release" value="19980611" />
 		<info name="alt_title" value="ポケットファイター"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51405,8 +51405,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pikinya! Excellent (Japan)</description>
 		<year>1998</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-01345"/>
-		<info name="release" value="19980716"/>
+		<info name="serial" value="SLPS-01345" />
+		<info name="release" value="19980716" />
 		<info name="alt_title" value="ピキーニャ エクセレンテ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51426,8 +51426,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pinball Fantasies Deluxe (Japan)</description>
 		<year>1996</year>
 		<publisher>VAP</publisher>
-		<info name="serial" value="SLPS-00482"/>
-		<info name="release" value="19961025"/>
+		<info name="serial" value="SLPS-00482" />
+		<info name="release" value="19961025" />
 		<info name="alt_title" value="ピンボール・ファンタジーズ・デラックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51447,8 +51447,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pitfall 3D - Beyond the Jungle (Japan)</description>
 		<year>1998</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-01669"/>
-		<info name="release" value="19981210"/>
+		<info name="serial" value="SLPS-01669" />
+		<info name="release" value="19981210" />
 		<info name="alt_title" value="ピットフォール3D"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51468,8 +51468,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Planet Dob (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-02111"/>
-		<info name="release" value="19991118"/>
+		<info name="serial" value="SLPS-02111" />
+		<info name="release" value="19991118" />
 		<info name="alt_title" value="プラネット・ドブ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51489,8 +51489,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Planet Laika (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86264"/>
-		<info name="release" value="19991021"/>
+		<info name="serial" value="SLPM-86264" />
+		<info name="release" value="19991021" />
 		<info name="alt_title" value="プラネットライカ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51510,8 +51510,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pocket Digimon World (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02800"/>
-		<info name="release" value="20000626"/>
+		<info name="serial" value="SLPS-02800" />
+		<info name="release" value="20000626" />
 		<info name="alt_title" value="ポケットデジモンワールド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51531,8 +51531,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pocket Digimon World - Wind Battle Disc (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02992"/>
-		<info name="release" value="20001026"/>
+		<info name="serial" value="SLPS-02992" />
+		<info name="release" value="20001026" />
 		<info name="alt_title" value="ポケットデジモンワールド ウイングバトルディスク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51552,8 +51552,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pocket Digimon World - Cool &amp; Nature Battle Disc (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03146"/>
-		<info name="release" value="20010222"/>
+		<info name="serial" value="SLPS-03146" />
+		<info name="release" value="20010222" />
 		<info name="alt_title" value="ポケットデジモンワールド クール&amp;ネイチャー バトルディスク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51573,8 +51573,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pocket MuuMuu (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10076"/>
-		<info name="release" value="19990204"/>
+		<info name="serial" value="SCPS-10076" />
+		<info name="release" value="19990204" />
 		<info name="alt_title" value="ポケットムームー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51594,8 +51594,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Poitter's Point 2 - Sodom no Inbou (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86061 (VX091-J1)"/>
-		<info name="release" value="19980709"/>
+		<info name="serial" value="SLPM-86061 (VX091-J1)" />
+		<info name="release" value="19980709" />
 		<info name="alt_title" value="ポイッターズポイント2 ～ソドムの陰謀～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51615,8 +51615,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Policenauts - Private Collection (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPS-00228"/>
-		<info name="release" value="19960209"/>
+		<info name="serial" value="SLPS-00228" />
+		<info name="release" value="19960209" />
 		<info name="alt_title" value="ポリスノーツ プライベートコレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51636,8 +51636,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pop'n Music - Disney Tunes (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86670 (VX222-J1)"/>
-		<info name="release" value="20001116"/>
+		<info name="serial" value="SLPM-86670 (VX222-J1)" />
+		<info name="release" value="20001116" />
 		<info name="alt_title" value="ポップンミュージックディズニーチューンズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51657,8 +51657,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pop'n Pop (Japan)</description>
 		<year>1998</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-01636"/>
-		<info name="release" value="19981022"/>
+		<info name="serial" value="SLPS-01636" />
+		<info name="release" value="19981022" />
 		<info name="alt_title" value="ぽっぷんぽっぷ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51678,8 +51678,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pop'n Tanks! (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86146"/>
-		<info name="release" value="19990729"/>
+		<info name="serial" value="SLPM-86146" />
+		<info name="release" value="19990729" />
 		<info name="alt_title" value="ポップンタンクス！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51699,8 +51699,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Potestas (Japan)</description>
 		<year>1996</year>
 		<publisher>Nexus</publisher>
-		<info name="serial" value="SLPS-00324 (PS-0001)"/>
-		<info name="release" value="19960412"/>
+		<info name="serial" value="SLPS-00324 (PS-0001)" />
+		<info name="release" value="19960412" />
 		<info name="alt_title" value="ポテスタス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51720,8 +51720,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi Pachi Saga (Japan)</description>
 		<year>1996</year>
 		<publisher>TEN Institute</publisher>
-		<info name="serial" value="SLPS-00288"/>
-		<info name="release" value="19960426"/>
+		<info name="serial" value="SLPS-00288" />
+		<info name="release" value="19960426" />
 		<info name="alt_title" value="パチパチサーガ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51741,8 +51741,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Princess Maker - Go! Go! Princess (Japan)</description>
 		<year>1999</year>
 		<publisher>NineLives</publisher>
-		<info name="serial" value="SLPS-01505"/>
-		<info name="release" value="19990121"/>
+		<info name="serial" value="SLPS-01505" />
+		<info name="release" value="19990121" />
 		<info name="alt_title" value="プリンセスメーカー GO!GO!プリンセス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51762,8 +51762,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Prism Court (Japan)</description>
 		<year>1998</year>
 		<publisher>FPS</publisher>
-		<info name="serial" value="SLPS-01226"/>
-		<info name="release" value="19980226"/>
+		<info name="serial" value="SLPS-01226" />
+		<info name="release" value="19980226" />
 		<info name="alt_title" value="プリズムコート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51783,8 +51783,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Action Puzzle - Prism Land (Japan, Honkakuha de 1300Yen Series)</description>
 		<year>2000</year>
 		<publisher>HECT</publisher>
-		<info name="serial" value="SLPS-02586"/>
-		<info name="release" value="20000224"/>
+		<info name="serial" value="SLPS-02586" />
+		<info name="release" value="20000224" />
 		<info name="alt_title" value="本格派DE 1300円 アクションパズル プリズムランド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51804,8 +51804,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Prisoner (Japan)</description>
 		<year>1999</year>
 		<publisher>Mainichi</publisher>
-		<info name="serial" value="SLPS-02387"/>
-		<info name="release" value="19991111"/>
+		<info name="serial" value="SLPS-02387" />
+		<info name="release" value="19991111" />
 		<info name="alt_title" value="プリズナー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51838,8 +51838,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Aruze Oukoku 5 (Japan)</description>
 		<year>2001</year>
 		<publisher>Aruze</publisher>
-		<info name="serial" value="SLPS-03280"/>
-		<info name="release" value="20011115"/>
+		<info name="serial" value="SLPS-03280" />
+		<info name="release" value="20011115" />
 		<info name="alt_title" value="パチスロ アルゼ王国5"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51859,8 +51859,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou - Battle Knight &amp; Atlantis Doom (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03108"/>
-		<info name="release" value="20001228"/>
+		<info name="serial" value="SLPS-03108" />
+		<info name="release" value="20001228" />
 		<info name="alt_title" value="パチスロ帝王〜バトルナイト・アトランチスドーム〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51880,8 +51880,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou - Maker Suishou Manual 3 - I'm Angel White 2 &amp; I'm Angel Blue 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03130"/>
-		<info name="release" value="20010426"/>
+		<info name="serial" value="SLPS-03130" />
+		<info name="release" value="20010426" />
 		<info name="alt_title" value="パチスロ帝王 メーカー推奨マニュアル3 アイムエンジェル〜ホワイト2&amp;ブルー2〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51901,8 +51901,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou - Maker Suishou Manual 5 - Race Queen 2 &amp; Tomcat (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03245"/>
-		<info name="release" value="20010830"/>
+		<info name="serial" value="SLPS-03245" />
+		<info name="release" value="20010830" />
 		<info name="alt_title" value="パチスロ帝王 メーカー推奨マニュアル5 〜レースクイーン2・トムキャット〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51922,8 +51922,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou Maker Suishou Manual 6 - Takarabune (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03329"/>
-		<info name="release" value="20011115"/>
+		<info name="serial" value="SLPS-03329" />
+		<info name="release" value="20011115" />
 		<info name="alt_title" value="パチスロ帝王 メーカー推奨マニュアル6 宝船"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51943,8 +51943,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou - Maker Suishou Manual 7 - Trick Monster 2 (Japan)</description>
 		<year>2002</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03391"/>
-		<info name="release" value="20020214"/>
+		<info name="serial" value="SLPS-03391" />
+		<info name="release" value="20020214" />
 		<info name="alt_title" value="パチスロ帝王 メーカー推奨マニュアル7 トリックモンスター2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51964,8 +51964,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou Mini - Dr. A7 (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-02114"/>
-		<info name="release" value="19990624"/>
+		<info name="serial" value="SLPS-02114" />
+		<info name="release" value="19990624" />
 		<info name="alt_title" value="パチスロ帝王 ミニ ドクターエー7"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -51985,8 +51985,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou 2 - Kagetsu &amp; 2 Pair &amp; Beaver X (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-02217"/>
-		<info name="release" value="19990826"/>
+		<info name="serial" value="SLPS-02217" />
+		<info name="release" value="19990826" />
 		<info name="alt_title" value="パチスロ帝王II 花月・ツーペア・マイマイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52006,8 +52006,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou 3 - Sea Master X &amp; Epsilon R &amp; Wai Wai Pulsar 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-02413"/>
-		<info name="release" value="19991202"/>
+		<info name="serial" value="SLPS-02413" />
+		<info name="release" value="19991202" />
 		<info name="alt_title" value="パチスロ帝王3～シーマスターX・イプシロンR・ワイワイパルサー2～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52027,8 +52027,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou 6 - Kung Fu Lady &amp; BangBang &amp; Prelude 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-02657"/>
-		<info name="release" value="20000622"/>
+		<info name="serial" value="SLPS-02657" />
+		<info name="release" value="20000622" />
 		<info name="alt_title" value="パチスロ帝王6 ～カンフーレディ・BANGBANG・プレリュード2～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52048,8 +52048,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou 7 - Maker Suishou Manual 1 - Beat the Dragon 2 &amp; Lupin Sansei &amp; Hot Rod Queen (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-02991"/>
-		<info name="release" value="20001012"/>
+		<info name="serial" value="SLPS-02991" />
+		<info name="release" value="20001012" />
 		<info name="alt_title" value="パチスロ帝王7 メーカー推奨マニュアル1 〜ビートザドラゴン2・ルパン三世・ホットロッドクイーン〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52069,8 +52069,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pachi-Slot Teiou - Twist &amp; Shimauta &amp; Nankoku Monogatari (Japan)</description>
 		<year>2002</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03442"/>
-		<info name="release" value="20020620"/>
+		<info name="serial" value="SLPS-03442" />
+		<info name="release" value="20020620" />
 		<info name="alt_title" value="パチスロ帝王〜Twist・島唄・南国物語〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52090,9 +52090,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Power Stakes (Japan)</description>
 		<year>1997</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques"/>
-		<info name="serial" value="SLPM-86032"/>
-		<info name="release" value="19970411"/>
+		<info name="developer" value="Aques" />
+		<info name="serial" value="SLPM-86032" />
+		<info name="release" value="19970411" />
 		<info name="alt_title" value="パワーステークス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52112,9 +52112,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Power Stakes Grade 1 (Japan)</description>
 		<year>1997</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques"/>
-		<info name="serial" value="SLPM-86050"/>
-		<info name="release" value="19971009"/>
+		<info name="developer" value="Aques" />
+		<info name="serial" value="SLPM-86050" />
+		<info name="release" value="19971009" />
 		<info name="alt_title" value="パワーステークス グレード1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52136,9 +52136,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pro Logic Mahjong Hai-Shin (Japan)</description>
 		<year>1997</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques"/>
-		<info name="serial" value="SLPM-86018"/>
-		<info name="release" value="19970131"/>
+		<info name="developer" value="Aques" />
+		<info name="serial" value="SLPM-86018" />
+		<info name="release" value="19970131" />
 		<info name="alt_title" value="プロロジック麻雀 牌神"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52158,8 +52158,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puchi Carat (Japan)</description>
 		<year>1998</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-01435"/>
-		<info name="release" value="19980625"/>
+		<info name="serial" value="SLPS-01435" />
+		<info name="release" value="19980625" />
 		<info name="alt_title" value="プチカラット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52179,8 +52179,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pukunpa - Joshikousei no Houkago... (Japan)</description>
 		<year>1996</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="SLPS-00409"/>
-		<info name="release" value="19960927"/>
+		<info name="serial" value="SLPS-00409" />
+		<info name="release" value="19960927" />
 		<info name="alt_title" value="ぷくんパ 女子高生の放課後…"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52200,8 +52200,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puyo Puyo Box (Japan)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
-		<info name="serial" value="SLPS-03114"/>
-		<info name="release" value="20001221"/>
+		<info name="serial" value="SLPS-03114" />
+		<info name="release" value="20001221" />
 		<info name="alt_title" value="ぷよぷよBOX"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52221,8 +52221,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puyo Puyo 4 - Car-kun to Issho (Japan)</description>
 		<year>1999</year>
 		<publisher>Compile</publisher>
-		<info name="serial" value="SLPS-02412"/>
-		<info name="release" value="19991216"/>
+		<info name="serial" value="SLPS-02412" />
+		<info name="release" value="19991216" />
 		<info name="alt_title" value="ぷよぷよ〜ん カーくんといっしょ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52242,8 +52242,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Puzzle Arena Toshinden (Japan)</description>
 		<year>1997</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-00879"/>
-		<info name="release" value="19970620"/>
+		<info name="serial" value="SLPS-00879" />
+		<info name="release" value="19970620" />
 		<info name="alt_title" value="パズルアリーナ闘神伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52263,8 +52263,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Pro Wrestling Sengokuden - Hyper Tag Match (Japan)</description>
 		<year>1997</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-01006"/>
-		<info name="release" value="19971023"/>
+		<info name="serial" value="SLPS-01006" />
+		<info name="release" value="19971023" />
 		<info name="alt_title" value="プロレス戦国伝 〜HYPER TAG MATCH〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52284,8 +52284,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Power Shovel ni Norou!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86629 (TCPS10031)"/>
-		<info name="release" value="20000921"/>
+		<info name="serial" value="SLPM-86629 (TCPS10031)" />
+		<info name="release" value="20000921" />
 		<info name="alt_title" value="パワーショベルに乗ろう!!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52305,8 +52305,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Qix 2000 (Japan, SuperLite 1500 Series)</description>
 		<year>2000</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86659"/>
-		<info name="release" value="20001026"/>
+		<info name="serial" value="SLPM-86659" />
+		<info name="release" value="20001026" />
 		<info name="alt_title" value="SuperLite1500シリーズ クイックス2000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52327,8 +52327,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Quantum Gate I - Akumu no Joshou (Japan)</description>
 		<year>1997</year>
 		<publisher>Gaga</publisher>
-		<info name="serial" value="SLPS-00399"/>
-		<info name="release" value="19970606"/>
+		<info name="serial" value="SLPS-00399" />
+		<info name="release" value="19970606" />
 		<info name="alt_title" value="クァンタム・ゲートI 〜悪夢の序章〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52348,8 +52348,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Quiz Charaokedon! Toei Tokusatsu Hero Part 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-02310"/>
-		<info name="release" value="19991021"/>
+		<info name="serial" value="SLPS-02310" />
+		<info name="release" value="19991021" />
 		<info name="alt_title" value="クイズキャラおけドン! 東映特撮ヒーローPART2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52369,8 +52369,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Quiz Darake no Jinsei Game - Un to Atama de Daifuugou!? (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02282"/>
-		<info name="release" value="19990930"/>
+		<info name="serial" value="SLPS-02282" />
+		<info name="release" value="19990930" />
 		<info name="alt_title" value="クイズだらけの人生ゲーム 運と頭で大富豪!?"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52390,8 +52390,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Quiz$Millionaire (Japan)</description>
 		<year>2001</year>
 		<publisher>Eidos</publisher>
-		<info name="serial" value="SLPS-03364"/>
-		<info name="release" value="20011220"/>
+		<info name="serial" value="SLPS-03364" />
+		<info name="release" value="20011220" />
 		<info name="alt_title" value="クイズ＄ミリオネア"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52414,8 +52414,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Quo Vadis - Iberukatsu Seneki (Japan)</description>
 		<year>1997</year>
 		<publisher>Glams</publisher>
-		<info name="serial" value="SLPS-00733"/>
-		<info name="release" value="19970418"/>
+		<info name="serial" value="SLPS-00733" />
+		<info name="release" value="19970418" />
 		<info name="alt_title" value="クオバディス 〜イベルカーツ戦役〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52435,8 +52435,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Race Drivin' A Go! Go! (Japan)</description>
 		<year>1996</year>
 		<publisher>Time Warner</publisher>
-		<info name="serial" value="SLPS-00167"/>
-		<info name="release" value="19960628"/>
+		<info name="serial" value="SLPS-00167" />
+		<info name="release" value="19960628" />
 		<info name="alt_title" value="レースドライビン a ゴー！ゴー！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52456,8 +52456,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rakugaki Showtime (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86272"/>
-		<info name="release" value="19990729"/>
+		<info name="serial" value="SLPM-86272" />
+		<info name="release" value="19990729" />
 		<info name="alt_title" value="ラクガキショータイム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52477,8 +52477,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rally de Africa (Japan)</description>
 		<year>1998</year>
 		<publisher>Prism Arts</publisher>
-		<info name="serial" value="SLPS-01601"/>
-		<info name="release" value="19980923"/>
+		<info name="serial" value="SLPS-01601" />
+		<info name="release" value="19980923" />
 		<info name="alt_title" value="ラリー・デ・アフリカ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52498,8 +52498,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rally de Europe (Japan)</description>
 		<year>2000</year>
 		<publisher>Prism Arts</publisher>
-		<info name="serial" value="SLPS-02679"/>
-		<info name="release" value="20000427"/>
+		<info name="serial" value="SLPS-02679" />
+		<info name="release" value="20000427" />
 		<info name="alt_title" value="ラリー・デ・ヨーロッパ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52519,8 +52519,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chippoke Ralph no Daibouken - The Adventure of Little Ralph (Japan)</description>
 		<year>1999</year>
 		<publisher>New</publisher>
-		<info name="serial" value="SLPS-01853"/>
-		<info name="release" value="19990603"/>
+		<info name="serial" value="SLPS-01853" />
+		<info name="release" value="19990603" />
 		<info name="alt_title" value="ちっぽけラルフの大冒険"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52541,8 +52541,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ranma ½ - Battle Renaissance (Japan)</description>
 		<year>1996</year>
 		<publisher>Shogakukan</publisher>
-		<info name="serial" value="SLPS-00522"/>
-		<info name="release" value="19961206"/>
+		<info name="serial" value="SLPS-00522" />
+		<info name="release" value="19961206" />
 		<info name="alt_title" value="らんま1/2 バトルルネッサンス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52562,8 +52562,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kaisoku Tenshi - The Rapid Angel (Japan)</description>
 		<year>1998</year>
 		<publisher>Techno Soleil</publisher>
-		<info name="serial" value="SLPS-01553"/>
-		<info name="release" value="19980813"/>
+		<info name="serial" value="SLPS-01553" />
+		<info name="release" value="19980813" />
 		<info name="alt_title" value="快速天使"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52584,8 +52584,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Groove Adventure Rave - Mikan no Hiseki (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87138 (VX265-J1)"/>
-		<info name="release" value="20020829"/>
+		<info name="serial" value="SLPM-87138 (VX265-J1)" />
+		<info name="release" value="20020829" />
 		<info name="alt_title" value="グルーヴアドベンチャーレイヴ　～未完の秘石～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52605,8 +52605,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Groove Adventure Rave - Yuukyuu no Kizuna (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87011 (VX253-J1)"/>
-		<info name="release" value="20020131"/>
+		<info name="serial" value="SLPM-87011 (VX253-J1)" />
+		<info name="release" value="20020131" />
 		<info name="alt_title" value="グルーブアドベンチャーレイヴ 悠久の絆"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52626,8 +52626,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rayman (Japan)</description>
 		<year>1995</year>
 		<publisher>Ubisoft</publisher>
-		<info name="serial" value="SLPS-00026"/>
-		<info name="release" value="19950922"/>
+		<info name="serial" value="SLPS-00026" />
+		<info name="release" value="19950922" />
 		<info name="alt_title" value="レイマン レイマンよ！エレクトゥーンを救え！~ Rayman - Rayman yo! Electroons o Sukue (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52647,8 +52647,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ray Tracers (Japan)</description>
 		<year>1997</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-00098"/>
-		<info name="release" value="19970117"/>
+		<info name="serial" value="SLPS-00098" />
+		<info name="release" value="19970117" />
 		<info name="alt_title" value="レイ・トレーサー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52671,8 +52671,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Real Bout Garou Densetsu Special - Dominated Mind (Japan, Limited Edition)</description>
 		<year>1998</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-86090~SLPM-86091"/>
-		<info name="release" value="19980625"/>
+		<info name="serial" value="SLPM-86090~SLPM-86091" />
+		<info name="release" value="19980625" />
 		<info name="alt_title" value="リアルバウト餓狼伝説スペシャル ドミネイテッドマインド 限定版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -52697,8 +52697,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Recipro Heat 5000 (Japan)</description>
 		<year>1997</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-00744"/>
-		<info name="release" value="19970731"/>
+		<info name="serial" value="SLPS-00744" />
+		<info name="release" value="19970731" />
 		<info name="alt_title" value="レシプロヒート5000"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52718,8 +52718,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ready Maid (Japan)</description>
 		<year>2002</year>
 		<publisher>Princess</publisher>
-		<info name="serial" value="SLPM-87157"/>
-		<info name="release" value="20021024"/>
+		<info name="serial" value="SLPM-87157" />
+		<info name="release" value="20021024" />
 		<info name="alt_title" value="れでぃ☆めいど"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52751,8 +52751,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Real Robots - Final Attack (Japan)</description>
 		<year>1998</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-01125"/>
-		<info name="release" value="19980108"/>
+		<info name="serial" value="SLPS-01125" />
+		<info name="release" value="19980108" />
 		<info name="alt_title" value="リアルロボッツ ファイナルアタック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52775,8 +52775,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Return to Zork (Japan)</description>
 		<year>1996</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00192~SLPS-00193"/>
-		<info name="release" value="19960927"/>
+		<info name="serial" value="SLPS-00192~SLPS-00193" />
+		<info name="release" value="19960927" />
 		<info name="alt_title" value="リターン・トゥ・ゾーク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -52801,8 +52801,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Riot Stars (Japan)</description>
 		<year>1997</year>
 		<publisher>Hect</publisher>
-		<info name="serial" value="SLPS-00829"/>
-		<info name="release" value="19970502"/>
+		<info name="serial" value="SLPS-00829" />
+		<info name="release" value="19970502" />
 		<info name="alt_title" value="ライアット・スターズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52822,8 +52822,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rise of Robots 2 - Resurrection (Japan)</description>
 		<year>1996</year>
 		<publisher>Acclaim</publisher>
-		<info name="serial" value="SLPS-00259"/>
-		<info name="release" value="19960913"/>
+		<info name="serial" value="SLPS-00259" />
+		<info name="release" value="19960913" />
 		<info name="alt_title" value="ライズ オブ ザ ロボット 2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52844,8 +52844,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rising Zan - The Samurai Gunman (Japan)</description>
 		<year>1999</year>
 		<publisher>UEP</publisher>
-		<info name="serial" value="SLPS-01691"/>
-		<info name="release" value="19990325"/>
+		<info name="serial" value="SLPS-01691" />
+		<info name="release" value="19990325" />
 		<info name="alt_title" value="ライジング ザン ザ・サムライガンマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52865,8 +52865,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Roommate - Inoue Ryoko (Japan)</description>
 		<year>1999</year>
 		<publisher>Datam Polystar</publisher>
-		<info name="serial" value="SLPS-02140"/>
-		<info name="release" value="19990729"/>
+		<info name="serial" value="SLPS-02140" />
+		<info name="release" value="19990729" />
 		<info name="alt_title" value="ルームメイト〜井上涼子〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52886,8 +52886,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Robin Lloyd no Daibouken (Japan)</description>
 		<year>2000</year>
 		<publisher>Gust</publisher>
-		<info name="serial" value="SLPS-02501"/>
-		<info name="release" value="20000106"/>
+		<info name="serial" value="SLPS-02501" />
+		<info name="release" value="20000106" />
 		<info name="alt_title" value="ロビン・ロイドの冒険"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52907,8 +52907,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Robot X Robot (Japan)</description>
 		<year>1999</year>
 		<publisher>Nemesys</publisher>
-		<info name="serial" value="SLPS-02331"/>
-		<info name="release" value="19991014"/>
+		<info name="serial" value="SLPS-02331" />
+		<info name="release" value="19991014" />
 		<info name="alt_title" value="ロボット×ロボット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52928,8 +52928,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Perfect Fishing - Rock Fishing (Japan)</description>
 		<year>2000</year>
 		<publisher>Seta</publisher>
-		<info name="serial" value="SLPS-02410"/>
-		<info name="release" value="20000304"/>
+		<info name="serial" value="SLPS-02410" />
+		<info name="release" value="20000304" />
 		<info name="alt_title" value="パーフェクトフィッシング 磯釣り"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52949,8 +52949,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Running High (Japan)</description>
 		<year>1997</year>
 		<publisher>REX Entertainment</publisher>
-		<info name="serial" value="SLPS-00751"/>
-		<info name="release" value="19970425"/>
+		<info name="serial" value="SLPS-00751" />
+		<info name="release" value="19970425" />
 		<info name="alt_title" value="ランニング・ハイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52970,8 +52970,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bishoujo Senshi Sailormoon Super S - Shin Shuyaku Soudatsusen (Japan, Genteiban)</description>
 		<year>1996</year>
 		<publisher>Angel</publisher>
-		<info name="serial" value="SLPS-00260"/>
-		<info name="release" value="19960308"/>
+		<info name="serial" value="SLPS-00260" />
+		<info name="release" value="19960308" />
 		<info name="alt_title" value="美少女戦士セーラームーンSuperS 真・主役争奪戦 限定版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -52991,8 +52991,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kids Station - Bishoujo Senshi Sailormoon World - Chibiusa to Tanoshii Mainichi (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03318"/>
-		<info name="release" value="20011129"/>
+		<info name="serial" value="SLPS-03318" />
+		<info name="release" value="20011129" />
 		<info name="alt_title" value="キッズステーション 美少女戦士セーラームーンワールド ちびうさとたのしいまいにち"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53012,8 +53012,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sakkyoku Surundamon - Dance Remix (Japan)</description>
 		<year>2000</year>
 		<publisher>Ving</publisher>
-		<info name="serial" value="SLPS-02808"/>
-		<info name="release" value="20000629"/>
+		<info name="serial" value="SLPS-02808" />
+		<info name="release" value="20000629" />
 		<info name="alt_title" value="作曲するんだもん ダンスリミックス編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53033,8 +53033,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sakuma Shiki Jinsei Game (Japan)</description>
 		<year>1998</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01740"/>
-		<info name="release" value="19981210"/>
+		<info name="serial" value="SLPS-01740" />
+		<info name="release" value="19981210" />
 		<info name="alt_title" value="さくま式人生ゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53054,8 +53054,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Salary Man Champ - Tatakau Salary Man (Japan)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86820"/>
-		<info name="release" value="20010531"/>
+		<info name="serial" value="SLPM-86820" />
+		<info name="release" value="20010531" />
 		<info name="alt_title" value="サラリーマンチャンプ たたかうサラリーマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53075,8 +53075,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Salary Man Kintarou - The Game (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02806"/>
-		<info name="release" value="20000622"/>
+		<info name="serial" value="SLPS-02806" />
+		<info name="release" value="20000622" />
 		<info name="alt_title" value="サラリーマン金太郎 THE GAME"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53096,8 +53096,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Salary Man Settai Mahjong (Japan)</description>
 		<year>2001</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPS-03175"/>
-		<info name="release" value="20010510"/>
+		<info name="serial" value="SLPS-03175" />
+		<info name="release" value="20010510" />
 		<info name="alt_title" value="サラリーマン接待麻雀"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53117,8 +53117,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Samurai Deeper Kyo (Japan, Limited Edition)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03505"/>
-		<info name="release" value="20021212"/>
+		<info name="serial" value="SLPS-03505" />
+		<info name="release" value="20021212" />
 		<info name="alt_title" value="サムライディーパー キョウ (初回生産限定仕様)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53139,8 +53139,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Samurai Spirits - Zankurou Musouken (Japan, PlayStation the Best)</description>
 		<year>1997</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPS-91024"/>
-		<info name="release" value="19970320"/>
+		<info name="serial" value="SLPS-91024" />
+		<info name="release" value="19970320" />
 		<info name="alt_title" value="サムライスピリッツ 斬紅郎無双剣 PlayStation the Best"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53161,8 +53161,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Samurai Spirits - Kenkaku Yubinan Pack (Japan)</description>
 		<year>1998</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPS-00647"/>
-		<info name="release" value="19980326"/>
+		<info name="serial" value="SLPS-00647" />
+		<info name="release" value="19980326" />
 		<info name="alt_title" value="サムライスピリッツ 剣客指南パック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53185,8 +53185,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shinsetsu Samurai Spirits - Bushidou Retsuden (Japan)</description>
 		<year>1997</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPS-00814"/>
-		<info name="release" value="19970627"/>
+		<info name="serial" value="SLPS-00814" />
+		<info name="release" value="19970627" />
 		<info name="alt_title" value="真説サムライスピリッツ 武士道烈伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53206,8 +53206,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi - Eiketsuden (Japan)</description>
 		<year>1996</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00309"/>
-		<info name="release" value="19960329"/>
+		<info name="serial" value="SLPS-00309" />
+		<info name="release" value="19960329" />
 		<info name="alt_title" value="三國志英傑伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53227,8 +53227,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi - Koumeiden (Japan)</description>
 		<year>1997</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00688"/>
-		<info name="release" value="19970214"/>
+		<info name="serial" value="SLPS-00688" />
+		<info name="release" value="19970214" />
 		<info name="alt_title" value="三國志孔明伝"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53248,8 +53248,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi II (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-01596"/>
-		<info name="release" value="19980923"/>
+		<info name="serial" value="SLPS-01596" />
+		<info name="release" value="19980923" />
 		<info name="alt_title" value="三國志II"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53269,8 +53269,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi III (Japan)</description>
 		<year>2001</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86747"/>
-		<info name="release" value="20010222"/>
+		<info name="serial" value="SLPM-86747" />
+		<info name="release" value="20010222" />
 		<info name="alt_title" value="三國志III"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53290,8 +53290,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi V (Asia)</description>
 		<year>1997?</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SCPS-45128"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SCPS-45128" />
+		<info name="release" value="" />
 		<info name="alt_title" value="三国志5"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53311,8 +53311,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi VI (Japan)</description>
 		<year>1998</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86129"/>
-		<info name="release" value="19981008"/>
+		<info name="serial" value="SLPM-86129" />
+		<info name="release" value="19981008" />
 		<info name="alt_title" value="三國志VI"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53332,8 +53332,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sangokushi Returns (Japan)</description>
 		<year>1997</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPS-00474"/>
-		<info name="release" value="19970320"/>
+		<info name="serial" value="SLPS-00474" />
+		<info name="release" value="19970320" />
 		<info name="alt_title" value="三國志リターンズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53353,8 +53353,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sanyo Pachinko Paradise 2 - Umi Monogatari Special (Japan)</description>
 		<year>1999</year>
 		<publisher>Irem</publisher>
-		<info name="serial" value="SLPS-02389"/>
-		<info name="release" value="19991118"/>
+		<info name="serial" value="SLPS-02389" />
+		<info name="release" value="19991118" />
 		<info name="alt_title" value="三洋パチンコパラダイス2 海物語スペシャル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53383,8 +53383,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Super Adventure Rockman (Japan)</description>
 		<year>1998</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-01051~SLPS-01053"/>
-		<info name="release" value="19980625"/>
+		<info name="serial" value="SLPS-01051~SLPS-01053" />
+		<info name="release" value="19980625" />
 		<info name="alt_title" value="スーパーアドベンチャーロックマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -53414,8 +53414,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SatelliTV (Japan)</description>
 		<year>1998</year>
 		<publisher>Nippon Ichi</publisher>
-		<info name="serial" value="SLPS-01203"/>
-		<info name="release" value="19980108"/>
+		<info name="serial" value="SLPS-01203" />
+		<info name="release" value="19980108" />
 		<info name="alt_title" value="サテライTV"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53435,8 +53435,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Satomi no Nazo (Japan)</description>
 		<year>1996</year>
 		<publisher>Sound Technology Japan</publisher>
-		<info name="serial" value="SLPS-00613"/>
-		<info name="release" value="19961206"/>
+		<info name="serial" value="SLPS-00613" />
+		<info name="release" value="19961206" />
 		<info name="alt_title" value="里見の謎"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53456,8 +53456,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Schrödinger no Neko - Die Katze von Schrödinger (Japan)</description>
 		<year>1997</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-00780"/>
-		<info name="release" value="19970530"/>
+		<info name="serial" value="SLPS-00780" />
+		<info name="release" value="19970530" />
 		<info name="alt_title" value="シュレディンガーの猫"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53477,8 +53477,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.02 - Afro Ken - The Puzzle (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03307"/>
-		<info name="release" value="20011025"/>
+		<info name="serial" value="SLPS-03307" />
+		<info name="release" value="20011025" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.02 アフロ犬 THE パズル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53498,8 +53498,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.03 - Kamen Rider - The Bike Race (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03308"/>
-		<info name="release" value="20011025"/>
+		<info name="serial" value="SLPS-03308" />
+		<info name="release" value="20011025" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.03 仮面ライダー THE バイクレース"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53519,8 +53519,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.04 - Jarinko Chie - The Hanafuda (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03350"/>
-		<info name="release" value="20011129"/>
+		<info name="serial" value="SLPS-03350" />
+		<info name="release" value="20011129" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.04 じゃりン子チエ THE 花札"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53540,8 +53540,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series vol.05 - Highschool Kimengumi - The Table Hockey (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03362"/>
-		<info name="release" value="20011220"/>
+		<info name="serial" value="SLPS-03362" />
+		<info name="release" value="20011220" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.05 ハイスクール奇面組 THE テーブルホッケー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53561,8 +53561,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.06 - Dokonjou Gaeru - The Mahjong (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03363"/>
-		<info name="release" value="20020124"/>
+		<info name="serial" value="SLPS-03363" />
+		<info name="release" value="20020124" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.06 ど根性ガエル THE 麻雀"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53582,8 +53582,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series vol.07 - Ikkyuu-san - The Quiz (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03418"/>
-		<info name="release" value="20020328"/>
+		<info name="serial" value="SLPS-03418" />
+		<info name="release" value="20020328" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.07 一休さん THE クイズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53603,8 +53603,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.09 - Tsuri Kichi Sanpei - The Tsuri (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03445"/>
-		<info name="release" value="20020627"/>
+		<info name="serial" value="SLPS-03445" />
+		<info name="release" value="20020627" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.09 釣りキチ三平 THE 釣り"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53624,8 +53624,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.10 - Sakigake!! Otojo Juku - The Dodgeball (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03457"/>
-		<info name="release" value="20020829"/>
+		<info name="serial" value="SLPS-03457" />
+		<info name="release" value="20020829" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.10 魁!!男塾 THE 怒馳暴流"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53645,8 +53645,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.12 - Kidou Butouden G Gundam - The Battle (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03471"/>
-		<info name="release" value="20021010"/>
+		<info name="serial" value="SLPS-03471" />
+		<info name="release" value="20021010" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ VOL.12 機動武闘伝Gガンダム THE バトル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53666,8 +53666,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series vol.13 - Kidou Senki Gundam W - The Battle (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03472"/>
-		<info name="release" value="20021010"/>
+		<info name="serial" value="SLPS-03472" />
+		<info name="release" value="20021010" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ VOL.13 新機動戦記ガンダムW THE バトル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53687,8 +53687,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.14 - Nante Tantei Idol - The Jigsaw Puzzle (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03473"/>
-		<info name="release" value="20021010"/>
+		<info name="serial" value="SLPS-03473" />
+		<info name="release" value="20021010" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.14 なんてっ探偵アイドル THE ジグソーパズル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53708,8 +53708,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series vol.15 - Cyborg 009 - The Block Kuzushi (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03474"/>
-		<info name="release" value="20021010"/>
+		<info name="serial" value="SLPS-03474" />
+		<info name="release" value="20021010" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.15 サイボーグ009 THE ブロックくずし"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53729,8 +53729,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple Characters 2000 Series Vol.16 - Ganba no Bouken - The Puzzle Action (Japan)</description>
 		<year>2003</year>
 		<publisher>Bandai / D3</publisher>
-		<info name="serial" value="SLPS-03546"/>
-		<info name="release" value="20030403"/>
+		<info name="serial" value="SLPS-03546" />
+		<info name="release" value="20030403" />
 		<info name="alt_title" value="SIMPLEキャラクター2000シリーズ Vol.16 ガンバの冒険 THE パズルアクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53750,8 +53750,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SD Gundam G Generation-F.I.F (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03195"/>
-		<info name="release" value="20010502"/>
+		<info name="serial" value="SLPS-03195" />
+		<info name="release" value="20010502" />
 		<info name="alt_title" value="SDガンダム ジージェネレーション・エフイフ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53777,8 +53777,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SD Gundam G - Generation-0 (Japan)</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02200~SLPS-02202"/>
-		<info name="release" value="19990812"/>
+		<info name="serial" value="SLPS-02200~SLPS-02202" />
+		<info name="release" value="19990812" />
 		<info name="alt_title" value="SDガンダム ジージェネレーション・ゼロ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -53817,8 +53817,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SD Gundam G Generation-F (Japan, Limited Edition)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02900~SLPS-02902"/>
-		<info name="release" value="20000803"/>
+		<info name="serial" value="SLPS-02900~SLPS-02902" />
+		<info name="release" value="20000803" />
 		<info name="alt_title" value="SDガンダム ジージェネレーション・エフ (限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -53848,8 +53848,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SD Gundam Eiyuu Den Daikessen!! - Kishi vs. Musha (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03145"/>
-		<info name="release" value="20010301"/>
+		<info name="serial" value="SLPS-03145" />
+		<info name="release" value="20010301" />
 		<info name="alt_title" value="SDガンダム英雄伝 大決戦!!騎士VS武者"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53869,8 +53869,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>SeaBass Fishing 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-00992"/>
-		<info name="release" value="19970925"/>
+		<info name="serial" value="SLPS-00992" />
+		<info name="release" value="19970925" />
 		<info name="alt_title" value="シーバス・フィッシング2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53890,8 +53890,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Seikai no Monshou (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02323"/>
-		<info name="release" value="20000525"/>
+		<info name="serial" value="SLPS-02323" />
+		<info name="release" value="20000525" />
 		<info name="alt_title" value="星界の紋章"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53911,8 +53911,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Seirei Shoukan - Princess of Darkness (Japan)</description>
 		<year>1998</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-01271"/>
-		<info name="release" value="19980625"/>
+		<info name="serial" value="SLPS-01271" />
+		<info name="release" value="19980625" />
 		<info name="alt_title" value="精霊召喚 〜プリンセス オブ ダークネス〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53932,8 +53932,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sengoku Mugen (Japan)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-03151"/>
-		<info name="release" value="20010531"/>
+		<info name="serial" value="SLPS-03151" />
+		<info name="release" value="20010531" />
 		<info name="alt_title" value="戦国夢幻"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53953,8 +53953,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Senkai Taisen - TV Animation Senkaiden Houshin Engi Yori (Japan)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-02736"/>
-		<info name="release" value="20000629"/>
+		<info name="serial" value="SLPS-02736" />
+		<info name="release" value="20000629" />
 		<info name="alt_title" value="仙界大戦 〜TVアニメーション仙界伝封神演義より〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53974,8 +53974,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Senryaku Shidan - Tora! Tora! Tora! Rikusen-hen (Japan)</description>
 		<year>2000</year>
 		<publisher>DaZZ</publisher>
-		<info name="serial" value="SLPS-02631 (PS-0014)"/>
-		<info name="release" value="20000224"/>
+		<info name="serial" value="SLPS-02631 (PS-0014)" />
+		<info name="release" value="20000224" />
 		<info name="alt_title" value="戦略師団 トラ!トラ!トラ! 陸戦編"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -53995,8 +53995,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sentimental Graffiti (Japan)</description>
 		<year>2001</year>
 		<publisher>NEC Interchannel</publisher>
-		<info name="serial" value="SLPS-03184 (NIPS-4013)"/>
-		<info name="release" value="20010329"/>
+		<info name="serial" value="SLPS-03184 (NIPS-4013)" />
+		<info name="release" value="20010329" />
 		<info name="alt_title" value="センチメンタルグラフティ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54016,8 +54016,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sentou Kokka Kai - Improved (Japan)</description>
 		<year>1997</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10034"/>
-		<info name="release" value="19970411"/>
+		<info name="serial" value="SCPS-10034" />
+		<info name="release" value="19970411" />
 		<info name="alt_title" value="戦闘国家－改－ インプルーブド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54037,8 +54037,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Super Football Champ (Japan)</description>
 		<year>1996</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-00569"/>
-		<info name="release" value="19961129"/>
+		<info name="serial" value="SLPS-00569" />
+		<info name="release" value="19961129" />
 		<info name="alt_title" value="スーパーフットボールチャンプ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54133,8 +54133,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Street Fighter Collection (Japan)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00800~SLPS-00801"/>
-		<info name="release" value="19971023"/>
+		<info name="serial" value="SLPS-00800~SLPS-00801" />
+		<info name="release" value="19971023" />
 		<info name="alt_title" value="ストリートファイターコレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -54159,8 +54159,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shachou Eiyuuden - The Eagle Shooting Heroes (Asia)</description>
 		<year>2000?</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-45510"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SCPS-45510" />
+		<info name="release" value="" />
 		<info name="alt_title" value="射雕英雄传"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54181,8 +54181,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shiibas 1-2-3 - Destiny! Unmei o Kaeru Mono! (Japan)</description>
 		<year>2000</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-01893"/>
-		<info name="release" value="20000106"/>
+		<info name="serial" value="SLPS-01893" />
+		<info name="release" value="20000106" />
 		<info name="alt_title" value="シーバス 1－2－3 ～DESTINY！運命を変える者！～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54202,8 +54202,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shin Megami Tensei (Japan)</description>
 		<year>2001</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-03170"/>
-		<info name="release" value="20010531"/>
+		<info name="serial" value="SLPS-03170" />
+		<info name="release" value="20010531" />
 		<info name="alt_title" value="真・女神転生"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54223,8 +54223,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>The Shinri Game (Japan)</description>
 		<year>1996</year>
 		<publisher>Visit</publisher>
-		<info name="serial" value="SLPS-00169"/>
-		<info name="release" value="19960426"/>
+		<info name="serial" value="SLPS-00169" />
+		<info name="release" value="19960426" />
 		<info name="alt_title" value="ザ・心理ゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54244,8 +54244,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shin SD Sengokuden - Kidou Musha Taisen (Japan, Limited Edition)</description>
 		<year>1996</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00576"/>
-		<info name="release" value="19961220"/>
+		<info name="serial" value="SLPS-00576" />
+		<info name="release" value="19961220" />
 		<info name="alt_title" value="新SD戦国伝 機動武者大戦(限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54265,8 +54265,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Hello Kitty vol.01 - Hello Kitty Bowling (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86866"/>
-		<info name="release" value="20010830"/>
+		<info name="serial" value="SLPM-86866" />
+		<info name="release" value="20010830" />
 		<info name="alt_title" value="SIMPLE1500シリーズ ハローキティ Vol.01 Hello Kitty ボウリング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54286,8 +54286,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Hello Kitty Vol.02 - Hello Kitty Illust Puzzle (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86867"/>
-		<info name="release" value="20010830"/>
+		<info name="serial" value="SLPM-86867" />
+		<info name="release" value="20010830" />
 		<info name="alt_title" value="SIMPLE1500シリーズ ハローキティ Vol.02 Hello Kitty イラストパズル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54307,8 +54307,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Hello Kitty vol.03 - Hello Kitty Block Kuzushi (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86911"/>
-		<info name="release" value="20011025"/>
+		<info name="serial" value="SLPM-86911" />
+		<info name="release" value="20011025" />
 		<info name="alt_title" value="SIMPLE1500シリーズ ハローキティ Vol.03 Hello Kitty ブロックくずし"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54328,8 +54328,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Hello Kitty Vol.04 - Hello Kitty Trump (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86910"/>
-		<info name="release" value="20011025"/>
+		<info name="serial" value="SLPM-86910" />
+		<info name="release" value="20011025" />
 		<info name="alt_title" value="SIMPLE1500シリーズ ハローキティ Vol.04 Hello Kitty トランプ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54349,8 +54349,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kato Hifumi Kudan - Shogi Club (Japan, Honkakuha de 1300Yen Series)</description>
 		<year>1999</year>
 		<publisher>Hect</publisher>
-		<info name="serial" value="SLPS-02078"/>
-		<info name="release" value="19990527"/>
+		<info name="serial" value="SLPS-02078" />
+		<info name="release" value="19990527" />
 		<info name="alt_title" value="本格派DE 1300円 加藤一二三 九段 将棋倶楽部"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54370,8 +54370,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shouryuu Sangoku Engi (Japan)</description>
 		<year>1996</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-00253"/>
-		<info name="release" value="19960216"/>
+		<info name="serial" value="SLPS-00253" />
+		<info name="release" value="19960216" />
 		<info name="alt_title" value="昇龍三国演義"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54411,8 +54411,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shura no Mon (Japan)</description>
 		<year>1998</year>
 		<publisher>Kodansha</publisher>
-		<info name="serial" value="SLPS-01202"/>
-		<info name="release" value="19980402"/>
+		<info name="serial" value="SLPS-01202" />
+		<info name="release" value="19980402" />
 		<info name="alt_title" value="修羅の門"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54432,8 +54432,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Side Pocket 3 - 3D Polygon Billiard Game (Japan)</description>
 		<year>1998</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-01079"/>
-		<info name="release" value="19980416"/>
+		<info name="serial" value="SLPS-01079" />
+		<info name="release" value="19980416" />
 		<info name="alt_title" value="サイドポケット3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54453,8 +54453,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sidewinder (Japan)</description>
 		<year>1996</year>
 		<publisher>Asmik</publisher>
-		<info name="serial" value="SLPS-00156"/>
-		<info name="release" value="19960126"/>
+		<info name="serial" value="SLPS-00156" />
+		<info name="release" value="19960126" />
 		<info name="alt_title" value="サイドワインダー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54474,8 +54474,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Silent Möbius - Genei no Datenshi (Japan, disc 1 only)</description>
 		<year>1998</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01803"/>
-		<info name="release" value="19981223"/>
+		<info name="serial" value="SLPS-01803" />
+		<info name="release" value="19981223" />
 		<info name="alt_title" value="サイレントメビウス 幻影の堕天使"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -54500,8 +54500,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Silhouette Mirage - Reprogrammed Hope (Japan)</description>
 		<year>1998</year>
 		<publisher>ESP</publisher>
-		<info name="serial" value="SLPS-01449"/>
-		<info name="release" value="19980723"/>
+		<info name="serial" value="SLPS-01449" />
+		<info name="release" value="19980723" />
 		<info name="alt_title" value="シルエットミラージュ リプログラムドホープ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54521,8 +54521,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Silhouette Stories (Japan)</description>
 		<year>1996</year>
 		<publisher>Kaneko</publisher>
-		<info name="serial" value="SLPS-00374"/>
-		<info name="release" value="19960927"/>
+		<info name="serial" value="SLPS-00374" />
+		<info name="release" value="19960927" />
 		<info name="alt_title" value="シルエット☆ストーリィズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54542,8 +54542,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simulation Zoo - Sekaiichi no Doubutsuen o Tsukurou (Japan)</description>
 		<year>1996</year>
 		<publisher>SoftBank</publisher>
-		<info name="serial" value="SLPS-00458"/>
-		<info name="release" value="19961129"/>
+		<info name="serial" value="SLPS-00458" />
+		<info name="release" value="19961129" />
 		<info name="alt_title" value="シミュレーションズー 世界一の動物園をつくろう"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54563,8 +54563,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sister Princess - Pure Stories (Japan)</description>
 		<year>2001</year>
 		<publisher>MediaWorks</publisher>
-		<info name="serial" value="SLPS-03360"/>
-		<info name="release" value="20011223"/>
+		<info name="serial" value="SLPS-03360" />
+		<info name="release" value="20011223" />
 		<info name="alt_title" value="シスター・プリンセス 〜ピュア・ストーリーズ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54584,8 +54584,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.01 - Norikae Annai -2000 Edition- (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPS-02842"/>
-		<info name="release" value="20000914"/>
+		<info name="serial" value="SLPS-02842" />
+		<info name="release" value="20000914" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.01 乗換案内〜2000年版〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54605,8 +54605,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.03 - Seimei Handan (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPS-02841"/>
-		<info name="release" value="20000824"/>
+		<info name="serial" value="SLPS-02841" />
+		<info name="release" value="20000824" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.03 姓名判断"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54626,8 +54626,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.04 - Ryouri (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPS-02839"/>
-		<info name="release" value="20000824"/>
+		<info name="serial" value="SLPS-02839" />
+		<info name="release" value="20000824" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.04 料理〜定番料理レシピ集〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54647,8 +54647,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.05 - Kusuri no Jiten - Pill Book 2001 Edition (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86706"/>
-		<info name="release" value="20010118"/>
+		<info name="serial" value="SLPM-86706" />
+		<info name="release" value="20010118" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.05 薬の事典〜ピルブック2001年版〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54668,8 +54668,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.06 - Cocktail no Recipe (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86707"/>
-		<info name="release" value="20010118"/>
+		<info name="serial" value="SLPM-86707" />
+		<info name="release" value="20010118" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.06 カクテルのレシピ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54689,8 +54689,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.07 - Tanoshiku Manabu Unten Menkyo (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86797"/>
-		<info name="release" value="20010502"/>
+		<info name="serial" value="SLPM-86797" />
+		<info name="release" value="20010502" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.07 楽しく学ぶ運転免許"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54710,8 +54710,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.08 - 1-Jikan de Wakaru Kabushiki Toushi (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86708"/>
-		<info name="release" value="20010726"/>
+		<info name="serial" value="SLPM-86708" />
+		<info name="release" value="20010726" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.08 1時間でわかる株式投資"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54731,8 +54731,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.09 - Watashi Style no Aromatherapy (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86843"/>
-		<info name="release" value="20010726"/>
+		<info name="serial" value="SLPM-86843" />
+		<info name="release" value="20010726" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.09 わたしスタイルのアロマセラピー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54752,8 +54752,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.10 - Tarot Uranai (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86913"/>
-		<info name="release" value="20011025"/>
+		<info name="serial" value="SLPM-86913" />
+		<info name="release" value="20011025" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.10 タロット占い"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54773,13 +54773,13 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.11 - Katei de Dekiru Tsubo Shiatsu (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86968"/>
-		<info name="release" value="20011213"/>
+		<info name="serial" value="SLPM-86968" />
+		<info name="release" value="20011213" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.11 家庭でできるツボ指圧"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="simple 1500 jitsuyou series vol.11 - katei de dekiru tsubo shiatsu (japan) [slpm-86968]" sha1="99e83ee7ce9f67b40ad512bde5167964e6539bbd" status="baddump"/>
+				<disk name="simple 1500 jitsuyou series vol.11 - katei de dekiru tsubo shiatsu (japan) [slpm-86968]" sha1="6328c634cd08e9fef0d3a3f39ca4a288e660c1e9" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>
@@ -54794,8 +54794,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.12 - Katei no Igaku (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86969"/>
-		<info name="release" value="20011213"/>
+		<info name="serial" value="SLPM-86969" />
+		<info name="release" value="20011213" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.12 家庭の医学"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54815,8 +54815,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.13 - Shinri Game - Soreike X Kokoroji (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87016"/>
-		<info name="release" value="20020214"/>
+		<info name="serial" value="SLPM-87016" />
+		<info name="release" value="20020214" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.13 心理ゲーム 〜それいけ×ココロジー ココロのウソの摩訶不思議〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54836,8 +54836,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.14 - Kurashi no Manner (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87022"/>
-		<info name="release" value="20020214"/>
+		<info name="serial" value="SLPM-87022" />
+		<info name="release" value="20020214" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.14 暮らしのマナー 〜冠婚葬祭編〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54857,8 +54857,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.15 - Inu no Kaikata - Sekai no Inu Catalog (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87051"/>
-		<info name="release" value="20020418"/>
+		<info name="serial" value="SLPM-87051" />
+		<info name="release" value="20020418" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.15 犬の飼い方 〜世界の犬カタログ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54878,8 +54878,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.16 - Neko no Kaikata - Sekai no Neko Catalog (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87052"/>
-		<info name="release" value="20020418"/>
+		<info name="serial" value="SLPM-87052" />
+		<info name="release" value="20020418" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.16 猫の飼い方 〜世界の猫カタログ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54899,8 +54899,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.17 - Planetarium (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87049"/>
-		<info name="release" value="20020418"/>
+		<info name="serial" value="SLPM-87049" />
+		<info name="release" value="20020418" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.17 THE プラネタリウム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54920,8 +54920,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Jitsuyou Series Vol.18 - Kanji Quiz - Kanji Keitei ni Challenge (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87072"/>
-		<info name="release" value="20020523"/>
+		<info name="serial" value="SLPM-87072" />
+		<info name="release" value="20020523" />
 		<info name="alt_title" value="SIMPLE1500実用シリーズ Vol.18 THE 漢字クイズ 〜漢字検定にチャレンジ〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54941,8 +54941,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Slap Happy Rhythm Busters (Japan)</description>
 		<year>2000</year>
 		<publisher>ASK</publisher>
-		<info name="serial" value="SLPS-02789"/>
-		<info name="release" value="20000629"/>
+		<info name="serial" value="SLPS-02789" />
+		<info name="release" value="20000629" />
 		<info name="alt_title" value="スラップ ハッピー リズム バスターズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54963,9 +54963,9 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Super Live Stadium (Japan)</description>
 		<year>1998</year>
 		<publisher>Squaresoft</publisher>
-		<info name="developer" value="Aques"/>
-		<info name="serial" value="SLPM-86019"/>
-		<info name="release" value="19980101"/>
+		<info name="developer" value="Aques" />
+		<info name="serial" value="SLPM-86019" />
+		<info name="release" value="19980101" />
 		<info name="alt_title" value="スーパーライブスタジアム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -54985,8 +54985,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kids Station - Motto! Oja Majo Dorami - MAHO-dou Smile Party (Japan)</description>
 		<year>2001</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03247"/>
-		<info name="release" value="20010726"/>
+		<info name="serial" value="SLPS-03247" />
+		<info name="release" value="20010726" />
 		<info name="alt_title" value="キッズステーション も〜っと！おジャ魔女どれみ MAHO堂スマイルパーテ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55006,8 +55006,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Snatcher (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPS-00154"/>
-		<info name="release" value="19960216"/>
+		<info name="serial" value="SLPS-00154" />
+		<info name="release" value="19960216" />
 		<info name="alt_title" value="スナッチャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55027,8 +55027,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>S.Q. - Sound Qube (Japan)</description>
 		<year>1998</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01309"/>
-		<info name="release" value="19980312"/>
+		<info name="serial" value="SLPS-01309" />
+		<info name="release" value="19980312" />
 		<info name="alt_title" value="S.Q. サウンドキューブ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55048,8 +55048,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Snobow Kids Plus (Japan)</description>
 		<year>1999</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-01823"/>
-		<info name="release" value="19990121"/>
+		<info name="serial" value="SLPS-01823" />
+		<info name="release" value="19990121" />
 		<info name="alt_title" value="スノボキッズプラス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55100,8 +55100,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Soukyugurentai - Oubushustugeki (Japan)</description>
 		<year>1997</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-01172"/>
-		<info name="release" value="19971225"/>
+		<info name="serial" value="SLPS-01172" />
+		<info name="release" value="19971225" />
 		<info name="alt_title" value="蒼穹紅蓮隊 黄武出撃"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55121,8 +55121,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gakuen Sentai Solblast (Japan)</description>
 		<year>1999</year>
 		<publisher>Creative Heads</publisher>
-		<info name="serial" value="SLPS-01852"/>
-		<info name="release" value="19990204"/>
+		<info name="serial" value="SLPS-01852" />
+		<info name="release" value="19990204" />
 		<info name="alt_title" value="学園戦隊ソルブラスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55145,8 +55145,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sonata (Japan)</description>
 		<year>1999</year>
 		<publisher>T&amp;E Soft</publisher>
-		<info name="serial" value="SLPS-01843~SLPS-01844"/>
-		<info name="release" value="19990304"/>
+		<info name="serial" value="SLPS-01843~SLPS-01844" />
+		<info name="release" value="19990304" />
 		<info name="alt_title" value="ソナタ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -55171,8 +55171,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Sotsugyou Crossworld (Japan)</description>
 		<year>1996</year>
 		<publisher>Hearty Robin</publisher>
-		<info name="serial" value="SLPS-00273"/>
-		<info name="release" value="19960628"/>
+		<info name="serial" value="SLPS-00273" />
+		<info name="release" value="19960628" />
 		<info name="alt_title" value="卒業クロスワールド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55192,8 +55192,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Space Invaders X (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPM-86419 (TCPS10014)"/>
-		<info name="release" value="20000217"/>
+		<info name="serial" value="SLPM-86419 (TCPS10014)" />
+		<info name="release" value="20000217" />
 		<info name="alt_title" value="スペースインベーダーX"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55213,8 +55213,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Spectral Blade (Japan)</description>
 		<year>1999</year>
 		<publisher>Idea Factory</publisher>
-		<info name="serial" value="SLPS-02526"/>
-		<info name="release" value="19991222"/>
+		<info name="serial" value="SLPS-02526" />
+		<info name="release" value="19991222" />
 		<info name="alt_title" value="スペクトラルブレイド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55234,8 +55234,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Speed King (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86013 (VX025-J1)"/>
-		<info name="release" value="19961213"/>
+		<info name="serial" value="SLPM-86013 (VX025-J1)" />
+		<info name="release" value="19961213" />
 		<info name="alt_title" value="スピードキング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55255,8 +55255,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Speed Power Gunbike (Japan)</description>
 		<year>1998</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-01066"/>
-		<info name="release" value="19980423"/>
+		<info name="serial" value="SLPS-01066" />
+		<info name="release" value="19980423" />
 		<info name="alt_title" value="可変走攻 ガンバイク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55276,8 +55276,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Spider-Man (Japan)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-86739"/>
-		<info name="release" value="20010426"/>
+		<info name="serial" value="SLPM-86739" />
+		<info name="release" value="20010426" />
 		<info name="alt_title" value="スパイダーマン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55297,7 +55297,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen alpha (japan) (v1.1)" sha1="55891934c6f643bad499999e441d019c9a14f478"/>
+				<disk name="super robot taisen alpha (japan) (v1.1)" sha1="55891934c6f643bad499999e441d019c9a14f478" />
 			</diskarea>
 		</part>
 	</software>
@@ -55312,7 +55312,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen alpha gaiden - premium edition (japan)" sha1="6d1c0aadeb797702d8de68b1d96b0c62ae84cf77"/>
+				<disk name="super robot taisen alpha gaiden - premium edition (japan)" sha1="6d1c0aadeb797702d8de68b1d96b0c62ae84cf77" />
 			</diskarea>
 		</part>
 	</software>
@@ -55327,7 +55327,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen alpha gaiden - shokai genteiban (japan)" sha1="104390ee61a56baf4902f45a945cb588d3b7c795"/>
+				<disk name="super robot taisen alpha gaiden - shokai genteiban (japan)" sha1="104390ee61a56baf4902f45a945cb588d3b7c795" />
 			</diskarea>
 		</part>
 	</software>
@@ -55345,7 +55345,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen - complete box (japan) (disc 1)" sha1="624cc4b224cb211199095a6c2daad947c9d4c6de"/>
+				<disk name="super robot taisen - complete box (japan) (disc 1)" sha1="624cc4b224cb211199095a6c2daad947c9d4c6de" />
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="psx_cdrom">
@@ -55366,7 +55366,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen f (japan)" sha1="3b86350787d8d9512e276f646a6ef7d8fe2191d4"/>
+				<disk name="super robot taisen f (japan)" sha1="3b86350787d8d9512e276f646a6ef7d8fe2191d4" />
 			</diskarea>
 		</part>
 	</software>
@@ -55382,7 +55382,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Banpresto</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super robot taisen f kanketsuhen (japan)" sha1="f2587e200ebb55eee1dcd7092b2e745102d5db3a"/>
+				<disk name="super robot taisen f kanketsuhen (japan)" sha1="f2587e200ebb55eee1dcd7092b2e745102d5db3a" />
 			</diskarea>
 		</part>
 	</software>
@@ -55397,8 +55397,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.37 - The Illustration Puzzle &amp; Slide Puzzle (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPS-02958"/>
-		<info name="release" value="20000914"/>
+		<info name="serial" value="SLPS-02958" />
+		<info name="release" value="20000914" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.37 THE イラストパズル&amp;スライドパズル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55418,8 +55418,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.51 - The Jigsaw Puzzle (Japan)</description>
 		<year>2000</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86700"/>
-		<info name="release" value="20001228"/>
+		<info name="serial" value="SLPM-86700" />
+		<info name="release" value="20001228" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.51 THE ジグソーパズル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55439,8 +55439,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.63 - The Gun Shooting 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86816"/>
-		<info name="release" value="20010531"/>
+		<info name="serial" value="SLPM-86816" />
+		<info name="release" value="20010531" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.63 THE ガンシューティング2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55460,8 +55460,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.67 - The Soccer - Dynamite Soccer 1500 (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86864"/>
-		<info name="release" value="20010809"/>
+		<info name="serial" value="SLPM-86864" />
+		<info name="release" value="20010809" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.67 THE サッカー 〜ダイナマイトサッカー1500〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55481,8 +55481,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.71 - The Ren'ai Simulation 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86870"/>
-		<info name="release" value="20010830"/>
+		<info name="serial" value="SLPM-86870" />
+		<info name="release" value="20010830" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.71 THE 恋愛シミュレーション2 〜ふれあい〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55502,8 +55502,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.72 - The Beach Volley (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86871"/>
-		<info name="release" value="20010830"/>
+		<info name="serial" value="SLPM-86871" />
+		<info name="release" value="20010830" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.72 THE ビーチバレー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55524,8 +55524,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.73 - The Invaders - Space Invaders 1500 (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86900"/>
-		<info name="release" value="20010927"/>
+		<info name="serial" value="SLPM-86900" />
+		<info name="release" value="20010927" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.73 THE インベーダー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55545,8 +55545,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.76 - The Dodgeball (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86914"/>
-		<info name="release" value="20011025"/>
+		<info name="serial" value="SLPM-86914" />
+		<info name="release" value="20011025" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.76 THE ドッヂボール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55566,8 +55566,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.83 - The Wakeboard - BursTrick Wake Boarding!! (Japan)</description>
 		<year>2001</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-86998"/>
-		<info name="release" value="20011220"/>
+		<info name="serial" value="SLPM-86998" />
+		<info name="release" value="20011220" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.83 THE ウェイクボード～バーストリック ウェイクボーディング！！～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55587,8 +55587,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.85 - The Sengoku Bushou - Tenka Touitsu no Yabou (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87008"/>
-		<info name="release" value="20020130"/>
+		<info name="serial" value="SLPM-87008" />
+		<info name="release" value="20020130" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.85 THE 戦国武将 〜天下統一の野望〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55608,8 +55608,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.88 - The Gal Mahjong - Love Songs - Idol wa High Rate (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87023"/>
-		<info name="release" value="20020328"/>
+		<info name="serial" value="SLPM-87023" />
+		<info name="release" value="20020328" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.88 THE ギャル麻雀 〜LoveSongs アイドルはハイレ〜ト〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55629,8 +55629,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.89 - The Power Shovel - Power Shovel ni Norou! (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87035"/>
-		<info name="release" value="20020328"/>
+		<info name="serial" value="SLPM-87035" />
+		<info name="release" value="20020328" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.89 THE パワーショベル 〜パワーショベルに乗ろう!!〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55650,8 +55650,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.90 - The Sensha (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87044"/>
-		<info name="release" value="20020328"/>
+		<info name="serial" value="SLPM-87044" />
+		<info name="release" value="20020328" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.90 THE 戦車"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55671,8 +55671,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.93 - The Puzzle Bobble 4 (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87057"/>
-		<info name="release" value="20020425"/>
+		<info name="serial" value="SLPM-87057" />
+		<info name="release" value="20020425" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.93 THE パズルボブル 〜パズルボブル4〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55692,8 +55692,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.97 - The Squash (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87088"/>
-		<info name="release" value="20020627"/>
+		<info name="serial" value="SLPM-87088" />
+		<info name="release" value="20020627" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.97 THE スカッシュ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55713,8 +55713,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.99 - The Kendo - Ken no Hanamichi (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87140"/>
-		<info name="release" value="20020829"/>
+		<info name="serial" value="SLPM-87140" />
+		<info name="release" value="20020829" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.99 THE 剣道 〜剣の花道〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55734,8 +55734,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series vol.101 - The Sentou (Japan)</description>
 		<year>2003</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87142"/>
-		<info name="release" value="20030130"/>
+		<info name="serial" value="SLPM-87142" />
+		<info name="release" value="20030130" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.101 THE 銭湯"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55755,8 +55755,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.102 - The Densha Untensha - Densha de Go! - Nagoya Tetsudou-hen (Japan)</description>
 		<year>2002</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87144"/>
-		<info name="release" value="20020829"/>
+		<info name="serial" value="SLPM-87144" />
+		<info name="release" value="20020829" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.102 THE 電車運転手〜電車でGO!名古屋鉄道編〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55776,8 +55776,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.103 - The Ganso Densha Utenshi - Densha De Go! (Japan)</description>
 		<year>2003</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87212"/>
-		<info name="release" value="20030130"/>
+		<info name="serial" value="SLPM-87212" />
+		<info name="release" value="20030130" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.103 THE 元祖電車運転士〜電車でGO!〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55819,8 +55819,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Simple 1500 Series Vol.104 - The Pink Panther - Pinkadelic Pursuit (Japan)</description>
 		<year>2003</year>
 		<publisher>D3 Publisher</publisher>
-		<info name="serial" value="SLPM-87215"/>
-		<info name="release" value="20030227"/>
+		<info name="serial" value="SLPM-87215" />
+		<info name="release" value="20030227" />
 		<info name="alt_title" value="SIMPLE1500シリーズ Vol.104 THE ピンクパンサー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55856,8 +55856,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Stahlfeder - Tetsukou Hikuudan (Japan)</description>
 		<year>1996</year>
 		<publisher>Santos</publisher>
-		<info name="serial" value="SLPS-00162"/>
-		<info name="release" value="19960126"/>
+		<info name="serial" value="SLPS-00162" />
+		<info name="release" value="19960126" />
 		<info name="alt_title" value="シュタールフェーダー 〜鉄甲飛空団〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55877,8 +55877,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Startling Odyssey 1 - Blue Evolution (Japan)</description>
 		<year>1999</year>
 		<publisher>RayForce</publisher>
-		<info name="serial" value="SLPS-02043"/>
-		<info name="release" value="19990715"/>
+		<info name="serial" value="SLPS-02043" />
+		<info name="release" value="19990715" />
 		<info name="alt_title" value="スタートリング・オデッセイ1 ブルーエヴォリューション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55898,8 +55898,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kotetsu Reiki - Steel Dom (Japan)</description>
 		<year>1996</year>
 		<publisher>TecnoSoft</publisher>
-		<info name="serial" value="SLPS-00431"/>
-		<info name="release" value="19960830"/>
+		<info name="serial" value="SLPS-00431" />
+		<info name="release" value="19960830" />
 		<info name="alt_title" value="鋼鉄霊域 (スティールダム)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55919,8 +55919,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Shin Theme Park (Japan)</description>
 		<year>1997</year>
 		<publisher>Electronic Arts Victor</publisher>
-		<info name="serial" value="SLPS-00810"/>
-		<info name="release" value="19970411"/>
+		<info name="serial" value="SLPS-00810" />
+		<info name="release" value="19970411" />
 		<info name="alt_title" value="新テーマパーク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -55940,8 +55940,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Suchie-Pai Adventure - Doki Doki Nightmare (Japan, disc 2 only)</description>
 		<year>1998</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-01265"/>
-		<info name="release" value="19980409"/>
+		<info name="serial" value="SLPS-01265" />
+		<info name="release" value="19980409" />
 		<info name="alt_title" value="スーチーパイアドベンチャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<!--
@@ -55974,8 +55974,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Idol Janshi Suchie-Pai II Limited (Japan)</description>
 		<year>1996</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-00290~SLPS-00292"/>
-		<info name="release" value="19960920"/>
+		<info name="serial" value="SLPS-00290~SLPS-00292" />
+		<info name="release" value="19960920" />
 		<info name="alt_title" value="アイドル雀士スーチーパイII リミテッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56005,8 +56005,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Idol Janshi Suchie-Pai Limited (Japan)</description>
 		<year>1995</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-00029"/>
-		<info name="release" value="19950324"/>
+		<info name="serial" value="SLPS-00029" />
+		<info name="release" value="19950324" />
 		<info name="alt_title" value="アイドル雀士スーチーパイ リミテッド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56053,8 +56053,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Suiko Enbu - Outlaws of the Lost Dynasty (Japan)</description>
 		<year>1996</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-00137"/>
-		<info name="release" value="19960126"/>
+		<info name="serial" value="SLPS-00137" />
+		<info name="release" value="19960126" />
 		<info name="alt_title" value="水滸演武"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56074,8 +56074,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.1 - Ikki &amp; Super Arabian (Japan)</description>
 		<year>2001</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03135"/>
-		<info name="release" value="20011004"/>
+		<info name="serial" value="SLPS-03135" />
+		<info name="release" value="20011004" />
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフト Vol.1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56095,8 +56095,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.2 - Route-16 Turbo &amp; Atlantis no Nazo (Japan)</description>
 		<year>2001</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03181"/>
-		<info name="release" value="20011206"/>
+		<info name="serial" value="SLPS-03181" />
+		<info name="release" value="20011206" />
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフトVOL.2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56116,8 +56116,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.3 - Madoola no Tsubasa &amp; Toukaidou Gojuusan Tsugi (Japan)</description>
 		<year>2001</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03366"/>
-		<info name="release" value="20011227"/>
+		<info name="serial" value="SLPS-03366" />
+		<info name="release" value="20011227" />
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフトVOL.3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56137,8 +56137,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.4 - Chou Wakusei Senki Metafight &amp; Ripple Island (Japan)</description>
 		<year>2002</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03382"/>
-		<info name="release" value="20020214"/>
+		<info name="serial" value="SLPS-03382" />
+		<info name="release" value="20020214" />
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフト VOL.4"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56158,8 +56158,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.5 - Raf World &amp; Hebereke (Japan)</description>
 		<year>2002</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03397"/>
-		<info name="release" value="20020328"/>
+		<info name="serial" value="SLPS-03397" />
+		<info name="release" value="20020328" />
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフト VOL.5"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56179,8 +56179,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Memorial Star Series - Sunsoft Vol.6 - Battle Formula &amp; Gimmick! (Japan)</description>
 		<year>2002</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-03486"/>
-		<info name="release" value="20021121"/>
+		<info name="serial" value="SLPS-03486" />
+		<info name="release" value="20021121" />
 		<info name="alt_title" value="メモリアル☆シリーズ サンソフトVOL.6"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56200,8 +56200,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tactics Ogre - Let Us Cling Together (Japan)</description>
 		<year>1997</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-00767"/>
-		<info name="release" value="19970925"/>
+		<info name="serial" value="SLPS-00767" />
+		<info name="release" value="19970925" />
 		<info name="alt_title" value="タクティクス・オウガ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56222,8 +56222,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tatsunoko Fight (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-02939"/>
-		<info name="release" value="20001005"/>
+		<info name="serial" value="SLPS-02939" />
+		<info name="release" value="20001005" />
 		<info name="alt_title" value="タツノコファイト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56243,8 +56243,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tenant Wars (Japan)</description>
 		<year>1998</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-01243"/>
-		<info name="release" value="19980211"/>
+		<info name="serial" value="SLPS-01243" />
+		<info name="release" value="19980211" />
 		<info name="alt_title" value="テナントウォーズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56267,8 +56267,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tenchi Muyou! Toukou Muyou (Japan)</description>
 		<year>1996</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-00451~SLPS-00452"/>
-		<info name="release" value="19960913"/>
+		<info name="serial" value="SLPS-00451~SLPS-00452" />
+		<info name="release" value="19960913" />
 		<info name="alt_title" value="天地無用！〜登校無用〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56293,8 +56293,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tenchi wo Kurau II - Sekiheki no Tatakai (Japan)</description>
 		<year>1996</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00203"/>
-		<info name="release" value="19960322"/>
+		<info name="serial" value="SLPS-00203" />
+		<info name="release" value="19960322" />
 		<info name="alt_title" value="天地を喰らうII"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56314,8 +56314,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ten Made Jack - Odoroki Manenoki Daitoubou!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
-		<info name="serial" value="SLPM-86368"/>
-		<info name="release" value="20000323"/>
+		<info name="serial" value="SLPM-86368" />
+		<info name="release" value="20000323" />
 		<info name="alt_title" value="天までジャック オドロキマメノキ大逃亡！！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56335,8 +56335,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tennis Arena (Japan)</description>
 		<year>1998</year>
 		<publisher>Ubi Soft</publisher>
-		<info name="serial" value="SLPS-01303"/>
-		<info name="release" value="19980319"/>
+		<info name="serial" value="SLPS-01303" />
+		<info name="release" value="19980319" />
 		<info name="alt_title" value="テニス・アリーナ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56356,8 +56356,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tensen Nyannyan - Gekijou-ban (Japan)</description>
 		<year>1998</year>
 		<publisher>Time Point</publisher>
-		<info name="serial" value="SLPS-01278"/>
-		<info name="release" value="19980226"/>
+		<info name="serial" value="SLPS-01278" />
+		<info name="release" value="19980226" />
 		<info name="alt_title" value="天仙娘々〜劇場版〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56377,8 +56377,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Oukyuu no Hihou - Tension (Japan)</description>
 		<year>1996</year>
 		<publisher>VAP</publisher>
-		<info name="serial" value="SLPS-00438"/>
-		<info name="release" value="19960927"/>
+		<info name="serial" value="SLPS-00438" />
+		<info name="release" value="19960927" />
 		<info name="alt_title" value="王宮の秘宝 テンション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56398,8 +56398,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tetris X (Japan)</description>
 		<year>1996</year>
 		<publisher>BPS</publisher>
-		<info name="serial" value="SLPS-00321"/>
-		<info name="release" value="19960329"/>
+		<info name="serial" value="SLPS-00321" />
+		<info name="release" value="19960329" />
 		<info name="alt_title" value="テトリス X"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56419,8 +56419,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Thunder Force V - Perfect System (Japan)</description>
 		<year>1998</year>
 		<publisher>TechnoSoft</publisher>
-		<info name="serial" value="SLPS-01406"/>
-		<info name="release" value="19980521"/>
+		<info name="serial" value="SLPS-01406" />
+		<info name="release" value="19980521" />
 		<info name="alt_title" value="サンダー・フォースＶ　～パーフェクト・システム～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56440,8 +56440,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>TFX - Tactical Fighter Experiment (Japan)</description>
 		<year>1996</year>
 		<publisher>Imageneer</publisher>
-		<info name="serial" value="SLPS-00511"/>
-		<info name="release" value="19961129"/>
+		<info name="serial" value="SLPS-00511" />
+		<info name="release" value="19961129" />
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -56469,8 +56469,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Time Gal &amp; Ninja Hayate (Japan)</description>
 		<year>1996</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-00383~SLPS-00384"/>
-		<info name="release" value="19960705"/>
+		<info name="serial" value="SLPS-00383~SLPS-00384" />
+		<info name="release" value="19960705" />
 		<info name="alt_title" value="タイムギャル&amp;忍者ハヤテ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56497,8 +56497,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>That's QT (Japan)</description>
 		<year>2000</year>
 		<publisher>Koei</publisher>
-		<info name="serial" value="SLPM-86340"/>
-		<info name="release" value="20010127"/>
+		<info name="serial" value="SLPM-86340" />
+		<info name="release" value="20010127" />
 		<info name="alt_title" value="ザッツキューティ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56518,8 +56518,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Theme Hospital (Japan)</description>
 		<year>1998</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="SLPS-01405"/>
-		<info name="release" value="19980618"/>
+		<info name="serial" value="SLPS-01405" />
+		<info name="release" value="19980618" />
 		<info name="alt_title" value="テーマホスピタル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56539,8 +56539,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tiny Bullets (Japan)</description>
 		<year>2000</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10130"/>
-		<info name="release" value="20000413"/>
+		<info name="serial" value="SCPS-10130" />
+		<info name="release" value="20000413" />
 		<info name="alt_title" value="タイニーバレット"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56560,8 +56560,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tantei Jinguuji Saburou - Early Collection (Japan)</description>
 		<year>1999</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-02157"/>
-		<info name="release" value="19990805"/>
+		<info name="serial" value="SLPS-02157" />
+		<info name="release" value="19990805" />
 		<info name="alt_title" value="探偵神宮寺三郎 アーリーコレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56581,8 +56581,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tantei Jinguuji Saburou - Mikan no Rupo (Japan, Popular Edition)</description>
 		<year>2000</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-03016"/>
-		<info name="release" value="20001214"/>
+		<info name="serial" value="SLPS-03016" />
+		<info name="release" value="20001214" />
 		<info name="alt_title" value="普及版1,500円シリーズ 探偵神宮寺三郎 未完のルポ 普及版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56602,8 +56602,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tantei Jinguuji Saburou - Tomoshibi ga Kienumani (Japan)</description>
 		<year>1999</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-02427"/>
-		<info name="release" value="19991125"/>
+		<info name="serial" value="SLPS-02427" />
+		<info name="release" value="19991125" />
 		<info name="alt_title" value="探偵 神宮寺三郎 灯火が消えぬ間に"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56623,8 +56623,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tantei Jinguuji Saburou - Yume no Owari ni (Japan)</description>
 		<year>1998</year>
 		<publisher>Data East</publisher>
-		<info name="serial" value="SLPS-01356"/>
-		<info name="release" value="19980423"/>
+		<info name="serial" value="SLPS-01356" />
+		<info name="release" value="19980423" />
 		<info name="alt_title" value="探偵 神宮寺三郎 夢の終わりに"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56644,8 +56644,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>T kara Hajimaru Monogatari (Japan)</description>
 		<year>1998</year>
 		<publisher>Jaleco</publisher>
-		<info name="serial" value="SLPS-01350"/>
-		<info name="release" value="19980604"/>
+		<info name="serial" value="SLPS-01350" />
+		<info name="release" value="19980604" />
 		<info name="alt_title" value="Tから始まる物語"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56668,8 +56668,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Toukidenshou - Angel Eyes (Japan)</description>
 		<year>1997</year>
 		<publisher>Tecmo</publisher>
-		<info name="serial" value="SLPS-01168"/>
-		<info name="release" value="19971211"/>
+		<info name="serial" value="SLPS-01168" />
+		<info name="release" value="19971211" />
 		<info name="alt_title" value="闘姫伝承 エンジェルアイズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56689,8 +56689,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial Taisen Puzzle-Dama (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86005 (VX036-J1)"/>
-		<info name="release" value="19960927"/>
+		<info name="serial" value="SLPM-86005 (VX036-J1)" />
+		<info name="release" value="19960927" />
 		<info name="alt_title" value="ときめきメモリアル対戦ぱずるだま"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56710,8 +56710,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 EVS Append Disc 1 (Kotoko - Miyuki - Kaedeko) (Japan)</description>
 		<year>2000</year>
 		<publisher>Aspect</publisher>
-		<info name="serial" value="SLPM-80527"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SLPM-80527" />
+		<info name="release" value="" />
 		<info name="alt_title" value=""/>
 		<info name="usage" value="This disc contains additional EVS tracks for Tokimeki Memorial 2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
@@ -56732,14 +56732,15 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 EVS Append Disc 2 (Homura - Akane - Kaori) (Japan)</description>
 		<year>2000</year>
 		<publisher>Aspect</publisher>
-		<info name="serial" value="SLPM-80544"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SLPM-80544" />
+		<info name="release" value="" />
 		<info name="alt_title" value=""/>
 		<info name="usage" value="This disc contains additional EVS tracks for Tokimeki Memorial 2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tokimeki memorial 2 emotional voice system (vol.2 - homura-akane-kaori) (japan) [slpm-80544]" sha1="a14c4bd793988821bc164c28cb07aa7c5b777c70" status="baddump"/>
+				<disk name="tokimeki memorial 2 emotional voice system (vol.2 - homura-akane-kaori) (japan) [slpm-80544]" sha1="a14c4bd793988821bc164c28cb07aa7c5b777c70" status="baddump"
+/>
 			</diskarea>
 		</part>
 	</software>
@@ -56754,14 +56755,15 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 EVS Append Disc 3 (Miho - Mei - Sumire) (Japan)</description>
 		<year>2000</year>
 		<publisher>Enterbrain</publisher>
-		<info name="serial" value="SLPM-80550"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SLPM-80550" />
+		<info name="release" value="" />
 		<info name="alt_title" value=""/>
 		<info name="usage" value="This disc contains additional EVS tracks for Tokimeki Memorial 2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tokimeki memorial 2 emotional voice system (vol.3 - miho-mei-sumire) (japan) [slpm-80550]" sha1="f1da5b225d32d08e35d762f0e473dc12212190e5" status="baddump"/>
+				<disk name="tokimeki memorial 2 emotional voice system (vol.3 - miho-mei-sumire) (japan) [slpm-80550]" sha1="f1da5b225d32d08e35d762f0e473dc12212190e5" status="baddump"
+/>
 			</diskarea>
 		</part>
 	</software>
@@ -56779,8 +56781,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 Substories Vol.1 - Dancing Summer Vacation (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86549~SLPM-86550 (VX200-J1)"/>
-		<info name="release" value="20000928"/>
+		<info name="serial" value="SLPM-86549~SLPM-86550 (VX200-J1)" />
+		<info name="release" value="20000928" />
 		<info name="alt_title" value="ときめきメモリアル2 サブストーリーズ 〜Dancing Summer Vacation〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56808,8 +56810,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 Substories Vol.2 - Leaping School Festival (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86775~SLPM-86776 (VX232-J1)"/>
-		<info name="release" value="20010329"/>
+		<info name="serial" value="SLPM-86775~SLPM-86776 (VX232-J1)" />
+		<info name="release" value="20010329" />
 		<info name="alt_title" value="ときめきメモリアル2 サブストーリーズ 〜Leaping School Festival〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56837,8 +56839,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial 2 Substories Vol.3 - Memories Ringing On (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86881~SLPM-86882 (VX247-J1)"/>
-		<info name="release" value="20010830"/>
+		<info name="serial" value="SLPM-86881~SLPM-86882 (VX247-J1)" />
+		<info name="release" value="20010830" />
 		<info name="alt_title" value="ときめきメモリアル2 サブストーリーズ 〜Memories Ringing On〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56863,8 +56865,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tenshi no Shippo (Japan)</description>
 		<year>2003</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03531"/>
-		<info name="release" value="20030227"/>
+		<info name="serial" value="SLPS-03531" />
+		<info name="release" value="20030227" />
 		<info name="alt_title" value="天使のしっぽ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56884,8 +56886,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tales of Fandom Vol.1 (Japan, Cless Version)</description>
 		<year>2002</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-03375"/>
-		<info name="release" value="20020131"/>
+		<info name="serial" value="SLPS-03375" />
+		<info name="release" value="20020131" />
 		<info name="alt_title" value="テイルズオブファンダム Vol.1 (クレス・ルーティー・ファラバージョン)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56908,8 +56910,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>To Heart (Japan)</description>
 		<year>1999</year>
 		<publisher>Aqua Plus</publisher>
-		<info name="serial" value="SLPS-01919~SLPS-01920"/>
-		<info name="release" value="19990325"/>
+		<info name="serial" value="SLPS-01919~SLPS-01920" />
+		<info name="release" value="19990325" />
 		<info name="alt_title" value="トゥハート"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -56959,8 +56961,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Toaplan Shooting Battle 1 (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00436"/>
-		<info name="release" value="19960830"/>
+		<info name="serial" value="SLPS-00436" />
+		<info name="release" value="19960830" />
 		<info name="alt_title" value="東亜プラン シューティングバトル1"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -56980,8 +56982,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>TOCA Touring Car Championship (Japan)</description>
 		<year>1998</year>
 		<publisher>Upstar</publisher>
-		<info name="serial" value="SLPS-01410"/>
-		<info name="release" value="19980618"/>
+		<info name="serial" value="SLPS-01410" />
+		<info name="release" value="19980618" />
 		<info name="alt_title" value="トカ ツーリングカーチャンピオンシップ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57001,8 +57003,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokimeki Memorial Drama Series Vol.1 - Nijiiro No Seishun (Japan, Konami the Best)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86360 (VX069-J2)"/>
-		<info name="release" value="19991125"/>
+		<info name="serial" value="SLPM-86360 (VX069-J2)" />
+		<info name="release" value="19991125" />
 		<info name="alt_title" value="タイトル ときめきメモリアル　ドラマシリーズVol.1　虹色の青春（ベスト）"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57028,8 +57030,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tokyo Majin Gakuen Gehouchou (Japan)</description>
 		<year>2002</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-03333~SLPS-03335"/>
-		<info name="release" value="20020124"/>
+		<info name="serial" value="SLPS-03333~SLPS-03335" />
+		<info name="release" value="20020124" />
 		<info name="alt_title" value="東京魔人学園外法帖"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -57059,8 +57061,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gekitotsu Toma L'Arc - Tomarunner vs. L'Arc~en~Ciel (Japan)</description>
 		<year>2000</year>
 		<publisher>Sony</publisher>
-		<info name="serial" value="SCPS-10134"/>
-		<info name="release" value="20000719"/>
+		<info name="serial" value="SCPS-10134" />
+		<info name="release" value="20000719" />
 		<info name="alt_title" value="激突トマラルク トマランナー vs ラルク アン シエル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57080,8 +57082,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Gekisou Tomarunner (Japan)</description>
 		<year>1999</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10087"/>
-		<info name="release" value="19990722"/>
+		<info name="serial" value="SCPS-10087" />
+		<info name="release" value="19990722" />
 		<info name="alt_title" value="激走トマランナー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57101,8 +57103,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ore! Tomba (Japan)</description>
 		<year>1997</year>
 		<publisher>Whoopee Camp</publisher>
-		<info name="serial" value="SLPS-01144"/>
-		<info name="release" value="19971225"/>
+		<info name="serial" value="SLPS-01144" />
+		<info name="release" value="19971225" />
 		<info name="alt_title" value="オレっ！トンバ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57122,8 +57124,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tomba! The Wild Adventures (Japan)</description>
 		<year>1999</year>
 		<publisher>Whoopee Camp</publisher>
-		<info name="serial" value="SLPS-02350"/>
-		<info name="release" value="19991028"/>
+		<info name="serial" value="SLPS-02350" />
+		<info name="release" value="19991028" />
 		<info name="alt_title" value="トンバ！ ザ・ワイルドアドベンチャー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57143,8 +57145,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tomica Town o Tsukurou! (Japan)</description>
 		<year>1999</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-01935"/>
-		<info name="release" value="19990311"/>
+		<info name="serial" value="SLPS-01935" />
+		<info name="release" value="19990311" />
 		<info name="alt_title" value="トミカタウンをつくろう!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57165,8 +57167,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>ToPoLo (Japan)</description>
 		<year>1996</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-00620"/>
-		<info name="release" value="19961206"/>
+		<info name="serial" value="SLPS-00620" />
+		<info name="release" value="19961206" />
 		<info name="alt_title" value="トポロ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57186,8 +57188,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Toshinden Card Quest (Japan)</description>
 		<year>1998</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01113"/>
-		<info name="release" value="19980402"/>
+		<info name="serial" value="SLPS-01113" />
+		<info name="release" value="19980402" />
 		<info name="alt_title" value="闘神伝 カードクエスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57207,8 +57209,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Touge Max G (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPS-02361"/>
-		<info name="release" value="20000113"/>
+		<info name="serial" value="SLPS-02361" />
+		<info name="release" value="20000113" />
 		<info name="alt_title" value="峠マックスG"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57229,7 +57231,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Toyota Netz Racing (Japan)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
-		<info name="serial" value="SLPM-80429"/>
+		<info name="serial" value="SLPM-80429" />
 		<info name="alt_title" value="ソフト ネッツ・レーシング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57249,8 +57251,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Toys Dream (Japan)</description>
 		<year>1998</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-01704"/>
-		<info name="release" value="19981126"/>
+		<info name="serial" value="SLPS-01704" />
+		<info name="release" value="19981126" />
 		<info name="alt_title" value="トイズドリーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57270,8 +57272,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tripuzz (Japan)</description>
 		<year>1997</year>
 		<publisher>Santos</publisher>
-		<info name="serial" value="SLPS-00911"/>
-		<info name="release" value="19971030"/>
+		<info name="serial" value="SLPS-00911" />
+		<info name="release" value="19971030" />
 		<info name="alt_title" value="トリパズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57291,8 +57293,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Trump Shiyouyo! (Japan)</description>
 		<year>1998</year>
 		<publisher>Bottom Up</publisher>
-		<info name="serial" value="SLPS-01440"/>
-		<info name="release" value="19981015"/>
+		<info name="serial" value="SLPS-01440" />
+		<info name="release" value="19981015" />
 		<info name="alt_title" value="トランプしようよ！"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57312,8 +57314,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tsun Tsun Kumi 2 - Moji Moji Bakkun (Japan)</description>
 		<year>1998</year>
 		<publisher>Kodansha</publisher>
-		<info name="serial" value="SLPS-01694"/>
-		<info name="release" value="19981119"/>
+		<info name="serial" value="SLPS-01694" />
+		<info name="release" value="19981119" />
 		<info name="alt_title" value="つんつん組2 ～もじもじぱっくん～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57333,8 +57335,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tsun Tsun Kumi 3 - Kanji Vader (Japan)</description>
 		<year>1999</year>
 		<publisher>Kodansha</publisher>
-		<info name="serial" value="SLPS-01839"/>
-		<info name="release" value="19990128"/>
+		<info name="serial" value="SLPS-01839" />
+		<info name="release" value="19990128" />
 		<info name="alt_title" value="つんつん組3 〜もじもじぱっくん〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57354,8 +57356,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tsuri Baka Nisshi (Japan)</description>
 		<year>1996</year>
 		<publisher>Shogakukan</publisher>
-		<info name="serial" value="SLPS-00440"/>
-		<info name="release" value="19960913"/>
+		<info name="serial" value="SLPS-00440" />
+		<info name="release" value="19960913" />
 		<info name="alt_title" value="釣りバカ日誌"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57375,8 +57377,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Twinbee Taisen Puzzle-Dama (Japan)</description>
 		<year>1994</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPS-00015"/>
-		<info name="release" value="19941209"/>
+		<info name="serial" value="SLPS-00015" />
+		<info name="release" value="19941209" />
 		<info name="alt_title" value="ツインビー対戦ぱずるだま"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57396,8 +57398,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>TwinBee RPG (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86077 (VX060-J1)"/>
-		<info name="release" value="19980402"/>
+		<info name="serial" value="SLPM-86077 (VX060-J1)" />
+		<info name="release" value="19980402" />
 		<info name="alt_title" value="ツインビーRPG"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57417,8 +57419,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Twin Goddesses (Japan)</description>
 		<year>1994</year>
 		<publisher>PolyGram</publisher>
-		<info name="serial" value="SLPS-00018"/>
-		<info name="release" value="19941222"/>
+		<info name="serial" value="SLPS-00018" />
+		<info name="release" value="19941222" />
 		<info name="alt_title" value="ツイン・ゴッデス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57438,8 +57440,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Twins Story - Kimi ni Tsutaetakute... (Japan)</description>
 		<year>1999</year>
 		<publisher>Panther</publisher>
-		<info name="serial" value="SLPS-02126"/>
-		<info name="release" value="19990624"/>
+		<info name="serial" value="SLPS-02126" />
+		<info name="release" value="19990624" />
 		<info name="alt_title" value="ツインズストーリー きみにつたえたくて…"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57461,8 +57463,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Two-Tenkaku (Japan)</description>
 		<year>1995</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-00131"/>
-		<info name="release" value="19951229"/>
+		<info name="serial" value="SLPS-00131" />
+		<info name="release" value="19951229" />
 		<info name="alt_title" value="通天閣"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57482,8 +57484,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>UFO - A Day in the Life (Japan)</description>
 		<year>1999</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-02032"/>
-		<info name="release" value="19990624"/>
+		<info name="serial" value="SLPS-02032" />
+		<info name="release" value="19990624" />
 		<info name="alt_title" value="UFO ～A day in the life～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57503,8 +57505,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ugetsu Kitan (Japan)</description>
 		<year>1996</year>
 		<publisher>Tonkin House</publisher>
-		<info name="serial" value="SLPS-00391"/>
-		<info name="release" value="19960705"/>
+		<info name="serial" value="SLPS-00391" />
+		<info name="release" value="19960705" />
 		<info name="alt_title" value="雨月奇譚 〜うげつきたん〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57524,8 +57526,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>UkiUki Tsuri Tengoku - Uogami Densetsu wo Oe (Japan)</description>
 		<year>2000</year>
 		<publisher>Teichiku</publisher>
-		<info name="serial" value="SLPS-02579"/>
-		<info name="release" value="20000217"/>
+		<info name="serial" value="SLPS-02579" />
+		<info name="release" value="20000217" />
 		<info name="alt_title" value="ウキウキ釣り天国〜魚神伝説を追え〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57545,8 +57547,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ultima Underworld - The Stygian Abyss (Japan)</description>
 		<year>1997</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="SLPS-00742"/>
-		<info name="release" value="19970314"/>
+		<info name="serial" value="SLPS-00742" />
+		<info name="release" value="19970314" />
 		<info name="alt_title" value="ウルティマ アンダーワールド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57593,8 +57595,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ultraman Tiga &amp; Ultraman Dyna Fighting Evolution - New Generations (Japan)</description>
 		<year>1998</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-01455"/>
-		<info name="release" value="19980716"/>
+		<info name="serial" value="SLPS-01455" />
+		<info name="release" value="19980716" />
 		<info name="alt_title" value="ウルトラマンティガ&amp;ダイナ 新たなる二つの光"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57614,8 +57616,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ultraman Zearth (Japan)</description>
 		<year>1996</year>
 		<publisher>Tohoku Shinsha</publisher>
-		<info name="serial" value="SLPS-00652"/>
-		<info name="release" value="19961220"/>
+		<info name="serial" value="SLPS-00652" />
+		<info name="release" value="19961220" />
 		<info name="alt_title" value="ウルトラマンゼアス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57635,8 +57637,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Bokujyou Keieiteki Board Game Umapoly (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86403 (VX167-J1)"/>
-		<info name="release" value="19991225"/>
+		<info name="serial" value="SLPM-86403 (VX167-J1)" />
+		<info name="release" value="19991225" />
 		<info name="alt_title" value="牧場経営的ボードゲーム うまぽりぃ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57656,8 +57658,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Umi no Nushi Tsuri - Takarajimi ni Mukatte (Japan)</description>
 		<year>1999</year>
 		<publisher>Pack-in-Soft</publisher>
-		<info name="serial" value="SLPS-02172"/>
-		<info name="release" value="19990722"/>
+		<info name="serial" value="SLPS-02172" />
+		<info name="release" value="19990722" />
 		<info name="alt_title" value="海のぬし釣り−宝島に向かって−"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57678,8 +57680,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Umihara Kawase Shun - Second Edition (Japan, Maruan Series 1)</description>
 		<year>2000</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-02549"/>
-		<info name="release" value="20000120"/>
+		<info name="serial" value="SLPS-02549" />
+		<info name="release" value="20000120" />
 		<info name="alt_title" value="マル安シリーズ1 海腹川背・旬 〜セカンドエディション〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57702,8 +57704,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Taiho Shichauzo! - You're Under Arrest (Japan)</description>
 		<year>2001</year>
 		<publisher>Pioneer</publisher>
-		<info name="serial" value="SLPM-86782~SLPM-86783"/>
-		<info name="release" value="20010329"/>
+		<info name="serial" value="SLPM-86782~SLPM-86783" />
+		<info name="release" value="20010329" />
 		<info name="alt_title" value="逮捕しちゃうぞ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -57728,8 +57730,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ungra Walker (Japan)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
-		<info name="serial" value="SLPM-87055"/>
-		<info name="release" value="20020606"/>
+		<info name="serial" value="SLPM-87055" />
+		<info name="release" value="20020606" />
 		<info name="alt_title" value="アングラウォーカー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57749,8 +57751,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Urawaza Mahjong - Korette Tenhoutte Yatsukai (Japan)</description>
 		<year>2000</year>
 		<publisher>Spike</publisher>
-		<info name="serial" value="SLPS-02807"/>
-		<info name="release" value="20000629"/>
+		<info name="serial" value="SLPS-02807" />
+		<info name="release" value="20000629" />
 		<info name="alt_title" value="裏技麻雀〜これって天和ってやつかい〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57770,8 +57772,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Assault Suits Valken 2 - Juusou Kihei Valken 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Masaya</publisher>
-		<info name="serial" value="SLPS-00854"/>
-		<info name="release" value="19990729"/>
+		<info name="serial" value="SLPS-00854" />
+		<info name="release" value="19990729" />
 		<info name="alt_title" value="重装機兵ヴァルケン2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57792,8 +57794,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Vampir Kyuuketsuki Densetsu (Japan)</description>
 		<year>1999</year>
 		<publisher>Artdink</publisher>
-		<info name="serial" value="SLPS-01932"/>
-		<info name="release" value="19990304"/>
+		<info name="serial" value="SLPS-01932" />
+		<info name="release" value="19990304" />
 		<info name="alt_title" value="ヴァンピール 吸血鬼伝説"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57813,8 +57815,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Vehicle Cavalier (Japan)</description>
 		<year>1996</year>
 		<publisher>Vanguard Works</publisher>
-		<info name="serial" value="SLPS-00232"/>
-		<info name="release" value="19960216"/>
+		<info name="serial" value="SLPS-00232" />
+		<info name="release" value="19960216" />
 		<info name="alt_title" value="ヴィーグル・キャヴァリアー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57834,8 +57836,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Vermin Kids (Japan)</description>
 		<year>1996</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="SLPS-00558"/>
-		<info name="release" value="19961101"/>
+		<info name="serial" value="SLPS-00558" />
+		<info name="release" value="19961101" />
 		<info name="alt_title" value="バーミン・キッズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57855,8 +57857,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Virtual Hiryuu no Ken (Japan)</description>
 		<year>1997</year>
 		<publisher>Culture Brain</publisher>
-		<info name="serial" value="SLPS-00338"/>
-		<info name="release" value="19970717"/>
+		<info name="serial" value="SLPS-00338" />
+		<info name="release" value="19970717" />
 		<info name="alt_title" value="バーチャル飛龍の拳"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57876,8 +57878,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Victory Zone - Real Pachinko Simulator (Japan)</description>
 		<year>1995</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10002"/>
-		<info name="release" value="19950331"/>
+		<info name="serial" value="SCPS-10002" />
+		<info name="release" value="19950331" />
 		<info name="alt_title" value="ヴィクトリーゾーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57897,8 +57899,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Virus - The Battle Field (Japan)</description>
 		<year>1999</year>
 		<publisher>PolyGram</publisher>
-		<info name="serial" value="SLPS-02008"/>
-		<info name="release" value="19990408"/>
+		<info name="serial" value="SLPS-02008" />
+		<info name="release" value="19990408" />
 		<info name="alt_title" value="ウイルス －ザ バトルフィールド－"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57918,8 +57920,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Virtual Kyoutei '98 (Japan)</description>
 		<year>1998</year>
 		<publisher>Nihon Bussan</publisher>
-		<info name="serial" value="SLPS-01396"/>
-		<info name="release" value="19980702"/>
+		<info name="serial" value="SLPS-01396" />
+		<info name="release" value="19980702" />
 		<info name="alt_title" value="バーチャル競艇 '98"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57939,8 +57941,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Volfoss (Japan)</description>
 		<year>2001</year>
 		<publisher>Namco</publisher>
-		<info name="serial" value="SLPS-03140"/>
-		<info name="release" value="20010222"/>
+		<info name="serial" value="SLPS-03140" />
+		<info name="release" value="20010222" />
 		<info name="alt_title" value="ボルフォス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57960,8 +57962,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Soukou Kihei Votoms - Lightning Slash (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
-		<info name="serial" value="SLPS-01961"/>
-		<info name="release" value="19990318"/>
+		<info name="serial" value="SLPS-01961" />
+		<info name="release" value="19990318" />
 		<info name="alt_title" value="装甲騎兵ボトムズ ライトニングスラッシュ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -57981,8 +57983,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Olympia Yamasa - Virtua Pachi-Slot II - Jissen! Bishoujo Kouryaku Hou (Japan)</description>
 		<year>1997</year>
 		<publisher>Map Japan</publisher>
-		<info name="serial" value="SLPS-00714"/>
-		<info name="release" value="19970418"/>
+		<info name="serial" value="SLPS-00714" />
+		<info name="release" value="19970418" />
 		<info name="alt_title" value="オリンピア・山佐 バーチャパチスロII〜必勝美少女攻略法〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58002,8 +58004,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Virtual Pro Wrestling (Japan)</description>
 		<year>1996</year>
 		<publisher>Asmik Ace</publisher>
-		<info name="serial" value="SLPS-00449"/>
-		<info name="release" value="19960913"/>
+		<info name="serial" value="SLPS-00449" />
+		<info name="release" value="19960913" />
 		<info name="alt_title" value="バーチャルプロレスリング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58023,8 +58025,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Victory Spike (Japan)</description>
 		<year>1996</year>
 		<publisher>Imagineer</publisher>
-		<info name="serial" value="SLPS-00372"/>
-		<info name="release" value="19960607"/>
+		<info name="serial" value="SLPS-00372" />
+		<info name="release" value="19960607" />
 		<info name="alt_title" value="ヴィクトリー・スパイク"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58044,8 +58046,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>V-Tennis 2 (Japan)</description>
 		<year>1996</year>
 		<publisher>Tonkin House</publisher>
-		<info name="serial" value="SLPS-00469"/>
-		<info name="release" value="19961129"/>
+		<info name="serial" value="SLPS-00469" />
+		<info name="release" value="19961129" />
 		<info name="alt_title" value="Vテニス2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58065,8 +58067,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Chiki Chiki Machine Mou Race - Wacky Races (Japan)</description>
 		<year>2001</year>
 		<publisher>Infogrames Hudson</publisher>
-		<info name="serial" value="SLPM-86845"/>
-		<info name="release" value="20010726"/>
+		<info name="serial" value="SLPM-86845" />
+		<info name="release" value="20010726" />
 		<info name="alt_title" value="ドタバタ爆笑レースゲーム チキチキマシン猛レース"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58086,8 +58088,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wagamama Fairy Mirumo de Pon! - Mirumo no Mahou Gakkou Monogatari (Japan)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-87220 (VX275-J1)"/>
-		<info name="release" value="20030320"/>
+		<info name="serial" value="SLPM-87220 (VX275-J1)" />
+		<info name="release" value="20030320" />
 		<info name="alt_title" value="わがままフェアリーミルモでポン! ミルモの魔法学校ものがたり"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58110,8 +58112,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wangan Trial (Japan)</description>
 		<year>1998</year>
 		<publisher>Pack-in-Soft</publisher>
-		<info name="serial" value="SLPS-01213~SLPS-01214"/>
-		<info name="release" value="19980307"/>
+		<info name="serial" value="SLPS-01213~SLPS-01214" />
+		<info name="release" value="19980307" />
 		<info name="alt_title" value="湾岸トライアル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -58136,8 +58138,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Warera Mitsubayashi Tankentai!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="SLPS-02658"/>
-		<info name="release" value="20000420"/>
+		<info name="serial" value="SLPS-02658" />
+		<info name="release" value="20000420" />
 		<info name="alt_title" value="われら密林探検隊!!"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58157,8 +58159,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Water Summer (Japan, Limited Edition)</description>
 		<year>2002</year>
 		<publisher>Princess Soft</publisher>
-		<info name="serial" value="SLPM-87085"/>
-		<info name="release" value="20020718"/>
+		<info name="serial" value="SLPM-87085" />
+		<info name="release" value="20020718" />
 		<info name="alt_title" value="ウォーターサマー (初回限定版)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58178,8 +58180,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wedding Peach - Doki Doki Oironaoshi Fashion Daisakusen (Japan)</description>
 		<year>1996</year>
 		<publisher>KSS</publisher>
-		<info name="serial" value="SLPS-00368"/>
-		<info name="release" value="19960927"/>
+		<info name="serial" value="SLPS-00368" />
+		<info name="release" value="19960927" />
 		<info name="alt_title" value="ウェディングピーチ ドキドキお色直し"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58199,8 +58201,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Welcome House (Japan)</description>
 		<year>1996</year>
 		<publisher>Gust</publisher>
-		<info name="serial" value="SLPS-00190"/>
-		<info name="release" value="19960223"/>
+		<info name="serial" value="SLPS-00190" />
+		<info name="release" value="19960223" />
 		<info name="alt_title" value="ウエルカムハウス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58220,8 +58222,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>White Diamond (Japan)</description>
 		<year>1999</year>
 		<publisher>Escot</publisher>
-		<info name="serial" value="SLPS-02352"/>
-		<info name="release" value="19991125"/>
+		<info name="serial" value="SLPS-02352" />
+		<info name="release" value="19991125" />
 		<info name="alt_title" value="ホワイトダイアモンド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58241,8 +58243,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wing Over (Japan)</description>
 		<year>1997</year>
 		<publisher>Pack-In Soft</publisher>
-		<info name="serial" value="SLPS-00598"/>
-		<info name="release" value="19970221"/>
+		<info name="serial" value="SLPS-00598" />
+		<info name="release" value="19970221" />
 		<info name="alt_title" value="ウイングオーバー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58262,8 +58264,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wizard's Harmony R (Japan)</description>
 		<year>1998</year>
 		<publisher>Arc System Works</publisher>
-		<info name="serial" value="SLPS-01716"/>
-		<info name="release" value="19981126"/>
+		<info name="serial" value="SLPS-01716" />
+		<info name="release" value="19981126" />
 		<info name="alt_title" value="ウィザーズハーモニーR"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58284,8 +58286,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>World League Soccer - Challenge Nippon! (Japan, Family Price 1500)</description>
 		<year>2000</year>
 		<publisher>Coconuts Japan</publisher>
-		<info name="serial" value="SLPS-02687"/>
-		<info name="release" value="20000330"/>
+		<info name="serial" value="SLPS-02687" />
+		<info name="release" value="20000330" />
 		<info name="alt_title" value="ワールドリーグサッカー"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58307,8 +58309,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wolf Fang Kuuga 2001 (Japan)</description>
 		<year>1996</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-00254"/>
-		<info name="release" value="19960510"/>
+		<info name="serial" value="SLPS-00254" />
+		<info name="release" value="19960510" />
 		<info name="alt_title" value="ウルフファング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58328,8 +58330,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wonder B-Cruise - Dogiborn Daisakusen (Japan)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="SLPS-02322"/>
-		<info name="release" value="19991007"/>
+		<info name="serial" value="SLPS-02322" />
+		<info name="release" value="19991007" />
 		<info name="alt_title" value="わんダービークルズ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58349,8 +58351,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Arcade Gears - Wonder 3 (Japan)</description>
 		<year>1998</year>
 		<publisher>Xing</publisher>
-		<info name="serial" value="SLPS-00927"/>
-		<info name="release" value="19980402"/>
+		<info name="serial" value="SLPS-00927" />
+		<info name="release" value="19980402" />
 		<info name="alt_title" value="ワンダー3"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58370,8 +58372,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Wonder Trek (Japan)</description>
 		<year>1998</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SCPS-10072"/>
-		<info name="release" value="19981210"/>
+		<info name="serial" value="SCPS-10072" />
+		<info name="release" value="19981210" />
 		<info name="alt_title" value="ワンダートレック"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58392,8 +58394,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Hiroki Matsukata Presents - World Fishing (Japan, BPS The Choice)</description>
 		<year>1999</year>
 		<publisher>BPS</publisher>
-		<info name="serial" value="SLPS-02041"/>
-		<info name="release" value="19990428"/>
+		<info name="serial" value="SLPS-02041" />
+		<info name="release" value="19990428" />
 		<info name="alt_title" value="BPS ザ・チョイス 松方弘樹のワールドフィッシング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58413,8 +58415,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>World Pro Tennis '98 (Japan)</description>
 		<year>1998</year>
 		<publisher>I.Magic</publisher>
-		<info name="serial" value="SLPS-01379"/>
-		<info name="release" value="19980806"/>
+		<info name="serial" value="SLPS-01379" />
+		<info name="release" value="19980806" />
 		<info name="alt_title" value="ワールドプロテニス98"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58434,8 +58436,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>WWF Wrestlemania - The Arcade Game (Japan)</description>
 		<year>1996</year>
 		<publisher>Acclaim</publisher>
-		<info name="serial" value="SLPS-00223"/>
-		<info name="release" value="19960126"/>
+		<info name="serial" value="SLPS-00223" />
+		<info name="release" value="19960126" />
 		<info name="alt_title" value="レッスルマニア・ジ・アーケードゲーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58466,8 +58468,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>X2 - No Relief (Japan)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPS-00766"/>
-		<info name="release" value="19970821"/>
+		<info name="serial" value="SLPS-00766" />
+		<info name="release" value="19970821" />
 		<info name="alt_title" value="エックス2"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58487,8 +58489,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Extra Bright (Japan)</description>
 		<year>1996</year>
 		<publisher>ASCII</publisher>
-		<info name="serial" value="SLPS-00625"/>
-		<info name="release" value="19961206"/>
+		<info name="serial" value="SLPS-00625" />
+		<info name="release" value="19961206" />
 		<info name="alt_title" value="エクストラブライト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58508,8 +58510,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>X. Racing (Japan)</description>
 		<year>1998</year>
 		<publisher>Nichibutsu</publisher>
-		<info name="serial" value="SLPS-01063"/>
-		<info name="release" value="19980211"/>
+		<info name="serial" value="SLPS-01063" />
+		<info name="release" value="19980211" />
 		<info name="alt_title" value="エックス・レーシング"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58530,8 +58532,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>TV Animation X - Unmei no Tatakai (Japan)</description>
 		<year>2002</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-03459"/>
-		<info name="release" value="20020822"/>
+		<info name="serial" value="SLPS-03459" />
+		<info name="release" value="20020822" />
 		<info name="alt_title" value="TV Animation X〜運命の選択〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58551,8 +58553,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yakiniku Bugyou (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03209"/>
-		<info name="release" value="20010524"/>
+		<info name="serial" value="SLPS-03209" />
+		<info name="release" value="20010524" />
 		<info name="alt_title" value="焼肉奉行"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58572,8 +58574,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yakitori Musume - Sugo Ude Hanjouki (Japan)</description>
 		<year>2002</year>
 		<publisher>Media Entertainment</publisher>
-		<info name="serial" value="SLPS-03435"/>
-		<info name="release" value="20020509"/>
+		<info name="serial" value="SLPS-03435" />
+		<info name="release" value="20020509" />
 		<info name="alt_title" value="やきとり娘〜スゴ腕繁盛記〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58602,8 +58604,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yamagata Digital Museum (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
-		<info name="serial" value="SLPS-02393~SLPS-02396"/>
-		<info name="release" value="19991118"/>
+		<info name="serial" value="SLPS-02393~SLPS-02396" />
+		<info name="release" value="19991118" />
 		<info name="alt_title" value="デジタルミュージアム ヒロ・ヤマガタ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -58646,8 +58648,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Youkai Hana Asobi (Japan)</description>
 		<year>2001</year>
 		<publisher>Unbalance</publisher>
-		<info name="serial" value="SLPM-86857"/>
-		<info name="release" value="20010809"/>
+		<info name="serial" value="SLPM-86857" />
+		<info name="release" value="20010809" />
 		<info name="alt_title" value="妖怪花あそび"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58667,8 +58669,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yoshimoto Muchicco Daikessen - Minami no Umi no Gorongo Shima (Japan)</description>
 		<year>1999</year>
 		<publisher>Sony Music Entertainment</publisher>
-		<info name="serial" value="SLPS-02308"/>
-		<info name="release" value="19990930"/>
+		<info name="serial" value="SLPS-02308" />
+		<info name="release" value="19990930" />
 		<info name="alt_title" value="ヨシモト ムチッ子大決戦 ～南の海のゴロンゴ島～"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58688,8 +58690,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yuugen Kaisha Chikyuu Boueitai - Guard of Earth Organization (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Rings</publisher>
-		<info name="serial" value="SLPS-02024"/>
-		<info name="release" value="19990428"/>
+		<info name="serial" value="SLPS-02024" />
+		<info name="release" value="19990428" />
 		<info name="alt_title" value="有限会社 地球防衛隊"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58709,8 +58711,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yu-Gi-Oh! - Monster Capsule Breed &amp; Battle (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-86096 (VX210-J1)"/>
-		<info name="release" value="19980723"/>
+		<info name="serial" value="SLPM-86096 (VX210-J1)" />
+		<info name="release" value="19980723" />
 		<info name="alt_title" value="遊戯王 モンスターカプセル ブリード&amp;バトル"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58730,8 +58732,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yukinko Burning (Japan)</description>
 		<year>2002</year>
 		<publisher>Princess Soft</publisher>
-		<info name="serial" value="SLPM-87013"/>
-		<info name="release" value="20020131"/>
+		<info name="serial" value="SLPM-87013" />
+		<info name="release" value="20020131" />
 		<info name="alt_title" value="ゆきんこ☆ばぁにんぐ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58751,8 +58753,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yume Iroiro - Yumemigaoka Gakuen Koutou Gakkou Dai 33-Kisei (Japan)</description>
 		<year>1998</year>
 		<publisher>Feathered</publisher>
-		<info name="serial" value="SLPS-01401"/>
-		<info name="release" value="19980730"/>
+		<info name="serial" value="SLPS-01401" />
+		<info name="release" value="19980730" />
 		<info name="alt_title" value="夢☆色いろ 夢美が丘学園高等学校第33期生"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58772,8 +58774,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yume no Tsubasa (Japan)</description>
 		<year>2000</year>
 		<publisher>KID</publisher>
-		<info name="serial" value="SLPS-02954"/>
-		<info name="release" value="20000928"/>
+		<info name="serial" value="SLPS-02954" />
+		<info name="release" value="20000928" />
 		<info name="alt_title" value="夢のつばさ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58793,8 +58795,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Ginga Ojousama Densetsu Yuna - Final Edition (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson</publisher>
-		<info name="serial" value="SLPS-01451"/>
-		<info name="release" value="19980625"/>
+		<info name="serial" value="SLPS-01451" />
+		<info name="release" value="19980625" />
 		<info name="alt_title" value="銀河お嬢様伝説ユナ ファイナル・エディション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58814,8 +58816,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Yuuyami Douri Tankentai (Japan)</description>
 		<year>1999</year>
 		<publisher>Spike</publisher>
-		<info name="serial" value="SLPS-02274"/>
-		<info name="release" value="19991007"/>
+		<info name="serial" value="SLPS-02274" />
+		<info name="release" value="19991007" />
 		<info name="alt_title" value="夕闇通り探検隊"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58835,8 +58837,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zap! Snowboarding Trix '98 (Japan)</description>
 		<year>1997</year>
 		<publisher>Pony Canyon</publisher>
-		<info name="serial" value="SLPS-00909"/>
-		<info name="release" value="19971225"/>
+		<info name="serial" value="SLPS-00909" />
+		<info name="release" value="19971225" />
 		<info name="alt_title" value="ザップ！ スノーボーディング・トリックス'98"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58856,8 +58858,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zeiramzone (Japan)</description>
 		<year>1996</year>
 		<publisher>Banpresto</publisher>
-		<info name="serial" value="SLPS-00575"/>
-		<info name="release" value="19961213"/>
+		<info name="serial" value="SLPS-00575" />
+		<info name="release" value="19961213" />
 		<info name="alt_title" value="ゼイラムゾーン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58877,8 +58879,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zeitgeist (Japan)</description>
 		<year>1995</year>
 		<publisher>Taito</publisher>
-		<info name="serial" value="SLPS-00034"/>
-		<info name="release" value="19950825"/>
+		<info name="serial" value="SLPS-00034" />
+		<info name="release" value="19950825" />
 		<info name="alt_title" value="ツァイトガイスト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58898,8 +58900,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zero4 Champ DooZy-J (Japan)</description>
 		<year>1997</year>
 		<publisher>Media Rings</publisher>
-		<info name="serial" value="SLPS-00755"/>
-		<info name="release" value="19970620"/>
+		<info name="serial" value="SLPS-00755" />
+		<info name="release" value="19970620" />
 		<info name="alt_title" value="ゼロヨンチャンプ ドゥーヅィ・ジェイ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58919,7 +58921,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Kidou Senshi Z-Gundam (Japan, demo)</description>
 		<year>1997</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPM-80139"/>
+		<info name="serial" value="SLPM-80139" />
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -58938,8 +58940,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zig Zag Ball (Japan)</description>
 		<year>1998</year>
 		<publisher>Upstar</publisher>
-		<info name="serial" value="SLPS-01483"/>
-		<info name="release" value="19981210"/>
+		<info name="serial" value="SLPS-01483" />
+		<info name="release" value="19981210" />
 		<info name="alt_title" value="ジグザグボール"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58959,8 +58961,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zipangujima - Unmei wa Saikoro ga Kimeru! (Japan)</description>
 		<year>1999</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-02260"/>
-		<info name="release" value="19991007"/>
+		<info name="serial" value="SLPS-02260" />
+		<info name="release" value="19991007" />
 		<info name="alt_title" value="じぱんぐ島 〜運命はサイコロが決める!?〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -58981,8 +58983,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zen-Nihon Joshi Pro Wrestling - Joou Densetsu Yume no Taikousen (Japan)</description>
 		<year>1998</year>
 		<publisher>TEN</publisher>
-		<info name="serial" value="SLPS-01475"/>
-		<info name="release" value="19980723"/>
+		<info name="serial" value="SLPS-01475" />
+		<info name="release" value="19980723" />
 		<info name="alt_title" value="全日本女子プロレス 女王伝説 夢の対抗戦"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59002,8 +59004,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zen-Nihon Pro Wrestling - Ouja no Kon (Japan)</description>
 		<year>1999</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPS-01849"/>
-		<info name="release" value="19990408"/>
+		<info name="serial" value="SLPS-01849" />
+		<info name="release" value="19990408" />
 		<info name="alt_title" value="全日本プロレス 王者の魂"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59023,8 +59025,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zoids - Teikoku vs Kyouwakoku - Meka Seitai no Idenshi (Japan)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-02982"/>
-		<info name="release" value="20001122"/>
+		<info name="serial" value="SLPS-02982" />
+		<info name="release" value="20001122" />
 		<info name="alt_title" value="ゾイド帝国vs共和国 メカ生体の遺伝子 / Zoids - ZENEBUS VS HERIC (Box)"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59044,8 +59046,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zoids 2 - Helic Kyouwakoku vs Guylos Teikoku (Japan)</description>
 		<year>2002</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-03389"/>
-		<info name="release" value="20020221"/>
+		<info name="serial" value="SLPS-03389" />
+		<info name="release" value="20020221" />
 		<info name="alt_title" value="ゾイド2 ヘリック共和国 VS ガイロス帝国 / Zoids 2 - HERIC VS GUYLOS"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59065,8 +59067,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zoids - Battle Card Game - Seihou Tairiku Senki (Japan)</description>
 		<year>2001</year>
 		<publisher>Tomy</publisher>
-		<info name="serial" value="SLPS-03255"/>
-		<info name="release" value="20010726"/>
+		<info name="serial" value="SLPS-03255" />
+		<info name="release" value="20010726" />
 		<info name="alt_title" value="ゾイドバトルカードゲーム 西方大陸戦記"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59095,8 +59097,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zoku Hatsukoi Monogatari - Shuugaku Ryokou (Japan)</description>
 		<year>1998</year>
 		<publisher>Tokuma Shoten</publisher>
-		<info name="serial" value="SLPS-01326~SLPS-01329"/>
-		<info name="release" value="19980326"/>
+		<info name="serial" value="SLPS-01326~SLPS-01329" />
+		<info name="release" value="19980326" />
 		<info name="alt_title" value="続 初恋物語 〜修学旅行〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom1" interface="psx_cdrom">
@@ -59131,8 +59133,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zork I - The Great Underground Empire (Japan)</description>
 		<year>1996</year>
 		<publisher>Shoeisha</publisher>
-		<info name="serial" value="SLPS-00271"/>
-		<info name="release" value="19960315"/>
+		<info name="serial" value="SLPS-00271" />
+		<info name="release" value="19960315" />
 		<info name="alt_title" value="ゾーク・ワン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59154,8 +59156,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Zutto Issho - With Me Everytime... (Japan, Major Wave Series)</description>
 		<year>2000</year>
 		<publisher>Hamster</publisher>
-		<info name="serial" value="SLPM-86523"/>
-		<info name="release" value="20000525"/>
+		<info name="serial" value="SLPM-86523" />
+		<info name="release" value="20000525" />
 		<info name="alt_title" value="Major Waveシリーズ ずっといっしょ"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59175,8 +59177,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>ZXE-D - Legend of Plasmatlite (Japan)</description>
 		<year>1996</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SLPS-00424"/>
-		<info name="release" value="19961220"/>
+		<info name="serial" value="SLPS-00424" />
+		<info name="release" value="19961220" />
 		<info name="alt_title" value="ゼクシード レジェンド・オブ・プラズマトライト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59199,8 +59201,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Final Fantasy Extra Collection (Japan)</description>
 		<year>199?</year>
 		<publisher>Squaresoft</publisher>
-		<info name="serial" value="SLPM-80073"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SLPM-80073" />
+		<info name="release" value="" />
 		<info name="alt_title" value="ファイナルファンタジー　エクストラコレクション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59220,8 +59222,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Squaresoft Memory Card Data CD (Japan)</description>
 		<year>199?</year>
 		<publisher>Squaresoft</publisher>
-		<info name="serial" value="SLPM-80556"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SLPM-80556" />
+		<info name="release" value="" />
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -59240,8 +59242,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Lalala PlayStation Trial Disk 1998 Summer (Japan, demo)</description>
 		<year>199?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="serial" value="PAPX-90052"/>
-		<info name="release" value=""/>
+		<info name="serial" value="PAPX-90052" />
+		<info name="release" value="" />
 		<info name="alt_title" value="ラララ　プレイステーション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59261,8 +59263,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Armored Core (Japan, demo)</description>
 		<year>1997</year>
 		<publisher>From Software</publisher>
-		<info name="serial" value="SLPM-80118"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SLPM-80118" />
+		<info name="release" value="" />
 		<info name="alt_title" value="装甲核心 - 体验版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59282,8 +59284,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Clock Tower 2 (Japan, Taikenban)</description>
 		<year>1996</year>
 		<publisher>Human</publisher>
-		<info name="serial" value="SLPM-80063"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SLPM-80063" />
+		<info name="release" value="" />
 		<info name="alt_title" value="クロックタワー2体験版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59303,8 +59305,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Granstream Denki (Japan, demo)</description>
 		<year>1997</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="PCPX-96087"/>
-		<info name="release" value=""/>
+		<info name="serial" value="PCPX-96087" />
+		<info name="release" value="" />
 		<info name="alt_title" value="グランストリーム伝紀 体験版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59324,8 +59326,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Koudelka (Japan, demo)</description>
 		<year>199?</year>
 		<publisher>SNK</publisher>
-		<info name="serial" value="SLPM-80490"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SLPM-80490" />
+		<info name="release" value="" />
 		<info name="alt_title" value="KOUDELKA クーデルカ 体験版"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59345,8 +59347,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Legaia Densetsu (Japan, demo)</description>
 		<year>1998</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="PAPX-90055"/>
-		<info name="release" value=""/>
+		<info name="serial" value="PAPX-90055" />
+		<info name="release" value="" />
 		<info name="alt_title" value="レガイア伝説"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59366,8 +59368,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Rescue Shot Bubibo &amp; BioHazard - Gun Survivor (Japan, demo)</description>
 		<year>200?</year>
 		<publisher>SCEI</publisher>
-		<info name="serial" value="SLPM-80522"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SLPM-80522" />
+		<info name="release" value="" />
 		<info name="alt_title" value="レスキューショットブービーぼー&amp;バイオハザードガンサバイバー ガンコン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59387,7 +59389,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Square's Preview 5 (Japan, Seiken Densetsu Demo)</description>
 		<year>1999</year>
 		<publisher>Squaresoft</publisher>
-		<info name="serial" value="SCPS-45417"/>
+		<info name="serial" value="SCPS-45417" />
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -59406,8 +59408,8 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Tamamayu Monogatari - Dennou Bijutsukan (Japan, demo)</description>
 		<year>199?</year>
 		<publisher>Genki</publisher>
-		<info name="serial" value="SLPM-80325"/>
-		<info name="release" value=""/>
+		<info name="serial" value="SLPM-80325" />
+		<info name="release" value="" />
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -59441,7 +59443,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-01564"/>
-		<info name="release" value="19990701"/>
+		<info name="release" value="19990701" />
 		<info name="barcode" value="7 11719 78752 5"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59458,7 +59460,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1996</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCED-00273 (9636229)"/>
-		<info name="release" value="199610xx"/>
+		<info name="release" value="199610xx" />
 		<info name="ring_code" value="DADC AUSTRIA   A0100197331-0101   15, DADC AUSTRIA   A0100197331-0101   35"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59490,7 +59492,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02812 (9184829)"/>
-		<info name="release" value="200009xx"/>
+		<info name="release" value="200009xx" />
 		<info name="ring_code" value="Sony DADC   A0100327637-0102   13 (Disc 1), Sony DADC   A0100327637-0202   23 (Disc 2)"/>
 		<info name="barcode" value="7 11719 18442 3, 7 11719 18432 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59515,7 +59517,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02834, SCES-02834-P"/>
-		<info name="release" value="200012xx"/>
+		<info name="release" value="200012xx" />
 		<info name="barcode" value="7 11719 23282 7, 7 11719 28422 2, 7 11719 28472 7"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -59590,7 +59592,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Microïds</publisher>
 		<info name="serial" value="SLES-02757"/>
-		<info name="release" value="20000206"/>
+		<info name="release" value="20000206" />
 		<info name="ring_code" value="Sony DADC   A0100320928-0102   45 (Disc 1), Sony DADC   A0100320928-0202   15 (Disc 2)"/>
 		<info name="barcode" value="3 342185 276601"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59614,7 +59616,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Infogrames Europe</publisher>
 		<info name="serial" value="SLES-02993#, SLES-02993-P"/>
-		<info name="release" value="20001117"/>
+		<info name="release" value="20001117" />
 		<info name="ring_code" value="Sony DADC   A0100343709-0102   65 (Disc 1), Sony DADC   A0100343709-0202   33 (Disc 2)"/>
 		<info name="barcode" value="3 546430 012703, 3 546430 021552"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59921,7 +59923,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02146"/>
-		<info name="release" value="20000419"/>
+		<info name="release" value="20000419" />
 		<info name="ring_code" value="Sony DADC   A0100316368-0101   13"/>
 		<info name="barcode" value="7 11719 16572 9, 7 11719 16612 2"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59938,7 +59940,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-03119, SLES-03119-P"/>
-		<info name="release" value="20000929"/>
+		<info name="release" value="20000929" />
 		<info name="ring_code" value="Sony DADC   A0100333924-0101   33"/>
 		<info name="barcode" value="5 030930 025366, 5 030945 029045"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59956,7 +59958,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02080 ANZ-P, SLES-02080"/>
-		<info name="release" value="19991001"/>
+		<info name="release" value="19991001" />
 		<info name="ring_code" value="DADC   A0100288304-0104   15, Sony DADC   A0100288304-0104   45 (Disc 1), DADC   A0100288304-0204   15, Sony DADC   A0100288304-0204   65 (Disc 2), DADC   A0100288304-0304   25, Sony DADC   A0100288304-0304   85 (Disc 3), DADC   A0100288304-0404   15 (Disc 4)"/>
 		<info name="barcode" value="7 11719 19392 0, 7 11719 85842 3, 7 11719 85902 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -59991,7 +59993,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Front Mission 3 (Europe, prototype 20000616)</description>
 		<year>2000</year>
 		<publisher>Square Europe</publisher>
-		<info name="release" value="20000616"/>
+		<info name="release" value="20000616" />
 		<info name="ring_code" value="R012-3848-2968"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60007,7 +60009,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02543"/>
-		<info name="release" value="20000420"/>
+		<info name="release" value="20000420" />
 		<info name="barcode" value="7 11719 16332 9, 7 11719 16402 9"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60023,7 +60025,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1998</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-00984, SCES-00984#"/>
-		<info name="release" value="19980505"/>
+		<info name="release" value="19980505" />
 		<info name="ring_code" value="DADC   A0100242488-0101   35, DADC   A0100242488-0101   45, DADC AUSTRIA   A0100242488-0101   25"/>
 		<info name="barcode" value="7 11719 72352 3, 7 11719 72392 9, 7 11719 74232 6, 7 11719 74252 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60040,7 +60042,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02380"/>
-		<info name="release" value="20000128"/>
+		<info name="release" value="20000128" />
 		<info name="ring_code" value="DADC   A0100306121-0102   15, DADC   A0100306121-0102   25 (Disc 1), DADC   A0100306121-0202   15, DADC   A0100306121-0202   25, DADC   A0100306121-0202   35 (Disc 2)"/>
 		<info name="barcode" value="7 11719 22012 1, 7 11719 22192 0, 7 11719 87822 3, 7 11719 87832 2, 7 11719 87842 1"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60064,7 +60066,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="SLES-01404#"/>
-		<info name="release" value="199910xx"/>
+		<info name="release" value="199910xx" />
 		<info name="ring_code" value="DADC   A0100294705-0101   15"/>
 		<info name="barcode" value="5 026555 190206, 5 026555 190794"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60082,7 +60084,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Infogrames Europe</publisher>
 		<info name="serial" value="SLES-01362 (0006672), SLES-01362#"/>
-		<info name="release" value="19991126"/>
+		<info name="release" value="19991126" />
 		<info name="ring_code" value="DADC   A0100300873-0101   15"/>
 		<info name="barcode" value="3 546430 011850, 3 546430 013830, 5 013156 900518, 5 013156 900563"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60099,7 +60101,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-03124, SLES-03124/P"/>
-		<info name="release" value="20001201"/>
+		<info name="release" value="20001201" />
 		<info name="ring_code" value="Sony DADC   A0100343956-0101   15"/>
 		<info name="barcode" value="5 030930 024659, 5 030930 028152, 5 030935 024654 >"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60116,7 +60118,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SLES-01370"/>
-		<info name="release" value="19990226"/>
+		<info name="release" value="19990226" />
 		<info name="ring_code" value="DADC   A0100267025-0102   15, DADC   A0100267025-0102   35 (Disc 1), DADC   A0100267025-0202   25, Sony DADC   A0100267025-0202   55 (Disc 2)"/>
 		<info name="barcode" value="4 012927 020067, 4 988602 749786"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60140,7 +60142,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Konami of Europe</publisher>
 		<info name="serial" value="SLES-02136"/>
-		<info name="release" value="199910xx"/>
+		<info name="release" value="199910xx" />
 		<info name="barcode" value="4 988602 676297"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60156,7 +60158,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>The Codemasters Software Company</publisher>
 		<info name="serial" value="SLES-00016#"/>
-		<info name="release" value="199703xx"/>
+		<info name="release" value="199703xx" />
 		<info name="barcode" value="5 024866 241532, 5 024866 241563"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60172,7 +60174,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-00469"/>
-		<info name="release" value="19971103"/>
+		<info name="release" value="19971103" />
 		<info name="ring_code" value="DADC AUSTRIA   A0100228657-0101   25, DADC AUSTRIA   A0100228657-0101   35"/>
 		<info name="barcode" value="5 030930 013257 >, 5 030935 013252 >"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60189,7 +60191,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="SCES-03037"/>
-		<info name="release" value="200011xx"/>
+		<info name="release" value="200011xx" />
 		<info name="ring_code" value="Sony DADC   A0100333381-0101   15"/>
 		<info name="barcode" value="7 11719 19482 8"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60206,7 +60208,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1998</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="SLES-01356"/>
-		<info name="release" value="199811xx"/>
+		<info name="release" value="199811xx" />
 		<info name="ring_code" value="DADC   A0100261573-0101   15"/>
 		<info name="barcode" value="5 024866 240504, 5 024866 240511, 5 024866 240542"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60223,7 +60225,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-00658"/>
-		<info name="release" value="199705xx"/>
+		<info name="release" value="199705xx" />
 		<info name="barcode" value="5 030945 012634"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60239,7 +60241,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1998</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-01154"/>
-		<info name="release" value="199804xx"/>
+		<info name="release" value="199804xx" />
 		<info name="barcode" value="5 030930 022723"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60271,7 +60273,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>GT Interactive Software Europe / Infogrames</publisher>
 		<info name="serial" value="SLES-00664, SLES-00664#"/>
-		<info name="release" value="199709xx"/>
+		<info name="release" value="199709xx" />
 		<info name="ring_code" value="DADC   A0100225498-0101   15, DADC   A0100225498-0101   35"/>
 		<info name="barcode" value="3 546430 010112 >, 5 029988 004676 >"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60304,7 +60306,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-00886#"/>
-		<info name="release" value="19971101"/>
+		<info name="release" value="19971101" />
 		<info name="barcode" value="7 11719 73022 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60336,7 +60338,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1997</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-00409, SCES-00409#"/>
-		<info name="release" value="19970701"/>
+		<info name="release" value="19970701" />
 		<info name="ring_code" value="DADC AUSTRIA   A0100212393-0101   15, DADC AUSTRIA   A0100212393-0101   25, DADC AUSTRIA   A0100212393-0101   35"/>
 		<info name="barcode" value="7 11719 18722 6, 7 11719 18732 5, 7 11719 65932 7, 7 11719 65942 6, 7 11719 71082 0"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60386,7 +60388,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="SCES-02569 (9169024)"/>
-		<info name="release" value="20000407"/>
+		<info name="release" value="20000407" />
 		<info name="ring_code" value="Sony DADC   A0100318110-0101   13, KODAK CD-R 74 9920 2404 1100"/>
 		<info name="barcode" value="7 11719 16832 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60403,7 +60405,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1996</year>
 		<publisher>Virgin Interactive Entertainment (Europe)</publisher>
 		<info name="serial" value="SLES-00200"/>
-		<info name="release" value="199608xx"/>
+		<info name="release" value="199608xx" />
 		<info name="barcode" value="5 028587 083846"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60450,7 +60452,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Konami Digital Entertainment</publisher>
 		<info name="serial" value="SLES-01514, SLES-01514 - P"/>
-		<info name="release" value="199908xx"/>
+		<info name="release" value="199908xx" />
 		<info name="ring_code" value="DADC   A0100284653-0101   15, Sony DADC   A0100284653-0101   63"/>
 		<info name="barcode" value="4 988602 068597, 4 988602 555660"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60499,7 +60501,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1998</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-01438 (9750925)"/>
-		<info name="release" value="19981001"/>
+		<info name="release" value="19981001" />
 		<info name="ring_code" value="DADC AUSTRIA   A0100257302-0101   15, DADC AUSTRIA   A0100257302-0101   35, Sony DADC   A0100257302-0101   75"/>
 		<info name="barcode" value="7 11719 75022 2, 7 11719 75072 7, 7 11719 88542 9, 7 11719 88972 4"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60517,7 +60519,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2001</year>
 		<publisher>Sony Computer Entertainment Europe</publisher>
 		<info name="serial" value="SCES-02835"/>
-		<info name="release" value="20011210"/> <!-- Rev. 1 -->
+		<info name="release" value="20011210" /> <!-- Rev. 1 -->
 		<info name="ring_code" value="Sony DADC   A0100342055-0101   15"/>
 		<info name="barcode" value="7 11719 283621, 7 11719 28392 8"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60581,7 +60583,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1998</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-00627"/>
-		<info name="release" value="199802xx"/>
+		<info name="release" value="199802xx" />
 		<info name="barcode" value="5 030930 022747"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60615,7 +60617,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2000</year>
 		<publisher>The Codemasters Software Company</publisher>
 		<info name="serial" value="SLES-02572, SLES-02572/P"/>
-		<info name="release" value="20000825"/>
+		<info name="release" value="20000825" />
 		<info name="barcode" value="5 024866 241297, 5 024866 241310, 5 024866 242256"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60631,7 +60633,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Eidos Interactive</publisher>
 		<info name="serial" value="SLES-02238, SLES-02238/ANZ"/>
-		<info name="release" value="199911xx"/>
+		<info name="release" value="199911xx" />
 		<info name="barcode" value="5 032921 008488"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60664,7 +60666,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>2001</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="SLES-02534"/>
-		<info name="release" value="20010331"/>
+		<info name="release" value="20010331" />
 		<info name="ring_code" value="Sony DADC   A0100355439-0101   23"/>
 		<info name="barcode" value="3 455192 121212, 3 455192 121236"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
@@ -60681,7 +60683,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<year>1999</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="SLES-02253"/>
-		<info name="release" value="19991216"/>
+		<info name="release" value="19991216" />
 		<info name="barcode" value="5 030930 021191"/>
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
@@ -60719,7 +60721,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Firebugs (Europe)</description>
 		<year>2002</year>
 		<publisher>Sony</publisher>
-		<info name="serial" value="SCES-03884"/>
+		<info name="serial" value="SCES-03884" />
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -60738,7 +60740,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<description>Terracon (Europe)</description>
 		<year>2000</year>
 		<publisher>Sony</publisher>
-		<info name="serial" value="SCES-02836"/>
+		<info name="serial" value="SCES-02836" />
 		<sharedfeat name="compatibility" value="PAL-E"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -60806,7 +60808,7 @@ A few comments on these:
 		<publisher>&lt;pirate&gt;</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ddrdmp" sha1="914d1980a4a46574adfedac1e3335ac2738ae5c1"/>
+				<disk name="ddrdmp" sha1="914d1980a4a46574adfedac1e3335ac2738ae5c1" />
 			</diskarea>
 		</part>
 	</software>
@@ -60815,7 +60817,7 @@ A few comments on these:
 <!-- Prototype discs -->
 
 	<!-- boot OK -->
-	<software name="bublbob2">
+	<software name="bublbob2" >
 		<!--
 		Original images
 		<rom name="bb2.bin" size="62620864" crc="1c2c9f63" sha1="2d9cf9e34057c93fe1d40940428c463a7224444e"/>
@@ -60843,22 +60845,22 @@ A few comments on these:
 		<description>Baldur's Gate (USA, prototype)</description>
 		<year>19??</year>
 		<publisher>Interplay</publisher>
-		<info name="serial" value="SLUS-01037"/>
+		<info name="serial" value="SLUS-01037" />
 		<part name="cdrom1" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="baldur's gate - disc 1" sha1="abe5d1c7f466150937c44802e559020ba479d941"/>
+				<disk name="baldur's gate - disc 1" sha1="abe5d1c7f466150937c44802e559020ba479d941" />
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="baldur's gate - disc 2" sha1="42db8585e1c0b68fbfb9274adaf0db8717427b28"/>
+				<disk name="baldur's gate - disc 2" sha1="42db8585e1c0b68fbfb9274adaf0db8717427b28" />
 			</diskarea>
 		</part>
 
 		<part name="cdrom3" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="baldur's gate - disc 3" sha1="a59f863f0304bb457ed6aaa4f7e9797f233ee91b"/>
+				<disk name="baldur's gate - disc 3" sha1="a59f863f0304bb457ed6aaa4f7e9797f233ee91b" />
 			</diskarea>
 		</part>
 	</software>
@@ -60873,7 +60875,7 @@ A few comments on these:
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="biohazard - 1995 - 08 - 04 - sample" sha1="de2b4d723709dd262553065849c9000807d1e4cc"/>
+				<disk name="biohazard - 1995 - 08 - 04 - sample" sha1="de2b4d723709dd262553065849c9000807d1e4cc" />
 			</diskarea>
 		</part>
 	</software>
@@ -60888,7 +60890,7 @@ A few comments on these:
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="biohazard - 1995 - 10 - 04 - sample" sha1="7c1e9f60c045fcf984c91dbaad7421d73a8aec73"/>
+				<disk name="biohazard - 1995 - 10 - 04 - sample" sha1="7c1e9f60c045fcf984c91dbaad7421d73a8aec73" />
 			</diskarea>
 		</part>
 	</software>
@@ -60903,7 +60905,7 @@ A few comments on these:
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bio hazard (j) (sample 1996.01.31) [slps-00222]" sha1="e73192b6a3f573b4b04e9dd4ba90275d9d978b7a"/>
+				<disk name="bio hazard (j) (sample 1996.01.31) [slps-00222]" sha1="e73192b6a3f573b4b04e9dd4ba90275d9d978b7a" />
 			</diskarea>
 		</part>
 	</software>
@@ -60919,7 +60921,7 @@ A few comments on these:
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="biohazard-2-beta" sha1="2b7148b98f05498329e7bf2ced2a9ce44f3d4e9a"/>
+				<disk name="biohazard-2-beta" sha1="2b7148b98f05498329e7bf2ced2a9ce44f3d4e9a" />
 			</diskarea>
 		</part>
 	</software>
@@ -60934,7 +60936,7 @@ A few comments on these:
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="biohazard 2 (beta 2)" sha1="6297f31f083406884e03a1f52fd9db577e017fd8"/>
+				<disk name="biohazard 2 (beta 2)" sha1="6297f31f083406884e03a1f52fd9db577e017fd8" />
 			</diskarea>
 		</part>
 	</software>
@@ -60964,7 +60966,7 @@ A few comments on these:
 		<publisher>Radical</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="breakneck" sha1="bc1e3088bb29c95681b59489d16e6cbb15171279"/>
+				<disk name="breakneck" sha1="bc1e3088bb29c95681b59489d16e6cbb15171279" />
 			</diskarea>
 		</part>
 	</software>
@@ -61011,7 +61013,7 @@ A few comments on these:
 		<publisher>Sony Computer Entertainment America</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="crash" sha1="8272aa46a2a959d2ffd54f281301a38bd1b2fbad"/>
+				<disk name="crash" sha1="8272aa46a2a959d2ffd54f281301a38bd1b2fbad" />
 			</diskarea>
 		</part>
 	</software>
@@ -61084,7 +61086,7 @@ A few comments on these:
 		<publisher>Midway</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="deuce (usa, prototype)" sha1="76911bb495fd3ff66e0e764eba1f1f7aa9aca8d2"/>
+				<disk name="deuce (usa, prototype)" sha1="76911bb495fd3ff66e0e764eba1f1f7aa9aca8d2" />
 			</diskarea>
 		</part>
 	</software>
@@ -61099,7 +61101,7 @@ A few comments on these:
 		<publisher>Electronic Arts</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="diablo" sha1="00fe192c6ac3496c76e7f4f8af157b949073dda8"/>
+				<disk name="diablo" sha1="00fe192c6ac3496c76e7f4f8af157b949073dda8" />
 			</diskarea>
 		</part>
 	</software>
@@ -61128,7 +61130,7 @@ A few comments on these:
 		<publisher>GT Interactive</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ttk" sha1="4531bb227e2444fbc10ee53807c71a309637c55e" status="baddump"/>
+				<disk name="ttk" sha1="4531bb227e2444fbc10ee53807c71a309637c55e" status="baddump" />
 			</diskarea>
 		</part>
 	</software>
@@ -61143,7 +61145,7 @@ A few comments on these:
 		<publisher>Psygnosis</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slus-01419" sha1="b8df7f15e32150e703780951fd7ccb6914c75c06"/>
+				<disk name="slus-01419" sha1="b8df7f15e32150e703780951fd7ccb6914c75c06" />
 			</diskarea>
 		</part>
 	</software>
@@ -61189,7 +61191,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Eidos</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legacy of kain - soul reaver (usa, prototype 19990628)" sha1="d0df73cdbfc9ef35076f13f9996593f2e8f50130"/>
+				<disk name="legacy of kain - soul reaver (usa, prototype 19990628)" sha1="d0df73cdbfc9ef35076f13f9996593f2e8f50130" />
 			</diskarea>
 		</part>
 	</software>
@@ -61205,7 +61207,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Eidos</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="legacy of kain - soul reaver (usa, prototype 19990512)" sha1="0255d212fba97680a57c7235d172940978d6c8d2"/>
+				<disk name="legacy of kain - soul reaver (usa, prototype 19990512)" sha1="0255d212fba97680a57c7235d172940978d6c8d2" />
 			</diskarea>
 		</part>
 	</software>
@@ -61220,7 +61222,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Electronic Arts</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="madden96" sha1="74c6c4e4cc13a8f4a12e26d5444ad6f829e50342"/>
+				<disk name="madden96" sha1="74c6c4e4cc13a8f4a12e26d5444ad6f829e50342" />
 			</diskarea>
 		</part>
 	</software>
@@ -61251,10 +61253,10 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<description>Metal Gear Solid (pilot disk)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
-		<info name="serial" value="SLPM-80254"/>
+		<info name="serial" value="SLPM-80254" />
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slpm-80254" sha1="304e7e9b7182d8f30315cd589abe41d18a19c55c"/>
+				<disk name="slpm-80254" sha1="304e7e9b7182d8f30315cd589abe41d18a19c55c" />
 			</diskarea>
 		</part>
 	</software>
@@ -61285,7 +61287,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Atlus</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="persona2xus" sha1="63910ca0f84d97496c5f4498e7a8d70299b14d64"/>
+				<disk name="persona2xus" sha1="63910ca0f84d97496c5f4498e7a8d70299b14d64" />
 			</diskarea>
 		</part>
 	</software>
@@ -61315,7 +61317,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rockman 8 beta v1" sha1="ef22ee21d0ab15b69c64d951e69099c5e46e189a"/>
+				<disk name="rockman 8 beta v1" sha1="ef22ee21d0ab15b69c64d951e69099c5e46e189a" />
 			</diskarea>
 		</part>
 	</software>
@@ -61330,7 +61332,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rockman 8 beta 1" sha1="fa1b3e5cac9463866f51e5f67e5321bc532b5a2b"/>
+				<disk name="rockman 8 beta 1" sha1="fa1b3e5cac9463866f51e5f67e5321bc532b5a2b" />
 			</diskarea>
 		</part>
 	</software>
@@ -61345,7 +61347,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rockman 8 beta 2" sha1="ee3149d9579cdf1ad7b32d2ab9103e9f9353e732"/>
+				<disk name="rockman 8 beta 2" sha1="ee3149d9579cdf1ad7b32d2ab9103e9f9353e732" />
 			</diskarea>
 		</part>
 	</software>
@@ -61357,10 +61359,10 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<description>Rockman Dash (Capcom Friendly Club demo)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLPM-80158"/>
+		<info name="serial" value="SLPM-80158" />
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="slpm-80158" sha1="e62186095e824961557607c78a35229217ae8ebf"/>
+				<disk name="slpm-80158" sha1="e62186095e824961557607c78a35229217ae8ebf" />
 			</diskarea>
 		</part>
 	</software>
@@ -61375,7 +61377,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Capcom</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rockman_x6" sha1="0ff73049e29de65b67f7bc682a9354ecbe5c8ede"/>
+				<disk name="rockman_x6" sha1="0ff73049e29de65b67f7bc682a9354ecbe5c8ede" />
 			</diskarea>
 		</part>
 	</software>
@@ -61390,7 +61392,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Konami</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="silent1" sha1="95a9401a0f0aaa1b6a1e27324651ed8f67690eb7"/>
+				<disk name="silent1" sha1="95a9401a0f0aaa1b6a1e27324651ed8f67690eb7" />
 			</diskarea>
 		</part>
 	</software>
@@ -61405,7 +61407,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Acclaim</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="spirit master (u) (prototype)" sha1="891a5584995be8c319c7422fa5cca1da60afebc8"/>
+				<disk name="spirit master (u) (prototype)" sha1="891a5584995be8c319c7422fa5cca1da60afebc8" />
 			</diskarea>
 		</part>
 	</software>
@@ -61421,7 +61423,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Accolade</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="starcon" sha1="cae7074b0498bc489d668a30a7bc94b541d10036"/>
+				<disk name="starcon" sha1="cae7074b0498bc489d668a30a7bc94b541d10036" />
 			</diskarea>
 		</part>
 	</software>
@@ -61453,7 +61455,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<info name="serial" value="SLUS-00752?"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="thrill kill" sha1="09721bf343ee69f13b7ed86cc92beb0be94db04a"/>
+				<disk name="thrill kill" sha1="09721bf343ee69f13b7ed86cc92beb0be94db04a" />
 			</diskarea>
 		</part>
 	</software>
@@ -61483,7 +61485,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Core Design</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider (beta)(07-22-1996)" sha1="8efa97244b2b7744dde94c68497d370f9bf7c999"/>
+				<disk name="tomb raider (beta)(07-22-1996)" sha1="8efa97244b2b7744dde94c68497d370f9bf7c999" />
 			</diskarea>
 		</part>
 	</software>
@@ -61500,7 +61502,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Core Design</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tomb raider ii (usa, prototype)" sha1="62036de387e8715afdbe30c3ba6c12aa1121cfeb"/>
+				<disk name="tomb raider ii (usa, prototype)" sha1="62036de387e8715afdbe30c3ba6c12aa1121cfeb" />
 			</diskarea>
 		</part>
 	</software>
@@ -61515,7 +61517,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Activision</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tony hawk's pro skater (usa) [beta]" sha1="f326e476b44f3d011efd65197df633b446f77101"/>
+				<disk name="tony hawk's pro skater (usa) [beta]" sha1="f326e476b44f3d011efd65197df633b446f77101" />
 			</diskarea>
 		</part>
 	</software>
@@ -61529,7 +61531,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Head Games</publisher>   <!-- Head Games were actually the developer, but I was unable to dig any info about actual publishing deals -->
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="torc - legend of the ogre crown (prototype)" sha1="fd93d28c7a64f047d6e9d40fb8333fc74a43b887"/>
+				<disk name="torc - legend of the ogre crown (prototype)" sha1="fd93d28c7a64f047d6e9d40fb8333fc74a43b887" />
 			</diskarea>
 		</part>
 	</software>
@@ -61576,7 +61578,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>THQ</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf smackdown (beta)" sha1="7aa0bc14fc4d33f785d0a9c911e8f177e737ad78"/>
+				<disk name="wwf smackdown (beta)" sha1="7aa0bc14fc4d33f785d0a9c911e8f177e737ad78" />
 			</diskarea>
 		</part>
 	</software>
@@ -61592,7 +61594,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<description>Resident Evil 2 (Europe, preview, CD Consoles No.38)</description>
 		<year>1997</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLED-00977"/>
+		<info name="serial" value="SLED-00977" />
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sled-00977" sha1="e4b02905f0032c4f834cddd45e8c4ba3f12150a3"/>
@@ -61608,10 +61610,10 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<description>Resident Evil 3 (Europe, demo)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
-		<info name="serial" value="SLED-02541"/>
+		<info name="serial" value="SLED-02541" />
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sled-02541" sha1="6bad1e2c7c6541ba21333ef9e7076d910088ce87"/>
+				<disk name="sled-02541" sha1="6bad1e2c7c6541ba21333ef9e7076d910088ce87" />
 			</diskarea>
 		</part>
 	</software>
@@ -61626,7 +61628,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Data West</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bountyarms" sha1="5543cc67b3e56de44ed2edf5faea7b8c002e9269"/>
+				<disk name="bountyarms" sha1="5543cc67b3e56de44ed2edf5faea7b8c002e9269" />
 			</diskarea>
 		</part>
 	</software>
@@ -61644,7 +61646,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>Konami</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sotn e3 demo" sha1="c3f5a41ee4722660ce9a708c22990bf9656d5949"/>
+				<disk name="sotn e3 demo" sha1="c3f5a41ee4722660ce9a708c22990bf9656d5949" />
 			</diskarea>
 		</part>
 	</software>
@@ -61689,7 +61691,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<description>Silent Hill (USA, trade demo)</description>
 		<year>1999</year>
 		<publisher>Konami of America</publisher>
-		<info name="serial" value="SLUS-80707"/>
+		<info name="serial" value="SLUS-80707" />
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
 				<disk name="slus-80707" sha1="3dc02338a4a00a5a9fb1e89308a7ec75854efec5"/>
@@ -61708,7 +61710,7 @@ use an alternate design found on the demo disk... It might be possible to enable
 		<publisher>SCEI</publisher>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tr1" sha1="a42bca9a943f660a6c080a38a2c8082109c78e79"/>
+				<disk name="tr1" sha1="a42bca9a943f660a6c080a38a2c8082109c78e79" />
 			</diskarea>
 		</part>
 	</software>

--- a/hash/segacd.xml
+++ b/hash/segacd.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
@@ -273,7 +273,7 @@ See: http://rawdump.net/
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4415"/>
-		<info name="release" value="199303xx" />
+		<info name="release" value="199303xx"/>
 		<info name="ring_code" value="CDAC-040200 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -301,12 +301,12 @@ See: http://rawdump.net/
 		<description>AH3 - ThunderStrike (USA)</description>
 		<year>1993</year>
 		<publisher>JVC</publisher>
-		<info name="release" value="199310xx" />
+		<info name="release" value="199310xx"/>
 		<info name="serial" value="T-60055"/>
 		<info name="ring_code" value="SEGAT60055RE R2D MFD BY JVC, SEGAT60055 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ah3 - thunderstrike (usa)" sha1="46d352674119dabf0728a07dc7354b54fe5a027b"/>
+				<disk name="ah3 - thunderstrike (usa)" sha1="465b952a84ff0e59a696356946cf4b25274c3a89"/>
 			</diskarea>
 		</part>
 	</software>
@@ -339,7 +339,7 @@ See: http://rawdump.net/
 		<description>Batman Returns (USA)</description>
 		<year>1993</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="199303xx" />
+		<info name="release" value="199303xx"/>
 		<info name="serial" value="4401"/>
 		<info name="ring_code" value="CDAC-040500 1"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -406,12 +406,12 @@ See: http://rawdump.net/
 		<description>Battlecorps (USA)</description>
 		<year>1994</year>
 		<publisher>Core Design</publisher>
-		<info name="release" value="199404xx" />
+		<info name="release" value="199404xx"/>
 		<info name="serial" value="T-115045"/>
 		<info name="ring_code" value="SEGAT115045 R1H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battlecorps (usa)" sha1="6ea60ddc9064f7aa770ea87f2fb2ff438793c037"/>
+				<disk name="battlecorps (usa)" sha1="4f489e565e3c7c3a5a4cd1d00bc5acac406da06b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -478,7 +478,7 @@ See: http://rawdump.net/
 		<description>Black Hole Assault (USA)</description>
 		<year>1993</year>
 		<publisher>Bignet</publisher>
-		<info name="alt_title" value="Blackhole Assault (Box)" />
+		<info name="alt_title" value="Blackhole Assault (Box)"/>
 		<info name="serial" value="PN-6400"/>
 		<info name="ring_code" value="CDAC-031700 1"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -504,7 +504,7 @@ See: http://rawdump.net/
 		<description>Bouncers (USA)</description>
 		<year>1994</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="199412xx" />
+		<info name="release" value="199412xx"/>
 		<info name="serial" value="4908"/>
 		<info name="ring_code" value="CDAC 082400 1"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -528,7 +528,7 @@ See: http://rawdump.net/
 		<description>Bram Stoker's Dracula (USA)</description>
 		<year>1992</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199311xx" />
+		<info name="release" value="199311xx"/>
 		<info name="serial" value="T-93065"/>
 		<info name="ring_code" value="CDAC-020100 4"/>  <!-- Possibly CDAC-050100 4 -->
 		<part name="cdrom" interface="scd_cdrom">
@@ -552,7 +552,7 @@ See: http://rawdump.net/
 		<description>Bram Stoker's Dracula (USA, alt)</description>
 		<year>1992</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199311xx" />
+		<info name="release" value="199311xx"/>
 		<info name="serial" value="T-60064"/>
 		<info name="ring_code" value="CDAC-050100 1"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -576,7 +576,7 @@ See: http://rawdump.net/
 		<description>Bram Stoker's Dracula (USA, rev. A)</description>
 		<year>1992</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199311xx" />
+		<info name="release" value="199311xx"/>
 		<info name="serial" value="T-93155"/>
 		<info name="ring_code" value="CDAC-068700 1"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -608,7 +608,7 @@ See: http://rawdump.net/
 		<description>Brutal - Paws of Fury (USA)</description>
 		<year>1994</year>
 		<publisher>GameTek</publisher>
-		<info name="release" value="199403xx" />
+		<info name="release" value="199403xx"/>
 		<info name="serial" value="T-83015"/>
 		<info name="ring_code" value="SEGAT830155 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -636,7 +636,7 @@ See: http://rawdump.net/
 		<description>Chuck Rock (USA)</description>
 		<year>1992</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199301xx" />
+		<info name="release" value="199301xx"/>
 		<info name="serial" value="T-6204"/>
 		<info name="ring_code" value="CDAC-032500 5"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -689,12 +689,12 @@ See: http://rawdump.net/
 		<description>Cliffhanger (USA)</description>
 		<year>1993</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199311xx" />
+		<info name="release" value="199311xx"/>
 		<info name="serial" value="T-93075"/>
 		<info name="ring_code" value="CDAC-053600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cliffhanger (usa)" sha1="71753bdebddc8de1f9920f19e06a7858a470f286"/>
+				<disk name="cliffhanger (usa)" sha1="4aca3b3e186015ffb0794e2c83762cbc2457eaec"/>
 			</diskarea>
 		</part>
 	</software>
@@ -709,11 +709,11 @@ See: http://rawdump.net/
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4402"/>
-		<info name="release" value="199211xx" />
+		<info name="release" value="199211xx"/>
 		<info name="ring_code" value="CDAC-031400 5"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cobra command (usa)" sha1="2d7c32591cec389f6d5feb5f0301495ff8021307"/>
+				<disk name="cobra command (usa)" sha1="53d79a6fe72bb5328c52328a135a9c5725170f03"/>
 			</diskarea>
 		</part>
 	</software>
@@ -755,7 +755,7 @@ Requires [32X] add-on
 		<info name="usage" value="Requires to be run with 32x_scd"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="corpse killer (usa, 32x)" sha1="68a6c75bc730025e90fa413c107090e7f4e377e0"/>
+				<disk name="corpse killer (usa, 32x)" sha1="2d8721e835e58b6c850b43fe2d76382d1bbf59f7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -783,7 +783,7 @@ Requires [32X] add-on
 		<info name="ring_code" value="CDAC-059200 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dark wizard (usa)" sha1="cf784af53b6dedc2777b91f5ac5f169f2f7b9c30"/>
+				<disk name="dark wizard (usa)" sha1="a7f15287245e324bb1338ddf436a4d615618830b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -801,7 +801,7 @@ Requires [32X] add-on
 		<info name="ring_code" value="CDAC-052900 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="double switch (usa)" sha1="2b727773fda836ddfb972dc98820bee7135da709"/>
+				<disk name="double switch (usa)" sha1="550ef74c39eb6dd55b4410012ad8b1cf83c92e6e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -825,15 +825,15 @@ Requires [disc swap]
 		<info name="serial" value="4420"/>
 		<info name="ring_code" value="CDAC-053000 14 (Disc 1) / CDAC-053100 4 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1" />
+			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="dracula unleashed (usa) (disc 1)" sha1="307c0779dace5d95f3e7a0ccee18c00356ca2362"/>
+				<disk name="dracula unleashed (usa) (disc 1)" sha1="bf3938a34c7c58b11ea577a54cf551ce3f0593b1"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2" />
+			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="dracula unleashed (usa) (disc 2)" sha1="e3adeebe60f32a3487e7d5afc86675b73057fba6"/>
+				<disk name="dracula unleashed (usa) (disc 2)" sha1="67a86dbf0718a76998d6b30b738ca856d64a756f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -851,7 +851,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT121015 R3D MFD BY JVC 13"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon's lair (usa)" sha1="724bc872d111ed67df10e95b134f8bf7fe2fcfe3"/>
+				<disk name="dragon's lair (usa)" sha1="4f7200a039d440ff83b0e80ad9d2b90715b85ed6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -880,7 +880,7 @@ Requires [disc swap]
 		<info name="ring_code" value="JVC SEGA4657 R2E 0 0"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dungeon explorer (usa)" sha1="432897f1f19e8a053c8f7d783e2331e7fd0f0b1f"/>
+				<disk name="dungeon explorer (usa)" sha1="9a935d5cec48a4c465e52bc6a968d5b5ba3eb32b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -912,7 +912,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-042000 1, CDAC-042000 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ecco the dolphin (usa)" sha1="7fb88d4f0fe34ee40991d724b9e90f7586081fd2"/>
+				<disk name="ecco the dolphin (usa)" sha1="dec9f9d8cc7e9edafcd56b7b03023349dd0174f0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -945,7 +945,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC 077400"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ecco - the tides of time (usa)" sha1="20cb72bf75a848568dd034188bebe316138b6186"/>
+				<disk name="ecco - the tides of time (usa)" sha1="928726593d409c09b6f2f4a7fd5d7143cb620c03"/>
 			</diskarea>
 		</part>
 	</software>
@@ -995,7 +995,7 @@ Requires [disc swap]
 		<info name="serial" value="T-93115"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="espn baseball tonight (usa)" sha1="3965f3f96579abe6d754360fb123f5cfb2e8cce1"/>
+				<disk name="espn baseball tonight (usa)" sha1="3357a6b8ecb7c152703125d1f85580d008f70ad4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1009,12 +1009,12 @@ Requires [disc swap]
 		<description>ESPN Sunday Night NFL (USA)</description>
 		<year>1994</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199411xx" />
+		<info name="release" value="199411xx"/>
 		<info name="serial" value="T-93105"/>
 		<info name="ring_code" value="CDAC-077600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="espn sunday night nfl (usa)" sha1="11504fbfcecc6ffdaa69960ba9e57d6cd343bd78"/>
+				<disk name="espn sunday night nfl (usa)" sha1="e34f71de1f6f4a712f3397a391038d20ba2eaa95"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1157,7 +1157,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-070100 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="eye of the beholder (usa)" sha1="8901e20ec6cb1cc8b8771b7bdac01d3220a067f5"/>
+				<disk name="eye of the beholder (usa)" sha1="6394fc55f8b8bf36cf835ab3514fa11535652df1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1180,19 +1180,19 @@ Requires [disc swap]
 		<notes><![CDATA[
 Has optional unemulated [32X] mode, which in turn needs [disc swap]
 ]]></notes>
-		<info name="release" value="199503xx" />
+		<info name="release" value="199503xx"/>
 		<info name="serial" value="4438"/>
 		<info name="ring_code" value="CDAC-088300 1 (Disc 1) / CDAC-088400 1 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Sega CD / Disc 1 - Key Disc" />
+			<feature name="part_id" value="Sega CD / Disc 1 - Key Disc"/>
 			<diskarea name="cdrom">
-				<disk name="fahrenheit (usa) (sega cd)" sha1="c53080012578fe291323197e6319842beb84ee9b"/>
+				<disk name="fahrenheit (usa) (sega cd)" sha1="8e5ce49c68edf4e0da5e0935fb419b3d29a52527"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="32X CD / Disc 2 - Insert Key Disc 1 First" />
+			<feature name="part_id" value="32X CD / Disc 2 - Insert Key Disc 1 First"/>
 			<diskarea name="cdrom">
-				<disk name="fahrenheit (usa) (32x cd)" sha1="f94ea9821ca030c3cc61eccc29eb9c692198415e"/>
+				<disk name="fahrenheit (usa) (32x cd)" sha1="8dac276eacfa72913c5fb2d12c5d3360bb513fe4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1254,7 +1254,7 @@ Has optional unemulated [32X] mode, which in turn needs [disc swap]
 		<info name="ring_code" value="CDAC-064000(9)1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fifa international soccer (usa)" sha1="3e32c3d5e99f5df103277aed209a59f888c06bec"/>
+				<disk name="fifa international soccer (usa)" sha1="a38b06e9812b31ab1bfb2ae10b3422c993d5fc2e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1293,11 +1293,11 @@ Has optional unemulated [32X] mode, which in turn needs [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4410"/>
-		<info name="release" value="199305xx" />
+		<info name="release" value="199305xx"/>
 		<info name="ring_code" value="CDAC-041400 6, CDAC-041400 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fight cd (usa)" sha1="bd0ae447a302d2e220f13c84a7a56a45007c7e83"/>
+				<disk name="final fight cd (usa)" sha1="922993f958901291c6a28dd34a368edd25d84f5d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1350,7 +1350,7 @@ Has optional unemulated [32X] mode, which in turn needs [disc swap]
 		<info name="ring_code" value="CDAC-063600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="formula one world championship - beyond the limit (usa)" sha1="da0c0fd84af458744d6b045c3fb44b5ac5f89152"/>
+				<disk name="formula one world championship - beyond the limit (usa)" sha1="3bbfccb65fb8c5185cbfbb5a52ee5c95d614c05d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1374,16 +1374,16 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-053200 2, CDAC-053200 4 (Disc 1) / CDAC-053300 1 (Disc 2)"/>
 		<info name="serial" value="T-93145"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1" />
+			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="ground zero texas (usa) (disc 1)" sha1="226bef5c19446c6be18674941707b3baebc11223"/>
+				<disk name="ground zero texas (usa) (disc 1)" sha1="a4f140fb429d5ed9623aa0860d6aee0db78f0c87"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2" />
+			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="ground zero texas (usa) (disc 2)" sha1="13c7cc77f2659155dec4deb4700d8ac8af95fb42"/>
+				<disk name="ground zero texas (usa) (disc 2)" sha1="00492e73180ba447b4216699be023588679b76f8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1438,11 +1438,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="T-70025"/>
-		<info name="release" value="199406xx" />
+		<info name="release" value="199406xx"/>
 		<info name="ring_code" value="HOTALIENRE R1H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heart of the alien - out of this world parts i and ii (usa)" sha1="a2784fa95bb3b29067b5d8148dd95877456577e7"/>
+				<disk name="heart of the alien - out of this world parts i and ii (usa)" sha1="085d32028c3dd4dfc1f0a05cd9be6fd3293c1f52"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1476,11 +1476,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-60145"/>
-		<info name="release" value="199404xx" />
+		<info name="release" value="199404xx"/>
 		<info name="ring_code" value="SEGAT60105 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heimdall (usa)" sha1="986813f0d66eff9c163c19ccdbe6e055bf75043d"/>
+				<disk name="heimdall (usa)" sha1="b429b7d57897b357d86529984e6c8fc787a12371"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1518,7 +1518,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-032400 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hook (usa)" sha1="310b67fc0163da2dbae236b1276624b2170425b0"/>
+				<disk name="hook (usa)" sha1="a713dc15bf82115230b7201860e2b99119f9d0da"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1536,7 +1536,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT124015 R2H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="iron helix (usa)" sha1="243a1c1691ab1a587371e34c1692663b28814184"/>
+				<disk name="iron helix (usa)" sha1="e617f0b6d0887517ff63a6be9676039f548c38f8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1552,11 +1552,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sony Imagesoft</publisher>
 		<info name="serial" value="T-93095"/>
-		<info name="release" value="199311xx" />
+		<info name="release" value="199311xx"/>
 		<info name="ring_code" value="CDAC-075900 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jeopardy (usa)" sha1="6f159f64d3ea62bb8eff70e9a2f84d02bfb54688"/>
+				<disk name="jeopardy (usa)" sha1="02b99541189e0982b82607aa64fa71505f944cb0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1575,11 +1575,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="T-4201"/>
-		<info name="release" value="199310xx" />
+		<info name="release" value="199310xx"/>
 		<info name="ring_code" value="SEGA4201 R1C MFD BY JVC, SEGA4201RE R2C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="joe montana's nfl football (usa)" sha1="a6c4dccb249c27d38846e204313446e5928c2b4d"/>
+				<disk name="joe montana's nfl football (usa)" sha1="a308351c13fc57c969671dc2f0ec24a00a9eabc3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1627,7 +1627,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4411RE R3C MFD BY JVC, SEGA4411RE R4C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jurassic park (usa)" sha1="8ab39eda898277571127b9ac03dce64546602caf"/>
+				<disk name="jurassic park (usa)" sha1="f1b842803f87841f2d442e438c2047ad4a5f889c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1645,7 +1645,7 @@ Requires [disc swap]
 		<info name="ring_code" value="GW 03611 SRCR##02"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kids on site (usa)" sha1="9a97c7c151cbe77121bb626954b50bd2223a9292"/>
+				<disk name="kids on site (usa)" sha1="04f4302d49e3f2f5b599e8bdd2fff08d92e70015"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1681,7 +1681,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-95015"/>
-		<info name="release" value="199311xx" />
+		<info name="release" value="199311xx"/>
 		<info name="ring_code" value="T95015-U11 2A7 C 39, T95015-U11 2B3 C 39, T95015-U11 2C2 C 39, T95015-U11 2C3 C 39"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -1722,7 +1722,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-95015"/>
-		<info name="release" value="199311xx" />
+		<info name="release" value="199311xx"/>
 		<info name="ring_code" value="T95015-U12 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -1762,11 +1762,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-95025"/>
-		<info name="release" value="19941124" />
+		<info name="release" value="19941124"/>
 		<info name="ring_code" value="T95025-U12 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lethal enforcers ii - gun fighters (usa)" sha1="7d63da6fa26441e31bd614474936d8c7adacd239"/>
+				<disk name="lethal enforcers ii - gun fighters (usa)" sha1="6f9fbcf9f5ab7bcbbb2740cbe72af63183112855"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1784,7 +1784,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT153015 R3J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="loadstar - the legend of tully bodine (usa)" sha1="a9b4df4c8b3ed81d14cfa5506961c3815387194e"/>
+				<disk name="loadstar - the legend of tully bodine (usa)" sha1="6208729d1723944354fabcd0e281cbc9f13874d4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1821,7 +1821,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4450 R1F"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lords of thunder (usa)" sha1="c4be0138ac50ee190fb8df9839a2efb97e9f30c2"/>
+				<disk name="lords of thunder (usa)" sha1="0dfac7659fc981eb1322f8dc801f45dcdb33eed3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1908,7 +1908,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT127045RE R1H"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar - eternal blue (usa)" sha1="1cc95c2b91d6c52d561a4f70e96c52ddc3c10313"/>
+				<disk name="lunar - eternal blue (usa)" sha1="e93c3f2cd946e0ea1ea3cdecbf24e55d7acb5732"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1931,7 +1931,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT111015 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mad dog mccree (usa)" sha1="244713e8c7c1d1ef38f5f9ba2232cb1a2b23a1f7"/>
+				<disk name="mad dog mccree (usa)" sha1="b31567eb08b7730f0dfef90650d162b7e2580316"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1946,12 +1946,12 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Vic Tokai</publisher>
 		<info name="serial" value="T-23015"/>
-		<info name="release" value="199402xx" />
+		<info name="release" value="199402xx"/>
 		<info name="ring_code" value="SEGAT23015 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
-			<feature name="peripheral" value="mouse" />
+			<feature name="peripheral" value="mouse"/>
 			<diskarea name="cdrom">
-				<disk name="mansion of hidden souls (usa)" sha1="1d1dba770de6d5969d23d2e86ad4028445d514c4"/>
+				<disk name="mansion of hidden souls (usa)" sha1="75095ab4f62cd1d351f4dadc5202ab84a3c269a9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1975,7 +1975,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-077800 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mary shelley's frankenstein (usa)" sha1="4d0d40a70d2a585e371d23d122ec98a6dce7b299"/>
+				<disk name="mary shelley's frankenstein (usa)" sha1="353b90dbcb159afca517218a0157b5ecc841379b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2016,7 +2016,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Sony Imagesoft</publisher>
 		<info name="serial" value="T-93265"/>
-		<info name="release" value="199411xx" />
+		<info name="release" value="199411xx"/>
 		<info name="ring_code" value="CDAC-073600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2045,7 +2045,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-055200 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="microcosm (usa)" sha1="bca8a59c2aa47d1207b0c2df1d2ff40cb5d11fb4"/>
+				<disk name="microcosm (usa)" sha1="d77d0f9575aa53d7aef0640fb4532f7978590282"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2063,7 +2063,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4439 R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="midnight raiders (usa)" sha1="83db51aee2ef658fa9d29e67acdc7d5774e69d3a"/>
+				<disk name="midnight raiders (usa)" sha1="741b1383164112074cf5d6fc09c5262015779869"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2097,11 +2097,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Arena</publisher>
 		<info name="serial" value="T-81025"/>
-		<info name="release" value="199404xx" />
+		<info name="release" value="199404xx"/>
 		<info name="ring_code" value="CDCA-060900 3, CDCA-061500 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat (usa)" sha1="454e23c8922380f813a3a5b9d94902a691109332"/>
+				<disk name="mortal kombat (usa)" sha1="06fc7e387c193c28d1068cf74609de36021eca2b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2123,11 +2123,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Arena</publisher>
 		<info name="serial" value="T-81035"/>
-		<info name="release" value="199412xx" />
+		<info name="release" value="199412xx"/>
 		<info name="ring_code" value="CDAC-074200 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nba jam (usa)" sha1="48b0fdb2476ac795b303bfdc11b40abb8609511b"/>
+				<disk name="nba jam (usa)" sha1="fbc1d8fed4b78c9a51cc29fb9b7feee6959b3f7c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2142,11 +2142,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4202"/>
-		<info name="release" value="199310xx" />
+		<info name="release" value="199310xx"/>
 		<info name="ring_code" value="CDAC-054500 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl's greatest - san francisco vs dallas 1978-1993 (usa)" sha1="20fc574d1912b92dd9d6c248734a8e897501b3ea"/>
+				<disk name="nfl's greatest - san francisco vs dallas 1978-1993 (usa)" sha1="0300f0b0bcff68a2a9995d1752044a16c1077708"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2238,11 +2238,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="T-50015"/>
-		<info name="release" value="199309xx" />
+		<info name="release" value="199309xx"/>
 		<info name="ring_code" value="CDAC-056700 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl '94 (usa)" sha1="ac34c65117668dc53e7075a0dbe9bd260fdb1c15"/>
+				<disk name="nhl '94 (usa)" sha1="7cde2688a9157ecc18dab9a1ee76b93dc8ffdc8e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2270,16 +2270,16 @@ Requires [disc swap]
 		<!--<sharedfeat name="requirement" value="32x"/>-->
 		<info name="usage" value="Requires to be run with 32x_scd"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1" />
+			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="night trap (usa, 32x) (disc 1)" sha1="a4407b3264ef29d343f7d4b984194bc4636009d3"/>
+				<disk name="night trap (usa, 32x) (disc 1)" sha1="672776292563c691e5dbf76d216946292b72d195"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2" />
+			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="night trap (usa, 32x) (disc 2)" sha1="18b2a72bf91589ef43986b3f3add9b70c609f346"/>
+				<disk name="night trap (usa, 32x) (disc 2)" sha1="598a58f0aa08c797b4e89978d6cd960aa40dac94"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2300,19 +2300,19 @@ Requires [disc swap]
 Required [disc swap]
 ]]></notes>
 		<info name="serial" value="4903"/>
-		<info name="release" value="199211xx" />
+		<info name="release" value="199211xx"/>
 		<info name="ring_code" value="CDRM-1027400 5 (Disc 1) / CDRM-1027410 2, CDRM-1027410 1 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1" />
+			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="night trap (usa) (disc 1)" sha1="c2c18c6af2aae9619ca5772fcb6aecc79a142a40"/>
+				<disk name="night trap (usa) (disc 1)" sha1="ae4fa663362cd3f044a6df8a9930d3cf2708b63c"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2" />
+			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="night trap (usa) (disc 2)" sha1="41c44780c325403d9c4522fc3d010912fc3dad5a"/>
+				<disk name="night trap (usa) (disc 2)" sha1="47689dd1d5aabb428de2076a57da4e1f0e83eea6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2333,19 +2333,19 @@ Required [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="4903"/>
-		<info name="release" value="199211xx" />
+		<info name="release" value="199211xx"/>
 		<info name="ring_code" value="CDRM-1027400 3 (Disc 1) / CDRM-1027410 2, CDRM-1027410 1 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1" />
+			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
 				<disk name="night trap (usa, alt) (disc 1)" sha1="d5d21d92798661d67ab7247acc41ea6602721a0b"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2" />
+			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="night trap (usa) (disc 2)" sha1="41c44780c325403d9c4522fc3d010912fc3dad5a"/>
+				<disk name="night trap (usa) (disc 2)" sha1="47689dd1d5aabb428de2076a57da4e1f0e83eea6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2371,13 +2371,13 @@ Requires [disc swap]
 No support for Mega CD cart slots
 ]]></notes>
 		<info name="serial" value="T-574013, T-574016, T-574016-50"/>
-		<info name="release" value="20101214" />
+		<info name="release" value="20101214"/>
 		<info name="ring_code" value="Enhanced Soundtrack Disc WM WM 2234612235072235144* Enhanced Soundtrack Disc WM B"/>
 		<!--<sharedfeat name="requirement" value="megadriv -psolar"/>-->
 		<info name="usage" value="Requires to be run with megadriv psolar cart"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pier solar and the great architects enhanced soundtrack disc (world)" sha1="1f26cce723ef044f449d87cdb624a2937f40f5d9"/>
+				<disk name="pier solar and the great architects enhanced soundtrack disc (world)" sha1="05dcd8e5d8dba48ed612f8c737fcf9c3e9812e57"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2433,11 +2433,11 @@ No support for Mega CD cart slots
 		<year>1995</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="T-127035"/>
-		<info name="release" value="19950223" />
+		<info name="release" value="19950223"/>
 		<info name="ring_code" value="SEGAT127035RE R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="popful mail (usa)" sha1="459853983b1e01fe297ffd6287502eab1678e8e4"/>
+				<disk name="popful mail (usa)" sha1="b87c7ffd99dbd37e6a775f4edc296365b260deb3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2475,11 +2475,11 @@ No support for Mega CD cart slots
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4652"/>
-		<info name="release" value="199212xx" />
+		<info name="release" value="199212xx"/>
 		<info name="ring_code" value="CDAC-032200 6"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="prince of persia (usa)" sha1="fd9250f32c23e0954b197d1833c20de705df43d3"/>
+				<disk name="prince of persia (usa)" sha1="99b2084db168bbbbbd78d23b3a06754cdd89825f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2514,11 +2514,11 @@ No support for Mega CD cart slots
 		<year>1994</year>
 		<publisher>Psygnosis</publisher>
 		<info name="serial" value="T-113035"/>
-		<info name="release" value="19940106" />
+		<info name="release" value="19940106"/>
 		<info name="ring_code" value="CDAC-053800 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="puggsy (usa)" sha1="307206f9f4154699e9386fa9b45bd79d5ed72e5d"/>
+				<disk name="puggsy (usa)" sha1="421e43f3e792a7a27ef5ef168d875a26362c879b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2545,7 +2545,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="CDAC-055000 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="racing aces (usa)" sha1="a2038d4de56b75d61db6ad757919cca00cc91c95"/>
+				<disk name="racing aces (usa)" sha1="d6b269de0f919164fc12ede376a054b0a2dccee2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2568,7 +2568,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="SEGAT86025 R1F MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rdf - global conflict (usa)" sha1="32cf1e068598e385962db8de493eb191aab7716b"/>
+				<disk name="rdf - global conflict (usa)" sha1="b6922a240c56bd3a145b9aba9fb63d76985644e5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2589,7 +2589,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="SEGAT49035 R1C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="revenge of the ninja (usa)" sha1="d6f0a13f1b630ba771cad7c86b607f31cf6092b7"/>
+				<disk name="revenge of the ninja (usa)" sha1="1c7bce3382cc768ec788c8f652a2cac633cc9cc2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2610,7 +2610,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="S604430RE R1D MFD BY JVC, S604430RE R2D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rise of the dragon (usa, rev. a)" sha1="412d819633740c597b67591cf12fdac7c7081194"/>
+				<disk name="rise of the dragon (usa, rev. a)" sha1="62c5e2a43a07f50351eb84bdbe90330750537712"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2628,7 +2628,7 @@ No support for Mega CD cart slots
 		<year>1993</year>
 		<publisher>Dynamix</publisher>
 		<info name="serial" value="4301"/>
-		<info name="release" value="199303xx" />
+		<info name="release" value="199303xx"/>
 		<info name="ring_code" value="CDAC-040300 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2652,11 +2652,11 @@ No support for Mega CD cart slots
 Black screen, requires sub CPU to be overclocked by 1.5x
 ]]></notes>
 		<info name="serial" value="T-6207"/>
-		<info name="release" value="199303xx" />
+		<info name="release" value="199303xx"/>
 		<info name="ring_code" value="SEGA6207 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="road avenger (usa)" sha1="05fa6ae67687aacdf99fe939b0f04ce13b6d527b"/>
+				<disk name="road avenger (usa)" sha1="2de47da786a49e07232662e6a33cb2fb17004280"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2671,11 +2671,11 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<year>1995</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4442"/>
-		<info name="release" value="19950502" />
+		<info name="release" value="19950502"/>
 		<info name="ring_code" value="SEGA4442 R1J"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="saban's mighty morphin power rangers (usa)" sha1="fffd902d4ab06d946c47b7eaa40cc5ddd9963299"/>
+				<disk name="saban's mighty morphin power rangers (usa)" sha1="11b426d181c3e3099e4b29654fdf6ba3b19398f3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2700,7 +2700,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<description>Sega Classics Arcade Collection (USA, 4 in 1, alt)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="19921015" />
+		<info name="release" value="19921015"/>
 		<info name="ring_code" value="SEGA4126RE R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2732,7 +2732,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="ring_code" value="CDAC-056800 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sega classics arcade collection (usa, 5 in 1)" sha1="9f4bdadabba7d8998b701a3becd2520d4d2a037d"/>
+				<disk name="sega classics arcade collection (usa, 5 in 1)" sha1="3e86e8fa7c3f1252b68008711e2261ca40862608"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2746,7 +2746,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="T-6201"/>
-		<info name="release" value="199212xx" />
+		<info name="release" value="199212xx"/>
 		<info name="ring_code" value="CDRM-1033200 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2764,11 +2764,11 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<year>1992</year>
 		<publisher>Sony Imagesoft</publisher>
 		<info name="serial" value="T-6201"/>
-		<info name="release" value="199212xx" />
+		<info name="release" value="199212xx"/>
 		<info name="ring_code" value="CDRM-1033200 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sewer shark (usa, rev. a)" sha1="0f339806d73c473c20906935836d49457339430f"/>
+				<disk name="sewer shark (usa, rev. a)" sha1="516b1db245a680afc0cb3220a1b255e80453be5d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2784,7 +2784,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4101"/>
-		<info name="release" value="199212xx" />
+		<info name="release" value="199212xx"/>
 		<info name="ring_code" value="610-5574P-00086 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2803,7 +2803,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<description>Sewer Shark (USA, rev. B, alt)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="199212xx" />
+		<info name="release" value="199212xx"/>
 		<info name="ring_code" value="CDRM-1095270 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2822,7 +2822,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<description>Sewer Shark (USA, rev. B, alt 2)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="199212xx" />
+		<info name="release" value="199212xx"/>
 		<info name="ring_code" value="CDRM-1095270 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2841,12 +2841,12 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<description>Sherlock Holmes - Consulting Detective Vol. I (USA)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="alt_title" value="Sherlock Holmes - Consulting Detective (Box)" />
-		<info name="release" value="19921015" />
+		<info name="alt_title" value="Sherlock Holmes - Consulting Detective (Box)"/>
+		<info name="release" value="19921015"/>
 		<info name="ring_code" value="CDAC-031300 1, CDAC-031300 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sherlock holmes - consulting detective vol. i (usa)" sha1="32d2f47f459927cd162376e46d6a02430572a82a"/>
+				<disk name="sherlock holmes - consulting detective vol. i (usa)" sha1="d295f474b188f7121282d92c17c952b9a907d02d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2868,19 +2868,19 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="4653"/>
-		<info name="release" value="199305xx" />
+		<info name="release" value="199305xx"/>
 		<info name="ring_code" value="CDAC-041000 1 (Disc 1), CDAC-041100 2 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1" />
+			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
-				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 1)" sha1="162af0ed791b8a18040ecb3925984a738dc72d49"/>
+				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 1)" sha1="470ca1a64ed2e3a3b664cdda8d685e2eaf2577ab"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2" />
+			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
-				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 2)" sha1="3de4f89de8920185197d8a65f0ea97a83e774a98"/>
+				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 2)" sha1="5b963168f6476a4e0f43050543ed6f0ffbd9dc38"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2981,7 +2981,7 @@ Requires [disc swap]
 		<info name="ring_code" value="3/95 6RA3 1008604656, 3/95 5RA1 1008604656"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="shining force cd (usa, alt)" sha1="ddb304849d01df44251d69b890df47c8db1d8642"/>
+				<disk name="shining force cd (usa, alt)" sha1="d6c24f360b8845e783d76f9a9af527ddf025ed08"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3002,11 +3002,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4423"/>
-		<info name="release" value="199310xx" />
+		<info name="release" value="199310xx"/>
 		<info name="ring_code" value="SEGA4423 R2D MFD BY JVC, SEGA4423RE R2D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="silpheed (usa)" sha1="f4d368f13f7998fb8d37c9a3439d42497e0ee359"/>
+				<disk name="silpheed (usa)" sha1="2d172387631ddcb056d8547a4a38b29721771c17"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3036,28 +3036,28 @@ Requires [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="T-162035"/>
-		<info name="release" value="199411xx" />
+		<info name="release" value="199411xx"/>
 		<info name="ring_code" value="GW 02711.1 RE-1 SRCR##01 (Disc 1) / GW 02711.2 RE-1 SRCR**01 (Disc 2) / GW 02711.3 RE-1 SRCR##01 (Disc 3) / GW 02711.4 RE-1 SRCR##01 (Disc 4)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1 - Fingers" />
+			<feature name="part_id" value="Disc 1 - Fingers"/>
 			<diskarea name="cdrom1">
 				<disk name="slam city with scottie pippen (usa, alt) (disc 1)" sha1="637ceb49d6e9ff89009b26d848b6097a54969d65"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2 - Juice" />
+			<feature name="part_id" value="Disc 2 - Juice"/>
 			<diskarea name="cdrom2">
 				<disk name="slam city with scottie pippen (usa, alt) (disc 2)" sha1="e5cc52a7686824b14ee471682f30b0b4a09dbe97"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 3 - Mad Dog" />
+			<feature name="part_id" value="Disc 3 - Mad Dog"/>
 			<diskarea name="cdrom3">
 				<disk name="slam city with scottie pippen (usa, alt) (disc 3)" sha1="6d144435110bc0fcd97313c75dbb56f472e4e123"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 4 - Smash" />
+			<feature name="part_id" value="Disc 4 - Smash"/>
 			<diskarea name="cdrom4">
 				<disk name="slam city with scottie pippen (usa, alt) (disc 4)" sha1="ddffdf4dd92fcb3f93f285ff24384815ba401cab"/>
 			</diskarea>
@@ -3093,11 +3093,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-95035"/>
-		<info name="release" value="19941130" />
+		<info name="release" value="19941130"/>
 		<info name="ring_code" value="T95035-U12 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="snatcher (usa)" sha1="815edc5df272e4b10edd5919b29c3a996a1799c2"/>
+				<disk name="snatcher (usa)" sha1="d38ada693efc354c1d3c4c663214ab173985bf95"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3128,11 +3128,11 @@ Requires [disc swap]
 		<description>Sol-Feace (USA)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="19921015" />
+		<info name="release" value="19921015"/>
 		<info name="ring_code" value="SEGA4130RE2 R3C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sol-feace (usa)" sha1="498ebd9c1fe4bd2f84cf6c32829b68e471eb3b07"/>
+				<disk name="sol-feace (usa)" sha1="ba813d3b0dfa00092dbdb7e323755953a2a60d85"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3180,8 +3180,8 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4407"/>
-		<info name="alt_title" value="Sonic CD (Box)" />
-		<info name="release" value="19931119" />
+		<info name="alt_title" value="Sonic CD (Box)"/>
+		<info name="release" value="19931119"/>
 		<info name="ring_code" value="SEGA4407 R1C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -3233,12 +3233,12 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4407"/>
-		<info name="alt_title" value="Sonic CD (Box)" />
-		<info name="release" value="19931119" />
+		<info name="alt_title" value="Sonic CD (Box)"/>
+		<info name="release" value="19931119"/>
 		<info name="ring_code" value="SEGA4407RE125 R7D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sonic cd (usa, alt)" sha1="a8a968a6239da07c6143dd420a6a3093f4dddcd2"/>
+				<disk name="sonic cd (usa, alt)" sha1="1645128fc656aaba3ea5da176e5430ef9e65a05e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3286,8 +3286,8 @@ Requires [disc swap]
 		<description>Sonic the Hedgehog CD (USA, alt 2)</description>
 		<year>1993</year>
 		<publisher>Sega</publisher>
-		<info name="alt_title" value="Sonic CD (Box)" />
-		<info name="release" value="19931119" />
+		<info name="alt_title" value="Sonic CD (Box)"/>
+		<info name="release" value="19931119"/>
 		<info name="ring_code" value="SEGA4407RE125 R8C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -3321,11 +3321,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Core Design</publisher>
 		<info name="serial" value="T-115035"/>
-		<info name="release" value="199409xx" />
+		<info name="release" value="199409xx"/>
 		<info name="ring_code" value="SEGAT115035 R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="soulstar (usa)" sha1="4e2ab5b51dca2a4c23700b4d3587a9a08ac6d29f"/>
+				<disk name="soulstar (usa)" sha1="43c5e634d37ab2dde53ad1387d5ebfbc8320a6d7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3343,7 +3343,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-080300 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space ace (usa)" sha1="d5f5125af3e9e59a59f775576ddc99b4aadaf505"/>
+				<disk name="space ace (usa)" sha1="2e158a2e79162324b70bca7a115068f0b5c6a675"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3358,11 +3358,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-60075"/>
-		<info name="release" value="199403xx" />
+		<info name="release" value="199403xx"/>
 		<info name="ring_code" value="SEGAT60075 R1D MFD BY JVC, SEGAT60075 R2C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star wars - rebel assault (usa)" sha1="f1049ddf315f3a9ecd29378bc026a05669120112"/>
+				<disk name="star wars - rebel assault (usa)" sha1="12d3691a5d48863343929bae82e444a58b66d567"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3380,7 +3380,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-073400 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="starblade (usa)" sha1="6233ca426d0797a5bccf98261b5164c44feb5203"/>
+				<disk name="starblade (usa)" sha1="5764dd497e86326a581891a7a3e6f9723788a0d0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3414,11 +3414,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Dynamix</publisher>
 		<info name="serial" value="T-110025"/>
-		<info name="release" value="199312xx" />
+		<info name="release" value="199312xx"/>
 		<info name="ring_code" value="SEGAT11025 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="stellar-fire (usa)" sha1="4e0245e30cac825c262551eda322eb774919e87b"/>
+				<disk name="stellar-fire (usa)" sha1="a5248d49dbc38491239e9905e9b8129ff8952691"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3460,7 +3460,7 @@ Requires [disc swap]
 		<info name="ring_code" value="1008604432 7/95 1RA2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the adventures of batman and robin (usa)" sha1="80e65ec95ea9440e59d64ea067b48921686006e8"/>
+				<disk name="the adventures of batman and robin (usa)" sha1="1fd748ba4a759ca4bd6d4b5962e17ce3ee06934f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3517,7 +3517,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4412"/>
-		<info name="release" value="199306xx" />
+		<info name="release" value="199306xx"/>
 		<info name="ring_code" value="CDAC-047100 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -3561,11 +3561,11 @@ Requires [disc swap]
 		<year>1992</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-60035"/>
-		<info name="release" value="199212xx" />
+		<info name="release" value="199212xx"/>
 		<info name="ring_code" value="SEGAT60035RE R1C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the secret of monkey island (usa)" sha1="a894a9e6ba908f742d686fb85b7ae3c700fb1d36"/>
+				<disk name="the secret of monkey island (usa)" sha1="1f90af90c880bad8e9acf6c0f2fa10000072abbe"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3580,7 +3580,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>The Software Toolworks</publisher>
 		<info name="serial" value="T-87035"/>
-		<info name="release" value="199405xx" />
+		<info name="release" value="199405xx"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="star wars chess (usa)" sha1="fe03505a7c2f1ebdef4d2c32c8b73677288d635b"/>
@@ -3606,11 +3606,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Virgin Games</publisher>
 		<info name="serial" value="T-70015"/>
-		<info name="release" value="199306xx" />
+		<info name="release" value="199306xx"/>
 		<info name="ring_code" value="SEGACD86003 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the terminator (usa)" sha1="43bf02bf06fc5d1bd32bc61b11acd1745d2d7a1d"/>
+				<disk name="the terminator (usa)" sha1="47c82ce49c926d3b381a46aa4505bcc03737abb4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3625,11 +3625,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Renovation</publisher>
 		<info name="serial" value="T-6214"/>
-		<info name="release" value="199305xx" />
+		<info name="release" value="199305xx"/>
 		<info name="ring_code" value="SEGAT49025 R2C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="time gal (usa)" sha1="22c4bc9adb5560c276f0fe88967e04bf279d54d0"/>
+				<disk name="time gal (usa)" sha1="268978a58bbf09a21e14c01534ac4f90fe55df5e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3644,7 +3644,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4429"/>
-		<info name="release" value="199403xx" />
+		<info name="release" value="199403xx"/>
 		<info name="ring_code" value="1008604429 9/95 1RA1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -3704,7 +3704,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT127025ARE R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vay (usa)" sha1="099e4c43d8ca5eb57854db25cbcbfc3139e41a9e"/>
+				<disk name="vay (usa)" sha1="2ce0a42e3fd56bf266b340dc9c2d2eab876845b4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3728,7 +3728,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-077500 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wheel of fortune (usa)" sha1="1c48a4dd3d70ed9d4450aea57bb5dc671e5c4a4c"/>
+				<disk name="wheel of fortune (usa)" sha1="a07fb24ca8d88b47d93ffca555a18d46afd54ee4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3746,7 +3746,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT111045 R1H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="who shot johnny rock (usa)" sha1="dc9675c0bfc19baae5be13ce1540062c09b930f3"/>
+				<disk name="who shot johnny rock (usa)" sha1="f6b657ae449bc9c39bd3c126e2371bdfa161b251"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3765,11 +3765,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="T-50045"/>
-		<info name="release" value="199302xx" />
+		<info name="release" value="199302xx"/>
 		<info name="ring_code" value="CDAC-059000 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wing commander (usa)" sha1="d36f61f84a87518691438a3c4f9862b2ce23e483"/>
+				<disk name="wing commander (usa)" sha1="4e4785c0fa94af17183bb12a7646fd2a01ba52b6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3787,7 +3787,7 @@ Requires [disc swap]
 		<info name="ring_code" value="1008604437 8/95 1RA2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wirehead (usa)" sha1="762bb917b936f1a781a2fbe66bbe3a9bf5dd5d43"/>
+				<disk name="wirehead (usa)" sha1="d5e5059d5b932655f0674de725957329761f3f24"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3821,7 +3821,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT79025 R2D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="world cup usa 94 (usa)" sha1="cb17c8ea42ec3a7d9562a0e188610a687f6b8829"/>
+				<disk name="world cup usa 94 (usa)" sha1="2d2040e8700b4e43d56f60e29af5879454077eef"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3836,11 +3836,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Arena</publisher>
 		<info name="serial" value="T-81015"/>
-		<info name="release" value="199311xx" />
+		<info name="release" value="199311xx"/>
 		<info name="ring_code" value="SEGAT81015 R3D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf rage in the cage (usa)" sha1="960a6ffa31b52e7ca8e7759f3d385940c8f2eb56"/>
+				<disk name="wwf rage in the cage (usa)" sha1="be3a229bc592d3c7d9da76a9294e469d174a4fcf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3873,8 +3873,8 @@ Requires [disc swap]
 		<description>Bari-Arm (USA)</description>
 		<year>1994</year>
 		<publisher>Sega</publisher>
-		<info name="alt_title" value="Android Assault - The Revenge of Bari-Arm (Box)" />
-		<info name="release" value="199410xx" />
+		<info name="alt_title" value="Android Assault - The Revenge of Bari-Arm (Box)"/>
+		<info name="release" value="199410xx"/>
 		<info name="serial" value="4445"/>
 		<info name="ring_code" value="T-163015-00"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -3972,7 +3972,7 @@ Requires [disc swap]
 		<description>Black Hole Assault (USA, alt)</description>
 		<year>1993</year>
 		<publisher>Bignet</publisher>
-		<info name="alt_title" value="Blackhole Assault (Box)" />
+		<info name="alt_title" value="Blackhole Assault (Box)"/>
 		<info name="serial" value="T-6401"/>
 		<info name="ring_code" value="CDAC-031700 2"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -3997,7 +3997,7 @@ Requires [disc swap]
 		<description>The Exterminators (USA, prototype)</description>
 		<year>2001</year>
 		<publisher>Good Deal Games</publisher>
-		<info name="alt_title" value="Bug Blasters - The Exterminators (Box)" />
+		<info name="alt_title" value="Bug Blasters - The Exterminators (Box)"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the exterminators (usa, prototype)" sha1="9c1e73e31c90d2cfdff50dce0e2c95c562934d96"/>
@@ -4020,7 +4020,7 @@ Requires [disc swap]
 		<description>The Exterminators - Special Edition (USA, prototype)</description>
 		<year>2003</year>
 		<publisher>Good Deal Games</publisher>
-		<info name="alt_title" value="Bug Blasters - The Exterminators (Box)" />
+		<info name="alt_title" value="Bug Blasters - The Exterminators (Box)"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the exterminators - special edition (usa, prototype)" sha1="cb14ae1bf6825ac804a5508142759ff64d1d5b70"/>
@@ -4036,7 +4036,7 @@ Requires [disc swap]
 		<description>C+C Music Factory (USA)</description>
 		<year>1993</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="alt_title" value="Power Factory featuring C+C Music Factory (Box)" />
+		<info name="alt_title" value="Power Factory featuring C+C Music Factory (Box)"/>
 		<info name="serial" value="T-93035"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4126,7 +4126,7 @@ Requires [disc swap]
 		<description>Corpse Killer (USA)</description>
 		<year>1994</year>
 		<publisher>Digital Pictures</publisher>
-		<info name="release" value="199411xx" />
+		<info name="release" value="199411xx"/>
 		<info name="serial" value="T-162055"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4159,7 +4159,7 @@ Requires [disc swap]
 		<description>Dune (USA)</description>
 		<year>1994</year>
 		<publisher>Virgin Interactive</publisher>
-		<info name="release" value="199312xx" />
+		<info name="release" value="199312xx"/>
 		<info name="serial" value="T-70065"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4205,7 +4205,7 @@ Requires [disc swap]
 		<description>ESPN National Hockey Night (USA)</description>
 		<year>1994</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199411xx" />
+		<info name="release" value="199411xx"/>
 		<info name="serial" value="T-93215"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4263,7 +4263,7 @@ Requires [disc swap]
 		<description>Force Striker (USA, prototype)</description>
 		<year>2006</year>
 		<publisher>Good Deal Games</publisher>
-		<info name="alt_title" value="Burning Fists - Force Striker (Box)" />
+		<info name="alt_title" value="Burning Fists - Force Striker (Box)"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="force striker (usa, prototype)" sha1="593892565e8ba7df9204128bd7bc36e72f92b803"/>
@@ -4308,13 +4308,13 @@ Requires [disc swap]
 		<info name="serial" value="T-93145"/>
 		<info name="ring_code" value="CDAC-053300 2 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1" />
+			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom1">
 				<disk name="ground zero texas (usa, alt) (disc 1)" sha1="cb019a26b3edec7a8f0119d74a0991aa5b258313"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2" />
+			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom2">
 				<disk name="ground zero texas (usa, alt) (disc 2)" sha1="4b3ebe516e2047d4df38590e0badf372262fa435"/>
 			</diskarea>
@@ -4369,7 +4369,7 @@ Requires [disc swap]
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="MK-4129 / OPCD-1630"/>
-		<info name="release" value="19921015" />
+		<info name="release" value="19921015"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hot hits - adventurous new music sampler (usa)" sha1="0a83a39a37faf3f7338d7926ac3e22471319a433"/>
@@ -4414,7 +4414,7 @@ Requires [disc swap]
 		<description>Jaguar XJ220 (USA)</description>
 		<year>1993</year>
 		<publisher>JVC</publisher>
-		<info name="release" value="199303xx" />
+		<info name="release" value="199303xx"/>
 		<info name="serial" value="T-6406"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4538,7 +4538,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>The Software Toolworks</publisher>
 		<info name="serial" value="T-87025"/>
-		<info name="release" value="199312xx" />
+		<info name="release" value="199312xx"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="megarace (usa)" sha1="d60afc89afa7de225f42deb3fac894f9202061b5"/>
@@ -4613,7 +4613,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="T-50035"/>
-		<info name="release" value="199401xx" />
+		<info name="release" value="199401xx"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="powermonger (usa)" sha1="0e281e66912a9d38edfd06bdee836ce8dba06244"/>
@@ -4641,14 +4641,14 @@ Requires [disc swap]
 		<info name="serial" value="MK-4206"/>
 		<info name="ring_code" value="CDAC-052700 2 (Disc 1)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1" />
+			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
 				<disk name="prize fighter (usa) (disc 1)" sha1="37742af63ba540380b8285a1e82be8d1898914e6"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2" />
+			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
 				<disk name="prize fighter (usa) (disc 2)" sha1="46f731d613d08eba5534331ce85fb5bab1e1b387"/>
 			</diskarea>
@@ -4736,7 +4736,7 @@ Requires [disc swap]
 		<year>1995</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-60175"/>
-		<info name="release" value="199501xx" />
+		<info name="release" value="199501xx"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="samurai shodown (usa)" sha1="5b12e3cea8f93635f25e98b184c68f6921e395d8"/>
@@ -4764,7 +4764,7 @@ Requires [disc swap]
 		<description>Sega Classics Arcade Collection (USA, 4 in 1)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="19921015" />
+		<info name="release" value="19921015"/>
 		<info name="ring_code" value="SEGA-4126RE2 R1C"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4798,31 +4798,31 @@ Requires [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="T-162035"/>
-		<info name="release" value="199411xx" />
+		<info name="release" value="199411xx"/>
 		<info name="ring_code" value="GW 02711.1 (Disc 1) / GW 02711.2 (Disc 2) / GW 02711.3 (Disc 3) / GW 02711.4 (Disc 4)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1 - Fingers" />
+			<feature name="part_id" value="Disc 1 - Fingers"/>
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa) (disc 1)" sha1="e458f2e459cb097ed32ea27ffaa7ab5cc47c9a18"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2 - Juice" />
+			<feature name="part_id" value="Disc 2 - Juice"/>
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa) (disc 2)" sha1="d900b5e5dcb904530edc089ce376d53ce404d6ec"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom3" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 3 - Mad Dog" />
+			<feature name="part_id" value="Disc 3 - Mad Dog"/>
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa) (disc 3)" sha1="11bfe9ce5081785bb8e9cbc0e9bd65c7605e817e"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom4" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 4 - Smash" />
+			<feature name="part_id" value="Disc 4 - Smash"/>
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa) (disc 4)" sha1="010bc11b7d8a078bbdd869ae7c7bf7ebfe04c916"/>
 			</diskarea>
@@ -4859,28 +4859,28 @@ Requires [disc swap]
 		<!-- <sharedfeat name="requirement" value="32x"/> -->
 		<info name="usage" value="Requires to be run with 32x_scd"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1 - Fingers" />
+			<feature name="part_id" value="Disc 1 - Fingers"/>
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa, 32x) (disc 1)" sha1="c0563dec08e2e89e42705d324b39f78b0056dcd5"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2 - Juice" />
+			<feature name="part_id" value="Disc 2 - Juice"/>
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa, 32x) (disc 2)" sha1="21044739e37a7faf11dd21e633d64c0f817f991b"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom3" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 3 - Mad Dog" />
+			<feature name="part_id" value="Disc 3 - Mad Dog"/>
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa, 32x) (disc 3)" sha1="cc4a4c7c64c16a0f8ce3d8a4d82e94d11466a769"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom4" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 4 - Smash" />
+			<feature name="part_id" value="Disc 4 - Smash"/>
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa, 32x) (disc 4)" sha1="6432d3447cb2be5e39fb79b69833dd80e4587c6c"/>
 			</diskarea>
@@ -4919,7 +4919,7 @@ Requires [disc swap]
 		<publisher>Good Deal Games</publisher>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star strike (usa, prototype)" sha1="65552aa20d2b799083fc4d27efc590fe91aa77af" />
+				<disk name="star strike (usa, prototype)" sha1="65552aa20d2b799083fc4d27efc590fe91aa77af"/>
 			</diskarea>
 		</part>
 	</software>
@@ -4941,16 +4941,16 @@ Requires [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="T-162045"/>
-		<info name="alt_title" value="Supreme Warrior - Ying Heung (Box)" />
+		<info name="alt_title" value="Supreme Warrior - Ying Heung (Box)"/>
 		<info name="ring_code" value="GW 02411.1 RE-1 (Disc 1), GW 02411.2 RE-1 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1 - Fire and Earth" />
+			<feature name="part_id" value="Disc 1 - Fire and Earth"/>
 			<diskarea name="cdrom">
 				<disk name="supreme warrior (usa) (disc 1)" sha1="dbdc3fcdee8c590401a815662878476632f42cf0"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2 - Wind and Tang Fu" />
+			<feature name="part_id" value="Disc 2 - Wind and Tang Fu"/>
 			<diskarea name="cdrom">
 				<disk name="supreme warrior (usa) (disc 2)" sha1="00344d23da869e465c322e154c9babf219271e49"/>
 			</diskarea>
@@ -4976,17 +4976,17 @@ Requires [32X] add-on
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="T-16203F"/>
-		<info name="alt_title" value="Supreme Warrior - Ying Heung (Box)" />
+		<info name="alt_title" value="Supreme Warrior - Ying Heung (Box)"/>
 		<!-- <sharedfeat name="requirement" value="32x"/> -->
 		<info name="usage" value="Requires to be run with 32x_scd"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1 - Fire and Earth" />
+			<feature name="part_id" value="Disc 1 - Fire and Earth"/>
 			<diskarea name="cdrom">
 				<disk name="supreme warrior (usa, 32x) (disc 1)" sha1="a9afa96f2300e19777724404909d4f204199f342"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2 - Wind and Tang Fu" />
+			<feature name="part_id" value="Disc 2 - Wind and Tang Fu"/>
 			<diskarea name="cdrom">
 				<disk name="supreme warrior (usa, 32x) (disc 2)" sha1="e99f121209bac853d9e0d88a1a395354b264ebd5"/>
 			</diskarea>
@@ -5115,7 +5115,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Extreme Entertainment Group</publisher>
 		<info name="serial" value="T-22025"/>
-		<info name="alt_title" value="Third World War (Box)" />
+		<info name="alt_title" value="Third World War (Box)"/>
 		<info name="ring_code" value="AE01941 R1C"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -5156,7 +5156,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="T-89015"/>
-		<info name="alt_title" value="Trivial Pursuit - Interactive Multimedia Game (Box)" />
+		<info name="alt_title" value="Trivial Pursuit - Interactive Multimedia Game (Box)"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="trivial pursuit (usa)" sha1="2e23b0b05b67fe4f30286448f030a391b9da9e9b"/>
@@ -5276,7 +5276,7 @@ Requires [disc swap]
 		<year>1992</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-6402"/>
-		<info name="release" value="199211xx" />
+		<info name="release" value="199211xx"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="wonder dog (usa)" sha1="dbb8d538de584c38f0d0217777d091b593e27999"/>
@@ -5295,7 +5295,7 @@ Requires [disc swap]
 		<description>BC Racers (USA)</description>
 		<year>1994</year>
 		<publisher>Core Design</publisher>
-		<info name="release" value="199412xx" />
+		<info name="release" value="199412xx"/>
 		<info name="serial" value="T-115075"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -5393,7 +5393,7 @@ Requires [disc swap]
 		<info name="serial" value="T-118025"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="compton's interactive encyclopedia v2.01s (usa)" sha1="79ca6bb38c296ac3cc6352823be337371ad7a396" />
+				<disk name="compton's interactive encyclopedia v2.01s (usa)" sha1="79ca6bb38c296ac3cc6352823be337371ad7a396"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5409,7 +5409,7 @@ Requires [disc swap]
 		<publisher>American Laser Games</publisher>
 		<info name="serial" value="T-111055"/>
 		<part name="cdrom" interface="scd_cdrom">
-			<feature name="peripheral" value="menacer" />
+			<feature name="peripheral" value="menacer"/>
 			<diskarea name="cdrom">
 				<disk name="crime patrol (usa)" sha1="544f2ac30e49c141d5a185a30c80b2ee51f12fd1"/>
 			</diskarea>
@@ -5538,14 +5538,14 @@ Requires [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1" />
+			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom1">
 				<disk name="johnny mnemonic (usa, prototype) (disc 1)" sha1="bd222aee2d7ebaf9524db3fc3cbc3d9782504d92" status="baddump"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2" />
+			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom2">
 				<disk name="johnny mnemonic (usa, prototype) (disc 2)" sha1="e2f626d382b861043fbedddacf948d59cce1f290" status="baddump"/>
 			</diskarea>
@@ -5582,7 +5582,7 @@ Requires [disc swap]
 		<info name="serial" value="ACDG-GP1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="karaoke - jvc cd+g karaoke - top hit sampler (usa)" sha1="e969df346a8106b837b471cc87670b6aab981ec3" status="baddump" />
+				<disk name="karaoke - jvc cd+g karaoke - top hit sampler (usa)" sha1="e969df346a8106b837b471cc87670b6aab981ec3" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5597,7 +5597,7 @@ Requires [disc swap]
 		<year>1995</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-60185"/>
-		<info name="release" value="199501xx" />
+		<info name="release" value="199501xx"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="keio flying squadron (usa)" sha1="4e47afd43c13ae481dd159fd6e0f2fc4d180a211"/>
@@ -5644,7 +5644,7 @@ Requires [disc swap]
 		<description>My Paint (USA)</description>
 		<year>1993</year>
 		<publisher>Saddleback Graphics</publisher>
-		<info name="alt_title" value="My Paint - The Animated Paint Program (Box)" />
+		<info name="alt_title" value="My Paint - The Animated Paint Program (Box)"/>
 		<info name="serial" value="T-109015"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -5688,13 +5688,13 @@ Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="T-162105"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1" />
+			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
 				<disk name="night trap (usa, re-release) (disc 1)" sha1="69cd893b1b2d971da405cac1c4c71114e8a91648"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2" />
+			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
 				<disk name="night trap (usa, re-release) (disc 2)" sha1="d8447c507abf9b7afc64b943fa3b4f794ddf25f1"/>
 			</diskarea>
@@ -5711,7 +5711,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Data East</publisher>
 		<info name="serial" value="T-13015"/>
-		<info name="release" value="199406xx" />
+		<info name="release" value="199406xx"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="panic (usa)" sha1="44216917d5e42f131c0854cd8fb5066f5e39c87f"/>
@@ -5729,13 +5729,13 @@ Requires [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1" />
+			<feature name="part_id" value="Disc 1"/>
 			<diskarea name="cdrom">
 				<disk name="penn and teller's smoke and mirrors (usa, prototype) (disc 1)" sha1="01d82d2f767df776c55fc49fe0bfe22132fc9e40" status="baddump"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2" />
+			<feature name="part_id" value="Disc 2"/>
 			<diskarea name="cdrom">
 				<disk name="penn and teller's smoke and mirrors (usa, prototype) (disc 2)" sha1="f7c989041a9775f525287981ed6eae778c5bd5b6" status="baddump"/>
 			</diskarea>
@@ -5786,7 +5786,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Tengen</publisher>
 		<info name="serial" value="T-48015"/>
-		<info name="release" value="199308xx" />
+		<info name="release" value="199308xx"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="robo aleste (usa)" sha1="16f734ed901182e0e435e6c2b4f559e99615f148"/>
@@ -5809,10 +5809,10 @@ Requires [disc swap]
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="MK-4128 / WCM-9201"/>
-		<info name="release" value="19921015" />
+		<info name="release" value="19921015"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rock paintings (usa)" sha1="614f3f8e89e4b91923ff69719c38baef679f8e8d" status="baddump" />
+				<disk name="rock paintings (usa)" sha1="614f3f8e89e4b91923ff69719c38baef679f8e8d" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>
@@ -5941,7 +5941,7 @@ Requires [disc swap]
 		<year>1995</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="T-143015"/>
-		<info name="alt_title" value="The Space Adventure (Box)" />
+		<info name="alt_title" value="The Space Adventure (Box)"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the space adventure - cobra the legendary bandit (usa)" sha1="51a755087713cc945adf5d5e85da713343ea3a0e"/>
@@ -5986,7 +5986,7 @@ Requires [disc swap]
 		<year>1992</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-6403"/>
-		<info name="release" value="199212xx" />
+		<info name="release" value="199212xx"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="wolfchild (usa)" sha1="700228109f9fe28bd5af6525c9fe0354913e1c6a"/>

--- a/hash/segacd.xml
+++ b/hash/segacd.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
@@ -273,7 +273,7 @@ See: http://rawdump.net/
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4415"/>
-		<info name="release" value="199303xx"/>
+		<info name="release" value="199303xx" />
 		<info name="ring_code" value="CDAC-040200 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -301,12 +301,12 @@ See: http://rawdump.net/
 		<description>AH3 - ThunderStrike (USA)</description>
 		<year>1993</year>
 		<publisher>JVC</publisher>
-		<info name="release" value="199310xx"/>
+		<info name="release" value="199310xx" />
 		<info name="serial" value="T-60055"/>
 		<info name="ring_code" value="SEGAT60055RE R2D MFD BY JVC, SEGAT60055 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ah3 - thunderstrike (usa)" sha1="465b952a84ff0e59a696356946cf4b25274c3a89"/>
+				<disk name="ah3 - thunderstrike (usa)" sha1="46d352674119dabf0728a07dc7354b54fe5a027b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -339,7 +339,7 @@ See: http://rawdump.net/
 		<description>Batman Returns (USA)</description>
 		<year>1993</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="199303xx"/>
+		<info name="release" value="199303xx" />
 		<info name="serial" value="4401"/>
 		<info name="ring_code" value="CDAC-040500 1"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -406,12 +406,12 @@ See: http://rawdump.net/
 		<description>Battlecorps (USA)</description>
 		<year>1994</year>
 		<publisher>Core Design</publisher>
-		<info name="release" value="199404xx"/>
+		<info name="release" value="199404xx" />
 		<info name="serial" value="T-115045"/>
 		<info name="ring_code" value="SEGAT115045 R1H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battlecorps (usa)" sha1="4f489e565e3c7c3a5a4cd1d00bc5acac406da06b"/>
+				<disk name="battlecorps (usa)" sha1="6ea60ddc9064f7aa770ea87f2fb2ff438793c037"/>
 			</diskarea>
 		</part>
 	</software>
@@ -478,7 +478,7 @@ See: http://rawdump.net/
 		<description>Black Hole Assault (USA)</description>
 		<year>1993</year>
 		<publisher>Bignet</publisher>
-		<info name="alt_title" value="Blackhole Assault (Box)"/>
+		<info name="alt_title" value="Blackhole Assault (Box)" />
 		<info name="serial" value="PN-6400"/>
 		<info name="ring_code" value="CDAC-031700 1"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -504,7 +504,7 @@ See: http://rawdump.net/
 		<description>Bouncers (USA)</description>
 		<year>1994</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="199412xx"/>
+		<info name="release" value="199412xx" />
 		<info name="serial" value="4908"/>
 		<info name="ring_code" value="CDAC 082400 1"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -528,7 +528,7 @@ See: http://rawdump.net/
 		<description>Bram Stoker's Dracula (USA)</description>
 		<year>1992</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199311xx"/>
+		<info name="release" value="199311xx" />
 		<info name="serial" value="T-93065"/>
 		<info name="ring_code" value="CDAC-020100 4"/>  <!-- Possibly CDAC-050100 4 -->
 		<part name="cdrom" interface="scd_cdrom">
@@ -552,7 +552,7 @@ See: http://rawdump.net/
 		<description>Bram Stoker's Dracula (USA, alt)</description>
 		<year>1992</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199311xx"/>
+		<info name="release" value="199311xx" />
 		<info name="serial" value="T-60064"/>
 		<info name="ring_code" value="CDAC-050100 1"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -576,7 +576,7 @@ See: http://rawdump.net/
 		<description>Bram Stoker's Dracula (USA, rev. A)</description>
 		<year>1992</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199311xx"/>
+		<info name="release" value="199311xx" />
 		<info name="serial" value="T-93155"/>
 		<info name="ring_code" value="CDAC-068700 1"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -608,7 +608,7 @@ See: http://rawdump.net/
 		<description>Brutal - Paws of Fury (USA)</description>
 		<year>1994</year>
 		<publisher>GameTek</publisher>
-		<info name="release" value="199403xx"/>
+		<info name="release" value="199403xx" />
 		<info name="serial" value="T-83015"/>
 		<info name="ring_code" value="SEGAT830155 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -636,7 +636,7 @@ See: http://rawdump.net/
 		<description>Chuck Rock (USA)</description>
 		<year>1992</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199301xx"/>
+		<info name="release" value="199301xx" />
 		<info name="serial" value="T-6204"/>
 		<info name="ring_code" value="CDAC-032500 5"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -689,12 +689,12 @@ See: http://rawdump.net/
 		<description>Cliffhanger (USA)</description>
 		<year>1993</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199311xx"/>
+		<info name="release" value="199311xx" />
 		<info name="serial" value="T-93075"/>
 		<info name="ring_code" value="CDAC-053600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cliffhanger (usa)" sha1="4aca3b3e186015ffb0794e2c83762cbc2457eaec"/>
+				<disk name="cliffhanger (usa)" sha1="71753bdebddc8de1f9920f19e06a7858a470f286"/>
 			</diskarea>
 		</part>
 	</software>
@@ -709,11 +709,11 @@ See: http://rawdump.net/
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4402"/>
-		<info name="release" value="199211xx"/>
+		<info name="release" value="199211xx" />
 		<info name="ring_code" value="CDAC-031400 5"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cobra command (usa)" sha1="53d79a6fe72bb5328c52328a135a9c5725170f03"/>
+				<disk name="cobra command (usa)" sha1="2d7c32591cec389f6d5feb5f0301495ff8021307"/>
 			</diskarea>
 		</part>
 	</software>
@@ -755,7 +755,7 @@ Requires [32X] add-on
 		<info name="usage" value="Requires to be run with 32x_scd"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="corpse killer (usa, 32x)" sha1="2d8721e835e58b6c850b43fe2d76382d1bbf59f7"/>
+				<disk name="corpse killer (usa, 32x)" sha1="68a6c75bc730025e90fa413c107090e7f4e377e0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -783,7 +783,7 @@ Requires [32X] add-on
 		<info name="ring_code" value="CDAC-059200 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dark wizard (usa)" sha1="a7f15287245e324bb1338ddf436a4d615618830b"/>
+				<disk name="dark wizard (usa)" sha1="cf784af53b6dedc2777b91f5ac5f169f2f7b9c30"/>
 			</diskarea>
 		</part>
 	</software>
@@ -801,7 +801,7 @@ Requires [32X] add-on
 		<info name="ring_code" value="CDAC-052900 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="double switch (usa)" sha1="550ef74c39eb6dd55b4410012ad8b1cf83c92e6e"/>
+				<disk name="double switch (usa)" sha1="2b727773fda836ddfb972dc98820bee7135da709"/>
 			</diskarea>
 		</part>
 	</software>
@@ -825,15 +825,15 @@ Requires [disc swap]
 		<info name="serial" value="4420"/>
 		<info name="ring_code" value="CDAC-053000 14 (Disc 1) / CDAC-053100 4 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1"/>
+			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="dracula unleashed (usa) (disc 1)" sha1="bf3938a34c7c58b11ea577a54cf551ce3f0593b1"/>
+				<disk name="dracula unleashed (usa) (disc 1)" sha1="307c0779dace5d95f3e7a0ccee18c00356ca2362"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2"/>
+			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="dracula unleashed (usa) (disc 2)" sha1="67a86dbf0718a76998d6b30b738ca856d64a756f"/>
+				<disk name="dracula unleashed (usa) (disc 2)" sha1="e3adeebe60f32a3487e7d5afc86675b73057fba6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -851,7 +851,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT121015 R3D MFD BY JVC 13"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon's lair (usa)" sha1="4f7200a039d440ff83b0e80ad9d2b90715b85ed6"/>
+				<disk name="dragon's lair (usa)" sha1="724bc872d111ed67df10e95b134f8bf7fe2fcfe3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -880,7 +880,7 @@ Requires [disc swap]
 		<info name="ring_code" value="JVC SEGA4657 R2E 0 0"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dungeon explorer (usa)" sha1="9a935d5cec48a4c465e52bc6a968d5b5ba3eb32b"/>
+				<disk name="dungeon explorer (usa)" sha1="432897f1f19e8a053c8f7d783e2331e7fd0f0b1f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -912,7 +912,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-042000 1, CDAC-042000 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ecco the dolphin (usa)" sha1="dec9f9d8cc7e9edafcd56b7b03023349dd0174f0"/>
+				<disk name="ecco the dolphin (usa)" sha1="7fb88d4f0fe34ee40991d724b9e90f7586081fd2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -945,7 +945,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC 077400"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ecco - the tides of time (usa)" sha1="928726593d409c09b6f2f4a7fd5d7143cb620c03"/>
+				<disk name="ecco - the tides of time (usa)" sha1="20cb72bf75a848568dd034188bebe316138b6186"/>
 			</diskarea>
 		</part>
 	</software>
@@ -995,7 +995,7 @@ Requires [disc swap]
 		<info name="serial" value="T-93115"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="espn baseball tonight (usa)" sha1="3357a6b8ecb7c152703125d1f85580d008f70ad4"/>
+				<disk name="espn baseball tonight (usa)" sha1="3965f3f96579abe6d754360fb123f5cfb2e8cce1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1009,12 +1009,12 @@ Requires [disc swap]
 		<description>ESPN Sunday Night NFL (USA)</description>
 		<year>1994</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199411xx"/>
+		<info name="release" value="199411xx" />
 		<info name="serial" value="T-93105"/>
 		<info name="ring_code" value="CDAC-077600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="espn sunday night nfl (usa)" sha1="e34f71de1f6f4a712f3397a391038d20ba2eaa95"/>
+				<disk name="espn sunday night nfl (usa)" sha1="11504fbfcecc6ffdaa69960ba9e57d6cd343bd78"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1157,7 +1157,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-070100 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="eye of the beholder (usa)" sha1="6394fc55f8b8bf36cf835ab3514fa11535652df1"/>
+				<disk name="eye of the beholder (usa)" sha1="8901e20ec6cb1cc8b8771b7bdac01d3220a067f5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1180,19 +1180,19 @@ Requires [disc swap]
 		<notes><![CDATA[
 Has optional unemulated [32X] mode, which in turn needs [disc swap]
 ]]></notes>
-		<info name="release" value="199503xx"/>
+		<info name="release" value="199503xx" />
 		<info name="serial" value="4438"/>
 		<info name="ring_code" value="CDAC-088300 1 (Disc 1) / CDAC-088400 1 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Sega CD / Disc 1 - Key Disc"/>
+			<feature name="part_id" value="Sega CD / Disc 1 - Key Disc" />
 			<diskarea name="cdrom">
-				<disk name="fahrenheit (usa) (sega cd)" sha1="8e5ce49c68edf4e0da5e0935fb419b3d29a52527"/>
+				<disk name="fahrenheit (usa) (sega cd)" sha1="c53080012578fe291323197e6319842beb84ee9b"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="32X CD / Disc 2 - Insert Key Disc 1 First"/>
+			<feature name="part_id" value="32X CD / Disc 2 - Insert Key Disc 1 First" />
 			<diskarea name="cdrom">
-				<disk name="fahrenheit (usa) (32x cd)" sha1="8dac276eacfa72913c5fb2d12c5d3360bb513fe4"/>
+				<disk name="fahrenheit (usa) (32x cd)" sha1="f94ea9821ca030c3cc61eccc29eb9c692198415e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1254,7 +1254,7 @@ Has optional unemulated [32X] mode, which in turn needs [disc swap]
 		<info name="ring_code" value="CDAC-064000(9)1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fifa international soccer (usa)" sha1="a38b06e9812b31ab1bfb2ae10b3422c993d5fc2e"/>
+				<disk name="fifa international soccer (usa)" sha1="3e32c3d5e99f5df103277aed209a59f888c06bec"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1293,11 +1293,11 @@ Has optional unemulated [32X] mode, which in turn needs [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4410"/>
-		<info name="release" value="199305xx"/>
+		<info name="release" value="199305xx" />
 		<info name="ring_code" value="CDAC-041400 6, CDAC-041400 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fight cd (usa)" sha1="922993f958901291c6a28dd34a368edd25d84f5d"/>
+				<disk name="final fight cd (usa)" sha1="bd0ae447a302d2e220f13c84a7a56a45007c7e83"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1350,7 +1350,7 @@ Has optional unemulated [32X] mode, which in turn needs [disc swap]
 		<info name="ring_code" value="CDAC-063600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="formula one world championship - beyond the limit (usa)" sha1="3bbfccb65fb8c5185cbfbb5a52ee5c95d614c05d"/>
+				<disk name="formula one world championship - beyond the limit (usa)" sha1="da0c0fd84af458744d6b045c3fb44b5ac5f89152"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1374,16 +1374,16 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-053200 2, CDAC-053200 4 (Disc 1) / CDAC-053300 1 (Disc 2)"/>
 		<info name="serial" value="T-93145"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1"/>
+			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="ground zero texas (usa) (disc 1)" sha1="a4f140fb429d5ed9623aa0860d6aee0db78f0c87"/>
+				<disk name="ground zero texas (usa) (disc 1)" sha1="226bef5c19446c6be18674941707b3baebc11223"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2"/>
+			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="ground zero texas (usa) (disc 2)" sha1="00492e73180ba447b4216699be023588679b76f8"/>
+				<disk name="ground zero texas (usa) (disc 2)" sha1="13c7cc77f2659155dec4deb4700d8ac8af95fb42"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1438,11 +1438,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="T-70025"/>
-		<info name="release" value="199406xx"/>
+		<info name="release" value="199406xx" />
 		<info name="ring_code" value="HOTALIENRE R1H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heart of the alien - out of this world parts i and ii (usa)" sha1="085d32028c3dd4dfc1f0a05cd9be6fd3293c1f52"/>
+				<disk name="heart of the alien - out of this world parts i and ii (usa)" sha1="a2784fa95bb3b29067b5d8148dd95877456577e7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1476,11 +1476,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-60145"/>
-		<info name="release" value="199404xx"/>
+		<info name="release" value="199404xx" />
 		<info name="ring_code" value="SEGAT60105 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heimdall (usa)" sha1="b429b7d57897b357d86529984e6c8fc787a12371"/>
+				<disk name="heimdall (usa)" sha1="986813f0d66eff9c163c19ccdbe6e055bf75043d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1518,7 +1518,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-032400 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hook (usa)" sha1="a713dc15bf82115230b7201860e2b99119f9d0da"/>
+				<disk name="hook (usa)" sha1="310b67fc0163da2dbae236b1276624b2170425b0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1536,7 +1536,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT124015 R2H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="iron helix (usa)" sha1="e617f0b6d0887517ff63a6be9676039f548c38f8"/>
+				<disk name="iron helix (usa)" sha1="243a1c1691ab1a587371e34c1692663b28814184"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1552,11 +1552,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sony Imagesoft</publisher>
 		<info name="serial" value="T-93095"/>
-		<info name="release" value="199311xx"/>
+		<info name="release" value="199311xx" />
 		<info name="ring_code" value="CDAC-075900 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jeopardy (usa)" sha1="02b99541189e0982b82607aa64fa71505f944cb0"/>
+				<disk name="jeopardy (usa)" sha1="6f159f64d3ea62bb8eff70e9a2f84d02bfb54688"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1575,11 +1575,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="T-4201"/>
-		<info name="release" value="199310xx"/>
+		<info name="release" value="199310xx" />
 		<info name="ring_code" value="SEGA4201 R1C MFD BY JVC, SEGA4201RE R2C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="joe montana's nfl football (usa)" sha1="a308351c13fc57c969671dc2f0ec24a00a9eabc3"/>
+				<disk name="joe montana's nfl football (usa)" sha1="a6c4dccb249c27d38846e204313446e5928c2b4d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1627,7 +1627,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4411RE R3C MFD BY JVC, SEGA4411RE R4C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jurassic park (usa)" sha1="f1b842803f87841f2d442e438c2047ad4a5f889c"/>
+				<disk name="jurassic park (usa)" sha1="8ab39eda898277571127b9ac03dce64546602caf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1645,7 +1645,7 @@ Requires [disc swap]
 		<info name="ring_code" value="GW 03611 SRCR##02"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kids on site (usa)" sha1="04f4302d49e3f2f5b599e8bdd2fff08d92e70015"/>
+				<disk name="kids on site (usa)" sha1="9a97c7c151cbe77121bb626954b50bd2223a9292"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1681,7 +1681,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-95015"/>
-		<info name="release" value="199311xx"/>
+		<info name="release" value="199311xx" />
 		<info name="ring_code" value="T95015-U11 2A7 C 39, T95015-U11 2B3 C 39, T95015-U11 2C2 C 39, T95015-U11 2C3 C 39"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -1722,7 +1722,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-95015"/>
-		<info name="release" value="199311xx"/>
+		<info name="release" value="199311xx" />
 		<info name="ring_code" value="T95015-U12 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -1762,11 +1762,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-95025"/>
-		<info name="release" value="19941124"/>
+		<info name="release" value="19941124" />
 		<info name="ring_code" value="T95025-U12 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lethal enforcers ii - gun fighters (usa)" sha1="6f9fbcf9f5ab7bcbbb2740cbe72af63183112855"/>
+				<disk name="lethal enforcers ii - gun fighters (usa)" sha1="7d63da6fa26441e31bd614474936d8c7adacd239"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1784,7 +1784,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT153015 R3J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="loadstar - the legend of tully bodine (usa)" sha1="6208729d1723944354fabcd0e281cbc9f13874d4"/>
+				<disk name="loadstar - the legend of tully bodine (usa)" sha1="a9b4df4c8b3ed81d14cfa5506961c3815387194e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1821,7 +1821,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4450 R1F"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lords of thunder (usa)" sha1="0dfac7659fc981eb1322f8dc801f45dcdb33eed3"/>
+				<disk name="lords of thunder (usa)" sha1="c4be0138ac50ee190fb8df9839a2efb97e9f30c2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1908,7 +1908,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT127045RE R1H"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar - eternal blue (usa)" sha1="e93c3f2cd946e0ea1ea3cdecbf24e55d7acb5732"/>
+				<disk name="lunar - eternal blue (usa)" sha1="1cc95c2b91d6c52d561a4f70e96c52ddc3c10313"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1931,7 +1931,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT111015 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mad dog mccree (usa)" sha1="b31567eb08b7730f0dfef90650d162b7e2580316"/>
+				<disk name="mad dog mccree (usa)" sha1="244713e8c7c1d1ef38f5f9ba2232cb1a2b23a1f7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1946,12 +1946,12 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Vic Tokai</publisher>
 		<info name="serial" value="T-23015"/>
-		<info name="release" value="199402xx"/>
+		<info name="release" value="199402xx" />
 		<info name="ring_code" value="SEGAT23015 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
-			<feature name="peripheral" value="mouse"/>
+			<feature name="peripheral" value="mouse" />
 			<diskarea name="cdrom">
-				<disk name="mansion of hidden souls (usa)" sha1="75095ab4f62cd1d351f4dadc5202ab84a3c269a9"/>
+				<disk name="mansion of hidden souls (usa)" sha1="1d1dba770de6d5969d23d2e86ad4028445d514c4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1975,7 +1975,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-077800 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mary shelley's frankenstein (usa)" sha1="353b90dbcb159afca517218a0157b5ecc841379b"/>
+				<disk name="mary shelley's frankenstein (usa)" sha1="4d0d40a70d2a585e371d23d122ec98a6dce7b299"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2016,7 +2016,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Sony Imagesoft</publisher>
 		<info name="serial" value="T-93265"/>
-		<info name="release" value="199411xx"/>
+		<info name="release" value="199411xx" />
 		<info name="ring_code" value="CDAC-073600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2045,7 +2045,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-055200 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="microcosm (usa)" sha1="d77d0f9575aa53d7aef0640fb4532f7978590282"/>
+				<disk name="microcosm (usa)" sha1="bca8a59c2aa47d1207b0c2df1d2ff40cb5d11fb4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2063,7 +2063,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4439 R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="midnight raiders (usa)" sha1="741b1383164112074cf5d6fc09c5262015779869"/>
+				<disk name="midnight raiders (usa)" sha1="83db51aee2ef658fa9d29e67acdc7d5774e69d3a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2097,11 +2097,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Arena</publisher>
 		<info name="serial" value="T-81025"/>
-		<info name="release" value="199404xx"/>
+		<info name="release" value="199404xx" />
 		<info name="ring_code" value="CDCA-060900 3, CDCA-061500 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat (usa)" sha1="06fc7e387c193c28d1068cf74609de36021eca2b"/>
+				<disk name="mortal kombat (usa)" sha1="454e23c8922380f813a3a5b9d94902a691109332"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2123,11 +2123,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Arena</publisher>
 		<info name="serial" value="T-81035"/>
-		<info name="release" value="199412xx"/>
+		<info name="release" value="199412xx" />
 		<info name="ring_code" value="CDAC-074200 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nba jam (usa)" sha1="fbc1d8fed4b78c9a51cc29fb9b7feee6959b3f7c"/>
+				<disk name="nba jam (usa)" sha1="48b0fdb2476ac795b303bfdc11b40abb8609511b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2142,11 +2142,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4202"/>
-		<info name="release" value="199310xx"/>
+		<info name="release" value="199310xx" />
 		<info name="ring_code" value="CDAC-054500 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl's greatest - san francisco vs dallas 1978-1993 (usa)" sha1="0300f0b0bcff68a2a9995d1752044a16c1077708"/>
+				<disk name="nfl's greatest - san francisco vs dallas 1978-1993 (usa)" sha1="20fc574d1912b92dd9d6c248734a8e897501b3ea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2238,11 +2238,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="T-50015"/>
-		<info name="release" value="199309xx"/>
+		<info name="release" value="199309xx" />
 		<info name="ring_code" value="CDAC-056700 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl '94 (usa)" sha1="7cde2688a9157ecc18dab9a1ee76b93dc8ffdc8e"/>
+				<disk name="nhl '94 (usa)" sha1="ac34c65117668dc53e7075a0dbe9bd260fdb1c15"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2270,16 +2270,16 @@ Requires [disc swap]
 		<!--<sharedfeat name="requirement" value="32x"/>-->
 		<info name="usage" value="Requires to be run with 32x_scd"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1"/>
+			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa, 32x) (disc 1)" sha1="672776292563c691e5dbf76d216946292b72d195"/>
+				<disk name="night trap (usa, 32x) (disc 1)" sha1="a4407b3264ef29d343f7d4b984194bc4636009d3"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2"/>
+			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa, 32x) (disc 2)" sha1="598a58f0aa08c797b4e89978d6cd960aa40dac94"/>
+				<disk name="night trap (usa, 32x) (disc 2)" sha1="18b2a72bf91589ef43986b3f3add9b70c609f346"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2300,19 +2300,19 @@ Requires [disc swap]
 Required [disc swap]
 ]]></notes>
 		<info name="serial" value="4903"/>
-		<info name="release" value="199211xx"/>
+		<info name="release" value="199211xx" />
 		<info name="ring_code" value="CDRM-1027400 5 (Disc 1) / CDRM-1027410 2, CDRM-1027410 1 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1"/>
+			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa) (disc 1)" sha1="ae4fa663362cd3f044a6df8a9930d3cf2708b63c"/>
+				<disk name="night trap (usa) (disc 1)" sha1="c2c18c6af2aae9619ca5772fcb6aecc79a142a40"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2"/>
+			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa) (disc 2)" sha1="47689dd1d5aabb428de2076a57da4e1f0e83eea6"/>
+				<disk name="night trap (usa) (disc 2)" sha1="41c44780c325403d9c4522fc3d010912fc3dad5a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2333,19 +2333,19 @@ Required [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="4903"/>
-		<info name="release" value="199211xx"/>
+		<info name="release" value="199211xx" />
 		<info name="ring_code" value="CDRM-1027400 3 (Disc 1) / CDRM-1027410 2, CDRM-1027410 1 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1"/>
+			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
 				<disk name="night trap (usa, alt) (disc 1)" sha1="d5d21d92798661d67ab7247acc41ea6602721a0b"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2"/>
+			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa) (disc 2)" sha1="47689dd1d5aabb428de2076a57da4e1f0e83eea6"/>
+				<disk name="night trap (usa) (disc 2)" sha1="41c44780c325403d9c4522fc3d010912fc3dad5a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2371,13 +2371,13 @@ Requires [disc swap]
 No support for Mega CD cart slots
 ]]></notes>
 		<info name="serial" value="T-574013, T-574016, T-574016-50"/>
-		<info name="release" value="20101214"/>
+		<info name="release" value="20101214" />
 		<info name="ring_code" value="Enhanced Soundtrack Disc WM WM 2234612235072235144* Enhanced Soundtrack Disc WM B"/>
 		<!--<sharedfeat name="requirement" value="megadriv -psolar"/>-->
 		<info name="usage" value="Requires to be run with megadriv psolar cart"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pier solar and the great architects enhanced soundtrack disc (world)" sha1="05dcd8e5d8dba48ed612f8c737fcf9c3e9812e57"/>
+				<disk name="pier solar and the great architects enhanced soundtrack disc (world)" sha1="1f26cce723ef044f449d87cdb624a2937f40f5d9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2433,11 +2433,11 @@ No support for Mega CD cart slots
 		<year>1995</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="T-127035"/>
-		<info name="release" value="19950223"/>
+		<info name="release" value="19950223" />
 		<info name="ring_code" value="SEGAT127035RE R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="popful mail (usa)" sha1="b87c7ffd99dbd37e6a775f4edc296365b260deb3"/>
+				<disk name="popful mail (usa)" sha1="459853983b1e01fe297ffd6287502eab1678e8e4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2475,11 +2475,11 @@ No support for Mega CD cart slots
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4652"/>
-		<info name="release" value="199212xx"/>
+		<info name="release" value="199212xx" />
 		<info name="ring_code" value="CDAC-032200 6"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="prince of persia (usa)" sha1="99b2084db168bbbbbd78d23b3a06754cdd89825f"/>
+				<disk name="prince of persia (usa)" sha1="fd9250f32c23e0954b197d1833c20de705df43d3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2514,11 +2514,11 @@ No support for Mega CD cart slots
 		<year>1994</year>
 		<publisher>Psygnosis</publisher>
 		<info name="serial" value="T-113035"/>
-		<info name="release" value="19940106"/>
+		<info name="release" value="19940106" />
 		<info name="ring_code" value="CDAC-053800 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="puggsy (usa)" sha1="421e43f3e792a7a27ef5ef168d875a26362c879b"/>
+				<disk name="puggsy (usa)" sha1="307206f9f4154699e9386fa9b45bd79d5ed72e5d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2545,7 +2545,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="CDAC-055000 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="racing aces (usa)" sha1="d6b269de0f919164fc12ede376a054b0a2dccee2"/>
+				<disk name="racing aces (usa)" sha1="a2038d4de56b75d61db6ad757919cca00cc91c95"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2568,7 +2568,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="SEGAT86025 R1F MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rdf - global conflict (usa)" sha1="b6922a240c56bd3a145b9aba9fb63d76985644e5"/>
+				<disk name="rdf - global conflict (usa)" sha1="32cf1e068598e385962db8de493eb191aab7716b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2589,7 +2589,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="SEGAT49035 R1C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="revenge of the ninja (usa)" sha1="1c7bce3382cc768ec788c8f652a2cac633cc9cc2"/>
+				<disk name="revenge of the ninja (usa)" sha1="d6f0a13f1b630ba771cad7c86b607f31cf6092b7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2610,7 +2610,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="S604430RE R1D MFD BY JVC, S604430RE R2D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rise of the dragon (usa, rev. a)" sha1="62c5e2a43a07f50351eb84bdbe90330750537712"/>
+				<disk name="rise of the dragon (usa, rev. a)" sha1="412d819633740c597b67591cf12fdac7c7081194"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2628,7 +2628,7 @@ No support for Mega CD cart slots
 		<year>1993</year>
 		<publisher>Dynamix</publisher>
 		<info name="serial" value="4301"/>
-		<info name="release" value="199303xx"/>
+		<info name="release" value="199303xx" />
 		<info name="ring_code" value="CDAC-040300 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2652,11 +2652,11 @@ No support for Mega CD cart slots
 Black screen, requires sub CPU to be overclocked by 1.5x
 ]]></notes>
 		<info name="serial" value="T-6207"/>
-		<info name="release" value="199303xx"/>
+		<info name="release" value="199303xx" />
 		<info name="ring_code" value="SEGA6207 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="road avenger (usa)" sha1="2de47da786a49e07232662e6a33cb2fb17004280"/>
+				<disk name="road avenger (usa)" sha1="05fa6ae67687aacdf99fe939b0f04ce13b6d527b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2671,11 +2671,11 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<year>1995</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4442"/>
-		<info name="release" value="19950502"/>
+		<info name="release" value="19950502" />
 		<info name="ring_code" value="SEGA4442 R1J"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="saban's mighty morphin power rangers (usa)" sha1="11b426d181c3e3099e4b29654fdf6ba3b19398f3"/>
+				<disk name="saban's mighty morphin power rangers (usa)" sha1="fffd902d4ab06d946c47b7eaa40cc5ddd9963299"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2700,7 +2700,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<description>Sega Classics Arcade Collection (USA, 4 in 1, alt)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="19921015"/>
+		<info name="release" value="19921015" />
 		<info name="ring_code" value="SEGA4126RE R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2732,7 +2732,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="ring_code" value="CDAC-056800 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sega classics arcade collection (usa, 5 in 1)" sha1="3e86e8fa7c3f1252b68008711e2261ca40862608"/>
+				<disk name="sega classics arcade collection (usa, 5 in 1)" sha1="9f4bdadabba7d8998b701a3becd2520d4d2a037d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2746,7 +2746,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="T-6201"/>
-		<info name="release" value="199212xx"/>
+		<info name="release" value="199212xx" />
 		<info name="ring_code" value="CDRM-1033200 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2764,11 +2764,11 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<year>1992</year>
 		<publisher>Sony Imagesoft</publisher>
 		<info name="serial" value="T-6201"/>
-		<info name="release" value="199212xx"/>
+		<info name="release" value="199212xx" />
 		<info name="ring_code" value="CDRM-1033200 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sewer shark (usa, rev. a)" sha1="516b1db245a680afc0cb3220a1b255e80453be5d"/>
+				<disk name="sewer shark (usa, rev. a)" sha1="0f339806d73c473c20906935836d49457339430f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2784,7 +2784,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4101"/>
-		<info name="release" value="199212xx"/>
+		<info name="release" value="199212xx" />
 		<info name="ring_code" value="610-5574P-00086 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2803,7 +2803,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<description>Sewer Shark (USA, rev. B, alt)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="199212xx"/>
+		<info name="release" value="199212xx" />
 		<info name="ring_code" value="CDRM-1095270 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2822,7 +2822,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<description>Sewer Shark (USA, rev. B, alt 2)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="199212xx"/>
+		<info name="release" value="199212xx" />
 		<info name="ring_code" value="CDRM-1095270 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -2841,12 +2841,12 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<description>Sherlock Holmes - Consulting Detective Vol. I (USA)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="alt_title" value="Sherlock Holmes - Consulting Detective (Box)"/>
-		<info name="release" value="19921015"/>
+		<info name="alt_title" value="Sherlock Holmes - Consulting Detective (Box)" />
+		<info name="release" value="19921015" />
 		<info name="ring_code" value="CDAC-031300 1, CDAC-031300 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sherlock holmes - consulting detective vol. i (usa)" sha1="d295f474b188f7121282d92c17c952b9a907d02d"/>
+				<disk name="sherlock holmes - consulting detective vol. i (usa)" sha1="32d2f47f459927cd162376e46d6a02430572a82a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2868,19 +2868,19 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="4653"/>
-		<info name="release" value="199305xx"/>
+		<info name="release" value="199305xx" />
 		<info name="ring_code" value="CDAC-041000 1 (Disc 1), CDAC-041100 2 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1"/>
+			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 1)" sha1="470ca1a64ed2e3a3b664cdda8d685e2eaf2577ab"/>
+				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 1)" sha1="162af0ed791b8a18040ecb3925984a738dc72d49"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2"/>
+			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 2)" sha1="5b963168f6476a4e0f43050543ed6f0ffbd9dc38"/>
+				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 2)" sha1="3de4f89de8920185197d8a65f0ea97a83e774a98"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2981,7 +2981,7 @@ Requires [disc swap]
 		<info name="ring_code" value="3/95 6RA3 1008604656, 3/95 5RA1 1008604656"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="shining force cd (usa, alt)" sha1="d6c24f360b8845e783d76f9a9af527ddf025ed08"/>
+				<disk name="shining force cd (usa, alt)" sha1="ddb304849d01df44251d69b890df47c8db1d8642"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3002,11 +3002,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4423"/>
-		<info name="release" value="199310xx"/>
+		<info name="release" value="199310xx" />
 		<info name="ring_code" value="SEGA4423 R2D MFD BY JVC, SEGA4423RE R2D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="silpheed (usa)" sha1="2d172387631ddcb056d8547a4a38b29721771c17"/>
+				<disk name="silpheed (usa)" sha1="f4d368f13f7998fb8d37c9a3439d42497e0ee359"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3036,28 +3036,28 @@ Requires [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="T-162035"/>
-		<info name="release" value="199411xx"/>
+		<info name="release" value="199411xx" />
 		<info name="ring_code" value="GW 02711.1 RE-1 SRCR##01 (Disc 1) / GW 02711.2 RE-1 SRCR**01 (Disc 2) / GW 02711.3 RE-1 SRCR##01 (Disc 3) / GW 02711.4 RE-1 SRCR##01 (Disc 4)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1 - Fingers"/>
+			<feature name="part_id" value="Disc 1 - Fingers" />
 			<diskarea name="cdrom1">
 				<disk name="slam city with scottie pippen (usa, alt) (disc 1)" sha1="637ceb49d6e9ff89009b26d848b6097a54969d65"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2 - Juice"/>
+			<feature name="part_id" value="Disc 2 - Juice" />
 			<diskarea name="cdrom2">
 				<disk name="slam city with scottie pippen (usa, alt) (disc 2)" sha1="e5cc52a7686824b14ee471682f30b0b4a09dbe97"/>
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 3 - Mad Dog"/>
+			<feature name="part_id" value="Disc 3 - Mad Dog" />
 			<diskarea name="cdrom3">
 				<disk name="slam city with scottie pippen (usa, alt) (disc 3)" sha1="6d144435110bc0fcd97313c75dbb56f472e4e123"/>
 			</diskarea>
 		</part>
 		<part name="cdrom4" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 4 - Smash"/>
+			<feature name="part_id" value="Disc 4 - Smash" />
 			<diskarea name="cdrom4">
 				<disk name="slam city with scottie pippen (usa, alt) (disc 4)" sha1="ddffdf4dd92fcb3f93f285ff24384815ba401cab"/>
 			</diskarea>
@@ -3093,11 +3093,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-95035"/>
-		<info name="release" value="19941130"/>
+		<info name="release" value="19941130" />
 		<info name="ring_code" value="T95035-U12 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="snatcher (usa)" sha1="d38ada693efc354c1d3c4c663214ab173985bf95"/>
+				<disk name="snatcher (usa)" sha1="815edc5df272e4b10edd5919b29c3a996a1799c2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3128,11 +3128,11 @@ Requires [disc swap]
 		<description>Sol-Feace (USA)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="19921015"/>
+		<info name="release" value="19921015" />
 		<info name="ring_code" value="SEGA4130RE2 R3C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sol-feace (usa)" sha1="ba813d3b0dfa00092dbdb7e323755953a2a60d85"/>
+				<disk name="sol-feace (usa)" sha1="498ebd9c1fe4bd2f84cf6c32829b68e471eb3b07"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3180,8 +3180,8 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4407"/>
-		<info name="alt_title" value="Sonic CD (Box)"/>
-		<info name="release" value="19931119"/>
+		<info name="alt_title" value="Sonic CD (Box)" />
+		<info name="release" value="19931119" />
 		<info name="ring_code" value="SEGA4407 R1C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -3233,12 +3233,12 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4407"/>
-		<info name="alt_title" value="Sonic CD (Box)"/>
-		<info name="release" value="19931119"/>
+		<info name="alt_title" value="Sonic CD (Box)" />
+		<info name="release" value="19931119" />
 		<info name="ring_code" value="SEGA4407RE125 R7D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sonic cd (usa, alt)" sha1="1645128fc656aaba3ea5da176e5430ef9e65a05e"/>
+				<disk name="sonic cd (usa, alt)" sha1="a8a968a6239da07c6143dd420a6a3093f4dddcd2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3286,8 +3286,8 @@ Requires [disc swap]
 		<description>Sonic the Hedgehog CD (USA, alt 2)</description>
 		<year>1993</year>
 		<publisher>Sega</publisher>
-		<info name="alt_title" value="Sonic CD (Box)"/>
-		<info name="release" value="19931119"/>
+		<info name="alt_title" value="Sonic CD (Box)" />
+		<info name="release" value="19931119" />
 		<info name="ring_code" value="SEGA4407RE125 R8C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -3321,11 +3321,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Core Design</publisher>
 		<info name="serial" value="T-115035"/>
-		<info name="release" value="199409xx"/>
+		<info name="release" value="199409xx" />
 		<info name="ring_code" value="SEGAT115035 R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="soulstar (usa)" sha1="43c5e634d37ab2dde53ad1387d5ebfbc8320a6d7"/>
+				<disk name="soulstar (usa)" sha1="4e2ab5b51dca2a4c23700b4d3587a9a08ac6d29f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3343,7 +3343,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-080300 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space ace (usa)" sha1="2e158a2e79162324b70bca7a115068f0b5c6a675"/>
+				<disk name="space ace (usa)" sha1="d5f5125af3e9e59a59f775576ddc99b4aadaf505"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3358,11 +3358,11 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-60075"/>
-		<info name="release" value="199403xx"/>
+		<info name="release" value="199403xx" />
 		<info name="ring_code" value="SEGAT60075 R1D MFD BY JVC, SEGAT60075 R2C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star wars - rebel assault (usa)" sha1="12d3691a5d48863343929bae82e444a58b66d567"/>
+				<disk name="star wars - rebel assault (usa)" sha1="f1049ddf315f3a9ecd29378bc026a05669120112"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3380,7 +3380,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-073400 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="starblade (usa)" sha1="5764dd497e86326a581891a7a3e6f9723788a0d0"/>
+				<disk name="starblade (usa)" sha1="6233ca426d0797a5bccf98261b5164c44feb5203"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3414,11 +3414,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Dynamix</publisher>
 		<info name="serial" value="T-110025"/>
-		<info name="release" value="199312xx"/>
+		<info name="release" value="199312xx" />
 		<info name="ring_code" value="SEGAT11025 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="stellar-fire (usa)" sha1="a5248d49dbc38491239e9905e9b8129ff8952691"/>
+				<disk name="stellar-fire (usa)" sha1="4e0245e30cac825c262551eda322eb774919e87b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3460,7 +3460,7 @@ Requires [disc swap]
 		<info name="ring_code" value="1008604432 7/95 1RA2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the adventures of batman and robin (usa)" sha1="1fd748ba4a759ca4bd6d4b5962e17ce3ee06934f"/>
+				<disk name="the adventures of batman and robin (usa)" sha1="80e65ec95ea9440e59d64ea067b48921686006e8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3517,7 +3517,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4412"/>
-		<info name="release" value="199306xx"/>
+		<info name="release" value="199306xx" />
 		<info name="ring_code" value="CDAC-047100 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -3561,11 +3561,11 @@ Requires [disc swap]
 		<year>1992</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-60035"/>
-		<info name="release" value="199212xx"/>
+		<info name="release" value="199212xx" />
 		<info name="ring_code" value="SEGAT60035RE R1C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the secret of monkey island (usa)" sha1="1f90af90c880bad8e9acf6c0f2fa10000072abbe"/>
+				<disk name="the secret of monkey island (usa)" sha1="a894a9e6ba908f742d686fb85b7ae3c700fb1d36"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3580,7 +3580,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>The Software Toolworks</publisher>
 		<info name="serial" value="T-87035"/>
-		<info name="release" value="199405xx"/>
+		<info name="release" value="199405xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="star wars chess (usa)" sha1="fe03505a7c2f1ebdef4d2c32c8b73677288d635b"/>
@@ -3606,11 +3606,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Virgin Games</publisher>
 		<info name="serial" value="T-70015"/>
-		<info name="release" value="199306xx"/>
+		<info name="release" value="199306xx" />
 		<info name="ring_code" value="SEGACD86003 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the terminator (usa)" sha1="47c82ce49c926d3b381a46aa4505bcc03737abb4"/>
+				<disk name="the terminator (usa)" sha1="43bf02bf06fc5d1bd32bc61b11acd1745d2d7a1d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3625,11 +3625,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Renovation</publisher>
 		<info name="serial" value="T-6214"/>
-		<info name="release" value="199305xx"/>
+		<info name="release" value="199305xx" />
 		<info name="ring_code" value="SEGAT49025 R2C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="time gal (usa)" sha1="268978a58bbf09a21e14c01534ac4f90fe55df5e"/>
+				<disk name="time gal (usa)" sha1="22c4bc9adb5560c276f0fe88967e04bf279d54d0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3644,7 +3644,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="4429"/>
-		<info name="release" value="199403xx"/>
+		<info name="release" value="199403xx" />
 		<info name="ring_code" value="1008604429 9/95 1RA1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -3704,7 +3704,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT127025ARE R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vay (usa)" sha1="2ce0a42e3fd56bf266b340dc9c2d2eab876845b4"/>
+				<disk name="vay (usa)" sha1="099e4c43d8ca5eb57854db25cbcbfc3139e41a9e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3728,7 +3728,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-077500 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wheel of fortune (usa)" sha1="a07fb24ca8d88b47d93ffca555a18d46afd54ee4"/>
+				<disk name="wheel of fortune (usa)" sha1="1c48a4dd3d70ed9d4450aea57bb5dc671e5c4a4c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3746,7 +3746,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT111045 R1H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="who shot johnny rock (usa)" sha1="f6b657ae449bc9c39bd3c126e2371bdfa161b251"/>
+				<disk name="who shot johnny rock (usa)" sha1="dc9675c0bfc19baae5be13ce1540062c09b930f3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3765,11 +3765,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="T-50045"/>
-		<info name="release" value="199302xx"/>
+		<info name="release" value="199302xx" />
 		<info name="ring_code" value="CDAC-059000 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wing commander (usa)" sha1="4e4785c0fa94af17183bb12a7646fd2a01ba52b6"/>
+				<disk name="wing commander (usa)" sha1="d36f61f84a87518691438a3c4f9862b2ce23e483"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3787,7 +3787,7 @@ Requires [disc swap]
 		<info name="ring_code" value="1008604437 8/95 1RA2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wirehead (usa)" sha1="d5e5059d5b932655f0674de725957329761f3f24"/>
+				<disk name="wirehead (usa)" sha1="762bb917b936f1a781a2fbe66bbe3a9bf5dd5d43"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3821,7 +3821,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT79025 R2D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="world cup usa 94 (usa)" sha1="2d2040e8700b4e43d56f60e29af5879454077eef"/>
+				<disk name="world cup usa 94 (usa)" sha1="cb17c8ea42ec3a7d9562a0e188610a687f6b8829"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3836,11 +3836,11 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Arena</publisher>
 		<info name="serial" value="T-81015"/>
-		<info name="release" value="199311xx"/>
+		<info name="release" value="199311xx" />
 		<info name="ring_code" value="SEGAT81015 R3D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf rage in the cage (usa)" sha1="be3a229bc592d3c7d9da76a9294e469d174a4fcf"/>
+				<disk name="wwf rage in the cage (usa)" sha1="960a6ffa31b52e7ca8e7759f3d385940c8f2eb56"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3873,8 +3873,8 @@ Requires [disc swap]
 		<description>Bari-Arm (USA)</description>
 		<year>1994</year>
 		<publisher>Sega</publisher>
-		<info name="alt_title" value="Android Assault - The Revenge of Bari-Arm (Box)"/>
-		<info name="release" value="199410xx"/>
+		<info name="alt_title" value="Android Assault - The Revenge of Bari-Arm (Box)" />
+		<info name="release" value="199410xx" />
 		<info name="serial" value="4445"/>
 		<info name="ring_code" value="T-163015-00"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -3972,7 +3972,7 @@ Requires [disc swap]
 		<description>Black Hole Assault (USA, alt)</description>
 		<year>1993</year>
 		<publisher>Bignet</publisher>
-		<info name="alt_title" value="Blackhole Assault (Box)"/>
+		<info name="alt_title" value="Blackhole Assault (Box)" />
 		<info name="serial" value="T-6401"/>
 		<info name="ring_code" value="CDAC-031700 2"/>
 		<part name="cdrom" interface="scd_cdrom">
@@ -3997,7 +3997,7 @@ Requires [disc swap]
 		<description>The Exterminators (USA, prototype)</description>
 		<year>2001</year>
 		<publisher>Good Deal Games</publisher>
-		<info name="alt_title" value="Bug Blasters - The Exterminators (Box)"/>
+		<info name="alt_title" value="Bug Blasters - The Exterminators (Box)" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the exterminators (usa, prototype)" sha1="9c1e73e31c90d2cfdff50dce0e2c95c562934d96"/>
@@ -4020,7 +4020,7 @@ Requires [disc swap]
 		<description>The Exterminators - Special Edition (USA, prototype)</description>
 		<year>2003</year>
 		<publisher>Good Deal Games</publisher>
-		<info name="alt_title" value="Bug Blasters - The Exterminators (Box)"/>
+		<info name="alt_title" value="Bug Blasters - The Exterminators (Box)" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the exterminators - special edition (usa, prototype)" sha1="cb14ae1bf6825ac804a5508142759ff64d1d5b70"/>
@@ -4036,7 +4036,7 @@ Requires [disc swap]
 		<description>C+C Music Factory (USA)</description>
 		<year>1993</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="alt_title" value="Power Factory featuring C+C Music Factory (Box)"/>
+		<info name="alt_title" value="Power Factory featuring C+C Music Factory (Box)" />
 		<info name="serial" value="T-93035"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4126,7 +4126,7 @@ Requires [disc swap]
 		<description>Corpse Killer (USA)</description>
 		<year>1994</year>
 		<publisher>Digital Pictures</publisher>
-		<info name="release" value="199411xx"/>
+		<info name="release" value="199411xx" />
 		<info name="serial" value="T-162055"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4159,7 +4159,7 @@ Requires [disc swap]
 		<description>Dune (USA)</description>
 		<year>1994</year>
 		<publisher>Virgin Interactive</publisher>
-		<info name="release" value="199312xx"/>
+		<info name="release" value="199312xx" />
 		<info name="serial" value="T-70065"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4205,7 +4205,7 @@ Requires [disc swap]
 		<description>ESPN National Hockey Night (USA)</description>
 		<year>1994</year>
 		<publisher>Sony Imagesoft</publisher>
-		<info name="release" value="199411xx"/>
+		<info name="release" value="199411xx" />
 		<info name="serial" value="T-93215"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4263,7 +4263,7 @@ Requires [disc swap]
 		<description>Force Striker (USA, prototype)</description>
 		<year>2006</year>
 		<publisher>Good Deal Games</publisher>
-		<info name="alt_title" value="Burning Fists - Force Striker (Box)"/>
+		<info name="alt_title" value="Burning Fists - Force Striker (Box)" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="force striker (usa, prototype)" sha1="593892565e8ba7df9204128bd7bc36e72f92b803"/>
@@ -4308,13 +4308,13 @@ Requires [disc swap]
 		<info name="serial" value="T-93145"/>
 		<info name="ring_code" value="CDAC-053300 2 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1"/>
+			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom1">
 				<disk name="ground zero texas (usa, alt) (disc 1)" sha1="cb019a26b3edec7a8f0119d74a0991aa5b258313"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2"/>
+			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom2">
 				<disk name="ground zero texas (usa, alt) (disc 2)" sha1="4b3ebe516e2047d4df38590e0badf372262fa435"/>
 			</diskarea>
@@ -4369,7 +4369,7 @@ Requires [disc swap]
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="MK-4129 / OPCD-1630"/>
-		<info name="release" value="19921015"/>
+		<info name="release" value="19921015" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hot hits - adventurous new music sampler (usa)" sha1="0a83a39a37faf3f7338d7926ac3e22471319a433"/>
@@ -4414,7 +4414,7 @@ Requires [disc swap]
 		<description>Jaguar XJ220 (USA)</description>
 		<year>1993</year>
 		<publisher>JVC</publisher>
-		<info name="release" value="199303xx"/>
+		<info name="release" value="199303xx" />
 		<info name="serial" value="T-6406"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4538,7 +4538,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>The Software Toolworks</publisher>
 		<info name="serial" value="T-87025"/>
-		<info name="release" value="199312xx"/>
+		<info name="release" value="199312xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="megarace (usa)" sha1="d60afc89afa7de225f42deb3fac894f9202061b5"/>
@@ -4613,7 +4613,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="T-50035"/>
-		<info name="release" value="199401xx"/>
+		<info name="release" value="199401xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="powermonger (usa)" sha1="0e281e66912a9d38edfd06bdee836ce8dba06244"/>
@@ -4641,14 +4641,14 @@ Requires [disc swap]
 		<info name="serial" value="MK-4206"/>
 		<info name="ring_code" value="CDAC-052700 2 (Disc 1)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1"/>
+			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
 				<disk name="prize fighter (usa) (disc 1)" sha1="37742af63ba540380b8285a1e82be8d1898914e6"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2"/>
+			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
 				<disk name="prize fighter (usa) (disc 2)" sha1="46f731d613d08eba5534331ce85fb5bab1e1b387"/>
 			</diskarea>
@@ -4736,7 +4736,7 @@ Requires [disc swap]
 		<year>1995</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-60175"/>
-		<info name="release" value="199501xx"/>
+		<info name="release" value="199501xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="samurai shodown (usa)" sha1="5b12e3cea8f93635f25e98b184c68f6921e395d8"/>
@@ -4764,7 +4764,7 @@ Requires [disc swap]
 		<description>Sega Classics Arcade Collection (USA, 4 in 1)</description>
 		<year>1992</year>
 		<publisher>Sega</publisher>
-		<info name="release" value="19921015"/>
+		<info name="release" value="19921015" />
 		<info name="ring_code" value="SEGA-4126RE2 R1C"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -4798,31 +4798,31 @@ Requires [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="T-162035"/>
-		<info name="release" value="199411xx"/>
+		<info name="release" value="199411xx" />
 		<info name="ring_code" value="GW 02711.1 (Disc 1) / GW 02711.2 (Disc 2) / GW 02711.3 (Disc 3) / GW 02711.4 (Disc 4)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1 - Fingers"/>
+			<feature name="part_id" value="Disc 1 - Fingers" />
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa) (disc 1)" sha1="e458f2e459cb097ed32ea27ffaa7ab5cc47c9a18"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2 - Juice"/>
+			<feature name="part_id" value="Disc 2 - Juice" />
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa) (disc 2)" sha1="d900b5e5dcb904530edc089ce376d53ce404d6ec"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom3" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 3 - Mad Dog"/>
+			<feature name="part_id" value="Disc 3 - Mad Dog" />
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa) (disc 3)" sha1="11bfe9ce5081785bb8e9cbc0e9bd65c7605e817e"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom4" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 4 - Smash"/>
+			<feature name="part_id" value="Disc 4 - Smash" />
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa) (disc 4)" sha1="010bc11b7d8a078bbdd869ae7c7bf7ebfe04c916"/>
 			</diskarea>
@@ -4859,28 +4859,28 @@ Requires [disc swap]
 		<!-- <sharedfeat name="requirement" value="32x"/> -->
 		<info name="usage" value="Requires to be run with 32x_scd"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1 - Fingers"/>
+			<feature name="part_id" value="Disc 1 - Fingers" />
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa, 32x) (disc 1)" sha1="c0563dec08e2e89e42705d324b39f78b0056dcd5"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2 - Juice"/>
+			<feature name="part_id" value="Disc 2 - Juice" />
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa, 32x) (disc 2)" sha1="21044739e37a7faf11dd21e633d64c0f817f991b"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom3" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 3 - Mad Dog"/>
+			<feature name="part_id" value="Disc 3 - Mad Dog" />
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa, 32x) (disc 3)" sha1="cc4a4c7c64c16a0f8ce3d8a4d82e94d11466a769"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom4" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 4 - Smash"/>
+			<feature name="part_id" value="Disc 4 - Smash" />
 			<diskarea name="cdrom">
 				<disk name="slam city with scottie pippen (usa, 32x) (disc 4)" sha1="6432d3447cb2be5e39fb79b69833dd80e4587c6c"/>
 			</diskarea>
@@ -4919,7 +4919,7 @@ Requires [disc swap]
 		<publisher>Good Deal Games</publisher>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star strike (usa, prototype)" sha1="65552aa20d2b799083fc4d27efc590fe91aa77af"/>
+				<disk name="star strike (usa, prototype)" sha1="65552aa20d2b799083fc4d27efc590fe91aa77af" />
 			</diskarea>
 		</part>
 	</software>
@@ -4941,16 +4941,16 @@ Requires [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="T-162045"/>
-		<info name="alt_title" value="Supreme Warrior - Ying Heung (Box)"/>
+		<info name="alt_title" value="Supreme Warrior - Ying Heung (Box)" />
 		<info name="ring_code" value="GW 02411.1 RE-1 (Disc 1), GW 02411.2 RE-1 (Disc 2)"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1 - Fire and Earth"/>
+			<feature name="part_id" value="Disc 1 - Fire and Earth" />
 			<diskarea name="cdrom">
 				<disk name="supreme warrior (usa) (disc 1)" sha1="dbdc3fcdee8c590401a815662878476632f42cf0"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2 - Wind and Tang Fu"/>
+			<feature name="part_id" value="Disc 2 - Wind and Tang Fu" />
 			<diskarea name="cdrom">
 				<disk name="supreme warrior (usa) (disc 2)" sha1="00344d23da869e465c322e154c9babf219271e49"/>
 			</diskarea>
@@ -4976,17 +4976,17 @@ Requires [32X] add-on
 Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="T-16203F"/>
-		<info name="alt_title" value="Supreme Warrior - Ying Heung (Box)"/>
+		<info name="alt_title" value="Supreme Warrior - Ying Heung (Box)" />
 		<!-- <sharedfeat name="requirement" value="32x"/> -->
 		<info name="usage" value="Requires to be run with 32x_scd"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1 - Fire and Earth"/>
+			<feature name="part_id" value="Disc 1 - Fire and Earth" />
 			<diskarea name="cdrom">
 				<disk name="supreme warrior (usa, 32x) (disc 1)" sha1="a9afa96f2300e19777724404909d4f204199f342"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2 - Wind and Tang Fu"/>
+			<feature name="part_id" value="Disc 2 - Wind and Tang Fu" />
 			<diskarea name="cdrom">
 				<disk name="supreme warrior (usa, 32x) (disc 2)" sha1="e99f121209bac853d9e0d88a1a395354b264ebd5"/>
 			</diskarea>
@@ -5115,7 +5115,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Extreme Entertainment Group</publisher>
 		<info name="serial" value="T-22025"/>
-		<info name="alt_title" value="Third World War (Box)"/>
+		<info name="alt_title" value="Third World War (Box)" />
 		<info name="ring_code" value="AE01941 R1C"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -5156,7 +5156,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="T-89015"/>
-		<info name="alt_title" value="Trivial Pursuit - Interactive Multimedia Game (Box)"/>
+		<info name="alt_title" value="Trivial Pursuit - Interactive Multimedia Game (Box)" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="trivial pursuit (usa)" sha1="2e23b0b05b67fe4f30286448f030a391b9da9e9b"/>
@@ -5276,7 +5276,7 @@ Requires [disc swap]
 		<year>1992</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-6402"/>
-		<info name="release" value="199211xx"/>
+		<info name="release" value="199211xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="wonder dog (usa)" sha1="dbb8d538de584c38f0d0217777d091b593e27999"/>
@@ -5295,7 +5295,7 @@ Requires [disc swap]
 		<description>BC Racers (USA)</description>
 		<year>1994</year>
 		<publisher>Core Design</publisher>
-		<info name="release" value="199412xx"/>
+		<info name="release" value="199412xx" />
 		<info name="serial" value="T-115075"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -5393,7 +5393,7 @@ Requires [disc swap]
 		<info name="serial" value="T-118025"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="compton's interactive encyclopedia v2.01s (usa)" sha1="79ca6bb38c296ac3cc6352823be337371ad7a396"/>
+				<disk name="compton's interactive encyclopedia v2.01s (usa)" sha1="79ca6bb38c296ac3cc6352823be337371ad7a396" />
 			</diskarea>
 		</part>
 	</software>
@@ -5409,7 +5409,7 @@ Requires [disc swap]
 		<publisher>American Laser Games</publisher>
 		<info name="serial" value="T-111055"/>
 		<part name="cdrom" interface="scd_cdrom">
-			<feature name="peripheral" value="menacer"/>
+			<feature name="peripheral" value="menacer" />
 			<diskarea name="cdrom">
 				<disk name="crime patrol (usa)" sha1="544f2ac30e49c141d5a185a30c80b2ee51f12fd1"/>
 			</diskarea>
@@ -5538,14 +5538,14 @@ Requires [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1"/>
+			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom1">
 				<disk name="johnny mnemonic (usa, prototype) (disc 1)" sha1="bd222aee2d7ebaf9524db3fc3cbc3d9782504d92" status="baddump"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2"/>
+			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom2">
 				<disk name="johnny mnemonic (usa, prototype) (disc 2)" sha1="e2f626d382b861043fbedddacf948d59cce1f290" status="baddump"/>
 			</diskarea>
@@ -5582,7 +5582,7 @@ Requires [disc swap]
 		<info name="serial" value="ACDG-GP1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="karaoke - jvc cd+g karaoke - top hit sampler (usa)" sha1="e969df346a8106b837b471cc87670b6aab981ec3" status="baddump"/>
+				<disk name="karaoke - jvc cd+g karaoke - top hit sampler (usa)" sha1="e969df346a8106b837b471cc87670b6aab981ec3" status="baddump" />
 			</diskarea>
 		</part>
 	</software>
@@ -5597,7 +5597,7 @@ Requires [disc swap]
 		<year>1995</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-60185"/>
-		<info name="release" value="199501xx"/>
+		<info name="release" value="199501xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="keio flying squadron (usa)" sha1="4e47afd43c13ae481dd159fd6e0f2fc4d180a211"/>
@@ -5644,7 +5644,7 @@ Requires [disc swap]
 		<description>My Paint (USA)</description>
 		<year>1993</year>
 		<publisher>Saddleback Graphics</publisher>
-		<info name="alt_title" value="My Paint - The Animated Paint Program (Box)"/>
+		<info name="alt_title" value="My Paint - The Animated Paint Program (Box)" />
 		<info name="serial" value="T-109015"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
@@ -5688,13 +5688,13 @@ Requires [disc swap]
 ]]></notes>
 		<info name="serial" value="T-162105"/>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1"/>
+			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
 				<disk name="night trap (usa, re-release) (disc 1)" sha1="69cd893b1b2d971da405cac1c4c71114e8a91648"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2"/>
+			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
 				<disk name="night trap (usa, re-release) (disc 2)" sha1="d8447c507abf9b7afc64b943fa3b4f794ddf25f1"/>
 			</diskarea>
@@ -5711,7 +5711,7 @@ Requires [disc swap]
 		<year>1994</year>
 		<publisher>Data East</publisher>
 		<info name="serial" value="T-13015"/>
-		<info name="release" value="199406xx"/>
+		<info name="release" value="199406xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="panic (usa)" sha1="44216917d5e42f131c0854cd8fb5066f5e39c87f"/>
@@ -5729,13 +5729,13 @@ Requires [disc swap]
 Requires [disc swap]
 ]]></notes>
 		<part name="cdrom1" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 1"/>
+			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
 				<disk name="penn and teller's smoke and mirrors (usa, prototype) (disc 1)" sha1="01d82d2f767df776c55fc49fe0bfe22132fc9e40" status="baddump"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
-			<feature name="part_id" value="Disc 2"/>
+			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
 				<disk name="penn and teller's smoke and mirrors (usa, prototype) (disc 2)" sha1="f7c989041a9775f525287981ed6eae778c5bd5b6" status="baddump"/>
 			</diskarea>
@@ -5786,7 +5786,7 @@ Requires [disc swap]
 		<year>1993</year>
 		<publisher>Tengen</publisher>
 		<info name="serial" value="T-48015"/>
-		<info name="release" value="199308xx"/>
+		<info name="release" value="199308xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="robo aleste (usa)" sha1="16f734ed901182e0e435e6c2b4f559e99615f148"/>
@@ -5809,10 +5809,10 @@ Requires [disc swap]
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="MK-4128 / WCM-9201"/>
-		<info name="release" value="19921015"/>
+		<info name="release" value="19921015" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rock paintings (usa)" sha1="614f3f8e89e4b91923ff69719c38baef679f8e8d" status="baddump"/>
+				<disk name="rock paintings (usa)" sha1="614f3f8e89e4b91923ff69719c38baef679f8e8d" status="baddump" />
 			</diskarea>
 		</part>
 	</software>
@@ -5941,7 +5941,7 @@ Requires [disc swap]
 		<year>1995</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="T-143015"/>
-		<info name="alt_title" value="The Space Adventure (Box)"/>
+		<info name="alt_title" value="The Space Adventure (Box)" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="the space adventure - cobra the legendary bandit (usa)" sha1="51a755087713cc945adf5d5e85da713343ea3a0e"/>
@@ -5986,7 +5986,7 @@ Requires [disc swap]
 		<year>1992</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="T-6403"/>
-		<info name="release" value="199212xx"/>
+		<info name="release" value="199212xx" />
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
 				<disk name="wolfchild (usa)" sha1="700228109f9fe28bd5af6525c9fe0354913e1c6a"/>

--- a/hash/segacd.xml
+++ b/hash/segacd.xml
@@ -306,7 +306,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT60055RE R2D MFD BY JVC, SEGAT60055 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ah3 - thunderstrike (usa)" sha1="46d352674119dabf0728a07dc7354b54fe5a027b"/>
+				<disk name="ah3 - thunderstrike (usa)" sha1="465b952a84ff0e59a696356946cf4b25274c3a89"/>
 			</diskarea>
 		</part>
 	</software>
@@ -411,7 +411,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="SEGAT115045 R1H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battlecorps (usa)" sha1="6ea60ddc9064f7aa770ea87f2fb2ff438793c037"/>
+				<disk name="battlecorps (usa)" sha1="4f489e565e3c7c3a5a4cd1d00bc5acac406da06b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -694,7 +694,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-053600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cliffhanger (usa)" sha1="71753bdebddc8de1f9920f19e06a7858a470f286"/>
+				<disk name="cliffhanger (usa)" sha1="4aca3b3e186015ffb0794e2c83762cbc2457eaec"/>
 			</diskarea>
 		</part>
 	</software>
@@ -713,7 +713,7 @@ See: http://rawdump.net/
 		<info name="ring_code" value="CDAC-031400 5"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cobra command (usa)" sha1="2d7c32591cec389f6d5feb5f0301495ff8021307"/>
+				<disk name="cobra command (usa)" sha1="53d79a6fe72bb5328c52328a135a9c5725170f03"/>
 			</diskarea>
 		</part>
 	</software>
@@ -755,7 +755,7 @@ Requires [32X] add-on
 		<info name="usage" value="Requires to be run with 32x_scd"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="corpse killer (usa, 32x)" sha1="68a6c75bc730025e90fa413c107090e7f4e377e0"/>
+				<disk name="corpse killer (usa, 32x)" sha1="2d8721e835e58b6c850b43fe2d76382d1bbf59f7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -783,7 +783,7 @@ Requires [32X] add-on
 		<info name="ring_code" value="CDAC-059200 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dark wizard (usa)" sha1="cf784af53b6dedc2777b91f5ac5f169f2f7b9c30"/>
+				<disk name="dark wizard (usa)" sha1="a7f15287245e324bb1338ddf436a4d615618830b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -801,7 +801,7 @@ Requires [32X] add-on
 		<info name="ring_code" value="CDAC-052900 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="double switch (usa)" sha1="2b727773fda836ddfb972dc98820bee7135da709"/>
+				<disk name="double switch (usa)" sha1="550ef74c39eb6dd55b4410012ad8b1cf83c92e6e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -827,13 +827,13 @@ Requires [disc swap]
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="dracula unleashed (usa) (disc 1)" sha1="307c0779dace5d95f3e7a0ccee18c00356ca2362"/>
+				<disk name="dracula unleashed (usa) (disc 1)" sha1="bf3938a34c7c58b11ea577a54cf551ce3f0593b1"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="dracula unleashed (usa) (disc 2)" sha1="e3adeebe60f32a3487e7d5afc86675b73057fba6"/>
+				<disk name="dracula unleashed (usa) (disc 2)" sha1="67a86dbf0718a76998d6b30b738ca856d64a756f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -851,7 +851,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT121015 R3D MFD BY JVC 13"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon's lair (usa)" sha1="724bc872d111ed67df10e95b134f8bf7fe2fcfe3"/>
+				<disk name="dragon's lair (usa)" sha1="4f7200a039d440ff83b0e80ad9d2b90715b85ed6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -880,7 +880,7 @@ Requires [disc swap]
 		<info name="ring_code" value="JVC SEGA4657 R2E 0 0"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dungeon explorer (usa)" sha1="432897f1f19e8a053c8f7d783e2331e7fd0f0b1f"/>
+				<disk name="dungeon explorer (usa)" sha1="9a935d5cec48a4c465e52bc6a968d5b5ba3eb32b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -912,7 +912,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-042000 1, CDAC-042000 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ecco the dolphin (usa)" sha1="7fb88d4f0fe34ee40991d724b9e90f7586081fd2"/>
+				<disk name="ecco the dolphin (usa)" sha1="dec9f9d8cc7e9edafcd56b7b03023349dd0174f0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -945,7 +945,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC 077400"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ecco - the tides of time (usa)" sha1="20cb72bf75a848568dd034188bebe316138b6186"/>
+				<disk name="ecco - the tides of time (usa)" sha1="928726593d409c09b6f2f4a7fd5d7143cb620c03"/>
 			</diskarea>
 		</part>
 	</software>
@@ -995,7 +995,7 @@ Requires [disc swap]
 		<info name="serial" value="T-93115"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="espn baseball tonight (usa)" sha1="3965f3f96579abe6d754360fb123f5cfb2e8cce1"/>
+				<disk name="espn baseball tonight (usa)" sha1="3357a6b8ecb7c152703125d1f85580d008f70ad4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1014,7 +1014,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-077600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="espn sunday night nfl (usa)" sha1="11504fbfcecc6ffdaa69960ba9e57d6cd343bd78"/>
+				<disk name="espn sunday night nfl (usa)" sha1="e34f71de1f6f4a712f3397a391038d20ba2eaa95"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1157,7 +1157,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-070100 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="eye of the beholder (usa)" sha1="8901e20ec6cb1cc8b8771b7bdac01d3220a067f5"/>
+				<disk name="eye of the beholder (usa)" sha1="6394fc55f8b8bf36cf835ab3514fa11535652df1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1186,13 +1186,13 @@ Has optional unemulated [32X] mode, which in turn needs [disc swap]
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Sega CD / Disc 1 - Key Disc" />
 			<diskarea name="cdrom">
-				<disk name="fahrenheit (usa) (sega cd)" sha1="c53080012578fe291323197e6319842beb84ee9b"/>
+				<disk name="fahrenheit (usa) (sega cd)" sha1="8e5ce49c68edf4e0da5e0935fb419b3d29a52527"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="32X CD / Disc 2 - Insert Key Disc 1 First" />
 			<diskarea name="cdrom">
-				<disk name="fahrenheit (usa) (32x cd)" sha1="f94ea9821ca030c3cc61eccc29eb9c692198415e"/>
+				<disk name="fahrenheit (usa) (32x cd)" sha1="8dac276eacfa72913c5fb2d12c5d3360bb513fe4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1254,7 +1254,7 @@ Has optional unemulated [32X] mode, which in turn needs [disc swap]
 		<info name="ring_code" value="CDAC-064000(9)1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="fifa international soccer (usa)" sha1="3e32c3d5e99f5df103277aed209a59f888c06bec"/>
+				<disk name="fifa international soccer (usa)" sha1="a38b06e9812b31ab1bfb2ae10b3422c993d5fc2e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1297,7 +1297,7 @@ Has optional unemulated [32X] mode, which in turn needs [disc swap]
 		<info name="ring_code" value="CDAC-041400 6, CDAC-041400 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="final fight cd (usa)" sha1="bd0ae447a302d2e220f13c84a7a56a45007c7e83"/>
+				<disk name="final fight cd (usa)" sha1="922993f958901291c6a28dd34a368edd25d84f5d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1350,7 +1350,7 @@ Has optional unemulated [32X] mode, which in turn needs [disc swap]
 		<info name="ring_code" value="CDAC-063600 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="formula one world championship - beyond the limit (usa)" sha1="da0c0fd84af458744d6b045c3fb44b5ac5f89152"/>
+				<disk name="formula one world championship - beyond the limit (usa)" sha1="3bbfccb65fb8c5185cbfbb5a52ee5c95d614c05d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1376,14 +1376,14 @@ Requires [disc swap]
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="ground zero texas (usa) (disc 1)" sha1="226bef5c19446c6be18674941707b3baebc11223"/>
+				<disk name="ground zero texas (usa) (disc 1)" sha1="a4f140fb429d5ed9623aa0860d6aee0db78f0c87"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="ground zero texas (usa) (disc 2)" sha1="13c7cc77f2659155dec4deb4700d8ac8af95fb42"/>
+				<disk name="ground zero texas (usa) (disc 2)" sha1="00492e73180ba447b4216699be023588679b76f8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1442,7 +1442,7 @@ Requires [disc swap]
 		<info name="ring_code" value="HOTALIENRE R1H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heart of the alien - out of this world parts i and ii (usa)" sha1="a2784fa95bb3b29067b5d8148dd95877456577e7"/>
+				<disk name="heart of the alien - out of this world parts i and ii (usa)" sha1="085d32028c3dd4dfc1f0a05cd9be6fd3293c1f52"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1480,7 +1480,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT60105 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heimdall (usa)" sha1="986813f0d66eff9c163c19ccdbe6e055bf75043d"/>
+				<disk name="heimdall (usa)" sha1="b429b7d57897b357d86529984e6c8fc787a12371"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1518,7 +1518,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-032400 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hook (usa)" sha1="310b67fc0163da2dbae236b1276624b2170425b0"/>
+				<disk name="hook (usa)" sha1="a713dc15bf82115230b7201860e2b99119f9d0da"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1536,7 +1536,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT124015 R2H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="iron helix (usa)" sha1="243a1c1691ab1a587371e34c1692663b28814184"/>
+				<disk name="iron helix (usa)" sha1="e617f0b6d0887517ff63a6be9676039f548c38f8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1556,7 +1556,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-075900 3"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jeopardy (usa)" sha1="6f159f64d3ea62bb8eff70e9a2f84d02bfb54688"/>
+				<disk name="jeopardy (usa)" sha1="02b99541189e0982b82607aa64fa71505f944cb0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1579,7 +1579,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4201 R1C MFD BY JVC, SEGA4201RE R2C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="joe montana's nfl football (usa)" sha1="a6c4dccb249c27d38846e204313446e5928c2b4d"/>
+				<disk name="joe montana's nfl football (usa)" sha1="a308351c13fc57c969671dc2f0ec24a00a9eabc3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1627,7 +1627,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4411RE R3C MFD BY JVC, SEGA4411RE R4C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jurassic park (usa)" sha1="8ab39eda898277571127b9ac03dce64546602caf"/>
+				<disk name="jurassic park (usa)" sha1="f1b842803f87841f2d442e438c2047ad4a5f889c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1645,7 +1645,7 @@ Requires [disc swap]
 		<info name="ring_code" value="GW 03611 SRCR##02"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kids on site (usa)" sha1="9a97c7c151cbe77121bb626954b50bd2223a9292"/>
+				<disk name="kids on site (usa)" sha1="04f4302d49e3f2f5b599e8bdd2fff08d92e70015"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1766,7 +1766,7 @@ Requires [disc swap]
 		<info name="ring_code" value="T95025-U12 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lethal enforcers ii - gun fighters (usa)" sha1="7d63da6fa26441e31bd614474936d8c7adacd239"/>
+				<disk name="lethal enforcers ii - gun fighters (usa)" sha1="6f9fbcf9f5ab7bcbbb2740cbe72af63183112855"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1784,7 +1784,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT153015 R3J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="loadstar - the legend of tully bodine (usa)" sha1="a9b4df4c8b3ed81d14cfa5506961c3815387194e"/>
+				<disk name="loadstar - the legend of tully bodine (usa)" sha1="6208729d1723944354fabcd0e281cbc9f13874d4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1821,7 +1821,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4450 R1F"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lords of thunder (usa)" sha1="c4be0138ac50ee190fb8df9839a2efb97e9f30c2"/>
+				<disk name="lords of thunder (usa)" sha1="0dfac7659fc981eb1322f8dc801f45dcdb33eed3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1908,7 +1908,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT127045RE R1H"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunar - eternal blue (usa)" sha1="1cc95c2b91d6c52d561a4f70e96c52ddc3c10313"/>
+				<disk name="lunar - eternal blue (usa)" sha1="e93c3f2cd946e0ea1ea3cdecbf24e55d7acb5732"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1931,7 +1931,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT111015 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mad dog mccree (usa)" sha1="244713e8c7c1d1ef38f5f9ba2232cb1a2b23a1f7"/>
+				<disk name="mad dog mccree (usa)" sha1="b31567eb08b7730f0dfef90650d162b7e2580316"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1951,7 +1951,7 @@ Requires [disc swap]
 		<part name="cdrom" interface="scd_cdrom">
 			<feature name="peripheral" value="mouse" />
 			<diskarea name="cdrom">
-				<disk name="mansion of hidden souls (usa)" sha1="1d1dba770de6d5969d23d2e86ad4028445d514c4"/>
+				<disk name="mansion of hidden souls (usa)" sha1="75095ab4f62cd1d351f4dadc5202ab84a3c269a9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1975,7 +1975,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-077800 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mary shelley's frankenstein (usa)" sha1="4d0d40a70d2a585e371d23d122ec98a6dce7b299"/>
+				<disk name="mary shelley's frankenstein (usa)" sha1="353b90dbcb159afca517218a0157b5ecc841379b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2045,7 +2045,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-055200 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="microcosm (usa)" sha1="bca8a59c2aa47d1207b0c2df1d2ff40cb5d11fb4"/>
+				<disk name="microcosm (usa)" sha1="d77d0f9575aa53d7aef0640fb4532f7978590282"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2063,7 +2063,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4439 R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="midnight raiders (usa)" sha1="83db51aee2ef658fa9d29e67acdc7d5774e69d3a"/>
+				<disk name="midnight raiders (usa)" sha1="741b1383164112074cf5d6fc09c5262015779869"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2101,7 +2101,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDCA-060900 3, CDCA-061500 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mortal kombat (usa)" sha1="454e23c8922380f813a3a5b9d94902a691109332"/>
+				<disk name="mortal kombat (usa)" sha1="06fc7e387c193c28d1068cf74609de36021eca2b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2127,7 +2127,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-074200 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nba jam (usa)" sha1="48b0fdb2476ac795b303bfdc11b40abb8609511b"/>
+				<disk name="nba jam (usa)" sha1="fbc1d8fed4b78c9a51cc29fb9b7feee6959b3f7c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2146,7 +2146,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-054500 4"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl's greatest - san francisco vs dallas 1978-1993 (usa)" sha1="20fc574d1912b92dd9d6c248734a8e897501b3ea"/>
+				<disk name="nfl's greatest - san francisco vs dallas 1978-1993 (usa)" sha1="0300f0b0bcff68a2a9995d1752044a16c1077708"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2242,7 +2242,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-056700 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nhl '94 (usa)" sha1="ac34c65117668dc53e7075a0dbe9bd260fdb1c15"/>
+				<disk name="nhl '94 (usa)" sha1="7cde2688a9157ecc18dab9a1ee76b93dc8ffdc8e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2272,14 +2272,14 @@ Requires [disc swap]
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa, 32x) (disc 1)" sha1="a4407b3264ef29d343f7d4b984194bc4636009d3"/>
+				<disk name="night trap (usa, 32x) (disc 1)" sha1="672776292563c691e5dbf76d216946292b72d195"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa, 32x) (disc 2)" sha1="18b2a72bf91589ef43986b3f3add9b70c609f346"/>
+				<disk name="night trap (usa, 32x) (disc 2)" sha1="598a58f0aa08c797b4e89978d6cd960aa40dac94"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2305,14 +2305,14 @@ Required [disc swap]
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa) (disc 1)" sha1="c2c18c6af2aae9619ca5772fcb6aecc79a142a40"/>
+				<disk name="night trap (usa) (disc 1)" sha1="ae4fa663362cd3f044a6df8a9930d3cf2708b63c"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa) (disc 2)" sha1="41c44780c325403d9c4522fc3d010912fc3dad5a"/>
+				<disk name="night trap (usa) (disc 2)" sha1="47689dd1d5aabb428de2076a57da4e1f0e83eea6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2345,7 +2345,7 @@ Requires [disc swap]
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="night trap (usa) (disc 2)" sha1="41c44780c325403d9c4522fc3d010912fc3dad5a"/>
+				<disk name="night trap (usa) (disc 2)" sha1="47689dd1d5aabb428de2076a57da4e1f0e83eea6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2377,7 +2377,7 @@ No support for Mega CD cart slots
 		<info name="usage" value="Requires to be run with megadriv psolar cart"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pier solar and the great architects enhanced soundtrack disc (world)" sha1="1f26cce723ef044f449d87cdb624a2937f40f5d9"/>
+				<disk name="pier solar and the great architects enhanced soundtrack disc (world)" sha1="05dcd8e5d8dba48ed612f8c737fcf9c3e9812e57"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2437,7 +2437,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="SEGAT127035RE R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="popful mail (usa)" sha1="459853983b1e01fe297ffd6287502eab1678e8e4"/>
+				<disk name="popful mail (usa)" sha1="b87c7ffd99dbd37e6a775f4edc296365b260deb3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2479,7 +2479,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="CDAC-032200 6"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="prince of persia (usa)" sha1="fd9250f32c23e0954b197d1833c20de705df43d3"/>
+				<disk name="prince of persia (usa)" sha1="99b2084db168bbbbbd78d23b3a06754cdd89825f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2518,7 +2518,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="CDAC-053800 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="puggsy (usa)" sha1="307206f9f4154699e9386fa9b45bd79d5ed72e5d"/>
+				<disk name="puggsy (usa)" sha1="421e43f3e792a7a27ef5ef168d875a26362c879b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2545,7 +2545,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="CDAC-055000 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="racing aces (usa)" sha1="a2038d4de56b75d61db6ad757919cca00cc91c95"/>
+				<disk name="racing aces (usa)" sha1="d6b269de0f919164fc12ede376a054b0a2dccee2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2568,7 +2568,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="SEGAT86025 R1F MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rdf - global conflict (usa)" sha1="32cf1e068598e385962db8de493eb191aab7716b"/>
+				<disk name="rdf - global conflict (usa)" sha1="b6922a240c56bd3a145b9aba9fb63d76985644e5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2589,7 +2589,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="SEGAT49035 R1C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="revenge of the ninja (usa)" sha1="d6f0a13f1b630ba771cad7c86b607f31cf6092b7"/>
+				<disk name="revenge of the ninja (usa)" sha1="1c7bce3382cc768ec788c8f652a2cac633cc9cc2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2610,7 +2610,7 @@ No support for Mega CD cart slots
 		<info name="ring_code" value="S604430RE R1D MFD BY JVC, S604430RE R2D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rise of the dragon (usa, rev. a)" sha1="412d819633740c597b67591cf12fdac7c7081194"/>
+				<disk name="rise of the dragon (usa, rev. a)" sha1="62c5e2a43a07f50351eb84bdbe90330750537712"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2656,7 +2656,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="ring_code" value="SEGA6207 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="road avenger (usa)" sha1="05fa6ae67687aacdf99fe939b0f04ce13b6d527b"/>
+				<disk name="road avenger (usa)" sha1="2de47da786a49e07232662e6a33cb2fb17004280"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2675,7 +2675,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="ring_code" value="SEGA4442 R1J"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="saban's mighty morphin power rangers (usa)" sha1="fffd902d4ab06d946c47b7eaa40cc5ddd9963299"/>
+				<disk name="saban's mighty morphin power rangers (usa)" sha1="11b426d181c3e3099e4b29654fdf6ba3b19398f3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2732,7 +2732,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="ring_code" value="CDAC-056800 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sega classics arcade collection (usa, 5 in 1)" sha1="9f4bdadabba7d8998b701a3becd2520d4d2a037d"/>
+				<disk name="sega classics arcade collection (usa, 5 in 1)" sha1="3e86e8fa7c3f1252b68008711e2261ca40862608"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2768,7 +2768,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="ring_code" value="CDRM-1033200 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sewer shark (usa, rev. a)" sha1="0f339806d73c473c20906935836d49457339430f"/>
+				<disk name="sewer shark (usa, rev. a)" sha1="516b1db245a680afc0cb3220a1b255e80453be5d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2846,7 +2846,7 @@ Black screen, requires sub CPU to be overclocked by 1.5x
 		<info name="ring_code" value="CDAC-031300 1, CDAC-031300 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sherlock holmes - consulting detective vol. i (usa)" sha1="32d2f47f459927cd162376e46d6a02430572a82a"/>
+				<disk name="sherlock holmes - consulting detective vol. i (usa)" sha1="d295f474b188f7121282d92c17c952b9a907d02d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2873,14 +2873,14 @@ Requires [disc swap]
 		<part name="cdrom1" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 1" />
 			<diskarea name="cdrom">
-				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 1)" sha1="162af0ed791b8a18040ecb3925984a738dc72d49"/>
+				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 1)" sha1="470ca1a64ed2e3a3b664cdda8d685e2eaf2577ab"/>
 			</diskarea>
 		</part>
 
 		<part name="cdrom2" interface="scd_cdrom">
 			<feature name="part_id" value="Disc 2" />
 			<diskarea name="cdrom">
-				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 2)" sha1="3de4f89de8920185197d8a65f0ea97a83e774a98"/>
+				<disk name="sherlock holmes - consulting detective vol ii (usa) (disc 2)" sha1="5b963168f6476a4e0f43050543ed6f0ffbd9dc38"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2981,7 +2981,7 @@ Requires [disc swap]
 		<info name="ring_code" value="3/95 6RA3 1008604656, 3/95 5RA1 1008604656"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="shining force cd (usa, alt)" sha1="ddb304849d01df44251d69b890df47c8db1d8642"/>
+				<disk name="shining force cd (usa, alt)" sha1="d6c24f360b8845e783d76f9a9af527ddf025ed08"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3006,7 +3006,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4423 R2D MFD BY JVC, SEGA4423RE R2D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="silpheed (usa)" sha1="f4d368f13f7998fb8d37c9a3439d42497e0ee359"/>
+				<disk name="silpheed (usa)" sha1="2d172387631ddcb056d8547a4a38b29721771c17"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3097,7 +3097,7 @@ Requires [disc swap]
 		<info name="ring_code" value="T95035-U12 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="snatcher (usa)" sha1="815edc5df272e4b10edd5919b29c3a996a1799c2"/>
+				<disk name="snatcher (usa)" sha1="d38ada693efc354c1d3c4c663214ab173985bf95"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3132,7 +3132,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4130RE2 R3C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sol-feace (usa)" sha1="498ebd9c1fe4bd2f84cf6c32829b68e471eb3b07"/>
+				<disk name="sol-feace (usa)" sha1="ba813d3b0dfa00092dbdb7e323755953a2a60d85"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3238,7 +3238,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGA4407RE125 R7D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sonic cd (usa, alt)" sha1="a8a968a6239da07c6143dd420a6a3093f4dddcd2"/>
+				<disk name="sonic cd (usa, alt)" sha1="1645128fc656aaba3ea5da176e5430ef9e65a05e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3325,7 +3325,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT115035 R1J MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="soulstar (usa)" sha1="4e2ab5b51dca2a4c23700b4d3587a9a08ac6d29f"/>
+				<disk name="soulstar (usa)" sha1="43c5e634d37ab2dde53ad1387d5ebfbc8320a6d7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3343,7 +3343,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-080300 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space ace (usa)" sha1="d5f5125af3e9e59a59f775576ddc99b4aadaf505"/>
+				<disk name="space ace (usa)" sha1="2e158a2e79162324b70bca7a115068f0b5c6a675"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3362,7 +3362,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT60075 R1D MFD BY JVC, SEGAT60075 R2C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="star wars - rebel assault (usa)" sha1="f1049ddf315f3a9ecd29378bc026a05669120112"/>
+				<disk name="star wars - rebel assault (usa)" sha1="12d3691a5d48863343929bae82e444a58b66d567"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3380,7 +3380,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-073400 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="starblade (usa)" sha1="6233ca426d0797a5bccf98261b5164c44feb5203"/>
+				<disk name="starblade (usa)" sha1="5764dd497e86326a581891a7a3e6f9723788a0d0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3418,7 +3418,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT11025 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="stellar-fire (usa)" sha1="4e0245e30cac825c262551eda322eb774919e87b"/>
+				<disk name="stellar-fire (usa)" sha1="a5248d49dbc38491239e9905e9b8129ff8952691"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3460,7 +3460,7 @@ Requires [disc swap]
 		<info name="ring_code" value="1008604432 7/95 1RA2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the adventures of batman and robin (usa)" sha1="80e65ec95ea9440e59d64ea067b48921686006e8"/>
+				<disk name="the adventures of batman and robin (usa)" sha1="1fd748ba4a759ca4bd6d4b5962e17ce3ee06934f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3565,7 +3565,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT60035RE R1C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the secret of monkey island (usa)" sha1="a894a9e6ba908f742d686fb85b7ae3c700fb1d36"/>
+				<disk name="the secret of monkey island (usa)" sha1="1f90af90c880bad8e9acf6c0f2fa10000072abbe"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3610,7 +3610,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGACD86003 R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the terminator (usa)" sha1="43bf02bf06fc5d1bd32bc61b11acd1745d2d7a1d"/>
+				<disk name="the terminator (usa)" sha1="47c82ce49c926d3b381a46aa4505bcc03737abb4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3629,7 +3629,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT49025 R2C MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="time gal (usa)" sha1="22c4bc9adb5560c276f0fe88967e04bf279d54d0"/>
+				<disk name="time gal (usa)" sha1="268978a58bbf09a21e14c01534ac4f90fe55df5e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3704,7 +3704,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT127025ARE R1D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vay (usa)" sha1="099e4c43d8ca5eb57854db25cbcbfc3139e41a9e"/>
+				<disk name="vay (usa)" sha1="2ce0a42e3fd56bf266b340dc9c2d2eab876845b4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3728,7 +3728,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-077500 1"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wheel of fortune (usa)" sha1="1c48a4dd3d70ed9d4450aea57bb5dc671e5c4a4c"/>
+				<disk name="wheel of fortune (usa)" sha1="a07fb24ca8d88b47d93ffca555a18d46afd54ee4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3746,7 +3746,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT111045 R1H MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="who shot johnny rock (usa)" sha1="dc9675c0bfc19baae5be13ce1540062c09b930f3"/>
+				<disk name="who shot johnny rock (usa)" sha1="f6b657ae449bc9c39bd3c126e2371bdfa161b251"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3769,7 +3769,7 @@ Requires [disc swap]
 		<info name="ring_code" value="CDAC-059000 2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wing commander (usa)" sha1="d36f61f84a87518691438a3c4f9862b2ce23e483"/>
+				<disk name="wing commander (usa)" sha1="4e4785c0fa94af17183bb12a7646fd2a01ba52b6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3787,7 +3787,7 @@ Requires [disc swap]
 		<info name="ring_code" value="1008604437 8/95 1RA2"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wirehead (usa)" sha1="762bb917b936f1a781a2fbe66bbe3a9bf5dd5d43"/>
+				<disk name="wirehead (usa)" sha1="d5e5059d5b932655f0674de725957329761f3f24"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3821,7 +3821,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT79025 R2D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="world cup usa 94 (usa)" sha1="cb17c8ea42ec3a7d9562a0e188610a687f6b8829"/>
+				<disk name="world cup usa 94 (usa)" sha1="2d2040e8700b4e43d56f60e29af5879454077eef"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3840,7 +3840,7 @@ Requires [disc swap]
 		<info name="ring_code" value="SEGAT81015 R3D MFD BY JVC"/>
 		<part name="cdrom" interface="scd_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wwf rage in the cage (usa)" sha1="960a6ffa31b52e7ca8e7759f3d385940c8f2eb56"/>
+				<disk name="wwf rage in the cage (usa)" sha1="be3a229bc592d3c7d9da76a9294e469d174a4fcf"/>
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
Updates to hashes on a number of titles across a few systems, attempting to address some of #2517.  The hashes are all based on the sources referenced in the comments for those entries.

Some minor fixes:
 - macross psx part 1 cdrom1 was incorrectly tagged as 'cdrom', so changed this to 'cdrom1' to match the standard being used for multi-disc entries
 - dreamcast alienfront source comment had spaces in it's 'size' field, fixed that

The xml parser I used updated these two entries, but the change seemed appropriate to leave:
- tkm2evs2 and tkm2evs3 in psx - the chd part tag in each title was spanning two lines, merged to one line
