### PR TITLE
cave.cpp: Fixed ymz clock for gaia and theroes

### DIFF
--- a/src/mame/misc/cave.cpp
+++ b/src/mame/misc/cave.cpp
@@ -2230,7 +2230,12 @@ void cave_state::gaia(machine_config &config)
 	MCFG_VIDEO_START_OVERRIDE(cave_state,spr_8bpp)
 
 	/* sound hardware */
-	add_ymz(config);
+	SPEAKER(config, "mono").front_center();
+
+	// Unlike other games also using ymz, gaia (and theroes) has 16MHz clock for it
+	ymz280b_device &ymz(YMZ280B(config, "ymz", 16_MHz_XTAL));
+	ymz.irq_handler().set(FUNC(cave_state::sound_irq_gen));
+	ymz.add_route(ALL_OUTPUTS, "mono", 1.0);
 }
 
 


### PR DESCRIPTION
Wrong clock for YMZ in Gaia Crusaders. That made the sound pitch a bit higher than original pcb.
Unlike other games also using ymz in cave driver, gaia (and theroes) has 16MHz clock for it, instead of 16.9344MHz one. 

Pictures of actual Gaia Crusaders pcb from two different sources:
[https://i.imgur.com/5uTlfh3.png](https://i.imgur.com/5uTlfh3.png)
[https://i.imgur.com/uCM3PFA.png](https://i.imgur.com/uCM3PFA.png)

Other games, such as ddonpach, esprade and dfeveron have different one:
[https://i.imgur.com/0YRIMwi.png](https://i.imgur.com/0YRIMwi.png)
[https://i.imgur.com/vlNZ1YT.png](https://i.imgur.com/vlNZ1YT.png)
[https://i.imgur.com/KkWfDjZ.png](https://i.imgur.com/KkWfDjZ.png)