### PR TITLE
render/drawsdl.cpp: Don't request OpenGL context

### DIFF
--- a/src/osd/modules/render/drawsdl.cpp
+++ b/src/osd/modules/render/drawsdl.cpp
@@ -717,7 +717,7 @@ public:
 	virtual std::unique_ptr<osd_renderer> create(osd_window &window) override;
 
 protected:
-	virtual unsigned flags() const override { return FLAG_INTERACTIVE | FLAG_SDL_NEEDS_OPENGL; }
+	virtual unsigned flags() const override { return FLAG_INTERACTIVE; }
 
 private:
 	static int get_scale_mode(char const *modestr);


### PR DESCRIPTION
Hello.

I found that when I specify the `-video soft` option, but OpenGL is loaded.
So I created a pull request with a fix so that the FLAG_SDL_NEEDS_OPENGL bit is not set. 

Please reject if my understanding is incorrect.

Best Regards.

----

Command line:

```bash
$ mame -video soft -videodriver directfb -verbose
```

Error log: `OpenGL not supported on this driver:`

```bash
...snip...
Available videodrivers: x11 wayland directfb KMSDRM dummy 
Current Videodriver: directfb
...snip...
Using SDL multi-window soft driver (SDL 2.0+)
Enter sdlwindow_init
...snip...
Leave sdlwindow_init
Enter sdl_info::create
OpenGL not supported on this driver: OpenGL support is either not configured in SDL or not available in current SDL video driver (directfb) or platform
Enter sdlwindow_exit
Leave sdlwindow_exit
video_init: Initialization failed!
```

Log after patch to source code:

```bash
...snip...
Available videodrivers: x11 wayland directfb KMSDRM dummy 
Current Videodriver: directfb
...snip...
Using SDL multi-window soft driver (SDL 2.0+)
Enter sdlwindow_init
...snip...
Leave sdlwindow_init
Enter sdl_info::create
...snip...
window: using renderer directfb
renderer: flag SDL_RENDERER_ACCELERATED
Leave renderer_sdl2::create
udio: Start initialization
Audio: Driver is pulseaudio
Audio: frequency: 48000, channels: 2, samples: 256
sdl_create_buffers: creating stream buffer of 25600 bytes
Audio: End initialization
...Starts normally!...
```