### PR TITLE
dragon_cart.xml: Entry replaced with good dump, added additional info from PCB, updated softlist to new standards

### DIFF
--- a/hash/dragon_cart.xml
+++ b/hash/dragon_cart.xml
@@ -8,7 +8,7 @@ license:CC0-1.0
 	ROMs dumped from RAM and marked as "bad dumps":
 		- Cumana DOS v2.0
 
-	TO DO: Most cartridges with two EPROMs have been dumped as one single ROM, such entries should be marked as "bad dump" until proper split dumps exist.
+	TO DO: Most cartridges with two EPROMs have been dumped as one single file, such entries should be marked as "bad dump" until proper split dumps exist.
 
 -->
 <softwarelist name="dragon_cart" description="Dragon cartridges">

--- a/hash/dragon_cart.xml
+++ b/hash/dragon_cart.xml
@@ -17,10 +17,10 @@ license:CC0-1.0
 		<description>Astroblast</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Mark Data Products" />
+		<info name="developer" value="Mark Data Products"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="astroblast (1982) (dragon data).rom" size="8192" crc="61143386" sha1="64e103c787d551d9504a6e2c5d70fb2c676c92e1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="astroblast (1982) (dragon data).rom" size="0x2000" crc="61143386" sha1="64e103c787d551d9504a6e2c5d70fb2c676c92e1"/>
 			</dataarea>
 		</part>
 	</software>
@@ -29,11 +29,11 @@ license:CC0-1.0
 		<description>AMTOR/AX25</description>
 		<year>1990</year>
 		<publisher>Grosvenor Software</publisher>
-		<info name="usage" value="EXEC 49152" />
+		<info name="usage" value="EXEC 49152"/>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="amtor" />
-			<dataarea name="rom" size="32768">
-				<rom name="ax25-amtor (1990) (grosvenor).rom" size="32768" crc="81ba0d4a" sha1="6ad86b5faa5ba07ad42256e96f1c798cd3f0ea5e"/>
+			<feature name="slot" value="amtor"/>
+			<dataarea name="rom" size="0x8000">
+				<rom name="ax25-amtor (1990) (grosvenor).rom" size="0x8000" crc="81ba0d4a" sha1="6ad86b5faa5ba07ad42256e96f1c798cd3f0ea5e"/>
 			</dataarea>
 		</part>
 	</software>
@@ -42,10 +42,10 @@ license:CC0-1.0
 		<description>Doodle Bug</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Computerware" />
+		<info name="developer" value="Computerware"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="doodle bug (1982) (dragon data).rom" size="8192" crc="410a0332" sha1="637d37bffb6ebfd4441ea356904d71989df87b3f" status="baddump"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="doodle bug (1982) (dragon data).rom" size="0x2000" crc="410a0332" sha1="637d37bffb6ebfd4441ea356904d71989df87b3f" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -55,9 +55,9 @@ license:CC0-1.0
 		<year>1989</year>
 		<publisher>3S</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc" />
-			<dataarea name="rom" size="8192">
-				<rom name="dosplus v4.9b (1989)(3s).rom" size="8192" crc="7c6dfca8" sha1="73ae74978a78ec2b97ebb1b0c808238779529bfa"/>
+			<feature name="slot" value="dragon_fdc"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="dosplus v4.9b (1989)(3s).rom" size="0x2000" crc="7c6dfca8" sha1="73ae74978a78ec2b97ebb1b0c808238779529bfa"/>
 			</dataarea>
 		</part>
 	</software>
@@ -67,9 +67,9 @@ license:CC0-1.0
 		<year>1989</year>
 		<publisher>3S</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc" />
-			<dataarea name="rom" size="8192">
-				<rom name="dosplus v4.8 (1989)(3s).rom" size="8192" crc="402b0617" sha1="c9209d3c042d61e8ef984915fc277816d62a25f1"/>
+			<feature name="slot" value="dragon_fdc"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="dosplus v4.8 (1989)(3s).rom" size="0x2000" crc="402b0617" sha1="c9209d3c042d61e8ef984915fc277816d62a25f1"/>
 			</dataarea>
 		</part>
 	</software>
@@ -79,8 +79,8 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>Compusense</publisher>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="dasm-demon (1983)(compusense).rom" size="8192" crc="f602f497" sha1="fe8ded4fcc529571f6d07cc02c5089638613e164"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="dasm-demon (1983)(compusense).rom" size="0x2000" crc="f602f497" sha1="fe8ded4fcc529571f6d07cc02c5089638613e164"/>
 			</dataarea>
 		</part>
 	</software>
@@ -90,8 +90,8 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>Compusense</publisher>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="edit+ (1983)(compusense).rom" size="8192" crc="135f1aba" sha1="90e67516d3fb3995e7a69649b14063551c1d63ef"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="edit+ (1983)(compusense).rom" size="0x2000" crc="135f1aba" sha1="90e67516d3fb3995e7a69649b14063551c1d63ef"/>
 			</dataarea>
 		</part>
 	</software>
@@ -101,9 +101,9 @@ license:CC0-1.0
 		<year>198?</year>
 		<publisher>Cumana</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc" />
-			<dataarea name="rom" size="16128">
-				<rom name="cumana dos v2.0 (198x)(cumana).rom" size="16128" crc="32910d47" sha1="9fd99441d32344b1a64c8c0a61c61714761a88f9" status="baddump"/>
+			<feature name="slot" value="dragon_fdc"/>
+			<dataarea name="rom" size="0x3F00">
+				<rom name="cumana dos v2.0 (198x)(cumana).rom" size="0x3F00" crc="32910d47" sha1="9fd99441d32344b1a64c8c0a61c61714761a88f9" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -112,12 +112,12 @@ license:CC0-1.0
 		<description>Alldream</description>
 		<year>1984</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Grosvenor Software" />
-		<info name="author" value="Mike Kerry" />
-		<info name="serial" value="A0516" />
+		<info name="developer" value="Grosvenor Software"/>
+		<info name="author" value="Mike Kerry"/>
+		<info name="serial" value="A0516"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="alldream (1984)(grosvenor software).rom" size="8192" crc="af91e6ff" sha1="7c6b769510a5472c970597528850db9d0ee19f5a"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="alldream (1984)(grosvenor software).rom" size="0x2000" crc="af91e6ff" sha1="7c6b769510a5472c970597528850db9d0ee19f5a"/>
 			</dataarea>
 		</part>
 	</software>
@@ -126,12 +126,12 @@ license:CC0-1.0
 		<description>Berserk</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Mark Data Products" />
-		<info name="author" value="Ron Krebs" />
-		<info name="serial" value="A0100" />
+		<info name="developer" value="Mark Data Products"/>
+		<info name="author" value="Ron Krebs"/>
+		<info name="serial" value="A0100"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="berserk (1982)(a0100)(mark data products).rom" size="8192" crc="7901a633" sha1="aa2265ff9215b019b4f0a0d65a13ed66fbe660fe"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="berserk (1982)(a0100)(mark data products).rom" size="0x2000" crc="7901a633" sha1="aa2265ff9215b019b4f0a0d65a13ed66fbe660fe"/>
 			</dataarea>
 		</part>
 	</software>
@@ -140,11 +140,11 @@ license:CC0-1.0
 		<description>Cave Hunter</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Mark Data Products" />
-		<info name="author" value="Ron Krebs" />
+		<info name="developer" value="Mark Data Products"/>
+		<info name="author" value="Ron Krebs"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="4096">
-				<rom name="cave hunter (1982)(mark data products).rom" size="4096" crc="8bcaed11" sha1="5fd9605b5f68830d7531a22adc6d59b5af5c95df"/>
+			<dataarea name="rom" size="0x1000">
+				<rom name="cave hunter (1982)(mark data products).rom" size="0x1000" crc="8bcaed11" sha1="5fd9605b5f68830d7531a22adc6d59b5af5c95df"/>
 			</dataarea>
 		</part>
 	</software>
@@ -153,11 +153,11 @@ license:CC0-1.0
 		<description>Cosmic Invaders</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Spectral Associates" />
-		<info name="serial" value="A0102" />
+		<info name="developer" value="Spectral Associates"/>
+		<info name="serial" value="A0102"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="cosmic invaders (1982)(a0102)(spectral associates).rom" size="8192" crc="2ad2f4e0" sha1="0d75e7f849a1c0407f566342dfde2e8a15317839"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="cosmic invaders (1982)(a0102)(spectral associates).rom" size="0x2000" crc="2ad2f4e0" sha1="0d75e7f849a1c0407f566342dfde2e8a15317839"/>
 			</dataarea>
 		</part>
 	</software>
@@ -166,18 +166,18 @@ license:CC0-1.0
 		<description>Cyrus</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Intelligent Software" />
-		<info name="author" value="David Levy &amp; Richard Lang" />
-		<info name="serial" value="A0108" />
-		<info name="alt_title" value="Cyrus Chess Program (manual)" />
-		<info name="alt_title" value="Chess (cartridge, box)" />
+		<info name="developer" value="Intelligent Software"/>
+		<info name="author" value="David Levy &amp; Richard Lang"/>
+		<info name="serial" value="A0108"/>
+		<info name="alt_title" value="Cyrus Chess Program (manual)"/>
+		<info name="alt_title" value="Chess (cartridge, box)"/>
 		<part name="cart" interface="coco_cart">
 			<feature name="pcb" value="21-83"/>
 			<feature name="ic1" value="TMS 2532JL-45 MEP8332"/>
 			<feature name="ic2" value="TMS 2532JL-45 MEP8332"/>
-			<dataarea name="rom" size="8192">
-				<rom name="0.ic1" size="4096" crc="6B452AC3" sha1="38f5c6804aa7c8c5ff791bfcfc01318449800fcd" offset="0x0000" />
-				<rom name="1.ic2" size="4096" crc="9A0D3B20" sha1="104a0d27ec35f25af33e784e302b079bf05f4f45" offset="0x1000" />
+			<dataarea name="rom" size="0x2000">
+				<rom name="0.ic1" size="0x1000" offset="0x0000" crc="6B452AC3" sha1="38f5c6804aa7c8c5ff791bfcfc01318449800fcd"/>
+				<rom name="1.ic2" size="0x1000" offset="0x1000" crc="9A0D3B20" sha1="104a0d27ec35f25af33e784e302b079bf05f4f45"/>
 			</dataarea>
 		</part>
 	</software>
@@ -186,10 +186,10 @@ license:CC0-1.0
 		<description>Demonstration</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="serial" value="A0109" />
+		<info name="serial" value="A0109"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="democart (1982)(a0109)(dragon data).rom" size="8192" crc="7e1cc4b3" sha1="42e07d3ccdb4099720701a0ec39f4e6958922912"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="democart (1982)(a0109)(dragon data).rom" size="0x2000" crc="7e1cc4b3" sha1="42e07d3ccdb4099720701a0ec39f4e6958922912"/>
 			</dataarea>
 		</part>
 	</software>
@@ -198,10 +198,10 @@ license:CC0-1.0
 		<description>DOS-Dream</description>
 		<year>1986</year>
 		<publisher>Dragon Data</publisher>
-		<info name="author" value="M.J. Kerry" />
+		<info name="author" value="M.J. Kerry"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="dos-dream (1986)(dragon data).rom" size="8192" crc="480032e2" sha1="7a93df2eb0ea672112caa356c4bbec01d1f942ee"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="dos-dream (1986)(dragon data).rom" size="0x2000" crc="480032e2" sha1="7a93df2eb0ea672112caa356c4bbec01d1f942ee"/>
 			</dataarea>
 		</part>
 	</software>
@@ -211,8 +211,8 @@ license:CC0-1.0
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="quick diagnostic rom (1982)(dragon data).rom" size="8192" crc="863cfcfc" sha1="c87b096bbec260ce7230bf2f8d4e27c5b0752038"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="quick diagnostic rom (1982)(dragon data).rom" size="0x2000" crc="863cfcfc" sha1="c87b096bbec260ce7230bf2f8d4e27c5b0752038"/>
 			</dataarea>
 		</part>
 	</software>
@@ -222,9 +222,9 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>Dragon Data</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc" />
-			<dataarea name="rom" size="8192">
-				<rom name="dragondos 1.0 (1983)(dragon data).rom" size="8192" crc="b44536f6" sha1="a8918c71d319237c1e3155bb38620acb114a80bc"/>
+			<feature name="slot" value="dragon_fdc"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="dragondos 1.0 (1983)(dragon data).rom" size="0x2000" crc="b44536f6" sha1="a8918c71d319237c1e3155bb38620acb114a80bc"/>
 			</dataarea>
 		</part>
 	</software>
@@ -234,9 +234,9 @@ license:CC0-1.0
 		<year>1985</year>
 		<publisher>Eurohard S.A.</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc" />
-			<dataarea name="rom" size="8192">
-				<rom name="dragondos 4.0 (1985)(dragon data).rom" size="8192" crc="14f4c54a" sha1="89f38825ddf72b9863c04d8066d5ab8cabb9197a"/>
+			<feature name="slot" value="dragon_fdc"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="dragondos 4.0 (1985)(dragon data).rom" size="0x2000" crc="14f4c54a" sha1="89f38825ddf72b9863c04d8066d5ab8cabb9197a"/>
 			</dataarea>
 		</part>
 	</software>
@@ -246,9 +246,9 @@ license:CC0-1.0
 		<year>1985</year>
 		<publisher>Eurohard S.A.</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc" />
-			<dataarea name="rom" size="8192">
-				<rom name="dragondos 4.0 (es)(1985)(dragon data).rom" size="8192" crc="3d31cae8" sha1="9cb2da08b25ea10112ae15bf2e9a827c01e99b61"/>
+			<feature name="slot" value="dragon_fdc"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="dragondos 4.0 (es)(1985)(dragon data).rom" size="0x2000" crc="3d31cae8" sha1="9cb2da08b25ea10112ae15bf2e9a827c01e99b61"/>
 			</dataarea>
 		</part>
 	</software>
@@ -258,9 +258,9 @@ license:CC0-1.0
 		<year>1985</year>
 		<publisher>Eurohard S.A.</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc" />
-			<dataarea name="rom" size="8192">
-				<rom name="dragondos 4.1 (1985)(dragon data).rom" size="8192" crc="16d25658" sha1="ef44a5a0f2f1d9e52a9082e87f9975485f6f0d7d"/>
+			<feature name="slot" value="dragon_fdc"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="dragondos 4.1 (1985)(dragon data).rom" size="0x2000" crc="16d25658" sha1="ef44a5a0f2f1d9e52a9082e87f9975485f6f0d7d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -269,12 +269,12 @@ license:CC0-1.0
 		<description>Ghost Attack</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Computerware" />
-		<info name="author" value="B.J. Chambless" />
-		<info name="serial" value="A0103" />
+		<info name="developer" value="Computerware"/>
+		<info name="author" value="B.J. Chambless"/>
+		<info name="serial" value="A0103"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="ghost attack (1982)(a0103)(computerware).rom" size="8192" crc="45c089f6" sha1="4447fa2c441415e781a0f47f50b65e81f5798ae3"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="ghost attack (1982)(a0103)(computerware).rom" size="0x2000" crc="45c089f6" sha1="4447fa2c441415e781a0f47f50b65e81f5798ae3"/>
 			</dataarea>
 		</part>
 	</software>
@@ -283,10 +283,10 @@ license:CC0-1.0
 		<description>Meteoroids</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Spectral Associates" />
+		<info name="developer" value="Spectral Associates"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="4096">
-				<rom name="meteors (1982)(spectral associates).rom" size="4096" crc="64aba2b0" sha1="cd6970056b4c56fc1599228574f0c1419f61176a"/>
+			<dataarea name="rom" size="0x1000">
+				<rom name="meteors (1982)(spectral associates).rom" size="0x1000" crc="64aba2b0" sha1="cd6970056b4c56fc1599228574f0c1419f61176a"/>
 			</dataarea>
 		</part>
 	</software>
@@ -296,8 +296,8 @@ license:CC0-1.0
 		<year>198?</year>
 		<publisher>Dragon Data</publisher>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="prestel for dragon alpha (198x)(dragon data).rom" size="8192" crc="c6820601" sha1="ae0d1833ab644e9c85cb21e75fc2007714f8bbfd"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="prestel for dragon alpha (198x)(dragon data).rom" size="0x2000" crc="c6820601" sha1="ae0d1833ab644e9c85cb21e75fc2007714f8bbfd"/>
 			</dataarea>
 		</part>
 	</software>
@@ -306,12 +306,12 @@ license:CC0-1.0
 		<description>Rail Runner</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Computerware" />
-		<info name="author" value="B.J. Chambless" />
-		<info name="serial" value="A0111" />
+		<info name="developer" value="Computerware"/>
+		<info name="author" value="B.J. Chambless"/>
+		<info name="serial" value="A0111"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="rail runner (1982)(a0111)(computerware).rom" size="8192" crc="53e4be03" sha1="4167a3e2add6d90b30911b6ad32f52163142345c"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="rail runner (1982)(a0111)(computerware).rom" size="0x2000" crc="53e4be03" sha1="4167a3e2add6d90b30911b6ad32f52163142345c"/>
 			</dataarea>
 		</part>
 	</software>
@@ -320,12 +320,12 @@ license:CC0-1.0
 		<description>Starship Chameleon</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Computerware" />
-		<info name="author" value="Kenneth Kalish" />
-		<info name="serial" value="A0106" />
+		<info name="developer" value="Computerware"/>
+		<info name="author" value="Kenneth Kalish"/>
+		<info name="serial" value="A0106"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="starship chameleon (1982)(a0106)(computerware).rom" size="8192" crc="06c9b4e7" sha1="3f44baf761162d9ba66c8d32f41f5ea10be83aa1"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="starship chameleon (1982)(a0106)(computerware).rom" size="0x2000" crc="06c9b4e7" sha1="3f44baf761162d9ba66c8d32f41f5ea10be83aa1"/>
 			</dataarea>
 		</part>
 	</software>
@@ -335,9 +335,9 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>FarmFax</publisher>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="cash planner.1" size="8192" crc="29309592" sha1="8b230ef1a234e9c24d6a322366a84270259cf244" offset="0x0000" />
-				<rom name="cash planner.2" size="8192" crc="d41465b3" sha1="bc368a31d8e30c56749c783b181f83b70fd50fad" offset="0x2000" />
+			<dataarea name="rom" size="0x4000">
+				<rom name="cash planner.1" size="0x2000" offset="0x0000" crc="29309592" sha1="8b230ef1a234e9c24d6a322366a84270259cf244"/>
+				<rom name="cash planner.2" size="0x2000" offset="0x2000" crc="d41465b3" sha1="bc368a31d8e30c56749c783b181f83b70fd50fad"/>
 			</dataarea>
 		</part>
 	</software>
@@ -347,9 +347,9 @@ license:CC0-1.0
 		<year>1984</year>
 		<publisher>FarmFax</publisher>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="dairy prediction.1" size="8192" crc="bb3d1a7e" sha1="d79850fabda1fae61bd4ade5af6f4b545e4f96ed" offset="0x0000" />
-				<rom name="dairy prediction.2" size="8192" crc="7858d11c" sha1="e13384ab1bb6f47deb5def36e488873720cce059" offset="0x2000" />
+			<dataarea name="rom" size="0x4000">
+				<rom name="dairy prediction.1" size="0x2000" offset="0x0000" crc="bb3d1a7e" sha1="d79850fabda1fae61bd4ade5af6f4b545e4f96ed"/>
+				<rom name="dairy prediction.2" size="0x2000" offset="0x2000" crc="7858d11c" sha1="e13384ab1bb6f47deb5def36e488873720cce059"/>
 			</dataarea>
 		</part>
 	</software>
@@ -359,9 +359,9 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>FarmFax</publisher>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="rotation formulation dairy.1" size="8192" crc="fd0dda29" sha1="c2f67e2cb89cf7d7dd4a7346e0e19c54f7f5e7d4" offset="0x0000" />
-				<rom name="rotation formulation dairy.2" size="8192" crc="d0de8e62" sha1="2adf61728c272c09277637ee28c2b7b586d3c01f" offset="0x2000" />
+			<dataarea name="rom" size="0x4000">
+				<rom name="rotation formulation dairy.1" size="0x2000" offset="0x0000" crc="fd0dda29" sha1="c2f67e2cb89cf7d7dd4a7346e0e19c54f7f5e7d4"/>
+				<rom name="rotation formulation dairy.2" size="0x2000" offset="0x2000" crc="d0de8e62" sha1="2adf61728c272c09277637ee28c2b7b586d3c01f"/>
 			</dataarea>
 		</part>
 	</software>
@@ -371,8 +371,8 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>FarmFax</publisher>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="trainer.rom" size="8192" crc="9fa36a89" sha1="aacfcba60e976807917340ee4f5af47c17fe8d43"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="trainer.rom" size="0x2000" crc="9fa36a89" sha1="aacfcba60e976807917340ee4f5af47c17fe8d43"/>
 			</dataarea>
 		</part>
 	</software>
@@ -381,11 +381,11 @@ license:CC0-1.0
 		<description>Delta DOS</description>
 		<year>1983</year>
 		<publisher>Premier Microsystems</publisher>
-		<info name="author" value="J.G. Johnson &amp; P.J. Rihan" />
+		<info name="author" value="J.G. Johnson &amp; P.J. Rihan"/>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="premier_fdc" />
-			<dataarea name="rom" size="8192">
-				<rom name="deltados (1983)(premier micros).rom" size="8192" crc="149eb4dd" sha1="eb686ce6afe63e4d4011b333a882ca812c69307f"/>
+			<feature name="slot" value="premier_fdc"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="deltados (1983)(premier micros).rom" size="0x2000" crc="149eb4dd" sha1="eb686ce6afe63e4d4011b333a882ca812c69307f"/>
 			</dataarea>
 		</part>
 	</software>
@@ -395,9 +395,9 @@ license:CC0-1.0
 		<year>1986</year>
 		<publisher>PNP Communications</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc" />
-			<dataarea name="rom" size="8192">
-				<rom name="superdos e6 (198x)(pnp).rom" size="8192" crc="8c1d6c45" sha1="ef157016386ed463374de6bac84d1f8ce654ed80"/>
+			<feature name="slot" value="dragon_fdc"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="superdos e6 (198x)(pnp).rom" size="0x2000" crc="8c1d6c45" sha1="ef157016386ed463374de6bac84d1f8ce654ed80"/>
 			</dataarea>
 		</part>
 	</software>
@@ -407,9 +407,9 @@ license:CC0-1.0
 		<year>1984</year>
 		<publisher>Telepost Systems</publisher>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="16384">
-				<rom name="terminal simulator 1 24-5-84.rom" size="8192" crc="6a7e8b36" sha1="dbd1871c5ecb338defd3209b387d83d5222ed4a6" offset="0x0000" />
-				<rom name="terminal simulator 2 24-5-84.rom" size="8192" crc="ea472a6a" sha1="d6fab40b421a3054bbd32e9d2641ec17fc614cd6" offset="0x2000" />
+			<dataarea name="rom" size="0x4000">
+				<rom name="terminal simulator 1 24-5-84.rom" size="0x2000" offset="0x0000" crc="6a7e8b36" sha1="dbd1871c5ecb338defd3209b387d83d5222ed4a6"/>
+				<rom name="terminal simulator 2 24-5-84.rom" size="0x2000" offset="0x2000" crc="ea472a6a" sha1="d6fab40b421a3054bbd32e9d2641ec17fc614cd6"/>
 			</dataarea>
 		</part>
 	</software>
@@ -418,14 +418,14 @@ license:CC0-1.0
 		<description>Test De Conducción</description>
 		<year>1982</year>
 		<publisher>Belrampa Servicios, SA</publisher>
-		<info name="usage" value="Disable Cart Auto-Start, EXEC 49152" />
+		<info name="usage" value="Disable Cart Auto-Start, EXEC 49152"/>
 		<part name="cart" interface="coco_cart">
 			<feature name="pcb" value="RE-075"/>		<!--	PCB with "59" written with marker	-->
 			<feature name="ic1" value="TMS ?"/>			<!--	Illegible	-->
 			<feature name="ic2" value="TMS 2564JDL-45 DBP8127"/>
-			<dataarea name="rom" size="16384">
-				<rom name="1.ic1" size="8192" crc="65d3153d" sha1="c44277f3d7ec615947465d20674b0771bdd44867" offset="0x0000" />
-				<rom name="2.ic2" size="8192" crc="477921ca" sha1="a3d23148842fd7eb3b4f04d63a701a88573cbfb5" offset="0x2000" />
+			<dataarea name="rom" size="0x4000">
+				<rom name="1.ic1" size="0x2000" offset="0x0000" crc="65d3153d" sha1="c44277f3d7ec615947465d20674b0771bdd44867"/>
+				<rom name="2.ic2" size="0x2000" offset="0x2000" crc="477921ca" sha1="a3d23148842fd7eb3b4f04d63a701a88573cbfb5"/>
 			</dataarea>
 		</part>
 	</software>
@@ -434,10 +434,10 @@ license:CC0-1.0
 		<description>Toolkit</description>
 		<year>1983</year>
 		<publisher>Premier Microsystems</publisher>
-		<info name="author" value="S.J Purdy" />
+		<info name="author" value="S.J Purdy"/>
 		<part name="cart" interface="coco_cart">
-			<dataarea name="rom" size="8192">
-				<rom name="toolkit (1983) (premier microsystems).rom" size="8192" crc="82ef981a" sha1="b9c0d29382ae1d685f196ab4b53fb75156e12404"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="toolkit (1983) (premier microsystems).rom" size="0x2000" crc="82ef981a" sha1="b9c0d29382ae1d685f196ab4b53fb75156e12404"/>
 			</dataarea>
 		</part>
 	</software>
@@ -449,9 +449,9 @@ license:CC0-1.0
 		<year>1984</year>
 		<publisher>Dragon data</publisher>
 		<part name="cart" interface="coco_cart">
-			<!-- <feature name="slot" value="epromprg" /> -->
-			<dataarea name="rom" size="4096">
-				<rom name="eprom_mkII_v21.rom" size="4096" crc="310bc0a0" sha1="4aba041033410ab912753407ae29e5fe89925440"/>
+			<!-- <feature name="slot" value="epromprg"/> -->
+			<dataarea name="rom" size="0x1000">
+				<rom name="eprom_mkII_v21.rom" size="0x1000" crc="310bc0a0" sha1="4aba041033410ab912753407ae29e5fe89925440"/>
 			</dataarea>
 		</part>
 	</software>
@@ -461,9 +461,9 @@ license:CC0-1.0
 		<year>1984</year>
 		<publisher>Steve's Electronics</publisher>
 		<part name="cart" interface="coco_cart">
-			<!-- <feature name="slot" value="epromprg" /> -->
-			<dataarea name="rom" size="4096">
-				<rom name="ecm_ep_kit.rom" size="4096" crc="f5e1d7f0" sha1="cce757b0662abb8c110e1a072cbf9f54d097d010"/>
+			<!-- <feature name="slot" value="epromprg"/> -->
+			<dataarea name="rom" size="0x1000">
+				<rom name="ecm_ep_kit.rom" size="0x1000" crc="f5e1d7f0" sha1="cce757b0662abb8c110e1a072cbf9f54d097d010"/>
 			</dataarea>
 		</part>
 	</software>
@@ -473,9 +473,9 @@ license:CC0-1.0
 		<year>1987</year>
 		<publisher>Peaksoft</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="serial" />
-			<dataarea name="rom" size="8192">
-				<rom name="comron_peaksoft.rom" size="8192" crc="9d18cf46" sha1="14124dfb4bd78d1907e80d779cd7f3bae30564c9"/>
+			<feature name="slot" value="serial"/>
+			<dataarea name="rom" size="0x2000">
+				<rom name="comron_peaksoft.rom" size="0x2000" crc="9d18cf46" sha1="14124dfb4bd78d1907e80d779cd7f3bae30564c9"/>
 			</dataarea>
 		</part>
 	</software>
@@ -485,9 +485,9 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>&lt;unknown;&gt;</publisher>
 		<part name="cart" interface="coco_cart">
-			<!-- <feature name="slot" value="soaktest" /> -->
-			<dataarea name="rom" size="4096">
-				<rom name="d32soaktest.rom" size="4096" crc="41c61438" sha1="6db94922a458ae292d7a5c3333d86f2d935212b6"/>
+			<!-- <feature name="slot" value="soaktest"/> -->
+			<dataarea name="rom" size="0x1000">
+				<rom name="d32soaktest.rom" size="0x1000" crc="41c61438" sha1="6db94922a458ae292d7a5c3333d86f2d935212b6"/>
 			</dataarea>
 		</part>
 	</software>
@@ -497,9 +497,9 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>J.C.B. (Microsystems)</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="jcbsnd" />
-			<dataarea name="rom" size="4096">
-				<rom name="D32SEM.ROM" size="4096" crc="4cd0f30b" sha1="d07bb9272e3d3928059853730ff656905a80b68e"/>
+			<feature name="slot" value="jcbsnd"/>
+			<dataarea name="rom" size="0x1000">
+				<rom name="D32SEM.ROM" size="0x1000" crc="4cd0f30b" sha1="d07bb9272e3d3928059853730ff656905a80b68e"/>
 			</dataarea>
 		</part>
 	</software>
@@ -509,9 +509,9 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>J.C.B. (Microsystems)</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="jcbspch" />
-			<dataarea name="rom" size="4096">
-				<rom name="jcb-speech.rom" size="4096" crc="e88dfe36" sha1="df3f64a7a3beeb91469932035af5e4f8a7872aad"/>
+			<feature name="slot" value="jcbspch"/>
+			<dataarea name="rom" size="0x1000">
+				<rom name="jcb-speech.rom" size="0x1000" crc="e88dfe36" sha1="df3f64a7a3beeb91469932035af5e4f8a7872aad"/>
 			</dataarea>
 		</part>
 	</software>
@@ -521,9 +521,9 @@ license:CC0-1.0
 		<year>1984</year>
 		<publisher>Ikon Computer Products</publisher>
 		<part name="cart" interface="coco_cart">
-			<!-- <feature name="slot" value="ultradrv" /> -->
-			<dataarea name="rom" size="4096">
-				<rom name="Dragonfly Tape system v1.3.rom" size="4096" crc="72618948" sha1="12cc90afc7eb1c0b0b720d4722f8d47e39932893"/>
+			<!-- <feature name="slot" value="ultradrv"/> -->
+			<dataarea name="rom" size="0x1000">
+				<rom name="Dragonfly Tape system v1.3.rom" size="0x1000" crc="72618948" sha1="12cc90afc7eb1c0b0b720d4722f8d47e39932893"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/dragon_cart.xml
+++ b/hash/dragon_cart.xml
@@ -167,14 +167,14 @@ license:CC0-1.0
 	</software>
 
 	<software name="cyrus">
-		<description>Cyrus</description>
+		<!-- marketed as "CHESS" - the boot screen says "CYRUS" while the manual says "CYRUS CHESS PROGRAM" -->
+		<description>Chess</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
 		<info name="developer" value="Intelligent Software" />
 		<info name="author" value="David Levy &amp; Richard Lang" />
 		<info name="serial" value="A0108" />
-		<info name="alt_title" value="Cyrus Chess Program (manual)" />
-		<info name="alt_title" value="Chess (cartridge, box)" />
+		<info name="alt_title" value="Cyrus Chess Program" />
 		<part name="cart" interface="coco_cart">
 			<feature name="pcb" value="21-83" />
 			<feature name="ic1" value="TMS 2532JL-45 MEP8332" />

--- a/hash/dragon_cart.xml
+++ b/hash/dragon_cart.xml
@@ -3,13 +3,13 @@
 <!--
 license:CC0-1.0
 
-Compiled by K1W1 and Cowering (from GoodCoCo)
+	Nearly all of the cartridges on this Dragon softwarelist will also run on the CoCo 2/3, CP400.
+	
+	ROMs dumped from RAM and marked as "bad dumps":
+		- Cumana DOS v2.0
 
-  * Nearly all of the cartridges on this Dragon softwarelist will also run on the CoCo 2/3, CP400.
+	TO DO: Most cartridges with two EPROMs have been dumped as one single ROM, such entries should be marked as "bad dump" until proper split dumps exist.
 
-  * These ROMs appear to have been dumped from RAM and have been marked as "Bad Dumps"
-
-    - Cumana DOS v2.0
 -->
 <softwarelist name="dragon_cart" description="Dragon cartridges">
 
@@ -163,15 +163,21 @@ Compiled by K1W1 and Cowering (from GoodCoCo)
 	</software>
 
 	<software name="cyrus">
-		<description>Cyrus Chess</description>
+		<description>Cyrus</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
 		<info name="developer" value="Intelligent Software" />
 		<info name="author" value="David Levy &amp; Richard Lang" />
 		<info name="serial" value="A0108" />
+		<info name="alt_title" value="Cyrus Chess Program (manual)" />
+		<info name="alt_title" value="Chess (cartridge, box)" />
 		<part name="cart" interface="coco_cart">
+			<feature name="pcb" value="21-83"/>
+			<feature name="ic1" value="TMS 2532JL-45 MEP8332"/>
+			<feature name="ic2" value="TMS 2532JL-45 MEP8332"/>
 			<dataarea name="rom" size="8192">
-				<rom name="cyrus chess (1982)(a0108)(dragon data).rom" size="8192" crc="d4c36a96" sha1="953f35586b0fc7c5b1f5ccb9fd20e0e6e1041d9c"/>
+				<rom name="0.ic1" size="4096" crc="6B452AC3" sha1="38f5c6804aa7c8c5ff791bfcfc01318449800fcd" offset="0x0000" />
+				<rom name="1.ic2" size="4096" crc="9A0D3B20" sha1="104a0d27ec35f25af33e784e302b079bf05f4f45" offset="0x1000" />
 			</dataarea>
 		</part>
 	</software>
@@ -414,9 +420,12 @@ Compiled by K1W1 and Cowering (from GoodCoCo)
 		<publisher>Belrampa Servicios, SA</publisher>
 		<info name="usage" value="Disable Cart Auto-Start, EXEC 49152" />
 		<part name="cart" interface="coco_cart">
+			<feature name="pcb" value="RE-075"/>		<!--	PCB with "59" written with marker	-->
+			<feature name="ic1" value="TMS ?"/>			<!--	Illegible	-->
+			<feature name="ic2" value="TMS 2564JDL-45 DBP8127"/>
 			<dataarea name="rom" size="16384">
-				<rom name="test de conduccion 1 (1982)(belrampa servicios, sa).rom" size="8192" crc="65d3153d" sha1="c44277f3d7ec615947465d20674b0771bdd44867" offset="0x0000" />
-				<rom name="test de conduccion 2 (1982)(belrampa servicios, sa).rom" size="8192" crc="477921ca" sha1="a3d23148842fd7eb3b4f04d63a701a88573cbfb5" offset="0x2000" />
+				<rom name="1.ic1" size="8192" crc="65d3153d" sha1="c44277f3d7ec615947465d20674b0771bdd44867" offset="0x0000" />
+				<rom name="2.ic2" size="8192" crc="477921ca" sha1="a3d23148842fd7eb3b4f04d63a701a88573cbfb5" offset="0x2000" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/dragon_cart.xml
+++ b/hash/dragon_cart.xml
@@ -2,25 +2,29 @@
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
-
-	Nearly all of the cartridges on this Dragon softwarelist will also run on the CoCo 2/3, CP400.
-	
-	ROMs dumped from RAM and marked as "bad dumps":
-		- Cumana DOS v2.0
-
-	TO DO: Most cartridges with two EPROMs have been dumped as one single file, such entries should be marked as "bad dump" until proper split dumps exist.
-
 -->
+
 <softwarelist name="dragon_cart" description="Dragon cartridges">
+	<!--
+	Nearly all of the cartridges on this Dragon software list will also run on the CoCo 2/3, CP400.
+
+	ROMs dumped from RAM and marked as "bad dumps":
+		Cumana DOS v2.0
+
+	TODO:
+		Most cartridges with two EPROMs have been dumped as one single file, such entries should be marked as "bad dump" until proper split dumps exist.
+		Add compatibility tags where needed.
+
+	-->
 
 	<software name="astrblst">
 		<description>Astroblast</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Mark Data Products"/>
+		<info name="developer" value="Mark Data Products" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="astroblast (1982) (dragon data).rom" size="0x2000" crc="61143386" sha1="64e103c787d551d9504a6e2c5d70fb2c676c92e1"/>
+				<rom name="astroblast (1982) (dragon data).rom" size="0x2000" crc="61143386" sha1="64e103c787d551d9504a6e2c5d70fb2c676c92e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -29,11 +33,11 @@ license:CC0-1.0
 		<description>AMTOR/AX25</description>
 		<year>1990</year>
 		<publisher>Grosvenor Software</publisher>
-		<info name="usage" value="EXEC 49152"/>
+		<info name="usage" value="EXEC 49152" />
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="amtor"/>
+			<feature name="slot" value="amtor" />
 			<dataarea name="rom" size="0x8000">
-				<rom name="ax25-amtor (1990) (grosvenor).rom" size="0x8000" crc="81ba0d4a" sha1="6ad86b5faa5ba07ad42256e96f1c798cd3f0ea5e"/>
+				<rom name="ax25-amtor (1990) (grosvenor).rom" size="0x8000" crc="81ba0d4a" sha1="6ad86b5faa5ba07ad42256e96f1c798cd3f0ea5e" />
 			</dataarea>
 		</part>
 	</software>
@@ -42,10 +46,10 @@ license:CC0-1.0
 		<description>Doodle Bug</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Computerware"/>
+		<info name="developer" value="Computerware" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="doodle bug (1982) (dragon data).rom" size="0x2000" crc="410a0332" sha1="637d37bffb6ebfd4441ea356904d71989df87b3f" status="baddump"/>
+				<rom name="doodle bug (1982) (dragon data).rom" size="0x2000" crc="410a0332" sha1="637d37bffb6ebfd4441ea356904d71989df87b3f" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -55,9 +59,9 @@ license:CC0-1.0
 		<year>1989</year>
 		<publisher>3S</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc"/>
+			<feature name="slot" value="dragon_fdc" />
 			<dataarea name="rom" size="0x2000">
-				<rom name="dosplus v4.9b (1989)(3s).rom" size="0x2000" crc="7c6dfca8" sha1="73ae74978a78ec2b97ebb1b0c808238779529bfa"/>
+				<rom name="dosplus v4.9b (1989)(3s).rom" size="0x2000" crc="7c6dfca8" sha1="73ae74978a78ec2b97ebb1b0c808238779529bfa" />
 			</dataarea>
 		</part>
 	</software>
@@ -67,9 +71,9 @@ license:CC0-1.0
 		<year>1989</year>
 		<publisher>3S</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc"/>
+			<feature name="slot" value="dragon_fdc" />
 			<dataarea name="rom" size="0x2000">
-				<rom name="dosplus v4.8 (1989)(3s).rom" size="0x2000" crc="402b0617" sha1="c9209d3c042d61e8ef984915fc277816d62a25f1"/>
+				<rom name="dosplus v4.8 (1989)(3s).rom" size="0x2000" crc="402b0617" sha1="c9209d3c042d61e8ef984915fc277816d62a25f1" />
 			</dataarea>
 		</part>
 	</software>
@@ -80,7 +84,7 @@ license:CC0-1.0
 		<publisher>Compusense</publisher>
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="dasm-demon (1983)(compusense).rom" size="0x2000" crc="f602f497" sha1="fe8ded4fcc529571f6d07cc02c5089638613e164"/>
+				<rom name="dasm-demon (1983)(compusense).rom" size="0x2000" crc="f602f497" sha1="fe8ded4fcc529571f6d07cc02c5089638613e164" />
 			</dataarea>
 		</part>
 	</software>
@@ -91,7 +95,7 @@ license:CC0-1.0
 		<publisher>Compusense</publisher>
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="edit+ (1983)(compusense).rom" size="0x2000" crc="135f1aba" sha1="90e67516d3fb3995e7a69649b14063551c1d63ef"/>
+				<rom name="edit+ (1983)(compusense).rom" size="0x2000" crc="135f1aba" sha1="90e67516d3fb3995e7a69649b14063551c1d63ef" />
 			</dataarea>
 		</part>
 	</software>
@@ -101,9 +105,9 @@ license:CC0-1.0
 		<year>198?</year>
 		<publisher>Cumana</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc"/>
-			<dataarea name="rom" size="0x3F00">
-				<rom name="cumana dos v2.0 (198x)(cumana).rom" size="0x3F00" crc="32910d47" sha1="9fd99441d32344b1a64c8c0a61c61714761a88f9" status="baddump"/>
+			<feature name="slot" value="dragon_fdc" />
+			<dataarea name="rom" size="0x3f00">
+				<rom name="cumana dos v2.0 (198x)(cumana).rom" size="0x3f00" crc="32910d47" sha1="9fd99441d32344b1a64c8c0a61c61714761a88f9" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -112,12 +116,12 @@ license:CC0-1.0
 		<description>Alldream</description>
 		<year>1984</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Grosvenor Software"/>
-		<info name="author" value="Mike Kerry"/>
-		<info name="serial" value="A0516"/>
+		<info name="developer" value="Grosvenor Software" />
+		<info name="author" value="Mike Kerry" />
+		<info name="serial" value="A0516" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="alldream (1984)(grosvenor software).rom" size="0x2000" crc="af91e6ff" sha1="7c6b769510a5472c970597528850db9d0ee19f5a"/>
+				<rom name="alldream (1984)(grosvenor software).rom" size="0x2000" crc="af91e6ff" sha1="7c6b769510a5472c970597528850db9d0ee19f5a" />
 			</dataarea>
 		</part>
 	</software>
@@ -126,12 +130,12 @@ license:CC0-1.0
 		<description>Berserk</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Mark Data Products"/>
-		<info name="author" value="Ron Krebs"/>
-		<info name="serial" value="A0100"/>
+		<info name="developer" value="Mark Data Products" />
+		<info name="author" value="Ron Krebs" />
+		<info name="serial" value="A0100" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="berserk (1982)(a0100)(mark data products).rom" size="0x2000" crc="7901a633" sha1="aa2265ff9215b019b4f0a0d65a13ed66fbe660fe"/>
+				<rom name="berserk (1982)(a0100)(mark data products).rom" size="0x2000" crc="7901a633" sha1="aa2265ff9215b019b4f0a0d65a13ed66fbe660fe" />
 			</dataarea>
 		</part>
 	</software>
@@ -140,11 +144,11 @@ license:CC0-1.0
 		<description>Cave Hunter</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Mark Data Products"/>
-		<info name="author" value="Ron Krebs"/>
+		<info name="developer" value="Mark Data Products" />
+		<info name="author" value="Ron Krebs" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x1000">
-				<rom name="cave hunter (1982)(mark data products).rom" size="0x1000" crc="8bcaed11" sha1="5fd9605b5f68830d7531a22adc6d59b5af5c95df"/>
+				<rom name="cave hunter (1982)(mark data products).rom" size="0x1000" crc="8bcaed11" sha1="5fd9605b5f68830d7531a22adc6d59b5af5c95df" />
 			</dataarea>
 		</part>
 	</software>
@@ -153,11 +157,11 @@ license:CC0-1.0
 		<description>Cosmic Invaders</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Spectral Associates"/>
-		<info name="serial" value="A0102"/>
+		<info name="developer" value="Spectral Associates" />
+		<info name="serial" value="A0102" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="cosmic invaders (1982)(a0102)(spectral associates).rom" size="0x2000" crc="2ad2f4e0" sha1="0d75e7f849a1c0407f566342dfde2e8a15317839"/>
+				<rom name="cosmic invaders (1982)(a0102)(spectral associates).rom" size="0x2000" crc="2ad2f4e0" sha1="0d75e7f849a1c0407f566342dfde2e8a15317839" />
 			</dataarea>
 		</part>
 	</software>
@@ -166,18 +170,18 @@ license:CC0-1.0
 		<description>Cyrus</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Intelligent Software"/>
-		<info name="author" value="David Levy &amp; Richard Lang"/>
-		<info name="serial" value="A0108"/>
-		<info name="alt_title" value="Cyrus Chess Program (manual)"/>
-		<info name="alt_title" value="Chess (cartridge, box)"/>
+		<info name="developer" value="Intelligent Software" />
+		<info name="author" value="David Levy &amp; Richard Lang" />
+		<info name="serial" value="A0108" />
+		<info name="alt_title" value="Cyrus Chess Program (manual)" />
+		<info name="alt_title" value="Chess (cartridge, box)" />
 		<part name="cart" interface="coco_cart">
-			<feature name="pcb" value="21-83"/>
-			<feature name="ic1" value="TMS 2532JL-45 MEP8332"/>
-			<feature name="ic2" value="TMS 2532JL-45 MEP8332"/>
+			<feature name="pcb" value="21-83" />
+			<feature name="ic1" value="TMS 2532JL-45 MEP8332" />
+			<feature name="ic2" value="TMS 2532JL-45 MEP8332" />
 			<dataarea name="rom" size="0x2000">
-				<rom name="0.ic1" size="0x1000" offset="0x0000" crc="6B452AC3" sha1="38f5c6804aa7c8c5ff791bfcfc01318449800fcd"/>
-				<rom name="1.ic2" size="0x1000" offset="0x1000" crc="9A0D3B20" sha1="104a0d27ec35f25af33e784e302b079bf05f4f45"/>
+				<rom name="0.ic1" size="0x1000" offset="0x0000" crc="6b452ac3" sha1="38f5c6804aa7c8c5ff791bfcfc01318449800fcd" />
+				<rom name="1.ic2" size="0x1000" offset="0x1000" crc="9a0d3b20" sha1="104a0d27ec35f25af33e784e302b079bf05f4f45" />
 			</dataarea>
 		</part>
 	</software>
@@ -186,10 +190,10 @@ license:CC0-1.0
 		<description>Demonstration</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="serial" value="A0109"/>
+		<info name="serial" value="A0109" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="democart (1982)(a0109)(dragon data).rom" size="0x2000" crc="7e1cc4b3" sha1="42e07d3ccdb4099720701a0ec39f4e6958922912"/>
+				<rom name="democart (1982)(a0109)(dragon data).rom" size="0x2000" crc="7e1cc4b3" sha1="42e07d3ccdb4099720701a0ec39f4e6958922912" />
 			</dataarea>
 		</part>
 	</software>
@@ -198,10 +202,10 @@ license:CC0-1.0
 		<description>DOS-Dream</description>
 		<year>1986</year>
 		<publisher>Dragon Data</publisher>
-		<info name="author" value="M.J. Kerry"/>
+		<info name="author" value="M.J. Kerry" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="dos-dream (1986)(dragon data).rom" size="0x2000" crc="480032e2" sha1="7a93df2eb0ea672112caa356c4bbec01d1f942ee"/>
+				<rom name="dos-dream (1986)(dragon data).rom" size="0x2000" crc="480032e2" sha1="7a93df2eb0ea672112caa356c4bbec01d1f942ee" />
 			</dataarea>
 		</part>
 	</software>
@@ -212,7 +216,7 @@ license:CC0-1.0
 		<publisher>Dragon Data</publisher>
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="quick diagnostic rom (1982)(dragon data).rom" size="0x2000" crc="863cfcfc" sha1="c87b096bbec260ce7230bf2f8d4e27c5b0752038"/>
+				<rom name="quick diagnostic rom (1982)(dragon data).rom" size="0x2000" crc="863cfcfc" sha1="c87b096bbec260ce7230bf2f8d4e27c5b0752038" />
 			</dataarea>
 		</part>
 	</software>
@@ -222,9 +226,9 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>Dragon Data</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc"/>
+			<feature name="slot" value="dragon_fdc" />
 			<dataarea name="rom" size="0x2000">
-				<rom name="dragondos 1.0 (1983)(dragon data).rom" size="0x2000" crc="b44536f6" sha1="a8918c71d319237c1e3155bb38620acb114a80bc"/>
+				<rom name="dragondos 1.0 (1983)(dragon data).rom" size="0x2000" crc="b44536f6" sha1="a8918c71d319237c1e3155bb38620acb114a80bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -234,9 +238,9 @@ license:CC0-1.0
 		<year>1985</year>
 		<publisher>Eurohard S.A.</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc"/>
+			<feature name="slot" value="dragon_fdc" />
 			<dataarea name="rom" size="0x2000">
-				<rom name="dragondos 4.0 (1985)(dragon data).rom" size="0x2000" crc="14f4c54a" sha1="89f38825ddf72b9863c04d8066d5ab8cabb9197a"/>
+				<rom name="dragondos 4.0 (1985)(dragon data).rom" size="0x2000" crc="14f4c54a" sha1="89f38825ddf72b9863c04d8066d5ab8cabb9197a" />
 			</dataarea>
 		</part>
 	</software>
@@ -246,9 +250,9 @@ license:CC0-1.0
 		<year>1985</year>
 		<publisher>Eurohard S.A.</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc"/>
+			<feature name="slot" value="dragon_fdc" />
 			<dataarea name="rom" size="0x2000">
-				<rom name="dragondos 4.0 (es)(1985)(dragon data).rom" size="0x2000" crc="3d31cae8" sha1="9cb2da08b25ea10112ae15bf2e9a827c01e99b61"/>
+				<rom name="dragondos 4.0 (es)(1985)(dragon data).rom" size="0x2000" crc="3d31cae8" sha1="9cb2da08b25ea10112ae15bf2e9a827c01e99b61" />
 			</dataarea>
 		</part>
 	</software>
@@ -258,9 +262,9 @@ license:CC0-1.0
 		<year>1985</year>
 		<publisher>Eurohard S.A.</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc"/>
+			<feature name="slot" value="dragon_fdc" />
 			<dataarea name="rom" size="0x2000">
-				<rom name="dragondos 4.1 (1985)(dragon data).rom" size="0x2000" crc="16d25658" sha1="ef44a5a0f2f1d9e52a9082e87f9975485f6f0d7d"/>
+				<rom name="dragondos 4.1 (1985)(dragon data).rom" size="0x2000" crc="16d25658" sha1="ef44a5a0f2f1d9e52a9082e87f9975485f6f0d7d" />
 			</dataarea>
 		</part>
 	</software>
@@ -269,12 +273,12 @@ license:CC0-1.0
 		<description>Ghost Attack</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Computerware"/>
-		<info name="author" value="B.J. Chambless"/>
-		<info name="serial" value="A0103"/>
+		<info name="developer" value="Computerware" />
+		<info name="author" value="B.J. Chambless" />
+		<info name="serial" value="A0103" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="ghost attack (1982)(a0103)(computerware).rom" size="0x2000" crc="45c089f6" sha1="4447fa2c441415e781a0f47f50b65e81f5798ae3"/>
+				<rom name="ghost attack (1982)(a0103)(computerware).rom" size="0x2000" crc="45c089f6" sha1="4447fa2c441415e781a0f47f50b65e81f5798ae3" />
 			</dataarea>
 		</part>
 	</software>
@@ -283,10 +287,10 @@ license:CC0-1.0
 		<description>Meteoroids</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Spectral Associates"/>
+		<info name="developer" value="Spectral Associates" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x1000">
-				<rom name="meteors (1982)(spectral associates).rom" size="0x1000" crc="64aba2b0" sha1="cd6970056b4c56fc1599228574f0c1419f61176a"/>
+				<rom name="meteors (1982)(spectral associates).rom" size="0x1000" crc="64aba2b0" sha1="cd6970056b4c56fc1599228574f0c1419f61176a" />
 			</dataarea>
 		</part>
 	</software>
@@ -297,7 +301,7 @@ license:CC0-1.0
 		<publisher>Dragon Data</publisher>
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="prestel for dragon alpha (198x)(dragon data).rom" size="0x2000" crc="c6820601" sha1="ae0d1833ab644e9c85cb21e75fc2007714f8bbfd"/>
+				<rom name="prestel for dragon alpha (198x)(dragon data).rom" size="0x2000" crc="c6820601" sha1="ae0d1833ab644e9c85cb21e75fc2007714f8bbfd" />
 			</dataarea>
 		</part>
 	</software>
@@ -306,12 +310,12 @@ license:CC0-1.0
 		<description>Rail Runner</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Computerware"/>
-		<info name="author" value="B.J. Chambless"/>
-		<info name="serial" value="A0111"/>
+		<info name="developer" value="Computerware" />
+		<info name="author" value="B.J. Chambless" />
+		<info name="serial" value="A0111" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="rail runner (1982)(a0111)(computerware).rom" size="0x2000" crc="53e4be03" sha1="4167a3e2add6d90b30911b6ad32f52163142345c"/>
+				<rom name="rail runner (1982)(a0111)(computerware).rom" size="0x2000" crc="53e4be03" sha1="4167a3e2add6d90b30911b6ad32f52163142345c" />
 			</dataarea>
 		</part>
 	</software>
@@ -320,12 +324,12 @@ license:CC0-1.0
 		<description>Starship Chameleon</description>
 		<year>1982</year>
 		<publisher>Dragon Data</publisher>
-		<info name="developer" value="Computerware"/>
-		<info name="author" value="Kenneth Kalish"/>
-		<info name="serial" value="A0106"/>
+		<info name="developer" value="Computerware" />
+		<info name="author" value="Kenneth Kalish" />
+		<info name="serial" value="A0106" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="starship chameleon (1982)(a0106)(computerware).rom" size="0x2000" crc="06c9b4e7" sha1="3f44baf761162d9ba66c8d32f41f5ea10be83aa1"/>
+				<rom name="starship chameleon (1982)(a0106)(computerware).rom" size="0x2000" crc="06c9b4e7" sha1="3f44baf761162d9ba66c8d32f41f5ea10be83aa1" />
 			</dataarea>
 		</part>
 	</software>
@@ -336,8 +340,8 @@ license:CC0-1.0
 		<publisher>FarmFax</publisher>
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x4000">
-				<rom name="cash planner.1" size="0x2000" offset="0x0000" crc="29309592" sha1="8b230ef1a234e9c24d6a322366a84270259cf244"/>
-				<rom name="cash planner.2" size="0x2000" offset="0x2000" crc="d41465b3" sha1="bc368a31d8e30c56749c783b181f83b70fd50fad"/>
+				<rom name="cash planner.1" size="0x2000" offset="0x0000" crc="29309592" sha1="8b230ef1a234e9c24d6a322366a84270259cf244" />
+				<rom name="cash planner.2" size="0x2000" offset="0x2000" crc="d41465b3" sha1="bc368a31d8e30c56749c783b181f83b70fd50fad" />
 			</dataarea>
 		</part>
 	</software>
@@ -348,8 +352,8 @@ license:CC0-1.0
 		<publisher>FarmFax</publisher>
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x4000">
-				<rom name="dairy prediction.1" size="0x2000" offset="0x0000" crc="bb3d1a7e" sha1="d79850fabda1fae61bd4ade5af6f4b545e4f96ed"/>
-				<rom name="dairy prediction.2" size="0x2000" offset="0x2000" crc="7858d11c" sha1="e13384ab1bb6f47deb5def36e488873720cce059"/>
+				<rom name="dairy prediction.1" size="0x2000" offset="0x0000" crc="bb3d1a7e" sha1="d79850fabda1fae61bd4ade5af6f4b545e4f96ed" />
+				<rom name="dairy prediction.2" size="0x2000" offset="0x2000" crc="7858d11c" sha1="e13384ab1bb6f47deb5def36e488873720cce059" />
 			</dataarea>
 		</part>
 	</software>
@@ -360,8 +364,8 @@ license:CC0-1.0
 		<publisher>FarmFax</publisher>
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x4000">
-				<rom name="rotation formulation dairy.1" size="0x2000" offset="0x0000" crc="fd0dda29" sha1="c2f67e2cb89cf7d7dd4a7346e0e19c54f7f5e7d4"/>
-				<rom name="rotation formulation dairy.2" size="0x2000" offset="0x2000" crc="d0de8e62" sha1="2adf61728c272c09277637ee28c2b7b586d3c01f"/>
+				<rom name="rotation formulation dairy.1" size="0x2000" offset="0x0000" crc="fd0dda29" sha1="c2f67e2cb89cf7d7dd4a7346e0e19c54f7f5e7d4" />
+				<rom name="rotation formulation dairy.2" size="0x2000" offset="0x2000" crc="d0de8e62" sha1="2adf61728c272c09277637ee28c2b7b586d3c01f" />
 			</dataarea>
 		</part>
 	</software>
@@ -372,7 +376,7 @@ license:CC0-1.0
 		<publisher>FarmFax</publisher>
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="trainer.rom" size="0x2000" crc="9fa36a89" sha1="aacfcba60e976807917340ee4f5af47c17fe8d43"/>
+				<rom name="trainer.rom" size="0x2000" crc="9fa36a89" sha1="aacfcba60e976807917340ee4f5af47c17fe8d43" />
 			</dataarea>
 		</part>
 	</software>
@@ -381,11 +385,11 @@ license:CC0-1.0
 		<description>Delta DOS</description>
 		<year>1983</year>
 		<publisher>Premier Microsystems</publisher>
-		<info name="author" value="J.G. Johnson &amp; P.J. Rihan"/>
+		<info name="author" value="J.G. Johnson &amp; P.J. Rihan" />
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="premier_fdc"/>
+			<feature name="slot" value="premier_fdc" />
 			<dataarea name="rom" size="0x2000">
-				<rom name="deltados (1983)(premier micros).rom" size="0x2000" crc="149eb4dd" sha1="eb686ce6afe63e4d4011b333a882ca812c69307f"/>
+				<rom name="deltados (1983)(premier micros).rom" size="0x2000" crc="149eb4dd" sha1="eb686ce6afe63e4d4011b333a882ca812c69307f" />
 			</dataarea>
 		</part>
 	</software>
@@ -395,9 +399,9 @@ license:CC0-1.0
 		<year>1986</year>
 		<publisher>PNP Communications</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="dragon_fdc"/>
+			<feature name="slot" value="dragon_fdc" />
 			<dataarea name="rom" size="0x2000">
-				<rom name="superdos e6 (198x)(pnp).rom" size="0x2000" crc="8c1d6c45" sha1="ef157016386ed463374de6bac84d1f8ce654ed80"/>
+				<rom name="superdos e6 (198x)(pnp).rom" size="0x2000" crc="8c1d6c45" sha1="ef157016386ed463374de6bac84d1f8ce654ed80" />
 			</dataarea>
 		</part>
 	</software>
@@ -408,24 +412,24 @@ license:CC0-1.0
 		<publisher>Telepost Systems</publisher>
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x4000">
-				<rom name="terminal simulator 1 24-5-84.rom" size="0x2000" offset="0x0000" crc="6a7e8b36" sha1="dbd1871c5ecb338defd3209b387d83d5222ed4a6"/>
-				<rom name="terminal simulator 2 24-5-84.rom" size="0x2000" offset="0x2000" crc="ea472a6a" sha1="d6fab40b421a3054bbd32e9d2641ec17fc614cd6"/>
+				<rom name="terminal simulator 1 24-5-84.rom" size="0x2000" offset="0x0000" crc="6a7e8b36" sha1="dbd1871c5ecb338defd3209b387d83d5222ed4a6" />
+				<rom name="terminal simulator 2 24-5-84.rom" size="0x2000" offset="0x2000" crc="ea472a6a" sha1="d6fab40b421a3054bbd32e9d2641ec17fc614cd6" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="testcond">
-		<description>Test De Conducción</description>
+		<description>Test de Conducción</description>
 		<year>1982</year>
 		<publisher>Belrampa Servicios, SA</publisher>
-		<info name="usage" value="Disable Cart Auto-Start, EXEC 49152"/>
+		<info name="usage" value="Disable Cart Auto-Start, EXEC 49152" />
 		<part name="cart" interface="coco_cart">
-			<feature name="pcb" value="RE-075"/>		<!--	PCB with "59" written with marker	-->
-			<feature name="ic1" value="TMS ?"/>			<!--	Illegible	-->
-			<feature name="ic2" value="TMS 2564JDL-45 DBP8127"/>
+			<feature name="pcb" value="RE-075" />		<!--	PCB with "59" written with marker	-->
+			<feature name="ic1" value="TMS ?" />			<!--	Illegible	-->
+			<feature name="ic2" value="TMS 2564JDL-45 DBP8127" />
 			<dataarea name="rom" size="0x4000">
-				<rom name="1.ic1" size="0x2000" offset="0x0000" crc="65d3153d" sha1="c44277f3d7ec615947465d20674b0771bdd44867"/>
-				<rom name="2.ic2" size="0x2000" offset="0x2000" crc="477921ca" sha1="a3d23148842fd7eb3b4f04d63a701a88573cbfb5"/>
+				<rom name="1.ic1" size="0x2000" offset="0x0000" crc="65d3153d" sha1="c44277f3d7ec615947465d20674b0771bdd44867" />
+				<rom name="2.ic2" size="0x2000" offset="0x2000" crc="477921ca" sha1="a3d23148842fd7eb3b4f04d63a701a88573cbfb5" />
 			</dataarea>
 		</part>
 	</software>
@@ -434,10 +438,10 @@ license:CC0-1.0
 		<description>Toolkit</description>
 		<year>1983</year>
 		<publisher>Premier Microsystems</publisher>
-		<info name="author" value="S.J Purdy"/>
+		<info name="author" value="S.J Purdy" />
 		<part name="cart" interface="coco_cart">
 			<dataarea name="rom" size="0x2000">
-				<rom name="toolkit (1983) (premier microsystems).rom" size="0x2000" crc="82ef981a" sha1="b9c0d29382ae1d685f196ab4b53fb75156e12404"/>
+				<rom name="toolkit (1983) (premier microsystems).rom" size="0x2000" crc="82ef981a" sha1="b9c0d29382ae1d685f196ab4b53fb75156e12404" />
 			</dataarea>
 		</part>
 	</software>
@@ -449,9 +453,9 @@ license:CC0-1.0
 		<year>1984</year>
 		<publisher>Dragon data</publisher>
 		<part name="cart" interface="coco_cart">
-			<!-- <feature name="slot" value="epromprg"/> -->
+			<!-- <feature name="slot" value="epromprg" /> -->
 			<dataarea name="rom" size="0x1000">
-				<rom name="eprom_mkII_v21.rom" size="0x1000" crc="310bc0a0" sha1="4aba041033410ab912753407ae29e5fe89925440"/>
+				<rom name="eprom_mkII_v21.rom" size="0x1000" crc="310bc0a0" sha1="4aba041033410ab912753407ae29e5fe89925440" />
 			</dataarea>
 		</part>
 	</software>
@@ -461,9 +465,9 @@ license:CC0-1.0
 		<year>1984</year>
 		<publisher>Steve's Electronics</publisher>
 		<part name="cart" interface="coco_cart">
-			<!-- <feature name="slot" value="epromprg"/> -->
+			<!-- <feature name="slot" value="epromprg" /> -->
 			<dataarea name="rom" size="0x1000">
-				<rom name="ecm_ep_kit.rom" size="0x1000" crc="f5e1d7f0" sha1="cce757b0662abb8c110e1a072cbf9f54d097d010"/>
+				<rom name="ecm_ep_kit.rom" size="0x1000" crc="f5e1d7f0" sha1="cce757b0662abb8c110e1a072cbf9f54d097d010" />
 			</dataarea>
 		</part>
 	</software>
@@ -473,9 +477,9 @@ license:CC0-1.0
 		<year>1987</year>
 		<publisher>Peaksoft</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="serial"/>
+			<feature name="slot" value="serial" />
 			<dataarea name="rom" size="0x2000">
-				<rom name="comron_peaksoft.rom" size="0x2000" crc="9d18cf46" sha1="14124dfb4bd78d1907e80d779cd7f3bae30564c9"/>
+				<rom name="comron_peaksoft.rom" size="0x2000" crc="9d18cf46" sha1="14124dfb4bd78d1907e80d779cd7f3bae30564c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -485,9 +489,9 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>&lt;unknown;&gt;</publisher>
 		<part name="cart" interface="coco_cart">
-			<!-- <feature name="slot" value="soaktest"/> -->
+			<!-- <feature name="slot" value="soaktest" /> -->
 			<dataarea name="rom" size="0x1000">
-				<rom name="d32soaktest.rom" size="0x1000" crc="41c61438" sha1="6db94922a458ae292d7a5c3333d86f2d935212b6"/>
+				<rom name="d32soaktest.rom" size="0x1000" crc="41c61438" sha1="6db94922a458ae292d7a5c3333d86f2d935212b6" />
 			</dataarea>
 		</part>
 	</software>
@@ -497,9 +501,9 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>J.C.B. (Microsystems)</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="jcbsnd"/>
+			<feature name="slot" value="jcbsnd" />
 			<dataarea name="rom" size="0x1000">
-				<rom name="D32SEM.ROM" size="0x1000" crc="4cd0f30b" sha1="d07bb9272e3d3928059853730ff656905a80b68e"/>
+				<rom name="D32SEM.ROM" size="0x1000" crc="4cd0f30b" sha1="d07bb9272e3d3928059853730ff656905a80b68e" />
 			</dataarea>
 		</part>
 	</software>
@@ -509,9 +513,9 @@ license:CC0-1.0
 		<year>1983</year>
 		<publisher>J.C.B. (Microsystems)</publisher>
 		<part name="cart" interface="coco_cart">
-			<feature name="slot" value="jcbspch"/>
+			<feature name="slot" value="jcbspch" />
 			<dataarea name="rom" size="0x1000">
-				<rom name="jcb-speech.rom" size="0x1000" crc="e88dfe36" sha1="df3f64a7a3beeb91469932035af5e4f8a7872aad"/>
+				<rom name="jcb-speech.rom" size="0x1000" crc="e88dfe36" sha1="df3f64a7a3beeb91469932035af5e4f8a7872aad" />
 			</dataarea>
 		</part>
 	</software>
@@ -521,9 +525,9 @@ license:CC0-1.0
 		<year>1984</year>
 		<publisher>Ikon Computer Products</publisher>
 		<part name="cart" interface="coco_cart">
-			<!-- <feature name="slot" value="ultradrv"/> -->
+			<!-- <feature name="slot" value="ultradrv" /> -->
 			<dataarea name="rom" size="0x1000">
-				<rom name="Dragonfly Tape system v1.3.rom" size="0x1000" crc="72618948" sha1="12cc90afc7eb1c0b0b720d4722f8d47e39932893"/>
+				<rom name="Dragonfly Tape system v1.3.rom" size="0x1000" crc="72618948" sha1="12cc90afc7eb1c0b0b720d4722f8d47e39932893" />
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
Modified software list formatting with the new standards.

Also added this entry:
- Cyrus Chess [Clawgrip, ICEknight]

PCB has two EPROMs, previous entry had been dumped as one ROM. The new dumps come from reading the EPROMs directly.

And finally, added more info to entry for "Test de conducción", based on PCB pics.