### PR TITLE
gba.xml: Added 21 prototypes.

### DIFF
--- a/hash/gba.xml
+++ b/hash/gba.xml
@@ -698,7 +698,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="aerope" cloneof="aero">
-		<!-- Dumped by LongwoodGeek, released by Forest of Illusion -->
 		<description>Aero the Acro-Bat - Rascal Rival Revenge (Europe, prototype earlier)</description>
 		<year>2001?</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -777,7 +776,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="agecart1">
-		<!-- Dumped by SmellyGhost, released by Forest of Illusion -->
 		<description>AGB Aging Cartridge (World, version 1.0)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
@@ -811,7 +809,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="agecart9">
-		<!-- Dumped by Suicune41, released by Forest of Illusion -->
 		<description>AGB Aging Cartridge (World, version 9.0)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
@@ -3074,7 +3071,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="command2">
-		<!-- Dumped by DillyDylan, released by Forest of Illusion -->
 		<description>Commandos 2 (USA, prototype, 20021128)</description>
 		<year>2002</year>
 		<publisher>Toyonaka Studios</publisher>
@@ -4912,7 +4908,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="chokkanp" cloneof="polarium">
-		<!-- Dumped by xprism, released by Forest of Illusion -->
 		<description>Chokkan Hitofude Advance (Japan, prototype)</description>
 		<year>20??</year>
 		<publisher>Nintendo</publisher>
@@ -6814,7 +6809,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="darkeden">
-		<!-- Dumped by Ian Dunlop, released by Forest of Illusion -->
 		<description>Dark Eden (demo)</description>
 		<year>2002</year>
 		<publisher>Rival Dreams</publisher>
@@ -7117,7 +7111,6 @@ license:CC0-1.0
 
 	<!-- Pitch demo for a GBA port. -->
 	<software name="demonscrest">
-		<!-- Ian Dunlop, released by Forest of Illusion in original and a patched version to get past the title screen. -->
 		<!-- The patch doesn't seem to be needed in MAME, but on other emulators, you have to patch 0x122384 with 0xc046c046. -->
 		<description>Demon's Crest (prototype)</description>
 		<year>????</year>
@@ -15368,19 +15361,6 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="holybibl">
-		<!-- Dumped by Gonz, released by Forest of Illusion -->
-		<description>The Holy Bible - World English Bible (USA, prototype)</description>
-		<year>2006</year>
-		<publisher>Crave Entertainment</publisher>
-		<part name="cart" interface="gba_cart">
-			<feature name="slot" value="gba_eeprom_64k" />
-			<dataarea name="rom" size="33554432">
-				<rom name="holy bible, the - world english bible (usa) (prototype).gba" size="33554432" crc="b8fda4f5" sha1="e2dd02ded617f7002ca887639cf91b9cac8cd745"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="homerang">
 		<description>Disney's Home on the Range (Europe)</description>
 		<year>2004</year>
@@ -17677,9 +17657,8 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<!-- Game crashes with Fatal error: 0800b2a4: Gb Undefined Thumb instruction: b2a9 error -->
 	<software name="kofex2up" cloneof="kofex2" supported="no">
-		<!-- Dumped by March42, released by Forest of Illusion -->
-		<!-- Game crashes with Fatal error: 0800b2a4: Gb Undefined Thumb instruction: b2a9 error -->
 		<description>The King of Fighters EX2 - Howling Blood (USA, prototype, 20030403)</description>
 		<year>2003</year>
 		<publisher>Marvelous Entertainment</publisher>
@@ -20418,7 +20397,6 @@ license:CC0-1.0
 
 		<!-- This is a later build of the game than the retail release, with a different title screen and an options screen; does not say "Licensed by Nintendo" on boot. -->
 	<software name="manicminl">
-		<!-- Released by March42 and Forest of Illusion -->
 		<description>Manic Miner (Europe, 20030307)</description>
 		<year>2003</year>
 		<publisher>Jester Interactive</publisher>
@@ -20679,7 +20657,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="mariokrtxxl">
-		<!-- Released by Forest of Illusion -->
 		<description>Mario Kart XXL (demo, 20040417)</description>
 		<year>2001</year>
 		<publisher>Denaris Entertainment Software</publisher>
@@ -25378,7 +25355,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-		<!-- Game does not work in MAME. -->
+	<!-- Game does not work in MAME, it freezes on the bios screen. -->
 	<software name="paradroid" supported="no">
 		<!-- Released by March42 and Forest of Illusion -->
 		<description>Paradroid (Europe, prototype, 20030320)</description>
@@ -27967,7 +27944,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="quake" supported="no">
-		<!-- Dumped by Randy Linden, released by Forest of Illusion -->
 		<!-- Game crashes immediately after loading, inputs become unresponsive. -->
 		<description>Quake (demo)</description>
 		<year>2003</year>
@@ -28003,7 +27979,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="r3ddemo">
-		<!-- Released by Forest of Illusion -->
 		<description>R3D-Demo V1 (Europe, demo)</description>
 		<year>2004</year>
 		<publisher>Denaris Entertainment Software</publisher>
@@ -28091,7 +28066,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="racinggaup">
-		<!-- Dumped by XBrav, released by Forest of Illusion -->
 		<description>Racing Gears Advance (USA, prototype, 20030922)</description>
 		<year>2003</year>
 		<publisher>Pier 3 Entertainment</publisher>
@@ -29989,7 +29963,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="seaboy">
-		<!-- Dumped by Ian Dunlop, released by Forest of Illusion -->
 		<description>Sea Boy (demo)</description>
 		<year>2003</year>
 		<publisher>Rival Dreams</publisher>
@@ -33148,7 +33121,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="swtrilgyup" cloneof="swtrilgy" supported="no">
-		<!-- Dumped by Rezrospect, released by Forest of Illusion -->
 		<description>Star Wars Trilogy - Apprentice of the Force (USA, prototype)</description>
 		<year>2004</year>
 		<publisher>Ubisoft</publisher>
@@ -37050,7 +37022,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="ultmusclp">
-		<!-- Dumped by Zach Lambert, released by Forest of Illusion -->
 		<description>Ultimate Muscle - The Kinnikuman Legacy - The Path of the Superhero (USA, prototype, 20030429)</description>
 		<year>2003</year>
 		<publisher>Bandai</publisher>
@@ -37273,7 +37244,6 @@ license:CC0-1.0
 	</software>
 
 	<software name="uridiump1">
-		<!-- Released by March42 and Forest of Illusion -->
 		<description>Uridium Advance (Europe, prototype, 20030307)</description>
 		<year>2003</year>
 		<publisher>Jester Interactive</publisher>
@@ -37284,9 +37254,8 @@ license:CC0-1.0
 		</part>
 	</software>
 
-		<!-- Game does not work in MAME. -->
+	<!-- Game does not work in MAME, it freezes on the bios screen. -->
 	<software name="uridiump2" supported="no">
-		<!-- Released by March42 and Forest of Illusion -->
 		<description>Uridium Advance (Europe, prototype, 20020911)</description>
 		<year>2003</year>
 		<publisher>Jester Interactive</publisher>
@@ -37297,9 +37266,8 @@ license:CC0-1.0
 		</part>
 	</software>
 
-		<!-- Game does not work in MAME. -->
+	<!-- Game does not work in MAME, it freezes on the bios screen. -->
 	<software name="uridpara" supported="no">
-		<!-- Released by March42 and Forest of Illusion -->
 		<description>Uridium Advance and Paradroid 2 in 1 (Europe, prototype, 20030430)</description>
 		<year>2003</year>
 		<publisher>Jester Interactive</publisher>
@@ -41700,6 +41668,20 @@ license:CC0-1.0
 			</dataarea>
 		</part>
 	</software>
+
+	<!-- Unreleased, software shows errors when saving bookmarks, but they work fine. -->
+	<software name="holybibl">
+		<description>The Holy Bible - World English Bible (USA, prototype)</description>
+		<year>2006</year>
+		<publisher>Crave Entertainment</publisher>
+		<part name="cart" interface="gba_cart">
+			<feature name="slot" value="gba_eeprom_64k" />
+			<dataarea name="rom" size="33554432">
+				<rom name="holy bible, the - world english bible (usa) (prototype).gba" size="33554432" crc="b8fda4f5" sha1="e2dd02ded617f7002ca887639cf91b9cac8cd745"/>
+			</dataarea>
+		</part>
+	</software>
+
 
 	<software name="mp3playr">
 		<description>Nintendo MP3 Player (Europe)</description>

--- a/hash/gba.xml
+++ b/hash/gba.xml
@@ -697,6 +697,18 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="aerope" cloneof="aero">
+		<!-- Dumped by LongwoodGeek, released by Forest of Illusion -->
+		<description>Aero the Acro-Bat - Rascal Rival Revenge (Europe, prototype earlier)</description>
+		<year>2001?</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="1030244">
+				<rom name="aero the acro-bat - rascal rival revenge (europe) (earlier).bin" size="1030244" crc="beed50f0" sha1="68c0a00275c7135ca1a116ccced1ecede75819b8"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="aero">
 		<description>Aero the Acro-Bat - Rascal Rival Revenge (Europe)</description>
 		<year>2002</year>
@@ -764,8 +776,26 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="agecart">
-		<description>Aging Cartridge (World, rev. 1)</description>
+	<software name="agecart1">
+		<!-- Dumped by SmellyGhost, released by Forest of Illusion -->
+		<description>AGB Aging Cartridge (World, version 1.0)</description>
+		<year>2001</year>
+		<publisher>Nintendo</publisher>
+		<info name="alt_title" value="AGB LCD用 カートリッジ"/>
+		<info name="serial" value="AGB-TCHK-0"/>
+		<part name="cart" interface="gba_cart">
+			<feature name="pcb" value="AGB-E03-01" />
+			<feature name="u1" value="U1 MASK ROM" />
+			<feature name="u2" value="U2 4K/64K EEPROM [9853]" />
+			<feature name="slot" value="gba_eeprom_4k" />
+			<dataarea name="rom" size="2097152">
+				<rom name="agb checker_tchk-0.gba" size="2097152" crc="bf553530" sha1="2445bf11a5f905695b00011d77d18c99e754b633"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="agecart7">
+		<description>AGB Aging Cartridge (World, version 7.0)</description>
 		<year>2002</year>
 		<publisher>Nintendo</publisher>
 		<info name="alt_title" value="エージングカートリッジ"/>
@@ -776,6 +806,22 @@ license:CC0-1.0
 			<feature name="slot" value="gba_eeprom_4k" />
 			<dataarea name="rom" size="2097152">
 				<rom name="agb-tchk-1.u1" size="2097152" crc="bbb6a960" sha1="c67e0a5e26ea5eba2bc11c99d003027a96e44060"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="agecart9">
+		<!-- Dumped by Suicune41, released by Forest of Illusion -->
+		<description>AGB Aging Cartridge (World, version 9.0)</description>
+		<year>2001</year>
+		<publisher>Nintendo</publisher>
+		<part name="cart" interface="gba_cart">
+			<feature name="pcb" value="AGB-E03-01" />
+			<feature name="u1" value="U1 MASK ROM" />
+			<feature name="u2" value="U2 4K/64K EEPROM [9853]" />
+			<feature name="slot" value="gba_eeprom_4k" />
+			<dataarea name="rom" size="2097152">
+				<rom name="agb_checker_tchk30.gba" size="2097152" crc="2e69686d" sha1="03d3a486482b61128872519fd755d0c072c12d93"/>
 			</dataarea>
 		</part>
 	</software>
@@ -3027,6 +3073,18 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="command2">
+		<!-- Dumped by DillyDylan, released by Forest of Illusion -->
+		<description>Commandos 2 (USA, prototype, 20021128)</description>
+		<year>2002</year>
+		<publisher>Toyonaka Studios</publisher>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="2644724">
+				<rom name="commandos 2 (prototype).gba" size="2644724" crc="dd58aecd" sha1="3750e5704ae5ee240c273a68d36001f36348bb48"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="dialhex">
 		<description>bit Generations - Dialhex (Japan)</description>
 		<year>2006</year>
@@ -4849,6 +4907,19 @@ license:CC0-1.0
 		<part name="cart" interface="gba_cart">
 			<dataarea name="rom" size="4194304">
 				<rom name="casper (usa) (en,fr,es).bin" size="4194304" crc="9f905e60" sha1="75392d01815d807f8fbd6846469d5d535a6aeeda"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="chokkanp" cloneof="polarium">
+		<!-- Dumped by xprism, released by Forest of Illusion -->
+		<description>Chokkan Hitofude Advance (Japan, prototype)</description>
+		<year>20??</year>
+		<publisher>Nintendo</publisher>
+		<info name="alt_title" value="直感ヒトフデADVANCE"/>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="1048576">
+				<rom name="chokkan hitofude advance (japan, prototype).gba" size="1048576" crc="9542e247" sha1="24b4be7f296fce5eae93d969eb02831951f00b7b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -6742,6 +6813,18 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="darkeden">
+		<!-- Dumped by Ian Dunlop, released by Forest of Illusion -->
+		<description>Dark Eden (demo)</description>
+		<year>2002</year>
+		<publisher>Rival Dreams</publisher>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="1361276">
+				<rom name="dark eden (demo).bin" size="1361276" crc="9cf479d2" sha1="df70db3a44117af3c744388aa17819ed8017e1d2"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="dariusr">
 		<description>Darius R (Japan)</description>
 		<year>2002</year>
@@ -7028,6 +7111,20 @@ license:CC0-1.0
 		<part name="cart" interface="gba_cart">
 			<dataarea name="rom" size="4194304">
 				<rom name="demon driver - time to burn rubber (usa).bin" size="4194304" crc="9374af5e" sha1="9dfe428843a22363ad8cc8ea0f818e439ef62f39"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Pitch demo for a GBA port. -->
+	<software name="demonscrest">
+		<!-- Ian Dunlop, released by Forest of Illusion in original and a patched version to get past the title screen. -->
+		<!-- The patch doesn't seem to be needed in MAME, but on other emulators, you have to patch 0x122384 with 0xc046c046. -->
+		<description>Demon's Crest (prototype)</description>
+		<year>????</year>
+		<publisher>Rival Dreams</publisher>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="1407220">
+				<rom name="demon's crest (prototype).gba" size="1407220" crc="134be954" sha1="0bb9824a77da4406f202c3234b4a5cbb77a43316"/>
 			</dataarea>
 		</part>
 	</software>
@@ -15271,6 +15368,19 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="holybibl">
+		<!-- Dumped by Gonz, released by Forest of Illusion -->
+		<description>The Holy Bible - World English Bible (USA, prototype)</description>
+		<year>2006</year>
+		<publisher>Crave Entertainment</publisher>
+		<part name="cart" interface="gba_cart">
+			<feature name="slot" value="gba_eeprom_64k" />
+			<dataarea name="rom" size="33554432">
+				<rom name="holy bible, the - world english bible (usa) (prototype).gba" size="33554432" crc="b8fda4f5" sha1="e2dd02ded617f7002ca887639cf91b9cac8cd745"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="homerang">
 		<description>Disney's Home on the Range (Europe)</description>
 		<year>2004</year>
@@ -17563,6 +17673,20 @@ license:CC0-1.0
 			<feature name="slot" value="gba_eeprom_4k" />
 			<dataarea name="rom" size="8388608">
 				<rom name="king of fighters ex2, the - howling blood (usa).bin" size="8388608" crc="15f8f9d5" sha1="a1d1d6fcc6f468ae366696dfab7b6c1bd91f1f44"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kofex2up" cloneof="kofex2" supported="no">
+		<!-- Dumped by March42, released by Forest of Illusion -->
+		<!-- Game crashes with Fatal error: 0800b2a4: Gb Undefined Thumb instruction: b2a9 error -->
+		<description>The King of Fighters EX2 - Howling Blood (USA, prototype, 20030403)</description>
+		<year>2003</year>
+		<publisher>Marvelous Entertainment</publisher>
+		<part name="cart" interface="gba_cart">
+			<feature name="slot" value="gba_eeprom_4k" />
+			<dataarea name="rom" size="8388608">
+				<rom name="king of fighters ex2, the - howling blood (usa, prototype, 20030403).gba" size="8388608" crc="7704ff39" sha1="b859122c1813a5ec9fb565dcca815a9f0a52bf18"/>
 			</dataarea>
 		</part>
 	</software>
@@ -20292,6 +20416,19 @@ license:CC0-1.0
 		</part>
 	</software>
 
+		<!-- This is a later build of the game than the retail release, with a different title screen and an options screen; does not say "Licensed by Nintendo" on boot. -->
+	<software name="manicminl">
+		<!-- Released by March42 and Forest of Illusion -->
+		<description>Manic Miner (Europe, 20030307)</description>
+		<year>2003</year>
+		<publisher>Jester Interactive</publisher>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="7562196">
+				<rom name="manic miner (europe, later) (en,fr,de,es,it).bin" size="7562196" crc="fb3d52bd" sha1="44576581ef231d2befb369800769ffee7e45f0e7"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="marchpen">
 		<description>March of the Penguins (Europe)</description>
 		<year>2006</year>
@@ -20537,6 +20674,19 @@ license:CC0-1.0
 			<feature name="slot" value="gba_flash" />
 			<dataarea name="rom" size="4194304">
 				<rom name="mario kart advance (japan).bin" size="4194304" crc="30e99fcd" sha1="88ffde363b05264a99a4d5ada0c80a00196a94d7"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mariokrtxxl">
+		<!-- Released by Forest of Illusion -->
+		<description>Mario Kart XXL (demo, 20040417)</description>
+		<year>2001</year>
+		<publisher>Denaris Entertainment Software</publisher>
+		<info name="alt_title" value="Mario Kart Demo V1.0"/>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="4194304">
+				<rom name="mario kart xxl (demo, 20040417).bin" size="4194304" crc="e3075601" sha1="ba1e75f780c41e737922f090dcb17526f1fd7a01"/>
 			</dataarea>
 		</part>
 	</software>
@@ -25228,6 +25378,19 @@ license:CC0-1.0
 		</part>
 	</software>
 
+		<!-- Game does not work in MAME. -->
+	<software name="paradroid" supported="no">
+		<!-- Released by March42 and Forest of Illusion -->
+		<description>Paradroid (Europe, prototype, 20030320)</description>
+		<year>2003</year>
+		<publisher>Jester Interactive</publisher>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="3716024">
+				<rom name="paradroid (prototype 20030320).bin" size="3716024" crc="0420d6ff" sha1="8cc61ed69ba2c3f6d8d546ce78b116e18c876bcb"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="pawclwdc">
 		<description>Paws &amp; Claws - Best Friends - Dogs &amp; Cats (USA)</description>
 		<year>2007</year>
@@ -27803,6 +27966,19 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="quake" supported="no">
+		<!-- Dumped by Randy Linden, released by Forest of Illusion -->
+		<!-- Game crashes immediately after loading, inputs become unresponsive. -->
+		<description>Quake (demo)</description>
+		<year>2003</year>
+		<publisher>Bobbee Tec</publisher>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="33554432">
+				<rom name="quake (demo).gba" size="33554432" crc="10e16dd4" sha1="91da59c27f06beb7d5ee1531300a0d1b7e4bfde2"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="qwakd" cloneof="qwak">
 		<description>Qwak (Europe, demo)</description>
 		<year>2007</year>
@@ -27822,6 +27998,18 @@ license:CC0-1.0
 			<feature name="slot" value="gba_sram" />
 			<dataarea name="rom" size="8388608">
 				<rom name="qwak (europe) (en,fr,de,es,it) (unl).bin" size="8388608" crc="9027917f" sha1="a5f5dde3d0d3f58f8903e44461e17a7001591649"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="r3ddemo">
+		<!-- Released by Forest of Illusion -->
+		<description>R3D-Demo V1 (Europe, demo)</description>
+		<year>2004</year>
+		<publisher>Denaris Entertainment Software</publisher>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="8388608">
+				<rom name="3-r3d_demo_v1.gba" size="8388608" crc="3e7f9100" sha1="48261a7984808f573a1b07be647c02b941af6247"/>
 			</dataarea>
 		</part>
 	</software>
@@ -27898,6 +28086,19 @@ license:CC0-1.0
 			<feature name="slot" value="gba_eeprom_4k" />
 			<dataarea name="rom" size="8388608">
 				<rom name="racing gears advance (usa).bin" size="8388608" crc="bf648e5c" sha1="3f053865f9a687a75927172cd281390b2560201c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="racinggaup">
+		<!-- Dumped by XBrav, released by Forest of Illusion -->
+		<description>Racing Gears Advance (USA, prototype, 20030922)</description>
+		<year>2003</year>
+		<publisher>Pier 3 Entertainment</publisher>
+		<part name="cart" interface="gba_cart">
+			<feature name="slot" value="gba_eeprom_4k" />
+			<dataarea name="rom" size="16777216">
+				<rom name="racing gears advance (usa, prototype, 20030922).gba" size="16777216" crc="86a05f93" sha1="d258526ce1dcfbed51b745a762f148c9bea01154"/>
 			</dataarea>
 		</part>
 	</software>
@@ -29783,6 +29984,19 @@ license:CC0-1.0
 			<feature name="slot" value="gba_eeprom_64k" />
 			<dataarea name="rom" size="16777216">
 				<rom name="sd gundam ggeneration advance (japan).bin" size="16777216" crc="7daf215c" sha1="7dd42beaacbd24cb832745a18e57cefda4a76827"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="seaboy">
+		<!-- Dumped by Ian Dunlop, released by Forest of Illusion -->
+		<description>Sea Boy (demo)</description>
+		<year>2003</year>
+		<publisher>Rival Dreams</publisher>
+		<part name="cart" interface="gba_cart">
+			<feature name="slot" value="gba_eeprom_4k" />
+			<dataarea name="rom" size="1658376">
+				<rom name="sea boy (demo).bin" size="1658376" crc="c822b1bc" sha1="5a00075f187d294ee7e1e711172d28a76046ba53"/>
 			</dataarea>
 		</part>
 	</software>
@@ -32929,6 +33143,19 @@ license:CC0-1.0
 			<feature name="slot" value="gba_eeprom_4k" />
 			<dataarea name="rom" size="8388608">
 				<rom name="star wars trilogy - apprentice of the force (usa) (en,fr,es).bin" size="8388608" crc="714a0d3a" sha1="b6c09b9f5588ff81aeb4bd5ed886933993f4575f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="swtrilgyup" cloneof="swtrilgy" supported="no">
+		<!-- Dumped by Rezrospect, released by Forest of Illusion -->
+		<description>Star Wars Trilogy - Apprentice of the Force (USA, prototype)</description>
+		<year>2004</year>
+		<publisher>Ubisoft</publisher>
+		<part name="cart" interface="gba_cart">
+			<feature name="slot" value="gba_eeprom_4k" />
+			<dataarea name="rom" size="8388608">
+				<rom name="star wars trilogy - apprentice of the force (usa, prototype).gba" size="8388608" crc="b5d61c72" sha1="ddf8edaa7436fd5a7282867369f294d6907f9a52"/>
 			</dataarea>
 		</part>
 	</software>
@@ -36822,6 +37049,19 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="ultmusclp">
+		<!-- Dumped by Zach Lambert, released by Forest of Illusion -->
+		<description>Ultimate Muscle - The Kinnikuman Legacy - The Path of the Superhero (USA, prototype, 20030429)</description>
+		<year>2003</year>
+		<publisher>Bandai</publisher>
+			<part name="cart" interface="gba_cart">
+			<feature name="slot" value="gba_eeprom_4k" />
+			<dataarea name="rom" size="16777216">
+				<rom name="ultimate muscle - the kinnikuman legacy - the path of the superhero (usa, prototype).bin" size="16777216" crc="65e2295b" sha1="314fe99854c8c3ab8786b633f4a20afba835d696"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="ultpuzzl">
 		<description>Ultimate Puzzle Games (USA)</description>
 		<year>2005</year>
@@ -37028,6 +37268,44 @@ license:CC0-1.0
 			<feature name="slot" value="gba_flash_512" />
 			<dataarea name="rom" size="33554432">
 				<rom name="urbz, the - sims in the city (japan).bin" size="33554432" crc="bbccc2fd" sha1="7af0ab8a437616befafddd7c0ea87c8dfb80c6cd"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="uridiump1">
+		<!-- Released by March42 and Forest of Illusion -->
+		<description>Uridium Advance (Europe, prototype, 20030307)</description>
+		<year>2003</year>
+		<publisher>Jester Interactive</publisher>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="4194304">
+				<rom name="uridium advance (prototype 20030307).bin" size="4194304" crc="7e617c46" sha1="13415d7845d4c4589cfbee1fd755202841aeba08"/>
+			</dataarea>
+		</part>
+	</software>
+
+		<!-- Game does not work in MAME. -->
+	<software name="uridiump2" supported="no">
+		<!-- Released by March42 and Forest of Illusion -->
+		<description>Uridium Advance (Europe, prototype, 20020911)</description>
+		<year>2003</year>
+		<publisher>Jester Interactive</publisher>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="3397356">
+				<rom name="uridium advance (prototype 20020911).bin" size="3397356" crc="aefa2250" sha1="40a3ba147fe8d75f12a8b0e41865cec0f9d06c3e"/>
+			</dataarea>
+		</part>
+	</software>
+
+		<!-- Game does not work in MAME. -->
+	<software name="uridpara" supported="no">
+		<!-- Released by March42 and Forest of Illusion -->
+		<description>Uridium Advance and Paradroid 2 in 1 (Europe, prototype, 20030430)</description>
+		<year>2003</year>
+		<publisher>Jester Interactive</publisher>
+		<part name="cart" interface="gba_cart">
+			<dataarea name="rom" size="7906272">
+				<rom name="uridium paradroid (prototype).gba" size="7906272" crc="18fb99b1" sha1="d4e9c438b82c96cbc0459c46d04bed1f0d10fde2"/>
 			</dataarea>
 		</part>
 	</software>

--- a/src/mame/jaleco/tetrisp2.cpp
+++ b/src/mame/jaleco/tetrisp2.cpp
@@ -2466,33 +2466,8 @@ dumped by sayu
 
 ROM_START( nndmseal )
 	ROM_REGION( 0x80000, "maincpu", 0 )     // 68000 Code
-	ROM_LOAD16_BYTE( "cawaii 1 ver1.3.1", 0x00000, 0x40000, CRC(c48ea4d9) SHA1(11a3510d6db293c8b48805959e1b353dd9388d98) )    // 1xxxxxxxxxxxxxxxxx = 0xFF
-	ROM_LOAD16_BYTE( "cawaii 3 ver1.3.3", 0x00001, 0x40000, CRC(a8b85eb6) SHA1(753372f6301bf1f802707ec59e825253ee3c1e79) )    // 1xxxxxxxxxxxxxxxxx = 0xFF
-
-	ROM_REGION( 0x100000, "sprite", ROMREGION_ERASE )    /* 8x8x8 (Sprites) */
-/* This game doesn't use sprites, but the region needs to be a valid size for at least one sprite 'page' for the init to work. */
-
-	ROM_REGION( 0x400000, "gfx2", 0 )   // 16x16x8 (Background)
-	ROM_LOAD( "mr97006-02.5", 0x000000, 0x200000, CRC(4793f84e) SHA1(05acba6cc8a527a6050af79a460b08c4676287aa) )
-	ROM_LOAD( "mr97001-01.6", 0x200000, 0x200000, CRC(dd648e8a) SHA1(7036ab30d0ea179c59d74c1fbe4372968722ec0f) )
-
-	ROM_REGION( 0x200000, "gfx3", 0 )   // 16x16x8 (Rotation)
-	ROM_LOAD( "mr97006-01.2", 0x000000, 0x200000, CRC(32283485) SHA1(14ccd25389b97825d9a727809c3a1de803687c16) )
-
-	ROM_REGION( 0x100000, "gfx4", 0 )   // 8x8x8 (Foreground)
-	ROM_LOAD( "mr97006-04.8", 0x000000, 0x100000, CRC(6726a25b) SHA1(4ea49c014477229eaf9de4a0b9bf83021b82c095) )
-
-	ROM_REGION( 0x40000, "oki", ROMREGION_ERASE )   // Samples
-	// filled in from "okisource"
-
-	ROM_REGION( 0x200000, "okisource", 0 )  // Samples
-	ROM_LOAD( "mr96017-04.9", 0x000000, 0x200000, CRC(c2e7b444) SHA1(e2b9d3d94720d01beff1108ef3dfbff805ddd1fd) )
-ROM_END
-
-ROM_START( nndmseal11 )
-	ROM_REGION( 0x80000, "maincpu", 0 )     // 68000 Code
-	ROM_LOAD16_BYTE( "cawaii 1 ver1.1.1", 0x00000, 0x40000, CRC(45acea25) SHA1(f2f2e78be261c3d8c0145a639bc3771f0588401d) )    // 1xxxxxxxxxxxxxxxxx = 0xFF
-	ROM_LOAD16_BYTE( "cawaii 3 ver1.1.3", 0x00001, 0x40000, CRC(0754d96a) SHA1(1da44994e8bcfd8832755e298c0125b38cfdd16e) )    // 1xxxxxxxxxxxxxxxxx = 0xFF
+	ROM_LOAD16_BYTE( "1.1", 0x00000, 0x40000, CRC(45acea25) SHA1(f2f2e78be261c3d8c0145a639bc3771f0588401d) )    // 1xxxxxxxxxxxxxxxxx = 0xFF
+	ROM_LOAD16_BYTE( "3.3", 0x00001, 0x40000, CRC(0754d96a) SHA1(1da44994e8bcfd8832755e298c0125b38cfdd16e) )    // 1xxxxxxxxxxxxxxxxx = 0xFF
 
 	ROM_REGION( 0x100000, "sprite", ROMREGION_ERASE )    /* 8x8x8 (Sprites) */
 /* This game doesn't use sprites, but the region needs to be a valid size for at least one sprite 'page' for the init to work. */
@@ -3381,8 +3356,7 @@ GAME( 1997, tetrisp2a, tetrisp2, tetrisp2, tetrisp2,  tetrisp2_state, empty_init
 GAME( 1997, tetrisp2j, tetrisp2, tetrisp2, tetrisp2j, tetrisp2_state, empty_init,   ROT0,    "Jaleco / The Tetris Company", "Tetris Plus 2 (Japan, V2.2)",          MACHINE_SUPPORTS_SAVE )
 GAME( 1997, tetrisp2ja,tetrisp2, tetrisp2, tetrisp2j, tetrisp2_state, empty_init,   ROT0,    "Jaleco / The Tetris Company", "Tetris Plus 2 (Japan, V2.1)",          MACHINE_SUPPORTS_SAVE )
 
-GAME( 1997, nndmseal,  0,        nndmseal, nndmseal,  tetrisp2_state, init_rockn,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco", "Nandemo Seal Iinkai (ver 1.3)",             MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1997, nndmseal11,nndmseal, nndmseal, nndmseal,  tetrisp2_state, init_rockn,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco", "Nandemo Seal Iinkai (ver 1.1)",             MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
+GAME( 1997, nndmseal,  0,        nndmseal, nndmseal,  tetrisp2_state, init_rockn,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco", "Nandemo Seal Iinkai",                       MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
 GAME( 1997, nndmseala, nndmseal, nndmseal, nndmseal,  tetrisp2_state, init_rockn,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco", "Nandemo Seal Iinkai (Astro Boy ver. 1.0?)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // version guessed
 GAME( 1997, nndmsealb, nndmseal, nndmseal, nndmseal,  tetrisp2_state, init_rockn,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco", "Nandemo Seal Iinkai (Astro Boy ver. 1.1)",  MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // appears to have one more mode than the one above, ver taken from PRG ROM labels
 GAME( 1997, nndmsealc, nndmseal, nndmseal, nndmseal,  tetrisp2_state, init_rockn,   ROT0 | ORIENTATION_FLIP_X, "I'Max / Jaleco", "Nandemo Seal Iinkai (alternate ver 1.0)",   MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // only shows Jaleco copyright even though I'Max is in strings in ROMs. Ver taken from PRG ROM labels

--- a/src/mame/konami/battlnts.cpp
+++ b/src/mame/konami/battlnts.cpp
@@ -324,10 +324,10 @@ void battlnts_state::machine_reset()
 void battlnts_state::battlnts(machine_config &config)
 {
 	// basic machine hardware
-	HD6309E(config, m_maincpu, XTAL(24'000'000) / 8); // HD63C09EP
+	HD6309(config, m_maincpu, XTAL(24'000'000) / 2);  // 3'000'000 * 4?
 	m_maincpu->set_addrmap(AS_PROGRAM, &battlnts_state::main_map);
 
-	Z80(config, m_audiocpu, XTAL(24'000'000) / 6); // 3579545? (no such XTAL on board)
+	Z80(config, m_audiocpu, XTAL(24'000'000) / 6); // 3579545?
 	m_audiocpu->set_addrmap(AS_PROGRAM, &battlnts_state::sound_map);
 
 	WATCHDOG_TIMER(config, "watchdog");

--- a/src/mame/konami/fastlane.cpp
+++ b/src/mame/konami/fastlane.cpp
@@ -370,7 +370,7 @@ void fastlane_state::machine_start()
 void fastlane_state::fastlane(machine_config &config)
 {
 	// basic machine hardware
-	HD6309E(config, m_maincpu, XTAL(24'000'000) / 8); // HD63C09EP, 3 MHz
+	HD6309(config, m_maincpu, XTAL(24'000'000) / 2); // 3 MHz(XTAL(24'000'000) / 8) internally
 	m_maincpu->set_addrmap(AS_PROGRAM, &fastlane_state::prg_map);
 	TIMER(config, "scantimer").configure_scanline(FUNC(fastlane_state::scanline), "screen", 0, 1);
 

--- a/src/mame/konami/labyrunr.cpp
+++ b/src/mame/konami/labyrunr.cpp
@@ -451,7 +451,7 @@ void labyrunr_state::machine_start()
 void labyrunr_state::labyrunr(machine_config &config)
 {
 	// basic machine hardware
-	HD6309E(config, m_maincpu, 24_MHz_XTAL / 8); // HD63C09EP
+	HD6309(config, m_maincpu, 3000000 * 4);      // 24MHz / 8?
 	m_maincpu->set_addrmap(AS_PROGRAM, &labyrunr_state::prg_map);
 	m_maincpu->set_periodic_int(FUNC(labyrunr_state::timer_interrupt), attotime::from_hz(4 * 60));
 

--- a/src/mame/konami/lethal.cpp
+++ b/src/mame/konami/lethal.cpp
@@ -654,7 +654,7 @@ void lethal_state::lethalen(machine_config &config)
 	constexpr XTAL SOUND_CLOCK = 18.432_MHz_XTAL;
 
 	/* basic machine hardware */
-	HD6309E(config, m_maincpu, MAIN_CLOCK/8);    /* verified on pcb */
+	HD6309(config, m_maincpu, MAIN_CLOCK/2);    /* verified on pcb */
 	m_maincpu->set_addrmap(AS_PROGRAM, &lethal_state::le_main);
 	m_maincpu->set_vblank_int("screen", FUNC(lethal_state::lethalen_interrupt));
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -21375,7 +21375,6 @@ skyfox                          // (c) 1987 Jaleco + Nichibutsu USA license
 
 @source:jaleco/tetrisp2.cpp
 nndmseal                        // (c) 1997 I'Max/Jaleco
-nndmseal11                      // (c) 1997 I'Max/Jaleco
 nndmseala                       // (c) 1997 I'Max/Jaleco
 nndmsealb                       // (c) 1997 I'Max/Jaleco
 nndmsealc                       // (c) 1997 I'Max/Jaleco
@@ -37732,7 +37731,6 @@ pocketbk2                       // 1994 Acorn Pocket Book II
 psion3a                         // 1993 Psion Series 3a
 psion3a2                        // 1995 Psion Series 3a
 psion3a2_de                     // 1995 Psion Series 3a (German)
-psion3a2_ru                     // 1997 Psion Series 3a (Russian)
 psion3c                         // 1996 Psion Series 3c
 psion3mx                        // 1998 Psion Series 3mx
 

--- a/src/mame/psion/psion3a.cpp
+++ b/src/mame/psion/psion3a.cpp
@@ -397,12 +397,6 @@ ROM_START(psion3a2_de)
 	ROMX_LOAD("s3a_v3.41f_deu.bin", 0x000000, 0x200000, CRC(1f21cb0a) SHA1(fbb9c3356cf8b1d89b8cf50fc12175568c74ce3e), ROM_BIOS(0))
 ROM_END
 
-ROM_START(psion3a2_ru)
-	ROM_REGION16_LE(0x200000, "rom", 0)
-	ROM_SYSTEM_BIOS(0, "343f", "V3.43F/RUS")
-	ROMX_LOAD("s3a_v3.43f_rus.bin", 0x000000, 0x200000, CRC(ada4da36) SHA1(24953197f5175596593e5e4045846812ca9b82e3), ROM_BIOS(0))
-ROM_END
-
 ROM_START(psion3c)
 	// Versions advertised: English, German, French, Flemish and Dutch
 	ROM_REGION16_LE(0x200000, "rom", 0)
@@ -430,6 +424,6 @@ COMP( 1993, psion3a,      0,        0,      psion3a,   psion3a,     psion3a_stat
 COMP( 1994, pocketbk2,    psion3a,  0,      psion3a,   pocketbk2,   psion3a_state, empty_init,  "Acorn Computers",  "Pocket Book II",           MACHINE_NOT_WORKING )
 COMP( 1995, psion3a2,     psion3a,  0,      psion3a2,  psion3a,     psion3a_state, empty_init,  "Psion",            "Series 3a (2M)",           MACHINE_NOT_WORKING )
 COMP( 1995, psion3a2_de,  psion3a,  0,      psion3a2,  psion3a_de,  psion3a_state, empty_init,  "Psion",            "Series 3a (2M) (German)",  MACHINE_NOT_WORKING )
-COMP( 1997, psion3a2_ru,  psion3a,  0,      psion3a2,  psion3a,     psion3a_state, empty_init,  "Psion",            "Series 3a (2M) (Russian)", MACHINE_NOT_WORKING )
+//COMP( 1996, psion3a2_ru,  psion3a,  0,      psion3a2,  psion3a,     psion3a_state, empty_init,  "Psion",            "Series 3a (2M) (Russian)", MACHINE_NOT_WORKING )
 COMP( 1996, psion3c,      0,        0,      psion3c,   psion3c,     psion3a_state, empty_init,  "Psion",            "Series 3c",                MACHINE_NOT_WORKING )
 COMP( 1998, psion3mx,     0,        0,      psion3mx,  psion3c,     psion3a_state, empty_init,  "Psion",            "Series 3mx",               MACHINE_NOT_WORKING )

--- a/src/mame/stern/mazerbla.cpp
+++ b/src/mame/stern/mazerbla.cpp
@@ -51,8 +51,6 @@ VSB-2000 - sound/speech/subcpu board (Voice and Sound Board)
 CRF-1001 - RF Filter board for video/audio output
  - this same board is shared with cliff hanger (cliffhgr.c)
 
-UIB-1000 - coin inputs, start/fire buttons and gun ADCs (Vin(-) and Vref/2 are calibrated by potentiometers)
-
 Versions:
 ======
 Mazer blazer's zpu-2000 roms are known to exist in at least the following versions:
@@ -108,10 +106,8 @@ video z80
 
 #include "emu.h"
 #include "cpu/z80/z80.h"
-#include "machine/adc0804.h"
 #include "machine/gen_latch.h"
 #include "machine/nvram.h"
-#include "machine/rescap.h"
 #include "sound/ay8910.h"
 #include "video/resnet.h"
 #include "video/mb_vcu.h"
@@ -137,8 +133,6 @@ public:
 		, m_vcu(*this,"vcu")
 		, m_screen(*this, "screen")
 		, m_soundlatch(*this, "soundlatch")
-		, m_uib_adc(*this, "adc%u", 0U)
-		, m_digital_inputs(*this, { "ZPU", "DSW0", "DSW1", "DSW2", "DSW3", "BUTTONS" })
 		, m_leds(*this, "led%u", 0U)
 		, m_lamps(*this, "lamp%u", 0U)
 	{ }
@@ -193,8 +187,6 @@ private:
 	required_device<mb_vcu_device> m_vcu;
 	required_device<screen_device> m_screen;
 	optional_device<generic_latch_8_device> m_soundlatch;
-	optional_device_array<adc0804_device, 4> m_uib_adc;
-	required_ioport_array<6> m_digital_inputs;
 	output_finder<3> m_leds;
 	output_finder<2> m_lamps;
 
@@ -397,24 +389,17 @@ Vertical movement of gun is Strobe 9, Bits 0-7.
 void mazerbla_state::zpu_bcd_decoder_w(uint8_t data)
 {
 	/* bcd decoder used a input select (a mux) for reads from port 0x62 */
-	if (m_bcd_7445 != (data & 0xf))
-	{
-		if (m_bcd_7445 >= 6 && m_bcd_7445 < 10 && m_uib_adc[m_bcd_7445 - 6].found())
-			m_uib_adc[m_bcd_7445 - 6]->wr_w(1);
-		m_bcd_7445 = data & 0xf;
-		if (m_bcd_7445 >= 6 && m_bcd_7445 < 10 && m_uib_adc[m_bcd_7445 - 6].found())
-			m_uib_adc[m_bcd_7445 - 6]->wr_w(0);
-	}
+	m_bcd_7445 = data & 0xf;
 }
 
 uint8_t mazerbla_state::zpu_inputs_r()
 {
-	uint8_t ret = 0xff;
+	static const char *const strobenames[] = { "ZPU", "DSW0", "DSW1", "DSW2", "DSW3", "BUTTONS", "STICK0_X", "STICK0_Y",
+												"STICK1_X", "STICK1_Y", "UNUSED", "UNUSED", "UNUSED", "UNUSED", "UNUSED", "UNUSED" };
 
-	if (m_bcd_7445 < 6)
-		ret = m_digital_inputs[m_bcd_7445]->read();
-	else if (m_bcd_7445 < 10 && m_uib_adc[m_bcd_7445 - 6].found())
-		ret = m_uib_adc[m_bcd_7445 - 6]->read();
+	uint8_t ret = 0;
+
+	ret = ioport(strobenames[m_bcd_7445])->read();
 
 	return ret;
 }
@@ -718,6 +703,15 @@ static INPUT_PORTS_START( mazerbla )
 
 	PORT_START("STICK0_Y")  /* Strobe 7: vertical movement of gun */
 	PORT_BIT( 0xff, 0x80, IPT_AD_STICK_Y ) PORT_SENSITIVITY(25) PORT_KEYDELTA(7) PORT_PLAYER(1)
+
+	PORT_START("STICK1_X")  /* Strobe 8: horizontal movement of gun */
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("STICK1_Y")  /* Strobe 9: vertical movement of gun */
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("UNUSED")
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( mazerblaa )
@@ -895,6 +889,9 @@ static INPUT_PORTS_START( greatgun )
 	PORT_START("STICK1_Y")  /* Strobe 9: vertical movement of gun */
 	// for whatever reason this should be inverted?
 	PORT_BIT( 0xff, 0x80, IPT_LIGHTGUN_Y ) PORT_MINMAX(0x00, 0xff) PORT_CROSSHAIR(Y, 1.0, 0.0, 0) PORT_SENSITIVITY(25) PORT_INVERT PORT_KEYDELTA(7) PORT_PLAYER(2)
+
+	PORT_START("UNUSED")
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 INPUT_PORTS_END
 
 /*************************************
@@ -956,6 +953,8 @@ void mazerbla_state::machine_start()
 
 void mazerbla_state::machine_reset()
 {
+	int i;
+
 	m_zpu_int_vector = 0xff;
 
 	m_gfx_rom_bank = 0xff;
@@ -970,13 +969,11 @@ void mazerbla_state::machine_reset()
 		m_soundlatch->acknowledge_w();
 	}
 
-	for (int i = 0; i < 4; i++)
+	for (i = 0; i < 4; i++)
 	{
 		m_ls670_0[i] = 0;
 		m_ls670_1[i] = 0;
 	}
-
-	zpu_bcd_decoder_w(0);
 }
 
 void mazerbla_state::mazerbla(machine_config &config)
@@ -1000,11 +997,6 @@ void mazerbla_state::mazerbla(machine_config &config)
     but handled differently for now
     */
 	sub2.set_vblank_int("screen", FUNC(mazerbla_state::irq0_line_hold));
-
-	for (int i = 0; i < 2; i++)
-		ADC0804(config, m_uib_adc[i], RES_R(10), CAP_P(150)).set_rd_mode(adc0804_device::RD_GROUNDED);
-	m_uib_adc[0]->vin_callback().set_ioport("STICK0_X");
-	m_uib_adc[1]->vin_callback().set_ioport("STICK0_Y");
 
 	/* synchronization forced on the fly */
 	MB_VCU(config, m_vcu, SOUND_CLOCK/4);
@@ -1048,13 +1040,6 @@ void mazerbla_state::greatgun(machine_config &config)
     but handled differently for now
     */
 	sub2.set_vblank_int("screen", FUNC(mazerbla_state::irq0_line_hold));
-
-	for (int i = 0; i < 4; i++)
-		ADC0804(config, m_uib_adc[i], RES_R(10), CAP_P(150)).set_rd_mode(adc0804_device::RD_GROUNDED);
-	m_uib_adc[0]->vin_callback().set_ioport("STICK0_X");
-	m_uib_adc[1]->vin_callback().set_ioport("STICK0_Y");
-	m_uib_adc[2]->vin_callback().set_ioport("STICK1_X");
-	m_uib_adc[3]->vin_callback().set_ioport("STICK1_Y");
 
 	MB_VCU(config, m_vcu, SOUND_CLOCK/4);
 	m_vcu->set_cpu_tag("sub2");

--- a/src/mame/subsino/subsino.cpp
+++ b/src/mame/subsino/subsino.cpp
@@ -223,7 +223,7 @@ To Do:
 ***************************************************************************/
 
 #include "emu.h"
-#include "subsino_crypt.h"
+#include "subsino_m.h"
 
 #include "cpu/z180/hd647180x.h"
 #include "machine/i8255.h"
@@ -3901,8 +3901,7 @@ ROM_END
 
 void subsino_state::init_victor5()
 {
-	uint8_t *rom = memregion( "maincpu" )->base();
-	subsino_decrypt(rom, victor5_bitswaps, victor5_xors, 0xc000);
+	subsino_decrypt(machine(), victor5_bitswaps, victor5_xors, 0xc000);
 
 	m_flash_packet = 0;
 	m_flash_packet_start = 0;
@@ -3915,14 +3914,12 @@ void subsino_state::init_victor5()
 
 void subsino_state::init_victor21()
 {
-	uint8_t *rom = memregion( "maincpu" )->base();
-	subsino_decrypt(rom, victor21_bitswaps, victor21_xors, 0xc000);
+	subsino_decrypt(machine(), victor21_bitswaps, victor21_xors, 0xc000);
 }
 
 void subsino_state::init_crsbingo()
 {
-	uint8_t *rom = memregion( "maincpu" )->base();
-	subsino_decrypt(rom, crsbingo_bitswaps, crsbingo_xors, 0xc000);
+	subsino_decrypt(machine(), crsbingo_bitswaps, crsbingo_xors, 0xc000);
 
 	m_flash_packet = 0;
 	m_flash_packet_start = 0;
@@ -3935,14 +3932,12 @@ void subsino_state::init_crsbingo()
 
 void subsino_state::init_sharkpy()
 {
-	uint8_t *rom = memregion( "maincpu" )->base();
-	subsino_decrypt(rom, sharkpy_bitswaps, sharkpy_xors, 0xa000);
+	subsino_decrypt(machine(), sharkpy_bitswaps, sharkpy_xors, 0xa000);
 }
 
 void subsino_state::init_sharkpye()
 {
-	uint8_t *rom = memregion( "maincpu" )->base();
-	subsino_decrypt(rom, victor5_bitswaps, victor5_xors, 0xa000);
+	subsino_decrypt(machine(), victor5_bitswaps, victor5_xors, 0xa000);
 }
 
 void subsino_state::init_smoto20()
@@ -3960,7 +3955,8 @@ void subsino_state::init_smoto13()
 void subsino_state::init_tisub()
 {
 	uint8_t *rom = memregion( "maincpu" )->base();
-	subsino_decrypt(rom, victor5_bitswaps, victor5_xors, 0xc000);
+
+	init_victor5();
 
 	/* this trips a z180 MMU core bug? It unmaps a region then the program code jumps to that region... */
 	rom[0x64c8] = 0x00;
@@ -3974,7 +3970,8 @@ void subsino_state::init_tisub()
 void subsino_state::init_tisuba()
 {
 	uint8_t *rom = memregion( "maincpu" )->base();
-	subsino_decrypt(rom, victor5_bitswaps, victor5_xors, 0xc000);
+
+	init_victor5();
 
 	/* this trips a z180 MMU core bug? It unmaps a region then the program code jumps to that region... */
 	rom[0x6491] = 0x00;
@@ -3987,8 +3984,9 @@ void subsino_state::init_tisuba()
 
 void subsino_state::init_tisubb()
 {
+	subsino_decrypt(machine(), tisubb_bitswaps, tisubb_xors, 0xc000);
+
 	uint8_t *rom = memregion( "maincpu" )->base();
-	subsino_decrypt(rom, tisubb_bitswaps, tisubb_xors, 0xc000);
 
 	/* this trips a z180 MMU core bug? It unmaps a region then the program code jumps to that region... */
 	rom[0x60da] = 0x00;

--- a/src/mame/subsino/subsino2.cpp
+++ b/src/mame/subsino/subsino2.cpp
@@ -55,8 +55,8 @@ by the otherwise seemingly unnecessary internal ROMs.
 ************************************************************************************************************/
 
 #include "emu.h"
-#include "subsino_crypt.h"
 #include "subsino_io.h"
+#include "subsino_m.h"
 
 #include "cpu/h8/h83048.h"
 #include "cpu/i86/i186.h"
@@ -3583,7 +3583,7 @@ ROM_END
 
 void subsino2_state::init_mtrain()
 {
-	subsino_decrypt(memregion("maincpu")->base(), crsbingo_bitswaps, crsbingo_xors, 0x8000);
+	subsino_decrypt(machine(), crsbingo_bitswaps, crsbingo_xors, 0x8000);
 }
 
 
@@ -3618,7 +3618,7 @@ ROM_END
 
 void subsino2_state::init_tbonusal()
 {
-	subsino_decrypt(memregion("maincpu")->base(), sharkpy_bitswaps, sharkpy_xors, 0x8000);
+	subsino_decrypt(machine(), sharkpy_bitswaps, sharkpy_xors, 0x8000);
 }
 
 /***************************************************************************
@@ -3919,7 +3919,7 @@ ROM_END
 
 void subsino2_state::init_wtrnymph()
 {
-	subsino_decrypt(memregion("maincpu")->base(), victor5_bitswaps, victor5_xors, 0x8000);
+	subsino_decrypt(machine(), victor5_bitswaps, victor5_xors, 0x8000);
 }
 
 GAME( 1996, mtrain,   0,        mtrain,   mtrain,   subsino2_state, init_mtrain,   ROT0, "Subsino",                          "Magic Train (Ver. 1.31)",               0 )

--- a/src/mame/subsino/subsino_m.cpp
+++ b/src/mame/subsino/subsino_m.cpp
@@ -81,14 +81,34 @@ void victor21_bitswaps(uint8_t *decrypt, int i)
 
 // Decrypt:
 
-void subsino_decrypt(uint8_t *region, void (*bitswaps)(uint8_t *decrypt, int i), const uint8_t *xors, int size)
+[[maybe_unused]] static void dump_decrypted(running_machine& machine, uint8_t* decrypt)
 {
-	std::unique_ptr<uint8_t[]> decrypt = std::make_unique<uint8_t[]>(size);
-
-	for (int i = 0; i < size; i++)
+	auto filename = "dat_" + std::string(machine.system().name);
+	auto fp = fopen(filename.c_str(), "w+b");
+	if (fp)
 	{
-		decrypt[i] = region[i] ^ xors[i & 7];
-		bitswaps(decrypt.get(), i);
+		fwrite(decrypt, 0x10000, 1, fp);
+		fclose(fp);
 	}
-	memcpy(region, decrypt.get(), size);
+}
+
+void subsino_decrypt(running_machine& machine, void (*bitswaps)(uint8_t *decrypt, int i), const uint8_t *xors, int size)
+{
+	std::unique_ptr<uint8_t[]> decrypt = std::make_unique<uint8_t[]>(0x10000);
+	uint8_t *const region = machine.root_device().memregion("maincpu")->base();
+
+	for (int i = 0; i < 0x10000; i++)
+	{
+		if (i < size)
+		{
+			decrypt[i] = region[i] ^ xors[i & 7];
+			bitswaps(decrypt.get(), i);
+		}
+		else
+		{
+			decrypt[i] = region[i];
+		}
+	}
+//  dump_decrypted(machine, decrypt);
+	memcpy(region, decrypt.get(), 0x10000);
 }

--- a/src/mame/subsino/subsino_m.h
+++ b/src/mame/subsino/subsino_m.h
@@ -1,7 +1,7 @@
 // license:BSD-3-Clause
 // copyright-holders:Luca Elia, David Haywood, Angelo Salese, Roberto Fresca
-#ifndef MAME_SUBSINO_SUBSINO_CRYPT_H
-#define MAME_SUBSINO_SUBSINO_CRYPT_H
+#ifndef MAME_SUBSINO_SUBSINO_M_H
+#define MAME_SUBSINO_SUBSINO_M_H
 
 #pragma once
 
@@ -18,6 +18,6 @@ void tisubb_bitswaps  (uint8_t *decrypt, int i);
 void victor5_bitswaps (uint8_t *decrypt, int i);
 void victor21_bitswaps(uint8_t *decrypt, int i);
 
-void subsino_decrypt(uint8_t *region, void (*bitswaps)(uint8_t *decrypt, int i), const uint8_t *xors, int size);
+void subsino_decrypt(running_machine& machine, void (*bitswaps)(uint8_t *decrypt, int i), const uint8_t *xors, int size);
 
-#endif // MAME_SUBSINO_SUBSINO_CRYPT_H
+#endif // MAME_SUBSINO_SUBSINO_M_H


### PR DESCRIPTION
New working software list items
-------------------------------
AGB Aging Cartridge (World, version 1.0) [SmellyGhost, Forest of Illusion]
AGB Aging Cartridge (World, version 9.0) [Suicune41, Forest of Illusion]
Aero the Acro-Bat - Rascal Rival Revenge (Europe, prototype earlier) [LongwoodGeek, Forest of Illusion]
Chokkan Hitofude Advance (Japan, prototype) [xprism, Forest of Illusion]
Commandos 2 (USA, prototype) [DillyDylan, Forest of Illusion]
Dark Eden (prototype) [Ian Dunlop, Forest of Illusion]
Demon's Crest (prototype) [Ian Dunlop, Forest of Illusion]
Manic Miner (Europe, 20030307) [March42, Forest of Illusion]
Mario Kart XXL (demo, 20040417) [Forest of Illusion]
R3D-Demo V1 (demo) [Forest of Illusion]
Racing Gears Advance (USA, prototype, 20030922) [XBrav, Forest of Illusion]
Sea Boy (prototype) [Ian Dunlop, Forest of Illusion]
Star Wars Trilogy - Apprentice of the Force (USA, prototype) [Rezrospect, Forest of Illusion]
The Holy Bible - World English Bible (USA, prototype) [Gonz, Forest of Illusion]
Ultimate Muscle - The Kinnikuman Legacy - The Path of the Superhero (USA, prototype, 20030429) [Zach Lambert, Forest of Illusion]
Uridium Advance (Europe, prototype, 20030307) [March42, Forest of Illusion]

New software list items marked not working
------------------------------------------
The King of Fighters EX2 - Howling Blood (USA, prototype, 20030403) [March42, Forest of Illusion]
Quake (demo) [Randy Linden, Forest of Illusion]
Paradroid (Europe, prototype, 20030320) [March42, Forest of Illusion]
Uridium Advance (Europe, prototype, 20020911) [March42, Forest of Illusion]
Uridium Advance and Paradroid 2 in 1 (Europe, prototype, 20030430) [March42, Forest of Illusion]