### PR TITLE
sound/mp3_audio: Implement save states for MP3 decoder

### DIFF
--- a/src/devices/sound/lc82310.cpp
+++ b/src/devices/sound/lc82310.cpp
@@ -35,9 +35,13 @@ void lc82310_device::device_start()
 	save_item(NAME(m_ckctl));
 	save_item(NAME(m_dictl));
 	save_item(NAME(m_doctl));
+	save_item(NAME(m_ctl_state));
+	save_item(NAME(m_ctl_cmd));
 	save_item(NAME(m_ctl_bits));
 	save_item(NAME(m_ctl_byte));
 	save_item(NAME(m_ctl_out_byte));
+
+	mp3dec->register_save(*this);
 }
 
 void lc82310_device::device_reset()

--- a/src/devices/sound/mas3507d.cpp
+++ b/src/devices/sound/mas3507d.cpp
@@ -87,6 +87,8 @@ void mas3507d_device::device_start()
 	save_item(NAME(playback_status));
 
 	save_item(NAME(frame_channels));
+
+	mp3dec->register_save(*this);
 }
 
 void mas3507d_device::device_reset()

--- a/src/devices/sound/mp3_audio.cpp
+++ b/src/devices/sound/mp3_audio.cpp
@@ -29,6 +29,17 @@ mp3_audio::~mp3_audio()
 {
 }
 
+void mp3_audio::register_save(device_t &host)
+{
+	host.save_item(NAME(m_found_stream));
+	host.save_item(NAME(dec->header));
+	host.save_item(NAME(dec->reserv_buf));
+	host.save_item(NAME(dec->mdct_overlap));
+	host.save_item(NAME(dec->qmf_state));
+	host.save_item(NAME(dec->reserv));
+	host.save_item(NAME(dec->free_format_bytes));
+}
+
 void mp3_audio::clear()
 {
 	mp3dec_init(dec.get());

--- a/src/devices/sound/mp3_audio.h
+++ b/src/devices/sound/mp3_audio.h
@@ -19,6 +19,8 @@ public:
 	mp3_audio(const void *base);
 	~mp3_audio();
 
+	void register_save(device_t &host);
+
 	bool decode_buffer(int &pos, int limit, short *output, int &output_samples, int &sample_rate, int &channels);
 
 	void clear();


### PR DESCRIPTION
Follow up to https://github.com/mamedev/mame/pull/11210 based on a comment from cuavas.

Tested save states in squizchs (Namco System 10) and ddrmax (Konami System 573) to make sure the known devices that use the MP3 decoder are working now. For ddrmax I tested both in the game menus where it plays an MP3 for BGM without anything special, and also in-game during a song to make sure everything looked fine with the notes as they scrolled. 

Also missed two save items in LC82310 so I added those in as well.