### PR TITLE
Skeleton driver for 600 Cellular Activation Tester

### DIFF
--- a/src/devices/cpu/m6800/m6801.cpp
+++ b/src/devices/cpu/m6800/m6801.cpp
@@ -334,28 +334,28 @@ m6803e_cpu_device::m6803e_cpu_device(const machine_config &mconfig, const char *
 {
 }
 
-hd6301_cpu_device::hd6301_cpu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
-	: m6801_cpu_device(mconfig, type, tag, owner, clock, hd63701_insn, cycles_63701)
+hd6301_cpu_device::hd6301_cpu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, const m6800_cpu_device::op_func *insn, const uint8_t *cycles, address_map_constructor internal)
+	: m6801_cpu_device(mconfig, type, tag, owner, clock, hd63701_insn, cycles_63701, internal)
 {
 }
 
 hd6301v1_cpu_device::hd6301v1_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: hd6301_cpu_device(mconfig, HD6301V1, tag, owner, clock)
+	: hd6301_cpu_device(mconfig, HD6301V1, tag, owner, clock, hd63701_insn, cycles_63701)
 {
 }
 
 hd63701v0_cpu_device::hd63701v0_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: hd6301_cpu_device(mconfig, HD63701V0, tag, owner, clock)
+	: hd6301_cpu_device(mconfig, HD63701V0, tag, owner, clock, hd63701_insn, cycles_63701)
 {
 }
 
 hd6303r_cpu_device::hd6303r_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: hd6301_cpu_device(mconfig, HD6303R, tag, owner, clock)
+	: hd6301_cpu_device(mconfig, HD6303R, tag, owner, clock, m6803_insn, cycles_6803, address_map_constructor(FUNC(hd6303r_cpu_device::m6803_mem), this))
 {
 }
 
 hd6301x_cpu_device::hd6301x_cpu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
-	: hd6301_cpu_device(mconfig, type, tag, owner, clock)
+	: hd6301_cpu_device(mconfig, type, tag, owner, clock, hd63701_insn, cycles_63701)
 	, m_in_portx_func(*this)
 	, m_out_portx_func(*this)
 {

--- a/src/devices/cpu/m6800/m6801.h
+++ b/src/devices/cpu/m6800/m6801.h
@@ -207,7 +207,7 @@ protected:
 class hd6301_cpu_device : public m6801_cpu_device
 {
 protected:
-	hd6301_cpu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	hd6301_cpu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, const m6800_cpu_device::op_func *insn, const uint8_t *cycles, address_map_constructor internal = address_map_constructor());
 
 	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
 
@@ -246,7 +246,6 @@ class hd6303r_cpu_device : public hd6301_cpu_device
 public:
 	hd6303r_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
-
 
 class hd6301x_cpu_device : public hd6301_cpu_device
 {

--- a/src/devices/machine/timekpr.cpp
+++ b/src/devices/machine/timekpr.cpp
@@ -31,6 +31,7 @@ DEFINE_DEVICE_TYPE(M48T37,  m48t37_device,  "m48t37",  "M48T37 Timekeeper")
 DEFINE_DEVICE_TYPE(M48T58,  m48t58_device,  "m48t58",  "M48T58 Timekeeper")
 DEFINE_DEVICE_TYPE(MK48T08, mk48t08_device, "mk48t08", "MK48T08 Timekeeper")
 DEFINE_DEVICE_TYPE(MK48T12, mk48t12_device, "mk48t12", "MK48T12 Timekeeper")
+DEFINE_DEVICE_TYPE(DS1643,  ds1643_device,  "ds1643",  "DS1643 Nonvolatile Timekeeping RAM")
 
 
 /***************************************************************************
@@ -48,12 +49,12 @@ DEFINE_DEVICE_TYPE(MK48T12, mk48t12_device, "mk48t12", "MK48T12 Timekeeper")
 
 #define CONTROL_W (0x80)
 #define CONTROL_R (0x40)
-#define CONTROL_S (0x20) /* not emulated */
-#define CONTROL_CALIBRATION (0x1f) /* not emulated */
+#define CONTROL_S (0x20) /* not emulated - unused on DS1643 */
+#define CONTROL_CALIBRATION (0x1f) /* not emulated - unused on DS1643 */
 
 #define SECONDS_ST (0x80)
 
-#define DAY_FT (0x40) /* M48T37 - not emulated */
+#define DAY_FT (0x40) /* M48T37/DS1643 - not emulated */
 #define DAY_CEB (0x20) /* M48T35/M48T58 */
 #define DAY_CB (0x10) /* M48T35/M48T58 */
 
@@ -163,6 +164,11 @@ m48t58_device::m48t58_device(const machine_config &mconfig, const char *tag, dev
 	m_offset_flags = -1;
 }
 
+m48t58_device::m48t58_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
+	: timekeeper_device(mconfig, type, tag, owner, clock, 0x2000)
+{
+}
+
 mk48t08_device::mk48t08_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: timekeeper_device(mconfig, MK48T08, tag, owner, clock, 0x2000)
 {
@@ -192,6 +198,11 @@ mk48t12_device::mk48t12_device(const machine_config &mconfig, const char *tag, d
 	m_offset_month = 0x7fe;
 	m_offset_year = 0x7ff;
 	m_offset_century = -1;
+}
+
+ds1643_device::ds1643_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: m48t58_device(mconfig, DS1643, tag, owner, clock)
+{
 }
 
 

--- a/src/devices/machine/timekpr.h
+++ b/src/devices/machine/timekpr.h
@@ -12,6 +12,9 @@
         - MK48T08
         - MK48T12
 
+    Dallas clones that have the same functional interface:
+        - DS1643
+
 ***************************************************************************/
 
 #ifndef MAME_MACHINE_TIMEKPR_H
@@ -119,6 +122,9 @@ class m48t58_device : public timekeeper_device
 {
 public:
 	m48t58_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
+
+protected:
+	m48t58_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 };
 
 class mk48t08_device : public timekeeper_device
@@ -133,6 +139,12 @@ public:
 	mk48t12_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
 };
 
+class ds1643_device : public m48t58_device
+{
+public:
+	ds1643_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
+};
+
 // device type definition
 DECLARE_DEVICE_TYPE(M48T02,  m48t02_device)
 DECLARE_DEVICE_TYPE(M48T35,  m48t35_device)
@@ -140,5 +152,6 @@ DECLARE_DEVICE_TYPE(M48T37,  m48t37_device)
 DECLARE_DEVICE_TYPE(M48T58,  m48t58_device)
 DECLARE_DEVICE_TYPE(MK48T08, mk48t08_device)
 DECLARE_DEVICE_TYPE(MK48T12, mk48t12_device)
+DECLARE_DEVICE_TYPE(DS1643,  ds1643_device)
 
 #endif // MAME_MACHINE_TIMEKPR_H

--- a/src/emu/screen.cpp
+++ b/src/emu/screen.cpp
@@ -889,7 +889,7 @@ void screen_device::device_start()
 	save_item(NAME(m_vblank_end_time));
 	save_item(NAME(m_frame_number));
 	if (m_oldstyle_vblank_supplied)
-		logerror("%s: Deprecated legacy Old Style screen configured (MCFG_SCREEN_VBLANK_TIME), please use MCFG_SCREEN_RAW_PARAMS instead.\n",this->tag());
+		logerror("%s: Deprecated legacy Old Style screen configured (set_vblank_time), please use set_raw instead.\n",this->tag());
 
 	m_is_primary_screen = (this == screen_device_enumerator(machine().root_device()).first());
 }

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -40796,6 +40796,9 @@ zx80                            // 1980 Sinclair ZX-80
 zx81                            // 1981 Sinclair ZX-81
 zx97                            //
 
+@source:skeleton/600cat.cpp
+600cat                          //
+
 @source:skeleton/aaa.cpp
 aaa                             //
 

--- a/src/mame/roland/roland_jx8p.cpp
+++ b/src/mame/roland/roland_jx8p.cpp
@@ -60,8 +60,6 @@ void roland_jx8p_state::leds_w(u8 data)
 
 void roland_jx8p_state::jx8p_assigner_map(address_map &map)
 {
-	map(0x0000, 0x001f).m(m_assignercpu, FUNC(hd6303r_cpu_device::m6801_io));
-	map(0x0080, 0x00ff).ram(); // internal RAM
 	map(0x2000, 0x3fff).rw("cartslot", FUNC(generic_slot_device::read_ram), FUNC(generic_slot_device::write_ram));
 	map(0x4000, 0x4007).mirror(0x1ff8).r(FUNC(roland_jx8p_state::switches_r));
 	map(0x6000, 0x6000).mirror(0x1fff).w(FUNC(roland_jx8p_state::leds_w));
@@ -72,8 +70,6 @@ void roland_jx8p_state::jx8p_assigner_map(address_map &map)
 
 void roland_jx8p_state::superjx_assigner_map(address_map &map)
 {
-	map(0x0000, 0x001f).m(m_assignercpu, FUNC(hd6303r_cpu_device::m6801_io));
-	map(0x0080, 0x00ff).ram(); // internal RAM
 	map(0x1000, 0x17ff).mirror(0x800).rw("keyscan", FUNC(mb63h149_device::read), FUNC(mb63h149_device::write));
 	map(0x2000, 0x3fff).rw("cartslot", FUNC(generic_slot_device::read_ram), FUNC(generic_slot_device::write_ram));
 	map(0x4000, 0x4007).mirror(0xff8).r(FUNC(roland_jx8p_state::switches_r));

--- a/src/mame/skeleton/600cat.cpp
+++ b/src/mame/skeleton/600cat.cpp
@@ -1,0 +1,155 @@
+// license:BSD-3-Clause
+// copyright-holders:Ryan Holtz
+/***********************************************************************************************************************************
+
+    Skeleton driver for Wavetek 600 Cellular Activation Tester.
+
+************************************************************************************************************************************/
+
+#include "emu.h"
+
+#include "cpu/m6800/m6801.h"
+#include "video/hd44780.h"
+
+#include "emupal.h"
+#include "screen.h"
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
+namespace {
+
+class _600cat_state : public driver_device
+{
+public:
+	_600cat_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_lcdc(*this, "lcdc")
+		, m_screen(*this, "screen")
+		, m_palette(*this, "palette")
+	{ }
+
+	void _600cat(machine_config &config);
+
+private:
+	void mem_map(address_map &map);
+
+	HD44780_PIXEL_UPDATE(lcd_pixel_update);
+
+	void lcd_palette(palette_device &palette) const;
+
+	void p1_w(u8 data);
+	void p2_w(u8 data);
+	void p3_w(u8 data);
+	void p4_w(u8 data);
+	void sc2_w(int state);
+	void ser_tx_w(int state);
+
+	required_device<hd6303r_cpu_device> m_maincpu;
+	required_device<hd44780_device> m_lcdc;
+	required_device<screen_device> m_screen;
+	required_device<palette_device> m_palette;
+};
+
+HD44780_PIXEL_UPDATE(_600cat_state::lcd_pixel_update)
+{
+	// char size is 5x8
+	if (x > 4 || y > 7)
+		return;
+
+	if (pos < 40)
+	{
+		if (pos >= 20)
+		{
+			line += 2;
+			pos -= 20;
+		}
+
+		if (line < 4)
+			bitmap.pix(line * (8 + 1) + y, pos * 6 + x) = state ? 1 : 2;
+	}
+}
+
+void _600cat_state::lcd_palette(palette_device &palette) const
+{
+	palette.set_pen_color(0, rgb_t(138, 146, 148)); // background
+	palette.set_pen_color(1, rgb_t( 92,  83,  88)); // lcd pixel on
+	palette.set_pen_color(2, rgb_t(131, 136, 139)); // lcd pixel off
+}
+
+void _600cat_state::p1_w(u8 data)
+{
+	LOG("p1_w: %02x\n", data);
+}
+
+void _600cat_state::p2_w(u8 data)
+{
+	LOG("p2_w: %02x\n", data);
+}
+
+void _600cat_state::p3_w(u8 data)
+{
+	LOG("p3_w: %02x\n", data);
+}
+
+void _600cat_state::p4_w(u8 data)
+{
+	LOG("p4_w: %02x\n", data);
+}
+
+void _600cat_state::sc2_w(int state)
+{
+	LOG("sc2_w: %d\n", state);
+}
+
+void _600cat_state::ser_tx_w(int state)
+{
+	LOG("ser_tx_w: %d\n", state);
+}
+
+void _600cat_state::mem_map(address_map &map)
+{
+	map(0x0380, 0x0381).rw(m_lcdc, FUNC(hd44780_device::read), FUNC(hd44780_device::write));
+	map(0x0400, 0x1ff0).ram();
+	map(0x2000, 0xffff).rom().region("maincpu", 0x2000);
+}
+
+static INPUT_PORTS_START(_600cat)
+INPUT_PORTS_END
+
+void _600cat_state::_600cat(machine_config &config)
+{
+	HD6303R(config, m_maincpu, 4'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &_600cat_state::mem_map);
+	m_maincpu->out_p1_cb().set(FUNC(_600cat_state::p1_w));
+	m_maincpu->out_p2_cb().set(FUNC(_600cat_state::p2_w));
+	m_maincpu->out_p3_cb().set(FUNC(_600cat_state::p3_w));
+	m_maincpu->out_p4_cb().set(FUNC(_600cat_state::p4_w));
+	m_maincpu->out_sc2_cb().set(FUNC(_600cat_state::sc2_w));
+	m_maincpu->out_ser_tx_cb().set(FUNC(_600cat_state::ser_tx_w));
+
+	SCREEN(config, m_screen, SCREEN_TYPE_LCD);
+	m_screen->set_refresh_hz(50);
+	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500));
+	m_screen->set_size(120, 36);
+	m_screen->set_visarea_full();
+	m_screen->set_screen_update(m_lcdc, FUNC(hd44780_device::screen_update));
+	m_screen->set_palette(m_palette);
+
+	PALETTE(config, m_palette, FUNC(_600cat_state::lcd_palette), 3);
+
+	HD44780(config, m_lcdc);
+	m_lcdc->set_lcd_size(4, 20);
+	m_lcdc->set_pixel_update_cb(FUNC(_600cat_state::lcd_pixel_update));
+}
+
+ROM_START( 600cat )
+	ROM_REGION(0x10000, "maincpu", 0)
+	ROM_LOAD( "600cat.bin", 0x00000, 0x10000, CRC(7cd375f2) SHA1(611a3b8f9d2b4d54f60db40556847b229a34a309) )
+ROM_END
+
+} // anonymous namespace
+
+//    YEAR  NAME    PARENT  COMPAT  MACHINE  INPUT    CLASS          INIT        COMPANY    FULLNAME                              FLAGS
+COMP( 199?, 600cat, 0,      0,      _600cat, _600cat, _600cat_state, empty_init, "Wavetek", "600 Cellular Activation Tester", MACHINE_IS_SKELETON )

--- a/src/mame/skeleton/digitech_gsp5.cpp
+++ b/src/mame/skeleton/digitech_gsp5.cpp
@@ -39,8 +39,6 @@ void gsp5_state::ls_w(offs_t offset, u8 data)
 
 void gsp5_state::mem_map(address_map &map)
 {
-	map(0x0000, 0x001f).m(m_maincpu, FUNC(hd6303r_cpu_device::m6801_io));
-	map(0x0080, 0x00ff).ram(); // internal RAM
 	map(0x2000, 0x2006).mirror(0x1ff8).w(FUNC(gsp5_state::ls_w));
 	map(0x4000, 0x5fff).ram().share("nvram");
 	map(0x8000, 0xffff).rom().region("eprom", 0);

--- a/src/mame/yamaha/ymdx7.cpp
+++ b/src/mame/yamaha/ymdx7.cpp
@@ -232,8 +232,6 @@ void yamaha_dx7_state::main_map(address_map &map)
 	//Y6 (0x3000) EGS
 	//Y7 (0x3800) NC
 
-	map(0x0000, 0x001f).m(m_maincpu, FUNC(m6801_cpu_device::m6801_io));
-	map(0x0080, 0x00ff).ram(); /* HR6303R built in RAM */
 	map(0x1000, 0x17ff).ram().share("ram1");/* 2kb RAM1 IC19 M5M118P (Voice Memory part1) */
 	map(0x1800, 0x1fff).ram().share("ram2");/* 2kb RAM2 IC20 M5M118P (Voice Memory part2) */
 	map(0x2000, 0x27ff).ram().share("ram3");/* 2kb RAM3 IC21 M5M118P (Working Area)       */

--- a/src/mame/yamaha/ymdx9.cpp
+++ b/src/mame/yamaha/ymdx9.cpp
@@ -206,9 +206,6 @@ void yamaha_dx9_state::palette_init(palette_device &palette)
  */
 void yamaha_dx9_state::mem_map(address_map &map)
 {
-	// Internal CPU registers.
-	map(0x0000, 0x001f).m(m_maincpu, FUNC(hd6303r_cpu_device::m6801_io));
-
 	map(0x0020, 0x0020).r(FUNC(yamaha_dx9_state::key_switch_scan_driver_r));
 
 	map(0x0022, 0x0022).r(m_adc, FUNC(m58990_device::data_r));
@@ -220,9 +217,6 @@ void yamaha_dx9_state::mem_map(address_map &map)
 	map(0x0028, 0x0029).rw("lcdc", FUNC(hd44780_device::read), FUNC(hd44780_device::write));
 	// LED.
 	map(0x002b, 0x002c).w(FUNC(yamaha_dx9_state::led_w));
-
-	// Internal RAM.
-	map(0x0040, 0x00ff).ram();
 
 	// External RAM.
 	// 2 * 2kb RAM1 IC19 M5M118P.

--- a/src/osd/modules/lib/osdobj_common.cpp
+++ b/src/osd/modules/lib/osdobj_common.cpp
@@ -109,7 +109,7 @@ const options_entry osd_options::s_option_entries[] =
 
 	{ nullptr,                                   nullptr,          core_options::option_type::HEADER,    "OSD ACCELERATED VIDEO OPTIONS" },
 	{ OSDOPTION_FILTER ";glfilter;flt",          "1",              core_options::option_type::BOOLEAN,   "use bilinear filtering when scaling emulated video" },
-	{ OSDOPTION_PRESCALE "(1-8)",                "1",              core_options::option_type::INTEGER,   "scale emulated video by this factor before applying filters/shaders" },
+	{ OSDOPTION_PRESCALE "(1-20)",               "1",              core_options::option_type::INTEGER,   "scale emulated video by this factor before applying filters/shaders" },
 
 #if USE_OPENGL
 	{ nullptr,                                   nullptr,          core_options::option_type::HEADER,    "OpenGL-SPECIFIC OPTIONS" },

--- a/src/osd/sdl/video.cpp
+++ b/src/osd/sdl/video.cpp
@@ -142,7 +142,7 @@ void sdl_osd_interface::extract_video_config()
 		video_config.syncrefresh = 0;
 	}
 
-	if (video_config.prescale < 1 || video_config.prescale > 8)
+	if (video_config.prescale < 1 || video_config.prescale > 20)
 	{
 		osd_printf_warning("Invalid prescale option, reverting to '1'\n");
 		video_config.prescale = 1;

--- a/src/osd/windows/video.cpp
+++ b/src/osd/windows/video.cpp
@@ -174,7 +174,7 @@ void windows_osd_interface::extract_video_config()
 	video_config.triplebuf     = options().triple_buffer();
 	video_config.switchres     = options().switch_res();
 
-	if (video_config.prescale < 1 || video_config.prescale > 8)
+	if (video_config.prescale < 1 || video_config.prescale > 20)
 	{
 		osd_printf_warning("Invalid prescale option, reverting to '1'\n");
 		video_config.prescale = 1;


### PR DESCRIPTION
In addition to a simple skeleton driver that at least shows an initial readout on the LCD, this includes the following other changes:

- Fixed the HD6303R CPU to use an internal map derived from the M6803, and removed the now-unneeded address map entries from drivers using it.
- A prescale limit of 8 for systems with particularly small LCDs still produces bad-looking results, so I raised it to 20, as it should be relatively harmless, and any accelerated renderers will clamp to the maximum-supported texture size anyway.
- I noticed that `screen_device` was still referring to old MCFG_ macros in its logerror call to exhort devs to use raw screen parameters, so I replaced both with the relevant member function names.
- The Dallas DS1643 is a near-identical clone of the STMicro M48T58, so I added it to `timekpr.h/.cpp`, and noted in comments where certain not-yet-emulated control bits don't apply to it.