### PR TITLE
atari/atarist.cpp: (ste) don't segfault immediately when starting up

### DIFF
--- a/src/mame/atari/atarist.cpp
+++ b/src/mame/atari/atarist.cpp
@@ -307,7 +307,10 @@ void st_state::write_monochrome(int state)
 
 void st_state::reset_w(int state)
 {
-	m_video->reset();
+	if (m_video.found())
+		m_video->reset();
+	if (m_videox.found())
+		m_videox->reset();
 	if (m_stb.found())
 		m_stb->reset();
 	m_mfp->reset();


### PR DESCRIPTION
`ste`, etc, use `m_videox` instead of `m_video`, which causes a segfault.