### PR TITLE
x68k_flop.xml: add 8 dumps from original disks

### DIFF
--- a/hash/x68k_flop.xml
+++ b/hash/x68k_flop.xml
@@ -1482,6 +1482,26 @@ Most info on release dates and Jpn titles come from the following (wonderful) re
 		<info name="release" value="19910620" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="3444339">
+				<rom name="armored_trooper_votoms_dead_ash_disk_a.mfm" size="3444339" crc="b20e1476" sha1="dccc9fb160793595314abbb5e670cee8861037d7" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B" />
+			<dataarea name="flop" size="3443871">
+				<rom name="armored_trooper_votoms_dead_ash_disk_b.mfm" size="3443871" crc="b463e7b4" sha1="469db2ccef1c69fe46f5c496a8b5bb61793afc18" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="votomsc" cloneof="votoms">
+		<description>Armored Trooper Votoms - Dead Ash (cracked)</description>
+		<year>1991</year>
+		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="alt_title" value="装甲騎兵ボトムズ DEAD ASH ~ Soukou Kihei Votoms Dead Ash" />
+		<info name="release" value="19910620" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A" />
 			<dataarea name="flop" size="1261824">
 				<rom name="armored trooper votoms dead ash (1991)(family soft)(disk 1 of 2)(disk a).dim" size="1261824" crc="542dc750" sha1="5a7a6064dedbbbd5d0a861bd58ad4b6a6afc03b2" />
 			</dataarea>
@@ -1581,8 +1601,22 @@ Most info on release dates and Jpn titles come from the following (wonderful) re
 		</part>
 	</software>
 
-	<software name="chelnov">
+	<!-- Hangs at the loading screen -->
+	<software name="chelnov" supported="no">
 		<description>Video Game Anthology Vol. 2 - Atomic Runner Chelnov</description>
+		<year>1993</year>
+		<publisher>電波新聞社 (Dempa Shinbunsha)</publisher>
+		<info name="alt_title" value="ビデオゲームアンソロジー vol.2 - チェルノブ" />
+		<info name="release" value="19930129" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="3444600">
+				<rom name="atomic_runner_chelnov.mfm" size="3444600" crc="1acdd3b4" sha1="58db64ced0171d97a4580a960bd94d6fd11a260a" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="chelnovc" cloneof="chelnov">
+		<description>Video Game Anthology Vol. 2 - Atomic Runner Chelnov (cracked)</description>
 		<year>1993</year>
 		<publisher>電波新聞社 (Dempa Shinbunsha)</publisher>
 		<info name="alt_title" value="ビデオゲームアンソロジー vol.2 - チェルノブ" />
@@ -2984,13 +3018,47 @@ Most info on release dates and Jpn titles come from the following (wonderful) re
 		</part>
 	</software>
 
-	<software name="cntinent">
+	<!-- Hangs after the Game Technopolis logo -->
+	<software name="cntinent" supported="no">
 		<description>Continental</description>
 		<year>1992</year>
 		<publisher>GAMEテクノポリス (Game Technopolis)</publisher>
 		<info name="alt_title" value="コンチネンタル" />
 		<info name="release" value="19920320" />
-		<info name="usage" value="Requires Disk 1 and Disk 3 mounted to boot" />
+		<info name="usage" value="Requires Disk A and Disk C mounted to boot" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="3444518">
+				<rom name="continental_disk_a.mfm" size="3444518" crc="e4f470a1" sha1="1f4452bf7c9a5a89a51650bf8bab1e58ca533b89" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B" />
+			<dataarea name="flop" size="3444480">
+				<rom name="continental_disk_b.mfm" size="3444480" crc="ef65bdaa" sha1="3e3fdf0e01382c21b6858098eb245ff813e568ac" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Disk C" />
+			<dataarea name="flop" size="3444506">
+				<rom name="continental_disk_c.mfm" size="3444506" crc="b12acfcc" sha1="8c373c9a8fddfa3191d555649b9cec3ecfa8fcf2" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Disk D" />
+			<dataarea name="flop" size="3444495">
+				<rom name="continental_disk_d.mfm" size="3444495" crc="abff8359" sha1="778d9a2fc5cdebbbaf9af7a65388977faccb06a0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cntinentc" cloneof="cntinent">
+		<description>Continental (cracked)</description>
+		<year>1992</year>
+		<publisher>GAMEテクノポリス (Game Technopolis)</publisher>
+		<info name="alt_title" value="コンチネンタル" />
+		<info name="release" value="19920320" />
+		<info name="usage" value="Requires Disk A and Disk C mounted to boot" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A" />
 			<dataarea name="flop" size="1261824">
@@ -3804,8 +3872,52 @@ Including "Daikairei Powerup kit to Shin Scenario Make kit" &amp; "Daikairei Tsu
 		</part>
 	</software>
 
-	<software name="diebahn" supported="no">
-		<description>Die Banhwelt</description>
+	<software name="diebahn">
+		<description>Die Bahnwelt</description>
+		<year>1992</year>
+		<publisher>グローディア (Glodia)</publisher>
+		<info name="alt_title" value="バーンウェルト" />
+		<info name="release" value="19921030" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="System Disk" />
+			<dataarea name="flop" size="3442528">
+				<rom name="die_bahnwelt_system_disk.mfm" size="3442528" crc="d7c56366" sha1="545fc9ceb76f7621b87ae49c62efe4ab7503cc81" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk A" />
+			<dataarea name="flop" size="3433320">
+				<rom name="die_bahnwelt_data_disk_a.mfm" size="3433320" crc="f7b2251c" sha1="012a2570cd38697ca0b12c37127b1fb71efeac58" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk B" />
+			<dataarea name="flop" size="3379433">
+				<rom name="die_bahnwelt_data_disk_b.mfm" size="3379433" crc="c1ab6bdb" sha1="3012af1359cdb34f149d85393bf5f5b5349cd7ba" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk C" />
+			<dataarea name="flop" size="3413587">
+				<rom name="die_bahnwelt_data_disk_c.mfm" size="3413587" crc="c385c836" sha1="039d033b607c303ed0aa3f75283b173c7e5136f8" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Opening Disk" />
+			<dataarea name="flop" size="3403961">
+				<rom name="die_bahnwelt_opening_disk.mfm" size="3403961" crc="420779eb" sha1="851dc412f08b32d4fd68acf39bd061ea397482ab" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Ending Disk" />
+			<dataarea name="flop" size="3412617">
+				<rom name="die_bahnwelt_ending_disk.mfm" size="3412617" crc="559a369b" sha1="006ab534aba1dea9982a7abfb6f343ff0ffb23dc" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="diebahnc" cloneof="diebahn">
+		<description>Die Bahnwelt (cracked)</description>
 		<year>1992</year>
 		<publisher>グローディア (Glodia)</publisher>
 		<info name="alt_title" value="バーンウェルト" />
@@ -7890,6 +8002,26 @@ Including "Daikairei Powerup kit to Shin Scenario Make kit" &amp; "Daikairei Tsu
 		<info name="release" value="19891208" />
 		<part name="flop1" interface="floppy_5_25">
 			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="3440540">
+				<rom name="knight_arms_disk_a.mfm" size="3440540" crc="b300b244" sha1="195a0f34de864c99557546accd17486a41dd4b2a" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B" />
+			<dataarea name="flop" size="3417157">
+				<rom name="knight_arms_disk_b.mfm" size="3417157" crc="f9a71730" sha1="795074656fc7abbeaf5fc2b35e0ae2be41db5558" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="knghtarmc" cloneof="knghtarm">
+		<description>Knight Arms - The Hyblid Framer (cracked)</description>
+		<year>1989</year>
+		<publisher>アルシスソフトウェア (Arsys Software)</publisher>
+		<info name="alt_title" value="ナイトアームズ" />
+		<info name="release" value="19891208" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A" />
 			<dataarea name="flop" size="1261824">
 				<rom name="knight arms the hyblid framer (1989)(arsys)(disk 1 of 2)(disk a).dim" size="1261824" crc="dccb9e79" sha1="30799db8e90a8f778046b660a03bc8eb14fb7dfd" />
 			</dataarea>
@@ -8282,8 +8414,35 @@ Including "Daikairei Powerup kit to Shin Scenario Make kit" &amp; "Daikairei Tsu
 		</part>
 	</software>
 
-	<software name="laplace">
+	<!-- The user disk creation process doesn't recognize the data disk. This happens in both the original and cracked versions. -->
+	<software name="laplace" supported="no">
 		<description>Laplace no Ma</description>
+		<year>1990</year>
+		<publisher>ハミングバード (HummingBird)</publisher>
+		<info name="alt_title" value="ラプラスの魔" />
+		<info name="release" value="19901221" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="System Disk" />
+			<dataarea name="flop" size="3417753">
+				<rom name="laplace_no_ma_system_disk.mfm" size="3417753" crc="8c56ffac" sha1="cf774f64df320ada24f847cd54e14f78043683e6" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Game Disk" />
+			<dataarea name="flop" size="3443500">
+				<rom name="laplace_no_ma_game_disk.mfm" size="3443500" crc="25b463ea" sha1="c939221426e0fbc11b93d04ab1e01cb22554f670" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Data Disk" />
+			<dataarea name="flop" size="3432819">
+				<rom name="laplace_no_ma_data_disk.mfm" size="3432819" crc="29c76ff5" sha1="f876cf30c33c4a54b8b57a8e2ba8be55c9916d79" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="laplacec" cloneof="laplace" supported="no">
+		<description>Laplace no Ma (cracked)</description>
 		<year>1990</year>
 		<publisher>ハミングバード (HummingBird)</publisher>
 		<info name="alt_title" value="ラプラスの魔" />
@@ -13197,6 +13356,26 @@ Typing "CD PACMAN" and enter key, Typing "PAC" (or "PAC.BAT") and enter key. The
 
 	<software name="scruiser">
 		<description>Star Cruiser</description>
+		<year>1989</year>
+		<publisher>アルシスソフトウェア (Arsys Software)</publisher>
+		<info name="alt_title" value="スタークルーザー" />
+		<info name="release" value="19890414" />
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="3441616">
+				<rom name="star_cruiser_disk_a.mfm" size="3441616" crc="86138b36" sha1="d4e54218a79a352218b0b07b05d57dcadb62ca0b" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Disk B" />
+			<dataarea name="flop" size="3440090">
+				<rom name="star_cruiser_disk_b.mfm" size="3440090" crc="fb9f289c" sha1="03310488a386f36bf1c0fd8d8305a643953c5bc3" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="scruiserc" cloneof="scruiser">
+		<description>Star Cruiser (cracked)</description>
 		<year>1989</year>
 		<publisher>アルシスソフトウェア (Arsys Software)</publisher>
 		<info name="alt_title" value="スタークルーザー" />
@@ -25368,11 +25547,25 @@ sold through Takeru vending machines -->
 		</part>
 	</software>
 
-	<!-- boot OK -->
-	<software name="fcrisis" supported="yes">
-		<description>First Crisis ma Jin no Toubou</description>
+	<software name="fcrisis">
+		<description>First Crisis - Ma-Jin no Toubou (v1.00)</description>
 		<year>1992</year>
 		<publisher>&lt;doujin&gt;</publisher>
+		<info name="alt_title" value="ふぁーすと・くらいしす　魔ＪＩＮの逃亡" />
+		<info name="developer" value="Minkey Soft" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="3424960">
+				<rom name="first_crisis.mfm" size="3424960" crc="0b976471" sha1="9432cdfa2f319cc2fe1f5afc633c44d2bd86fd02" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- boot OK -->
+	<software name="fcrisiso" cloneof="fcrisis" supported="yes">
+		<description>First Crisis - Ma-Jin no Toubou (v0.91)</description>
+		<year>1992</year>
+		<publisher>&lt;doujin&gt;</publisher>
+		<info name="alt_title" value="ふぁーすと・くらいしす　魔ＪＩＮの逃亡" />
 		<info name="developer" value="Minkey Soft" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1261824">


### PR DESCRIPTION
New working software list additions
-----------------------------------
Armored Trooper Votoms - Dead Ash [krugman]
Die Bahnwelt [krugman]
First Crisis - Ma-Jin no Toubou (v1.00) [krugman]
Knight Arms - The Hyblid Framer [krugman]
Star Cruiser [krugman]

New not working software list additions
---------------------------------------
Continental [krugman]
Laplace no Ma [krugman]
Video Game Anthology Vol. 2 - Atomic Runner Chelnov [krugman]

Software list items promoted to working
---------------------------------------
Die Bahnwelt (cracked) [crazyc]


All of these are copy-protected except First Crisis (it's a doujin release) and I have checked that all the working ones crash or complain if you try to run them from a copy made with DISKCOPY (the Votoms protection trigger is actually pretty funny, it replaces all the graphics with silly sprites), so I'm reasonably sure that MAME is emulating everything needed for the protection, at least for those.

About promoting Die Bahnwelt to working: I have tested it in old versions and indeed it didn't work at all (didn't recognize its own system disk). I haven't traced the exact commit, but it got fixed between 0.236 and 0.237, so I'm pretty sure that it is b8cd4f01c4abf27d598404176f72ae56394f0a00, since I haven't found anything else related to the 765 around that time.