### PR TITLE
i960 movre instruction will result in out of bounds read/write on platforms where double is 8-bytes in size.

### DIFF
--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -1797,28 +1797,7 @@ void i960_cpu_device::execute_op(uint32_t opcode)
 		case 0x6e:
 			switch((opcode >> 7) & 0xf) {
 			case 0x1: // movre
-				{
-					uint32_t *src=nullptr, *dst=nullptr;
-
-					m_icount -= 8;
-
-					if(!(opcode & 0x00000800)) {
-						src = (uint32_t *)&m_r[opcode & 0x1e];
-					} else {
-						int idx = opcode & 0x1f;
-						if(idx < 4)
-							src = (uint32_t *)&m_fp[idx];
-					}
-
-					if(!(opcode & 0x00002000)) {
-						dst = (uint32_t *)&m_r[(opcode>>19) & 0x1e];
-					} else if(!(opcode & 0x00e00000))
-						dst = (uint32_t *)&m_fp[(opcode>>19) & 3];
-
-					dst[0] = src[0];
-					dst[1] = src[1];
-					dst[2] = src[2]&0xffff;
-				}
+                movre();
 				break;
 			case 0x2: // cpysre
 				m_icount -= 8;
@@ -2389,4 +2368,28 @@ void i960_cpu_device::device_reset()
 std::unique_ptr<util::disasm_interface> i960_cpu_device::create_disassembler()
 {
 	return std::make_unique<i960_disassembler>();
+}
+
+void i960_cpu_device::movre() 
+{
+    uint32_t *src=nullptr, *dst=nullptr;
+
+    m_icount -= 8;
+
+    if(!(opcode & 0x00000800)) {
+        src = (uint32_t *)&m_r[opcode & 0x1e];
+    } else {
+        int idx = opcode & 0x1f;
+        if(idx < 4)
+            src = (uint32_t *)&m_fp[idx];
+    }
+
+    if(!(opcode & 0x00002000)) {
+        dst = (uint32_t *)&m_r[(opcode>>19) & 0x1e];
+    } else if(!(opcode & 0x00e00000))
+        dst = (uint32_t *)&m_fp[(opcode>>19) & 3];
+
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2]&0xffff;
 }

--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -317,7 +317,7 @@ void i960_cpu_device::set_rif(uint32_t opcode, RawExtendedReal val)
 	if(!(opcode & 0x00002000))
 		m_r[(opcode>>19) & 0x1f] = f2u(val);
 	else if(!(opcode & 0x00e00000))
-		m_fp[(opcode>>19) & 3] = val;
+		m_fp[(opcode>>19) & 3].floatValue = val;
 	else
 		fatalerror("I960: %x: set_rif on literal?\n", m_PIP);
 }
@@ -385,7 +385,7 @@ void i960_cpu_device::set_rifl(uint32_t opcode, RawExtendedReal val)
 		m_r[(opcode>>19) & 0x1e] = v;
 		m_r[((opcode>>19) & 0x1e)+1] = v>>32;
 	} else if(!(opcode & 0x00e00000))
-		m_fp[(opcode>>19) & 3] = val;
+		m_fp[(opcode>>19) & 3].floatValue = val;
 	else
 		fatalerror("I960: %x: set_rifl on literal?\n", m_PIP);
 }
@@ -2432,7 +2432,8 @@ void i960_cpu_device::movre(uint32_t opcode)
         src = static_cast<uint32_t*>(&m_r[opcode & 0x1e]);
     } else {
         if(auto idx = opcode & 0x1f; idx < 4) {
-            src = static_cast<uint32_t*>(&m_fp[idx]);
+            // allow pointer decay
+            src = m_fp[idx].storage;
         }
     }
 
@@ -2442,7 +2443,7 @@ void i960_cpu_device::movre(uint32_t opcode)
         /// hardware if that is the case.
         dst = static_cast<uint32_t*>(&m_r[srcDestIndex & 0b11100]);
     } else if(!(opcode & 0x00e00000)) {
-        dst = static_cast<uint32_t*>(&m_fp[srcDestIndex & 0b00011]);
+        dst = m_fp[srcDestIndex & 0b00011].storage;
     }
 
     dst[0] = src[0];

--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -12,6 +12,7 @@
 
 
 DEFINE_DEVICE_TYPE(I960, i960_cpu_device, "i960kb", "Intel i960KB")
+ALLOW_SAVE_TYPE(ExtendedReal);
 
 
 i960_cpu_device::i960_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)

--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -260,35 +260,59 @@ void i960_cpu_device::set_ri64(uint32_t opcode, uint64_t val)
 		fatalerror("I960: %x: set_ri64 on literal?\n", m_PIP);
 }
 
-double i960_cpu_device::get_1_rif(uint32_t opcode)
+RawExtendedReal i960_cpu_device::get_1_rif(uint32_t opcode)
 {
 	if(!(opcode & 0x00000800))
 		return u2f(m_r[opcode & 0x1f]);
 	else {
 		int idx = opcode & 0x1f;
 		if(idx < 4)
-			return m_fp[idx];
+			return m_fp[idx].floatValue;
 		if(idx == 0x16)
 			return 1.0;
+        /// @todo only respond with 0.0 with specific opcode, otherwise
+        /// generate an invalid operand fault (or an undefined value). 
+        /// From 80960MC Programmers Reference Manual July88 page B3:
+        ///
+        /// For floating-point instructions, if the mode bit is set to 0, the respective src1 or src2 field
+        /// specifies a global or local register (just as it does for non-floating-point instructions). If the
+        /// mode bit is set to 1, the field specifies either a floating-point register or one of two real-number
+        /// literals (+0.0 or + 1.0). All of the other encoding when the mode bit is set to 1 are reserved.
+        /// When a reserved encoding is used as a source, the processor either signals an invalid opcode
+        /// fault or produces an undefined value.
+        /// 
+        /// @todo what does the i960SB do? Will need to check on my board.
 		return 0.0;
 	}
 }
 
-double i960_cpu_device::get_2_rif(uint32_t opcode)
+RawExtendedReal i960_cpu_device::get_2_rif(uint32_t opcode)
 {
 	if(!(opcode & 0x00001000))
 		return u2f(m_r[(opcode>>14) & 0x1f]);
 	else {
 		int idx = (opcode>>14) & 0x1f;
 		if(idx < 4)
-			return m_fp[idx];
+			return m_fp[idx].floatValue;
 		if(idx == 0x16)
 			return 1.0;
+        /// @todo only respond with 0.0 with specific opcode, otherwise
+        /// generate an invalid operand fault (or an undefined value). 
+        /// From 80960MC Programmers Reference Manual July88 page B3:
+        ///
+        /// For floating-point instructions, if the mode bit is set to 0, the respective src1 or src2 field
+        /// specifies a global or local register (just as it does for non-floating-point instructions). If the
+        /// mode bit is set to 1, the field specifies either a floating-point register or one of two real-number
+        /// literals (+0.0 or + 1.0). All of the other encoding when the mode bit is set to 1 are reserved.
+        /// When a reserved encoding is used as a source, the processor either signals an invalid opcode
+        /// fault or produces an undefined value.
+        /// 
+        /// @todo what does the i960SB do? Will need to check on my board.
 		return 0.0;
 	}
 }
 
-void i960_cpu_device::set_rif(uint32_t opcode, double val)
+void i960_cpu_device::set_rif(uint32_t opcode, RawExtendedReal val)
 {
 	if(!(opcode & 0x00002000))
 		m_r[(opcode>>19) & 0x1f] = f2u(val);
@@ -298,7 +322,7 @@ void i960_cpu_device::set_rif(uint32_t opcode, double val)
 		fatalerror("I960: %x: set_rif on literal?\n", m_PIP);
 }
 
-double i960_cpu_device::get_1_rifl(uint32_t opcode)
+RawExtendedReal i960_cpu_device::get_1_rifl(uint32_t opcode)
 {
 	if(!(opcode & 0x00000800)) {
 		uint64_t v = m_r[opcode & 0x1e];
@@ -307,14 +331,26 @@ double i960_cpu_device::get_1_rifl(uint32_t opcode)
 	} else {
 		int idx = opcode & 0x1f;
 		if(idx < 4)
-			return m_fp[idx];
+			return m_fp[idx].floatValue;
 		if(idx == 0x16)
 			return 1.0;
+        /// @todo only respond with 0.0 with specific opcode, otherwise
+        /// generate an invalid operand fault (or an undefined value). 
+        /// From 80960MC Programmers Reference Manual July88 page B3:
+        ///
+        /// For floating-point instructions, if the mode bit is set to 0, the respective src1 or src2 field
+        /// specifies a global or local register (just as it does for non-floating-point instructions). If the
+        /// mode bit is set to 1, the field specifies either a floating-point register or one of two real-number
+        /// literals (+0.0 or + 1.0). All of the other encoding when the mode bit is set to 1 are reserved.
+        /// When a reserved encoding is used as a source, the processor either signals an invalid opcode
+        /// fault or produces an undefined value.
+        /// 
+        /// @todo what does the i960SB do? Will need to check on my board.
 		return 0.0;
 	}
 }
 
-double i960_cpu_device::get_2_rifl(uint32_t opcode)
+RawExtendedReal i960_cpu_device::get_2_rifl(uint32_t opcode)
 {
 	if(!(opcode & 0x00001000)) {
 		uint64_t v = m_r[(opcode >> 14) & 0x1e];
@@ -323,14 +359,26 @@ double i960_cpu_device::get_2_rifl(uint32_t opcode)
 	} else {
 		int idx = (opcode>>14) & 0x1f;
 		if(idx < 4)
-			return m_fp[idx];
+			return m_fp[idx].floatValue;
 		if(idx == 0x16)
 			return 1.0;
+        /// @todo only respond with 0.0 with specific opcode, otherwise
+        /// generate an invalid operand fault (or an undefined value). 
+        /// From 80960MC Programmers Reference Manual July88 page B3:
+        ///
+        /// For floating-point instructions, if the mode bit is set to 0, the respective src1 or src2 field
+        /// specifies a global or local register (just as it does for non-floating-point instructions). If the
+        /// mode bit is set to 1, the field specifies either a floating-point register or one of two real-number
+        /// literals (+0.0 or + 1.0). All of the other encoding when the mode bit is set to 1 are reserved.
+        /// When a reserved encoding is used as a source, the processor either signals an invalid opcode
+        /// fault or produces an undefined value.
+        /// 
+        /// @todo what does the i960SB do? Will need to check on my board.
 		return 0.0;
 	}
 }
 
-void i960_cpu_device::set_rifl(uint32_t opcode, double val)
+void i960_cpu_device::set_rifl(uint32_t opcode, RawExtendedReal val)
 {
 	if(!(opcode & 0x00002000)) {
 		uint64_t v = d2u(val);
@@ -405,7 +453,7 @@ void i960_cpu_device::concmp_u(uint32_t v1, uint32_t v2)
 		m_AC |= 1;
 }
 
-void i960_cpu_device::cmp_d(double v1, double v2)
+void i960_cpu_device::cmp_d(RawExtendedReal v1, RawExtendedReal v2)
 {
 	m_AC &= ~7;
 	if(v1<v2)
@@ -693,7 +741,7 @@ void i960_cpu_device::execute_burst_stall_op(uint32_t opcode)
 void i960_cpu_device::execute_op(uint32_t opcode)
 {
 	uint32_t t1, t2;
-	double t1f, t2f;
+	RawExtendedReal t1f, t2f;
 
 	switch(opcode >> 24) {
 		case 0x08: // b
@@ -1556,27 +1604,27 @@ void i960_cpu_device::execute_op(uint32_t opcode)
 			case 0x4: // cvtir
 				m_icount -= 30;
 				t1 = get_1_ri(opcode);
-				set_rif(opcode, (double)(int32_t)t1);
+				set_rif(opcode, (RawExtendedReal)(int32_t)t1);
 				break;
 
 			case 0x5: // cvtilr
 				m_icount -= 30;
 				t1 = get_1_ri(opcode);
-				set_rifl(opcode, (double)(int32_t)t1);
+				set_rifl(opcode, (RawExtendedReal)(int32_t)t1);
 				break;
 
 			case 0x6: // scalerl
 				m_icount -= 30;
 				t1 = get_1_ri(opcode);
 				t2f = get_2_rifl(opcode);
-				set_rifl(opcode, t2f * pow(2.0, (double)(int32_t)t1));
+				set_rifl(opcode, t2f * pow(2.0, (RawExtendedReal)(int32_t)t1));
 				break;
 
 			case 0x7: // scaler
 				m_icount -= 30;
 				t1 = get_1_ri(opcode);
 				t2f = get_2_rif(opcode);
-			set_rif(opcode, t2f * pow(2.0, (double)(int32_t)t1));
+			set_rif(opcode, t2f * pow(2.0, (RawExtendedReal)(int32_t)t1));
 				break;
 
 			default:
@@ -1642,7 +1690,7 @@ void i960_cpu_device::execute_op(uint32_t opcode)
 				{
 					int32_t st1 = get_1_rif(opcode);
 					m_icount -= 69;
-					set_rif(opcode, (double)st1);
+					set_rif(opcode, (RawExtendedReal)st1);
 				}
 				break;
 
@@ -1713,7 +1761,7 @@ void i960_cpu_device::execute_op(uint32_t opcode)
 				{
 					int32_t st1 = get_1_rifl(opcode);
 					m_icount -= 70;
-					set_rifl(opcode, (double)st1);
+					set_rifl(opcode, (RawExtendedReal)st1);
 				}
 				break;
 
@@ -1797,7 +1845,7 @@ void i960_cpu_device::execute_op(uint32_t opcode)
 		case 0x6e:
 			switch((opcode >> 7) & 0xf) {
 			case 0x1: // movre
-                movre();
+                movre(opcode);
 				break;
 			case 0x2: // cpysre
 				m_icount -= 8;

--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -103,6 +103,8 @@ public:
      * space is always available.
      */
     union ExtendedReal {
+        constexpr ExtendedReal() : floatValue(0.0) { }
+        explicit constexpr ExtendedReal(long double fval) : floatValue(fval) { }
         /**
          * @brief the float as a long double in all cases, on non x86 platforms
          * this usually is an alias for double so it will be safe to just use

--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -96,6 +96,7 @@ public:
      * @brief The name given to 64-bit IEEE754 floating point numbers inside the 80960MC Reference Manual
      */
     using LongReal = double;
+    using RawExtendedReal = long double;
     /**
      * @brief The i960KB/SB/MC/XA all use the same floating point unit as the 80386 processor (in fact, the FPU came from the i960). 
      * Because of this, the i960 supports Intel's Extended Real format (fp80);
@@ -109,7 +110,7 @@ public:
          * @brief the float as a long double in all cases, on non x86 platforms
          * this usually is an alias for double so it will be safe to just use
          */
-        long double floatValue;
+        RawExtendedReal floatValue;
         /**
          * @brief The underlying three register's worth of space required for correctness.
          */
@@ -169,7 +170,7 @@ private:
 	// I960_RCACHE_SIZE or greater means out of cache, must save to memory.
 	int32_t m_rcache_pos;
 
-	double m_fp[4];
+    ExtendedReal m_fp[4];
 
 	uint32_t m_SAT;
 	uint32_t m_PRCB;
@@ -202,12 +203,12 @@ private:
 	void set_ri(uint32_t opcode, uint32_t val);
 	void set_ri2(uint32_t opcode, uint32_t val, uint32_t val2);
 	void set_ri64(uint32_t opcode, uint64_t val);
-	double get_1_rif(uint32_t opcode);
-	double get_2_rif(uint32_t opcode);
-	void set_rif(uint32_t opcode, double val);
-	double get_1_rifl(uint32_t opcode);
-	double get_2_rifl(uint32_t opcode);
-	void set_rifl(uint32_t opcode, double val);
+	RawExtendedReal get_1_rif(uint32_t opcode);
+	RawExtendedReal get_2_rif(uint32_t opcode);
+	void set_rif(uint32_t opcode, RawExtendedReal val);
+	RawExtendedReal get_1_rifl(uint32_t opcode);
+	RawExtendedReal get_2_rifl(uint32_t opcode);
+	void set_rifl(uint32_t opcode, RawExtendedReal val);
 	uint32_t get_1_ci(uint32_t opcode);
 	uint32_t get_2_ci(uint32_t opcode);
 	uint32_t get_disp(uint32_t opcode);
@@ -216,7 +217,7 @@ private:
 	void cmp_u(uint32_t v1, uint32_t v2);
 	void concmp_s(int32_t v1, int32_t v2);
 	void concmp_u(uint32_t v1, uint32_t v2);
-	void cmp_d(double v1, double v2);
+	void cmp_d(RawExtendedReal v1, RawExtendedReal v2);
 	void bxx(uint32_t opcode, int mask);
 	void bxx_s(uint32_t opcode, int mask);
 	void fxx(uint32_t opcode, int mask);

--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -179,6 +179,8 @@ private:
 	void do_call(uint32_t adr, int type, uint32_t stack);
 	void do_ret_0();
 	void do_ret();
+private:
+    void movre();
 };
 
 

--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -110,7 +110,12 @@ union ExtendedReal {
      * @brief The underlying three register's worth of space required for correctness.
      */
     Ordinal storage[3];
+    ExtendedReal& operator=(const int value) noexcept {
+        floatValue = value;
+        return *this;
+    }
 };
+
 
 class i960_cpu_device :  public cpu_device
 {

--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -227,7 +227,7 @@ private:
 	void do_ret_0();
 	void do_ret();
 private:
-    void movre();
+    void movre(uint32_t opcode);
 };
 
 

--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -64,58 +64,58 @@ enum
 	I960_IRQ3 = 3
 };
 
+/**
+ * @brief While not 100% safe, we can usually assume that if long double
+ * is 10 bytes in size then it is probably intel's fp80 format.
+ */
+static constexpr bool ExtendedRealIsProbablyIntelFormat = sizeof(long double) == 10;
+/**
+ * @brief A compile time flag to denote if double and long double are the
+ * same type
+ */
+static constexpr bool ExtendedRealIsTheSameAsDouble = std::is_same_v<double, long double>;
+/**
+ * @brief According to the 80960MC programmers reference (and all other i960 references), Ordinals are 32-bit unsigned numbers
+ */
+using Ordinal = uint32_t;
+
+/**
+ * @brief According to the 80960MC programmers reference (and all other i960 references), Integers are 32-bit unsigned numbers
+ */
+using Integer = int32_t;
+/**
+ * @brief The name given to 32-bit IEEE754 floating point numbers inside the 80960MC Reference Manual
+ */
+using Real = float;
+/**
+ * @brief The name given to 64-bit IEEE754 floating point numbers inside the 80960MC Reference Manual
+ */
+using LongReal = double;
+using RawExtendedReal = long double;
+/**
+ * @brief The i960KB/SB/MC/XA all use the same floating point unit as the 80386 processor (in fact, the FPU came from the i960). 
+ * Because of this, the i960 supports Intel's Extended Real format (fp80);
+ * This struct provides a hack to make sure that three ordinal's worth of
+ * space is always available.
+ */
+union ExtendedReal {
+    constexpr ExtendedReal() : floatValue(0.0) { }
+    explicit constexpr ExtendedReal(long double fval) : floatValue(fval) { }
+    /**
+     * @brief the float as a long double in all cases, on non x86 platforms
+     * this usually is an alias for double so it will be safe to just use
+     */
+    RawExtendedReal floatValue;
+    /**
+     * @brief The underlying three register's worth of space required for correctness.
+     */
+    Ordinal storage[3];
+};
 
 class i960_cpu_device :  public cpu_device
 {
 public:
 	static constexpr uint16_t BURST = 0x0001;
-    /**
-     * @brief While not 100% safe, we can usually assume that if long double
-     * is 10 bytes in size then it is probably intel's fp80 format.
-     */
-    static constexpr bool ExtendedRealIsProbablyIntelFormat = sizeof(long double) == 10;
-    /**
-     * @brief A compile time flag to denote if double and long double are the
-     * same type
-     */
-    static constexpr bool ExtendedRealIsTheSameAsDouble = std::is_same_v<double, long double>;
-    /**
-     * @brief According to the 80960MC programmers reference (and all other i960 references), Ordinals are 32-bit unsigned numbers
-     */
-    using Ordinal = uint32_t;
-
-    /**
-     * @brief According to the 80960MC programmers reference (and all other i960 references), Integers are 32-bit unsigned numbers
-     */
-    using Integer = int32_t;
-    /**
-     * @brief The name given to 32-bit IEEE754 floating point numbers inside the 80960MC Reference Manual
-     */
-    using Real = float;
-    /**
-     * @brief The name given to 64-bit IEEE754 floating point numbers inside the 80960MC Reference Manual
-     */
-    using LongReal = double;
-    using RawExtendedReal = long double;
-    /**
-     * @brief The i960KB/SB/MC/XA all use the same floating point unit as the 80386 processor (in fact, the FPU came from the i960). 
-     * Because of this, the i960 supports Intel's Extended Real format (fp80);
-     * This struct provides a hack to make sure that three ordinal's worth of
-     * space is always available.
-     */
-    union ExtendedReal {
-        constexpr ExtendedReal() : floatValue(0.0) { }
-        explicit constexpr ExtendedReal(long double fval) : floatValue(fval) { }
-        /**
-         * @brief the float as a long double in all cases, on non x86 platforms
-         * this usually is an alias for double so it will be safe to just use
-         */
-        RawExtendedReal floatValue;
-        /**
-         * @brief The underlying three register's worth of space required for correctness.
-         */
-        Ordinal storage[3];
-    };
 
     
 	// construction/destruction

--- a/src/devices/cpu/i960/i960.h
+++ b/src/devices/cpu/i960/i960.h
@@ -4,7 +4,9 @@
 #define MAME_CPU_I960_I960_H
 
 #pragma once
-
+#include <variant>
+#include <type_traits>
+#include <cstdint>
 
 enum
 {
@@ -67,7 +69,52 @@ class i960_cpu_device :  public cpu_device
 {
 public:
 	static constexpr uint16_t BURST = 0x0001;
+    /**
+     * @brief While not 100% safe, we can usually assume that if long double
+     * is 10 bytes in size then it is probably intel's fp80 format.
+     */
+    static constexpr bool ExtendedRealIsProbablyIntelFormat = sizeof(long double) == 10;
+    /**
+     * @brief A compile time flag to denote if double and long double are the
+     * same type
+     */
+    static constexpr bool ExtendedRealIsTheSameAsDouble = std::is_same_v<double, long double>;
+    /**
+     * @brief According to the 80960MC programmers reference (and all other i960 references), Ordinals are 32-bit unsigned numbers
+     */
+    using Ordinal = uint32_t;
 
+    /**
+     * @brief According to the 80960MC programmers reference (and all other i960 references), Integers are 32-bit unsigned numbers
+     */
+    using Integer = int32_t;
+    /**
+     * @brief The name given to 32-bit IEEE754 floating point numbers inside the 80960MC Reference Manual
+     */
+    using Real = float;
+    /**
+     * @brief The name given to 64-bit IEEE754 floating point numbers inside the 80960MC Reference Manual
+     */
+    using LongReal = double;
+    /**
+     * @brief The i960KB/SB/MC/XA all use the same floating point unit as the 80386 processor (in fact, the FPU came from the i960). 
+     * Because of this, the i960 supports Intel's Extended Real format (fp80);
+     * This struct provides a hack to make sure that three ordinal's worth of
+     * space is always available.
+     */
+    union ExtendedReal {
+        /**
+         * @brief the float as a long double in all cases, on non x86 platforms
+         * this usually is an alias for double so it will be safe to just use
+         */
+        long double floatValue;
+        /**
+         * @brief The underlying three register's worth of space required for correctness.
+         */
+        Ordinal storage[3];
+    };
+
+    
 	// construction/destruction
 	i960_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 


### PR DESCRIPTION
Given the following instruction sequence:

movre g0, fp0 

The old implementation used a double as the underlying storage for fp0:4. On most platforms this is going to be 8 bytes but an extended real is 10 bytes in length. This will result in data corruption when this instruction is used. Reading or writing to fp3 will result in the next 32-bit number being pulled in. 

This pull request fixes this by making sure that each floating point register is _at least_ 96-bits wide. To do this, a union is introduced which is comprised of a long double and a array of three Ordinals. On platforms which treat double and long double the same (most non x86 platforms) then it will treated as a double. On x86 based platforms, the underlying type will be a proper long double in the same format as real hardware. 

With the use of the union, it is now safe to just use the pointer decay of the array for the transfer. Regardless of platform, this will just work now!

NOTE: you will also see some @todo statements around checking to see what a real i960 will do with reserved floating point literals. I have not done the test because my own i960 single board computer is currently non functioning. I will see what the chip does if you give it bogus floating point literal values once I get it back up and functioning. 
