### PR TITLE
z80.cpp - Add EI to IM0 handler

### DIFF
--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -3323,6 +3323,8 @@ void z80_device::take_interrupt()
 					if (irq_vector == 0xfb)
 					{
 						// EI
+						CC(op, 0xfb);
+						T(m_icount_executing);
 						ei();
 					}
 					else if ((irq_vector & 0xc7) == 0xc7)

--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -3320,11 +3320,22 @@ void z80_device::take_interrupt()
 					PCD = irq_vector & 0xffff;
 					break;
 				default:        /* rst (or other opcodes?) */
-					/* RST $xx cycles */
-					CC(op, 0xff);
-					T(m_icount_executing - MTM * 2);
-					wm16_sp(m_pc);
-					PCD = irq_vector & 0x0038;
+					if (irq_vector == 0xfb)
+					{
+						// EI
+						ei();
+					}
+					else if ((irq_vector & 0xc7) == 0xc7)
+					{
+						/* RST $xx cycles */
+						CC(op, 0xff);
+						T(m_icount_executing - MTM * 2);
+						wm16_sp(m_pc);
+						PCD = irq_vector & 0x0038;
+					}
+					else {
+						logerror("z80device::take_interrupt unexpected opcode in im0 mode: 0x%02x\n", irq_vector);
+					}
 					break;
 			}
 		}


### PR DESCRIPTION
The heath/h89.cpp with a z37 soft-sectored controller uses IM0 and places an EI instruction on the bus when DRQ signal is received from the WD disk controller.

I'm putting this part up early to get comments. Maybe someone with more experience with the z80 code could implement the top TODO in this file
```
- Interrupt mode 0 should be able to execute arbitrary opcodes
```