### PR TITLE
BGFX and D3D9 renderer fixes for issues #11104, #11106, and #11107

### DIFF
--- a/bgfx/chains/hlsl.json
+++ b/bgfx/chains/hlsl.json
@@ -93,7 +93,6 @@
 		{ "type": "float", "name": "scanline_bright_scale",  "text": "Scanline Brightness Scale",  "default": 2.00, "max": 4.00, "min": 0.0, "step": 0.01, "format": "%1.2f", "screen": "crt" },
 		{ "type": "float", "name": "scanline_bright_offset", "text": "Scanline Brightness Offset", "default": 1.50, "max": 4.00, "min": 0.0, "step": 0.01, "format": "%1.2f", "screen": "crt" },
 		{ "type": "float", "name": "scanline_jitter_amount", "text": "Scanline Jitter Amount",     "default": 0.00, "max": 4.00, "min": 0.0, "step": 0.01, "format": "%1.2f", "screen": "crt" },
-		{ "type": "float", "name": "scanline_variation",     "text": "Scanline Variation",         "default": 1.00, "max": 4.00, "min": 0.0, "step": 0.01, "format": "%1.2f", "screen": "crt" },
 
 		{ "type": "intenum", "name": "shadow_tile_mode", "text": "Shadow Mask Tile Mode",    "default":  0,               "max": 1,                "min": 0,                "step": 1,     "format": "%s",    "screen": "any", "strings": [ "Screen", "Source" ] },
 		{ "type": "float",   "name": "shadow_alpha",     "text": "Shadow Mask Amount",       "default": 0.50,             "max": 1.00,             "min": 0.00,             "step": 0.01,  "format": "%1.2f", "screen": "crt" },

--- a/src/osd/modules/render/d3d/d3dhlsl.cpp
+++ b/src/osd/modules/render/d3d/d3dhlsl.cpp
@@ -1570,12 +1570,16 @@ void shaders::render_quad(poly_info *poly, int vertnum)
 		//next_index = phosphor_pass(rt, next_index, poly, vertnum);
 
 		// create bloom textures
-		int old_index = next_index;
-		next_index = post_pass(rt, next_index, poly, vertnum, true);
-		next_index = downsample_pass(rt, next_index, poly, vertnum);
+		bool bloom_enabled = (options->bloom_scale > 0.0f);
+		if (bloom_enabled)
+		{
+			int old_index = next_index;
+			next_index = post_pass(rt, next_index, poly, vertnum, true);
+			next_index = downsample_pass(rt, next_index, poly, vertnum);
+			next_index = old_index;
+		}
 
-		// apply bloom textures
-		next_index = old_index;
+		// apply bloom textures (if enabled) and other post effects
 		next_index = post_pass(rt, next_index, poly, vertnum, false);
 		next_index = bloom_pass(rt, next_index, poly, vertnum);
 		next_index = phosphor_pass(rt, next_index, poly, vertnum);

--- a/src/osd/modules/render/drawd3d.cpp
+++ b/src/osd/modules/render/drawd3d.cpp
@@ -755,6 +755,9 @@ void renderer_d3d9::begin_frame()
 
 	if (m_shaders->enabled())
 		m_shaders->begin_frame(window().m_primlist);
+
+	// set an initial default texture
+	set_texture(nullptr);
 }
 
 void renderer_d3d9::process_primitives()


### PR DESCRIPTION
Fix for #11107: Simply removed the erroneously copy/pasted line.

Fix for #11106: Avoiding redundant state-set calls was going awry. We now ensure that the first `set_texture` call of a scene always succeeds by clearing the cached texture pointer at frame start.

Fix for #11104: Calling `post_pass` and `downsample_pass` to generate bloom targets when bloom is disabled was causing issues when applying the post/shadowmask pass. Avoid calling them entirely if bloom is disabled, since the downsampled targets are not used anyway.