### PR TITLE
at.cpp, pc.cpp, genpc.cpp: adding BIOS versions

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -34940,6 +34940,7 @@ mkp286                          // Morse KP-286 motherboard (286)
 n8810m15                        // 1987 Nixdorf 8810 M15 Laptop - PC07
 n8810m16c                       // 1990 Nixdorf 8810 M16 Laptop - PC17 - CGA version
 n8810m16v                       // 1990 Nixdorf 8810 M16 Laptop - PC17 - VGA version
+n8810m20						// 1989 Nixdorf 8810/20 Laptop VGA
 n8810m30                        // 1990 Nixdorf 8810 M30
 n8810m55                        // 1986 Nixdorf 8810 M55
 ncr3302                         // NCR Class 3302 Model 0110
@@ -34950,6 +34951,7 @@ necapciv                        // NEC APC IV
 o286foxii                       // Octek Fox II motherboard (286)
 ocfoxm                          // Octek Fox M 286
 octekg2                         // Octek motherboard with Headland G2 chipset (286)
+ocxt286							// Octek XT-286 motherboard
 olim203                         // Olivetti 286 motherboard
 olyport40                       // AEG Olympia Olyport 40
 pc30iii                         // Commodore PC 30-III
@@ -35334,6 +35336,7 @@ gogostrk                        //
 @source:pc/pc.cpp
 ataripc1                        // Atari PC1
 ataripc3                        // Atari PC3
+auvip800						// AUVA VIP 800
 bw230                           // 1985 Bondwell (CGA)
 cadd810                         // CompuAdd 810
 comdesk                         // Compaq Deskpro
@@ -35347,6 +35350,8 @@ dtkerso                         // 198? PC-XT clones with a DTK/ERSO BIOS
 eaglespirit                     // Eagle PC Spirit
 eppc                            // 1985 Ericsson Portable PC
 hyo88t                          // Hyosung Topstar 88T
+hyu16t							// Hyundai Super 16 T
+hyu16te							// Hyundai Super 16 TE
 ibm5550                         //
 iskr3104                        //
 ittxtra                         // 1984 ITT XTRA
@@ -35364,6 +35369,7 @@ mpc1600                         // Columbia Data Products MPC 1600
 mc1702                          //
 mk88                            //
 ncrpc4i                         // NCR PC4i
+ncrpc6							// NCR PC6
 nixpc01                         // Nixdorf 8810/25 - PC01
 olivm15                         // Olivetti M15
 olystar20f                      // AEG Olympia Olystar 20F

--- a/src/mame/pc/at.cpp
+++ b/src/mame/pc/at.cpp
@@ -2401,6 +2401,17 @@ ROM_START( kma202f )
 ROM_END
 
 
+// ***** unknown chipset
+
+// Octek XT-286 V1.1 - "Keyboard error or locked"
+ROM_START( ocxt286 )
+	ROM_REGION16_LE(0x20000, "bios", 0)
+	ROM_SYSTEM_BIOS(0, "ocxt286_1", "Octek XT-286 V1.1")
+	ROMX_LOAD( "xt286-328.bin", 0x1e000, 0x2000, CRC(d9caefcc) SHA1(dab3403678feb023362df614596d1306ef7f85db), ROM_BIOS(0))
+	ROM_SYSTEM_BIOS(1, "ocxt286_2", "Hedaka HED-919")
+	ROMX_LOAD( "hed919-328f.bin", 0x1e000, 0x2000, CRC(15117381) SHA1(d9dfa796edf7e94b9dacf984763ac046cf80f26d), ROM_BIOS(1))
+ROM_END
+
 //**************************************************************************
 //  80286 Desktop
 //**************************************************************************
@@ -4122,6 +4133,18 @@ ROM_END
 //**************************************************************************
 //  80386 SX and DX Laptop/Notebook
 //**************************************************************************
+
+// Nixdorf N8810/20 - CPU: Intel 80386DX-20 clocked at 20MHz or 8MHz, Motherboard: FT-3 DFUP0279ZAB3
+// Chipset: VLSI 9021BT 201141 VL16C452-QC, G2 GC132-PC, SED1345F, Headland HT133/A1A4324, Bt476KP50 128 9020
+// RAM: 1MB, upgradeable via memory cards, this example has 4MB ROM: Phoenix keyboard ROM (missing dump)
+// Mass storage: Floppy 3.5" 1.44MB, 3.5" HDD 40MB JVC JDE 3848V10-1A, Video: Paradise PVGA1A-JK
+// Display: 12" bw double supertwisted LCD VGA, Ports: 2xser, Par, beeper, Bus: ISA16bit: 1, OSC: 28.6838M, 40.000MHz
+// Origin: Software dump of the upper 256K
+ROM_START( n8810m20 ) // "Keyboard clock line failure", but keyboard works
+	ROM_REGION32_LE(0x20000, "bios", 0 )
+	ROM_LOAD( "n8810m20_trim.bin", 0x00000, 0x20000, CRC(21b5394d) SHA1(691f50e65398e5c775dedbd9bda71a95ba6a6a29))
+	// LCD Parameter Copyright MEI 1989 DAFT3C1 (missing dump), Keyboard-BIOS: Compability Software Phoenix Technologies LTD RBIOS Even 3ND1A4 Odd 3N1B4 (missing dump)
+ROM_END
 
 // Toshiba T3200SXC - CPU: 80386sx-20 - Floppy - 120 MB Hard disk - 1 MB RAM on board, 4 MB extra memory already installed. Can be upgraded to a total of 13 MB.
 // TFT Display, 640x480, 256 colors - WD 90C21 video chip, 256 KB RAM - ISA8: 1, ISA16: 1
@@ -5968,6 +5991,7 @@ COMP( 1986, necapciv,  ibm5170, 0,       atturbo,   0,     at_state,     init_at
 COMP( 198?, o286foxii, ibm5170, 0,       atturbo,   0,     at_state,     init_at,        "Octek",       "Fox II", MACHINE_NOT_WORKING )
 COMP( 1990, ocfoxm,    ibm5170, 0,       atturbo,   0,     at_state,     init_at,        "Octek", "Fox M 286", MACHINE_NOT_WORKING )
 COMP( 199?, octekg2,   ibm5170, 0,       atturbo,   0,     at_state,     init_at,        "Octek", "286 motherboard with Headland G2 chipset", MACHINE_NOT_WORKING )
+COMP( 198?, ocxt286,   ibm5170, 0,       ibm5170,   0,     at_state,     init_at,        "Octek", "XT-286 motherboard", MACHINE_NOT_WORKING )
 COMP( 199?, olim203,   ibm5170, 0,       atturbo,   0,     at_state,     init_at,        "Olivetti", "M203 motherboard", MACHINE_NOT_WORKING )
 COMP( 1988, pc30iii,   ibm5170, 0,       pc30iii,   0,     at_state,     init_at,        "Commodore Business Machines",  "PC 30-III", MACHINE_NOT_WORKING )
 COMP( 1988, pc40iii,   ibm5170, 0,       pc40iii,   0,     at_state,     init_at,        "Commodore Business Machines",  "PC 40-III", MACHINE_NOT_WORKING )
@@ -6094,6 +6118,7 @@ COMP( 199?, megapcpla, megapc,  0,       megapcpla, 0,     at_vrom_fix_state, in
 COMP( 199?, mokp386,   ibm5170, 0,       at386,     0,     at_state,     init_at,        "Morse", "KP920121523 V2.20", MACHINE_NOT_WORKING )
 COMP( 199?, mom3v3,    ibm5170, 0,       at386,     0,     at_state,     init_at,        "Morse", "M3 V3.0", MACHINE_NOT_WORKING )
 COMP( 199?, mx83c305,  ibm5170, 0,       at386,     0,     at_state,     init_at,        "<unknown>", "386 motherboards using the MX83C305(A)(FC)/MX83C05(A)(FC) chipset", MACHINE_NOT_WORKING )
+COMP( 1989, n8810m20,  ibm5170, 0,       at386,     0,     at_state,     init_at,        "Nixdorf", "8810/20", MACHINE_NOT_WORKING )
 COMP( 1992, ocjagii,   ibm5170, 0,       at386,     0,     at_state,     init_at,        "Octek",       "Jaguar II", MACHINE_NOT_WORKING )
 COMP( 1992, ocjagv,    ibm5170, 0,       at386,     0,     at_state,     init_at,        "Octek",       "Jaguar V v1.4", MACHINE_NOT_WORKING )
 COMP( 199?, op82c381,  ibm5170, 0,       at386,     0,     at_state,     init_at,        "<unknown>",   "386 motherboards using the OPTi 82C381 chipset", MACHINE_NOT_WORKING )

--- a/src/mame/pc/genpc.cpp
+++ b/src/mame/pc/genpc.cpp
@@ -284,6 +284,9 @@ ROM_START(pc)
 	// Phoenix ROM BIOS Ver 2.52
 	ROM_SYSTEM_BIOS(46, "vipmxm10", "VIP M X M/10")
 	ROMX_LOAD( "xt-vip-mxm-10.bin", 0x8000, 0x8000, CRC(6fd64a0a) SHA1(43808f758e9e92d8920e8c3590c3050ec68415aa), ROM_BIOS(46))
+	// 47: JUKO BABY XT BXM/12
+	ROM_SYSTEM_BIOS(47, "bxm12", "JUKO Baby XT BXM/12")
+	ROMX_LOAD("juko_baby_xt_bxm_12.bin", 0xe000, 0x2000, CRC(22d29b06) SHA1(75a504f50e4779d7fc0f0e0b0b1c17d3705cab42), ROM_BIOS(47))
 ROM_END
 
 // BIOS versions specifically for NEC V20 CPUs, these don't run on plain 8088
@@ -300,6 +303,9 @@ ROM_START( pcv20 )
 	ROM_SYSTEM_BIOS(2, "v365", "c't v3.65")
 	ROMX_LOAD( "xt_ls-1720_u52.bin", 0xe000, 0x2000, CRC(7082371a) SHA1(9965dbae5fa4355bc6325ac27a9acc176cc454c3), ROM_BIOS(2))
 	// ROM_LOAD( "xt_ls-1720_u8.bin", 0x0000, 0x2000, CRC(aa1d3916) SHA1(bb1723fc637d5d8a9af82b2bdd9e3b11689f0cb9)))
+	ROM_SYSTEM_BIOS(3, "glabios_0.24", "GLaBIOS 0.24") // Open Source XT clone BIOS under GPL3 https://github.com/640-KB/GLaBIOS
+	// Versions of this BIOS exist for 8088, V20, pure emulation, homebrew projects, XT chipsets and genuine IBM 5150/5160 machines
+	ROMX_LOAD( "glabios_0.2.4_vt.rom", 0xe000, 0x2000, CRC(7c173fe3) SHA1(4ac6ca07453890e02c203617fbbdeefb53098cdb), ROM_BIOS(3))
 ROM_END
 
 

--- a/src/mame/pc/pc.cpp
+++ b/src/mame/pc/pc.cpp
@@ -924,6 +924,52 @@ ROM_START( ncrpc4i )
 ROM_END
 
 
+/****************************************************************** NCR PC6 ***
+
+Links: 	https://www.1000bit.it/ad/bro/ncr/ncr-pc6.pdf
+Info: 	ID-Nr. 3285-1011 (256KB RAM, 5.25 360KB flex drive), 3285-1012 (256KB RAM, 2x360KB flex drives), 3285-1014 (512KB RAM, 360KB flex and 20MB fixed drive),
+		3285-1015 (same as 1014, but adding a 10MB tape streamer); the motherboard is said to be the VLSI version of the PC4i mentioned there.
+Form factor: Desktop
+CPU: 8088-2 @ 4.77 MHz or 8 MHz
+RAM: 256K / 512K, up to 640K on board, four banks
+Bus: 8xISA8
+On board ports: 2xserial, parallel, floppy, speaker
+Video: Extended CGA, Hercules, EGA (mono or color)
+
+DIP settings:
+SW1:	SW1/1	SW1/2	SW1/3	SW1/4	SW1/5	SW1/6	SW1/7	SW1/8
+		N/A		
+				ON														FPU not installed
+						N/A		N/A
+										OFF		OFF						monochrome display
+										OFF		ON						color/graphics 40x25
+										ON		OFF						color/graphics 80x25
+										ON		ON						no display
+														ON		ON		1 flexible disk drive
+														OFF		ON		2 flexible disk drives
+														ON		OFF		3 flexible disk drives
+														OFF		OFF		4 flexible disk drives
+
+SWA:	SWA/1	SWA/2	SWA/3	SWA/4	SWA/5	SWA/6	SWA/7	SWA/8
+		OFF		OFF														256K RAM, 4x64K banks
+		OFF		ON														256K in bank 0
+		ON		OFF														640K (64K-64K-256K-256K) or 448K (64K-64K-256K-64K)
+		ON		ON														640K (256K-256K-64K-64K) or 576K (256K-256K-64K) or 512K (256K-256K-0K-0K)
+						ON												serial ports enabled
+								ON										parallel port enabled
+										ON								XP installed (turbo switch to 8 MHz)
+												N/A		N/A		N/A
+						
+
+
+******************************************************************************/
+
+ROM_START( ncrpc6 )
+	ROM_REGION(0x10000, "bios", 0)
+	ROM_LOAD( "ncr_pc6_bios_27128a@dip28_01_v3.5.bin", 0xc000, 0x4000, CRC(602e756a) SHA1 (890c19f5007b53701ebe32d074c8ba60a1b2e1d2))
+ROM_END
+
+
 /************************************************************* Olivetti M15 ***
 
 Links:  http://www.1000bit.it/ad/bro/olivetti/olivettiM15.pdf , http://electrickery.xs4all.nl/comp/m15/ ,
@@ -2338,6 +2384,63 @@ ROM_START( mpu9088vf ) // From a motherboard marked MY-COM MPU-9088-VF SAN-MS94V
 	ROM_LOAD( "27128-mpu-9088-vf_rom1.bin", 0xc000, 0x4000, CRC(a211e539) SHA1(1a45627fb34e38f6e3485c1526ff1d9a645c8683))
 ROM_END
 
+/****************************************************** Hyundai Super 16 T ***
+
+Model: Hyundai Super 16 T
+Form factor: Desktop
+CPU: Intel 8088 @ 8 MHz, can be toggled to 4.77 MHz using CTRL-ALT-ENTER; FPU: socket provided
+RAM: 640 KB
+OSC: 1.843200 MHz, 14.31818, 24.000
+Mass storage: 360K 5.25" floppy drive
+Sound: Built in Speaker
+Video: CGA Graphics
+On board: 2 x serial, 1x parallel, floppy, RTC
+ISA: 6 slots
+
+*****************************************************************************/
+
+ROM_START( hyu16t )
+	ROM_REGION(0x10000, "bios", 0) 
+	ROM_LOAD( "hea_v1.12ta_1986.bin", 0xc000, 0x4000, CRC(66573361) SHA1(6d0ef7ef6cd0bfbe2917ee52602e470cd143075f))
+ROM_END
+
+
+/***************************************************** Hyundai Super 16 TE ***
+
+Form factor: Desktop
+CPU: Intel 8088 @ 10MHz, FPU: socket provided
+RAM: 640 KB
+OSC: 1.8432 MHz, 14.31818, 30.000000MHz
+Mass storage: 360K 5.25" floppy drive, Seagate 20MB HDD
+Sound: Built in Speaker
+Video: CGA Graphics
+On board: 2 x serial, 1x parallel, floppy, RTC
+Keyboard: 101key
+ISA: 5 slots
+
+*****************************************************************************/
+
+ROM_START( hyu16te )
+	ROM_REGION(0x10000, "bios", 0) 
+	ROM_LOAD( "v2.00id_1989.bin", 0xc000, 0x4000, CRC(9a7a9917) SHA1(e114fdcc7b8caf76070f633bdab8c792eaa7eda0))
+ROM_END
+
+
+/************************************************************ AUVA VIP 800 ***
+
+Form factor: Desktop
+Motherboard: Juko Baby BXM/10-III
+CPU: NEC V20 @ 8 MHz
+RAM: up to 1MB, the Juko utilities can use the extra RAM as a RAM Disk, printer Buffer or harddisk cache
+OSC: 24.000 MHz, 14.31818
+ISA: 8 slots
+
+*****************************************************************************/
+
+ROM_START( auvip800 ) // a v2.30 Juko BIOS exists on this MB, cf. juko8
+	ROM_REGION(0x10000, "bios", 0) 
+	ROM_LOAD( "bxm10_phoenix_ver 2.52d.bin", 0xe000, 0x2000, CRC(9c964c80) SHA1(59a60425aa867abd33d30303300ed3c587969d2a))
+ROM_END
 } // anonymous namespace
 
 
@@ -2356,6 +2459,7 @@ COMP( 198?, olytext30,      ibm5150, 0,      olytext30,      pccga,    pc_state,
 COMP( 1987, earthst,        ibm5150, 0,      earthst,        pccga,    pc_state, empty_init,    "Alloy",                           "EarthStation-I",        MACHINE_NOT_WORKING )
 COMP( 1987, ataripc1,       ibm5150, 0,      ataripc1,       pccga,    pc_state, empty_init,    "Atari",                           "PC1",                   0 )
 COMP( 1988, ataripc3,       ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "Atari",                           "PC3",                   0 )
+COMP( 198?, auvip800,       ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "AUVA",							   "VIP 800",				MACHINE_NOT_WORKING )
 COMP( 1985, bw230,          ibm5150, 0,      bondwell,       bondwell, pc_state, init_bondwell, "Bondwell Holding",                "BW230 (PRO28 Series)",  0 )
 COMP( 1982, mpc1600,        ibm5150, 0,      mpc1600,        pccga,    pc_state, empty_init,    "Columbia Data Products",          "MPC 1600",              0 )
 COMP( 198?, coppc21,        ibm5150, 0,      coppc400,       pccga,    pc_state, empty_init,    "Corona Data Systems, Inc.",       "Corona PPC-21",         MACHINE_NOT_WORKING )
@@ -2372,6 +2476,8 @@ COMP( 1990, ec1847,         ibm5150, 0,      ec1847,         pccga,    pc_state,
 COMP( 1985, eppc,           ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "Ericsson Information System",     "Ericsson Portable PC",  MACHINE_NOT_WORKING )
 COMP( 1989, fraking,        ibm5150, 0,      fraking,        pccga,    pc_state, empty_init,    "Frael",                           "King",                  MACHINE_NOT_WORKING )
 COMP( 198?, hyo88t,         ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "Hyosung",                         "Topstar 88T",           MACHINE_NOT_WORKING )
+COMP( 1986, hyu16t,			ibm5150, 0, 	 pccga,          pccga,    pc_state, empty_init,    "Hyundai",						   "Super 16 T",	        MACHINE_NOT_WORKING )
+COMP( 1987, hyu16te,		ibm5150, 0, 	 pccga,          pccga,    pc_state, empty_init,    "Hyundai",						   "Super 16 TE",           MACHINE_NOT_WORKING )
 COMP( 1983, ibm5550,        ibm5150, 0,      ibm5550,        pccga,    pc_state, empty_init,    "International Business Machines", "5550",                  MACHINE_NOT_WORKING )
 COMP( 1984, ittxtra,        ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "ITT Information Systems",         "ITT XTRA",              MACHINE_NOT_WORKING )
 COMP( 198?, juko8,          ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "JUKO",                            "NEST 8088 and V20",     MACHINE_NOT_WORKING )
@@ -2384,6 +2490,7 @@ COMP( 198?, ledgmodm,       ibm5150, 0,      siemens,        pccga,    pc_state,
 COMP( 198?, mpx16,          ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "Micromint",                       "MPX-16",                MACHINE_NOT_WORKING )
 COMP( 198?, mpu9088vf,      ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "MY-COM",                          "MPU-9088-VF",           MACHINE_NOT_WORKING )
 COMP( 1985, ncrpc4i,        ibm5150, 0,      ncrpc4i,        pccga,    pc_state, empty_init,    "NCR",                             "PC4i",                  MACHINE_NOT_WORKING )
+COMP( 1985, ncrpc6,         ibm5150, 0,      ncrpc4i,        pccga,    pc_state, empty_init,    "NCR",                             "PC6",                   MACHINE_NOT_WORKING )
 COMP( 198?, nixpc01,        ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "Nixdorf Computer AG",             "8810/25 CPC - PC01",    MACHINE_NOT_WORKING )
 COMP( 198?, olivm15,        ibm5150, 0,      m15,            pccga,    pc_state, empty_init,    "Olivetti",                        "M15",                   0 )
 COMP( 198?, nms9100,        ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "Philips",                         "NMS 9100",              MACHINE_NOT_WORKING )

--- a/src/mame/pc/pc.cpp
+++ b/src/mame/pc/pc.cpp
@@ -926,9 +926,9 @@ ROM_END
 
 /****************************************************************** NCR PC6 ***
 
-Links: 	https://www.1000bit.it/ad/bro/ncr/ncr-pc6.pdf
-Info: 	ID-Nr. 3285-1011 (256KB RAM, 5.25 360KB flex drive), 3285-1012 (256KB RAM, 2x360KB flex drives), 3285-1014 (512KB RAM, 360KB flex and 20MB fixed drive),
-		3285-1015 (same as 1014, but adding a 10MB tape streamer); the motherboard is said to be the VLSI version of the PC4i mentioned there.
+Links:  https://www.1000bit.it/ad/bro/ncr/ncr-pc6.pdf
+Info:   ID-Nr. 3285-1011 (256KB RAM, 5.25 360KB flex drive), 3285-1012 (256KB RAM, 2x360KB flex drives), 3285-1014 (512KB RAM, 360KB flex and 20MB fixed drive),
+        3285-1015 (same as 1014, but adding a 10MB tape streamer); the motherboard is said to be the VLSI version of the PC4i mentioned there.
 Form factor: Desktop
 CPU: 8088-2 @ 4.77 MHz or 8 MHz
 RAM: 256K / 512K, up to 640K on board, four banks
@@ -937,29 +937,29 @@ On board ports: 2xserial, parallel, floppy, speaker
 Video: Extended CGA, Hercules, EGA (mono or color)
 
 DIP settings:
-SW1:	SW1/1	SW1/2	SW1/3	SW1/4	SW1/5	SW1/6	SW1/7	SW1/8
-		N/A		
-				ON														FPU not installed
-						N/A		N/A
-										OFF		OFF						monochrome display
-										OFF		ON						color/graphics 40x25
-										ON		OFF						color/graphics 80x25
-										ON		ON						no display
-														ON		ON		1 flexible disk drive
-														OFF		ON		2 flexible disk drives
-														ON		OFF		3 flexible disk drives
-														OFF		OFF		4 flexible disk drives
+SW1:    SW1/1   SW1/2   SW1/3   SW1/4   SW1/5   SW1/6   SW1/7   SW1/8
+        N/A
+                ON                                                      FPU not installed
+                        N/A     N/A
+                                        OFF     OFF                     monochrome display
+                                        OFF     ON                      color/graphics 40x25
+                                        ON      OFF                     color/graphics 80x25
+                                        ON      ON                      no display
+                                                        ON      ON      1 flexible disk drive
+                                                        OFF     ON      2 flexible disk drives
+                                                        ON      OFF     3 flexible disk drives
+                                                        OFF     OFF     4 flexible disk drives
 
-SWA:	SWA/1	SWA/2	SWA/3	SWA/4	SWA/5	SWA/6	SWA/7	SWA/8
-		OFF		OFF														256K RAM, 4x64K banks
-		OFF		ON														256K in bank 0
-		ON		OFF														640K (64K-64K-256K-256K) or 448K (64K-64K-256K-64K)
-		ON		ON														640K (256K-256K-64K-64K) or 576K (256K-256K-64K) or 512K (256K-256K-0K-0K)
-						ON												serial ports enabled
-								ON										parallel port enabled
-										ON								XP installed (turbo switch to 8 MHz)
-												N/A		N/A		N/A
-						
+SWA:    SWA/1   SWA/2   SWA/3   SWA/4   SWA/5   SWA/6   SWA/7   SWA/8
+        OFF     OFF                                                     256K RAM, 4x64K banks
+        OFF     ON                                                      256K in bank 0
+        ON      OFF                                                     640K (64K-64K-256K-256K) or 448K (64K-64K-256K-64K)
+        ON      ON                                                      640K (256K-256K-64K-64K) or 576K (256K-256K-64K) or 512K (256K-256K-0K-0K)
+                        ON                                              serial ports enabled
+                                ON                                      parallel port enabled
+                                        ON                              XP installed (turbo switch to 8 MHz)
+                                                N/A     N/A     N/A
+
 
 
 ******************************************************************************/
@@ -2400,7 +2400,7 @@ ISA: 6 slots
 *****************************************************************************/
 
 ROM_START( hyu16t )
-	ROM_REGION(0x10000, "bios", 0) 
+	ROM_REGION(0x10000, "bios", 0)
 	ROM_LOAD( "hea_v1.12ta_1986.bin", 0xc000, 0x4000, CRC(66573361) SHA1(6d0ef7ef6cd0bfbe2917ee52602e470cd143075f))
 ROM_END
 
@@ -2421,7 +2421,7 @@ ISA: 5 slots
 *****************************************************************************/
 
 ROM_START( hyu16te )
-	ROM_REGION(0x10000, "bios", 0) 
+	ROM_REGION(0x10000, "bios", 0)
 	ROM_LOAD( "v2.00id_1989.bin", 0xc000, 0x4000, CRC(9a7a9917) SHA1(e114fdcc7b8caf76070f633bdab8c792eaa7eda0))
 ROM_END
 
@@ -2438,9 +2438,10 @@ ISA: 8 slots
 *****************************************************************************/
 
 ROM_START( auvip800 ) // a v2.30 Juko BIOS exists on this MB, cf. juko8
-	ROM_REGION(0x10000, "bios", 0) 
+	ROM_REGION(0x10000, "bios", 0)
 	ROM_LOAD( "bxm10_phoenix_ver 2.52d.bin", 0xe000, 0x2000, CRC(9c964c80) SHA1(59a60425aa867abd33d30303300ed3c587969d2a))
 ROM_END
+
 } // anonymous namespace
 
 
@@ -2459,7 +2460,7 @@ COMP( 198?, olytext30,      ibm5150, 0,      olytext30,      pccga,    pc_state,
 COMP( 1987, earthst,        ibm5150, 0,      earthst,        pccga,    pc_state, empty_init,    "Alloy",                           "EarthStation-I",        MACHINE_NOT_WORKING )
 COMP( 1987, ataripc1,       ibm5150, 0,      ataripc1,       pccga,    pc_state, empty_init,    "Atari",                           "PC1",                   0 )
 COMP( 1988, ataripc3,       ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "Atari",                           "PC3",                   0 )
-COMP( 198?, auvip800,       ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "AUVA",							   "VIP 800",				MACHINE_NOT_WORKING )
+COMP( 198?, auvip800,       ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "AUVA",                            "VIP 800",               MACHINE_NOT_WORKING )
 COMP( 1985, bw230,          ibm5150, 0,      bondwell,       bondwell, pc_state, init_bondwell, "Bondwell Holding",                "BW230 (PRO28 Series)",  0 )
 COMP( 1982, mpc1600,        ibm5150, 0,      mpc1600,        pccga,    pc_state, empty_init,    "Columbia Data Products",          "MPC 1600",              0 )
 COMP( 198?, coppc21,        ibm5150, 0,      coppc400,       pccga,    pc_state, empty_init,    "Corona Data Systems, Inc.",       "Corona PPC-21",         MACHINE_NOT_WORKING )
@@ -2476,8 +2477,8 @@ COMP( 1990, ec1847,         ibm5150, 0,      ec1847,         pccga,    pc_state,
 COMP( 1985, eppc,           ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "Ericsson Information System",     "Ericsson Portable PC",  MACHINE_NOT_WORKING )
 COMP( 1989, fraking,        ibm5150, 0,      fraking,        pccga,    pc_state, empty_init,    "Frael",                           "King",                  MACHINE_NOT_WORKING )
 COMP( 198?, hyo88t,         ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "Hyosung",                         "Topstar 88T",           MACHINE_NOT_WORKING )
-COMP( 1986, hyu16t,			ibm5150, 0, 	 pccga,          pccga,    pc_state, empty_init,    "Hyundai",						   "Super 16 T",	        MACHINE_NOT_WORKING )
-COMP( 1987, hyu16te,		ibm5150, 0, 	 pccga,          pccga,    pc_state, empty_init,    "Hyundai",						   "Super 16 TE",           MACHINE_NOT_WORKING )
+COMP( 1986, hyu16t,         ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "Hyundai",                         "Super 16 T",            MACHINE_NOT_WORKING )
+COMP( 1987, hyu16te,        ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "Hyundai",                         "Super 16 TE",           MACHINE_NOT_WORKING )
 COMP( 1983, ibm5550,        ibm5150, 0,      ibm5550,        pccga,    pc_state, empty_init,    "International Business Machines", "5550",                  MACHINE_NOT_WORKING )
 COMP( 1984, ittxtra,        ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "ITT Information Systems",         "ITT XTRA",              MACHINE_NOT_WORKING )
 COMP( 198?, juko8,          ibm5150, 0,      pccga,          pccga,    pc_state, empty_init,    "JUKO",                            "NEST 8088 and V20",     MACHINE_NOT_WORKING )


### PR DESCRIPTION
Added BIOS revisions to pc and pcv20, NCR PC6 [eggimac], AUVA VIP 800 [fdiskitup], Hyundai Super 16T and TE [sequoia], Octec XT-286 [ozzyrules] and Nixdorf 8810-20 [MajorMaxdom]