### PR TITLE
add 3 Roland cards 

### DIFF
--- a/hash/r8_card.xml
+++ b/hash/r8_card.xml
@@ -61,4 +61,14 @@ external internal   external internal
 			</dataarea>
 		</part>
 	</software>
+	<software name="sn_r8_09">
+		<description>SN-R8-09 Power Drums U.S.A.</description>
+		<year>1990</year>
+		<publisher>Roland</publisher>
+		<part name="card" interface="r8_card">
+			<dataarea name="rom" size="0x80000">
+				<rom name="sn-r8-09.bin" size="0x80000" crc="bb3c9453" sha1="68a50437b0665dbc49caeef32be1eb5c73457e88"/>
+			</dataarea>
+		</part>
+	</software>
 </softwarelist>

--- a/hash/roland_tnsc1.xml
+++ b/hash/roland_tnsc1.xml
@@ -2,9 +2,7 @@
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
--->
-<softwarelist name="roland_tnsc1" description="Roland TN-SC1 Music Style Cards">
-<!--
+
     Known cards:
       Dumped Serial    Type             Name               Contents
           No TN-SC1-01 Music Style Card Country            Bluegrass, Tex / Mex, Country Waltz, Country Rock
@@ -21,8 +19,13 @@ license:CC0-1.0
           No TN-SC1-12 Music Style Card Dance 2            Bossanova 2, Samba 3, Lambada, Son
           No TN-SC1-13 Music Style Card Dance 3            Boogie 2, Rock 'n' Roll 3, Shuffle 2, Rag Time
           No TN-SC1-14 Music Style Card Dance 4            16 Beat 4, Blues, Slow Swing, Slow Soul 2
+
+Releases according to http://www.rolandmuseum.de/indizees/roland_ch.html:
+    TN-SC1-01..09: 1989
+    TN-SC1-10..14: 1990
 -->
 
+<softwarelist name="roland_tnsc1" description="Roland TN-SC1 Music Style Cards">
 	<software name="tnsc102" supported="no">
 		<!--
 		    1. M'Town
@@ -31,7 +34,7 @@ license:CC0-1.0
 		    4. Slow Soul
 		-->
 		<description>50's and 60's (TN-SC1-02)</description>
-		<year>19??</year>
+		<year>1989</year>
 		<publisher>Roland</publisher>
 		<part name="cart" interface="roland_tnsc1">
 			<dataarea name="rom" size="0x8000">
@@ -48,7 +51,7 @@ license:CC0-1.0
 		    4. Big Rock
 		-->
 		<description>70's and 80's (TN-SC1-03)</description>
-		<year>19??</year>
+		<year>1989</year>
 		<publisher>Roland</publisher>
 		<part name="cart" interface="roland_tnsc1">
 			<dataarea name="rom" size="0x8000">
@@ -65,7 +68,7 @@ license:CC0-1.0
 		    4. Caribbean
 		-->
 		<description>Around the World 2 (TN-SC1-05)</description>
-		<year>19??</year>
+		<year>1989</year>
 		<publisher>Roland</publisher>
 		<part name="cart" interface="roland_tnsc1">
 			<dataarea name="rom" size="0x8000">
@@ -82,7 +85,7 @@ license:CC0-1.0
 		    4. Ballad 3
 		-->
 		<description>Piano Bar (TN-SC1-06)</description>
-		<year>19??</year>
+		<year>1989</year>
 		<publisher>Roland</publisher>
 		<part name="cart" interface="roland_tnsc1">
 			<dataarea name="rom" size="0x8000">
@@ -99,7 +102,7 @@ license:CC0-1.0
 		    4. Paso Doble
 		-->
 		<description>Latin (TN-SC1-07)</description>
-		<year>19??</year>
+		<year>1989</year>
 		<publisher>Roland</publisher>
 		<part name="cart" interface="roland_tnsc1">
 			<dataarea name="rom" size="0x8000">

--- a/hash/roland_tnsc2.xml
+++ b/hash/roland_tnsc2.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+license:CC0-1.0
+
+Known cards:
+  Dumped  Serial     Name                 Contents
+      No  TN-SC2-01  Italian Folk         Mazurka, Waltz 5, Fox Trot 2, Polka 3, Quadriglia, Tarantella, Saltarello, Tango 3
+      No  TN-SC2-02  Beatles              Yesterday, Let It Be, Michelle, Hey Jude, The Long And, And I Love Her, Girl, Oh Darling
+      No  TN-SC2-03  Country              Two Step, Country Swing, Country Waltz 2, Train-Beats, Ballad 4, Bluegrass 2, Cajun, Country Rock 2
+     Yes  TN-SC2-04  Dance                Dance 2, Dance 3, Dance 4, Dance 5, Dance 6, Dance 7, Dance 8, Dance 9
+      No  TN-SC2-05  50´s & 60´s          Rock'N 4, Rock'N 5, Rock'N 6, Rock'N 7, Sl Rock 4, Limborck, Poprock, Twist 2
+      No  TN-SC2-06  Classic              Bolero, W'Waltz, W'Polka, March 3, Minuetto, Toccata, Rossini, Pavane
+      No  TN-SC2-07  Latin                Bossa 3, Bossa 4, Chacha 2, Rhumba 2, Mambo 2, Beguine 3, Samba 4, Samba 5
+      No  TN-SC2-08  Scandinavian         Fast 4/4, Sl Shuffle, Country 2/4, Shuffle 3, Fast 2/4, Boogie 3, Slow 4/4, 60's
+      No  TN-SC2-09  Evergreen 1          Blues, Slow Swing, Boogie 2, Ragtime, Lambada, Son, Samba 2, Mambo (styles from TN-SC1 cards)
+      No  TN-SC2-10  Evergreen 2          Slow Waltz, Standard, Ballad 2, Reggae 2, Caribbean, M'Town, Mexican Rock, Country Waltz (styles from TN-SC1 cards)
+      No  TN-SC2-11  Evergreen 3          Rock 1, Rock 2, Funk 1, Funk 2, 8 Beat 1, 8 Beat 2, 16 Beat 1, 16 Beat 2 (styles from E-20)
+      No  TN-SC2-12  Evergreen 4          Reggae, Swing, Country, Waltz 2, Polka, Bossa Nova, Rhumba, Fusion (styles from E-20)
+      No  TN-SC2-13  ?                    ?
+      No  TN-SC2-14  Big Band             Jazz Band, Big Band, BigBand Ballad, Standard 2
+      No  TN-SC2-15  Showtime             Music Hall, Broadway, Bubbles
+      No  TN-SC2-16  Country 2            Country Swing 2, Two Step 2, Country Waltz 3, Hoe Down
+      No  TN-SC2-17  Gospel               Gospel, Revival, Anthem, Gospel Ballad
+      No  TN-SC2-18  East Europe?         ?
+      No  TN-SC2-51  American Collection  Rock 3, Rock 4, Funk 4, R & B, Gospel, Big Band, Modern Ballad, Jazz Waltz
+      No  TN-SC2-52  Piano Styles         Popular Piano 1, Popular Piano 2, Contemporary, 50's Ballad, Ballad Shuffle, Swing Pop, Jazz Piano, Slow Waltz 3
+
+Releases according to http://www.rolandmuseum.de/indizees/roland_ch.html:
+    TN-SC2-01..07: 1992
+    TN-SC2-09..12: 1995
+    TN-SC2-51..52: 1995
+    TN-SC2-14..17: 1997
+    The other cards (08, 13, 18) are missing from the list.
+    Especially cards 13 and 18 seem to have barely any information online.
+-->
+
+<softwarelist name="roland_tnsc2" description="Roland TN-SC2 Music Style Cards">
+	<software name="tn_sc2_04" supported="no">
+		<!--
+		    1. Dance 2
+		    2. Dance 3
+		    3. Dance 4
+		    4. Dance 5
+		    5. Dance 6
+		    6. Dance 7
+		    7. Dance 8
+		    8. Dance 9
+		-->
+		<description>TN-SC2-04 Dance</description>
+		<year>1992</year>
+		<publisher>Roland</publisher>
+		<part name="cart" interface="roland_tnsc2">
+			<dataarea name="rom" size="0x10000">
+				<rom name="tn-sc2-04.bin" size="0x10000" crc="7fd52461" sha1="38e76a348eca1644999361650e2d99f55578a141"/>
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/u110_card.xml
+++ b/hash/u110_card.xml
@@ -4,12 +4,19 @@
 license:CC0-1.0
 
 Undumped cards:
-- all Rhodes SN-U01-xxR cards
-- Roland SN-SPLA-01/03
+- Roland SN-SPLA-03
 - Musitronics 2 Voices (U-22)
 - Musitronics 5 Eldek (U-21)
 - Musitronics 6 Analog Synthesizer (U-20)
   -> see https://www.playkeyboardnow.com/Roland_D70_Soundbanks/page63/index.html
+
+Notes:
+- Roland SN-SPLA-xx wave cards are listed in this file as well.
+  They work just fine in a U-110 despite them being intended for the Roland D-70.
+- The "Rhodes SN-U01-xxR" seem to be rebranded "SN-U110-xx" cards with the same ROM.
+  Their ROM is a bit-perfect match with the "SN-U110-xx" counterparts.
+- SN-U01-xxR cards that were verified to be a bit-perfect match of the respective SN-U110-xx card:
+  - SN-U01-03R Ethnic
 
 Release dates were taken from http://www.rolandmuseum.de/z_syn_wc.php
 
@@ -68,6 +75,17 @@ external internal   external internal
 		<part name="card" interface="u110_card">
 			<dataarea name="rom" size="0x80000">
 				<rom name="sn-mv30-02.bin" size="0x80000" crc="596254dc" sha1="1081973aad7ad5941329d3ab8a20db654c063a2e"/>
+			</dataarea>
+		</part>
+	</software>
+	<software name="sn_spla_01">
+		<description>SN-SPLA-01 Sound Elements Vol. 1 (U-01)</description>
+		<year>1990</year>
+		<publisher>Roland</publisher>
+		<!-- Note: The card reports itself with ID 01, which is also used by SN-U110-01. -->
+		<part name="card" interface="u110_card">
+			<dataarea name="rom" size="0x80000">
+				<rom name="sn-spla-01.bin" size="0x80000" crc="809bb699" sha1="2d2119b2d5f81b973076ed8471f329fc0741eebf"/>
 			</dataarea>
 		</part>
 	</software>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -37995,6 +37995,9 @@ tb303                           // Roland
 @source:roland/roland_tnsc1.cpp
 rlndtnsc1                       // Roland TN-SC1 ROM cards
 
+@source:roland/roland_tnsc2.cpp
+rlndtnsc2                       // Roland TN-SC2 ROM cards
+
 @source:roland/roland_tr505.cpp
 tr505                           //
 

--- a/src/mame/roland/roland_tnsc2.cpp
+++ b/src/mame/roland/roland_tnsc2.cpp
@@ -8,17 +8,17 @@
     Once a supported system is dumped this can be removed and the list can be hooked up to that
 
     Possible systems:
-      Roland E-5
-      Roland E-20
-      Roland E-30
       Roland E-35
+      Roland E-36
+      Roland E-56
       Roland E-70
-      Roland Pro-E
-      Roland E/RA-50
       Roland RA-90
-      Roland CA-30
-      Roland KR-500
-      Roland KR-3000
+      Roland KR-650
+      Roland KR-3500
+      Roland KR-4500
+      Roland KR-5500
+
+    The ROM dump of TN-SC2-04 begins with "Roland E-70A", so this was probably the first system the cards were intended for.
 */
 
 #include "emu.h"
@@ -29,25 +29,25 @@
 
 namespace {
 
-class rlndtnsc1_state : public driver_device
+class rlndtnsc2_state : public driver_device
 {
 public:
-	rlndtnsc1_state(const machine_config &mconfig, device_type type, const char *tag) :
+	rlndtnsc2_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_cart(*this, "cartslot")
 	{ }
 
-	void rlndtnsc1(machine_config &config);
+	void rlndtnsc2(machine_config &config);
 protected:
 	DECLARE_DEVICE_IMAGE_LOAD_MEMBER(cart_load);
 	optional_device<generic_slot_device> m_cart;
 };
 
 
-static INPUT_PORTS_START( rlndtnsc1 )
+static INPUT_PORTS_START( rlndtnsc2 )
 INPUT_PORTS_END
 
-DEVICE_IMAGE_LOAD_MEMBER(rlndtnsc1_state::cart_load)
+DEVICE_IMAGE_LOAD_MEMBER(rlndtnsc2_state::cart_load)
 {
 	uint32_t size = m_cart->common_get_size("rom");
 	m_cart->rom_alloc(size, GENERIC_ROM16_WIDTH, ENDIANNESS_LITTLE);
@@ -55,20 +55,20 @@ DEVICE_IMAGE_LOAD_MEMBER(rlndtnsc1_state::cart_load)
 	return std::make_pair(std::error_condition(), std::string());
 }
 
-void rlndtnsc1_state::rlndtnsc1(machine_config &config)
+void rlndtnsc2_state::rlndtnsc2(machine_config &config)
 {
-	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "roland_tnsc1");
+	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "roland_tnsc2");
 	m_cart->set_width(GENERIC_ROM16_WIDTH);
-	m_cart->set_device_load(FUNC(rlndtnsc1_state::cart_load));
+	m_cart->set_device_load(FUNC(rlndtnsc2_state::cart_load));
 	m_cart->set_must_be_loaded(true);
 
-	SOFTWARE_LIST(config, "cart_list").set_original("roland_tnsc1");
+	SOFTWARE_LIST(config, "cart_list").set_original("roland_tnsc2");
 }
 
-ROM_START( rlndtnsc1 )
+ROM_START( rlndtnsc2 )
 ROM_END
 
 } // anonymous namespace
 
 
-CONS( 198?, rlndtnsc1, 0, 0, rlndtnsc1, rlndtnsc1, rlndtnsc1_state, empty_init, "Roland", "Roland Music Style Card TN-SC1 Software List holder", MACHINE_IS_SKELETON )
+CONS( 198?, rlndtnsc2, 0, 0, rlndtnsc2, rlndtnsc2, rlndtnsc2_state, empty_init, "Roland", "Roland Music Style Card TN-SC2 Software List holder", MACHINE_IS_SKELETON )


### PR DESCRIPTION
This PR adds:

- a new TN-SC-2 softlist (`hash/roland_tnsc2.xml`), as well as a dummy system for the softlist, similar to TN-SC1
- the following Roland cards:
  - PCM card: SN-R8-09 Power Drums U.S.A.
  - PCM card: SN-SPLA-01 Sound Elements Vol. 1
  - style card: TN-SC2-04 Dance