### PR TITLE
video/epic12.cpp: Fix clipping of CV1K games

### DIFF
--- a/src/devices/video/epic12.h
+++ b/src/devices/video/epic12.h
@@ -34,8 +34,8 @@ public:
 
 	u16* m_ram16;
 	u32 m_gfx_addr;
-	u32 m_gfx_scroll_0_x, m_gfx_scroll_0_y;
-	u32 m_gfx_scroll_1_x, m_gfx_scroll_1_y;
+	u32 m_gfx_scroll_x, m_gfx_scroll_y;
+	u32 m_gfx_clip_x, m_gfx_clip_y;
 
 	int m_gfx_size;
 	std::unique_ptr<bitmap_rgb32> m_bitmaps;
@@ -50,8 +50,7 @@ public:
 	u32 blitter_r(offs_t offset, u32 mem_mask = ~0);
 	void blitter_w(address_space &space, offs_t offset, u32 data, u32 mem_mask = ~0);
 	u32 m_gfx_addr_shadowcopy;
-	u32 m_gfx_scroll_0_x_shadowcopy, m_gfx_scroll_0_y_shadowcopy;
-	u32 m_gfx_scroll_1_x_shadowcopy, m_gfx_scroll_1_y_shadowcopy;
+	u32 m_gfx_clip_x_shadowcopy, m_gfx_clip_y_shadowcopy;
 	std::unique_ptr<u16[]> m_ram16_copy;
 	inline void gfx_upload_shadow_copy(address_space &space, offs_t *addr);
 	inline void gfx_create_shadow_copy(address_space &space);

--- a/src/mame/misc/cv1k.cpp
+++ b/src/mame/misc/cv1k.cpp
@@ -176,7 +176,6 @@ Touchscreen
 
 Remaining Video issues
  - mmpork startup screen flicker - the FOR USE IN JAPAN screen doesn't appear on the real PCB until after the graphics are fully loaded, it still displays 'please wait' until that point.
- - is the use of the 'scroll' registers 100% correct? (related to above?)
  - Sometimes the 'sprites' in mushisam lag by a frame vs the 'backgrounds' is this a timing problem, does the real game do it?
  - End of Blit should send IRQ1. (one game has a valid irq routine that looks like it was used for profiling, but nothing depends on it)
 


### PR DESCRIPTION
Change clipping for CV1K games to draw 32 pixels surrounding the visible area.

This can be easily seen in Muchi Muchi Pork, which has a VRAM viewer in Special mode (Object Test), which will show 32 px drawn around the visible areas of framebuffers.
See: https://www.arcade-projects.com/threads/research-into-cv1000-blitter-performance-and-behavior.24385/#post-364121

For most gamers, this wont really matter at all... except for in Muchi Muchi Pork, where changing this actually fixes a bug for Rafute (yellow ship).

When Bombing with Rafute (not the other two character), the screen background will go wavy in a sine-like pattern. Currently in mame, the top of screen will show black pixels when this happens.

Like this: http://img.buffis.com/mmppatch/without_patch.png

With this fix for clipping, the background will instead be visible correctly.
Like this: http://img.buffis.com/mmppatch/with_patch.png

Theres still some potential for artifacts though, both at top and on right side of screen... but this happens on PCB too.

Mame with patch, top artifact: http://img.buffis.com/mmppatch/mame_top_artifacts.png
Mame with patch, right artifact: http://img.buffis.com/mmppatch/mame_top_artifacts.png

PCB top artifact: http://img.buffis.com/mmppatch/pcb_top.jpg and http://img.buffis.com/mmppatch/pcb_top2.jpg
PCB right artifact: http://img.buffis.com/mmppatch/pcb_right.png

PCB footage of some bombs for reference: http://img.buffis.com/mmppatch/pcb_footage.mp4


Also renamed the "scroll registers" to have it more clear which one of these are actually used as a "scroll register" (or rather offset for drawing), and which one is strictly used for clipping.