### PR TITLE
Fix divide-by-zero in SDL2 OSD renderer when using Emscripten

### DIFF
--- a/src/osd/modules/render/draw13.cpp
+++ b/src/osd/modules/render/draw13.cpp
@@ -365,7 +365,7 @@ void renderer_sdl2::render_quad(texture_info *texture, const render_primitive &p
 			copyinfo->time += (m_last_blit_time * (int64_t) (texture->raw_width() * texture->raw_height())) / (int64_t) m_last_blit_pixels;
 		}
 		copyinfo->samples++;
-		copyinfo->perf = ( texture->m_copyinfo->pixel_count * (osd_ticks_per_second()/1000)) / texture->m_copyinfo->time;
+		copyinfo->perf = (texture->m_copyinfo->pixel_count * (osd_ticks_per_second()/1000)) / std::max(texture->m_copyinfo->time, 1LL);
 	}
 	else
 	{

--- a/src/osd/modules/render/draw13.cpp
+++ b/src/osd/modules/render/draw13.cpp
@@ -365,7 +365,7 @@ void renderer_sdl2::render_quad(texture_info *texture, const render_primitive &p
 			copyinfo->time += (m_last_blit_time * (int64_t) (texture->raw_width() * texture->raw_height())) / (int64_t) m_last_blit_pixels;
 		}
 		copyinfo->samples++;
-		copyinfo->perf = (texture->m_copyinfo->pixel_count * (osd_ticks_per_second()/1000)) / std::max(texture->m_copyinfo->time, 1LL);
+		copyinfo->perf = (texture->m_copyinfo->pixel_count * (osd_ticks_per_second()/1000)) / std::max<int64_t>(texture->m_copyinfo->time, 1);
 	}
 	else
 	{


### PR DESCRIPTION
I built the hh_sm510 driver from 0.256 using Emscripten, but there was an occasional divide-by-zero exception when running with `-video accel`. Debugging revealed it came from `renderer_sdl2::render_quad` in the SDL2 OSD renderer. For some reason, `texture->m_copyinfo->time` was 0 when trying to calculate `texture->m_copyinfo->perf`. I suspect the timer that backs `osd_ticks` might be too imprecise under Emscripten. Since this is only used for performance diagnostics, I assumed it was safe to use 1 as a denominator when `texture->m_copyinfo->time` is 0. After rebuilding with this change, I have not observed the divide-by-zero exception again.