### PR TITLE
Added Sinistar (Cockpit version)

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -27497,6 +27497,7 @@ robotron87                      //
 robotron12                      //
 robotrontd                      //
 sinistar                        // (c) 1982
+sinistarc                       // (c) 1982 (cockpit version with stereo sound)
 sinistar2                       // (c) 1982
 sinistarp                       // (c) 1982 prototype (shown at AMOA 1982 show)
 spdball                         // (c) 1985

--- a/src/mame/midway/williams.cpp
+++ b/src/mame/midway/williams.cpp
@@ -713,6 +713,15 @@ void blaster_state::sound2_map(address_map &map)
 	map(0xb000, 0xffff).rom();
 }
 
+/* Same as above, but for second sound board */
+void sinistar_state::sound2_map(address_map &map)
+{
+	map(0x0000, 0x007f).ram(); // internal RAM
+	map(0x0080, 0x00ff).ram(); // MC6810 RAM
+	map(0x0400, 0x0403).mirror(0x8000).rw(m_pia[3], FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xb000, 0xffff).rom();
+}
+
 
 
 /*************************************
@@ -1109,6 +1118,37 @@ INPUT_PORTS_END
 
 
 static INPUT_PORTS_START( sinistar )
+	PORT_START("IN0")
+	// pseudo analog joystick, see below
+
+	PORT_START("IN1")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1 )
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON2 )
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_START1 )
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_START2 )
+	PORT_BIT( 0xc0, IP_ACTIVE_HIGH, IPT_UNKNOWN )
+
+	PORT_START("IN2")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_SERVICE1 ) PORT_NAME("Auto Up / Manual Down") PORT_TOGGLE
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_SERVICE ) PORT_NAME("Advance")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_COIN3 )
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_MEMORY_RESET ) PORT_NAME("High Score Reset")
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_COIN1 )
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_COIN2 )
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_TILT )
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_UNKNOWN )
+
+	PORT_START("49WAYX") // converted by port_0_49way_r()
+	PORT_BIT( 0xff, 0x38, IPT_AD_STICK_X ) PORT_MINMAX(0x00,0x6f) PORT_SENSITIVITY(100) PORT_KEYDELTA(10)
+
+	PORT_START("49WAYY") // converted by port_0_49way_r()
+	PORT_BIT( 0xff, 0x38, IPT_AD_STICK_Y ) PORT_MINMAX(0x00,0x6f) PORT_SENSITIVITY(100) PORT_KEYDELTA(10) PORT_REVERSE
+INPUT_PORTS_END
+
+/* 
+   In order to get the cockpit version of Sinistar working, the ports have been duplicated.
+*/
+static INPUT_PORTS_START( sinistac )
 	PORT_START("IN0")
 	// pseudo analog joystick, see below
 
@@ -1694,6 +1734,41 @@ void sinistar_state::sinistar(machine_config &config)
 	// sound hardware
 	HC55516(config, "cvsd", 0).add_route(ALL_OUTPUTS, "speaker", 0.8);
 }
+
+void sinistar_state::sinistac(machine_config &config)
+{
+	sinistar(config);
+
+	// basic machine hardware
+	M6808(config, m_soundcpu_b, SOUND_CLOCK); // internal clock divider of 4, effective frequency is 894.886kHz
+	m_soundcpu_b->set_addrmap(AS_PROGRAM, &sinistar_state::sound2_map);
+
+	// sound hardware
+	config.device_remove("speaker");
+	config.device_remove("dac");
+	config.device_remove("cvsd");
+	
+	SPEAKER(config, "lspeaker").front_left();
+	SPEAKER(config, "rspeaker").front_right();
+	
+	HC55516(config, "cvsd", 0).add_route(ALL_OUTPUTS, "lspeaker", 0.8);
+
+	MC1408(config, "ldac", 0).add_route(ALL_OUTPUTS, "lspeaker", 0.25); // unknown DAC
+	MC1408(config, "rdac", 0).add_route(ALL_OUTPUTS, "rspeaker", 0.25); // unknown DAC
+
+	// pia
+	INPUT_MERGER_ANY_HIGH(config, "soundirq_b").output_handler().set_inputline(m_soundcpu_b, M6808_IRQ_LINE);
+
+	m_pia[1]->writepb_handler().set(FUNC(sinistar_state::sinistar_snd_cmd_w));
+	m_pia[2]->writepa_handler().set("ldac", FUNC(dac_byte_interface::data_w));
+
+	PIA6821(config, m_pia[3], 0);
+	m_pia[3]->writepa_handler().set("rdac", FUNC(dac_byte_interface::data_w));
+	m_pia[3]->irqa_handler().set("soundirq_b", FUNC(input_merger_any_high_device::in_w<0>));
+	m_pia[3]->irqb_handler().set("soundirq_b", FUNC(input_merger_any_high_device::in_w<1>));
+
+}
+
 
 void playball_state::playball(machine_config &config)
 {
@@ -3130,7 +3205,17 @@ Although not currently dumped, "true" rev.1 Sinistar ROMs are believed to be num
 There is known to be a "perfect" version of Sinistar, that being the original version presented to Williams by the
   dev team. The dev team thought this version had the best game play while Williams decided it was too easy (IE: it
   could be played too long on one quarter)
-
+  
+Sinistar's cockpit cabinet features two sound boards, one for the front speakers and another for the rear.  The rear
+  sound board uses a different ROM, Video Sound ROM 10.  This is nearly identicial to Video Sound ROM 9, except for 
+  a routine that adds a slight delay to some of the sound effects which produces the stereo separation effect.
+It also disables the extra ship and bounce sound effects.  As seen in the drawing set for Sinistar, there are no
+  speech ROMs connected to the rear board, so only the front speakers play speech.
+  
+If you disconnect the speech ROMs from the upright sound board, Video Sound ROM 9 will play two replacement sound
+  effects for the Sinistar's missing audio.  Any line of dialogue will be replaced by a generic alarm noise,
+  while the Sinistar roar is replaced by a loud square wave synth noise that attempts to emulate the "sini-scream".
+  Video Sound Rom 10 disables this functionality so that it doesn't play any error sounds during speech calls.
 */
 ROM_START( sinistar ) // rev. 3
 	ROM_REGION( 0x19000, "maincpu", 0 ) // solid RED labels with final production part numbers
@@ -3153,14 +3238,36 @@ ROM_START( sinistar ) // rev. 3
 	ROM_LOAD( "3004_speech_ic4_r1_16-3004-49.ic4", 0xe000, 0x1000, CRC(4b56a626) SHA1(44430cd5c110ec751b0bfb8ae99b26d443350db1) )
 	ROM_LOAD( "video_sound_rom_9_std.808.ic12",    0xf000, 0x1000, CRC(b82f4ddb) SHA1(c70c7dd6e88897920d7709a260f27810f66aade1) )
 
-/*
+	ROM_REGION( 0x0400, "proms", 0 )
+	ROM_LOAD( "decoder_rom_4.3g", 0x0000, 0x0200, CRC(e6631c23) SHA1(9988723269367fb44ef83f627186a1c88cf7877e) ) // Universal Horizontal decoder ROM - 7641-5 BPROM - P/N A-5342-09694
+	ROM_LOAD( "decoder_rom_6.3c", 0x0200, 0x0200, CRC(83faf25e) SHA1(30002643d08ed983a6701a7c4b5ee74a2f4a1adb) ) // Universal Vertical decoder ROM - 7641-5 BPROM - P/N A-5342-09821
+ROM_END
+
+ROM_START( sinistarc ) // rev. 3 (cockpit version with stereo sound)
+	ROM_REGION( 0x19000, "maincpu", 0 ) // solid RED labels with final production part numbers
+	ROM_LOAD( "sinistar_rom_10-b_16-3004-47.4c", 0x0e000, 0x1000, CRC(3d670417) SHA1(81802622bee8dbea5c0f08019d87d941dcdbe292) ) //  == rev. 3 PN 16-3004-62
+	ROM_LOAD( "sinistar_rom_11-b_16-3004-48.4a", 0x0f000, 0x1000, CRC(792c8b00) SHA1(1f847ca8a67595927c36d69cead02813c2431c7b) ) //  unique to rev. 2
+	ROM_LOAD( "sinistar_rom_1-b_16-3004-38.1d",  0x10000, 0x1000, CRC(f6f3a22c) SHA1(026d8cab07734fa294a5645edbe65a904bcbc302) ) //  == rev. 3 PN 16-3004-53
+	ROM_LOAD( "sinistar_rom_2-b_16-3004-39.1c",  0x11000, 0x1000, CRC(cab3185c) SHA1(423d1e3b0c07333ec582529bc4d0b7baf591820a) ) //  == rev. 3 PN 16-3004-54
+	ROM_LOAD( "sinistar_rom_3-b_16-3004-40.1a",  0x12000, 0x1000, CRC(1ce1b3cc) SHA1(5bc03d7249529d827dc60c087e074ab3e4ea7361) ) //  == rev. 3 PN 16-3004-55
+	ROM_LOAD( "sinistar_rom_4-b_16-3004-41.2d",  0x13000, 0x1000, CRC(6da632ba) SHA1(72c0c3d5a5ca87ca4d95fcedaf834206e4633950) ) //  == rev. 3 PN 16-3004-56
+	ROM_LOAD( "sinistar_rom_5-b_16-3004-42.2c",  0x14000, 0x1000, CRC(b662e8fc) SHA1(828a89d2ea13d8a362dae708f86bff54cb231887) ) //  == rev. 3 PN 16-3004-57
+	ROM_LOAD( "sinistar_rom_6-b_16-3004-43.2a",  0x15000, 0x1000, CRC(2306183d) SHA1(703e29e6446856615760a4897c0f5d79cc7bdfb2) ) //  == rev. 3 PN 16-3004-57
+	ROM_LOAD( "sinistar_rom_7-b_16-3004-44.3d",  0x16000, 0x1000, CRC(e5dd918e) SHA1(bf4e2ada6a59d246218544d822ba5355da925924) ) //  == rev. 3 PN 16-3004-59
+	ROM_LOAD( "sinistar_rom_8-b_16-3004-45.3c",  0x17000, 0x1000, CRC(d7ecee45) SHA1(f9552035409bce0a36ed93a677b28f8cd361f8f1) ) //  unique to rev. 2
+	ROM_LOAD( "sinistar_rom_9-b_16-3004-46.3a",  0x18000, 0x1000, CRC(50cb63ad) SHA1(96e28e4fef98fff2649741a266fa590e0313e3b0) ) //  == rev. 3 PN 16-3004-61
+
+	ROM_REGION( 0x10000, "soundcpu", 0 )
+	ROM_LOAD( "3004_speech_ic7_r1_16-3004-52.ic7", 0xb000, 0x1000, CRC(e1019568) SHA1(442f4f3ccd2e1db2136d2ffb121ea442921f87ca) )
+	ROM_LOAD( "3004_speech_ic5_r1_16-3004-50.ic5", 0xc000, 0x1000, CRC(cf3b5ffd) SHA1(d5d51c550581c9d46ab331dd4fd32541a2ef598e) )
+	ROM_LOAD( "3004_speech_ic6_r1_16-3004-51.ic6", 0xd000, 0x1000, CRC(ff8d2645) SHA1(16fa2a602acbbc182dd96bab113ab18356f3daf0) )
+	ROM_LOAD( "3004_speech_ic4_r1_16-3004-49.ic4", 0xe000, 0x1000, CRC(4b56a626) SHA1(44430cd5c110ec751b0bfb8ae99b26d443350db1) )
+	ROM_LOAD( "video_sound_rom_9_std.808.ic12",    0xf000, 0x1000, CRC(b82f4ddb) SHA1(c70c7dd6e88897920d7709a260f27810f66aade1) )
+
+
     ROM_REGION( 0x10000, "soundcpu_b", 0 ) // Stereo sound requires 2nd sound board as used in the cockpit version
-    ROM_LOAD( "3004_speech_ic7_r1_16-3004-52.ic7", 0xb000, 0x1000, CRC(e1019568) SHA1(442f4f3ccd2e1db2136d2ffb121ea442921f87ca) )
-    ROM_LOAD( "3004_speech_ic5_r1_16-3004-50.ic5", 0xc000, 0x1000, CRC(cf3b5ffd) SHA1(d5d51c550581c9d46ab331dd4fd32541a2ef598e) )
-    ROM_LOAD( "3004_speech_ic6_r1_16-3004-51.ic6", 0xd000, 0x1000, CRC(ff8d2645) SHA1(16fa2a602acbbc182dd96bab113ab18356f3daf0) )
-    ROM_LOAD( "3004_speech_ic4_r1_16-3004-49.ic4", 0xe000, 0x1000, CRC(4b56a626) SHA1(44430cd5c110ec751b0bfb8ae99b26d443350db1) )
-    ROM_LOAD( "video_sound_rom_10_std.ic12",       0xf000, 0x1000, CRC(b5c70082) SHA1(643af087b57da3a71c68372c79c5777e0c1fbef7) ) // not sure if all speech ROMs need to be here too
-*/
+    ROM_LOAD( "video_sound_rom_10_std.ic12",       0xf000, 0x1000, CRC(b5c70082) SHA1(643af087b57da3a71c68372c79c5777e0c1fbef7) ) // no speech board is connected
+
 
 	ROM_REGION( 0x0400, "proms", 0 )
 	ROM_LOAD( "decoder_rom_4.3g", 0x0000, 0x0200, CRC(e6631c23) SHA1(9988723269367fb44ef83f627186a1c88cf7877e) ) // Universal Horizontal decoder ROM - 7641-5 BPROM - P/N A-5342-09694
@@ -3187,15 +3294,6 @@ ROM_START( sinistar2 ) // rev. 2
 	ROM_LOAD( "3004_speech_ic6_r1_16-3004-51.ic6", 0xd000, 0x1000, CRC(ff8d2645) SHA1(16fa2a602acbbc182dd96bab113ab18356f3daf0) )
 	ROM_LOAD( "3004_speech_ic4_r1_16-3004-49.ic4", 0xe000, 0x1000, CRC(4b56a626) SHA1(44430cd5c110ec751b0bfb8ae99b26d443350db1) )
 	ROM_LOAD( "video_sound_rom_9_std.808.ic12",    0xf000, 0x1000, CRC(b82f4ddb) SHA1(c70c7dd6e88897920d7709a260f27810f66aade1) )
-
-/*
-    ROM_REGION( 0x10000, "soundcpu_b", 0 ) // Stereo sound requires 2nd sound board as used in the cockpit version
-    ROM_LOAD( "3004_speech_ic7_r1_16-3004-52.ic7", 0xb000, 0x1000, CRC(e1019568) SHA1(442f4f3ccd2e1db2136d2ffb121ea442921f87ca) )
-    ROM_LOAD( "3004_speech_ic5_r1_16-3004-50.ic5", 0xc000, 0x1000, CRC(cf3b5ffd) SHA1(d5d51c550581c9d46ab331dd4fd32541a2ef598e) )
-    ROM_LOAD( "3004_speech_ic6_r1_16-3004-51.ic6", 0xd000, 0x1000, CRC(ff8d2645) SHA1(16fa2a602acbbc182dd96bab113ab18356f3daf0) )
-    ROM_LOAD( "3004_speech_ic4_r1_16-3004-49.ic4", 0xe000, 0x1000, CRC(4b56a626) SHA1(44430cd5c110ec751b0bfb8ae99b26d443350db1) )
-    ROM_LOAD( "video_sound_rom_10_std.ic12",       0xf000, 0x1000, CRC(b5c70082) SHA1(643af087b57da3a71c68372c79c5777e0c1fbef7) ) // not sure if all speech ROMs need to be here too
-*/
 
 	ROM_REGION( 0x0400, "proms", 0 )
 	ROM_LOAD( "decoder_rom_4.3g", 0x0000, 0x0200, CRC(e6631c23) SHA1(9988723269367fb44ef83f627186a1c88cf7877e) ) // Universal Horizontal decoder ROM - 7641-5 BPROM - P/N A-5342-09694
@@ -3785,6 +3883,7 @@ GAME( 1982, bubblesp,   bubbles,  williams_b1,    bubbles,  bubbles_state,   emp
 GAME( 1982, splat,      0,        splat,          splat,    wms_muxed_state, empty_init,    ROT0,   "Williams", "Splat!", MACHINE_SUPPORTS_SAVE )
 
 GAME( 1982, sinistar,   0,        sinistar,       sinistar, sinistar_state,  empty_init,    ROT270, "Williams", "Sinistar (revision 3)",        MACHINE_SUPPORTS_SAVE )
+GAME( 1982, sinistarc,  sinistar, sinistac,       sinistac, sinistar_state,  empty_init,    ROT270, "Williams", "Sinistar (Cockpit version)",   MACHINE_SUPPORTS_SAVE )
 GAME( 1982, sinistar2,  sinistar, sinistar,       sinistar, sinistar_state,  empty_init,    ROT270, "Williams", "Sinistar (revision 2)",        MACHINE_SUPPORTS_SAVE )
 GAME( 1982, sinistarp,  sinistar, sinistar,       sinistar, sinistar_state,  empty_init,    ROT270, "Williams", "Sinistar (AMOA-82 prototype)", MACHINE_SUPPORTS_SAVE )
 

--- a/src/mame/midway/williams.h
+++ b/src/mame/midway/williams.h
@@ -173,14 +173,23 @@ class sinistar_state : public williams_state
 {
 public:
 	sinistar_state(const machine_config &mconfig, device_type type, const char *tag) :
-		williams_state(mconfig, type, tag)
+		williams_state(mconfig, type, tag),
+		m_soundcpu_b(*this, "soundcpu_b")
 	{ }
 
+	void sinistac(machine_config &config);
 	void sinistar(machine_config &config);
 
 private:
 	virtual void vram_select_w(u8 data) override;
 	virtual void main_map(address_map &map) override;
+	
+	optional_device<cpu_device> m_soundcpu_b;
+	
+	TIMER_CALLBACK_MEMBER(deferred_snd_cmd_w);
+	virtual void sinistar_snd_cmd_w(u8 data);
+	
+	void sound2_map(address_map &map);	
 };
 
 // Playball: more soundlatch bits

--- a/src/mame/midway/williams_m.cpp
+++ b/src/mame/midway/williams_m.cpp
@@ -358,7 +358,20 @@ void sinistar_state::vram_select_w(u8 data)
 	m_blitter_window_enable = data & 0x04;
 }
 
+TIMER_CALLBACK_MEMBER(sinistar_state::deferred_snd_cmd_w)
+{
+	m_pia[2]->portb_w(param);
+	m_pia[2]->cb1_w((param == 0xff) ? 0 : 1);
+	
+	m_pia[3]->portb_w(param);
+	m_pia[3]->cb1_w((param == 0xff) ? 0 : 1);
+}
 
+void sinistar_state::sinistar_snd_cmd_w(u8 data)
+{
+	/* the high two bits are set externally, and should be 1 */
+	machine().scheduler().synchronize(timer_expired_delegate(FUNC(sinistar_state::deferred_snd_cmd_w),this), data | 0xc0);
+}
 
 /*************************************
  *


### PR DESCRIPTION
Hi there, this is my first time contributing code to Mame.  I used the driver code for Blaster's stereo sound to implement the rear sound board found in the cockpit version of Sinistar.  The difference between Blaster's audio set up is that both sound boards in Sinistar receive the exact same input triggers as they share the same ribbon cable (according to the drawing set for the game).

The rear sound board also doesn't have a speech daughter board attached so only the front speaker plays speech.

As a side note, I was also able to reconstruct the source code to Video Sound Rom 9 and 10.  If you are interested, you can look at the repository here: 
https://github.com/synamaxmusic/Sinistar-Sound-ROM/tree/main

Thanks in advance!