### PR TITLE
namco54: fix interrupt handling

### DIFF
--- a/src/devices/cpu/mb88xx/mb88xx.cpp
+++ b/src/devices/cpu/mb88xx/mb88xx.cpp
@@ -429,9 +429,6 @@ void mb88_cpu_device::update_pio( int cycles )
 		{
 			/* if we have a live external source, call the irqcallback */
 			standard_irq_callback( 0, intpc );
-			/* The datasheet doesn't mention if the interrupt flag
-			 * is cleared, but it seems to be only for this case. */
-			m_pio &= ~INT_CAUSE_EXTERNAL;
 			m_PC = 0x02;
 		}
 		else if (m_pending_interrupt & m_pio & INT_CAUSE_TIMER)

--- a/src/mame/namco/namco54.cpp
+++ b/src/mame/namco/namco54.cpp
@@ -109,7 +109,7 @@ void namco_54xx_device::chip_select(int state)
 
 ROM_START( namco_54xx )
 	ROM_REGION( 0x400, "mcu", 0 )
-	ROM_LOAD( "54xx.bin",     0x0000, 0x0400, CRC(ee7357e0) SHA1(01bdf984a49e8d0cc8761b2cc162fd6434d5afbe) )
+	ROM_LOAD( "54xx.bin",     0x0000, 0x0400, CRC(3697dff5) SHA1(2d4c60660c6eff6051d809c0317564168837edf3) )
 ROM_END
 
 DEFINE_DEVICE_TYPE(NAMCO_54XX, namco_54xx_device, "namco54", "Namco 54xx")


### PR DESCRIPTION
There seems to be a bit flip in the 54xx ROM dump. Byte 0x10 is 0x3E, instruction EN #04, enabling interrupts. This occurs early in the interrupt routine and has no effect as interrupts are already enabled. At byte 0x174 is another EN #04, this time correct as it enables interrupts right before ending the routine. This happens again at 0x1BD, 0x1D9, 0x1F6, and 0x214.

This first EN should be a DIS, disabling interrupts during the interrupt routine. This is opcode 0x3F, so the low bit seemingly got flipped.