### PR TITLE
Add hiscore plugin support for Sonic Spinball

### DIFF
--- a/plugins/hiscore/hiscore.dat
+++ b/plugins/hiscore/hiscore.dat
@@ -12284,6 +12284,11 @@ logicpr2:
 
 ;@s:sega/mdconsole.cpp
 
+genesis,sspinu:
+megadriv,sspin:
+megadrij,sspinj:
+@:maincpu,program,fff8da,1e,ff,c8
+
 genesis,tf3:
 @:maincpu,program,fff2ac,4,00,90
 

--- a/plugins/hiscore/init.lua
+++ b/plugins/hiscore/init.lua
@@ -175,7 +175,7 @@ function hiscore.startplugin()
 			  end
 			elseif string.find(line, rm_match) then --- match this game
 			  current_is_match = true;
-			elseif string.find(line, '^[a-z0-9_]+:') then --- some game
+			elseif string.find(line, '^[a-z0-9_,]+:') then --- some game
 			  if current_is_match and string.len(cluster) > 0 then
 				break; -- we're done
 			  end


### PR DESCRIPTION
I made a fix for the hiscore plugin lua, software list entries were not detected as the start of a new cluster. As a result games defined just before software list games also read the memory regions from the following software. I discovered this because sonic spinball was waiting forever for the tf3 memory region to get its initial values.

The hiscore.dat definition does not include the settings menu data which gets cleared on restart, should that be included here?