### PR TITLE
heathkit/tlb.cpp Implement interrupt handling for break key

### DIFF
--- a/src/mame/heathkit/tlb.cpp
+++ b/src/mame/heathkit/tlb.cpp
@@ -315,14 +315,14 @@ void heath_tlb_device::check_for_reset()
 
 void heath_tlb_device::reset_key_w(int state)
 {
-	m_reset_key = (state == CLEAR_LINE);
+	m_reset_key = (state == 0);
 
 	check_for_reset();
 }
 
 void heath_tlb_device::right_shift_w(int state)
 {
-	m_right_shift = (state == CLEAR_LINE);
+	m_right_shift = (state == 0);
 
 	check_for_reset();
 }
@@ -335,7 +335,7 @@ void heath_tlb_device::repeat_key_w(int state)
 
 void heath_tlb_device::break_key_w(int state)
 {
-	m_break_key_irq_raised = (state == CLEAR_LINE);
+	m_break_key_irq_raised = (state == 0);
 
 	set_irq_line();
 }

--- a/src/mame/heathkit/tlb.h
+++ b/src/mame/heathkit/tlb.h
@@ -35,6 +35,7 @@ public:
 	void reset_key_w(int state);
 	void right_shift_w(int state);
 	void repeat_key_w(int state);
+	void break_key_w(int state);
 	void serial_irq_w(int state);
 
 protected:
@@ -100,6 +101,7 @@ private:
 	bool     m_reset_key;
 	bool     m_keyboard_irq_raised;
 	bool     m_serial_irq_raised;
+	bool     m_break_key_irq_raised;
 };
 
 class heath_super19_tlb_device : public heath_tlb_device


### PR DESCRIPTION
Implement the interrupt processing that happens on the H19 terminal board when the break key is pressed.
Note: the actual break functionality will not work until the INS8250 properly handles the "Set Interrupt" bit in it's LCR register.