### PR TITLE
cpc_cass.xml: Metadata cleanups

### DIFF
--- a/hash/cpc_cass.xml
+++ b/hash/cpc_cass.xml
@@ -146,7 +146,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="007tlds" cloneof="007tld" supported="no">
-		<description>007 The Living Daylights (Spa)</description>
+		<description>007 The Living Daylights (Spain)</description>
 		<year>1987</year>
 		<publisher>Domark</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -244,7 +244,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="medodyss" supported="no">
-		<description>1001 BC - A Mediterranean Odyssey (Fra, BASIC 1.0)</description>
+		<description>1001 BC - A Mediterranean Odyssey (France, BASIC 1.0)</description>
 		<year>1986</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -268,7 +268,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="1942s" cloneof="1942" supported="no">
-		<description>1942 (Spa)</description>
+		<description>1942 (Spain)</description>
 		<year>1986</year>
 		<publisher>Elite Systems</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -280,7 +280,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="1942batt" supported="no">
-		<description>1942 + Batty (Spa)</description>
+		<description>1942 + Batty (Spain)</description>
 		<year>1989</year>
 		<publisher>MCM Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -304,7 +304,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ador" supported="no">
-		<description>Les 100% A d'Or (Fra)</description>
+		<description>Les 100% A d'Or (France)</description>
 		<year>1989</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -394,7 +394,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="2112ad" supported="no">
-		<description>2112 AD (Euro?, 64K)</description>
+		<description>2112 AD (Europe?, 64K)</description>
 		<year>1986</year>
 		<publisher>Design Design</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -406,7 +406,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="3as" supported="no">
-		<description>3 As (Euro?)</description>
+		<description>3 As (Europe?)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -486,7 +486,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="3dfight" supported="no">
-		<description>3D Fight (Fra)</description>
+		<description>3D Fight (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -608,7 +608,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="3dplot4" supported="no">
-		<description>3D-Plot 4 (Ger)</description>
+		<description>3D-Plot 4 (Germany)</description>
 		<year>1985</year>
 		<publisher>Profisoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -620,7 +620,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="3dsub" supported="no">
-		<description>3D-Sub (Fra)</description>
+		<description>3D-Sub (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -809,7 +809,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="5axe" supported="no">
-		<description>Le 5eme Axe (Fra)</description>
+		<description>Le 5eme Axe (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -843,7 +843,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="6pak3" supported="no">
-		<description>6-Pak Volume 3 (UK, Incomplete Dump)</description>
+		<description>6-Pak Volume 3 (UK, incomplete dump)</description>
 		<year>1988</year>
 		<publisher>Elite Systems</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -912,7 +912,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="a320" supported="no">
-		<description>A 320 (Fra)</description>
+		<description>A 320 (France)</description>
 		<year>1988</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -940,7 +940,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ateam" supported="no">
-		<description>The A Team (Spa)</description>
+		<description>The A Team (Spain)</description>
 		<year>1988</year>
 		<publisher>Zafiro Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -958,7 +958,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ateamlg" cloneof="ateam" supported="no">
-		<description>The A Team (Spa, Lightgun)</description>
+		<description>The A Team (Spain, lightgun)</description>
 		<year>1988</year>
 		<publisher>Zafiro Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -975,7 +975,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="aaargh" supported="no">
-		<description>Aaargh! (Spa)</description>
+		<description>Aaargh! (Spain)</description>
 		<year>1988</year>
 		<publisher>Melbourne House</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -987,7 +987,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="abadiacr" supported="no">
-		<description>La Abadia del Crimen (Spa)</description>
+		<description>La Abadia del Crimen (Spain)</description>
 		<year>1987</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -999,7 +999,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="abracada" supported="no">
-		<description>Abracadabra (Spa)</description>
+		<description>Abracadabra (Spain)</description>
 		<year>1988</year>
 		<publisher>Proein Soft Line</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1016,7 +1016,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="abusimbl" supported="no">
-		<description>Abu Simbel Profanation (Spa)</description>
+		<description>Abu Simbel Profanation (Spain)</description>
 		<year>1986</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1070,7 +1070,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ace2s" cloneof="ace2" supported="no">
-		<description>ACE 2 (Spa)</description>
+		<description>ACE 2 (Spain)</description>
 		<year>1988</year>
 		<publisher>Gamebusters</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1195,7 +1195,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="adidasfbs" cloneof="adidasfb" supported="no">
-		<description>Adidas Championship Football (Spa)</description>
+		<description>Adidas Championship Football (Spain)</description>
 		<year>1990</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1237,7 +1237,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="grafspees" cloneof="grafspee" supported="no">
-		<description>Admiral Graf Spee (Spa)</description>
+		<description>Admiral Graf Spee (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1250,7 +1250,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ads" supported="no">
-		<description>Advanced Destroyer Simulator (Spa)</description>
+		<description>Advanced Destroyer Simulator (Spain)</description>
 		<year>1990</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1315,7 +1315,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="veracruzg" cloneof="veracruz" supported="no">
-		<description>Die Affaire Vera Cruz (Ger)</description>
+		<description>Die Affaire Vera Cruz (Germany)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1332,7 +1332,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="veracruz" supported="no">
-		<description>L'Affaire Vera Cruz (Fra)</description>
+		<description>L'Affaire Vera Cruz (France)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1344,7 +1344,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="afrtrail" supported="no">
-		<description>African Trail Simulator (Spa)</description>
+		<description>African Trail Simulator (Spain)</description>
 		<year>1990</year>
 		<publisher>Positive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1402,7 +1402,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="afterwars" cloneof="afterwar" supported="no">
-		<description>After the War (Spa)</description>
+		<description>After the War (Spain)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1432,7 +1432,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="afteroid" supported="no">
-		<description>Afteroids (Spa)</description>
+		<description>Afteroids (Spain)</description>
 		<year>1988</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1468,7 +1468,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="aigledor" supported="no">
-		<description>L'Aigle d'Or (Fra)</description>
+		<description>L'Aigle d'Or (France)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1541,7 +1541,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="airwolfa" cloneof="airwolf" supported="no">
-		<description>Airwolf (UK, Alt)</description>
+		<description>Airwolf (UK, alt)</description>
 		<year>1985</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1553,7 +1553,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="airwolf2" supported="no">
-		<description>Airwolf II (Spa)</description>
+		<description>Airwolf II (Spain)</description>
 		<year>1987</year>
 		<publisher>Elite Systems</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1577,7 +1577,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="albmubi2" supported="no">
-		<description>L'Album UBI 2 (Fra)</description>
+		<description>L'Album UBI 2 (France)</description>
 		<year>1989</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1624,7 +1624,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="alertmis" cloneof="harratck" supported="no">
-		<description>Alerta Misiles (Spa)</description>
+		<description>Alerta Misiles (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1660,7 +1660,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="algebref" supported="no">
-		<description>Algebre (Fra)</description>
+		<description>Algebre (France)</description>
 		<year>1986</year>
 		<publisher>Vifi International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1672,7 +1672,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="alicandl" supported="no">
-		<description>Ali Candil Y El Tesoro De Sierra Morena (Spa)</description>
+		<description>Ali Candil Y El Tesoro De Sierra Morena (Spain)</description>
 		<year>1986</year>
 		<publisher>Edisoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1746,7 +1746,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="alienlgn" supported="no">
-		<description>Alien Legion (Spa)</description>
+		<description>Alien Legion (Spain)</description>
 		<year>1991</year>
 		<publisher>Mega Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1770,7 +1770,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="aliensyns" cloneof="aliensyn" supported="no">
-		<description>Alien Syndrome (Spa)</description>
+		<description>Alien Syndrome (Spain)</description>
 		<year>1987</year>
 		<publisher>Ace</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1908,7 +1908,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amstramg" supported="no">
-		<description>Am Stram Graph (Fra)</description>
+		<description>Am Stram Graph (France)</description>
 		<year>1985</year>
 		<publisher>Micro Programmes 5</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1954,7 +1954,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amstragn" supported="no">
-		<description>Amstragenda (Spa)</description>
+		<description>Amstragenda (Spain)</description>
 		<year>1986</year>
 		<publisher>Software Center</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1967,7 +1967,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="shrinkin" supported="no">
-		<description>The Amazing Shrinking Man (Euro)</description>
+		<description>The Amazing Shrinking Man (Europe)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -1996,7 +1996,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amcs" cloneof="amc" supported="no">
-		<description>AMC - Astro Marine Corps (Spa)</description>
+		<description>AMC - Astro Marine Corps (Spain)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2083,7 +2083,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amelminu" supported="no">
-		<description>Amelie Minuit (Fra)</description>
+		<description>Amelie Minuit (France)</description>
 		<year>1985</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2107,7 +2107,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amerfoots" cloneof="amerfoot" supported="no">
-		<description>American Football (Spa, BASIC 1.0)</description>
+		<description>American Football (Spain, BASIC 1.0)</description>
 		<year>1984</year>
 		<publisher>Compulogical</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2148,7 +2148,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ameritkl" cloneof="ameritk" supported="no">
-		<description>American Turbo King (UK, LightGun)</description>
+		<description>American Turbo King (UK, lightgun)</description>
 		<year>1989</year>
 		<publisher>Mastertronic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2160,7 +2160,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amlettre" cloneof="easiaw" supported="no">
-		<description>Amlettres (Fra)</description>
+		<description>Amlettres (France)</description>
 		<year>1984</year>
 		<publisher>Amsoft France</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2172,7 +2172,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amomundo" supported="no">
-		<description>Amo del Mundo (Spa)</description>
+		<description>Amo del Mundo (Spain)</description>
 		<year>1990</year>
 		<publisher>Positive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2201,7 +2201,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amsbase" supported="no">
-		<description>Amsbase (Spa)</description>
+		<description>Amsbase (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2251,7 +2251,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amsilvan" supported="no">
-		<description>Amsilvania Castle (Spa)</description>
+		<description>Amsilvania Castle (Spain)</description>
 		<year>1987</year>
 		<publisher>Magic Team</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2359,7 +2359,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amstests" cloneof="amstest" supported="no">
-		<description>Amstest (Spa)</description>
+		<description>Amstest (Spain)</description>
 		<year>1985</year>
 		<publisher>Indescomp</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2371,7 +2371,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amsdames" supported="no">
-		<description>Amstra-Dames (Fra)</description>
+		<description>Amstra-Dames (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2454,7 +2454,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amsgold3" supported="no">
-		<description>Amstrad Gold Hits 3 (UK, Split Version?)</description>
+		<description>Amstrad Gold Hits 3 (UK, split version?)</description>
 		<year>1988</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2537,7 +2537,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amstroid" supported="no">
-		<description>Amstroid (Fra)</description>
+		<description>Amstroid (France)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2561,7 +2561,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amswords" cloneof="amsword" supported="no">
-		<description>Amsword (Spa)</description>
+		<description>Amsword (Spain)</description>
 		<year>1984</year>
 		<publisher>Tasman Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2597,7 +2597,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="anatomie" supported="no">
-		<description>Anatomie (Fra)</description>
+		<description>Anatomie (France)</description>
 		<year>1985</year>
 		<publisher>Core</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2645,7 +2645,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="angecris" cloneof="getdext2" supported="no">
-		<description>L'Ange de Cristal (Fra)</description>
+		<description>L'Ange de Cristal (France)</description>
 		<year>1988</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2657,7 +2657,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ang500cc" supported="no">
-		<description>Angel Nieto Pole 500 (Spa)</description>
+		<description>Angel Nieto Pole 500 (Spain)</description>
 		<year>1990</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2705,7 +2705,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="avmf" cloneof="avm" supported="no">
-		<description>Animal / Vegetal / Mineral (Fra)</description>
+		<description>Animal / Vegetal / Mineral (France)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2717,7 +2717,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="avms" cloneof="avm" supported="no">
-		<description>Animal / Vegetable / Mineral (Spa)</description>
+		<description>Animal / Vegetable / Mineral (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2765,7 +2765,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zengara" supported="no">
-		<description>L'Anneau de Zengara (Fra)</description>
+		<description>L'Anneau de Zengara (France)</description>
 		<year>1987</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2828,7 +2828,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="antares" supported="no">
-		<description>Antares (Spa)</description>
+		<description>Antares (Spain)</description>
 		<year>1987</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2857,7 +2857,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="apocpnew" supported="no">
-		<description>Apocalipsis New (Spa)</description>
+		<description>Apocalipsis New (Spain)</description>
 		<year>1988</year>
 		<publisher>Idealogic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2869,7 +2869,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="appsorcr" supported="no">
-		<description>L'Apprenti Sorcier (Fra)</description>
+		<description>L'Apprenti Sorcier (France)</description>
 		<year>1985</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2893,7 +2893,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="astrosol" supported="no">
-		<description>Aprende Astronomia con el Sol (Spa, BASIC 1.1)</description>
+		<description>Aprende Astronomia con el Sol (Spain, BASIC 1.1)</description>
 		<year>19??</year>
 		<publisher>G.T.S. EDITORIAL</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2905,7 +2905,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="astroter" supported="no">
-		<description>Aprende Astronomia Con La Tierra (Spa)</description>
+		<description>Aprende Astronomia Con La Tierra (Spain)</description>
 		<year>19??</year>
 		<publisher>G.T.S. EDITORIAL</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2917,7 +2917,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="aquad" supported="no">
-		<description>Aquad (Fra)</description>
+		<description>Aquad (France)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -2988,7 +2988,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="archits1" supported="no">
-		<description>Arcade Hits 1 (UK, Incomplete Dump)</description>
+		<description>Arcade Hits 1 (UK, incomplete dump)</description>
 		<year>1986</year>
 		<publisher>Elite Systems</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3040,7 +3040,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="arctfox" supported="no">
-		<description>ArcticFox (Spa)</description>
+		<description>ArcticFox (Spain)</description>
 		<year>1988</year>
 		<publisher>Electronics Arts</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3100,7 +3100,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="arknoid2s" cloneof="arknoid2" supported="no">
-		<description>Arkanoid - Revenge of Doh (Spa)</description>
+		<description>Arkanoid - Revenge of Doh (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3112,7 +3112,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="arkos" supported="no">
-		<description>Arkos (Spa)</description>
+		<description>Arkos (Spain)</description>
 		<year>1987</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3129,7 +3129,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="antiriads" cloneof="antiriad" supported="no">
-		<description>La Armadura Sacrada de Antiriad (Spa)</description>
+		<description>La Armadura Sacrada de Antiriad (Spain)</description>
 		<year>1986</year>
 		<publisher>Palace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3165,7 +3165,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="armymoves" cloneof="armymove" supported="no">
-		<description>Army Moves (Spa)</description>
+		<description>Army Moves (Spain)</description>
 		<year>1986</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3216,7 +3216,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="arnhem" supported="no">
-		<description>Arnhem (Spa)</description>
+		<description>Arnhem (Spain)</description>
 		<year>1985</year>
 		<publisher>Cases Computer Simulators</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3240,7 +3240,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="arturas" cloneof="artura" supported="no">
-		<description>Artura (Spa)</description>
+		<description>Artura (Spain)</description>
 		<year>1988</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3264,7 +3264,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="asalto" supported="no">
-		<description>Asalto (Spa)</description>
+		<description>Asalto (Spain)</description>
 		<year>1985</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3276,7 +3276,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="aspargp" cloneof="gpmaster" supported="no">
-		<description>Aspar GP Master (Spa)</description>
+		<description>Aspar GP Master (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3288,7 +3288,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="asphalt" supported="no">
-		<description>Asphalt (Fra)</description>
+		<description>Asphalt (France)</description>
 		<year>1987</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3341,7 +3341,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="asterixs" cloneof="asterix" supported="no">
-		<description>Asterix y el Caldero Magico (Spa)</description>
+		<description>Asterix y el Caldero Magico (Spain)</description>
 		<year>1987</year>
 		<publisher>Melbourne House</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3401,7 +3401,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="atahualp" supported="no">
-		<description>Atahualpa (Fra)</description>
+		<description>Atahualpa (France)</description>
 		<year>1985</year>
 		<publisher>Transoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3425,7 +3425,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="athlete" supported="no">
-		<description>Athlete (Fra)</description>
+		<description>Athlete (France)</description>
 		<year>1986</year>
 		<publisher>Microids</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3461,7 +3461,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="atomsmshs" cloneof="atomsmsh" supported="no">
-		<description>Atom Smasher (Spa)</description>
+		<description>Atom Smasher (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3485,7 +3485,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="atomdriv" supported="no">
-		<description>Atomic Driver (Fra)</description>
+		<description>Atomic Driver (France)</description>
 		<year>1988</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3497,7 +3497,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="atrog" supported="no">
-		<description>Atrog (Spa)</description>
+		<description>Atrog (Spain)</description>
 		<year>1988</year>
 		<publisher>Zafiro Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3538,7 +3538,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="climbitc" supported="no">
-		<description>Aufwarts Zur Rettung (Ger)</description>
+		<description>Aufwarts Zur Rettung (Germany)</description>
 		<year>1985</year>
 		<publisher>QuelleSoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3550,7 +3550,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="aremonty" cloneof="awmonty" supported="no">
-		<description>Au Revoir Monty (Fra)</description>
+		<description>Au Revoir Monty (France)</description>
 		<year>1987</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3562,7 +3562,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ausgames" supported="no">
-		<description>Australian Games (Spa)</description>
+		<description>Australian Games (Spain)</description>
 		<year>1990</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3591,7 +3591,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="autocrsh" supported="no">
-		<description>Autocrash (Spa)</description>
+		<description>Autocrash (Spain)</description>
 		<year>1991</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3603,7 +3603,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="automec" supported="no">
-		<description>Automec (Fra)</description>
+		<description>Automec (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3628,7 +3628,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="avenspac" supported="no">
-		<description>La Aventura Espacial (Spa)</description>
+		<description>La Aventura Espacial (Spain)</description>
 		<year>1990</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3662,7 +3662,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jburton" cloneof="bigtroub" supported="no">
-		<description>Les Aventures de Jack Burton (Fra)</description>
+		<description>Les Aventures de Jack Burton (France)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3674,7 +3674,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="averno" supported="no">
-		<description>Averno (Spa)</description>
+		<description>Averno (Spain)</description>
 		<year>1989</year>
 		<publisher>Proein Soft Line</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3756,7 +3756,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="backgmas" supported="no">
-		<description>Backgammon (Spa, Ace Software)</description>
+		<description>Backgammon (Spain, Ace Software)</description>
 		<year>1985</year>
 		<publisher>CP Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3780,7 +3780,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bacterik" supported="no">
-		<description>Bacterik Dream (Fra)</description>
+		<description>Bacterik Dream (France)</description>
 		<year>1987</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3804,7 +3804,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bactronf" cloneof="bactron" supported="no">
-		<description>Bactron (Fra)</description>
+		<description>Bactron (France)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3828,7 +3828,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="badmax" supported="no">
-		<description>Bad Max (Fra)</description>
+		<description>Bad Max (France)</description>
 		<year>1985</year>
 		<publisher>Transoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3852,7 +3852,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bagnenep" supported="no">
-		<description>Le Bagne de Nepharia (Fra)</description>
+		<description>Le Bagne de Nepharia (France)</description>
 		<year>1985</year>
 		<publisher>France Logiciel</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3869,7 +3869,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="balbigbn" supported="no">
-		<description>Balade au Pays de Big-Ben (UK, Fra, Incomplete Dump)</description>
+		<description>Balade au Pays de Big-Ben (UK, France, incomplete dump)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3893,7 +3893,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- MOVE TO CPC_FLOP! THIS TAPE WAS INCLUDED IN DISK PACK -->
 	<software name="balbigau" supported="no">
-		<description>Balade au Pays de Big-Ben (UK, Audio Tape)</description>
+		<description>Balade au Pays de Big-Ben (UK, audio tape)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3920,7 +3920,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="outrhin" supported="no">
-		<description>Balade Outre-Rhin (Euro?)</description>
+		<description>Balade Outre-Rhin (Europe?)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -3960,7 +3960,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- Title screen is the same as in Ball Breaker 1, but it is a sequel!! -->
 	<software name="ballbrk2" supported="no">
-		<description>Ball Breaker 2 (Spa)</description>
+		<description>Ball Breaker 2 (Spain)</description>
 		<year>1988</year>
 		<publisher>CRL Group</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4091,7 +4091,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="barriop" supported="no">
-		<description>Barrio Peligroso (Spa)</description>
+		<description>Barrio Peligroso (Spain)</description>
 		<year>1987</year>
 		<publisher>Edisoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4127,7 +4127,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="basicpsw" supported="no">
-		<description>BASIC Program Status Window v3 (UK, Ripped from Amstrad Action Issue 105 Covertape)</description>
+		<description>BASIC Program Status Window v3 (UK, ripped from Amstrad Action Issue 105 covertape)</description>
 		<year>1994</year>
 		<publisher>Amstrad Action</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4164,7 +4164,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="basketmsa" cloneof="basketms" supported="no">
-		<description>Basket Master (UK, Alt)</description>
+		<description>Basket Master (UK, alt)</description>
 		<year>1987</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4176,7 +4176,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="midwayf" cloneof="midway" supported="no">
-		<description>Bataille Pour Midway (Fra)</description>
+		<description>Bataille Pour Midway (France)</description>
 		<year>1985</year>
 		<publisher>Pss</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4188,7 +4188,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="battlebrs" cloneof="battlebr" supported="no">
-		<description>Batalla de Inglaterra (Spa)</description>
+		<description>Batalla de Inglaterra (Spain)</description>
 		<year>1985</year>
 		<publisher>Pss</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4241,7 +4241,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="batmanmvs" cloneof="batmanmv" supported="no">
-		<description>Batman - The Movie (Spa)</description>
+		<description>Batman - The Movie (Spain)</description>
 		<year>1989</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4505,7 +4505,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bestwarrlg" cloneof="bestwarr" supported="no">
-		<description>Bestial Warrior (Spa, Lightgun)</description>
+		<description>Bestial Warrior (Spain, lightgun)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4517,7 +4517,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bestwarr" supported="no">
-		<description>Bestial Warrior (Spa)</description>
+		<description>Bestial Warrior (Spain)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4555,7 +4555,7 @@ Please stick to using the floppy versions for the time being...
 	<software name="bhcop" supported="no">
 		<description>Beverly Hills Cop (UK)</description>
 		<year>1990</year>
-		<publisher>Ibsa</publisher>
+		<publisher>IBSA</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
 		<part name="cass1" interface="cpc_cass">
 			<dataarea name="cass" size="155995">
@@ -4577,7 +4577,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="icepalacs" cloneof="icepalac" supported="no">
-		<description>Beyond The Ice Palace (Spa)</description>
+		<description>Beyond The Ice Palace (Spain)</description>
 		<year>1988</year>
 		<publisher>Elite Systems</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4589,7 +4589,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chezams" cloneof="welcams" supported="no">
-		<description>Bienvenue Chez Amsoft (Fra)</description>
+		<description>Bienvenue Chez Amsoft (France)</description>
 		<year>1984</year>
 		<publisher>Schneider Computer Division</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4712,7 +4712,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="billy" supported="no">
-		<description>Billy La Banlieue (Fra)</description>
+		<description>Billy La Banlieue (France)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4724,7 +4724,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="billys" cloneof="billy" supported="no">
-		<description>Billy La Banlieue (Spa)</description>
+		<description>Billy La Banlieue (Spain)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4737,7 +4737,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="billy2" supported="no">
-		<description>Billy 2 (Fra)</description>
+		<description>Billy 2 (France)</description>
 		<year>1987</year>
 		<publisher>Proein Soft Line</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4761,7 +4761,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="billykidlg" cloneof="billykid" supported="no">
-		<description>Billy The Kid (UK, LightGun)</description>
+		<description>Billy The Kid (UK, lightgun)</description>
 		<year>1989</year>
 		<publisher>Mastertronic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4797,7 +4797,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bionicc" supported="no">
-		<description>Bionic Commando (UK, Colour Screen)</description>
+		<description>Bionic Commando (UK, colour screen)</description>
 		<year>1988</year>
 		<publisher>Go!</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4809,7 +4809,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bioniccgs" cloneof="bionicc" supported="no">
-		<description>Bionic Commando (UK, Green Screen)</description>
+		<description>Bionic Commando (UK, green screen)</description>
 		<year>1988</year>
 		<publisher>Go!</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4833,7 +4833,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="biorythm" supported="no">
-		<description>Biorythme (Fra)</description>
+		<description>Biorythme (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4857,7 +4857,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bivouac" cloneof="chamonix" supported="no">
-		<description>Bivouac (Fra)</description>
+		<description>Bivouac (France)</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4869,7 +4869,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="blackbrds" cloneof="blackbrd" supported="no">
-		<description>Black Beard (Spa)</description>
+		<description>Black Beard (Spain)</description>
 		<year>1988</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4910,7 +4910,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="blackmags" cloneof="blackmag" supported="no">
-		<description>Black Magic (Spa)</description>
+		<description>Black Magic (Spain)</description>
 		<year>1987</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -4956,7 +4956,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bladeruns" cloneof="bladerun" supported="no">
-		<description>Blade Runner (Spa)</description>
+		<description>Blade Runner (Spain)</description>
 		<year>1986</year>
 		<publisher>CRL Group</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5040,7 +5040,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="blitz" supported="no">
-		<description>Blitz! (UK, Ripped from Amstrad Action Issue 105 Covertape)</description>
+		<description>Blitz! (UK, ripped from Amstrad Action Issue 105 covertape)</description>
 		<year>1994</year>
 		<publisher>Amstrad Action</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5088,7 +5088,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bloodval" supported="no">
-		<description>Blood Valley (Spa)</description>
+		<description>Blood Valley (Spain)</description>
 		<year>1987</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5158,7 +5158,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bmxninjaa" cloneof="bmxninja" supported="no">
-		<description>BMX Ninja (UK, Alt)</description>
+		<description>BMX Ninja (UK, alt)</description>
 		<year>1989</year>
 		<publisher>Alternative Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5199,7 +5199,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bobenpol" supported="no">
-		<description>Bob en el Polo (Spa)</description>
+		<description>Bob en el Polo (Spain)</description>
 		<year>1986</year>
 		<publisher>Monser</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5211,7 +5211,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bobmjung" cloneof="lenfamaz" supported="no">
-		<description>Bob Morane - Jungle 1 (Fra)</description>
+		<description>Bob Morane - Jungle 1 (France)</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5223,7 +5223,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bobmsf" cloneof="lenfspac" supported="no">
-		<description>Bob Morane - Science Fiction (Fra)</description>
+		<description>Bob Morane - Science Fiction (France)</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5240,7 +5240,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bobmsfs" cloneof="lenfspac" supported="no">
-		<description>Bob Morane Espacio (Spa)</description>
+		<description>Bob Morane Espacio (Spain)</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5387,7 +5387,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bombard" supported="no">
-		<description>Bombardero (Spa)</description>
+		<description>Bombardero (Spain)</description>
 		<year>1984</year>
 		<publisher>Amstrad Computer User</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5721,7 +5721,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="breaker" supported="no">
-		<description>The Breaker (Spa)</description>
+		<description>The Breaker (Spain)</description>
 		<year>1987</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5734,7 +5734,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="brick" supported="no">
-		<description>The Brick (Spa)</description>
+		<description>The Brick (Spain)</description>
 		<year>1989</year>
 		<publisher>Delta Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5818,7 +5818,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bronx" supported="no">
-		<description>Bronx (Spa)</description>
+		<description>Bronx (Spain)</description>
 		<year>1989</year>
 		<publisher>MCM Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5871,7 +5871,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bublbobls" cloneof="bublbobl" supported="no">
-		<description>Bubble Bobble (Spa)</description>
+		<description>Bubble Bobble (Spain)</description>
 		<year>1987</year>
 		<publisher>Firebird</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5900,7 +5900,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bubghost" supported="no">
-		<description>Bubble Ghost (Fra)</description>
+		<description>Bubble Ghost (France)</description>
 		<year>1988</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5924,7 +5924,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="budget" supported="no">
-		<description>Budget (Ger)</description>
+		<description>Budget (Germany)</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5936,7 +5936,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="budokan" supported="no">
-		<description>Budokan - The Martial Spirit (Spa)</description>
+		<description>Budokan - The Martial Spirit (Spain)</description>
 		<year>1990</year>
 		<publisher>Electronics Arts</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5975,7 +5975,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="buggy2" supported="no">
-		<description>Buggy II (Fra)</description>
+		<description>Buggy II (France)</description>
 		<year>1986</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -5999,7 +5999,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="buggyrng" supported="no">
-		<description>Buggy Ranger (Spa)</description>
+		<description>Buggy Ranger (Spain)</description>
 		<year>1990</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6011,7 +6011,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bugsbust" supported="no">
-		<description>Bugs Buster (Fra)</description>
+		<description>Bugs Buster (France)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6052,7 +6052,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="buitre" supported="no">
-		<description>Buitre - Emilio Butragueno Futbol (Spa)</description>
+		<description>Buitre - Emilio Butragueno Futbol (Spain)</description>
 		<year>1988</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6100,7 +6100,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="bumpy" supported="no">
-		<description>Bumpy (Fra)</description>
+		<description>Bumpy (France)</description>
 		<year>1989</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6112,7 +6112,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="buran" supported="no">
-		<description>Buran (Spa)</description>
+		<description>Buran (Spain)</description>
 		<year>1990</year>
 		<publisher>Omk</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6124,7 +6124,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="burbujos" supported="no">
-		<description>Burbujo (Spa)</description>
+		<description>Burbujo (Spain)</description>
 		<year>1986</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6178,7 +6178,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="calcul" supported="no">
-		<description>Calcul (Fra)</description>
+		<description>Calcul (France)</description>
 		<year>1985</year>
 		<publisher>Hatier</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6195,7 +6195,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="calcment" supported="no">
-		<description>Calcul Mental (Fra)</description>
+		<description>Calcul Mental (France)</description>
 		<year>1985</year>
 		<publisher>Logys</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6207,7 +6207,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="calcnew" supported="no">
-		<description>Calculator New (Spa)</description>
+		<description>Calculator New (Spain)</description>
 		<year>1986</year>
 		<publisher>DIMensionNEW</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6219,7 +6219,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="caldrmag" supported="no">
-		<description>El Caldero Magico (Spa)</description>
+		<description>El Caldero Magico (Spain)</description>
 		<year>1986</year>
 		<publisher>Humanes</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6265,7 +6265,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="camelmot" supported="no">
-		<description>Camelemots (Fra, BASIC 1.0)</description>
+		<description>Camelemots (France, BASIC 1.0)</description>
 		<year>1985</year>
 		<publisher>Core</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6301,7 +6301,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="camelwars" cloneof="camelwar" supported="no">
-		<description>Camelot Warriors (Spa)</description>
+		<description>Camelot Warriors (Spain)</description>
 		<year>1986</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6313,7 +6313,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="campeons" supported="no">
-		<description>Campeones (Spa)</description>
+		<description>Campeones (Spain)</description>
 		<year>1985</year>
 		<publisher>Indescomp</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6325,7 +6325,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="canadair" supported="no">
-		<description>Canadair (Fra)</description>
+		<description>Canadair (France)</description>
 		<year>1987</year>
 		<publisher>Fil</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6342,7 +6342,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="caphorn" supported="no">
-		<description>Cap Horn (Fra)</description>
+		<description>Cap Horn (France)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6354,7 +6354,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="capdakar" supported="no">
-		<description>Cap sur Dakar (Fra, BASIC 1.0)</description>
+		<description>Cap sur Dakar (France, BASIC 1.0)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6413,7 +6413,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="caperuza" supported="no">
-		<description>Caperuza (Spa)</description>
+		<description>Caperuza (Spain)</description>
 		<year>1986</year>
 		<publisher>Monser</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6425,7 +6425,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sevilla" supported="no">
-		<description>Capitan Sevilla (Spa)</description>
+		<description>Capitan Sevilla (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6442,7 +6442,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="trueno" supported="no">
-		<description>El Capitan Trueno (Spa)</description>
+		<description>El Capitan Trueno (Spain)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6478,7 +6478,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="capblood" supported="no">
-		<description>Captain Blood (Euro)</description>
+		<description>Captain Blood (Europe)</description>
 		<year>1988</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6532,7 +6532,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="csainz" supported="no">
-		<description>Carlos Sainz (Spa)</description>
+		<description>Carlos Sainz (Spain)</description>
 		<year>1990</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6544,7 +6544,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="carteuro" supported="no">
-		<description>Carte d'Europe (Fra)</description>
+		<description>Carte d'Europe (France)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6556,7 +6556,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="casanova" supported="no">
-		<description>Casanova (Spa)</description>
+		<description>Casanova (Spain)</description>
 		<year>1989</year>
 		<publisher>Iber Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6597,7 +6597,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cpc1eran" supported="no">
-		<description>Cassette CPC HS 1er Anniversaire (Fra)</description>
+		<description>Cassette CPC HS 1er Anniversaire (France)</description>
 		<year>1986</year>
 		<publisher>CPC</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6650,7 +6650,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cmaster" supported="no">
-		<description>Castle Master (Euro)</description>
+		<description>Castle Master (Europe)</description>
 		<year>1990</year>
 		<publisher>Incentive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6662,7 +6662,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cmasters" cloneof="cmaster" supported="no">
-		<description>Castle Master (Spa)</description>
+		<description>Castle Master (Spain)</description>
 		<year>1990</year>
 		<publisher>Incentive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6686,7 +6686,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cmastr12" supported="no">
-		<description>Castle Master + Castle Master II - The Crypt (Euro?)</description>
+		<description>Castle Master + Castle Master II - The Crypt (Europe?)</description>
 		<year>1990</year>
 		<publisher>Incentive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6751,7 +6751,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cauldronf" cloneof="cauldron" supported="no">
-		<description>Cauldron (Fra)</description>
+		<description>Cauldron (France)</description>
 		<year>1985</year>
 		<publisher>Palace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6775,7 +6775,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cauldrn2f" cloneof="cauldrn2" supported="no">
-		<description>Cauldron II (Fra)</description>
+		<description>Cauldron II (France)</description>
 		<year>1986</year>
 		<publisher>Palace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6787,7 +6787,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cauldrn2s" cloneof="cauldrn2" supported="no">
-		<description>Cauldron II (Spa)</description>
+		<description>Cauldron II (Spain)</description>
 		<year>1986</year>
 		<publisher>Palace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6811,7 +6811,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cavdeath" supported="no">
-		<description>Caverns of the Death (Spa)</description>
+		<description>Caverns of the Death (Spain)</description>
 		<year>1987</year>
 		<publisher>Discovery Informatic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6835,7 +6835,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ccourt" supported="no">
-		<description>Centre Court (Spa)</description>
+		<description>Centre Court (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6871,7 +6871,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cessna" supported="no">
-		<description>Cessna Over Moscow (Spa)</description>
+		<description>Cessna Over Moscow (Spain)</description>
 		<year>1987</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6883,7 +6883,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chad" supported="no">
-		<description>Chad (Spa)</description>
+		<description>Chad (Spain)</description>
 		<year>1987</year>
 		<publisher>Edisoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6900,7 +6900,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chada" cloneof="chad" supported="no">
-		<description>Chad (Spa, Alt)</description>
+		<description>Chad (Spain, alt)</description>
 		<year>1987</year>
 		<publisher>Edisoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6912,7 +6912,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chainrec" supported="no">
-		<description>Chain Reaction (Spa)</description>
+		<description>Chain Reaction (Spain)</description>
 		<year>1988</year>
 		<publisher>Elite Systems</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -6952,7 +6952,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="challngr" supported="no">
-		<description>Challenger (Euro)</description>
+		<description>Challenger (Europe)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7068,7 +7068,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="champwsks" cloneof="champwsk" supported="no">
-		<description>Championship Waterskiing (Spa)</description>
+		<description>Championship Waterskiing (Spain)</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7097,7 +7097,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chardiam" supported="no">
-		<description>Charly Diams (Fra)</description>
+		<description>Charly Diams (France)</description>
 		<year>1987</year>
 		<publisher>Proein Soft Line</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7200,7 +7200,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cheops" supported="no">
-		<description>Cheops (UK, Fast Tape)</description>
+		<description>Cheops (UK, fast tape)</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7212,7 +7212,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cheopsa" cloneof="cheops" supported="no">
-		<description>Cheops (UK, Slow Tape)</description>
+		<description>Cheops (UK, slow tape)</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7224,7 +7224,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cheopsf" cloneof="cheops" supported="no">
-		<description>Cheops (Fra)</description>
+		<description>Cheops (France)</description>
 		<year>1985</year>
 		<publisher>No Man's Land</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7248,7 +7248,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cm2000s" cloneof="cm2000" supported="no">
-		<description>The Chessmaster 2000 (Spa)</description>
+		<description>The Chessmaster 2000 (Spain)</description>
 		<year>1990</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7260,7 +7260,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chevalir" supported="no">
-		<description>Les Chevaliers (Fra)</description>
+		<description>Les Chevaliers (France)</description>
 		<year>1990</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7309,7 +7309,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chicag30s" cloneof="chicag30" supported="no">
-		<description>Chicago '30 (Spa)</description>
+		<description>Chicago '30 (Spain)</description>
 		<year>1988</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7333,7 +7333,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chicag90" supported="no">
-		<description>Chicago 90 (Fra)</description>
+		<description>Chicago 90 (France)</description>
 		<year>1989</year>
 		<publisher>Microids</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7357,7 +7357,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chiflett" supported="no">
-		<description>Des Chiffres et des Lettres (Fra)</description>
+		<description>Des Chiffres et des Lettres (France)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7369,7 +7369,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chiffmag" cloneof="happynmb" supported="no">
-		<description>Les Chiffres Magiques (Fra)</description>
+		<description>Les Chiffres Magiques (France)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7422,7 +7422,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chipchals" cloneof="chipchal" supported="no">
-		<description>Chip's Challenge (Spa)</description>
+		<description>Chip's Challenge (Spain)</description>
 		<year>1990</year>
 		<publisher>Epyx</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7452,7 +7452,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chirolog" supported="no">
-		<description>Chirologie (Fra)</description>
+		<description>Chirologie (France)</description>
 		<year>1985</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7488,7 +7488,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chosegrt" supported="no">
-		<description>La Chose de Grotemburg (Fra)</description>
+		<description>La Chose de Grotemburg (France)</description>
 		<year>1987</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7505,7 +7505,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="choylee" supported="no">
-		<description>Choy Lee Fut Kung-Fu Warrior (Spa)</description>
+		<description>Choy Lee Fut Kung-Fu Warrior (Spain)</description>
 		<year>1990</year>
 		<publisher>Positive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7611,7 +7611,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="elcids" cloneof="elcid" supported="no">
-		<description>El Cid (Spa)</description>
+		<description>El Cid (Spain)</description>
 		<year>1987</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7623,7 +7623,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ciencnt6" supported="no">
-		<description>Ciencias Naturales - 6. E. G. B. (Spa, BASIC 1.1)</description>
+		<description>Ciencias Naturales - 6. E. G. B. (Spain, BASIC 1.1)</description>
 		<year>1986</year>
 		<publisher>Centro Pedagogico De Informatica, S. A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7640,7 +7640,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ciencnt7" supported="no">
-		<description>Ciencias Naturales - 7. E. G. B. (Spa)</description>
+		<description>Ciencias Naturales - 7. E. G. B. (Spain)</description>
 		<year>1986</year>
 		<publisher>Centro Pedagogico De Informatica, S. A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7657,7 +7657,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ciencnt8" supported="no">
-		<description>Ciencias Naturales - 8. E. G. B. (Spa)</description>
+		<description>Ciencias Naturales - 8. E. G. B. (Spain)</description>
 		<year>1986</year>
 		<publisher>Centro Pedagogico De Informatica, S. A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7674,7 +7674,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ciencsc7" supported="no">
-		<description>Ciencias Sociales - 7. E. G. B. (Spa)</description>
+		<description>Ciencias Sociales - 7. E. G. B. (Spain)</description>
 		<year>1986</year>
 		<publisher>Centro Pedagogico De Informatica, S. A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7906,7 +7906,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cleversm" supported="no">
-		<description>Clever &amp; Smart (Euro)</description>
+		<description>Clever &amp; Smart (Europe)</description>
 		<year>1987</year>
 		<publisher>Magic Bytes</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7931,7 +7931,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- This has been dumped from a tape whose title was "Climb It" with no dash between the two words (on the tape label) -->
 	<software name="climbita" cloneof="climbit" supported="no">
-		<description>Climb-It (UK, Alt)</description>
+		<description>Climb-It (UK, alt)</description>
 		<year>1984</year>
 		<publisher>Tynesoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -7979,7 +7979,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cobrapinf" cloneof="cobrapin" supported="no">
-		<description>Cobra Pinball (Fra)</description>
+		<description>Cobra Pinball (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8003,7 +8003,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cobracs" supported="no">
-		<description>Cobra (Fra, Cobra Soft)</description>
+		<description>Cobra (France, Cobra Soft)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8015,7 +8015,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cobrarc" supported="no">
-		<description>Cobra's Arc (Spa)</description>
+		<description>Cobra's Arc (Spain)</description>
 		<year>1986</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8027,7 +8027,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="coderout" supported="no">
-		<description>Code de la Route (Fra)</description>
+		<description>Code de la Route (France)</description>
 		<year>1985</year>
 		<publisher>Microloisirs</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8080,7 +8080,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="coffret6" supported="no">
-		<description>Coffret de 6 Jeux (Fra)</description>
+		<description>Coffret de 6 Jeux (France)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8154,7 +8154,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="colecdin" supported="no">
-		<description>Coleccion de Exitos Dinamic - 1985 - 1988 (Spa)</description>
+		<description>Coleccion de Exitos Dinamic - 1985 - 1988 (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8181,7 +8181,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="coliseum" cloneof="coloseum" supported="no">
-		<description>Coliseum (Spa)</description>
+		<description>Coliseum (Spain)</description>
 		<year>1988</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8299,7 +8299,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="comando4" supported="no">
-		<description>Comando Quatro (Spa)</description>
+		<description>Comando Quatro (Spain)</description>
 		<year>1989</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8311,7 +8311,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cmdtrace" cloneof="lastcomm" supported="no">
-		<description>Comando Tracer (Spa)</description>
+		<description>Comando Tracer (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8412,7 +8412,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="compfil" supported="no">
-		<description>Compilation FIL (Fra)</description>
+		<description>Compilation FIL (France)</description>
 		<year>1987</year>
 		<publisher>FIL</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8522,7 +8522,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="computin" supported="no">
-		<description>Computing Experimental - Baukasten Construction Kit (Ger)</description>
+		<description>Computing Experimental - Baukasten Construction Kit (Germany)</description>
 		<year>1987</year>
 		<publisher>Fischertechnik</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8551,7 +8551,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="confl2k" supported="no">
-		<description>Conflit en l'An 2000 (Fra)</description>
+		<description>Conflit en l'An 2000 (France)</description>
 		<year>1985</year>
 		<publisher>Power Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8582,7 +8582,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="contabam" supported="no">
-		<description>Contabilidad Domestica (Spa, Amsoft)</description>
+		<description>Contabilidad Domestica (Spain, Amsoft)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8594,7 +8594,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="contabrp" supported="no">
-		<description>Contabilidad Domestica (Spa, RPA Systems)</description>
+		<description>Contabilidad Domestica (Spain, RPA Systems)</description>
 		<year>1985</year>
 		<publisher>RPA Systems Inc</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8606,7 +8606,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="contaprs" supported="no">
-		<description>Contabilidad Personal (Spa)</description>
+		<description>Contabilidad Personal (Spain)</description>
 		<year>1985</year>
 		<publisher>FPS Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8618,7 +8618,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="contamin" supported="no">
-		<description>Contamination (Euro)</description>
+		<description>Contamination (Europe)</description>
 		<year>1985</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8630,7 +8630,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="contaminuk" cloneof="contamin" supported="no">
-		<description>Contamination (UK, 2 faces)</description>
+		<description>Contamination (UK, 2 sides)</description>
 		<year>1985</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8664,7 +8664,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="contcircs" cloneof="contcirc" supported="no">
-		<description>Continental Circus (Spa)</description>
+		<description>Continental Circus (Spain)</description>
 		<year>1989</year>
 		<publisher>Virgin Games</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8705,7 +8705,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="contstck" supported="no">
-		<description>Control de Stocks (Spa)</description>
+		<description>Control de Stocks (Spain)</description>
 		<year>1985</year>
 		<publisher>RPA Systems Inc</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8729,7 +8729,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="convoys" cloneof="convoy" supported="no">
-		<description>Convoy Raider (Spa)</description>
+		<description>Convoy Raider (Spain)</description>
 		<year>1987</year>
 		<publisher>Erbe Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8753,7 +8753,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="copymast" supported="no">
-		<description>Copymaster (Ger)</description>
+		<description>Copymaster (Germany)</description>
 		<year>1986</year>
 		<publisher>RSE Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8777,7 +8777,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="corona" supported="no">
-		<description>La Corona (Spa)</description>
+		<description>La Corona (Spain)</description>
 		<year>1988</year>
 		<publisher>System 4 de Espana</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8789,7 +8789,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="coronamg" supported="no">
-		<description>La Corona Magica (Spa, BASIC 1.1)</description>
+		<description>La Corona Magica (Spain, BASIC 1.1)</description>
 		<year>1990</year>
 		<publisher>Proein Soft Line</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8814,7 +8814,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- MOVE TO CPC_FLOP! THIS TAPE WAS INCLUDED IN DISK PACK -->
 	<software name="corruptn" supported="no">
-		<description>Corruption (UK, Audio Tape)</description>
+		<description>Corruption (UK, audio tape)</description>
 		<year>1988</year>
 		<publisher>Rainbird Software</publisher>
 		<info name="usage" value="Face A : Prologue + Musique d'intro" />
@@ -8831,7 +8831,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="corsars" supported="no">
-		<description>Corsarios (Spa)</description>
+		<description>Corsarios (Spain)</description>
 		<year>1988</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8848,7 +8848,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cosanos" supported="no">
-		<description>Cosa Nostra (Fra)</description>
+		<description>Cosa Nostra (France)</description>
 		<year>1986</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8860,7 +8860,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cosanoss" cloneof="cosanos" supported="no">
-		<description>Cosa Nostra (Spa)</description>
+		<description>Cosa Nostra (Spain)</description>
 		<year>1986</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8872,7 +8872,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cosmicsh" supported="no">
-		<description>Cosmic Sheriff (Spa)</description>
+		<description>Cosmic Sheriff (Spain)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8956,7 +8956,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cntrycot" supported="no">
-		<description>Country Cottages (Ger)</description>
+		<description>Country Cottages (Germany)</description>
 		<year>1984</year>
 		<publisher>Sterling Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8980,7 +8980,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="coursolf" supported="no">
-		<description>Cours de Solfege, Niveau 1 (Fra)</description>
+		<description>Cours de Solfege, Niveau 1 (France)</description>
 		<year>1984</year>
 		<publisher>TMPI</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -8992,7 +8992,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="courbous" cloneof="maprally" supported="no">
-		<description>La Course a la Boussole (Fra)</description>
+		<description>La Course a la Boussole (France)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9057,7 +9057,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cpgraph" supported="no">
-		<description>Cpgraph (Fra)</description>
+		<description>Cpgraph (France)</description>
 		<year>1985</year>
 		<publisher>Core</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9098,7 +9098,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="craftonxs" cloneof="getdextr" supported="no">
-		<description>Crafton &amp; Xunk (Spa)</description>
+		<description>Crafton &amp; Xunk (Spain)</description>
 		<year>1986</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9110,7 +9110,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="craftonx" cloneof="getdextr" supported="no">
-		<description>Crafton &amp; Xunk (Euro)</description>
+		<description>Crafton &amp; Xunk (Europe)</description>
 		<year>1986</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9122,7 +9122,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cray5" supported="no">
-		<description>Cray 5 (Spa)</description>
+		<description>Cray 5 (Spain)</description>
 		<year>1987</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9134,7 +9134,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="crayopt" cloneof="cadlpen" supported="no">
-		<description>Crayon Optique Trojan LP-1 (Fra)</description>
+		<description>Crayon Optique Trojan LP-1 (France)</description>
 		<year>1985</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9146,7 +9146,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="crazycar" supported="no">
-		<description>Crazy Cars (Spa)</description>
+		<description>Crazy Cars (Spain)</description>
 		<year>1988</year>
 		<publisher>Titus</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9182,7 +9182,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="crazyrac" supported="no">
-		<description>Crazy Race (Spa)</description>
+		<description>Crazy Race (Spain)</description>
 		<year>1992</year>
 		<publisher>Mega Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9194,7 +9194,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="crazysht" supported="no">
-		<description>Crazy Shot (Spa)</description>
+		<description>Crazy Shot (Spain)</description>
 		<year>1989</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9300,7 +9300,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ccastles" supported="no">
-		<description>Crystal Castles - Diamond Plateaus In Space (UK)</description>
+		<description>Crystal Castles - Diamond Plateaus in Space (UK)</description>
 		<year>1986</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9335,9 +9335,9 @@ Please stick to using the floppy versions for the time being...
 		</part>
 	</software>
 
-	<!-- Not sure whether this was confirmed to be the same between Spa & UK releases or not... -->
+	<!-- Not sure whether this was confirmed to be the same between Spain & UK releases or not... -->
 	<software name="4ggam2" supported="no">
-		<description>Cuatro Grandes Juegos Vol. II (Spa?)</description>
+		<description>Cuatro Grandes Juegos Vol. II (Spain?)</description>
 		<year>19??</year>
 		<publisher>Micro Value</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9365,7 +9365,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="4x1" supported="no">
-		<description>Cuatro Por Uno (Spa)</description>
+		<description>Cuatro Por Uno (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9394,7 +9394,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="chu_fvit" supported="no">
-		<description>El Cuerpo Humano - Funciones Vitales (Spa)</description>
+		<description>El Cuerpo Humano - Funciones Vitales (Spain)</description>
 		<year>1986</year>
 		<publisher>Tasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9428,7 +9428,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="currojim" supported="no">
-		<description>Curro Jiminez (Spa)</description>
+		<description>Curro Jiminez (Spain)</description>
 		<year>1989</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9452,7 +9452,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cursobs1" cloneof="teachbs1" supported="no">
-		<description>Curso Autodidactico de Basic I (Spa)</description>
+		<description>Curso Autodidactico de Basic I (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9469,7 +9469,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cursomat" supported="no">
-		<description>Cursos Educativos - Matematicas (Spa)</description>
+		<description>Cursos Educativos - Matematicas (Spain)</description>
 		<year>1985</year>
 		<publisher>Monser</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9525,7 +9525,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cyberbals" cloneof="cyberbal" supported="no">
-		<description>Cyberball (Spa)</description>
+		<description>Cyberball (Spain)</description>
 		<year>1990</year>
 		<publisher>Domark</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9578,7 +9578,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cybor" supported="no">
-		<description>Cybor (Spa)</description>
+		<description>Cybor (Spain)</description>
 		<year>1987</year>
 		<publisher>Softhawk</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9626,7 +9626,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="cyrus2chg" cloneof="cyrus2ch" supported="no">
-		<description>Cyrus II Schach (Ger)</description>
+		<description>Cyrus II Schach (Germany)</description>
 		<year>1985</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9638,7 +9638,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dams" cloneof="adam" supported="no">
-		<description>D.A.M.S. (Fra)</description>
+		<description>D.A.M.S. (France)</description>
 		<year>1985</year>
 		<publisher>Micro Application</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9662,7 +9662,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="daleyocs" cloneof="daleyoc" supported="no">
-		<description>Daley Thompson's Olympic Challenge (Spa)</description>
+		<description>Daley Thompson's Olympic Challenge (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9692,7 +9692,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- MOVE TO CPC_FLOP! THIS TAPE WAS INCLUDED IN DISK PACK -->
 	<software name="daleyaud" supported="no">
-		<description>Daley Thompson's Olympic Challenge (UK, Audio Tape)</description>
+		<description>Daley Thompson's Olympic Challenge (UK, audio tape)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9733,7 +9733,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="damas" supported="no">
-		<description>Damas (Spa)</description>
+		<description>Damas (Spain)</description>
 		<year>1985</year>
 		<publisher>Idealogic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9745,7 +9745,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dandares" cloneof="dandare" supported="no">
-		<description>Dan Dare - Pilot of the Future [Discovery Informatic] (UK)</description>
+		<description>Dan Dare - Pilot of the Future (UK, Discovery Informatic)</description>
 		<year>1986</year>
 		<publisher>Discovery Informatic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9757,7 +9757,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dandare" supported="no">
-		<description>Dan Dare - Pilot of the Future [Virgin Games] (UK)</description>
+		<description>Dan Dare - Pilot of the Future (UK, Virgin Games)</description>
 		<year>1986</year>
 		<publisher>Virgin Games</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -9870,7 +9870,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dangstrt" supported="no">
-		<description>Danger Street (Fra)</description>
+		<description>Danger Street (France)</description>
 		<year>1987</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10019,7 +10019,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams01" supported="no">
-		<description>Data Amstrad 01 (Spa)</description>
+		<description>Data Amstrad 01 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10031,7 +10031,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams02" supported="no">
-		<description>Data Amstrad 02 (Spa)</description>
+		<description>Data Amstrad 02 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10043,7 +10043,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams03" supported="no">
-		<description>Data Amstrad 03 (Spa)</description>
+		<description>Data Amstrad 03 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10055,7 +10055,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams05" supported="no">
-		<description>Data Amstrad 05 (Spa)</description>
+		<description>Data Amstrad 05 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10067,7 +10067,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams06" supported="no">
-		<description>Data Amstrad 06 (Spa)</description>
+		<description>Data Amstrad 06 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10079,7 +10079,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams07" supported="no">
-		<description>Data Amstrad 07 (Spa)</description>
+		<description>Data Amstrad 07 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10091,7 +10091,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams07a" cloneof="datams07" supported="no">
-		<description>Data Amstrad 07 (Spa, 2 Sides)</description>
+		<description>Data Amstrad 07 (Spain, 2 sides)</description>
 		<year>1986</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10108,7 +10108,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams11" supported="no">
-		<description>Data Amstrad 11 (Spa)</description>
+		<description>Data Amstrad 11 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10120,7 +10120,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams12" supported="no">
-		<description>Data Amstrad 12 (Spa)</description>
+		<description>Data Amstrad 12 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10132,7 +10132,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams13" supported="no">
-		<description>Data Amstrad 13 (Spa)</description>
+		<description>Data Amstrad 13 (Spain)</description>
 		<year>1987</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10144,7 +10144,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams14" supported="no">
-		<description>Data Amstrad 14 (Spa)</description>
+		<description>Data Amstrad 14 (Spain)</description>
 		<year>1987</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10156,7 +10156,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams17" supported="no">
-		<description>Data Amstrad 17 - Poker Less (Spa)</description>
+		<description>Data Amstrad 17 - Poker Less (Spain)</description>
 		<year>1986</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10168,7 +10168,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="datams18" supported="no">
-		<description>Data Amstrad 18 - Gamesed (Spa)</description>
+		<description>Data Amstrad 18 - Gamesed (Spain)</description>
 		<year>1987</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10238,7 +10238,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="deactivs" cloneof="deactiv" supported="no">
-		<description>Deactivators (Spa)</description>
+		<description>Deactivators (Spain)</description>
 		<year>1986</year>
 		<publisher>Ariolasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10274,7 +10274,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="doaa" cloneof="doa" supported="no">
-		<description>Dead or Alive (UK, Alt)</description>
+		<description>Dead or Alive (UK, alt)</description>
 		<year>1987</year>
 		<publisher>Alternative Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10382,7 +10382,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dedalos" supported="no">
-		<description>Dedalos (Fra)</description>
+		<description>Dedalos (France)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10418,7 +10418,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="defcom" supported="no">
-		<description>Defcom (Spa)</description>
+		<description>Defcom (Spain)</description>
 		<year>1986</year>
 		<publisher>Quicksilva</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10430,7 +10430,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="defcom1" supported="no">
-		<description>Defcom 1 (Spa)</description>
+		<description>Defcom 1 (Spain)</description>
 		<year>1989</year>
 		<publisher>Iber Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10454,7 +10454,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="defearth" supported="no">
-		<description>Defenders of the Earth (Euro)</description>
+		<description>Defenders of the Earth (Europe)</description>
 		<year>1990</year>
 		<publisher>Enigma Variations</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10496,7 +10496,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="deliverns" cloneof="delivern" supported="no">
-		<description>Deliverance (Spa)</description>
+		<description>Deliverance (Spain)</description>
 		<year>1990</year>
 		<publisher>Hewson</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10533,7 +10533,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dermetro" supported="no">
-		<description>Dernier Metro (Fra)</description>
+		<description>Dernier Metro (France)</description>
 		<year>1985</year>
 		<publisher>Micro Programmes 5</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10593,7 +10593,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="desperd2" supported="no">
-		<description>Desperado 2 (Spa)</description>
+		<description>Desperado 2 (Spain)</description>
 		<year>1991</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10605,7 +10605,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="desperad" cloneof="gunsmoke" supported="no">
-		<description>Desperado (Spa)</description>
+		<description>Desperado (Spain)</description>
 		<year>1987</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10622,7 +10622,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="despotik" supported="no">
-		<description>Despotik Design (Euro)</description>
+		<description>Despotik Design (Europe)</description>
 		<year>1987</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10634,7 +10634,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="demath6e" supported="no">
-		<description>Destination Maths 6e-5e (Fra)</description>
+		<description>Destination Maths 6e-5e (France)</description>
 		<year>1989</year>
 		<publisher>Generation 5</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10661,7 +10661,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="demathc1" supported="no">
-		<description>Destination Maths Ce1-Ce2 (Fra)</description>
+		<description>Destination Maths Ce1-Ce2 (France)</description>
 		<year>1989</year>
 		<publisher>Generation 5</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10700,7 +10700,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="deutsch1" supported="no">
-		<description>Deutschstunde 1 (Ger)</description>
+		<description>Deutschstunde 1 (Germany)</description>
 		<year>1986</year>
 		<publisher>Europa Computer Club</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10712,7 +10712,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="deutsch2" supported="no">
-		<description>Deutschstunde 2 (Ger)</description>
+		<description>Deutschstunde 2 (Germany)</description>
 		<year>1986</year>
 		<publisher>Europa Computer Club</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10724,7 +10724,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="deutsch3" supported="no">
-		<description>Deutschstunde 3 (Ger)</description>
+		<description>Deutschstunde 3 (Germany)</description>
 		<year>1986</year>
 		<publisher>Europa Computer Club</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10789,7 +10789,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="diamanmd" supported="no">
-		<description>Le Diamant de l'Ile Maudite (Fra)</description>
+		<description>Le Diamant de l'Ile Maudite (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10806,7 +10806,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="diampeur" supported="no">
-		<description>Les Diamants de la Peur (Fra)</description>
+		<description>Les Diamants de la Peur (France)</description>
 		<year>1985</year>
 		<publisher>Power Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10830,7 +10830,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dianne" supported="no">
-		<description>Dianne - Mission Rubidiums (Fra)</description>
+		<description>Dianne - Mission Rubidiums (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10854,7 +10854,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="didacten" supported="no">
-		<description>Didact-English -College- (Fra)</description>
+		<description>Didact-English -College- (France)</description>
 		<year>1987</year>
 		<publisher>Carraz Editions</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10890,7 +10890,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dimomega" supported="no">
-		<description>Dimension Omega (Spa)</description>
+		<description>Dimension Omega (Spain)</description>
 		<year>1989</year>
 		<publisher>Positive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -10939,7 +10939,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="diosacoz" supported="no">
-		<description>La Diosa de Cozumel (Spa)</description>
+		<description>La Diosa de Cozumel (Spain)</description>
 		<year>1990</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11167,7 +11167,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dogf2187" supported="no">
-		<description>Dogfight 2187 (Spa)</description>
+		<description>Dogfight 2187 (Spain)</description>
 		<year>1987</year>
 		<publisher>Starlight Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11203,7 +11203,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="domino" supported="no">
-		<description>Domino (Spa)</description>
+		<description>Domino (Spain)</description>
 		<year>1985</year>
 		<publisher>Idealogic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11227,7 +11227,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="donquijo" supported="no">
-		<description>Don Quijote (Spa)</description>
+		<description>Don Quijote (Spain)</description>
 		<year>1987</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11256,7 +11256,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="donaldam" supported="no">
-		<description>Donald y el Alfabeto Magico (Spa)</description>
+		<description>Donald y el Alfabeto Magico (Spain)</description>
 		<year>1991</year>
 		<publisher>Disney</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11316,7 +11316,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="doomdreva" cloneof="doomdrev" supported="no">
-		<description>Doomdark's Revenge (UK, Alt)</description>
+		<description>Doomdark's Revenge (UK, alt)</description>
 		<year>1986</year>
 		<publisher>Beyond Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11405,7 +11405,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ddragons" cloneof="ddragon" supported="no">
-		<description>Double Dragon (Spa)</description>
+		<description>Double Dragon (Spain)</description>
 		<year>1988</year>
 		<publisher>Animagic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11578,7 +11578,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="drdoomrvs" cloneof="drdoomrv" supported="no">
-		<description>The Amazing Spiderman and Captain America in Doctor Doom's Revenge! (Spa)</description>
+		<description>The Amazing Spiderman and Captain America in Doctor Doom's Revenge! (Spain)</description>
 		<year>1989</year>
 		<publisher>Empire</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11613,7 +11613,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="draculaa" cloneof="dracula" supported="no">
-		<description>Dracula (UK, 2 Tapes)</description>
+		<description>Dracula (UK, 2 tapes)</description>
 		<year>1986</year>
 		<publisher>CRL Group</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11652,7 +11652,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dninjas" cloneof="dninja" supported="no">
-		<description>Dragon Ninja (Spa)</description>
+		<description>Dragon Ninja (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11741,7 +11741,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="drakkar" supported="no">
-		<description>Drakkar (Spa)</description>
+		<description>Drakkar (Spain)</description>
 		<year>1989</year>
 		<publisher>Delta Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11772,7 +11772,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="petrovic" supported="no">
-		<description>Drazen Petrovic Basket (Spa)</description>
+		<description>Drazen Petrovic Basket (Spain)</description>
 		<year>1989</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11845,7 +11845,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="drillers" cloneof="driller" supported="no">
-		<description>Driller (Spa)</description>
+		<description>Driller (Spain)</description>
 		<year>1987</year>
 		<publisher>Incentive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11869,7 +11869,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="duel" supported="no">
-		<description>Duel (Fra)</description>
+		<description>Duel (France)</description>
 		<year>1986</year>
 		<publisher>Gasoline Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11956,7 +11956,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dustin" supported="no">
-		<description>Dustin (Spa)</description>
+		<description>Dustin (Spain)</description>
 		<year>1986</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -11968,7 +11968,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dwarf" supported="no">
-		<description>Dwarf (Spa)</description>
+		<description>Dwarf (Spain)</description>
 		<year>1987</year>
 		<publisher>Softhawk</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12004,7 +12004,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dynamduos" cloneof="dynamduo" supported="no">
-		<description>Dynamic Duo (Spa)</description>
+		<description>Dynamic Duo (Spain)</description>
 		<year>1988</year>
 		<publisher>Firebird</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12028,7 +12028,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dynadansc" cloneof="dynadan" supported="no">
-		<description>Dynamite Dan (Spa, Circulo de Soft)</description>
+		<description>Dynamite Dan (Spain, Circulo de Soft)</description>
 		<year>1985</year>
 		<publisher>Circulo de Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12040,7 +12040,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="dynadansm" cloneof="dynadan" supported="no">
-		<description>Dynamite Dan (Spa, Mirrorsoft)</description>
+		<description>Dynamite Dan (Spain, Mirrorsoft)</description>
 		<year>1985</year>
 		<publisher>Mirrorsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12112,7 +12112,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="emotions" cloneof="emotion" supported="no">
-		<description>E-Motion (Spa)</description>
+		<description>E-Motion (Spain)</description>
 		<year>1990</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12124,7 +12124,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="exit" supported="no">
-		<description>E.X.I.T (Fra)</description>
+		<description>E.X.I.T (France)</description>
 		<year>1988</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12165,7 +12165,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="easiaws" cloneof="easiaw" supported="no">
-		<description>Easi-Amsword (Spa)</description>
+		<description>Easi-Amsword (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12177,7 +12177,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="easytopw" cloneof="easiaw" supported="no">
-		<description>Easy Topword (Ger)</description>
+		<description>Easy Topword (Germany)</description>
 		<year>1984</year>
 		<publisher>Schneider Computer Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12189,7 +12189,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="easyfile" supported="no">
-		<description>Easy File (Fra)</description>
+		<description>Easy File (France)</description>
 		<year>1984</year>
 		<publisher>Power Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12235,7 +12235,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="economat" supported="no">
-		<description>Economat (Fra)</description>
+		<description>Economat (France)</description>
 		<year>1985</year>
 		<publisher>Micro Programmes 5</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12247,7 +12247,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ecuacion" supported="no">
-		<description>Ecuaciones (Spa, BASIC 1.1)</description>
+		<description>Ecuaciones (Spain, BASIC 1.1)</description>
 		<year>1986</year>
 		<publisher>Monser</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12283,7 +12283,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="edenblue" cloneof="doomblue" supported="no">
-		<description>Eden Blues (Fra)</description>
+		<description>Eden Blues (France)</description>
 		<year>1986</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12295,7 +12295,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="editmus" supported="no">
-		<description>Edit-Music (Fra)</description>
+		<description>Edit-Music (France)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12307,7 +12307,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="educa1" supported="no">
-		<description>Educatif 1 (Fra)</description>
+		<description>Educatif 1 (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12324,7 +12324,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="educa2" supported="no">
-		<description>Educatif 2 (Fra)</description>
+		<description>Educatif 2 (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12341,7 +12341,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="educa3" supported="no">
-		<description>Educatif 3 (Fra)</description>
+		<description>Educatif 3 (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12358,7 +12358,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="educa6" supported="no">
-		<description>Educatif 6 (Fra)</description>
+		<description>Educatif 6 (France)</description>
 		<year>1986</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12459,7 +12459,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="elevators" cloneof="elevator" supported="no">
-		<description>Elevator Action (Spa)</description>
+		<description>Elevator Action (Spain)</description>
 		<year>1987</year>
 		<publisher>Mind Games Espana</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12507,7 +12507,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="eliteg" cloneof="elite" supported="no">
-		<description>Elite (Ger)</description>
+		<description>Elite (Germany)</description>
 		<year>1986</year>
 		<publisher>Firebird</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12543,7 +12543,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ebutrag2" supported="no">
-		<description>Emilio Butragueno II (Spa)</description>
+		<description>Emilio Butragueno II (Spain)</description>
 		<year>1989</year>
 		<publisher>Erbe Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12560,7 +12560,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="esanchez" supported="no">
-		<description>Emilio Sanchez Vicario Grand Slam (Spa)</description>
+		<description>Emilio Sanchez Vicario Grand Slam (Spain)</description>
 		<year>1989</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12596,7 +12596,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="empirel" supported="no">
-		<description>Empire (Fra, Loriciels)</description>
+		<description>Empire (France, Loriciels)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12608,7 +12608,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="arcalian" supported="no">
-		<description>En Busca del Arca de la Alianza (Spa, BASIC 1.1)</description>
+		<description>En Busca del Arca de la Alianza (Spain, BASIC 1.1)</description>
 		<year>1986</year>
 		<publisher>Creativos Editoriales S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12620,7 +12620,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="enchantd" supported="no">
-		<description>Enchanted (Spa)</description>
+		<description>Enchanted (Spain)</description>
 		<year>1989</year>
 		<publisher>Positive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12683,9 +12683,9 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="enduroi" cloneof="enduro" supported="no">
-		<description>Enduro Racer (UK, Ibsa)</description>
+		<description>Enduro Racer (UK, IBSA)</description>
 		<year>1987</year>
-		<publisher>Ibsa</publisher>
+		<publisher>IBSA</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
 		<part name="cass1" interface="cpc_cass">
 			<dataarea name="cass" size="54055">
@@ -12725,7 +12725,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- MOVE TO CPC_FLOP! THIS TAPE WAS INCLUDED IN DISK PACK -->
 	<software name="enigmaud" supported="no">
-		<description>Enigme a Oxford (UK, Audio Tape)</description>
+		<description>Enigme a Oxford (UK, audio tape)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12752,7 +12752,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="enigmoxf" supported="no">
-		<description>Enigme a Oxford (UK, Fra)</description>
+		<description>Enigme a Oxford (UK, France)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12865,7 +12865,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="erbschaf" cloneof="inherit" supported="no">
-		<description>Die Erbschaft (Ger)</description>
+		<description>Die Erbschaft (Germany)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12883,7 +12883,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="escape" supported="no">
-		<description>Escape (Spa)</description>
+		<description>Escape (Spain)</description>
 		<year>1987</year>
 		<publisher>Edisoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12950,7 +12950,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="espsagrd" supported="no">
-		<description>La Espada Sagrada (Spa)</description>
+		<description>La Espada Sagrada (Spain)</description>
 		<year>1990</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -12962,7 +12962,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="espcoma1" supported="no">
-		<description>Espana - Comunidades Autonomas 1 (Spa)</description>
+		<description>Espana - Comunidades Autonomas 1 (Spain)</description>
 		<year>1986</year>
 		<publisher>Tasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13013,7 +13013,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="estrelmu" supported="no">
-		<description>La Estrella de la Muerte (Spa)</description>
+		<description>La Estrella de la Muerte (Spain)</description>
 		<year>1986</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13048,7 +13048,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="eswats" cloneof="eswat" supported="no">
-		<description>ESWAT - Cyber Police (Spa, 64K)</description>
+		<description>ESWAT - Cyber Police (Spain, 64K)</description>
 		<year>1990</year>
 		<publisher>Erbe</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13077,7 +13077,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="europawz" supported="no">
-		<description>Europa - Teatro de Operaciones + War Zone (Spa)</description>
+		<description>Europa - Teatro de Operaciones + War Zone (Spain)</description>
 		<year>1986</year>
 		<publisher>Hobby Press</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13202,7 +13202,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="everywals" cloneof="everywal" supported="no">
-		<description>Everyone's A Wally - Meet The Gang (Spa)</description>
+		<description>Everyone's A Wally - Meet The Gang (Spain)</description>
 		<year>1985</year>
 		<publisher>System 4 de Espana</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13244,7 +13244,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="exolons" cloneof="exolon" supported="no">
-		<description>Exolon (Spa)</description>
+		<description>Exolon (Spain)</description>
 		<year>1987</year>
 		<publisher>Hewson</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13292,7 +13292,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="exploitz" supported="no">
-		<description>Exploitez Votre Amstrad (Fra)</description>
+		<description>Exploitez Votre Amstrad (France)</description>
 		<year>1985</year>
 		<publisher>Vismo</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13364,7 +13364,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="f1" supported="no">
-		<description>F-1 (Spa)</description>
+		<description>F-1 (Spain)</description>
 		<year>1991</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13400,7 +13400,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="f15ses" cloneof="f15se" supported="no">
-		<description>F15 Strike Eagle (Spa)</description>
+		<description>F15 Strike Eagle (Spain)</description>
 		<year>1987</year>
 		<publisher>Erbe Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13412,7 +13412,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="f16cp" supported="no">
-		<description>F-16 Combat Pilot (Euro)</description>
+		<description>F-16 Combat Pilot (Europe)</description>
 		<year>1991</year>
 		<publisher>Digital Integration</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13476,7 +13476,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="facupa" cloneof="facup" supported="no">
-		<description>FA Cup Football (UK, 2 faces)</description>
+		<description>FA Cup Football (UK, 2 sides)</description>
 		<year>1986</year>
 		<publisher>Virgin Games</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13510,7 +13510,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="factura" supported="no">
-		<description>Facturacion (Spa)</description>
+		<description>Facturacion (Spain)</description>
 		<year>1985</year>
 		<publisher>RPA Systems Inc</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13632,7 +13632,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fantcity" supported="no">
-		<description>Fantome City (Fra)</description>
+		<description>Fantome City (France)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13680,7 +13680,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fernandzs" cloneof="fernandz" supported="no">
-		<description>Fernandez Must Die (Spa)</description>
+		<description>Fernandez Must Die (Spain)</description>
 		<year>1988</year>
 		<publisher>Image Works</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13692,7 +13692,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="martinbms" cloneof="basketms" supported="no">
-		<description>Fernando Martin Basket Master (Spa)</description>
+		<description>Fernando Martin Basket Master (Spain)</description>
 		<year>1987</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13728,7 +13728,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fichebib" supported="no">
-		<description>Fichero Bibliografico (Spa)</description>
+		<description>Fichero Bibliografico (Spain)</description>
 		<year>1985</year>
 		<publisher>RPA Systems Inc</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13740,7 +13740,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fichedsc" supported="no">
-		<description>Fichero Discografico (Spa)</description>
+		<description>Fichero Discografico (Spain)</description>
 		<year>1985</year>
 		<publisher>RPA Systems Inc</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13752,7 +13752,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ficheemp" supported="no">
-		<description>Fichero Empresarial (Spa)</description>
+		<description>Fichero Empresarial (Spain)</description>
 		<year>1985</year>
 		<publisher>RPA Systems Inc</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13834,7 +13834,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fightpils" cloneof="fightpil" supported="no">
-		<description>Fighter Pilot (Spa)</description>
+		<description>Fighter Pilot (Spain)</description>
 		<year>1985</year>
 		<publisher>Digital Integration</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13846,7 +13846,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fightpila" cloneof="fightpil" supported="no">
-		<description>Fighter Pilot (Euro?)</description>
+		<description>Fighter Pilot (Europe?)</description>
 		<year>1985</year>
 		<publisher>Digital Integration</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13858,7 +13858,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fightsoc" supported="no">
-		<description>Fighting Soccer (Spa, 64K)</description>
+		<description>Fighting Soccer (Spain, 64K)</description>
 		<year>1989</year>
 		<publisher>Activision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -13959,7 +13959,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="firefox" cloneof="laserwrp" supported="no">
-		<description>Fire Fox (Spa)</description>
+		<description>Fire Fox (Spain)</description>
 		<year>1985</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14029,7 +14029,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="firezonef" cloneof="firezone" supported="no">
-		<description>Firezone (Fra)</description>
+		<description>Firezone (France)</description>
 		<year>1987</year>
 		<publisher>Pss</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14046,7 +14046,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="firmamen" supported="no">
-		<description>El Firmamento (Spa, BASIC 1.1)</description>
+		<description>El Firmamento (Spain, BASIC 1.1)</description>
 		<year>1984</year>
 		<publisher>G.T.S. EDITORIAL</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14111,7 +14111,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="flash" supported="no">
-		<description>Flash (Fra)</description>
+		<description>Flash (France)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14147,7 +14147,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="flghtsim" supported="no">
-		<description>Flight Simulation (UK, Fast Load Version)</description>
+		<description>Flight Simulation (UK, fast load version)</description>
 		<year>1984</year>
 		<publisher>Myrddin Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14159,7 +14159,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="flghtsimsl" cloneof="flghtsim" supported="no">
-		<description>Flight Simulation (UK, Slow Load Version)</description>
+		<description>Flight Simulation (UK, slow load version)</description>
 		<year>1984</year>
 		<publisher>Myrddin Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14219,7 +14219,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fluglehr" supported="no">
-		<description>Fluglehrer (Ger)</description>
+		<description>Fluglehrer (Germany)</description>
 		<year>1984</year>
 		<publisher>Microland</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14231,7 +14231,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="flunky" supported="no">
-		<description>Flunky (Euro)</description>
+		<description>Flunky (Europe)</description>
 		<year>1987</year>
 		<publisher>Piranha</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14350,7 +14350,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fbmangr2s" cloneof="fbmangr2" supported="no">
-		<description>Football Manager 2 (Spa)</description>
+		<description>Football Manager 2 (Spain)</description>
 		<year>1988</year>
 		<publisher>System 4</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14398,7 +14398,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fbmangwcs" cloneof="fbmangwc" supported="no">
-		<description>Football Manager World Cup Edition (Spa)</description>
+		<description>Football Manager World Cup Edition (Spain)</description>
 		<year>1990</year>
 		<publisher>System 4</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14470,7 +14470,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="foretinf" cloneof="nightprk" supported="no">
-		<description>La Foret Infernale (Fra)</description>
+		<description>La Foret Infernale (France)</description>
 		<year>1985</year>
 		<publisher>Strategy Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14530,7 +14530,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="elfoso" supported="no">
-		<description>El Foso (Spa)</description>
+		<description>El Foso (Spain)</description>
 		<year>1985</year>
 		<publisher>Jasap Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14576,7 +14576,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="france" supported="no">
-		<description>La France (Fra)</description>
+		<description>La France (France)</description>
 		<year>1985</year>
 		<publisher>Core</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14588,7 +14588,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="franceg" supported="no">
-		<description>France Geo (Fra)</description>
+		<description>France Geo (France)</description>
 		<year>1986</year>
 		<publisher>Micro Futur</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14698,7 +14698,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fred" cloneof="rolandrp" supported="no">
-		<description>Fred (Spa)</description>
+		<description>Fred (Spain)</description>
 		<year>1984</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14727,7 +14727,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fredhards" cloneof="fredhard" supported="no">
-		<description>Freddy Hardest (Spa)</description>
+		<description>Freddy Hardest (Spain)</description>
 		<year>1987</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14744,7 +14744,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fhardman" cloneof="guardang" supported="no">
-		<description>Freddy Hardest en Manhattan Sur (Spa)</description>
+		<description>Freddy Hardest en Manhattan Sur (Spain)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -14810,7 +14810,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="frontier" supported="no">
-		<description>Frontiers (Spa)</description>
+		<description>Frontiers (Spain)</description>
 		<year>1988</year>
 		<publisher>Zafiro Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15061,7 +15061,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="furys" cloneof="fury" supported="no">
-		<description>The Fury (Spa)</description>
+		<description>The Fury (Spain)</description>
 		<year>1988</year>
 		<publisher>Martech</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15073,7 +15073,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="fusion2" supported="no">
-		<description>Fusion II (Fra)</description>
+		<description>Fusion II (France)</description>
 		<year>1988</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15114,7 +15114,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="futworld" supported="no">
-		<description>Future World (Ger)</description>
+		<description>Future World (Germany)</description>
 		<year>1985</year>
 		<publisher>Data Media GMBH</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15138,7 +15138,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="galachip" supported="no">
-		<description>Galachip (Fra)</description>
+		<description>Galachip (France)</description>
 		<year>1985</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15295,7 +15295,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gameovers" cloneof="gameover" supported="no">
-		<description>Game Over (Spa)</description>
+		<description>Game Over (Spain)</description>
 		<year>1986</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15329,7 +15329,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gameov12" supported="no">
-		<description>Game Over II + Game Over (Spa)</description>
+		<description>Game Over II + Game Over (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15451,7 +15451,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="linekssf" cloneof="lineksss" supported="no">
-		<description>Gary Lineker's Super Star Football (Fra)</description>
+		<description>Gary Lineker's Super Star Football (France)</description>
 		<year>1987</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15586,7 +15586,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gazzas" cloneof="gazza" supported="no">
-		<description>Gazza's Super Soccer (Spa)</description>
+		<description>Gazza's Super Soccer (Spain)</description>
 		<year>1989</year>
 		<publisher>Empire</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15598,7 +15598,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gbabsktbs" cloneof="gbabsktb" supported="no">
-		<description>GBA Championship Basketball - 2 on 2 (Spa)</description>
+		<description>GBA Championship Basketball - 2 on 2 (Spain)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15622,7 +15622,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="geantarc" supported="no">
-		<description>Les Geants de l'Arcade (Fra)</description>
+		<description>Les Geants de l'Arcade (France)</description>
 		<year>1988</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15724,7 +15724,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="genghis" supported="no">
-		<description>Genghis Khan (Spa)</description>
+		<description>Genghis Khan (Spain)</description>
 		<year>1991</year>
 		<publisher>Positive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15736,7 +15736,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="geo" supported="no">
-		<description>Geo (Fra)</description>
+		<description>Geo (France)</description>
 		<year>1986</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15775,7 +15775,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="geomspc" supported="no">
-		<description>Geometria del Espacio (Spa)</description>
+		<description>Geometria del Espacio (Spain)</description>
 		<year>1986</year>
 		<publisher>Tasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15802,7 +15802,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="geomplan" supported="no">
-		<description>Geometria del Plano (Spa)</description>
+		<description>Geometria del Plano (Spain)</description>
 		<year>1986</year>
 		<publisher>Tasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15829,7 +15829,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="elgerent" supported="no">
-		<description>El Gerente (Spa)</description>
+		<description>El Gerente (Spain)</description>
 		<year>1985</year>
 		<publisher>Idealogic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15841,7 +15841,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="artillac" supported="no">
-		<description>La Geste d'Artillac (Fra)</description>
+		<description>La Geste d'Artillac (France)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15863,7 +15863,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gestfich" cloneof="filemang" supported="no">
-		<description>Gestion de Fichiers (Fra)</description>
+		<description>Gestion de Fichiers (France)</description>
 		<year>1984</year>
 		<publisher>Core</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15875,7 +15875,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gestf464" supported="no">
-		<description>Gestion de Fichier CPC 464 (Fra)</description>
+		<description>Gestion de Fichier CPC 464 (France)</description>
 		<year>1984</year>
 		<publisher>Sprites</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -15916,7 +15916,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gflchamp" supported="no">
-		<description>GFL Championship Football (Spa)</description>
+		<description>GFL Championship Football (Spain)</description>
 		<year>1987</year>
 		<publisher>Activision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16017,7 +16017,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gihero" supported="no">
-		<description>GI Hero (Spa)</description>
+		<description>GI Hero (Spain)</description>
 		<year>1988</year>
 		<publisher>Firebird</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16165,7 +16165,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="goldbskt" supported="no">
-		<description>Golden Basket (Spa)</description>
+		<description>Golden Basket (Spain)</description>
 		<year>1990</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16190,7 +16190,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="golftrop" supported="no">
-		<description>Golf Trophee (Fra)</description>
+		<description>Golf Trophee (France)</description>
 		<year>1987</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16202,7 +16202,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="goliath" supported="no">
-		<description>Goliath - Le Defi (Fra)</description>
+		<description>Goliath - Le Defi (France)</description>
 		<year>1986</year>
 		<publisher>Rainbow Production</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16214,7 +16214,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gonzalez" supported="no">
-		<description>Gonzzalezz (Spa)</description>
+		<description>Gonzzalezz (Spain)</description>
 		<year>1989</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16231,7 +16231,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="goody" supported="no">
-		<description>Goody (Spa)</description>
+		<description>Goody (Spain)</description>
 		<year>1987</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16255,7 +16255,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gorbaf" supported="no">
-		<description>Gorbaf El Vikingo (Spa)</description>
+		<description>Gorbaf El Vikingo (Spain)</description>
 		<year>1986</year>
 		<publisher>Magic Team</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16291,7 +16291,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gp500cc" cloneof="500ccgp" supported="no">
-		<description>Grand Prix 500cc (Fra)</description>
+		<description>Grand Prix 500cc (France)</description>
 		<year>1986</year>
 		<publisher>Microids</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16303,7 +16303,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gp500ccs" cloneof="500ccgp" supported="no">
-		<description>Grand Prix 500cc (Spa)</description>
+		<description>Grand Prix 500cc (Spain)</description>
 		<year>1986</year>
 		<publisher>Microids</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16411,7 +16411,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="granghils" cloneof="granghil" supported="no">
-		<description>Grange Hill (Spa)</description>
+		<description>Grange Hill (Spain)</description>
 		<year>1987</year>
 		<publisher>Grandslam</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16423,7 +16423,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="graphpak" supported="no">
-		<description>Graph Pack (Fra)</description>
+		<description>Graph Pack (France)</description>
 		<year>1986</year>
 		<publisher>Software Center</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16440,7 +16440,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="graphpaks" cloneof="graphpak" supported="no">
-		<description>Graph Pack (Spa)</description>
+		<description>Graph Pack (Spain)</description>
 		<year>1986</year>
 		<publisher>Software Center</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16469,7 +16469,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="graphis" supported="no">
-		<description>Graphis (Fra)</description>
+		<description>Graphis (France)</description>
 		<year>1985</year>
 		<publisher>Micro Bureautique 92</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16481,7 +16481,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="graphist" supported="no">
-		<description>Graphisto (Fra, BASIC 1.0)</description>
+		<description>Graphisto (France, BASIC 1.0)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16493,7 +16493,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="grapholg" supported="no">
-		<description>Graphologie (Fra)</description>
+		<description>Graphologie (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16607,7 +16607,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gremlinss" cloneof="gremlins" supported="no">
-		<description>Gremlins - The Adventure (Spa)</description>
+		<description>Gremlins - The Adventure (Spain)</description>
 		<year>1985</year>
 		<publisher>Adventure International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16631,7 +16631,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gremlin2s" cloneof="gremlin2" supported="no">
-		<description>Gremlins 2 - The New Batch (Spa)</description>
+		<description>Gremlins 2 - The New Batch (Spain)</description>
 		<year>1990</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16727,7 +16727,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gryzors" cloneof="gryzor" supported="no">
-		<description>Gryzor (Spa)</description>
+		<description>Gryzor (Spain)</description>
 		<year>1987</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16792,7 +16792,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="vajillas" supported="no">
-		<description>La Guerra de Las Vajillas (Spa)</description>
+		<description>La Guerra de Las Vajillas (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16809,7 +16809,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gwars" cloneof="gwar" supported="no">
-		<description>Guerrilla War (Spa)</description>
+		<description>Guerrilla War (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16843,7 +16843,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="guillemb" supported="no">
-		<description>Guillem de Bergueda (Spa)</description>
+		<description>Guillem de Bergueda (Spain)</description>
 		<year>1985</year>
 		<publisher>Ace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -16855,7 +16855,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="gtell" supported="no">
-		<description>Guillermo Tell (Spa)</description>
+		<description>Guillermo Tell (Spain)</description>
 		<year>1989</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17085,7 +17085,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- MOVE TO CPC_FLOP! THIS TAPE WAS INCLUDED IN DISK PACK -->
 	<software name="handisla" supported="no">
-		<description>Han d'Islande (Fra, Audio Tape)</description>
+		<description>Han d'Islande (France, audio tape)</description>
 		<year>1988</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17114,7 +17114,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hanse" supported="no">
-		<description>Hanse (Ger)</description>
+		<description>Hanse (Germany)</description>
 		<year>1986</year>
 		<publisher>Ariolasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17198,7 +17198,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="harrican" supported="no">
-		<description>Harricana - Raid International Motoneige (Fra)</description>
+		<description>Harricana - Raid International Motoneige (France)</description>
 		<year>1990</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17258,7 +17258,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hates" cloneof="hate" supported="no">
-		<description>HATE - Hostile All Terrain Encounter (Spa)</description>
+		<description>HATE - Hostile All Terrain Encounter (Spain)</description>
 		<year>1989</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17282,7 +17282,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="madness" supported="no">
-		<description>Having Fits of Madness (Spa, BASIC 1.1)</description>
+		<description>Having Fits of Madness (Spain, BASIC 1.1)</description>
 		<year>19??</year>
 		<publisher>PJ Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17348,7 +17348,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="antiriadg" cloneof="antiriad" supported="no">
-		<description>Die Heilige Rustung Des Antiriad (Ger)</description>
+		<description>Die Heilige Rustung Des Antiriad (Germany)</description>
 		<year>1986</year>
 		<publisher>Palace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17360,7 +17360,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="heritage" cloneof="inherit" supported="no">
-		<description>L'Heritage (Fra)</description>
+		<description>L'Heritage (France)</description>
 		<year>1986</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17378,7 +17378,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="2hmbh" supported="no">
-		<description>Heavy Metal + Beach-Head (Spa)</description>
+		<description>Heavy Metal + Beach-Head (Spain)</description>
 		<year>1990</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17407,7 +17407,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hebdhs1" supported="no">
-		<description>Hebdogiciel Hors Serie 1 (Fra)</description>
+		<description>Hebdogiciel Hors Serie 1 (France)</description>
 		<year>1985</year>
 		<publisher>Hebdogiciel</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17486,7 +17486,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="helicp2k" cloneof="choppers" supported="no">
-		<description>Helicoptero 2000 (Spa)</description>
+		<description>Helicoptero 2000 (Spain)</description>
 		<year>1984</year>
 		<publisher>Interceptor Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17498,7 +17498,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="heliot" supported="no">
-		<description>Heliot (Fra)</description>
+		<description>Heliot (France)</description>
 		<year>1984</year>
 		<publisher>Sprites</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17510,7 +17510,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="heltersk" supported="no">
-		<description>Helter Skelter (Spa)</description>
+		<description>Helter Skelter (Spain)</description>
 		<year>1990</year>
 		<publisher>Audiogenic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17522,7 +17522,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="herbdruns" cloneof="herbdrun" supported="no">
-		<description>Herbert's Dummy Run (Spa)</description>
+		<description>Herbert's Dummy Run (Spain)</description>
 		<year>1986</year>
 		<publisher>Mikrogen</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17628,7 +17628,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hexenkuc" cloneof="cauldron" supported="no">
-		<description>Hexenkueche (Ger)</description>
+		<description>Hexenkueche (Germany)</description>
 		<year>1985</year>
 		<publisher>Palace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17640,7 +17640,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hexenku2" cloneof="cauldrn2" supported="no">
-		<description>Hexenkueche II (Ger)</description>
+		<description>Hexenkueche II (Germany)</description>
 		<year>1986</year>
 		<publisher>Palace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -17681,7 +17681,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="highepid" supported="no">
-		<description>High Epidemy (Fra)</description>
+		<description>High Epidemy (France)</description>
 		<year>1988</year>
 		<publisher>Fil</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18038,7 +18038,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hitscol1" supported="no">
-		<description>Hits Collection 1 (Fra)</description>
+		<description>Hits Collection 1 (France)</description>
 		<year>1987</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18055,7 +18055,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hitslor1" supported="no">
-		<description>Les Hits 1 de Loriciels (Fra)</description>
+		<description>Les Hits 1 de Loriciels (France)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18072,7 +18072,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hitslor2" supported="no">
-		<description>Les Hits 2 de Loriciels (Fra)</description>
+		<description>Les Hits 2 de Loriciels (France)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18101,7 +18101,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hmscobra" supported="no">
-		<description>HMS Cobra (Spa)</description>
+		<description>HMS Cobra (Spain)</description>
 		<year>1986</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18137,7 +18137,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hockey" cloneof="slapshot" supported="no">
-		<description>Hockey (Spa)</description>
+		<description>Hockey (Spain)</description>
 		<year>1985</year>
 		<publisher>Indescomp</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18149,7 +18149,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="holdup" supported="no">
-		<description>Hold-Up (Fra)</description>
+		<description>Hold-Up (France)</description>
 		<year>1984</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18385,7 +18385,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="howard" supported="no">
-		<description>Howard The Duck (Spa)</description>
+		<description>Howard The Duck (Spain)</description>
 		<year>1987</year>
 		<publisher>Activision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18431,7 +18431,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="humphrey" supported="no">
-		<description>Humphrey (Spa)</description>
+		<description>Humphrey (Spain)</description>
 		<year>1988</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18506,7 +18506,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hundras" cloneof="hundra" supported="no">
-		<description>Hundra (Spa)</description>
+		<description>Hundra (Spain)</description>
 		<year>1987</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18530,7 +18530,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="huntred" supported="no">
-		<description>The Hunt for Red October (Spa?, Based on the Novel)</description>
+		<description>The Hunt for Red October (Spain?, based on the novel)</description>
 		<year>1987</year>
 		<publisher>Grandslam</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18542,7 +18542,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="huntredm" supported="no">
-		<description>The Hunt for Red October (UK, Based on the Movie)</description>
+		<description>The Hunt for Red October (UK, based on the movie)</description>
 		<year>1990</year>
 		<publisher>Grandslam</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18699,7 +18699,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hyperspc" supported="no">
-		<description>Hyperspace - Aventures Spatio-Temporelles (Fra)</description>
+		<description>Hyperspace - Aventures Spatio-Temporelles (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18764,7 +18764,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="icebreak" supported="no">
-		<description>Ice Breaker (Spa)</description>
+		<description>Ice Breaker (Spain)</description>
 		<year>1990</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18882,7 +18882,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="impossams" cloneof="impossam" supported="no">
-		<description>Impossamole (Spa)</description>
+		<description>Impossamole (Spain)</description>
 		<year>1990</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -18993,7 +18993,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="indorace" supported="no">
-		<description>Indoor Race (Spa)</description>
+		<description>Indoor Race (Spain)</description>
 		<year>1987</year>
 		<publisher>Mind Games Espana</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19029,7 +19029,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="inertie" supported="no">
-		<description>Inertie (Fra)</description>
+		<description>Inertie (France)</description>
 		<year>1987</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19041,7 +19041,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="inferunr" supported="no">
-		<description>Infernal Runner (Fra)</description>
+		<description>Infernal Runner (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19100,7 +19100,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="inhuman" supported="no">
-		<description>Los Inhumanos (Spa)</description>
+		<description>Los Inhumanos (Spain)</description>
 		<year>1990</year>
 		<publisher>Delta Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19117,7 +19117,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="initbas1" cloneof="teachbs1" supported="no">
-		<description>Initiation Au Basic Amstrad - 1ere Partie - Premiers Pas (Fra)</description>
+		<description>Initiation Au Basic Amstrad - 1ere Partie - Premiers Pas (France)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19144,7 +19144,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="inquisit" supported="no">
-		<description>Inquisitor - Shade of Swords (Fra)</description>
+		<description>Inquisitor - Shade of Swords (France)</description>
 		<year>1987</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19168,7 +19168,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="insidoutds" cloneof="insidout" supported="no">
-		<description>Inside Outing (Spa)</description>
+		<description>Inside Outing (Spain)</description>
 		<year>1987</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19262,7 +19262,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ikps" cloneof="ikp" supported="no">
-		<description>International Karate Plus (Spa)</description>
+		<description>International Karate Plus (Spain)</description>
 		<year>1988</year>
 		<publisher>System 3</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19375,7 +19375,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="eaglenst" supported="no">
-		<description>Into the Eagle's Nest (UK, S.A.T.A.R Demo on Side B)</description>
+		<description>Into the Eagle's Nest (UK, S.A.T.A.R demo on side B)</description>
 		<year>1987</year>
 		<publisher>Pandora</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19404,7 +19404,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="invygana" supported="no">
-		<description>Invierte y Gana (Spa)</description>
+		<description>Invierte y Gana (Spain)</description>
 		<year>1986</year>
 		<publisher>Idealogic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19416,7 +19416,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="invitatn" supported="no">
-		<description>Invitation (Fra)</description>
+		<description>Invitation (France)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19445,7 +19445,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="isoleur" supported="no">
-		<description>Isoleur (Fra)</description>
+		<description>Isoleur (France)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19522,7 +19522,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="iznogoud" supported="no">
-		<description>Iznogoud (Spa)</description>
+		<description>Iznogoud (Spain)</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19534,7 +19534,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jabato" supported="no">
-		<description>Jabato (Spa)</description>
+		<description>Jabato (Spain)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19563,7 +19563,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="nicklaus" supported="no">
-		<description>Jack Nicklaus Golf (Spa)</description>
+		<description>Jack Nicklaus Golf (Spain)</description>
 		<year>1989</year>
 		<publisher>Accolade</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19644,7 +19644,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jackcity" supported="no">
-		<description>Jackson City (Spa)</description>
+		<description>Jackson City (Spain)</description>
 		<year>1990</year>
 		<publisher>GLL Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19656,7 +19656,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jksquash" supported="no">
-		<description>Jahangir Khan World Championship Squash (Euro)</description>
+		<description>Jahangir Khan World Championship Squash (Europe)</description>
 		<year>1991</year>
 		<publisher>Krisalis Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19668,7 +19668,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jaialai" supported="no">
-		<description>Jai Alai (Spa)</description>
+		<description>Jai Alai (Spain)</description>
 		<year>1990</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19704,7 +19704,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="shoguns" cloneof="shogun" supported="no">
-		<description>James Clavell's Shogun (Spa)</description>
+		<description>James Clavell's Shogun (Spain)</description>
 		<year>1986</year>
 		<publisher>Virgin Games</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19716,7 +19716,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="debugmip" supported="no">
-		<description>James Debug - Le Mystere de l'Ile Perdue (Fra, 64K)</description>
+		<description>James Debug - Le Mystere de l'Ile Perdue (France, 64K)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19833,7 +19833,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jeuduroy" supported="no">
-		<description>Le Jeu du Roy (Fra)</description>
+		<description>Le Jeu du Roy (France)</description>
 		<year>1988</year>
 		<publisher>Fil</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -19894,7 +19894,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jimmybus" supported="no">
-		<description>Jimmy Business (Fra)</description>
+		<description>Jimmy Business (France)</description>
 		<year>1985</year>
 		<publisher>Andromeda Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20026,7 +20026,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jewelbabf" cloneof="jewelbab" supported="no">
-		<description>Les Joyaux de Babylone (Fra)</description>
+		<description>Les Joyaux de Babylone (France)</description>
 		<year>1984</year>
 		<publisher>Interceptor Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20038,7 +20038,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="joydraw" supported="no">
-		<description>Joydraw (Ger)</description>
+		<description>Joydraw (Germany)</description>
 		<year>1985</year>
 		<publisher>ESCON GmbH</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20050,7 +20050,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="juegooca" supported="no">
-		<description>El Juego de la Oca (Spa)</description>
+		<description>El Juego de la Oca (Spain)</description>
 		<year>1989</year>
 		<publisher>Zafiro Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20074,7 +20074,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jump" supported="no">
-		<description>Jump (Spa)</description>
+		<description>Jump (Spain)</description>
 		<year>1991</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20086,7 +20086,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jumpjet" supported="no">
-		<description>Jump Jet (Spa)</description>
+		<description>Jump Jet (Spain)</description>
 		<year>1985</year>
 		<publisher>Anirog Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20139,7 +20139,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jungwarr" supported="no">
-		<description>Jungle Warrior (Spa)</description>
+		<description>Jungle Warrior (Spain)</description>
 		<year>1990</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20156,7 +20156,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="justicer" supported="no">
-		<description>Les Justiciers (Fra?)</description>
+		<description>Les Justiciers (France?)</description>
 		<year>1989</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20178,7 +20178,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kya" supported="no">
-		<description>K.Y.A. (Fra)</description>
+		<description>K.Y.A. (France)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20190,7 +20190,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kyas" cloneof="kya" supported="no">
-		<description>K.Y.A. (Spa)</description>
+		<description>K.Y.A. (Spain)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20202,7 +20202,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kaiserg" cloneof="kaiser" supported="no">
-		<description>Kaiser (Ger, BASIC 1.0)</description>
+		<description>Kaiser (Germany, BASIC 1.0)</description>
 		<year>1986</year>
 		<publisher>Ariolasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20255,7 +20255,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="karateka" supported="no">
-		<description>Karateka (Fra)</description>
+		<description>Karateka (France)</description>
 		<year>1990</year>
 		<publisher>Brøderbund France</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20272,7 +20272,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="karatekas" cloneof="karateka" supported="no">
-		<description>Karateka (Spa)</description>
+		<description>Karateka (Spain)</description>
 		<year>1990</year>
 		<publisher>Brøderbund France</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20330,7 +20330,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kerulenp" supported="no">
-		<description>Ke Rulen los Petas (Spa)</description>
+		<description>Ke Rulen los Petas (Spain)</description>
 		<year>1989</year>
 		<publisher>Iber Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20354,7 +20354,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kennydmt" supported="no">
-		<description>Kenny Dalglish Soccer Match (Spa)</description>
+		<description>Kenny Dalglish Soccer Match (Spain)</description>
 		<year>1990</year>
 		<publisher>Impressions</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20366,7 +20366,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kentel" supported="no">
-		<description>Kentel (Fra)</description>
+		<description>Kentel (France)</description>
 		<year>1987</year>
 		<publisher>Enter</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20407,7 +20407,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kettle" supported="no">
-		<description>Kettle (UK, Fast Load Version)</description>
+		<description>Kettle (UK, fast load version)</description>
 		<year>1986</year>
 		<publisher>Alligata Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20419,7 +20419,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kettlels" cloneof="kettle" supported="no">
-		<description>Kettle (UK, Slow Load Version)</description>
+		<description>Kettle (UK, slow load version)</description>
 		<year>1986</year>
 		<publisher>Alligata Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20431,7 +20431,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="keyfactr" supported="no">
-		<description>The Key Factor (Spa)</description>
+		<description>The Key Factor (Spain)</description>
 		<year>1985</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20443,7 +20443,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kickoff" supported="no">
-		<description>Kick Off (Euro)</description>
+		<description>Kick Off (Europe)</description>
 		<year>1990</year>
 		<publisher>Anco Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20467,7 +20467,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kickoff2s" cloneof="kickoff2" supported="no">
-		<description>Kick Off 2 (Spa)</description>
+		<description>Kick Off 2 (Spain)</description>
 		<year>1990</year>
 		<publisher>Anco Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20595,7 +20595,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kinetik" supported="no">
-		<description>Kinetik (Spa)</description>
+		<description>Kinetik (Spain)</description>
 		<year>1987</year>
 		<publisher>Firebird</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20607,7 +20607,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kingleon" supported="no">
-		<description>King Leonard (Spa)</description>
+		<description>King Leonard (Spain)</description>
 		<year>1986</year>
 		<publisher>Mind Games Espana</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20660,7 +20660,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="knigtgst" supported="no">
-		<description>Knight Ghosts (Spa)</description>
+		<description>Knight Ghosts (Spain)</description>
 		<year>1987</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20778,7 +20778,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kongsrev" supported="no">
-		<description>Kong's Revenge (Spa)</description>
+		<description>Kong's Revenge (Spain)</description>
 		<year>1991</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20867,7 +20867,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kungfums" cloneof="kungfum" supported="no">
-		<description>Kung-Fu Master (Spa)</description>
+		<description>Kung-Fu Master (Spain)</description>
 		<year>1986</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20903,7 +20903,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ladronspa" cloneof="ladronsp" supported="no">
-		<description>El Ladron del Sol Purpura (Spa, 2 Faces)</description>
+		<description>El Ladron del Sol Purpura (Spain, 2 sides)</description>
 		<year>1986</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -20921,7 +20921,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ladronsp" supported="no">
-		<description>El Ladron del Sol Purpura (Spa)</description>
+		<description>El Ladron del Sol Purpura (Spain)</description>
 		<year>1986</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21060,7 +21060,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lastmiss" supported="no">
-		<description>The Last Mission (Spa)</description>
+		<description>The Last Mission (Spain)</description>
 		<year>1987</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21072,7 +21072,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lastmissf" cloneof="lastmiss" supported="no">
-		<description>The Last Mission (Fra)</description>
+		<description>The Last Mission (France)</description>
 		<year>1987</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21120,7 +21120,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lazertag" supported="no">
-		<description>Lazertag (Spa)</description>
+		<description>Lazertag (Spain)</description>
 		<year>1987</year>
 		<publisher>Go!</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21260,7 +21260,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="legend" supported="no">
-		<description>Legend (Spa)</description>
+		<description>Legend (Spain)</description>
 		<year>1990</year>
 		<publisher>Delta Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21313,7 +21313,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="leng7egb" supported="no">
-		<description>Lenguaje - 7. E. G. B. (Spa)</description>
+		<description>Lenguaje - 7. E. G. B. (Spain)</description>
 		<year>1986</year>
 		<publisher>Centro Pedagogico de Informatica, S. A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21330,7 +21330,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lisp" supported="no">
-		<description>Lenguaje LISP (Spa)</description>
+		<description>Lenguaje LISP (Spain)</description>
 		<year>1986</year>
 		<publisher>Amstrad Especial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21388,7 +21388,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lic2kills" cloneof="lic2kill" supported="no">
-		<description>Licencia Para Matar (Spa)</description>
+		<description>Licencia Para Matar (Spain)</description>
 		<year>1989</year>
 		<publisher>Domark</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21465,7 +21465,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lpmk2a" cloneof="lpmk2" supported="no">
-		<description>Light Pen - Mark II (UK, 2 Tapes)</description>
+		<description>Light Pen - Mark II (UK, 2 tapes)</description>
 		<year>1985</year>
 		<publisher>Electrics Studio</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21527,7 +21527,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- DOUBLE CHECK: SHALL WE MOVE THIS TO CPC_FLOP? WHERE DOES IT COME FROM? -->
 	<software name="linkwfau" supported="no">
-		<description>Linkword Language Course - French (UK, Audio Tape)</description>
+		<description>Linkword Language Course - French (UK, audio tape)</description>
 		<year>1984</year>
 		<publisher>Protek</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21657,7 +21657,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="livingst" supported="no">
-		<description>Livingstone Supongo (Spa)</description>
+		<description>Livingstone Supongo (Spain)</description>
 		<year>1986</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21698,7 +21698,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="logiform" supported="no">
-		<description>Logiformes (Fra)</description>
+		<description>Logiformes (France)</description>
 		<year>1986</year>
 		<publisher>Langage et Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21724,7 +21724,7 @@ Please stick to using the floppy versions for the time being...
 	<software name="loopz" supported="no">
 		<description>Loopz (UK)</description>
 		<year>1991</year>
-		<publisher>Ibsa</publisher>
+		<publisher>IBSA</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
 		<part name="cass1" interface="cpc_cass">
 			<dataarea name="cass" size="54313">
@@ -21795,7 +21795,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lordchao" supported="no">
-		<description>Lords of Chaos (UK, Fra)</description>
+		<description>Lords of Chaos (UK, France)</description>
 		<year>1990</year>
 		<publisher>Blade Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21812,7 +21812,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lordchaoex1" cloneof="lordchao" supported="no">
-		<description>Lords of Chaos - Expansion Kit One (UK, Fra)</description>
+		<description>Lords of Chaos - Expansion Kit One (UK, France)</description>
 		<year>1990</year>
 		<publisher>Blade Software</publisher>
 		<info name="usage" value="Requires &quot;Lords of Chaos&quot; to work" />
@@ -21853,7 +21853,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lorigrph" supported="no">
-		<description>Lorigraph (Euro?)</description>
+		<description>Lorigraph (Europe?)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21865,7 +21865,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lorna" supported="no">
-		<description>Lorna (Spa)</description>
+		<description>Lorna (Spain)</description>
 		<year>1990</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21901,7 +21901,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="loteriap" supported="no">
-		<description>Loteria Primitiva (Spa, BASIC 1.1)</description>
+		<description>Loteria Primitiva (Spain, BASIC 1.1)</description>
 		<year>1987</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21930,7 +21930,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lotuss" cloneof="lotus" supported="no">
-		<description>Lotus Esprit Turbo Challenge (Spa)</description>
+		<description>Lotus Esprit Turbo Challenge (Spain)</description>
 		<year>1990</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21959,7 +21959,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="menfin" supported="no">
-		<description>M'Enfin (Fra)</description>
+		<description>M'Enfin (France)</description>
 		<year>1987</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21976,7 +21976,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mabase" supported="no">
-		<description>M.A. Base (Fra)</description>
+		<description>M.A. Base (France)</description>
 		<year>1985</year>
 		<publisher>Micro Application</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -21989,7 +21989,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="macabumpf" cloneof="macabump" supported="no">
-		<description>Macadam Bumper (Fra)</description>
+		<description>Macadam Bumper (France)</description>
 		<year>1985</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22025,7 +22025,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mach3f" cloneof="mach3" supported="no">
-		<description>Mach 3 (Fra)</description>
+		<description>Mach 3 (France)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22049,7 +22049,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="madmixs" cloneof="madmix" supported="no">
-		<description>Mad Mix Game (Spa)</description>
+		<description>Mad Mix Game (Spain)</description>
 		<year>1988</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22061,7 +22061,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="madmix2" supported="no">
-		<description>Mad Mix Game 2 - El Castillo de los Fantasmas (Spa)</description>
+		<description>Mad Mix Game 2 - El Castillo de los Fantasmas (Spain)</description>
 		<year>1989</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22133,7 +22133,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="magicj" supported="no">
-		<description>Magic Johnson's Basketball (Spa)</description>
+		<description>Magic Johnson's Basketball (Spain)</description>
 		<year>1990</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22201,7 +22201,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mallette" supported="no">
-		<description>Mallette 1 (Fra)</description>
+		<description>Mallette 1 (France)</description>
 		<year>1988</year>
 		<publisher>FIL</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22240,7 +22240,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mambo" supported="no">
-		<description>Mambo (Spa)</description>
+		<description>Mambo (Spain)</description>
 		<year>1989</year>
 		<publisher>Positive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22264,7 +22264,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="managerf" supported="no">
-		<description>Manager (Fra)</description>
+		<description>Manager (France)</description>
 		<year>1985</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22276,7 +22276,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="manchest" supported="no">
-		<description>Manchester United Football Club (Euro, 64K)</description>
+		<description>Manchester United Football Club (Europe, 64K)</description>
 		<year>1990</year>
 		<publisher>Krisalis Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22303,7 +22303,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="manchests" cloneof="manchest" supported="no">
-		<description>Manchester United Football Club (Spa, 64K)</description>
+		<description>Manchester United Football Club (Spain, 64K)</description>
 		<year>1990</year>
 		<publisher>System 4</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22320,7 +22320,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="manuteur" supported="no">
-		<description>Manchester United In Europe (Euro)</description>
+		<description>Manchester United In Europe (Europe)</description>
 		<year>1991</year>
 		<publisher>Krisalis Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22337,7 +22337,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mandragr" supported="no">
-		<description>Mandragore (Fra)</description>
+		<description>Mandragore (France)</description>
 		<year>1985</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22354,7 +22354,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mangcail" supported="no">
-		<description>Mange Cailloux (Fra)</description>
+		<description>Mange Cailloux (France)</description>
 		<year>1987</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22366,7 +22366,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="manhat95" supported="no">
-		<description>Manhattan 95 (Fra)</description>
+		<description>Manhattan 95 (France)</description>
 		<year>1986</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22414,7 +22414,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mansdrac" supported="no">
-		<description>La Mansion del Conde Dracula (Spa)</description>
+		<description>La Mansion del Conde Dracula (Spain)</description>
 		<year>1986</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22427,7 +22427,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mansencd" cloneof="usher" supported="no">
-		<description>La Mansion Encantada (Spa)</description>
+		<description>La Mansion Encantada (Spain)</description>
 		<year>1984</year>
 		<publisher>Anirog Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22439,7 +22439,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mantis1" supported="no">
-		<description>Mantis 1 (Spa)</description>
+		<description>Mantis 1 (Spain)</description>
 		<year>1990</year>
 		<publisher>MCM Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22451,7 +22451,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mantis2" supported="no">
-		<description>Mantis 2 (Spa)</description>
+		<description>Mantis 2 (Spain)</description>
 		<year>1990</year>
 		<publisher>MCM Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22475,7 +22475,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mapaciel" supported="no">
-		<description>Mapa del Cielo (Spa)</description>
+		<description>Mapa del Cielo (Spain)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22487,7 +22487,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mapgame" supported="no">
-		<description>Mapgame (Spa)</description>
+		<description>Mapgame (Spain)</description>
 		<year>1985</year>
 		<publisher>Erbe Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22499,7 +22499,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="maracaib" supported="no">
-		<description>Maracaibo (Fra)</description>
+		<description>Maracaibo (France)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22571,7 +22571,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tresfoot" cloneof="soccer86" supported="no">
-		<description>Marius Tresor Foot (Fra)</description>
+		<description>Marius Tresor Foot (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22607,7 +22607,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="masks" cloneof="mask" supported="no">
-		<description>Mask (Spa)</description>
+		<description>Mask (Spain)</description>
 		<year>1987</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22691,7 +22691,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mastcalc" supported="no">
-		<description>Mastercalc 464 (Spa)</description>
+		<description>Mastercalc 464 (Spain)</description>
 		<year>1985</year>
 		<publisher>Campbell Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22715,7 +22715,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mastfile" supported="no">
-		<description>Masterfile 464 v1.1 (Fra)</description>
+		<description>Masterfile 464 v1.1 (France)</description>
 		<year>1984</year>
 		<publisher>Campbell Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22739,7 +22739,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="matahari" supported="no">
-		<description>Mata Hari (Spa)</description>
+		<description>Mata Hari (Spain)</description>
 		<year>1988</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22787,7 +22787,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="matchdy2s" cloneof="matchdy2" supported="no">
-		<description>Match Day II (Spa)</description>
+		<description>Match Day II (Spain)</description>
 		<year>1987</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22811,7 +22811,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="matchpnta" cloneof="matchpnt" supported="no">
-		<description>Match Point (UK, Alt)</description>
+		<description>Match Point (UK, alt)</description>
 		<year>1985</year>
 		<publisher>Psion</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22823,7 +22823,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mate7egb" supported="no">
-		<description>Matematicas - 7. E. G. B. (Spa)</description>
+		<description>Matematicas - 7. E. G. B. (Spain)</description>
 		<year>1986</year>
 		<publisher>Centro Pedagogico De Informatica, S. A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22840,7 +22840,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mathstar" supported="no">
-		<description>Mathe-Star (Ger)</description>
+		<description>Mathe-Star (Germany)</description>
 		<year>1985</year>
 		<publisher>Star-Division</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22852,7 +22852,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mathest1" supported="no">
-		<description>MatheStunde1 (Ger)</description>
+		<description>MatheStunde1 (Germany)</description>
 		<year>1986</year>
 		<publisher>Europa Computer Club</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22881,7 +22881,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="maths2c" supported="no">
-		<description>Maths-Second-Cycle 2 (Fra)</description>
+		<description>Maths-Second-Cycle 2 (France)</description>
 		<year>1987</year>
 		<publisher>Micro C</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22925,7 +22925,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="maxheadrs" cloneof="maxheadr" supported="no">
-		<description>Max Headroom (Spa)</description>
+		<description>Max Headroom (Spain)</description>
 		<year>1986</year>
 		<publisher>Mind Games Espana</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22937,7 +22937,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mayhem" supported="no">
-		<description>Mayhem (Spa)</description>
+		<description>Mayhem (Spain)</description>
 		<year>1985</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22949,7 +22949,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mazemani" supported="no">
-		<description>Maze Mania (Spa)</description>
+		<description>Maze Mania (Spain)</description>
 		<year>1989</year>
 		<publisher>Hewson</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -22985,7 +22985,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mega4" supported="no">
-		<description>Mega 4 (Spa)</description>
+		<description>Mega 4 (Spain)</description>
 		<year>1991</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23024,7 +23024,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="megachss" supported="no">
-		<description>Mega Chess (Spa)</description>
+		<description>Mega Chess (Spain)</description>
 		<year>1984</year>
 		<publisher>CP Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23063,7 +23063,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="megapack" supported="no">
-		<description>Le Mega Pack (Fra)</description>
+		<description>Le Mega Pack (France)</description>
 		<year>1989</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23104,7 +23104,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="megacorp" supported="no">
-		<description>Megacorp (Spa)</description>
+		<description>Megacorp (Spain)</description>
 		<year>1987</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23180,7 +23180,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="meganovas" cloneof="meganova" supported="no">
-		<description>Meganova (Spa)</description>
+		<description>Meganova (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23197,7 +23197,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="megapac2" supported="no">
-		<description>Megapack 2 (Fra)</description>
+		<description>Megapack 2 (France)</description>
 		<year>1990</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23248,7 +23248,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="menacart" supported="no">
-		<description>Menace sur l'Arctique (Fra)</description>
+		<description>Menace sur l'Arctique (France)</description>
 		<year>1987</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23260,7 +23260,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mercenar" supported="no">
-		<description>Mercenaire (Fra)</description>
+		<description>Mercenaire (France)</description>
 		<year>1986</year>
 		<publisher>Rainbow Production</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23289,7 +23289,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mercenryg" cloneof="mercenry" supported="no">
-		<description>Mercenary - Flucht Aus Targ (Ger)</description>
+		<description>Mercenary - Flucht Aus Targ (Germany)</description>
 		<year>1987</year>
 		<publisher>Novagen Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23318,7 +23318,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mercss" cloneof="mercs" supported="no">
-		<description>Mercs (Spa)</description>
+		<description>Mercs (Spain)</description>
 		<year>1991</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23395,7 +23395,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="metr2018" supported="no">
-		<description>Metro 2018 (Fra)</description>
+		<description>Metro 2018 (France)</description>
 		<year>1985</year>
 		<publisher>Initiel</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23424,7 +23424,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="metropol" supported="no">
-		<description>Metropol (Spa, BASIC 1.1)</description>
+		<description>Metropol (Spain, BASIC 1.1)</description>
 		<year>1988</year>
 		<publisher>Zafiro Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23436,7 +23436,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="metropts" supported="no">
-		<description>Metropolis (Spa, Topo Soft)</description>
+		<description>Metropolis (Spain, Topo Soft)</description>
 		<year>1989</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23460,7 +23460,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="meurgvit" supported="no">
-		<description>Meurtre A Grande Vitesse (Fra)</description>
+		<description>Meurtre a Grande Vitesse (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23478,7 +23478,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="meuratln" supported="no">
-		<description>Meurtre sur l'Atlantique (Fra)</description>
+		<description>Meurtre sur l'Atlantique (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23512,7 +23512,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mgt" supported="no">
-		<description>MGT - Magnetik Tank (Fra)</description>
+		<description>MGT - Magnetik Tank (France)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23524,7 +23524,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mgts" cloneof="mgt" supported="no">
-		<description>MGT - Magnetik Tank (Spa)</description>
+		<description>MGT - Magnetik Tank (Spain)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23572,7 +23572,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="michelss" supported="no">
-		<description>Michel Futbol Master Super Skills (Spa)</description>
+		<description>Michel Futbol Master Super Skills (Spain)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23613,7 +23613,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="microsap" supported="no">
-		<description>Micro Sapiens (Fra)</description>
+		<description>Micro Sapiens (France)</description>
 		<year>1985</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23625,7 +23625,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="microscr" supported="no">
-		<description>Micro Scrabble (Fra)</description>
+		<description>Micro Scrabble (France)</description>
 		<year>1985</year>
 		<publisher>Leisure Genius</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23667,7 +23667,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mpsoccer" supported="no">
-		<description>Microprose Soccer (Spa)</description>
+		<description>Microprose Soccer (Spain)</description>
 		<year>1989</year>
 		<publisher>Microprose Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23701,7 +23701,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="midress" cloneof="midres" supported="no">
-		<description>Midnight Resistance (Spa)</description>
+		<description>Midnight Resistance (Spain)</description>
 		<year>1990</year>
 		<publisher>Erbe Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23730,7 +23730,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mikegunn" supported="no">
-		<description>Mike Gunner (Spa)</description>
+		<description>Mike Gunner (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23766,7 +23766,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mikies" cloneof="mikie" supported="no">
-		<description>Mikie (Spa)</description>
+		<description>Mikie (Spain)</description>
 		<year>1986</year>
 		<publisher>Erbe Serie Leyenda</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23802,7 +23802,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="millionf" supported="no">
-		<description>Le Millionnaire (Fra)</description>
+		<description>Le Millionnaire (France)</description>
 		<year>1985</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23872,7 +23872,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="minesor2" supported="no">
-		<description>Mines d'Or Vol 2 (Fra)</description>
+		<description>Mines d'Or Vol 2 (France)</description>
 		<year>1989</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23906,7 +23906,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="missions" cloneof="mission" supported="no">
-		<description>Mission (Spa)</description>
+		<description>Mission (Spain)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23918,7 +23918,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mission" supported="no">
-		<description>Mission (Fra)</description>
+		<description>Mission (France)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23942,7 +23942,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="misdelta" supported="no">
-		<description>Mission Delta (Fra)</description>
+		<description>Mission Delta (France)</description>
 		<year>1985</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23954,7 +23954,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="misdeltas" cloneof="misdelta" supported="no">
-		<description>Mission Delta (Spa)</description>
+		<description>Mission Delta (Spain)</description>
 		<year>1985</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -23966,7 +23966,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="misdetec" supported="no">
-		<description>Mission Detector (Fra, BASIC 1.0)</description>
+		<description>Mission Detector (France, BASIC 1.0)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24038,7 +24038,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mistnilo" cloneof="mystnile" supported="no">
-		<description>El Misterio del Nilo (Spa)</description>
+		<description>El Misterio del Nilo (Spain)</description>
 		<year>1987</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24050,7 +24050,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mlm3d" supported="no">
-		<description>MLM 3D - Evasion de la Lune (Fra, BASIC 1.0)</description>
+		<description>MLM 3D - Evasion de la Lune (France, BASIC 1.0)</description>
 		<year>1986</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24062,7 +24062,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mobilemn" supported="no">
-		<description>Mobile Man (Fra)</description>
+		<description>Mobile Man (France)</description>
 		<year>1990</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24098,7 +24098,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="momieblu" supported="no">
-		<description>Momie Blues (Fra)</description>
+		<description>Momie Blues (France)</description>
 		<year>1986</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24110,7 +24110,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="monde" supported="no">
-		<description>Le Monde (Fra)</description>
+		<description>Le Monde (France)</description>
 		<year>1985</year>
 		<publisher>Core</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24164,7 +24164,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="moneymol" supported="no">
-		<description>Money Molch (Euro?)</description>
+		<description>Money Molch (Europe?)</description>
 		<year>1985</year>
 		<publisher>Rainbow Arts</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24176,7 +24176,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="monopolc" supported="no">
-		<description>Monopolic (Fra)</description>
+		<description>Monopolic (France)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24200,7 +24200,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="monopolyf" cloneof="monopoly" supported="no">
-		<description>Monopoly (Fra)</description>
+		<description>Monopoly (France)</description>
 		<year>1984</year>
 		<publisher>Leisure Genius</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24236,7 +24236,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="montsegr" supported="no">
-		<description>Montsegur (Fra)</description>
+		<description>Montsegur (France)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24248,7 +24248,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="montyruns" cloneof="montyrun" supported="no">
-		<description>Monty on the Run (Spa)</description>
+		<description>Monty on the Run (Spain)</description>
 		<year>1986</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24397,7 +24397,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mortadel" cloneof="cleversm" supported="no">
-		<description>Mortadelo Y Filemon (Spa)</description>
+		<description>Mortadelo Y Filemon (Spain)</description>
 		<year>1987</year>
 		<publisher>Magic Bytes</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24409,7 +24409,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mortadl2" supported="no">
-		<description>Mortadelo y Filemon II (Spa)</description>
+		<description>Mortadelo y Filemon II (Spain)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24426,7 +24426,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mot" supported="no">
-		<description>Mot (Spa)</description>
+		<description>Mot (Spain)</description>
 		<year>1989</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24443,7 +24443,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="motinnav" supported="no">
-		<description>Motin en la Nave (Spa)</description>
+		<description>Motin en la Nave (Spain)</description>
 		<year>1987</year>
 		<publisher>Edisoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24508,7 +24508,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="motos" supported="no">
-		<description>Motos (Spa)</description>
+		<description>Motos (Spain)</description>
 		<year>1987</year>
 		<publisher>Mastertronic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24533,7 +24533,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mbikerac" supported="no">
-		<description>Mountain Bike Racer (Spa)</description>
+		<description>Mountain Bike Racer (Spain)</description>
 		<year>1989</year>
 		<publisher>Positive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24593,7 +24593,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mrpingo" supported="no">
-		<description>Mr Pingo (Euro?)</description>
+		<description>Mr Pingo (Europe?)</description>
 		<year>1986</year>
 		<publisher>Rainbow Arts</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24694,7 +24694,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="multiges" supported="no">
-		<description>Multi-Gestion (Fra)</description>
+		<description>Multi-Gestion (France)</description>
 		<year>1984</year>
 		<publisher>Core</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24718,7 +24718,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mundialf" supported="no">
-		<description>Mundial de Futbol (Spa)</description>
+		<description>Mundial de Futbol (Spain)</description>
 		<year>1990</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24747,7 +24747,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="musicore" supported="no">
-		<description>Musi Core (Fra)</description>
+		<description>Musi Core (France)</description>
 		<year>1985</year>
 		<publisher>Core</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24806,7 +24806,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="musicams" supported="no">
-		<description>Musica Maestro (Spa)</description>
+		<description>Musica Maestro (Spain)</description>
 		<year>1985</year>
 		<publisher>Indescomp</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24818,7 +24818,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mutnzone" supported="no">
-		<description>Mutan Zone (Spa)</description>
+		<description>Mutan Zone (Spain)</description>
 		<year>1988</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24893,7 +24893,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mutantss" cloneof="mutants" supported="no">
-		<description>Mutants (Spa)</description>
+		<description>Mutants (Spain)</description>
 		<year>1987</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24922,7 +24922,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="kikekan" supported="no">
-		<description>Le Mystere de Kikekankoi (Fra)</description>
+		<description>Le Mystere de Kikekankoi (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24980,7 +24980,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mystical" supported="no">
-		<description>Mystical (Fra)</description>
+		<description>Mystical (France)</description>
 		<year>1990</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -24992,7 +24992,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="myth" supported="no">
-		<description>Myth - History In The Making (UK)</description>
+		<description>Myth - History in the Making (UK)</description>
 		<year>1989</year>
 		<publisher>System 3</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25004,7 +25004,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="mythos" supported="no">
-		<description>Mythos (Spa)</description>
+		<description>Mythos (Spain)</description>
 		<year>1990</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25103,7 +25103,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="navymoves" cloneof="navymove" supported="no">
-		<description>Navy Moves (Spa)</description>
+		<description>Navy Moves (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25120,7 +25120,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="2navarmy" supported="no">
-		<description>Navy Moves + Army Moves (Spa)</description>
+		<description>Navy Moves + Army Moves (Spain)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25185,7 +25185,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="nemwrlk" supported="no">
-		<description>Nemesis The Warlock (Spa)</description>
+		<description>Nemesis The Warlock (Spain)</description>
 		<year>1987</year>
 		<publisher>Martech</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25306,7 +25306,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="nibbler" supported="no">
-		<description>Nibbler (Euro?)</description>
+		<description>Nibbler (Europe?)</description>
 		<year>1985</year>
 		<publisher>Rainbow Arts</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25359,7 +25359,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="nightboo" supported="no">
-		<description>Night Booster (Fra)</description>
+		<description>Night Booster (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25371,7 +25371,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="nightgun" supported="no">
-		<description>Night Gunner (Euro?)</description>
+		<description>Night Gunner (Europe?)</description>
 		<year>1986</year>
 		<publisher>Digital Integration</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25573,7 +25573,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ninjawars" cloneof="ninjawar" supported="no">
-		<description>The Ninja Warriors (Spa)</description>
+		<description>The Ninja Warriors (Spain)</description>
 		<year>1989</year>
 		<publisher>Virgin Games</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25626,7 +25626,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="nonameds" cloneof="nonamed" supported="no">
-		<description>Nonamed (Spa)</description>
+		<description>Nonamed (Spain)</description>
 		<year>1986</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25650,7 +25650,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="northns" supported="no">
-		<description>North &amp; South - Les Tuniques Bleues (Euro, 64K)</description>
+		<description>North &amp; South - Les Tuniques Bleues (Europe, 64K)</description>
 		<year>1989</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25857,7 +25857,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="othelo" supported="no">
-		<description>O'thelo (Spa)</description>
+		<description>O'thelo (Spain)</description>
 		<year>1988</year>
 		<publisher>Idealogic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25869,7 +25869,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="eloasis" supported="no">
-		<description>El Oasis (Spa)</description>
+		<description>El Oasis (Spain)</description>
 		<year>1986</year>
 		<publisher>Alea</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25886,7 +25886,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="oberon69" supported="no">
-		<description>Oberon 69 (Spa, 64K)</description>
+		<description>Oberon 69 (Spain, 64K)</description>
 		<year>1990</year>
 		<publisher>GLL Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25910,7 +25910,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="obliters" cloneof="obliter" supported="no">
-		<description>Obliterator (Spa)</description>
+		<description>Obliterator (Spain)</description>
 		<year>1989</year>
 		<publisher>Melbourne House</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25946,7 +25946,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="obsidianf" cloneof="obsidian" supported="no">
-		<description>Obsidian (Fra)</description>
+		<description>Obsidian (France)</description>
 		<year>1985</year>
 		<publisher>Artic Computing</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -25983,7 +25983,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="oeilset" supported="no">
-		<description>L'Oeil de Set (Fra, Version 464)</description>
+		<description>L'Oeil de Set (France, Version 464)</description>
 		<year>1987</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26048,7 +26048,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ohmummys" cloneof="ohmummy" supported="no">
-		<description>Oh Mummy (Spa)</description>
+		<description>Oh Mummy (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26085,7 +26085,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="oletoro" supported="no">
-		<description>Ole Toro (Spa)</description>
+		<description>Ole Toro (Spain)</description>
 		<year>1985</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26275,7 +26275,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="opwolflg" cloneof="opwolf" supported="no">
-		<description>Operation Wolf (UK, Lightgun)</description>
+		<description>Operation Wolf (UK, lightgun)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26287,7 +26287,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="opwolfs" cloneof="opwolf" supported="no">
-		<description>Operation Wolf (Spa)</description>
+		<description>Operation Wolf (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26299,7 +26299,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="orditirc" supported="no">
-		<description>Ordi Tierce (Fra)</description>
+		<description>Ordi Tierce (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26328,7 +26328,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="orgamess" cloneof="orgames" supported="no">
-		<description>Oriental Games (Spa)</description>
+		<description>Oriental Games (Spain)</description>
 		<year>1990</year>
 		<publisher>Micro Style</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26345,7 +26345,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ormuz" supported="no">
-		<description>Ormuz (Spa)</description>
+		<description>Ormuz (Spain)</description>
 		<year>1988</year>
 		<publisher>Iber Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26357,7 +26357,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="orthocrk" supported="no">
-		<description>Orthocrack (Fra)</description>
+		<description>Orthocrack (France)</description>
 		<year>1985</year>
 		<publisher>Hatier</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26374,7 +26374,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="orthogc2" supported="no">
-		<description>Orthographe CE2 (Fra)</description>
+		<description>Orthographe CE2 (France)</description>
 		<year>1985</year>
 		<publisher>Hatier</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26391,7 +26391,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="orthustr" supported="no">
-		<description>Orthustrad (Fra, BASIC 1.0)</description>
+		<description>Orthustrad (France, BASIC 1.0)</description>
 		<year>1985</year>
 		<publisher>Core</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26428,7 +26428,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- MOVE TO CPC_FLOP! THIS TAPE WAS INCLUDED IN DISK PACK (+ as side B of an undumped 1-sided tape version by USGold) -->
 	<software name="outrunau" supported="no">
-		<description>Out Run (UK, Audio Tape)</description>
+		<description>Out Run (UK, audio tape)</description>
 		<year>1987</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26546,7 +26546,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pacifics" cloneof="pacific" supported="no">
-		<description>Pacific (Spa)</description>
+		<description>Pacific (Spain)</description>
 		<year>1986</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26570,7 +26570,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pajarbgk" supported="no">
-		<description>Los Pajaros de Bangkok (Spa)</description>
+		<description>Los Pajaros de Bangkok (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26611,7 +26611,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="palitrons" cloneof="palitron" supported="no">
-		<description>Palitron (Spa)</description>
+		<description>Palitron (Spain)</description>
 		<year>1986</year>
 		<publisher>The Edge</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26647,7 +26647,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="panzakbf" cloneof="panzakb" supported="no">
-		<description>Panza Kick Boxing (Fra)</description>
+		<description>Panza Kick Boxing (France)</description>
 		<year>1990</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26664,7 +26664,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="panzakb" supported="no">
-		<description>Panza Kick Boxing (Spa)</description>
+		<description>Panza Kick Boxing (Spain)</description>
 		<year>1990</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26693,7 +26693,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="panzadoms" cloneof="panzadom" supported="no">
-		<description>Panzadrome (Spa)</description>
+		<description>Panzadrome (Spain)</description>
 		<year>1985</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26765,7 +26765,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="paranoia" supported="no">
-		<description>The Paranoia Complex (Spa)</description>
+		<description>The Paranoia Complex (Spain)</description>
 		<year>1989</year>
 		<publisher>Magic Bytes</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26777,7 +26777,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pdakar" supported="no">
-		<description>Paris-Dakar (Spa)</description>
+		<description>Paris-Dakar (Spain)</description>
 		<year>1988</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26903,7 +26903,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="payrolla" cloneof="payroll" supported="no">
-		<description>Payroll (UK, Alt)</description>
+		<description>Payroll (UK, alt)</description>
 		<year>1984</year>
 		<publisher>Abacus Business Systems</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26920,7 +26920,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pearlhrb" supported="no">
-		<description>Pearl Harbour (Fra, BASIC 1.0)</description>
+		<description>Pearl Harbour (France, BASIC 1.0)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -26932,7 +26932,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pgramm6" supported="no">
-		<description>Pedagogiciel - Grammaire 6eme (Fra)</description>
+		<description>Pedagogiciel - Grammaire 6eme (France)</description>
 		<year>1985</year>
 		<publisher>Eurologiciel</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27013,7 +27013,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pepebequ" supported="no">
-		<description>Pepe Bequilles (Fra)</description>
+		<description>Pepe Bequilles (France)</description>
 		<year>1987</year>
 		<publisher>Softhawk</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27037,7 +27037,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pericode" supported="no">
-		<description>Perico Delgado Maillot Amarillo (Spa)</description>
+		<description>Perico Delgado Maillot Amarillo (Spain)</description>
 		<year>1989</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27114,7 +27114,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="shiltons" cloneof="shilton" supported="no">
-		<description>Peter Shilton's Handball Maradona (Spa)</description>
+		<description>Peter Shilton's Handball Maradona (Spain)</description>
 		<year>1986</year>
 		<publisher>Zafiro</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27126,7 +27126,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amityvil" supported="no">
-		<description>Peur sur Amityville (Fra, 64K)</description>
+		<description>Peur sur Amityville (France, 64K)</description>
 		<year>1987</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27143,7 +27143,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="phantis" supported="no">
-		<description>Phantis (Spa)</description>
+		<description>Phantis (Spain)</description>
 		<year>1987</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27172,7 +27172,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="phantclbs" cloneof="phantclb" supported="no">
-		<description>Phantom Club (Spa)</description>
+		<description>Phantom Club (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27184,7 +27184,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="phantom2" cloneof="vampire" supported="no">
-		<description>Phantomas 2 (Spa)</description>
+		<description>Phantomas 2 (Spain)</description>
 		<year>1986</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27196,7 +27196,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="phantatq" supported="no">
-		<description>Phanton en Ataque (Spa, BASIC 1.1)</description>
+		<description>Phanton en Ataque (Spain, BASIC 1.1)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27208,7 +27208,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pharaon" supported="no">
-		<description>Pharaon (Fra)</description>
+		<description>Pharaon (France)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27225,7 +27225,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pharaons" cloneof="pharaon" supported="no">
-		<description>Pharaon (Spa)</description>
+		<description>Pharaon (Spain)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27242,7 +27242,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="phenixno" supported="no">
-		<description>Phenix Noir (Fra)</description>
+		<description>Phenix Noir (France)</description>
 		<year>1987</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27266,7 +27266,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="phmpegas" supported="no">
-		<description>P.H.M. Pegasus (Spa)</description>
+		<description>P.H.M. Pegasus (Spain)</description>
 		<year>1987</year>
 		<publisher>Electronics Arts</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27278,7 +27278,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pictions" cloneof="piction" supported="no">
-		<description>Pictionary (Spa)</description>
+		<description>Pictionary (Spain)</description>
 		<year>1989</year>
 		<publisher>Domark</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27312,7 +27312,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pillensc" supported="no">
-		<description>Pillenschlucken (Ger)</description>
+		<description>Pillenschlucken (Germany)</description>
 		<year>1985</year>
 		<publisher>Tynesoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27324,7 +27324,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pinmagic" supported="no">
-		<description>Pinball Magic (Fra)</description>
+		<description>Pinball Magic (France)</description>
 		<year>1990</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27366,7 +27366,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pinwizrds" cloneof="pinwizrd" supported="no">
-		<description>Pinball Wizard (Spa)</description>
+		<description>Pinball Wizard (Spain)</description>
 		<year>1985</year>
 		<publisher>CP Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27414,7 +27414,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="piquefic" supported="no">
-		<description>Pique-Fiche (Fra)</description>
+		<description>Pique-Fiche (France)</description>
 		<year>1986</year>
 		<publisher>Sermap</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27431,7 +27431,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pisozero" supported="no">
-		<description>Piso Zero (Spa)</description>
+		<description>Piso Zero (Spain)</description>
 		<year>1991</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27472,7 +27472,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="plagagal" cloneof="galaplag" supported="no">
-		<description>La Plaga Galactica (Spa)</description>
+		<description>La Plaga Galactica (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27513,7 +27513,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="p1cielo" supported="no">
-		<description>Planetario - El Cielo (Spa)</description>
+		<description>Planetario - El Cielo (Spain)</description>
 		<year>1988</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27530,7 +27530,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="p2terra" supported="no">
-		<description>Planetario - La Tierra (Spa)</description>
+		<description>Planetario - La Tierra (Spain)</description>
 		<year>1988</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27547,7 +27547,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="planetss" supported="no">
-		<description>Los Planetas del Sistema Solar (Spa)</description>
+		<description>Los Planetas del Sistema Solar (Spain)</description>
 		<year>1985</year>
 		<publisher>G.T.S. EDITORIAL</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27559,7 +27559,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="planbase" supported="no">
-		<description>Planete Base (Fra)</description>
+		<description>Planete Base (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27584,7 +27584,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- MOVE TO CPC_FLOP! THIS TAPE WAS INCLUDED IN DISK PACK -->
 	<software name="platonau" supported="no">
-		<description>Platoon (UK, Audio Tape)</description>
+		<description>Platoon (UK, audio tape)</description>
 		<year>1987</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27596,7 +27596,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="platoons" cloneof="platoon" supported="no">
-		<description>Platoon (Spa)</description>
+		<description>Platoon (Spain)</description>
 		<year>1987</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27625,7 +27625,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="playbox" supported="no">
-		<description>Playbox (Fra, BASIC 1.0)</description>
+		<description>Playbox (France, BASIC 1.0)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27649,7 +27649,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="plutnatk" supported="no">
-		<description>Pluton Ataca (Spa)</description>
+		<description>Pluton Ataca (Spain)</description>
 		<year>1987</year>
 		<publisher>Edisoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27678,7 +27678,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="elpodero" supported="no">
-		<description>El Poder Oscuro (Spa)</description>
+		<description>El Poder Oscuro (Spain)</description>
 		<year>1988</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27702,7 +27702,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="polidiaz" supported="no">
-		<description>Poli Diaz Boxeo (Spa)</description>
+		<description>Poli Diaz Boxeo (Spain)</description>
 		<year>1991</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27714,7 +27714,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="poogaboo" supported="no">
-		<description>Poogaboo (Spa)</description>
+		<description>Poogaboo (Spain)</description>
 		<year>1991</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27767,7 +27767,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="popeye2a" cloneof="popeye2" supported="no">
-		<description>Popeye 2 (UK, Alt)</description>
+		<description>Popeye 2 (UK, alt)</description>
 		<year>1990</year>
 		<publisher>Alternative Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27832,7 +27832,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pouvoir" supported="no">
-		<description>Pouvoir (Fra)</description>
+		<description>Pouvoir (France)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27849,7 +27849,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="powmagic" supported="no">
-		<description>Power and Magic (Spa)</description>
+		<description>Power and Magic (Spain)</description>
 		<year>1990</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27895,7 +27895,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="powrplay" supported="no">
-		<description>Powerplay - The Game of the Gods (Spa)</description>
+		<description>Powerplay - The Game of the Gods (Spain)</description>
 		<year>1986</year>
 		<publisher>Arcana Software Design</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -27993,7 +27993,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="predators" cloneof="predator" supported="no">
-		<description>Predator (Spa)</description>
+		<description>Predator (Spain)</description>
 		<year>1988</year>
 		<publisher>Activision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28029,7 +28029,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="prehist2" supported="no">
-		<description>Prehistorik II (Euro)</description>
+		<description>Prehistorik II (Europe)</description>
 		<year>1993</year>
 		<publisher>Titus</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28082,7 +28082,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="primathc" supported="no">
-		<description>Primary Maths Course (Fra)</description>
+		<description>Primary Maths Course (France)</description>
 		<year>1986</year>
 		<publisher>Mentor Educational Services</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28099,7 +28099,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ppersiaf" cloneof="ppersia" supported="no">
-		<description>Prince de Perse (Fra, BASIC 1.0)</description>
+		<description>Prince de Perse (France, BASIC 1.0)</description>
 		<year>1990</year>
 		<publisher>Brøderbund France</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28205,7 +28205,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="prosnook" supported="no">
-		<description>Pro Snooker Simulator (Euro)</description>
+		<description>Pro Snooker Simulator (Europe)</description>
 		<year>1986</year>
 		<publisher>Codemasters Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28246,7 +28246,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="protennt" cloneof="greatcrt" supported="no">
-		<description>Pro Tennis Tour (Spa)</description>
+		<description>Pro Tennis Tour (Spain)</description>
 		<year>1989</year>
 		<publisher>MCM Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28270,7 +28270,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="prodigys" cloneof="prodigy" supported="no">
-		<description>Prodigy (Spa)</description>
+		<description>Prodigy (Spain)</description>
 		<year>1986</year>
 		<publisher>Activision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28282,7 +28282,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="profanat" supported="no">
-		<description>Profanation (Fra)</description>
+		<description>Profanation (France)</description>
 		<year>1987</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28369,7 +28369,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="profibas" supported="no">
-		<description>Profibasic (Ger)</description>
+		<description>Profibasic (Germany)</description>
 		<year>1985</year>
 		<publisher>Power Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28381,7 +28381,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="prohibit" supported="no">
-		<description>Prohibition (Euro, 64K)</description>
+		<description>Prohibition (Europe, 64K)</description>
 		<year>1987</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28429,7 +28429,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="proteus" supported="no">
-		<description>Proteus (Ger)</description>
+		<description>Proteus (Germany)</description>
 		<year>1985</year>
 		<publisher>Ultrasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28501,7 +28501,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="psysoldr" supported="no">
-		<description>Psycho Soldier (Spa)</description>
+		<description>Psycho Soldier (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28518,7 +28518,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pubgames" supported="no">
-		<description>Pub Games (Spa)</description>
+		<description>Pub Games (Spain)</description>
 		<year>1987</year>
 		<publisher>Alligata Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28559,7 +28559,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="pulsator" supported="no">
-		<description>Pulsator (Spa)</description>
+		<description>Pulsator (Spain)</description>
 		<year>1987</year>
 		<publisher>Martech</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28607,7 +28607,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="punkstar" supported="no">
-		<description>Punk Star (Spa)</description>
+		<description>Punk Star (Spain)</description>
 		<year>1988</year>
 		<publisher>Iber Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28749,7 +28749,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="quad" supported="no">
-		<description>Quad (Spa)</description>
+		<description>Quad (Spain)</description>
 		<year>1987</year>
 		<publisher>Microids</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28761,7 +28761,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="quadrel" supported="no">
-		<description>Quadrel (Fra)</description>
+		<description>Quadrel (France)</description>
 		<year>1991</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28778,7 +28778,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="quaterne" supported="no">
-		<description>Quaterne (Fra)</description>
+		<description>Quaterne (France)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28865,7 +28865,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="questor" supported="no">
-		<description>Questor (Spa)</description>
+		<description>Questor (Spain)</description>
 		<year>1986</year>
 		<publisher>Cascade Games</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28913,7 +28913,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="quiniela" supported="no">
-		<description>Quinielas (Spa)</description>
+		<description>Quinielas (Spain)</description>
 		<year>1985</year>
 		<publisher>Ace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -28925,7 +28925,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="quinpyc" supported="no">
-		<description>Quinielas - Pronosticos y Combinaciones (Spa)</description>
+		<description>Quinielas - Pronosticos y Combinaciones (Spain)</description>
 		<year>1988</year>
 		<publisher>Idealogic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29096,7 +29096,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rally2f" cloneof="rally2" supported="no">
-		<description>Rally II (Fra)</description>
+		<description>Rally II (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29132,7 +29132,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ram" supported="no">
-		<description>RAM (Spa)</description>
+		<description>RAM (Spain)</description>
 		<year>1990</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29156,7 +29156,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ramblas" supported="no">
-		<description>Ramblas, Investigador Privado - El Caso Vega (Spa)</description>
+		<description>Ramblas, Investigador Privado - El Caso Vega (Spain)</description>
 		<year>1986</year>
 		<publisher>Mind Games Espana</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29216,7 +29216,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ranaramas" cloneof="ranarama" supported="no">
-		<description>Ranarama (Spa)</description>
+		<description>Ranarama (Spain)</description>
 		<year>1987</year>
 		<publisher>Hewson</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29240,7 +29240,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="randomfm" supported="no">
-		<description>Random-Format (Spa)</description>
+		<description>Random-Format (Spain)</description>
 		<year>1985</year>
 		<publisher>Indescomp</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29317,7 +29317,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ratasdes" cloneof="desrtrat" supported="no">
-		<description>Ratas del Desierto (Spa)</description>
+		<description>Ratas del Desierto (Spain)</description>
 		<year>1985</year>
 		<publisher>Cases Computer Simulators</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29329,7 +29329,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="raththa" supported="no">
-		<description>Rath-Tha (Spa)</description>
+		<description>Rath-Tha (Spain)</description>
 		<year>1989</year>
 		<publisher>Positive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29341,7 +29341,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="razasnoc" cloneof="nightbrd" supported="no">
-		<description>Razas de Noche (Spa)</description>
+		<description>Razas de Noche (Spain)</description>
 		<year>1990</year>
 		<publisher>Erbe Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29452,7 +29452,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rechnung" supported="no">
-		<description>Rechnungsschreibung v4.0 (Ger)</description>
+		<description>Rechnungsschreibung v4.0 (Germany)</description>
 		<year>1984</year>
 		<publisher>Microland</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29493,7 +29493,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="reddynam" supported="no">
-		<description>Red Dynamite Pack (Euro?)</description>
+		<description>Red Dynamite Pack (Europe?)</description>
 		<year>1991</year>
 		<publisher>Positive</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29527,7 +29527,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="redled" supported="no">
-		<description>Red L.E.D. (Spa)</description>
+		<description>Red L.E.D. (Spain)</description>
 		<year>1987</year>
 		<publisher>Starlight Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29575,7 +29575,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="relifact" supported="no">
-		<description>Relief Action (Fra)</description>
+		<description>Relief Action (France)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29604,7 +29604,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="renaud" cloneof="sidewalk" supported="no">
-		<description>Renaud (Spa)</description>
+		<description>Renaud (Spain)</description>
 		<year>1987</year>
 		<publisher>Zafiro</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29628,7 +29628,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="renegades" cloneof="renegade" supported="no">
-		<description>Renegade (Spa)</description>
+		<description>Renegade (Spain)</description>
 		<year>1987</year>
 		<publisher>Imagine Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29664,7 +29664,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rescatln" supported="no">
-		<description>Rescate Atlantida (Spa)</description>
+		<description>Rescate Atlantida (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29681,7 +29681,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rescgolf" supported="no">
-		<description>Rescate en el Golfo (Spa)</description>
+		<description>Rescate en el Golfo (Spain)</description>
 		<year>1990</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29758,7 +29758,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="reversi" supported="no">
-		<description>Reversi Champion (Fra)</description>
+		<description>Reversi Champion (France)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29794,7 +29794,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rexs" cloneof="rex" supported="no">
-		<description>Rex (Spa)</description>
+		<description>Rex (Spain)</description>
 		<year>1989</year>
 		<publisher>Martech</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29828,7 +29828,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rexhard" supported="no">
-		<description>Rex Hard (Spa)</description>
+		<description>Rex Hard (Spain)</description>
 		<year>1988</year>
 		<publisher>Zafiro Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29840,7 +29840,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rexhardmc" cloneof="rexhard" supported="no">
-		<description>Rex Hard (Spa, Mister Chip)</description>
+		<description>Rex Hard (Spain, Mister Chip)</description>
 		<year>1986</year>
 		<publisher>Mister Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29876,7 +29876,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rickdng2s" cloneof="rickdng2" supported="no">
-		<description>Rick Dangerous II (Spa)</description>
+		<description>Rick Dangerous II (Spain)</description>
 		<year>1990</year>
 		<publisher>Micro Style</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -29965,7 +29965,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="riskyhol" supported="no">
-		<description>Risky Holding (Spa)</description>
+		<description>Risky Holding (Spain)</description>
 		<year>1986</year>
 		<publisher>Idealogic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30018,7 +30018,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="robbbots" cloneof="robbbot" supported="no">
-		<description>Robbbot (Spa)</description>
+		<description>Robbbot (Spain)</description>
 		<year>1986</year>
 		<publisher>War Games</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30030,7 +30030,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="robbbot" supported="no">
-		<description>Robbbot (Euro)</description>
+		<description>Robbbot (Europe)</description>
 		<year>1986</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30083,7 +30083,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="robocops" cloneof="robocop" supported="no">
-		<description>Robocop (Spa)</description>
+		<description>Robocop (Spain)</description>
 		<year>1989</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30153,7 +30153,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rockrolr" supported="no">
-		<description>Rock 'N Roller (Spa)</description>
+		<description>Rock 'N Roller (Spain)</description>
 		<year>1988</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30182,7 +30182,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rocknluc" cloneof="rocknwrs" supported="no">
-		<description>Rock'N Lucha (Spa)</description>
+		<description>Rock'N Lucha (Spain)</description>
 		<year>1985</year>
 		<publisher>Melbourne House</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30259,7 +30259,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rockys" cloneof="rocky" supported="no">
-		<description>Rocky (Spa, BASIC 1.0)</description>
+		<description>Rocky (Spain, BASIC 1.0)</description>
 		<year>1985</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30375,7 +30375,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="rolandsp" supported="no">
-		<description>Roland en el Espacio (Spa)</description>
+		<description>Roland en el Espacio (Spain)</description>
 		<year>1984</year>
 		<publisher>Indescomp</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30495,7 +30495,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="room10" supported="no">
-		<description>Room Ten (Euro)</description>
+		<description>Room Ten (Europe)</description>
 		<year>1986</year>
 		<publisher>CRL Group</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30519,7 +30519,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="royrover" supported="no">
-		<description>Roy of the Rovers (Euro?)</description>
+		<description>Roy of the Rovers (Europe?)</description>
 		<year>1988</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30674,7 +30674,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sosspace" supported="no">
-		<description>S.O.S Space (Fra, BASIC 1.1)</description>
+		<description>S.O.S Space (France, BASIC 1.1)</description>
 		<year>1986</year>
 		<publisher>Minipuce</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30734,7 +30734,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="saboter2s" cloneof="saboter2" supported="no">
-		<description>Saboteur 2 (Spa)</description>
+		<description>Saboteur 2 (Spain)</description>
 		<year>1987</year>
 		<publisher>Durell Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30770,7 +30770,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sabrina" supported="no">
-		<description>Sabrina (Spa)</description>
+		<description>Sabrina (Spain)</description>
 		<year>1989</year>
 		<publisher>Iber Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30806,7 +30806,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="saicombtf" cloneof="saicombt" supported="no">
-		<description>Sai Combat (Fra)</description>
+		<description>Sai Combat (France)</description>
 		<year>1986</year>
 		<publisher>Gasoline Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30888,7 +30888,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="salamands" cloneof="salamand" supported="no">
-		<description>Salamander - Nemesis 2 (Spa)</description>
+		<description>Salamander - Nemesis 2 (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30912,7 +30912,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="salutart" cloneof="scrndes" supported="no">
-		<description>Salut l'Artiste (Fra)</description>
+		<description>Salut l'Artiste (France)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30924,7 +30924,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="foxstrip" supported="no">
-		<description>Samantha Fox Strip Poker (Spa)</description>
+		<description>Samantha Fox Strip Poker (Spain)</description>
 		<year>1986</year>
 		<publisher>Martech</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30955,7 +30955,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="samurait" supported="no">
-		<description>Samurai Trilogy (Euro)</description>
+		<description>Samurai Trilogy (Europe)</description>
 		<year>1987</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30972,7 +30972,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="samuwarr" supported="no">
-		<description>Samurai Warrior (Spa)</description>
+		<description>Samurai Warrior (Spain)</description>
 		<year>1988</year>
 		<publisher>Firebird</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -30996,7 +30996,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sapiensf" cloneof="sapiens" supported="no">
-		<description>Sapiens (Fra)</description>
+		<description>Sapiens (France)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31080,7 +31080,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="satans" cloneof="satan" supported="no">
-		<description>Satan (Spa)</description>
+		<description>Satan (Spain)</description>
 		<year>1989</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31177,7 +31177,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lehrbas1" cloneof="teachbs1" supported="no">
-		<description>Schneider Basic-Lehrbuch Teil 1 (Ger)</description>
+		<description>Schneider Basic-Lehrbuch Teil 1 (Germany)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31204,7 +31204,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lehrbas2" cloneof="teachbs2" supported="no">
-		<description>Schneider Basic-Lehrbuch Teil 2 (Ger)</description>
+		<description>Schneider Basic-Lehrbuch Teil 2 (Germany)</description>
 		<year>1985</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31267,7 +31267,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="scor3020" supported="no">
-		<description>Score 3020 (Spa)</description>
+		<description>Score 3020 (Spain)</description>
 		<year>1988</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31380,7 +31380,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="secretags" cloneof="secretag" supported="no">
-		<description>Secret Agent (Spa)</description>
+		<description>Secret Agent (Spain)</description>
 		<year>1990</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31416,7 +31416,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sectomb" supported="no">
-		<description>Le Secret du Tombeau (Fra)</description>
+		<description>Le Secret du Tombeau (France)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31428,7 +31428,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sectumba" cloneof="sectomb" supported="no">
-		<description>El Secreto de la Tumba (Spa)</description>
+		<description>El Secreto de la Tumba (Spain)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31499,7 +31499,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sendasal" supported="no">
-		<description>Senda Salvaje (Spa)</description>
+		<description>Senda Salvaje (Spain)</description>
 		<year>1990</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31528,7 +31528,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sepulcris" cloneof="sepulcri" supported="no">
-		<description>Sepulcri (Spa)</description>
+		<description>Sepulcri (Spain)</description>
 		<year>1986</year>
 		<publisher>Ariolasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31564,7 +31564,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sernoire" supported="no">
-		<description>Serie Noire (Fra, BASIC 1.0)</description>
+		<description>Serie Noire (France, BASIC 1.0)</description>
 		<year>1985</year>
 		<publisher>Micro Application</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31576,7 +31576,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="seymatmv" supported="no">
-		<description>Seymour At The Movies (UK)</description>
+		<description>Seymour at the Movies (UK)</description>
 		<year>1991</year>
 		<publisher>Codemasters Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31588,7 +31588,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sgrizam" supported="no">
-		<description>Sgrizam (Spa)</description>
+		<description>Sgrizam (Spain)</description>
 		<year>1986</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31791,7 +31791,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="shermnm4" supported="no">
-		<description>Sherman M4 (Spa)</description>
+		<description>Sherman M4 (Spain)</description>
 		<year>1990</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31832,7 +31832,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ship" supported="no">
-		<description>Ship (Spa)</description>
+		<description>Ship (Spain)</description>
 		<year>1988</year>
 		<publisher>System 4 de Espana</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31909,7 +31909,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="shflpuck" supported="no">
-		<description>Shufflepuck Cafe (Fra, BASIC 1.0)</description>
+		<description>Shufflepuck Cafe (France, BASIC 1.0)</description>
 		<year>1989</year>
 		<publisher>Brøderbund France</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31939,7 +31939,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="siderwar" supported="no">
-		<description>Sideral War (Spa)</description>
+		<description>Sideral War (Spain)</description>
 		<year>1989</year>
 		<publisher>Delta Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31963,7 +31963,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sigma7s" cloneof="sigma7" supported="no">
-		<description>Sigma Seven (Spa)</description>
+		<description>Sigma Seven (Spain)</description>
 		<year>1987</year>
 		<publisher>Durell Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -31999,7 +31999,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="silshadws" cloneof="silshadw" supported="no">
-		<description>Silent Shadow (Spa)</description>
+		<description>Silent Shadow (Spain)</description>
 		<year>1988</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32064,7 +32064,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="protenns" cloneof="protenn" supported="no">
-		<description>Simulador Profesional de Tenis (Spa)</description>
+		<description>Simulador Profesional de Tenis (Spain)</description>
 		<year>1990</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32076,7 +32076,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sintevoz" supported="no">
-		<description>Sintetizador de Voz (Spa)</description>
+		<description>Sintetizador de Voz (Spain)</description>
 		<year>1985</year>
 		<publisher>MHT Ingenieros</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32093,7 +32093,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sirbob" supported="no">
-		<description>Sir Bob (Spa)</description>
+		<description>Sir Bob (Spain)</description>
 		<year>1986</year>
 		<publisher>Monser</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32105,7 +32105,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sirfred" supported="no">
-		<description>Sir Fred (Spa, Mister Chip)</description>
+		<description>Sir Fred (Spain, Mister Chip)</description>
 		<year>1986</year>
 		<publisher>Mister Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32117,7 +32117,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sirfredz" cloneof="sirfred" supported="no">
-		<description>Sir Fred (Spa, Zigurat)</description>
+		<description>Sir Fred (Spain, Zigurat)</description>
 		<year>1986</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32158,7 +32158,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sitopons" supported="no">
-		<description>Sito Pons 500cc Grand Prix (Spa)</description>
+		<description>Sito Pons 500cc Grand Prix (Spain)</description>
 		<year>1990</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32170,7 +32170,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="skatebalf" cloneof="skatewar" supported="no">
-		<description>Skate Ball (Fra)</description>
+		<description>Skate Ball (France)</description>
 		<year>1989</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32182,7 +32182,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="skatebals" cloneof="skatewar" supported="no">
-		<description>Skate Ball (Spa)</description>
+		<description>Skate Ball (Spain)</description>
 		<year>1989</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32329,7 +32329,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="skweekf" cloneof="skweek" supported="no">
-		<description>Skweek (Fra)</description>
+		<description>Skweek (France)</description>
 		<year>1989</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32341,7 +32341,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="skweeks" cloneof="skweek" supported="no">
-		<description>Skweek (Spa)</description>
+		<description>Skweek (Spain)</description>
 		<year>1989</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32365,7 +32365,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="skyhunt" supported="no">
-		<description>Sky Hunter (Spa)</description>
+		<description>Sky Hunter (Spain)</description>
 		<year>1988</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32377,7 +32377,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="skyfoxs" cloneof="skyfox" supported="no">
-		<description>Skyfox (Spa)</description>
+		<description>Skyfox (Spain)</description>
 		<year>1985</year>
 		<publisher>Electronics Arts</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32449,7 +32449,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="smaily" supported="no">
-		<description>Smaily (Spa)</description>
+		<description>Smaily (Spain)</description>
 		<year>1990</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32485,7 +32485,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="snoball" supported="no">
-		<description>Snoball In Hell! (UK)</description>
+		<description>Snoball in Hell! (UK)</description>
 		<year>1989</year>
 		<publisher>Atlantis Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32711,7 +32711,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="solnegro" supported="no">
-		<description>Sol Negro (Spa)</description>
+		<description>Sol Negro (Spain)</description>
 		<year>1988</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32752,7 +32752,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="soldlghts" cloneof="soldlght" supported="no">
-		<description>Soldier of Light (Spa)</description>
+		<description>Soldier of Light (Spain)</description>
 		<year>1989</year>
 		<publisher>Ace</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32776,7 +32776,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="solo" supported="no">
-		<description>Solo (Spa)</description>
+		<description>Solo (Spain)</description>
 		<year>1989</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32817,7 +32817,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sootland" supported="no">
-		<description>Sootland (Spa)</description>
+		<description>Sootland (Spain)</description>
 		<year>1989</year>
 		<publisher>Zafiro Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32834,7 +32834,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sootlandlg" cloneof="sootland" supported="no">
-		<description>Sootland (Spa, Lightgun)</description>
+		<description>Sootland (Spain, lightgun)</description>
 		<year>1989</year>
 		<publisher>Zafiro Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32964,7 +32964,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="spacecrss" cloneof="spacecrs" supported="no">
-		<description>Space Crusade (Spa, 64K)</description>
+		<description>Space Crusade (Spain, 64K)</description>
 		<year>1992</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -32976,7 +32976,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="spacecrs" supported="no">
-		<description>Space Crusade (UK, Fra, 64K)</description>
+		<description>Space Crusade (UK, France, 64K)</description>
 		<year>1992</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33034,7 +33034,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="spacercrf" cloneof="spacercr" supported="no">
-		<description>Space Racer (Fra)</description>
+		<description>Space Racer (France)</description>
 		<year>1988</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33046,7 +33046,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="spacercr" supported="no">
-		<description>Space Racer (Spa)</description>
+		<description>Space Racer (Spain)</description>
 		<year>1988</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33082,7 +33082,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sshutsim" supported="no">
-		<description>Space Shuttle Simulateur (Fra)</description>
+		<description>Space Shuttle Simulateur (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33094,7 +33094,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ssmugglr" supported="no">
-		<description>Space Smugglers (Spa)</description>
+		<description>Space Smugglers (Spain)</description>
 		<year>1989</year>
 		<publisher>MHT Ingenieros</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33118,7 +33118,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="spacewlf" supported="no">
-		<description>Space Wolf (Fra)</description>
+		<description>Space Wolf (France)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33236,7 +33236,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="spedzones" cloneof="spedzone" supported="no">
-		<description>Speedzone (Spa)</description>
+		<description>Speedzone (Spain)</description>
 		<year>1988</year>
 		<publisher>Mastertronic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33272,7 +33272,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="spellbnda" cloneof="spellbnd" supported="no">
-		<description>Spellbound - A True Graphic Adventure (UK, No Loading Screen)</description>
+		<description>Spellbound - A True Graphic Adventure (UK, no loading screen)</description>
 		<year>1985</year>
 		<publisher>Mastertronic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33356,7 +33356,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="spirits" supported="no">
-		<description>Spirits (Spa)</description>
+		<description>Spirits (Spain)</description>
 		<year>1987</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33397,7 +33397,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="spitfr40s" cloneof="spitfr40" supported="no">
-		<description>Spitfire 40 (Spa)</description>
+		<description>Spitfire 40 (Spain)</description>
 		<year>1985</year>
 		<publisher>Mirrorsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33527,7 +33527,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sputnik" supported="no">
-		<description>Sputnik (Spa)</description>
+		<description>Sputnik (Spain)</description>
 		<year>1988</year>
 		<publisher>System 4 de Espana</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33575,7 +33575,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="spyvsspya" cloneof="spyvsspy" supported="no">
-		<description>Spy vs Spy (UK, Alt)</description>
+		<description>Spy vs Spy (UK, alt)</description>
 		<year>1985</year>
 		<publisher>First Star Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33664,7 +33664,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="staravngs" cloneof="staravng" supported="no">
-		<description>Star Avenger (Spa)</description>
+		<description>Star Avenger (Spain)</description>
 		<year>1984</year>
 		<publisher>Kuma Computers</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33700,7 +33700,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="starcomma" cloneof="starcomm" supported="no">
-		<description>Star Commando (UK, Later?)</description>
+		<description>Star Commando (UK, later?)</description>
 		<year>1984</year>
 		<publisher>Terminal software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33736,7 +33736,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stargraf" supported="no">
-		<description>Star Graf (Spa)</description>
+		<description>Star Graf (Spain)</description>
 		<year>1986</year>
 		<publisher>War Games</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33808,7 +33808,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="jedis" cloneof="jedi" supported="no">
-		<description>Star Wars - Return of the Jedi (Spa)</description>
+		<description>Star Wars - Return of the Jedi (Spain)</description>
 		<year>1989</year>
 		<publisher>Domark</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33868,7 +33868,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="starboy" supported="no">
-		<description>Starboy (Fra)</description>
+		<description>Starboy (France)</description>
 		<year>1986</year>
 		<publisher>Gasoline Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33880,7 +33880,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="starbyte" supported="no">
-		<description>Starbyte (Spa)</description>
+		<description>Starbyte (Spain)</description>
 		<year>1987</year>
 		<publisher>Mister Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33892,7 +33892,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stardusts" cloneof="stardust" supported="no">
-		<description>Stardust (Spa)</description>
+		<description>Stardust (Spain)</description>
 		<year>1987</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33969,7 +33969,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="starlife" supported="no">
-		<description>Starlife (Spa)</description>
+		<description>Starlife (Spain)</description>
 		<year>1988</year>
 		<publisher>Zafiro Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -33993,7 +33993,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="hollywod" supported="no">
-		<description>Les Stars d'Hollywood (Fra)</description>
+		<description>Les Stars d'Hollywood (France)</description>
 		<year>1990</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34049,7 +34049,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="startest" supported="no">
-		<description>Startest (Ger)</description>
+		<description>Startest (Germany)</description>
 		<year>1987</year>
 		<publisher>DMV Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34109,7 +34109,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stifflipg" cloneof="stifflip" supported="no">
-		<description>Stifflip &amp; Co (Ger)</description>
+		<description>Stifflip &amp; Co (Germany)</description>
 		<year>1987</year>
 		<publisher>Palace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34126,7 +34126,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stifflip" supported="no">
-		<description>Stifflip &amp; Co (Spa)</description>
+		<description>Stifflip &amp; Co (Spain)</description>
 		<year>1987</year>
 		<publisher>Palace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34160,7 +34160,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stockaids" cloneof="stockaid" supported="no">
-		<description>Stock-Aid (Spa)</description>
+		<description>Stock-Aid (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34208,7 +34208,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stopball" supported="no">
-		<description>Stop-Ball (Spa)</description>
+		<description>Stop-Ball (Spain)</description>
 		<year>1988</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34280,7 +34280,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="storysf4" supported="no">
-		<description>The Story So Far Vol 4 (Spa)</description>
+		<description>The Story So Far Vol 4 (Spain)</description>
 		<year>1990</year>
 		<publisher>Elite Systems</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34307,7 +34307,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stradgrf" cloneof="stargraf" supported="no">
-		<description>Stradgraf (Fra)</description>
+		<description>Stradgraf (France)</description>
 		<year>1986</year>
 		<publisher>War Games</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34336,7 +34336,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="strategy" supported="no">
-		<description>Strategy (Fra)</description>
+		<description>Strategy (France)</description>
 		<year>1985</year>
 		<publisher>Norsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34442,7 +34442,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stretmacg" cloneof="stretmac" supported="no">
-		<description>Street Machine (Ger)</description>
+		<description>Street Machine (Germany)</description>
 		<year>1986</year>
 		<publisher>Software Invasion</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34454,7 +34454,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stretmacs" cloneof="stretmac" supported="no">
-		<description>Street Machine (Spa)</description>
+		<description>Street Machine (Spain)</description>
 		<year>1986</year>
 		<publisher>Mind Games Espana</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34478,7 +34478,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stretbsk" supported="no">
-		<description>Street Sports Basketball (Spa)</description>
+		<description>Street Sports Basketball (Spain)</description>
 		<year>1988</year>
 		<publisher>Epyx</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34584,7 +34584,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stripp" supported="no">
-		<description>Strip Poker (Fra)</description>
+		<description>Strip Poker (France)</description>
 		<year>1985</year>
 		<publisher>Core</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34613,7 +34613,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stroper" supported="no">
-		<description>Stroper (Spa)</description>
+		<description>Stroper (Spain)</description>
 		<year>1992</year>
 		<publisher>Zigurat</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34625,7 +34625,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="stryfe" supported="no">
-		<description>Stryfe - The Everlasting Battle (Euro)</description>
+		<description>Stryfe - The Everlasting Battle (Europe)</description>
 		<year>1986</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34661,7 +34661,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="studpokr" supported="no">
-		<description>Stud Poker - Stud Jack (Ger)</description>
+		<description>Stud Poker - Stud Jack (Germany)</description>
 		<year>1985</year>
 		<publisher>Data Media GMBH</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34726,7 +34726,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sub" supported="no">
-		<description>Sub (Fra)</description>
+		<description>Sub (France)</description>
 		<year>1988</year>
 		<publisher>Gasoline Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34738,7 +34738,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="subs" cloneof="sub" supported="no">
-		<description>Sub (Spa)</description>
+		<description>Sub (Spain)</description>
 		<year>1988</year>
 		<publisher>Gasoline Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34750,7 +34750,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="subbuteos" cloneof="subbuteo" supported="no">
-		<description>Subbuteo (Spa)</description>
+		<description>Subbuteo (Spain)</description>
 		<year>1990</year>
 		<publisher>Electronic Zoo</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34810,7 +34810,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sultanmzs" cloneof="sultanmz" supported="no">
-		<description>Sultan's Maze (Spa)</description>
+		<description>Sultan's Maze (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34897,7 +34897,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="supercld" supported="no">
-		<description>Super Cauldron (Euro)</description>
+		<description>Super Cauldron (Europe)</description>
 		<year>1993</year>
 		<publisher>Titus</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -34933,7 +34933,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="supercycs" cloneof="supercyc" supported="no">
-		<description>Super Cycle (Spa)</description>
+		<description>Super Cycle (Spain)</description>
 		<year>1986</year>
 		<publisher>Epyx</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35068,7 +35068,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="supersap" supported="no">
-		<description>Super Sapiens (Spa)</description>
+		<description>Super Sapiens (Spain)</description>
 		<year>1989</year>
 		<publisher>Proein Soft Line</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35141,7 +35141,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="superskif" cloneof="superski" supported="no">
-		<description>Super Ski (Fra)</description>
+		<description>Super Ski (France)</description>
 		<year>1988</year>
 		<publisher>Microids</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35153,7 +35153,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sskweekf" cloneof="sskweek" supported="no">
-		<description>Super Skweek (Fra)</description>
+		<description>Super Skweek (France)</description>
 		<year>1990</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35170,7 +35170,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="sskweek" supported="no">
-		<description>Super Skweek (Spa)</description>
+		<description>Super Skweek (Spain)</description>
 		<year>1990</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35228,7 +35228,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ssprints" cloneof="ssprint" supported="no">
-		<description>Super Sprint (Spa)</description>
+		<description>Super Sprint (Spain)</description>
 		<year>1987</year>
 		<publisher>Proein Soft Line</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35312,7 +35312,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="wboymlnds" cloneof="wboymlnd" supported="no">
-		<description>Super Wonder Boy in Monster Land (Spa)</description>
+		<description>Super Wonder Boy in Monster Land (Spain)</description>
 		<year>1989</year>
 		<publisher>Activision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35336,7 +35336,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="superksp" supported="no">
-		<description>Superkid In Space (UK)</description>
+		<description>Superkid in Space (UK)</description>
 		<year>1991</year>
 		<publisher>Atlantis Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35401,7 +35401,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="suptripp" supported="no">
-		<description>Supertripper (Spa)</description>
+		<description>Supertripper (Spain)</description>
 		<year>1985</year>
 		<publisher>Indescomp</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35425,7 +35425,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="survivnt" cloneof="covenant" supported="no">
-		<description>Le Survivant (Fra)</description>
+		<description>Le Survivant (France)</description>
 		<year>1985</year>
 		<publisher>Pss</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35443,7 +35443,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="survivnta" cloneof="covenant" supported="no">
-		<description>Le Survivant (Fra, Echantillon Gratuit Amstrad Magazine)</description>
+		<description>Le Survivant (France, Echantillon Gratuit Amstrad Magazine)</description>
 		<year>1985</year>
 		<publisher>Pss</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35455,7 +35455,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="survivors" cloneof="survivor" supported="no">
-		<description>Survivor (Spa, Topo Soft)</description>
+		<description>Survivor (Spain, Topo Soft)</description>
 		<year>1987</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35585,7 +35585,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="syclone2" supported="no">
-		<description>Syclone 2 (Spa)</description>
+		<description>Syclone 2 (Spain)</description>
 		<year>1985</year>
 		<publisher>Pride Utilities</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35725,7 +35725,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="osiris" supported="no">
-		<description>Le Talisman d'Osiris (Fra)</description>
+		<description>Le Talisman d'Osiris (France)</description>
 		<year>1987</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35845,7 +35845,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="targetp" supported="no">
-		<description>Target Plus (Spa)</description>
+		<description>Target Plus (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35869,7 +35869,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="targtrens" cloneof="targtren" supported="no">
-		<description>Target: Renegade (Spa)</description>
+		<description>Target: Renegade (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35881,7 +35881,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tarot" supported="no">
-		<description>Tarot (Fra)</description>
+		<description>Tarot (France)</description>
 		<year>1986</year>
 		<publisher>Run Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35905,7 +35905,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tascopy4" supported="no">
-		<description>Tascopy 464 (Spa)</description>
+		<description>Tascopy 464 (Spain)</description>
 		<year>1984</year>
 		<publisher>Microbyte</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -35934,7 +35934,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tasprint" supported="no">
-		<description>Tasprint 464 (Spa)</description>
+		<description>Tasprint 464 (Spain)</description>
 		<year>1984</year>
 		<publisher>Microbyte</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36021,7 +36021,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="teatreur" cloneof="theateur" supported="no">
-		<description>Teatro de Europa (Spa)</description>
+		<description>Teatro de Europa (Spain)</description>
 		<year>1985</year>
 		<publisher>Pss</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36033,7 +36033,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="synthvoc" supported="no">
-		<description>Techni Musique - Synthetiseur Vocal (Fra)</description>
+		<description>Techni Musique - Synthetiseur Vocal (France)</description>
 		<year>1986</year>
 		<publisher>TMPI</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36062,7 +36062,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="teclamst" supported="no">
-		<description>El Teclado del Amstrad (Spa)</description>
+		<description>El Teclado del Amstrad (Spain)</description>
 		<year>19??</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36125,7 +36125,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="teenquen" supported="no">
-		<description>Teenage Queen (Spa)</description>
+		<description>Teenage Queen (Spain)</description>
 		<year>1989</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36142,7 +36142,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="telebing" supported="no">
-		<description>Telebingo (Spa)</description>
+		<description>Telebingo (Spain)</description>
 		<year>1986</year>
 		<publisher>Pemhi</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36166,7 +36166,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tempsagr" supported="no">
-		<description>Los Templos Sagrados (Spa)</description>
+		<description>Los Templos Sagrados (Spain)</description>
 		<year>1991</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36183,7 +36183,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="temphero" supported="no">
-		<description>Le Temps des Heros (Euro?)</description>
+		<description>Le Temps des Heros (Europe?)</description>
 		<year>1991</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36237,7 +36237,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tennis3d" supported="no">
-		<description>Tennis 3D (Fra)</description>
+		<description>Tennis 3D (France)</description>
 		<year>1986</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36249,7 +36249,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tenniscp" supported="no">
-		<description>Tennis Cup (Fra)</description>
+		<description>Tennis Cup (France)</description>
 		<year>1989</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36261,7 +36261,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tensions" supported="no">
-		<description>Tensions (Euro)</description>
+		<description>Tensions (Europe)</description>
 		<year>1986</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36273,7 +36273,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tensionss" cloneof="tensions" supported="no">
-		<description>Tensions (Spa)</description>
+		<description>Tensions (Spain)</description>
 		<year>1986</year>
 		<publisher>Ere Informatique</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36338,7 +36338,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="terrecnq" supported="no">
-		<description>Terres &amp; Conquerants (Fra)</description>
+		<description>Terres &amp; Conquerants (France)</description>
 		<year>1989</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36365,7 +36365,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="terrorfc" supported="no">
-		<description>Terror en la Facultad (Spa)</description>
+		<description>Terror en la Facultad (Spain)</description>
 		<year>1987</year>
 		<publisher>Edisoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36406,7 +36406,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="terrorpds" cloneof="terrorpd" supported="no">
-		<description>Terrorpods (Spa)</description>
+		<description>Terrorpods (Spain)</description>
 		<year>1988</year>
 		<publisher>Melbourne House</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36430,7 +36430,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="td2" supported="no">
-		<description>Test Drive 2 - Duel (Spa)</description>
+		<description>Test Drive 2 - Duel (Spain)</description>
 		<year>1989</year>
 		<publisher>Accolade</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36459,7 +36459,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tetriss" cloneof="tetris" supported="no">
-		<description>Tetris (Spa)</description>
+		<description>Tetris (Spain)</description>
 		<year>1987</year>
 		<publisher>Mirrorsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36483,7 +36483,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="thaiboxn" supported="no">
-		<description>Thai Boxing (Spa)</description>
+		<description>Thai Boxing (Spain)</description>
 		<year>1986</year>
 		<publisher>Anco Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36696,7 +36696,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ww3" supported="no">
-		<description>Third World War (Fra)</description>
+		<description>Third World War (France)</description>
 		<year>1985</year>
 		<publisher>Free Game Blot</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36732,7 +36732,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="thorr1" supported="no">
-		<description>Thorr 1 - Die letzten Tage von Burg Ghorrodt (Ger)</description>
+		<description>Thorr 1 - Die letzten Tage von Burg Ghorrodt (Germany)</description>
 		<year>1984</year>
 		<publisher>Data Media GMBH</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36744,7 +36744,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="thorr2" supported="no">
-		<description>Thorr 2 - Die Flucht Nach Thyrros (Ger)</description>
+		<description>Thorr 2 - Die Flucht Nach Thyrros (Germany)</description>
 		<year>1984</year>
 		<publisher>Data Media GMBH</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36756,7 +36756,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="thorr3" supported="no">
-		<description>Thorr 3 - Das Geheimnis von Thyrros (Ger)</description>
+		<description>Thorr 3 - Das Geheimnis von Thyrros (Germany)</description>
 		<year>1985</year>
 		<publisher>Data Media GMBH</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36944,7 +36944,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- MOVE TO CPC_FLOP! THIS TAPE WAS INCLUDED IN DISK PACK -->
 	<software name="tbirdaud" supported="no">
-		<description>Thunderbirds (UK, Audio Tape)</description>
+		<description>Thunderbirds (UK, audio tape)</description>
 		<year>1989</year>
 		<publisher>Grandslam</publisher>
 		<info name="usage" value="" />
@@ -36968,7 +36968,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tiburon" cloneof="jaws" supported="no">
-		<description>Tiburon (Spa)</description>
+		<description>Tiburon (Spain)</description>
 		<year>1989</year>
 		<publisher>Screen 7</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -36980,7 +36980,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tiebreak" supported="no">
-		<description>Tie Break (Fra)</description>
+		<description>Tie Break (France)</description>
 		<year>1985</year>
 		<publisher>Sprites</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37016,7 +37016,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="time" supported="no">
-		<description>Time (Euro)</description>
+		<description>Time (Europe)</description>
 		<year>1985</year>
 		<publisher>Rainbow Arts</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37040,7 +37040,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="timeouts" supported="no">
-		<description>Time Out (Spa)</description>
+		<description>Time Out (Spain)</description>
 		<year>1988</year>
 		<publisher>Zafiro Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37057,7 +37057,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="timescan" supported="no">
-		<description>Time Scanner (Spa)</description>
+		<description>Time Scanner (Spain)</description>
 		<year>1989</year>
 		<publisher>MCM</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37146,7 +37146,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tintin" supported="no">
-		<description>Tintin on the Moon (Euro)</description>
+		<description>Tintin on the Moon (Europe)</description>
 		<year>1989</year>
 		<publisher>Infogrames</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37175,7 +37175,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="titan" supported="no">
-		<description>Titan (Spa)</description>
+		<description>Titan (Spain)</description>
 		<year>1988</year>
 		<publisher>Titus</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37187,7 +37187,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="titanics" cloneof="titanic" supported="no">
-		<description>Titanic (Spa)</description>
+		<description>Titanic (Spain)</description>
 		<year>1988</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37228,7 +37228,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tituscl1" supported="no">
-		<description>Titus Classiques Volume 1 (Fra)</description>
+		<description>Titus Classiques Volume 1 (France)</description>
 		<year>1987</year>
 		<publisher>Titus</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37292,7 +37292,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="toadruns" cloneof="toadrun" supported="no">
-		<description>Toad Runner (Spa)</description>
+		<description>Toad Runner (Spain)</description>
 		<year>1986</year>
 		<publisher>Ariolasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37316,7 +37316,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tobrouk" supported="no">
-		<description>Tobruk 1942 (Fra)</description>
+		<description>Tobruk 1942 (France)</description>
 		<year>1986</year>
 		<publisher>Pss</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37333,7 +37333,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="toiacid" supported="no">
-		<description>Toi Acid Game (Spa)</description>
+		<description>Toi Acid Game (Spain)</description>
 		<year>1990</year>
 		<publisher>Iber Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37350,7 +37350,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tokyogng" supported="no">
-		<description>Tokyo Gang (Spa)</description>
+		<description>Tokyo Gang (Spain)</description>
 		<year>1990</year>
 		<publisher>GLL Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37362,7 +37362,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tolleoma" cloneof="supgran" supported="no">
-		<description>Tolle Oma (Ger)</description>
+		<description>Tolle Oma (Germany)</description>
 		<year>1985</year>
 		<publisher>QuelleSoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37374,7 +37374,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tomjerr2" supported="no">
-		<description>Tom &amp; Jerry 2 (Spa)</description>
+		<description>Tom &amp; Jerry 2 (Spain)</description>
 		<year>1990</year>
 		<publisher>Erbe Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37386,7 +37386,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tomjerry" supported="no">
-		<description>Tom &amp; Jerry (Spa)</description>
+		<description>Tom &amp; Jerry (Spain)</description>
 		<year>1990</year>
 		<publisher>Erbe Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37446,7 +37446,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tonytrnd" supported="no">
-		<description>Tony Truand (Fra)</description>
+		<description>Tony Truand (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37492,7 +37492,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="topbuch" supported="no">
-		<description>Top Buch v1.2 - Die Komfortabele Buchverwaltung (Ger)</description>
+		<description>Top Buch v1.2 - Die Komfortabele Buchverwaltung (Germany)</description>
 		<year>1985</year>
 		<publisher>Topsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37504,7 +37504,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="toptopo" supported="no">
-		<description>Top By Topo (Spa)</description>
+		<description>Top By Topo (Spain)</description>
 		<year>1990</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37567,7 +37567,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="topvideo" supported="no">
-		<description>Top-Video (Ger)</description>
+		<description>Top-Video (Germany)</description>
 		<year>1985</year>
 		<publisher>Topsoft Gmbh</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37579,7 +37579,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="torann" supported="no">
-		<description>Torann (Fra)</description>
+		<description>Torann (France)</description>
 		<year>1985</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37644,7 +37644,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tour91" supported="no">
-		<description>Tour 91 (Spa)</description>
+		<description>Tour 91 (Spain)</description>
 		<year>1991</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37673,7 +37673,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tourmd80" supported="no">
-		<description>Tour du Monde en 80 Jours (Fra, BASIC 1.0)</description>
+		<description>Tour du Monde en 80 Jours (France, BASIC 1.0)</description>
 		<year>1984</year>
 		<publisher>No Man's Land</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37685,7 +37685,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="toursnok" cloneof="prosnook" supported="no">
-		<description>Tournament Snooker (Euro)</description>
+		<description>Tournament Snooker (Europe)</description>
 		<year>1986</year>
 		<publisher>Magnificent 7</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37697,7 +37697,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="toursiec" supported="no">
-		<description>Le Tournoi du Siecle (Fra)</description>
+		<description>Le Tournoi du Siecle (France)</description>
 		<year>1985</year>
 		<publisher>Power Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37726,7 +37726,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="toys" supported="no">
-		<description>Toys (Spa, BASIC 1.1)</description>
+		<description>Toys (Spain, BASIC 1.1)</description>
 		<year>19??</year>
 		<publisher>PJ Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37786,7 +37786,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="trains" cloneof="train" supported="no">
-		<description>The Train (Spa)</description>
+		<description>The Train (Spain)</description>
 		<year>1988</year>
 		<publisher>Accolade</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37810,7 +37810,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="traitbzz" supported="no">
-		<description>Traitement Bzzz (Fra)</description>
+		<description>Traitement Bzzz (France)</description>
 		<year>1987</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37822,7 +37822,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="amswordf" cloneof="amsword" supported="no">
-		<description>Traitement de Textes Pro (Fra)</description>
+		<description>Traitement de Textes Pro (France)</description>
 		<year>1984</year>
 		<publisher>Tasman Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -37870,7 +37870,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="transfrt" supported="no">
-		<description>Transfert (Fra)</description>
+		<description>Transfert (France)</description>
 		<year>1987</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38001,7 +38001,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="lucesglr" supported="no">
-		<description>Las Tres Luces de Glaurung (Spa)</description>
+		<description>Las Tres Luces de Glaurung (Spain)</description>
 		<year>1986</year>
 		<publisher>Erbe Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38013,7 +38013,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tresamaz" cloneof="tracker" supported="no">
-		<description>Le Tresor de l'Amazone (Fra)</description>
+		<description>Le Tresor de l'Amazone (France)</description>
 		<year>1985</year>
 		<publisher>Power Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38061,7 +38061,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="trigger" supported="no">
-		<description>Trigger (Spa)</description>
+		<description>Trigger (Spain)</description>
 		<year>1989</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38073,7 +38073,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="apshai" supported="no">
-		<description>La Trilogie du Temple d'Apshai (Fra)</description>
+		<description>La Trilogie du Temple d'Apshai (France)</description>
 		<year>1987</year>
 		<publisher>D3M</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38107,7 +38107,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="trios" cloneof="trio" supported="no">
-		<description>Trio (Spa)</description>
+		<description>Trio (Spain)</description>
 		<year>1987</year>
 		<publisher>Elite Systems</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38124,7 +38124,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="triplecm" supported="no">
-		<description>Triple Comando (Spa)</description>
+		<description>Triple Comando (Spain)</description>
 		<year>1988</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38136,7 +38136,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tripods" supported="no">
-		<description>The Tripods (UK, Fast Load Version)</description>
+		<description>The Tripods (UK, fast load version)</description>
 		<year>1984</year>
 		<publisher>Red Shift</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38148,7 +38148,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tripodssl" cloneof="tripods" supported="no">
-		<description>The Tripods (UK, Slow Load Version)</description>
+		<description>The Tripods (UK, slow load version)</description>
 		<year>1984</year>
 		<publisher>Red Shift</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38160,7 +38160,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="triton2" supported="no">
-		<description>Triton II (Spa)</description>
+		<description>Triton II (Spain)</description>
 		<year>1986</year>
 		<publisher>Edisoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38206,7 +38206,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="trivials" cloneof="trivial" supported="no">
-		<description>Trivial Pursuit - Genus (Spa)</description>
+		<description>Trivial Pursuit - Genus (Spain)</description>
 		<year>1986</year>
 		<publisher>Domark</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38218,7 +38218,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="trivialf" cloneof="trivial" supported="no">
-		<description>Trivial Pursuit - Edition Genus (Fra)</description>
+		<description>Trivial Pursuit - Edition Genus (France)</description>
 		<year>1986</year>
 		<publisher>Domark</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38257,7 +38257,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="triviajr" supported="no">
-		<description>Trivial Pursuit - Edition Junior (Fra)</description>
+		<description>Trivial Pursuit - Edition Junior (France)</description>
 		<year>1988</year>
 		<publisher>Domark</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38296,7 +38296,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="triviag2" cloneof="trivianb" supported="no">
-		<description>Trivial Pursuit - Genus II (Fra)</description>
+		<description>Trivial Pursuit - Genus II (France)</description>
 		<year>1988</year>
 		<publisher>Domark</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38313,7 +38313,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="triviarv" supported="no">
-		<description>Trivial Pursuit - Edition Revolution (Fra)</description>
+		<description>Trivial Pursuit - Edition Revolution (France)</description>
 		<year>1989</year>
 		<publisher>Domark</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38335,7 +38335,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="troglo" supported="no">
-		<description>Troglo (Spa)</description>
+		<description>Troglo (Spain)</description>
 		<year>1986</year>
 		<publisher>Ace Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38383,7 +38383,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tuareg" supported="no">
-		<description>Tuareg (Spa)</description>
+		<description>Tuareg (Spain)</description>
 		<year>1988</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38419,7 +38419,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="tujads" cloneof="tujad" supported="no">
-		<description>Tujad (Spa)</description>
+		<description>Tujad (Spain)</description>
 		<year>1986</year>
 		<publisher>Ariolasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38496,7 +38496,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="turbocupf" cloneof="turbocup" supported="no">
-		<description>Turbo Cup (Fra)</description>
+		<description>Turbo Cup (France)</description>
 		<year>1988</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38532,7 +38532,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="turboesps" cloneof="turboesp" supported="no">
-		<description>Turbo Esprit (Spa)</description>
+		<description>Turbo Esprit (Spain)</description>
 		<year>1986</year>
 		<publisher>Durell Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38556,7 +38556,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="turbogrl" cloneof="turbobik" supported="no">
-		<description>Turbo Girl (Spa)</description>
+		<description>Turbo Girl (Spain)</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38730,7 +38730,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="typhoons" cloneof="typhoon" supported="no">
-		<description>Typhoon (Spa)</description>
+		<description>Typhoon (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38759,7 +38759,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ulises" supported="no">
-		<description>Ulises (Spa)</description>
+		<description>Ulises (Spain)</description>
 		<year>1989</year>
 		<publisher>Opera Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38795,7 +38795,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="ultron1" supported="no">
-		<description>Ultron 1 (Fra)</description>
+		<description>Ultron 1 (France)</description>
 		<year>1987</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38819,7 +38819,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="unitraxs" cloneof="unitrax" supported="no">
-		<description>Unitrax (Spa)</description>
+		<description>Unitrax (Spain)</description>
 		<year>1987</year>
 		<publisher>Domark</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38860,7 +38860,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="urggg" supported="no">
-		<description>Urggg (Spa)</description>
+		<description>Urggg (Spain)</description>
 		<year>1990</year>
 		<publisher>MegaOcio</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38961,7 +38961,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="venganza" supported="no">
-		<description>Venganza (Spa)</description>
+		<description>Venganza (Spain)</description>
 		<year>1986</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -38997,7 +38997,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="vermeer" supported="no">
-		<description>Vermeer (Ger, BASIC 1.0)</description>
+		<description>Vermeer (Germany, BASIC 1.0)</description>
 		<year>1987</year>
 		<publisher>Ariolasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39026,7 +39026,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="vctierra" supported="no">
-		<description>Viaje al Centro de la Tierra (Spa)</description>
+		<description>Viaje al Centro de la Tierra (Spain)</description>
 		<year>1989</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39038,7 +39038,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="viajealu" supported="no">
-		<description>Viaje Alucinante (Spa)</description>
+		<description>Viaje Alucinante (Spain)</description>
 		<year>1986</year>
 		<publisher>Idealogic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39050,7 +39050,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="victroads" cloneof="victroad" supported="no">
-		<description>Victory Road - The Pathway to Fear (Spa)</description>
+		<description>Victory Road - The Pathway to Fear (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39123,7 +39123,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="villeinf" supported="no">
-		<description>La Ville Infernale (Fra)</description>
+		<description>La Ville Infernale (France)</description>
 		<year>1985</year>
 		<publisher>Cobra Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39147,7 +39147,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="thevindcs" cloneof="thevindc" supported="no">
-		<description>The Vindicator (Spa)</description>
+		<description>The Vindicator (Spain)</description>
 		<year>1988</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39189,7 +39189,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- MOVE TO CPC_FLOP! THIS TAPE WAS INCLUDED IN DISK PACK -->
 	<software name="visahprk" supported="no">
-		<description>Visa Pour Hyde Park (Fra, Audio Tape)</description>
+		<description>Visa Pour Hyde Park (France, audio tape)</description>
 		<year>1987</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39250,7 +39250,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="volley" supported="no">
-		<description>Volley-Ball (Fra)</description>
+		<description>Volley-Ball (France)</description>
 		<year>1987</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39262,7 +39262,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="vballsim" supported="no">
-		<description>Volleyball Simulator (Spa)</description>
+		<description>Volleyball Simulator (Spain)</description>
 		<year>1987</year>
 		<publisher>Time Warp Productions</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39279,7 +39279,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="volumes" supported="no">
-		<description>Volumes (Fra)</description>
+		<description>Volumes (France)</description>
 		<year>1986</year>
 		<publisher>SVM</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39303,7 +39303,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="votezmoi" supported="no">
-		<description>Votez Pour Moi (Fra)</description>
+		<description>Votez Pour Moi (France)</description>
 		<year>1985</year>
 		<publisher>Coktel Vision</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39327,7 +39327,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="wander3d" supported="no">
-		<description>Wanderer 3D (Spa)</description>
+		<description>Wanderer 3D (Spain)</description>
 		<year>1988</year>
 		<publisher>Elite Systems</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39351,7 +39351,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="wars" cloneof="war" supported="no">
-		<description>W.A.R (Spa)</description>
+		<description>W.A.R (Spain)</description>
 		<year>1987</year>
 		<publisher>Martech</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39380,7 +39380,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="walkyrie" supported="no">
-		<description>Walkyrie (Fra, BASIC 1.0)</description>
+		<description>Walkyrie (France, BASIC 1.0)</description>
 		<year>1985</year>
 		<publisher>JRD</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39404,7 +39404,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="warmideas" cloneof="warmidea" supported="no">
-		<description>War In Middle Earth (Spa)</description>
+		<description>War in Middle Earth (Spain)</description>
 		<year>1989</year>
 		<publisher>Melbourne House</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39452,7 +39452,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="warzones" cloneof="warzone" supported="no">
-		<description>War Zone (Spa)</description>
+		<description>War Zone (Spain)</description>
 		<year>1984</year>
 		<publisher>Cases Computer Simulators</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39505,7 +39505,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="warlocks" cloneof="warlock" supported="no">
-		<description>Warlock (Spa)</description>
+		<description>Warlock (Spain)</description>
 		<year>1987</year>
 		<publisher>The Edge</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39541,7 +39541,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="warrior" supported="no">
-		<description>Warrior (Fra, BASIC 1.0)</description>
+		<description>Warrior (France, BASIC 1.0)</description>
 		<year>1985</year>
 		<publisher>Rainbow Production</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39645,7 +39645,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="welcamso" cloneof="welcams" supported="no">
-		<description>Welcome to Amsoft (Spa, BASIC 1.0)</description>
+		<description>Welcome to Amsoft (Spain, BASIC 1.0)</description>
 		<year>1984</year>
 		<publisher>Schneider Computer Division</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39662,7 +39662,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="welcamsg" cloneof="welcams" supported="no">
-		<description>Welcome to Amstrad (Ger)</description>
+		<description>Welcome to Amstrad (Germany)</description>
 		<year>1984</year>
 		<publisher>Schneider Computer Division</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39679,7 +39679,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="welcams" supported="no">
-		<description>Welcome to Amstrad (Spa, BASIC 1.0)</description>
+		<description>Welcome to Amstrad (Spain, BASIC 1.0)</description>
 		<year>1988</year>
 		<publisher>Schneider Computer Division</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39696,7 +39696,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="wellsfrg" supported="no">
-		<description>Wells &amp; Fargo (Spa)</description>
+		<description>Wells &amp; Fargo (Spain)</description>
 		<year>1988</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39733,7 +39733,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- DOUBLE CHECK: SHALL WE MOVE THIS TO CPC_FLOP? WHERE DOES IT COME FROM? -->
 	<software name="werewaud" supported="no">
-		<description>Werewolf Rap - Silver Bullet Remix (UK, Audio Tape)</description>
+		<description>Werewolf Rap - Silver Bullet Remix (UK, audio tape)</description>
 		<year>1987</year>
 		<publisher>Ariolasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39745,7 +39745,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="werewolvs" cloneof="werewolv" supported="no">
-		<description>Werewolves of London (Spa)</description>
+		<description>Werewolves of London (Spain)</description>
 		<year>1987</year>
 		<publisher>Ariolasoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39781,7 +39781,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="werner" supported="no">
-		<description>Werner Mach Hin (Ger)</description>
+		<description>Werner Mach Hin (Germany)</description>
 		<year>1986</year>
 		<publisher>Micro-Partner</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39793,7 +39793,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="westbanks" cloneof="westbank" supported="no">
-		<description>West Bank (Spa)</description>
+		<description>West Bank (Spain)</description>
 		<year>1986</year>
 		<publisher>Dinamic Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39817,7 +39817,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="westgame" supported="no">
-		<description>Western Games (Spa)</description>
+		<description>Western Games (Spain)</description>
 		<year>1987</year>
 		<publisher>Magic Bytes</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39841,7 +39841,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="whopper" supported="no">
-		<description>Whopper Chase (Spa)</description>
+		<description>Whopper Chase (Spain)</description>
 		<year>1987</year>
 		<publisher>Erbe Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -39937,7 +39937,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="wingsoff" supported="no">
-		<description>Wings of Fury - Tant Qu'Il y Aura des Zeros (Fra)</description>
+		<description>Wings of Fury - Tant Qu'Il y Aura des Zeros (France)</description>
 		<year>1989</year>
 		<publisher>Brøderbund France</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40186,7 +40186,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="wordhanga" cloneof="wordhang" supported="no">
-		<description>Wordhang (UK, Ger)</description>
+		<description>Wordhang (UK, Germany)</description>
 		<year>1984</year>
 		<publisher>Schneider Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40227,7 +40227,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="wcboxmngf" cloneof="wcboxmng" supported="no">
-		<description>World Championship Boxing Manager (Fra)</description>
+		<description>World Championship Boxing Manager (France)</description>
 		<year>1990</year>
 		<publisher>Krisalis Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40343,7 +40343,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="italia90s" cloneof="italia90" supported="no">
-		<description>World Cup Soccer Italia '90 (Spa)</description>
+		<description>World Cup Soccer Italia '90 (Spain)</description>
 		<year>1990</year>
 		<publisher>Virgin Games</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40420,7 +40420,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="worldwisf" cloneof="worldwis" supported="no">
-		<description>World-Wise (Fra)</description>
+		<description>World-Wise (France)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40644,7 +40644,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="xenons" cloneof="xenon" supported="no">
-		<description>Xenon (Spa)</description>
+		<description>Xenon (Spain)</description>
 		<year>1988</year>
 		<publisher>Melbourne House</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40669,7 +40669,7 @@ Please stick to using the floppy versions for the time being...
 
 	<!-- DOUBLE CHECK: SHALL WE MOVE THIS TO CPC_FLOP? WHERE DOES IT COME FROM? -->
 	<software name="xenopaud" supported="no">
-		<description>Xenophobe (UK, Audio Tape)</description>
+		<description>Xenophobe (UK, audio tape)</description>
 		<year>1989</year>
 		<publisher>Micro Style</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40734,7 +40734,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="yahtzee" supported="no">
-		<description>Y'ahtzee (Spa)</description>
+		<description>Y'ahtzee (Spain)</description>
 		<year>1985</year>
 		<publisher>Idealogic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40899,7 +40899,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zampabol" supported="no">
-		<description>Zampabolas (Spa)</description>
+		<description>Zampabolas (Spain)</description>
 		<year>1988</year>
 		<publisher>System 4 de Espana</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40911,7 +40911,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zampalos" supported="no">
-		<description>Zampalos (Spa)</description>
+		<description>Zampalos (Spain)</description>
 		<year>1992</year>
 		<publisher>Mega Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40935,7 +40935,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zargon" supported="no">
-		<description>Zargon (Ger)</description>
+		<description>Zargon (Germany)</description>
 		<year>1985</year>
 		<publisher>Data Media GMBH</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40959,7 +40959,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zaxx" supported="no">
-		<description>Zaxx (Fra)</description>
+		<description>Zaxx (France)</description>
 		<year>1986</year>
 		<publisher>Chip</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -40971,7 +40971,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zedis2" supported="no">
-		<description>Zedis II (Spa)</description>
+		<description>Zedis II (Spain)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41000,7 +41000,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zipiyzap" supported="no">
-		<description>Zipi Y Zape (Spa)</description>
+		<description>Zipi Y Zape (Spain)</description>
 		<year>1989</year>
 		<publisher>Dro Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41041,7 +41041,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zombi" supported="no">
-		<description>Zombi (Fra, 64K)</description>
+		<description>Zombi (France, 64K)</description>
 		<year>1986</year>
 		<publisher>UBI Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41053,7 +41053,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zona0" supported="no">
-		<description>Zona 0 (Spa)</description>
+		<description>Zona 0 (Spain)</description>
 		<year>1991</year>
 		<publisher>Topo Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41089,7 +41089,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zox2099" supported="no">
-		<description>Zox 2099 (Fra)</description>
+		<description>Zox 2099 (France)</description>
 		<year>1987</year>
 		<publisher>Loriciels</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41125,7 +41125,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zynapss" cloneof="zynaps" supported="no">
-		<description>Zynaps (Spa)</description>
+		<description>Zynaps (Spain)</description>
 		<year>1987</year>
 		<publisher>Hewson</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41137,7 +41137,7 @@ Please stick to using the floppy versions for the time being...
 	</software>
 
 	<software name="zynapsa" cloneof="zynaps" supported="no">
-		<description>Zynaps (UK, Alt)</description>
+		<description>Zynaps (UK, alt)</description>
 		<year>1987</year>
 		<publisher>Hewson</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41536,7 +41536,7 @@ Covertapes
 	</software>
 
 	<software name="amsdisc1" supported="no">
-		<description>Amstrad Disco 1 (Spa)</description>
+		<description>Amstrad Disco 1 (Spain)</description>
 		<year>19??</year>
 		<publisher>Ediciones Manali S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41553,7 +41553,7 @@ Covertapes
 	</software>
 
 	<software name="amsgam1" supported="no">
-		<description>Amstrad Games 01 - Xider (Spa, BASIC 1.1)</description>
+		<description>Amstrad Games 01 - Xider (Spain, BASIC 1.1)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41570,7 +41570,7 @@ Covertapes
 	</software>
 
 	<software name="amsgam2" supported="no">
-		<description>Amstrad Games 02 - S.O.S. (Spa)</description>
+		<description>Amstrad Games 02 - S.O.S. (Spain)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41582,7 +41582,7 @@ Covertapes
 	</software>
 
 	<software name="amsgam3" supported="no">
-		<description>Amstrad Games 03 - Tomy en el Slalom (Spa)</description>
+		<description>Amstrad Games 03 - Tomy en el Slalom (Spain)</description>
 		<year>1987</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41594,7 +41594,7 @@ Covertapes
 	</software>
 
 	<software name="amsgam4" supported="no">
-		<description>Amstrad Games 04 - Circuito De Lemans (Spa)</description>
+		<description>Amstrad Games 04 - Circuito De Lemans (Spain)</description>
 		<year>1987</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41606,7 +41606,7 @@ Covertapes
 	</software>
 
 	<software name="amsgam5" supported="no">
-		<description>Amstrad Games 05 - Cosmic Galactica (Spa)</description>
+		<description>Amstrad Games 05 - Cosmic Galactica (Spain)</description>
 		<year>1987</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41618,7 +41618,7 @@ Covertapes
 	</software>
 
 	<software name="amsgam6" supported="no">
-		<description>Amstrad Games 06 - Beta 2515 (Spa)</description>
+		<description>Amstrad Games 06 - Beta 2515 (Spain)</description>
 		<year>1987</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41630,7 +41630,7 @@ Covertapes
 	</software>
 
 	<software name="amsgam7" supported="no">
-		<description>Amstrad Games 07 - Transx (Spa)</description>
+		<description>Amstrad Games 07 - Transx (Spain)</description>
 		<year>1987</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41642,7 +41642,7 @@ Covertapes
 	</software>
 
 	<software name="amsmani1" supported="no">
-		<description>Amstrad Mania 1 (Spa)</description>
+		<description>Amstrad Mania 1 (Spain)</description>
 		<year>1986</year>
 		<publisher>Editorial Cometa</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41659,7 +41659,7 @@ Covertapes
 	</software>
 
 	<software name="amsmani2" supported="no">
-		<description>Amstrad Mania 2 (Spa)</description>
+		<description>Amstrad Mania 2 (Spain)</description>
 		<year>1986</year>
 		<publisher>Editorial Cometa</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41676,7 +41676,7 @@ Covertapes
 	</software>
 
 	<software name="amsmani3" supported="no">
-		<description>Amstrad Mania 3 (Spa)</description>
+		<description>Amstrad Mania 3 (Spain)</description>
 		<year>1986</year>
 		<publisher>Editorial Cometa</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41693,7 +41693,7 @@ Covertapes
 	</software>
 
 	<software name="amsmani4" supported="no">
-		<description>Amstrad Mania 4 (Spa)</description>
+		<description>Amstrad Mania 4 (Spain)</description>
 		<year>1986</year>
 		<publisher>Editorial Cometa</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41710,7 +41710,7 @@ Covertapes
 	</software>
 
 	<software name="amsmani5" supported="no">
-		<description>Amstrad Mania 5 (Spa)</description>
+		<description>Amstrad Mania 5 (Spain)</description>
 		<year>1986</year>
 		<publisher>Editorial Cometa</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41727,7 +41727,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp01" supported="no">
-		<description>Amstrad Video-Play 01 - Feliz Navidad (Spa)</description>
+		<description>Amstrad Video-Play 01 - Feliz Navidad (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41744,7 +41744,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp02" supported="no">
-		<description>Amstrad Video-Play 02 - Defender (Spa)</description>
+		<description>Amstrad Video-Play 02 - Defender (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41761,7 +41761,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp03" supported="no">
-		<description>Amstrad Video-Play 03 - Super Robot (Spa)</description>
+		<description>Amstrad Video-Play 03 - Super Robot (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41773,7 +41773,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp04" supported="no">
-		<description>Amstrad Video-Play 04 - Back-Tron (Spa)</description>
+		<description>Amstrad Video-Play 04 - Back-Tron (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41785,7 +41785,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp05" supported="no">
-		<description>Amstrad Video-Play 05 - Woxxox (Spa)</description>
+		<description>Amstrad Video-Play 05 - Woxxox (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41802,7 +41802,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp06" supported="no">
-		<description>Amstrad Video-Play 06 - Siro (Spa)</description>
+		<description>Amstrad Video-Play 06 - Siro (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41814,7 +41814,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp07" supported="no">
-		<description>Amstrad Video-Play 07 - Zone (Spa)</description>
+		<description>Amstrad Video-Play 07 - Zone (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41826,7 +41826,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp08" supported="no">
-		<description>Amstrad Video-Play 08 - Dirk (Spa)</description>
+		<description>Amstrad Video-Play 08 - Dirk (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41838,7 +41838,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp09" supported="no">
-		<description>Amstrad Video-Play 09 - Fly (Spa)</description>
+		<description>Amstrad Video-Play 09 - Fly (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41850,7 +41850,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp10" supported="no">
-		<description>Amstrad Video-Play 10 - Tron Warrior (Spa)</description>
+		<description>Amstrad Video-Play 10 - Tron Warrior (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41862,7 +41862,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp11" supported="no">
-		<description>Amstrad Video-Play 11 - Buscate La Vida (Spa)</description>
+		<description>Amstrad Video-Play 11 - Buscate La Vida (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41874,7 +41874,7 @@ Covertapes
 	</software>
 
 	<software name="amsvp12" supported="no">
-		<description>Amstrad Video-Play 12 - Eagle (Spa)</description>
+		<description>Amstrad Video-Play 12 - Eagle (Spain)</description>
 		<year>1987</year>
 		<publisher>P.P.P. Ediciones</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41886,7 +41886,7 @@ Covertapes
 	</software>
 
 	<software name="audams2" supported="no">
-		<description>Audio Amstrad 2 (Spa)</description>
+		<description>Audio Amstrad 2 (Spain)</description>
 		<year>19??</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41898,7 +41898,7 @@ Covertapes
 	</software>
 
 	<software name="audams3" supported="no">
-		<description>Audio Amstrad 3 (Spa)</description>
+		<description>Audio Amstrad 3 (Spain)</description>
 		<year>19??</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41910,7 +41910,7 @@ Covertapes
 	</software>
 
 	<software name="audams4" supported="no">
-		<description>Audio Amstrad 4 (Spa)</description>
+		<description>Audio Amstrad 4 (Spain)</description>
 		<year>19??</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41922,7 +41922,7 @@ Covertapes
 	</software>
 
 	<software name="audams5" supported="no">
-		<description>Audio Amstrad 5 (Spa)</description>
+		<description>Audio Amstrad 5 (Spain)</description>
 		<year>19??</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41934,7 +41934,7 @@ Covertapes
 	</software>
 
 	<software name="audams6" supported="no">
-		<description>Audio Amstrad 6 - Tenis 3D (Spa)</description>
+		<description>Audio Amstrad 6 - Tenis 3D (Spain)</description>
 		<year>19??</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41946,7 +41946,7 @@ Covertapes
 	</software>
 
 	<software name="audams7" supported="no">
-		<description>Audio Amstrad 7 - Space Crazy (Spa)</description>
+		<description>Audio Amstrad 7 - Space Crazy (Spain)</description>
 		<year>19??</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41958,7 +41958,7 @@ Covertapes
 	</software>
 
 	<software name="clubams1" supported="no">
-		<description>Club Amstrad 01 (Spa)</description>
+		<description>Club Amstrad 01 (Spain)</description>
 		<year>1986</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41975,7 +41975,7 @@ Covertapes
 	</software>
 
 	<software name="clubams2" supported="no">
-		<description>Club Amstrad 02 (Spa)</description>
+		<description>Club Amstrad 02 (Spain)</description>
 		<year>1986</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -41992,7 +41992,7 @@ Covertapes
 	</software>
 
 	<software name="clubams3" supported="no">
-		<description>Club Amstrad 03 (Spa)</description>
+		<description>Club Amstrad 03 (Spain)</description>
 		<year>1986</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42009,7 +42009,7 @@ Covertapes
 	</software>
 
 	<software name="clubams4" supported="no">
-		<description>Club Amstrad 04 (Spa)</description>
+		<description>Club Amstrad 04 (Spain)</description>
 		<year>1986</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42026,7 +42026,7 @@ Covertapes
 	</software>
 
 	<software name="clubams5" supported="no">
-		<description>Club Amstrad 05 (Spa)</description>
+		<description>Club Amstrad 05 (Spain)</description>
 		<year>1986</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42043,7 +42043,7 @@ Covertapes
 	</software>
 
 	<software name="amsmag05" supported="no">
-		<description>Compilation Amstrad Magazine Numero 05 (Fra)</description>
+		<description>Compilation Amstrad Magazine Numero 05 (France)</description>
 		<year>1985</year>
 		<publisher>&lt;covertape&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42165,7 +42165,7 @@ Covertapes
 	</software>
 
 	<software name="cpc13" supported="no">
-		<description>CPC Cassette 13 (Fra)</description>
+		<description>CPC Cassette 13 (France)</description>
 		<year>1986</year>
 		<publisher>Editions Soracom</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42182,7 +42182,7 @@ Covertapes
 	</software>
 
 	<software name="dboxhi1" supported="no">
-		<description>CPC Databox - Highlights 1 (Ger)</description>
+		<description>CPC Databox - Highlights 1 (Germany)</description>
 		<year>1985</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42194,7 +42194,7 @@ Covertapes
 	</software>
 
 	<software name="dboxhi2" supported="no">
-		<description>CPC Databox - Highlights 2 (Ger)</description>
+		<description>CPC Databox - Highlights 2 (Germany)</description>
 		<year>1985</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42206,7 +42206,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0885" supported="no">
-		<description>Databox 08-85 (Ger)</description>
+		<description>Databox 08-85 (Germany)</description>
 		<year>1985</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42218,7 +42218,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0985" supported="no">
-		<description>Databox 09-85 (Ger)</description>
+		<description>Databox 09-85 (Germany)</description>
 		<year>1985</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42230,7 +42230,7 @@ Covertapes
 	</software>
 
 	<software name="dbox1085" supported="no">
-		<description>Databox 10-85 (Ger)</description>
+		<description>Databox 10-85 (Germany)</description>
 		<year>1985</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42242,7 +42242,7 @@ Covertapes
 	</software>
 
 	<software name="dbox1185" supported="no">
-		<description>Databox 11-85 (Ger)</description>
+		<description>Databox 11-85 (Germany)</description>
 		<year>1985</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42254,7 +42254,7 @@ Covertapes
 	</software>
 
 	<software name="dbox1285" supported="no">
-		<description>Databox 12-85 (Ger)</description>
+		<description>Databox 12-85 (Germany)</description>
 		<year>1985</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42266,7 +42266,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0186" supported="no">
-		<description>Databox 01-86 (Ger)</description>
+		<description>Databox 01-86 (Germany)</description>
 		<year>1986</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42278,7 +42278,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0386" supported="no">
-		<description>Databox 03-86 (Ger)</description>
+		<description>Databox 03-86 (Germany)</description>
 		<year>1986</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42290,7 +42290,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0486" supported="no">
-		<description>Databox 04-86 (Ger)</description>
+		<description>Databox 04-86 (Germany)</description>
 		<year>1986</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42302,7 +42302,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0686" supported="no">
-		<description>Databox 06-86 (Ger)</description>
+		<description>Databox 06-86 (Germany)</description>
 		<year>1986</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42314,7 +42314,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0786" supported="no">
-		<description>Databox 07-86 (Ger)</description>
+		<description>Databox 07-86 (Germany)</description>
 		<year>1986</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42326,7 +42326,7 @@ Covertapes
 	</software>
 
 	<software name="dbox1086" supported="no">
-		<description>Databox 10-86 (Ger)</description>
+		<description>Databox 10-86 (Germany)</description>
 		<year>1986</year>
 		<publisher>CPC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42338,7 +42338,7 @@ Covertapes
 	</software>
 
 	<software name="dbox1186" supported="no">
-		<description>Databox 11-86 (Ger)</description>
+		<description>Databox 11-86 (Germany)</description>
 		<year>1986</year>
 		<publisher>CPC + PC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42350,7 +42350,7 @@ Covertapes
 	</software>
 
 	<software name="dbox1286" supported="no">
-		<description>Databox 12-86 (Ger)</description>
+		<description>Databox 12-86 (Germany)</description>
 		<year>1986</year>
 		<publisher>CPC + PC Schneider International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42362,7 +42362,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0688" supported="no">
-		<description>Databox 06-88 (Ger)</description>
+		<description>Databox 06-88 (Germany)</description>
 		<year>1988</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42374,7 +42374,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0788" supported="no">
-		<description>Databox 07-88 (Ger)</description>
+		<description>Databox 07-88 (Germany)</description>
 		<year>1988</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42386,7 +42386,7 @@ Covertapes
 	</software>
 
 	<software name="dbox1188" supported="no">
-		<description>Databox 11-88 (Ger)</description>
+		<description>Databox 11-88 (Germany)</description>
 		<year>1988</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42398,7 +42398,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0290" supported="no">
-		<description>Databox 02-90 (Ger)</description>
+		<description>Databox 02-90 (Germany)</description>
 		<year>1990</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42410,7 +42410,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0390" supported="no">
-		<description>Databox 03-90 (Ger)</description>
+		<description>Databox 03-90 (Germany)</description>
 		<year>1990</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42422,7 +42422,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0490" supported="no">
-		<description>Databox 04-90 (Ger)</description>
+		<description>Databox 04-90 (Germany)</description>
 		<year>1990</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42434,7 +42434,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0590" supported="no">
-		<description>Databox 05-90 (Ger)</description>
+		<description>Databox 05-90 (Germany)</description>
 		<year>1990</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42446,7 +42446,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0690" supported="no">
-		<description>Databox 06-07-90 (Ger)</description>
+		<description>Databox 06-07-90 (Germany)</description>
 		<year>1990</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42463,7 +42463,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0890" supported="no">
-		<description>Databox 08-09-90 (Ger)</description>
+		<description>Databox 08-09-90 (Germany)</description>
 		<year>1990</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42480,7 +42480,7 @@ Covertapes
 	</software>
 
 	<software name="dbox1090" supported="no">
-		<description>Databox 10-11-90 (Ger)</description>
+		<description>Databox 10-11-90 (Germany)</description>
 		<year>1990</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42492,7 +42492,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0291" supported="no">
-		<description>Databox 02-03-91 (Ger)</description>
+		<description>Databox 02-03-91 (Germany)</description>
 		<year>1991</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42509,7 +42509,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0491" supported="no">
-		<description>Databox 04-05-91 (Ger)</description>
+		<description>Databox 04-05-91 (Germany)</description>
 		<year>1991</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42526,7 +42526,7 @@ Covertapes
 	</software>
 
 	<software name="dbox0691" supported="no">
-		<description>Databox 06-07-91 (Ger)</description>
+		<description>Databox 06-07-91 (Germany)</description>
 		<year>1991</year>
 		<publisher>PC Amstrad International</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42543,7 +42543,7 @@ Covertapes
 	</software>
 
 	<software name="ebdok71" supported="no">
-		<description>EBDOK7 1 (Fra)</description>
+		<description>EBDOK7 1 (France)</description>
 		<year>1987</year>
 		<publisher>&lt;covertape&gt;</publisher>
 		<info name="magazine" value="Amstradebdo et PC" />
@@ -42561,7 +42561,7 @@ Covertapes
 	</software>
 
 	<software name="elmeja01" supported="no">
-		<description>El Mejor Amstrad 01 - Perdido en la Selva de los Guanaminos (Spa)</description>
+		<description>El Mejor Amstrad 01 - Perdido en la Selva de los Guanaminos (Spain)</description>
 		<year>1986</year>
 		<publisher>Sygran</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42573,7 +42573,7 @@ Covertapes
 	</software>
 
 	<software name="elmeja01a" cloneof="elmeja01" supported="no">
-		<description>El Mejor Amstrad 01 - Perdido en la Selva de los Guanaminos (Spa, 2 Sides)</description>
+		<description>El Mejor Amstrad 01 - Perdido en la Selva de los Guanaminos (Spain, 2 sides)</description>
 		<year>1986</year>
 		<publisher>Sygran</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42590,7 +42590,7 @@ Covertapes
 	</software>
 
 	<software name="elmeja03" supported="no">
-		<description>El Mejor Amstrad 03 - Axy (Spa)</description>
+		<description>El Mejor Amstrad 03 - Axy (Spain)</description>
 		<year>1987</year>
 		<publisher>Sygran</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42602,7 +42602,7 @@ Covertapes
 	</software>
 
 	<software name="juegams1a" cloneof="juegams1" supported="no">
-		<description>Juegue con Su Amstrad 01 - Kart 3000 (Spa, Alt)</description>
+		<description>Juegue con Su Amstrad 01 - Kart 3000 (Spain, alt)</description>
 		<year>1986</year>
 		<publisher>Sygran</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42614,7 +42614,7 @@ Covertapes
 	</software>
 
 	<software name="juegams1" supported="no">
-		<description>Juegue con Su Amstrad 01 - Kart 3000 (Spa)</description>
+		<description>Juegue con Su Amstrad 01 - Kart 3000 (Spain)</description>
 		<year>1986</year>
 		<publisher>Sygran</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42626,7 +42626,7 @@ Covertapes
 	</software>
 
 	<software name="juegams2" supported="no">
-		<description>Juegue con Su Amstrad 02 - West (Spa)</description>
+		<description>Juegue con Su Amstrad 02 - West (Spain)</description>
 		<year>1987</year>
 		<publisher>Sygran</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42638,7 +42638,7 @@ Covertapes
 	</software>
 
 	<software name="juegams3" supported="no">
-		<description>Juegue con Su Amstrad 03 - Max (Spa)</description>
+		<description>Juegue con Su Amstrad 03 - Max (Spain)</description>
 		<year>1987</year>
 		<publisher>Sygran</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42650,7 +42650,7 @@ Covertapes
 	</software>
 
 	<software name="juegams7" supported="no">
-		<description>Juegue con Su Amstrad 07 - Aton (Spa)</description>
+		<description>Juegue con Su Amstrad 07 - Aton (Spain)</description>
 		<year>1987</year>
 		<publisher>Sygran</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42662,7 +42662,7 @@ Covertapes
 	</software>
 
 	<software name="logstar4" supported="no">
-		<description>Log'Star 4 (Fra)</description>
+		<description>Log'Star 4 (France)</description>
 		<year>1989</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42679,7 +42679,7 @@ Covertapes
 	</software>
 
 	<software name="logstar5" supported="no">
-		<description>Log'Star 5 (Fra)</description>
+		<description>Log'Star 5 (France)</description>
 		<year>1990</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42696,7 +42696,7 @@ Covertapes
 	</software>
 
 	<software name="logstar6" supported="no">
-		<description>Log'Star 6 (Fra)</description>
+		<description>Log'Star 6 (France)</description>
 		<year>1990</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42713,7 +42713,7 @@ Covertapes
 	</software>
 
 	<software name="logist01" supported="no">
-		<description>Logistrad 01 (Fra)</description>
+		<description>Logistrad 01 (France)</description>
 		<year>1986</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42725,7 +42725,7 @@ Covertapes
 	</software>
 
 	<software name="logist02" supported="no">
-		<description>Logistrad 02 (Fra)</description>
+		<description>Logistrad 02 (France)</description>
 		<year>1986</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42737,7 +42737,7 @@ Covertapes
 	</software>
 
 	<software name="logist03" supported="no">
-		<description>Logistrad 03 (Fra)</description>
+		<description>Logistrad 03 (France)</description>
 		<year>1986</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42749,7 +42749,7 @@ Covertapes
 	</software>
 
 	<software name="logist04" supported="no">
-		<description>Logistrad 04 (Fra)</description>
+		<description>Logistrad 04 (France)</description>
 		<year>1986</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42761,7 +42761,7 @@ Covertapes
 	</software>
 
 	<software name="logist05" supported="no">
-		<description>Logistrad 05 (Fra)</description>
+		<description>Logistrad 05 (France)</description>
 		<year>1987</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42773,7 +42773,7 @@ Covertapes
 	</software>
 
 	<software name="logist06" supported="no">
-		<description>Logistrad 06 (Fra)</description>
+		<description>Logistrad 06 (France)</description>
 		<year>1987</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42785,7 +42785,7 @@ Covertapes
 	</software>
 
 	<software name="logist07" supported="no">
-		<description>Logistrad 07 (Fra)</description>
+		<description>Logistrad 07 (France)</description>
 		<year>1987</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42797,7 +42797,7 @@ Covertapes
 	</software>
 
 	<software name="logist08" supported="no">
-		<description>Logistrad 08 (Fra)</description>
+		<description>Logistrad 08 (France)</description>
 		<year>1987</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42809,7 +42809,7 @@ Covertapes
 	</software>
 
 	<software name="logist10" supported="no">
-		<description>Logistrad 10 (Fra)</description>
+		<description>Logistrad 10 (France)</description>
 		<year>1988</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42821,7 +42821,7 @@ Covertapes
 	</software>
 
 	<software name="logist11" supported="no">
-		<description>Logistrad 11 (Fra)</description>
+		<description>Logistrad 11 (France)</description>
 		<year>1988</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42838,7 +42838,7 @@ Covertapes
 	</software>
 
 	<software name="logist12" supported="no">
-		<description>Logistrad 12 (Fra)</description>
+		<description>Logistrad 12 (France)</description>
 		<year>1988</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42855,7 +42855,7 @@ Covertapes
 	</software>
 
 	<software name="nouvlog1" supported="no">
-		<description>Nouveau Logistrad 1 (Fra)</description>
+		<description>Nouveau Logistrad 1 (France)</description>
 		<year>1989</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42872,7 +42872,7 @@ Covertapes
 	</software>
 
 	<software name="nouvlog2" supported="no">
-		<description>Nouveau Logistrad 2 (Fra)</description>
+		<description>Nouveau Logistrad 2 (France)</description>
 		<year>1989</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42889,7 +42889,7 @@ Covertapes
 	</software>
 
 	<software name="nouvlog3" supported="no">
-		<description>Nouveau Logistrad 3 (Fra)</description>
+		<description>Nouveau Logistrad 3 (France)</description>
 		<year>1989</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42906,7 +42906,7 @@ Covertapes
 	</software>
 
 	<software name="progams1" supported="no">
-		<description>Programando Mi Amstrad 1 (Spa)</description>
+		<description>Programando Mi Amstrad 1 (Spain)</description>
 		<year>1986</year>
 		<publisher>Editorial Cometa</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42923,7 +42923,7 @@ Covertapes
 	</software>
 
 	<software name="progams2" supported="no">
-		<description>Programando Mi Amstrad 2 (Spa)</description>
+		<description>Programando Mi Amstrad 2 (Spain)</description>
 		<year>1986</year>
 		<publisher>Editorial Cometa</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42940,7 +42940,7 @@ Covertapes
 	</software>
 
 	<software name="progams3" supported="no">
-		<description>Programando Mi Amstrad 3 (Spa)</description>
+		<description>Programando Mi Amstrad 3 (Spain)</description>
 		<year>1986</year>
 		<publisher>Editorial Cometa</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42957,7 +42957,7 @@ Covertapes
 	</software>
 
 	<software name="runstar3" supported="no">
-		<description>Run'Star 3 (Fra)</description>
+		<description>Run'Star 3 (France)</description>
 		<year>1988</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42974,7 +42974,7 @@ Covertapes
 	</software>
 
 	<software name="runstar5" supported="no">
-		<description>Run'Star 5 (Fra)</description>
+		<description>Run'Star 5 (France)</description>
 		<year>1990</year>
 		<publisher>Logipresse</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -42991,7 +42991,7 @@ Covertapes
 	</software>
 
 	<software name="todoam01" supported="no">
-		<description>Todo Sobre el Amstrad 01 (Spa)</description>
+		<description>Todo Sobre el Amstrad 01 (Spain)</description>
 		<year>1985</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43008,7 +43008,7 @@ Covertapes
 	</software>
 
 	<software name="todoam02" supported="no">
-		<description>Todo Sobre el Amstrad 02 (Spa)</description>
+		<description>Todo Sobre el Amstrad 02 (Spain)</description>
 		<year>1985</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43025,7 +43025,7 @@ Covertapes
 	</software>
 
 	<software name="todoam03" supported="no">
-		<description>Todo Sobre el Amstrad 03 (Spa)</description>
+		<description>Todo Sobre el Amstrad 03 (Spain)</description>
 		<year>1985</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43042,7 +43042,7 @@ Covertapes
 	</software>
 
 	<software name="todoam04" supported="no">
-		<description>Todo Sobre el Amstrad 04 (Spa)</description>
+		<description>Todo Sobre el Amstrad 04 (Spain)</description>
 		<year>1985</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43059,7 +43059,7 @@ Covertapes
 	</software>
 
 	<software name="todoam05" supported="no">
-		<description>Todo Sobre el Amstrad 05 (Spa)</description>
+		<description>Todo Sobre el Amstrad 05 (Spain)</description>
 		<year>1985</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43076,7 +43076,7 @@ Covertapes
 	</software>
 
 	<software name="todoam06" supported="no">
-		<description>Todo Sobre el Amstrad 06 (Spa)</description>
+		<description>Todo Sobre el Amstrad 06 (Spain)</description>
 		<year>1985</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43093,7 +43093,7 @@ Covertapes
 	</software>
 
 	<software name="todoam07" supported="no">
-		<description>Todo Sobre el Amstrad 07 (Spa)</description>
+		<description>Todo Sobre el Amstrad 07 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43110,7 +43110,7 @@ Covertapes
 	</software>
 
 	<software name="todoam08" supported="no">
-		<description>Todo Sobre el Amstrad 08 (Spa)</description>
+		<description>Todo Sobre el Amstrad 08 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43127,7 +43127,7 @@ Covertapes
 	</software>
 
 	<software name="todoam09" supported="no">
-		<description>Todo Sobre el Amstrad 09 (Spa)</description>
+		<description>Todo Sobre el Amstrad 09 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43144,7 +43144,7 @@ Covertapes
 	</software>
 
 	<software name="todoam10" supported="no">
-		<description>Todo Sobre el Amstrad 10 (Spa)</description>
+		<description>Todo Sobre el Amstrad 10 (Spain)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43161,7 +43161,7 @@ Covertapes
 	</software>
 
 	<software name="todoam11" supported="no">
-		<description>Todo Sobre el Amstrad 11 - Boloncio en la Mansion de los Monsters (Spa)</description>
+		<description>Todo Sobre el Amstrad 11 - Boloncio en la Mansion de los Monsters (Spain)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43173,7 +43173,7 @@ Covertapes
 	</software>
 
 	<software name="todoam12" supported="no">
-		<description>Todo Sobre el Amstrad 12 - Infiltrado (Spa)</description>
+		<description>Todo Sobre el Amstrad 12 - Infiltrado (Spain)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43185,7 +43185,7 @@ Covertapes
 	</software>
 
 	<software name="todoam13" supported="no">
-		<description>Todo Sobre el Amstrad 13 - U-29 Submarine (Spa)</description>
+		<description>Todo Sobre el Amstrad 13 - U-29 Submarine (Spain)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43197,7 +43197,7 @@ Covertapes
 	</software>
 
 	<software name="todoam14" supported="no">
-		<description>Todo Sobre el Amstrad 14 - Bugs (Spa)</description>
+		<description>Todo Sobre el Amstrad 14 - Bugs (Spain)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43209,7 +43209,7 @@ Covertapes
 	</software>
 
 	<software name="todoam15" supported="no">
-		<description>Todo Sobre el Amstrad 15 - Laser (Spa)</description>
+		<description>Todo Sobre el Amstrad 15 - Laser (Spain)</description>
 		<year>1986</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43226,7 +43226,7 @@ Covertapes
 	</software>
 
 	<software name="todoam16" supported="no">
-		<description>Todo Sobre el Amstrad 16 - Air Attack (Spa)</description>
+		<description>Todo Sobre el Amstrad 16 - Air Attack (Spain)</description>
 		<year>1987</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43238,7 +43238,7 @@ Covertapes
 	</software>
 
 	<software name="todoam17" supported="no">
-		<description>Todo Sobre el Amstrad 17 - Galaxia (Spa)</description>
+		<description>Todo Sobre el Amstrad 17 - Galaxia (Spain)</description>
 		<year>1987</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43255,7 +43255,7 @@ Covertapes
 	</software>
 
 	<software name="todoam18" supported="no">
-		<description>Todo Sobre el Amstrad 18 - Pluton (Spa)</description>
+		<description>Todo Sobre el Amstrad 18 - Pluton (Spain)</description>
 		<year>1987</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43267,7 +43267,7 @@ Covertapes
 	</software>
 
 	<software name="todoam19" supported="no">
-		<description>Todo Sobre el Amstrad 19 - Air Cobra (Spa)</description>
+		<description>Todo Sobre el Amstrad 19 - Air Cobra (Spain)</description>
 		<year>1987</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43279,7 +43279,7 @@ Covertapes
 	</software>
 
 	<software name="todoam20" supported="no">
-		<description>Todo Sobre el Amstrad 20 - Jet (Spa)</description>
+		<description>Todo Sobre el Amstrad 20 - Jet (Spain)</description>
 		<year>1987</year>
 		<publisher>G.T.S. Editorial</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43291,7 +43291,7 @@ Covertapes
 	</software>
 
 	<software name="turbams1" supported="no">
-		<description>Turbo Amstrad 1 (Spa)</description>
+		<description>Turbo Amstrad 1 (Spain)</description>
 		<year>19??</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43303,7 +43303,7 @@ Covertapes
 	</software>
 
 	<software name="turbams7" supported="no">
-		<description>Turbo Amstrad 7 (Spa)</description>
+		<description>Turbo Amstrad 7 (Spain)</description>
 		<year>19??</year>
 		<publisher>G.E.A.S.A.</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43315,7 +43315,7 @@ Covertapes
 	</software>
 
 	<software name="vidams01" supported="no">
-		<description>VideoAmstrad 01 (Spa)</description>
+		<description>VideoAmstrad 01 (Spain)</description>
 		<year>1985</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43332,7 +43332,7 @@ Covertapes
 	</software>
 
 	<software name="vidams02" supported="no">
-		<description>VideoAmstrad 02 (Spa)</description>
+		<description>VideoAmstrad 02 (Spain)</description>
 		<year>1985</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43349,7 +43349,7 @@ Covertapes
 	</software>
 
 	<software name="vidams03" supported="no">
-		<description>VideoAmstrad 03 (Spa)</description>
+		<description>VideoAmstrad 03 (Spain)</description>
 		<year>1985</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43366,7 +43366,7 @@ Covertapes
 	</software>
 
 	<software name="vidams04" supported="no">
-		<description>VideoAmstrad 04 (Spa)</description>
+		<description>VideoAmstrad 04 (Spain)</description>
 		<year>1985</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43383,7 +43383,7 @@ Covertapes
 	</software>
 
 	<software name="vidams05" supported="no">
-		<description>VideoAmstrad 05 (Spa)</description>
+		<description>VideoAmstrad 05 (Spain)</description>
 		<year>1985</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43400,7 +43400,7 @@ Covertapes
 	</software>
 
 	<software name="vidams06" supported="no">
-		<description>VideoAmstrad 06 (Spa)</description>
+		<description>VideoAmstrad 06 (Spain)</description>
 		<year>1985</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43417,7 +43417,7 @@ Covertapes
 	</software>
 
 	<software name="vidams07" supported="no">
-		<description>VideoAmstrad 07 (Spa)</description>
+		<description>VideoAmstrad 07 (Spain)</description>
 		<year>1985</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43434,7 +43434,7 @@ Covertapes
 	</software>
 
 	<software name="vidams08" supported="no">
-		<description>VideoAmstrad 08 (Spa)</description>
+		<description>VideoAmstrad 08 (Spain)</description>
 		<year>1985</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43451,7 +43451,7 @@ Covertapes
 	</software>
 
 	<software name="vidams09" supported="no">
-		<description>VideoAmstrad 09 (Spa)</description>
+		<description>VideoAmstrad 09 (Spain)</description>
 		<year>1985</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43468,7 +43468,7 @@ Covertapes
 	</software>
 
 	<software name="vidams10" supported="no">
-		<description>VideoAmstrad 10 (Spa)</description>
+		<description>VideoAmstrad 10 (Spain)</description>
 		<year>1985</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43485,7 +43485,7 @@ Covertapes
 	</software>
 
 	<software name="vidams11" supported="no">
-		<description>VideoAmstrad 11 (Spa)</description>
+		<description>VideoAmstrad 11 (Spain)</description>
 		<year>1986</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43502,7 +43502,7 @@ Covertapes
 	</software>
 
 	<software name="vidams12" supported="no">
-		<description>VideoAmstrad 12 (Spa)</description>
+		<description>VideoAmstrad 12 (Spain)</description>
 		<year>1986</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43519,7 +43519,7 @@ Covertapes
 	</software>
 
 	<software name="vidams13" supported="no">
-		<description>VideoAmstrad 13 (Spa)</description>
+		<description>VideoAmstrad 13 (Spain)</description>
 		<year>1986</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43536,7 +43536,7 @@ Covertapes
 	</software>
 
 	<software name="vidams14" supported="no">
-		<description>VideoAmstrad 14 (Spa)</description>
+		<description>VideoAmstrad 14 (Spain)</description>
 		<year>1986</year>
 		<publisher>Software Editores</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43553,7 +43553,7 @@ Covertapes
 	</software>
 
 	<software name="yourcmp1" supported="no">
-		<description>Your Computer 1 (Spa)</description>
+		<description>Your Computer 1 (Spain)</description>
 		<year>1985</year>
 		<publisher>&lt;covertape&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43565,7 +43565,7 @@ Covertapes
 	</software>
 
 	<software name="yourcmp2" supported="no">
-		<description>Your Computer 2 (Spa)</description>
+		<description>Your Computer 2 (Spain)</description>
 		<year>1985</year>
 		<publisher>&lt;covertape&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43577,7 +43577,7 @@ Covertapes
 	</software>
 
 	<software name="yourcmp3" supported="no">
-		<description>Your Computer 3 (Spa)</description>
+		<description>Your Computer 3 (Spain)</description>
 		<year>1986</year>
 		<publisher>&lt;covertape&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43589,7 +43589,7 @@ Covertapes
 	</software>
 
 	<software name="yourcmp4" supported="no">
-		<description>Your Computer 4 (Spa)</description>
+		<description>Your Computer 4 (Spain)</description>
 		<year>1986</year>
 		<publisher>&lt;covertape&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43601,7 +43601,7 @@ Covertapes
 	</software>
 
 	<software name="yourcmp5" supported="no">
-		<description>Your Computer 5 (Spa)</description>
+		<description>Your Computer 5 (Spain)</description>
 		<year>1986</year>
 		<publisher>&lt;covertape&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43613,7 +43613,7 @@ Covertapes
 	</software>
 
 	<software name="yourcmp6" supported="no">
-		<description>Your Computer 6 (Spa)</description>
+		<description>Your Computer 6 (Spain)</description>
 		<year>1986</year>
 		<publisher>&lt;covertape&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43625,7 +43625,7 @@ Covertapes
 	</software>
 
 	<software name="yourcmp7" supported="no">
-		<description>Your Computer 7 (Spa)</description>
+		<description>Your Computer 7 (Spain)</description>
 		<year>1986</year>
 		<publisher>&lt;covertape&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -43646,7 +43646,7 @@ Covertapes
 
 
 	<software name="464nraid" supported="no">
-		<description>464 Night Raider (Spa)</description>
+		<description>464 Night Raider (Spain)</description>
 		<year>1984</year>
 		<publisher>&lt;type-in&gt;</publisher>
 		<info name="magazine" value="Your Computer Vol. 4 No. 10 (Oct 1984)" />
@@ -43659,7 +43659,7 @@ Covertapes
 	</software>
 
 	<software name="amstrads" supported="no">
-		<description>Amstrad Sound Editor (Spa)</description>
+		<description>Amstrad Sound Editor (Spain)</description>
 		<year>1984</year>
 		<publisher>&lt;type-in&gt;</publisher>
 		<info name="magazine" value="Your Computer Vol. 4 No. 10 (Oct 1984)" />
@@ -43698,7 +43698,7 @@ Covertapes
 	</software>
 
 	<software name="cedricjp" supported="no">
-		<description>Cedric y los Juguetes Perdidos (Spa)</description>
+		<description>Cedric y los Juguetes Perdidos (Spain)</description>
 		<year>1985</year>
 		<publisher>&lt;type-in&gt;</publisher>
 		<info name="magazine" value="MicroHobby Amstrad Semanal Ano 1 No. 8 (22-28 Oct 1985)" />
@@ -43711,7 +43711,7 @@ Covertapes
 	</software>
 
 	<software name="dallas" supported="no">
-		<description>Dallas (Fra)</description>
+		<description>Dallas (France)</description>
 		<year>1986</year>
 		<publisher>&lt;type-in&gt;</publisher>
 		<info name="magazine" value="Les Cahiers d'Amstrad Magazine No. 2 (Feb / Mar 1986)" />
@@ -43724,7 +43724,7 @@ Covertapes
 	</software>
 
 	<software name="eggblitz" supported="no">
-		<description>Egg Blitz (Spa)</description>
+		<description>Egg Blitz (Spain)</description>
 		<year>1985</year>
 		<publisher>&lt;type-in&gt;</publisher>
 		<info name="magazine" value="MicroHobby Amstrad Semanal Ano 1 No. 2 (10-16 Sep 1985)" />
@@ -43750,7 +43750,7 @@ Covertapes
 	</software>
 
 	<software name="landscap" supported="no">
-		<description>The Landscape Creator Demo (Spa)</description>
+		<description>The Landscape Creator Demo (Spain)</description>
 		<year>1985</year>
 		<publisher>&lt;type-in&gt;</publisher>
 		<info name="magazine" value="Your Computer Vol. 5 No. 5 (May 1985) and No. 6 (June 1985)" />
@@ -43763,7 +43763,7 @@ Covertapes
 	</software>
 
 	<software name="musicsyn" supported="no">
-		<description>Music Synthetiser and Sound Effects Plotter (Spa)</description>
+		<description>Music Synthetiser and Sound Effects Plotter (Spain)</description>
 		<year>1984</year>
 		<publisher>&lt;type-in&gt;</publisher>
 		<info name="magazine" value="Your Computer Vol. 4 No. 12 (Dec 1984)" />
@@ -43789,7 +43789,7 @@ Covertapes
 	</software>
 
 	<software name="roulette" supported="no">
-		<description>Roulette (Spa)</description>
+		<description>Roulette (Spain)</description>
 		<year>1984</year>
 		<publisher>&lt;type-in&gt;</publisher>
 		<info name="magazine" value="Your Computer Vol. 4 No. 11 (Nov 1984)" />
@@ -43837,7 +43837,7 @@ Covertapes
 	</software>
 
 	<software name="arcos" supported="no">
-		<description>Arcos (Spa)</description>
+		<description>Arcos (Spain)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Kabuto Factory" />
@@ -43850,7 +43850,7 @@ Covertapes
 	</software>
 
 	<software name="auxilaer" supported="no">
-		<description>Auxilio Aereo (Spa)</description>
+		<description>Auxilio Aereo (Spain)</description>
 		<year>2014</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Byterealms" />
@@ -43863,7 +43863,7 @@ Covertapes
 	</software>
 
 	<software name="balonacyd" cloneof="balonacy" supported="no">
-		<description>Balloonacy (UK, Demo)</description>
+		<description>Balloonacy (UK, demo)</description>
 		<year>2007</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Cronosoft" />
@@ -44024,7 +44024,7 @@ Covertapes
 	</software>
 
 	<software name="hunteror" supported="no">
-		<description>Hunter or Hunted (Spa)</description>
+		<description>Hunter or Hunted (Spain)</description>
 		<year>2014</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Byterealms" />
@@ -44050,7 +44050,7 @@ Covertapes
 	</software>
 
 	<software name="ilogical" supported="no">
-		<description>ilogic All (Spa)</description>
+		<description>ilogic All (Spain)</description>
 		<year>2009</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="ESP Soft + CEZ Games Studio" />
@@ -44068,7 +44068,7 @@ Covertapes
 	</software>
 
 	<software name="imagicol" supported="no">
-		<description>Imaginario Colectivo (Spa, Slow Version)</description>
+		<description>Imaginario Colectivo (Spain, slow version)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="ESP Soft" />
@@ -44081,7 +44081,7 @@ Covertapes
 	</software>
 
 	<software name="imagicolf" cloneof="imagicol" supported="no">
-		<description>Imaginario Colectivo (Spa, Fast Version)</description>
+		<description>Imaginario Colectivo (Spain, fast version)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="ESP Soft" />
@@ -44094,7 +44094,7 @@ Covertapes
 	</software>
 
 	<software name="imagicolt" cloneof="imagicol" supported="no">
-		<description>Imaginario Colectivo (Spa, Turbo Version)</description>
+		<description>Imaginario Colectivo (Spain, turbo version)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="ESP Soft" />
@@ -44107,7 +44107,7 @@ Covertapes
 	</software>
 
 	<software name="zombimona" cloneof="zombimon" supported="no">
-		<description>Invasion of the Zombie Monsters (Spa)</description>
+		<description>Invasion of the Zombie Monsters (Spain)</description>
 		<year>2013</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Relevo Videogames" />
@@ -44120,7 +44120,7 @@ Covertapes
 	</software>
 
 	<software name="zombimon" supported="no">
-		<description>Invasion of the Zombie Monsters (Spa, v1.2)</description>
+		<description>Invasion of the Zombie Monsters (Spain, v1.2)</description>
 		<year>2013</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Relevo Videogames" />
@@ -44146,7 +44146,7 @@ Covertapes
 	</software>
 
 	<software name="jetpac" supported="no">
-		<description>Jetpac (UK, v1.1, Converted from ZX)</description>
+		<description>Jetpac (UK, v1.1, converted from ZX Spectrum)</description>
 		<year>2014</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="40CRISIS" />
@@ -44159,7 +44159,7 @@ Covertapes
 	</software>
 
 	<software name="jetpaca" cloneof="jetpac" supported="no">
-		<description>Jetpac (UK, Converted from ZX)</description>
+		<description>Jetpac (UK, converted from ZX Spectrum)</description>
 		<year>2014</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="40CRISIS" />
@@ -44185,7 +44185,7 @@ Covertapes
 	</software>
 
 	<software name="justin" supported="no">
-		<description>Justin (Euro?)</description>
+		<description>Justin (Europe?)</description>
 		<year>2005</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="CNGSOFT" />
@@ -44198,7 +44198,7 @@ Covertapes
 	</software>
 
 	<software name="knigtdem" supported="no">
-		<description>Knights &amp; Demons (Spa)</description>
+		<description>Knights &amp; Demons (Spain)</description>
 		<year>2013</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Kabuto Factory" />
@@ -44211,7 +44211,7 @@ Covertapes
 	</software>
 
 	<software name="kotorshd" supported="no">
-		<description>Kotoran's Shadow (Spa)</description>
+		<description>Kotoran's Shadow (Spain)</description>
 		<year>2014</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Byterealms" />
@@ -44237,7 +44237,7 @@ Covertapes
 	</software>
 
 	<software name="cpcerdo" supported="no">
-		<description>The Legend of CPCerdo (Spa)</description>
+		<description>The Legend of CPCerdo (Spain)</description>
 		<year>2014</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Byterealms" />
@@ -44250,7 +44250,7 @@ Covertapes
 	</software>
 
 	<software name="manskal2" supported="no">
-		<description>Mansion Kali II (Spa)</description>
+		<description>Mansion Kali II (Spain)</description>
 		<year>2014</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Miguel Sky" />
@@ -44302,7 +44302,7 @@ Covertapes
 	</software>
 
 	<software name="orcdungn" supported="no">
-		<description>Orc's Dungeon (Spa)</description>
+		<description>Orc's Dungeon (Spain)</description>
 		<year>2014</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Byterealms" />
@@ -44328,7 +44328,7 @@ Covertapes
 	</software>
 
 	<software name="prisoners" cloneof="prisoner" supported="no">
-		<description>El Prisionero (Spa)</description>
+		<description>El Prisionero (Spain)</description>
 		<year>2013</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Miguel Sky" />
@@ -44367,7 +44367,7 @@ Covertapes
 	</software>
 
 	<software name="sardina" supported="no">
-		<description>Sardina Forever (Spa)</description>
+		<description>Sardina Forever (Spain)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="GenSoft" />
@@ -44406,7 +44406,7 @@ Covertapes
 	</software>
 
 	<software name="strandedd" cloneof="stranded" supported="no">
-		<description>Stranded (UK, Demo)</description>
+		<description>Stranded (UK, demo)</description>
 		<year>2005</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Cronosoft" />
@@ -44445,7 +44445,7 @@ Covertapes
 	</software>
 
 	<software name="sudokud" cloneof="sudoku" supported="no">
-		<description>Sudoku (UK, Demo)</description>
+		<description>Sudoku (UK, demo)</description>
 		<year>2008</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Cronosoft" />
@@ -44471,7 +44471,7 @@ Covertapes
 	</software>
 
 	<software name="sugarlumsl" cloneof="sugarlum" supported="no">
-		<description>Sugarlumps Demo (UK, Slow Loader)</description>
+		<description>Sugarlumps Demo (UK, slow loader)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Doz" />
@@ -44484,7 +44484,7 @@ Covertapes
 	</software>
 
 	<software name="sugarlum" supported="no">
-		<description>Sugarlumps Demo (UK, Fast Loader)</description>
+		<description>Sugarlumps Demo (UK, fast loader)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Doz" />
@@ -44497,7 +44497,7 @@ Covertapes
 	</software>
 
 	<software name="srrr" supported="no">
-		<description>Super Retro Robot Rampage (Spa)</description>
+		<description>Super Retro Robot Rampage (Spain)</description>
 		<year>2014</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Byterealms" />
@@ -44510,7 +44510,7 @@ Covertapes
 	</software>
 
 	<software name="teonovols" cloneof="teonovol" supported="no">
-		<description>Teodoro No Sabe Volar (Spa)</description>
+		<description>Teodoro No Sabe Volar (Spain)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Retroworks" />
@@ -44536,7 +44536,7 @@ Covertapes
 	</software>
 
 	<software name="totemsco" supported="no">
-		<description>Totems (Spa)</description>
+		<description>Totems (Spain)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="ESP Soft" />
@@ -44549,7 +44549,7 @@ Covertapes
 	</software>
 
 	<software name="vctierex" supported="no">
-		<description>Viaje al Centro de la Tierra - Version Extendida (Spa)</description>
+		<description>Viaje al Centro de la Tierra - Version Extendida (Spain)</description>
 		<year>2012</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="CNGSOFT" />
@@ -44562,7 +44562,7 @@ Covertapes
 	</software>
 
 	<software name="voidhawk" supported="no">
-		<description>Void Hawk (Spa)</description>
+		<description>Void Hawk (Spain)</description>
 		<year>2014</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="developer" value="Byterealms" />
@@ -44586,7 +44586,7 @@ Covertapes
 
 
 	<software name="amdraw1s" cloneof="amdraw1" supported="no">
-		<description>Amdraw I (Spa?)</description>
+		<description>Amdraw I (Spain?)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44598,7 +44598,7 @@ Covertapes
 	</software>
 
 	<software name="amscannr" supported="no">
-		<description>Amscanner (Spa)</description>
+		<description>Amscanner (Spain)</description>
 		<year>1985</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44610,7 +44610,7 @@ Covertapes
 	</software>
 
 	<software name="assmon1" supported="no">
-		<description>Assmon1 - Assembler/Editor fur KC compact (Ger)</description>
+		<description>Assmon1 - Assembler/Editor fur KC compact (Germany)</description>
 		<year>1989</year>
 		<publisher>Veb Mikroelectronik</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44622,7 +44622,7 @@ Covertapes
 	</software>
 
 	<software name="bardtalea" cloneof="bardtale" supported="no">
-		<description>The Bard's Tale (UK, 2 Tapes)</description>
+		<description>The Bard's Tale (UK, 2 tapes)</description>
 		<year>1988</year>
 		<publisher>Electronics Arts</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44650,7 +44650,7 @@ Covertapes
 
 	<!-- This dump was removed by CPC-Power DB... why? -->
 	<software name="blodbros" supported="no">
-		<description>Blood Brothers (Spa?)</description>
+		<description>Blood Brothers (Spain?)</description>
 		<year>1988</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44662,7 +44662,7 @@ Covertapes
 	</software>
 
 	<software name="bombjacka" cloneof="bombjack" supported="no">
-		<description>Bomb Jack (Alt)</description>
+		<description>Bomb Jack (alt)</description>
 		<year>1986</year>
 		<publisher>Elite Systems</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44674,7 +44674,7 @@ Covertapes
 	</software>
 
 	<software name="copion" supported="no">
-		<description>Copion (Spa)</description>
+		<description>Copion (Spain)</description>
 		<year>1985</year>
 		<publisher>Iron Valley Soft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44698,7 +44698,7 @@ Covertapes
 	</software>
 
 	<software name="easiawa" cloneof="easiaw" supported="no">
-		<description>Easi-Amsword (UK, Alt)</description>
+		<description>Easi-Amsword (UK, alt)</description>
 		<year>1984</year>
 		<publisher>Amsoft</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44728,7 +44728,7 @@ Covertapes
 	</software>
 
 	<software name="grafik1" supported="no">
-		<description>Grafik1 (Ger, BASIC 1.1)</description>
+		<description>Grafik1 (Germany, BASIC 1.1)</description>
 		<year>198?</year>
 		<publisher>Veb Mikroelectronik</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44740,7 +44740,7 @@ Covertapes
 	</software>
 
 	<software name="heroqstf" cloneof="heroqst" supported="no">
-		<description>Hero Quest (Fra, 64K)</description>
+		<description>Hero Quest (France, 64K)</description>
 		<year>1991</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44783,7 +44783,7 @@ Covertapes
 
 	<!-- This dump was removed by CPC-Power DB... why? -->
 	<software name="hkms" cloneof="hkm" supported="no">
-		<description>Human Killing Machine (Spa?)</description>
+		<description>Human Killing Machine (Spain?)</description>
 		<year>1989</year>
 		<publisher>Erbe Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44813,7 +44813,7 @@ Covertapes
 	</software>
 
 	<software name="kcpascal" supported="no">
-		<description>KC Pascal v1.0 (Ger)</description>
+		<description>KC Pascal v1.0 (Germany)</description>
 		<year>19??</year>
 		<publisher>Veb Mikroelectronik</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44843,7 +44843,7 @@ Covertapes
 
 	<!-- This dump was removed by CPC-Power DB... why? -->
 	<software name="leviathns" cloneof="leviathn" supported="no">
-		<description>Leviathan (Spa?)</description>
+		<description>Leviathan (Spain?)</description>
 		<year>1987</year>
 		<publisher>English Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44930,7 +44930,7 @@ Covertapes
 	</software>
 
 	<software name="qstgegga" cloneof="qstgegg" supported="no">
-		<description>The Quest for the Golden Eggcup (UK, Alt)</description>
+		<description>The Quest for the Golden Eggcup (UK, alt)</description>
 		<year>1988</year>
 		<publisher>Mastertronic</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44954,7 +44954,7 @@ Covertapes
 	</software>
 
 	<software name="rebelstra" cloneof="rebelstr" supported="no">
-		<description>Rebelstar (UK, Alt)</description>
+		<description>Rebelstar (UK, alt)</description>
 		<year>1986</year>
 		<publisher>Firebird</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44966,7 +44966,7 @@ Covertapes
 	</software>
 
 	<software name="savages" cloneof="savage" supported="no">
-		<description>Savage (Spa)</description>
+		<description>Savage (Spain)</description>
 		<year>1988</year>
 		<publisher>MCM</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -44994,7 +44994,7 @@ Covertapes
 
 	<!-- This dump was removed by CPC-Power DB... why? -->
 	<software name="shangkar" supported="no">
-		<description>Shanghai Karate (Spa?)</description>
+		<description>Shanghai Karate (Spain?)</description>
 		<year>1988</year>
 		<publisher>Players</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -45006,7 +45006,7 @@ Covertapes
 	</software>
 
 	<software name="spielbox" supported="no">
-		<description>Spielbox 1 (Ger, BASIC 1.1)</description>
+		<description>Spielbox 1 (Germany, BASIC 1.1)</description>
 		<year>19??</year>
 		<publisher>Veb Mikroelectronik</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -45018,7 +45018,7 @@ Covertapes
 	</software>
 
 	<software name="spielbox01" cloneof="spielbox" supported="no">
-		<description>Spielbox 2 (Ger, BASIC 1.1)</description>
+		<description>Spielbox 2 (Germany, BASIC 1.1)</description>
 		<year>19??</year>
 		<publisher>Veb Mikroelectronik</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -45030,7 +45030,7 @@ Covertapes
 	</software>
 
 	<software name="spielbox02" cloneof="spielbox" supported="no">
-		<description>Spielbox 5 (Ger, BASIC 1.1)</description>
+		<description>Spielbox 5 (Germany, BASIC 1.1)</description>
 		<year>19??</year>
 		<publisher>Veb Mikroelectronik</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />
@@ -45060,7 +45060,7 @@ Covertapes
 	</software>
 
 	<software name="wizballa" cloneof="wizball" supported="no">
-		<description>Wizball (UK, Alt)</description>
+		<description>Wizball (UK, alt)</description>
 		<year>1987</year>
 		<publisher>Ocean Software</publisher>
 		<info name="usage" value="Load with |TAPE and then RUN&quot;&quot;" />


### PR DESCRIPTION
- Replaced countries' abbreviation by their full name.
- Lowercase on descriptive words (like: "Alt", "Demo", "Side", "Incomplete Dump", etc...)