### PR TITLE
fix SN76496 chip balance in banbam/pettanp

### DIFF
--- a/src/mame/sunelectronics/markham.cpp
+++ b/src/mame/sunelectronics/markham.cpp
@@ -593,9 +593,10 @@ void markham_state::markham(machine_config &config)
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 
-	SN76496(config, m_sn[0], CPU_CLOCK/2).add_route(ALL_OUTPUTS, "mono", 0.75);
-
-	SN76496(config, m_sn[1], CPU_CLOCK/2).add_route(ALL_OUTPUTS, "mono", 0.75);
+	// volume balance based on the OST release of Pettan Pyuu,
+	// "LEGEND OF GAME MUSIC 2 PLATINUM BOX" (SCDC-00473~82)
+	SN76496(config, m_sn[0], CPU_CLOCK/2).add_route(ALL_OUTPUTS, "mono", 0.2);
+	SN76496(config, m_sn[1], CPU_CLOCK/2).add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
 void markham_state::strnskil(machine_config &config)


### PR DESCRIPTION
The current balance between the two SN76496 chips is off.

A hardware recording can be seen here: https://www.youtube.com/watch?v=CQIogpkafoU

There is a "fill-in" segment in the music that is very clearly audible in the video at 0:28. However, in MAME it is barely audible at all due one of the chips being too quiet.

---

I fixed the balance by measuring the distance of the jump between the "high" and "low" states of the square waves in the intro segment present in each stage music.
This segment has a low tone played on sn1 and a higher tone played on sn2. I measured the distance in the OST recording of the song and adjusted the balance in MAME accordingly. The balance ended up 1/5 to 1/1.

Note that the overall music volume is decreased a lot (by about -8 db) as result of the rebalancing. The game uses very quiet volume levels on "sn2".

This fixes <https://mametesters.org/view.php?id=8662>.
