### PR TITLE
apple2gs: rom1 ram size logic

### DIFF
--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -728,13 +728,19 @@ void apple2gs_state::machine_start()
 	m_cnxx_slot = CNXX_UNCLAIMED;
 
 
+	// install memory beyond 256K
 	int ramsize = m_ram_size;
+	if (!m_is_rom3 && m_ram_size <= 1280 * 1024)
+	{
+		ramsize -= 0x40000; // subtract 256k for banks 0, 1, e0, e1
+	}
+	else if (m_is_rom3 || m_ram_size == 1024 * 1024 * 8)
+	{
+		ramsize -= 0x20000; // subtract 128K for banks 0 and 1, which are handled specially
+	}
 
-	if (!m_is_rom3 && m_ram_size <= 1280 * 1024) ramsize -= 0x40000; // subtract 256k for banks 0, 1, e0, e1
-	else if (m_is_rom3 || m_ram_size == 1024 * 1024 * 8) ramsize -= 0x20000; // subtract 128K for banks 0 and 1, which are handled specially
-
-
-	if (ramsize) {
+	if (ramsize)
+	{
 		address_space& space = m_maincpu->space(AS_PROGRAM);
 		// RAM sizes for both classes of machine no longer include the Mega II RAM
 		space.install_ram(0x020000, ramsize - 1 + 0x20000, m_ram_ptr + 0x020000);

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -727,12 +727,18 @@ void apple2gs_state::machine_start()
 	m_inh_slot = -1;
 	m_cnxx_slot = CNXX_UNCLAIMED;
 
-	// install memory beyond 256K/1M
-	address_space& space = m_maincpu->space(AS_PROGRAM);
-	int ramsize = m_ram_size - 0x20000; // subtract 128K for banks 0 and 1, which are handled specially
 
-	// RAM sizes for both classes of machine no longer include the Mega II RAM
-	space.install_ram(0x020000, ramsize - 1 + 0x20000, m_ram_ptr + 0x020000);
+	int ramsize = m_ram_size;
+
+	if (!m_is_rom3 && m_ram_size <= 1280 * 1024) ramsize -= 0x40000; // subtract 256k for banks 0, 1, e0, e1
+	else if (m_is_rom3 || m_ram_size == 1024 * 1024 * 8) ramsize -= 0x20000; // subtract 128K for banks 0 and 1, which are handled specially
+
+
+	if (ramsize) {
+		address_space& space = m_maincpu->space(AS_PROGRAM);
+		// RAM sizes for both classes of machine no longer include the Mega II RAM
+		space.install_ram(0x020000, ramsize - 1 + 0x20000, m_ram_ptr + 0x020000);
+	}
 
 	// setup save states
 	save_item(NAME(m_speaker_state));


### PR DESCRIPTION
The ROM 1, the ram size calculation is a little off. For the base case of 256K-1.125MB, the e0/e1 memory needs to be subtracted as well. (Currently, a 256K apple2gsr1 has 384k).  Once you start getting into 2MB and 4MB, etc memory cards, that memory shouldn't be subtracted - if you install a 4MB card, you have 4megs on top of 0/1/e0/e1, for a total of 4.25MB.