### PR TITLE
formats/fs_coco_rsdos.cpp: Fix directory entry count

### DIFF
--- a/src/lib/formats/fs_coco_rsdos.cpp
+++ b/src/lib/formats/fs_coco_rsdos.cpp
@@ -45,7 +45,7 @@ public:
 		{
 			rsdos_dirent    m_dirent;
 			u8              m_unused[16];
-		} m_entries[4];
+		} m_entries[8];
 	};
 
 	class granule_iterator


### PR DESCRIPTION
There are 8 entries per sector, not 4.