### PR TITLE
coco_fdc: Allow FLEX to work on CoCo machines

### DIFF
--- a/src/devices/bus/coco/coco_fdc.cpp
+++ b/src/devices/bus/coco/coco_fdc.cpp
@@ -88,6 +88,7 @@
 #include "formats/os9_dsk.h"
 #include "formats/sdf_dsk.h"
 #include "formats/vdk_dsk.h"
+#include "formats/flex_dsk.h"
 
 #define LOG_WDFDC   (1U << 1) // Shows register setup
 #define LOG_WDIO    (1U << 2) // Shows data read and write
@@ -146,10 +147,11 @@ protected:
 void coco_family_fdc_device_base::floppy_formats(format_registration &fr)
 {
 	fr.add_mfm_containers();
+	fr.add(FLOPPY_FLEX_FORMAT);
 	fr.add(FLOPPY_DMK_FORMAT);
+	fr.add(FLOPPY_SDF_FORMAT);
 	fr.add(FLOPPY_JVC_FORMAT);
 	fr.add(FLOPPY_VDK_FORMAT);
-	fr.add(FLOPPY_SDF_FORMAT);
 	fr.add(FLOPPY_OS9_FORMAT);
 	fr.add(fs::COCO_RSDOS);
 	fr.add(fs::COCO_OS9);
@@ -249,7 +251,7 @@ coco_fdc_device_base::coco_fdc_device_base(const machine_config &mconfig, device
 void coco_fdc_device_base::update_lines()
 {
 	// clear HALT enable under certain circumstances
-	if (intrq() && (dskreg() & 0x20))
+	if (intrq())
 		set_dskreg(dskreg() & ~0x80);  // clear halt enable
 
 	// set the NMI line
@@ -648,7 +650,7 @@ namespace
 	void coco_scii_device::update_lines()
 	{
 		// clear HALT enable under certain circumstances
-		if (intrq() && (dskreg() & 0x20))
+		if (intrq())
 			set_dskreg(dskreg() & ~0x80);  // clear halt enable
 
 		if ((m_cache_controler & 0x02) == 0) /* cache disabled */


### PR DESCRIPTION
There are two parts to the change.  First is a correction to the coco_fdc hardware emulation. Second is file format ordering adjustments wich make things easier for using FLEX on CoCos.

For the hardware change:  Before the change FLEX was unable to boot on CoCo machines.  The behaviour and troubleshooting showed that while the FLEX kernel started up it was unable to read anything from Track 0.  Standard FLEX disks have SD(FM) on Track 0, and the remainder of the disks (for CoCo FLEX) are normally DD(MFM) or could also be SD(FM).  The bug was in the handling of the WDC FDC's INTRQ line.  Reviewing the available documentation and schematics showed that when the FDC asserts INTRQ two things happen.  NMI is asserted on the CoCo bus and the HALT signal is cleared.  The MAME code added an incorrect condition on clearing HALT: It only happened when Double-Density operation was selected.  This change fixes the logic to work the same way as is shown in the schematics, that HALT is cleared any time INTRQ is asserted. SD(FM) disk operations work properly and FLEX boots completely and runs correctly after making this change.  
[Color Computer Disk Cart FD502 26-3133 Schematic (Tandy) INTRQ HALT Logic.pdf](https://github.com/mamedev/mame/files/11715407/Color.Computer.Disk.Cart.FD502.26-3133.Schematic.Tandy.INTRQ.HALT.Logic.pdf)

File Format Ordering Adjustments:  This part of the change makes it easiser to use FLEX in CoCo emulation with a wider variety of FLEX-formatted disk images.  The issue here is that due to the way the JVC disk format works it winds up being a catch-all for disk images.  Because FLEX has specific formatting requirements and code to handle this and JVC has no support for this special formatting, FLEX formats along with DMK and SDF are moved to come before JVC in the formats list.  This allows a wider variery of FLEX-formatted disk images to be properly detected.

The DMK disk image from the following recent restoration of FHL Color FLEX was used for testing:

https://archive.org/details/color-flex-5.0.4-frank-hogg-laboratory