### PR TITLE
Fix Qt6 detection on Linux

### DIFF
--- a/scripts/src/osd/modules.lua
+++ b/scripts/src/osd/modules.lua
@@ -378,12 +378,19 @@ function qtdebuggerbuild()
 			MOC = "moc"
 		else
 			if _OPTIONS["QT_HOME"]~=nil then
-				QMAKETST = backtick(_OPTIONS["QT_HOME"] .. "/bin/qmake --version 2>/dev/null")
-				if (QMAKETST=='') then
-					print("Qt's Meta Object Compiler (moc) wasn't found!")
-					os.exit(1)
+				MOCTST = backtick(_OPTIONS["QT_HOME"] .. "/bin/moc --version 2>/dev/null")
+				if (MOCTST=='') then
+					MOCTST = backtick(_OPTIONS["QT_HOME"] .. "/libexec/moc --version 2>/dev/null")
+					if (MOCTST=='') then
+						print("Qt's Meta Object Compiler (moc) wasn't found!")
+						os.exit(1)
+					else
+						MOC = _OPTIONS["QT_HOME"] .. "/libexec/moc"
+					end
+				else
+					MOC = _OPTIONS["QT_HOME"] .. "/bin/moc"
 				end
-				MOC = _OPTIONS["QT_HOME"] .. "/bin/moc"
+				MOC = _OPTIONS["QT_HOME"] .. "/libexec/moc"
 			else
 				MOCTST = backtick("which moc-qt5 2>/dev/null")
 				if (MOCTST=='') then
@@ -494,14 +501,23 @@ function osdmodulestargetconf()
 			}
 		else
 			if _OPTIONS["QT_HOME"]~=nil then
+				local qt_version = str_to_version(backtick(_OPTIONS["QT_HOME"] .. "/bin/qmake -query QT_VERSION"))
 				linkoptions {
 					"-L" .. backtick(_OPTIONS["QT_HOME"] .. "/bin/qmake -query QT_INSTALL_LIBS"),
 				}
-				links {
-					"Qt5Core",
-					"Qt5Gui",
-					"Qt5Widgets",
-				}
+				if qt_version < 60000 then
+					links {
+						"Qt5Core",
+						"Qt5Gui",
+						"Qt5Widgets",
+					}
+				else
+					links {
+						"Qt6Core",
+						"Qt6Gui",
+						"Qt6Widgets",
+					}
+				end
 			else
 				local str = backtick(pkgconfigcmd() .. " --libs Qt5Widgets")
 				addlibfromstring(str)

--- a/src/osd/modules/debugger/qt/breakpointswindow.cpp
+++ b/src/osd/modules/debugger/qt/breakpointswindow.cpp
@@ -8,7 +8,11 @@
 
 #include "util/xmlfile.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QtGui/QActionGroup>
+#else
 #include <QtWidgets/QActionGroup>
+#endif
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QMenuBar>

--- a/src/osd/modules/debugger/qt/dasmwindow.cpp
+++ b/src/osd/modules/debugger/qt/dasmwindow.cpp
@@ -13,7 +13,12 @@
 #include <QtGui/QKeyEvent>
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QVBoxLayout>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QtGui/QAction>
+#include <QtGui/QActionGroup>
+#else
 #include <QtWidgets/QAction>
+#endif
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QMenuBar>
 
@@ -86,7 +91,7 @@ DasmWindow::DasmWindow(DebuggerQt &debugger, QWidget *parent) :
 	m_breakpointEnableAct = new QAction("Disable Breakpoint at Cursor", this);
 	m_runToCursorAct = new QAction("Run to Cursor", this);
 	m_breakpointToggleAct->setShortcut(Qt::Key_F9);
-	m_breakpointEnableAct->setShortcut(Qt::SHIFT + Qt::Key_F9);
+	m_breakpointEnableAct->setShortcut(Qt::SHIFT | Qt::Key_F9);
 	m_runToCursorAct->setShortcut(Qt::Key_F4);
 	connect(m_breakpointToggleAct, &QAction::triggered, this, &DasmWindow::toggleBreakpointAtCursor);
 	connect(m_breakpointEnableAct, &QAction::triggered, this, &DasmWindow::enableBreakpointAtCursor);

--- a/src/osd/modules/debugger/qt/mainwindow.cpp
+++ b/src/osd/modules/debugger/qt/mainwindow.cpp
@@ -11,7 +11,12 @@
 #include "util/xmlfile.h"
 
 #include <QtGui/QCloseEvent>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QtGui/QAction>
+#include <QtGui/QActionGroup>
+#else
 #include <QtWidgets/QAction>
+#endif
 #include <QtWidgets/QDockWidget>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QMenu>
@@ -61,7 +66,7 @@ MainWindow::MainWindow(DebuggerQt &debugger, QWidget *parent) :
 	m_breakpointEnableAct = new QAction("Disable Breakpoint at Cursor", this);
 	m_runToCursorAct = new QAction("Run to Cursor", this);
 	m_breakpointToggleAct->setShortcut(Qt::Key_F9);
-	m_breakpointEnableAct->setShortcut(Qt::SHIFT + Qt::Key_F9);
+	m_breakpointEnableAct->setShortcut(Qt::SHIFT | Qt::Key_F9);
 	m_runToCursorAct->setShortcut(Qt::Key_F4);
 	connect(m_breakpointToggleAct, &QAction::triggered, this, &MainWindow::toggleBreakpointAtCursor);
 	connect(m_breakpointEnableAct, &QAction::triggered, this, &MainWindow::enableBreakpointAtCursor);

--- a/src/osd/modules/debugger/qt/memorywindow.cpp
+++ b/src/osd/modules/debugger/qt/memorywindow.cpp
@@ -12,7 +12,11 @@
 #include <QtGui/QClipboard>
 #include <QtGui/QKeyEvent>
 #include <QtGui/QMouseEvent>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QtGui/QActionGroup>
+#else
 #include <QtWidgets/QActionGroup>
+#endif
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QMenu>


### PR DESCRIPTION
- Look for MOC in QT_HOME/libexec if not found in QT_HOME/bin

- Use the Qt6* libraries if the Qt version is >= 6