### PR TITLE
dataeast/dec8.cpp: Split classes for reduce optional shared functions, Reduce runtime tag lookups

### DIFF
--- a/src/mame/dataeast/dec0.h
+++ b/src/mame/dataeast/dec0.h
@@ -217,7 +217,6 @@ private:
 
 	void main_map(address_map &map);
 	void sound_map(address_map &map);
-	void sound_protection_map(address_map &map);
 };
 
 

--- a/src/mame/dataeast/dec8.cpp
+++ b/src/mame/dataeast/dec8.cpp
@@ -58,9 +58,9 @@ To do:
 /******************************************************************************/
 
 
-void dec8_state::dec8_mxc06_karn_buffer_spriteram_w(uint8_t data)
+void base_state::buffer_spriteram16_w(u8 data)
 {
-	uint8_t* spriteram = m_spriteram->live();
+	u8* spriteram = m_spriteram->live();
 	// copy to a 16-bit region for the sprite chip
 	for (int i=0;i<0x800/2;i++)
 	{
@@ -69,26 +69,26 @@ void dec8_state::dec8_mxc06_karn_buffer_spriteram_w(uint8_t data)
 }
 
 /* Only used by ghostb, gondo, garyoret, other games can control buffering */
-void dec8_state::screen_vblank_dec8(int state)
+void lastmisn_state::screen_vblank(int state)
 {
 	// rising edge
 	if (state)
 	{
-		dec8_mxc06_karn_buffer_spriteram_w(0);
+		buffer_spriteram16_w(0);
 	}
 }
 
-uint8_t dec8_state::i8751_h_r()
+u8 mcu_state::i8751_h_r()
 {
 	return m_i8751_return >> 8; /* MSB */
 }
 
-uint8_t dec8_state::i8751_l_r()
+u8 mcu_state::i8751_l_r()
 {
 	return m_i8751_return & 0xff; /* LSB */
 }
 
-void dec8_state::i8751_reset_w(uint8_t data)
+void mcu_state::i8751_reset_w(u8 data)
 {
 	// ? reset the actual MCU?
 	//m_i8751_return = 0;
@@ -96,30 +96,17 @@ void dec8_state::i8751_reset_w(uint8_t data)
 
 /******************************************************************************/
 
-uint8_t dec8_state::gondo_player_1_r(offs_t offset)
+template<unsigned Which>
+u8 gondo_state::player_io_r(offs_t offset)
 {
-	int val = 1 << ioport("AN0")->read();
+	int val = 1 << m_analog_io[Which]->read();
 
 	switch (offset)
 	{
 		case 0: /* Rotary low byte */
 			return ~(val & 0xff);
 		case 1: /* Joystick = bottom 4 bits, rotary = top 4 */
-			return ((~val >> 4) & 0xf0) | (ioport("IN0")->read() & 0xf);
-	}
-	return 0xff;
-}
-
-uint8_t dec8_state::gondo_player_2_r(offs_t offset)
-{
-	int val = 1 << ioport("AN1")->read();
-
-	switch (offset)
-	{
-		case 0: /* Rotary low byte */
-			return ~(val & 0xff);
-		case 1: /* Joystick = bottom 4 bits, rotary = top 4 */
-			return ((~val >> 4) & 0xf0) | (ioport("IN1")->read() & 0xf);
+			return ((~val >> 4) & 0xf0) | (m_in_io[Which]->read() & 0xf);
 	}
 	return 0xff;
 }
@@ -132,21 +119,21 @@ uint8_t dec8_state::gondo_player_2_r(offs_t offset)
 *
 ***************************************************/
 
-TIMER_CALLBACK_MEMBER(dec8_state::mcu_irq_clear)
+TIMER_CALLBACK_MEMBER(mcu_state::mcu_irq_clear)
 {
 	// The schematics show a clocked LS194 shift register (3A) is used to automatically
 	// clear the IRQ request.  The MCU does not clear it itself.
 	m_mcu->set_input_line(MCS51_INT1_LINE, CLEAR_LINE);
 }
 
-TIMER_CALLBACK_MEMBER(dec8_state::audiocpu_nmi_clear)
+TIMER_CALLBACK_MEMBER(base_state::audiocpu_nmi_clear)
 {
 	// Gondomania schematics show a LS194 for the sound IRQ, sharing the 6502 clock
 	// S1=H, S0=L, LSI=H, and QA is the only output connected (to NMI)
 	m_audiocpu->set_input_line(INPUT_LINE_NMI, CLEAR_LINE);
 }
 
-void dec8_state::dec8_i8751_w(offs_t offset, uint8_t data)
+void mcu_state::i8751_w(offs_t offset, u8 data)
 {
 	switch (offset)
 	{
@@ -163,13 +150,13 @@ void dec8_state::dec8_i8751_w(offs_t offset, uint8_t data)
 
 /******************************************************************************/
 
-void dec8_state::dec8_bank_w(uint8_t data)
+void oscar_state::bank_w(u8 data)
 {
 	m_mainbank->set_entry(data & 0x0f);
 }
 
 /* Used by Ghostbusters, Meikyuu Hunter G & Gondomania */
-void dec8_state::ghostb_bank_w(uint8_t data)
+void lastmisn_state::ghostb_bank_w(u8 data)
 {
 	/* Bit 0: SECCLR - acknowledge interrupt from I8751
 	   Bit 1: NMI enable/disable
@@ -197,7 +184,7 @@ void dec8_state::ghostb_bank_w(uint8_t data)
 	flip_screen_set(BIT(data, 3));
 }
 
-void csilver_state::csilver_control_w(uint8_t data)
+void csilver_state::control_w(u8 data)
 {
 	/*
 	    Bit 0x0f - ROM bank switch.
@@ -209,14 +196,14 @@ void csilver_state::csilver_control_w(uint8_t data)
 	m_mainbank->set_entry(data & 0x0f);
 }
 
-void dec8_state::dec8_sound_w(uint8_t data)
+void base_state::sound_w(u8 data)
 {
 	m_soundlatch->write(data);
 	m_audiocpu->set_input_line(m6502_device::NMI_LINE, ASSERT_LINE);
 	m_m6502_timer->adjust(m_audiocpu->cycles_to_attotime(3));
 }
 
-void csilver_state::csilver_adpcm_int(int state)
+void csilver_state::adpcm_int(int state)
 {
 	m_toggle ^= 1;
 	if (m_toggle)
@@ -226,230 +213,230 @@ void csilver_state::csilver_adpcm_int(int state)
 	m_msm5205next <<= 4;
 }
 
-uint8_t csilver_state::csilver_adpcm_reset_r()
+u8 csilver_state::adpcm_reset_r()
 {
 	m_msm->reset_w(0);
 	return 0;
 }
 
-void csilver_state::csilver_adpcm_data_w(uint8_t data)
+void csilver_state::adpcm_data_w(u8 data)
 {
 	m_msm5205next = data;
 }
 
-void csilver_state::csilver_sound_bank_w(uint8_t data)
+void csilver_state::sound_bank_w(u8 data)
 {
 	m_soundbank->set_entry((data & 0x08) >> 3);
 }
 
 /******************************************************************************/
 
-void dec8_state::main_irq_on_w(uint8_t data)
+void base_state::main_irq_on_w(u8 data)
 {
 	m_maincpu->set_input_line(M6809_IRQ_LINE, ASSERT_LINE);
 }
 
-void dec8_state::main_irq_off_w(uint8_t data)
+void base_state::main_irq_off_w(u8 data)
 {
 	m_maincpu->set_input_line(M6809_IRQ_LINE, CLEAR_LINE);
 }
 
-void dec8_state::main_firq_off_w(uint8_t data)
+void base_state::main_firq_off_w(u8 data)
 {
 	m_maincpu->set_input_line(M6809_FIRQ_LINE, CLEAR_LINE);
 }
 
-void dec8_state::sub_irq_on_w(uint8_t data)
+void base_state::sub_irq_on_w(u8 data)
 {
 	m_subcpu->set_input_line(M6809_IRQ_LINE, ASSERT_LINE);
 }
 
-void dec8_state::sub_irq_off_w(uint8_t data)
+void base_state::sub_irq_off_w(u8 data)
 {
 	m_subcpu->set_input_line(M6809_IRQ_LINE, CLEAR_LINE);
 }
 
-void dec8_state::sub_firq_off_w(uint8_t data)
+void base_state::sub_firq_off_w(u8 data)
 {
 	m_subcpu->set_input_line(M6809_FIRQ_LINE, CLEAR_LINE);
 }
 
 /******************************************************************************/
 
-void dec8_state::flip_screen_w(uint8_t data) { flip_screen_set(data); }
+void base_state::flip_screen_w(u8 data) { flip_screen_set(data); }
 
 /******************************************************************************/
 
-void dec8_state::lastmisn_map(address_map &map)
+void lastmisn_state::lastmisn_map(address_map &map)
 {
 	map(0x0000, 0x0fff).ram().share("share1");
 	map(0x1000, 0x13ff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x1400, 0x17ff).ram().w(m_palette, FUNC(deco_rmc3_device::write8_ext)).share("palette_ext");
-	map(0x1800, 0x1800).portr("IN0").w(FUNC(dec8_state::sub_irq_off_w));
-	map(0x1801, 0x1801).portr("IN1").w(FUNC(dec8_state::main_irq_off_w));
-	map(0x1802, 0x1802).portr("IN2").w(FUNC(dec8_state::main_firq_off_w));
-	map(0x1803, 0x1803).portr("DSW0").w(FUNC(dec8_state::main_irq_on_w));
-	map(0x1804, 0x1804).portr("DSW1").w(FUNC(dec8_state::sub_irq_on_w));
-	map(0x1805, 0x1805).w(FUNC(dec8_state::dec8_mxc06_karn_buffer_spriteram_w)); /* DMA */
-	map(0x1806, 0x1806).r(FUNC(dec8_state::i8751_h_r));
-	map(0x1807, 0x1807).rw(FUNC(dec8_state::i8751_l_r), FUNC(dec8_state::flip_screen_w));
-	map(0x1809, 0x1809).w(FUNC(dec8_state::lastmisn_scrollx_w)); /* Scroll LSB */
-	map(0x180b, 0x180b).w(FUNC(dec8_state::lastmisn_scrolly_w)); /* Scroll LSB */
-	map(0x180c, 0x180c).w(FUNC(dec8_state::dec8_sound_w));
-	map(0x180d, 0x180d).w(FUNC(dec8_state::lastmisn_control_w)); /* Bank switch + Scroll MSB */
-	map(0x180e, 0x180f).w(FUNC(dec8_state::dec8_i8751_w));
-	map(0x2000, 0x27ff).ram().w(FUNC(dec8_state::dec8_videoram_w)).share("videoram");
+	map(0x1800, 0x1800).portr("IN0").w(FUNC(lastmisn_state::sub_irq_off_w));
+	map(0x1801, 0x1801).portr("IN1").w(FUNC(lastmisn_state::main_irq_off_w));
+	map(0x1802, 0x1802).portr("IN2").w(FUNC(lastmisn_state::main_firq_off_w));
+	map(0x1803, 0x1803).portr("DSW0").w(FUNC(lastmisn_state::main_irq_on_w));
+	map(0x1804, 0x1804).portr("DSW1").w(FUNC(lastmisn_state::sub_irq_on_w));
+	map(0x1805, 0x1805).w(FUNC(lastmisn_state::buffer_spriteram16_w)); /* DMA */
+	map(0x1806, 0x1806).r(FUNC(lastmisn_state::i8751_h_r));
+	map(0x1807, 0x1807).rw(FUNC(lastmisn_state::i8751_l_r), FUNC(lastmisn_state::flip_screen_w));
+	map(0x1809, 0x1809).w(FUNC(lastmisn_state::lastmisn_scrollx_w)); /* Scroll LSB */
+	map(0x180b, 0x180b).w(FUNC(lastmisn_state::lastmisn_scrolly_w)); /* Scroll LSB */
+	map(0x180c, 0x180c).w(FUNC(lastmisn_state::sound_w));
+	map(0x180d, 0x180d).w(FUNC(lastmisn_state::lastmisn_control_w)); /* Bank switch + Scroll MSB */
+	map(0x180e, 0x180f).w(FUNC(lastmisn_state::i8751_w));
+	map(0x2000, 0x27ff).ram().w(FUNC(lastmisn_state::videoram_w)).share(m_videoram);
 	map(0x2800, 0x2fff).ram().share("spriteram");
 	map(0x3000, 0x37ff).ram().share("share2");
-	map(0x3800, 0x3fff).rw(FUNC(dec8_state::dec8_bg_data_r), FUNC(dec8_state::dec8_bg_data_w)).share("bg_data");
-	map(0x4000, 0x7fff).bankr("mainbank");
+	map(0x3800, 0x3fff).rw(FUNC(lastmisn_state::bg_ram_r), FUNC(lastmisn_state::bg_ram_w)).share("bg_ram");
+	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
 
-void dec8_state::lastmisn_sub_map(address_map &map)
+void lastmisn_state::lastmisn_sub_map(address_map &map)
 {
 	map(0x0000, 0x0fff).ram().share("share1");
 	map(0x1000, 0x13ff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x1400, 0x17ff).ram().w(m_palette, FUNC(deco_rmc3_device::write8_ext)).share("palette_ext");
-	map(0x1800, 0x1800).portr("IN0").w(FUNC(dec8_state::sub_irq_off_w));
-	map(0x1801, 0x1801).portr("IN1").w(FUNC(dec8_state::main_irq_off_w));
-	map(0x1802, 0x1802).portr("IN2").w(FUNC(dec8_state::main_firq_off_w));
-	map(0x1803, 0x1803).portr("DSW0").w(FUNC(dec8_state::main_irq_on_w));
-	map(0x1804, 0x1804).portr("DSW1").w(FUNC(dec8_state::sub_irq_on_w));
-	map(0x1805, 0x1805).w(FUNC(dec8_state::dec8_mxc06_karn_buffer_spriteram_w)); /* DMA */
-	map(0x1806, 0x1806).r(FUNC(dec8_state::i8751_h_r));
-	map(0x1807, 0x1807).rw(FUNC(dec8_state::i8751_l_r), FUNC(dec8_state::flip_screen_w));
-	map(0x180c, 0x180c).w(FUNC(dec8_state::dec8_sound_w));
-	map(0x180e, 0x180f).w(FUNC(dec8_state::dec8_i8751_w));
-	map(0x2000, 0x27ff).ram().w(FUNC(dec8_state::dec8_videoram_w));
+	map(0x1800, 0x1800).portr("IN0").w(FUNC(lastmisn_state::sub_irq_off_w));
+	map(0x1801, 0x1801).portr("IN1").w(FUNC(lastmisn_state::main_irq_off_w));
+	map(0x1802, 0x1802).portr("IN2").w(FUNC(lastmisn_state::main_firq_off_w));
+	map(0x1803, 0x1803).portr("DSW0").w(FUNC(lastmisn_state::main_irq_on_w));
+	map(0x1804, 0x1804).portr("DSW1").w(FUNC(lastmisn_state::sub_irq_on_w));
+	map(0x1805, 0x1805).w(FUNC(lastmisn_state::buffer_spriteram16_w)); /* DMA */
+	map(0x1806, 0x1806).r(FUNC(lastmisn_state::i8751_h_r));
+	map(0x1807, 0x1807).rw(FUNC(lastmisn_state::i8751_l_r), FUNC(lastmisn_state::flip_screen_w));
+	map(0x180c, 0x180c).w(FUNC(lastmisn_state::sound_w));
+	map(0x180e, 0x180f).w(FUNC(lastmisn_state::i8751_w));
+	map(0x2000, 0x27ff).ram().w(FUNC(lastmisn_state::videoram_w));
 	map(0x2800, 0x2fff).writeonly().share("spriteram");
 	map(0x3000, 0x37ff).ram().share("share2");
-	map(0x3800, 0x3fff).rw(FUNC(dec8_state::dec8_bg_data_r), FUNC(dec8_state::dec8_bg_data_w));
+	map(0x3800, 0x3fff).rw(FUNC(lastmisn_state::bg_ram_r), FUNC(lastmisn_state::bg_ram_w));
 	map(0x4000, 0xffff).rom();
 }
 
-void dec8_state::shackled_map(address_map &map)
+void lastmisn_state::shackled_map(address_map &map)
 {
 	map(0x0000, 0x0fff).ram().share("share1");
 	map(0x1000, 0x13ff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x1400, 0x17ff).ram().w(m_palette, FUNC(deco_rmc3_device::write8_ext)).share("palette_ext");
-	map(0x1800, 0x1800).portr("IN0").w(FUNC(dec8_state::sub_irq_off_w));
-	map(0x1801, 0x1801).portr("IN1").w(FUNC(dec8_state::main_irq_off_w));
-	map(0x1802, 0x1802).portr("IN2").w(FUNC(dec8_state::sub_firq_off_w));
-	map(0x1803, 0x1803).portr("DSW0").w(FUNC(dec8_state::main_irq_on_w));
-	map(0x1804, 0x1804).portr("DSW1").w(FUNC(dec8_state::sub_irq_on_w));
-	map(0x1805, 0x1805).w(FUNC(dec8_state::dec8_mxc06_karn_buffer_spriteram_w)); /* DMA */
-	map(0x1807, 0x1807).w(FUNC(dec8_state::flip_screen_w));
-	map(0x1809, 0x1809).w(FUNC(dec8_state::lastmisn_scrollx_w)); /* Scroll LSB */
-	map(0x180b, 0x180b).w(FUNC(dec8_state::lastmisn_scrolly_w)); /* Scroll LSB */
-	map(0x180c, 0x180c).w(FUNC(dec8_state::dec8_sound_w));
-	map(0x180d, 0x180d).w(FUNC(dec8_state::shackled_control_w)); /* Bank switch + Scroll MSB */
-	map(0x2000, 0x27ff).ram().w(FUNC(dec8_state::dec8_videoram_w));
+	map(0x1800, 0x1800).portr("IN0").w(FUNC(lastmisn_state::sub_irq_off_w));
+	map(0x1801, 0x1801).portr("IN1").w(FUNC(lastmisn_state::main_irq_off_w));
+	map(0x1802, 0x1802).portr("IN2").w(FUNC(lastmisn_state::sub_firq_off_w));
+	map(0x1803, 0x1803).portr("DSW0").w(FUNC(lastmisn_state::main_irq_on_w));
+	map(0x1804, 0x1804).portr("DSW1").w(FUNC(lastmisn_state::sub_irq_on_w));
+	map(0x1805, 0x1805).w(FUNC(lastmisn_state::buffer_spriteram16_w)); /* DMA */
+	map(0x1807, 0x1807).w(FUNC(lastmisn_state::flip_screen_w));
+	map(0x1809, 0x1809).w(FUNC(lastmisn_state::lastmisn_scrollx_w)); /* Scroll LSB */
+	map(0x180b, 0x180b).w(FUNC(lastmisn_state::lastmisn_scrolly_w)); /* Scroll LSB */
+	map(0x180c, 0x180c).w(FUNC(lastmisn_state::sound_w));
+	map(0x180d, 0x180d).w(FUNC(lastmisn_state::shackled_control_w)); /* Bank switch + Scroll MSB */
+	map(0x2000, 0x27ff).ram().w(FUNC(lastmisn_state::videoram_w));
 	map(0x2800, 0x2fff).ram().share("spriteram");
 	map(0x3000, 0x37ff).ram().share("share2");
-	map(0x3800, 0x3fff).rw(FUNC(dec8_state::dec8_bg_data_r), FUNC(dec8_state::dec8_bg_data_w)).share("bg_data");
-	map(0x4000, 0x7fff).bankr("mainbank");
+	map(0x3800, 0x3fff).rw(FUNC(lastmisn_state::bg_ram_r), FUNC(lastmisn_state::bg_ram_w)).share("bg_ram");
+	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
 
-void dec8_state::shackled_sub_map(address_map &map)
+void lastmisn_state::shackled_sub_map(address_map &map)
 {
 	map(0x0000, 0x0fff).ram().share("share1");
 	map(0x1000, 0x13ff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x1400, 0x17ff).ram().w(m_palette, FUNC(deco_rmc3_device::write8_ext)).share("palette_ext");
-	map(0x1800, 0x1800).portr("IN0").w(FUNC(dec8_state::sub_irq_off_w));
-	map(0x1801, 0x1801).portr("IN1").w(FUNC(dec8_state::main_irq_off_w));
-	map(0x1802, 0x1802).portr("IN2").w(FUNC(dec8_state::sub_firq_off_w));
-	map(0x1803, 0x1803).portr("DSW0").w(FUNC(dec8_state::main_irq_on_w));
-	map(0x1804, 0x1804).portr("DSW1").w(FUNC(dec8_state::sub_irq_on_w));
-	map(0x1805, 0x1805).w(FUNC(dec8_state::dec8_mxc06_karn_buffer_spriteram_w)); /* DMA */
-	map(0x1806, 0x1806).r(FUNC(dec8_state::i8751_h_r));
-	map(0x1807, 0x1807).rw(FUNC(dec8_state::i8751_l_r), FUNC(dec8_state::flip_screen_w));
-	map(0x1809, 0x1809).w(FUNC(dec8_state::lastmisn_scrollx_w)); /* Scroll LSB */
-	map(0x180b, 0x180b).w(FUNC(dec8_state::lastmisn_scrolly_w)); /* Scroll LSB */
-	map(0x180c, 0x180c).w(FUNC(dec8_state::dec8_sound_w));
-	map(0x180d, 0x180d).w(FUNC(dec8_state::shackled_control_w)); /* Bank switch + Scroll MSB */
-	map(0x180e, 0x180f).w(FUNC(dec8_state::dec8_i8751_w));
-	map(0x2000, 0x27ff).ram().w(FUNC(dec8_state::dec8_videoram_w)).share("videoram");
+	map(0x1800, 0x1800).portr("IN0").w(FUNC(lastmisn_state::sub_irq_off_w));
+	map(0x1801, 0x1801).portr("IN1").w(FUNC(lastmisn_state::main_irq_off_w));
+	map(0x1802, 0x1802).portr("IN2").w(FUNC(lastmisn_state::sub_firq_off_w));
+	map(0x1803, 0x1803).portr("DSW0").w(FUNC(lastmisn_state::main_irq_on_w));
+	map(0x1804, 0x1804).portr("DSW1").w(FUNC(lastmisn_state::sub_irq_on_w));
+	map(0x1805, 0x1805).w(FUNC(lastmisn_state::buffer_spriteram16_w)); /* DMA */
+	map(0x1806, 0x1806).r(FUNC(lastmisn_state::i8751_h_r));
+	map(0x1807, 0x1807).rw(FUNC(lastmisn_state::i8751_l_r), FUNC(lastmisn_state::flip_screen_w));
+	map(0x1809, 0x1809).w(FUNC(lastmisn_state::lastmisn_scrollx_w)); /* Scroll LSB */
+	map(0x180b, 0x180b).w(FUNC(lastmisn_state::lastmisn_scrolly_w)); /* Scroll LSB */
+	map(0x180c, 0x180c).w(FUNC(lastmisn_state::sound_w));
+	map(0x180d, 0x180d).w(FUNC(lastmisn_state::shackled_control_w)); /* Bank switch + Scroll MSB */
+	map(0x180e, 0x180f).w(FUNC(lastmisn_state::i8751_w));
+	map(0x2000, 0x27ff).ram().w(FUNC(lastmisn_state::videoram_w)).share(m_videoram);
 	map(0x2800, 0x2fff).ram().share("spriteram");
 	map(0x3000, 0x37ff).ram().share("share2");
-	map(0x3800, 0x3fff).rw(FUNC(dec8_state::dec8_bg_data_r), FUNC(dec8_state::dec8_bg_data_w));
+	map(0x3800, 0x3fff).rw(FUNC(lastmisn_state::bg_ram_r), FUNC(lastmisn_state::bg_ram_w));
 	map(0x4000, 0xffff).rom();
 }
 
-void dec8_state::gondo_map(address_map &map)
+void gondo_state::gondo_map(address_map &map)
 {
 	map(0x0000, 0x17ff).ram();
-	map(0x1800, 0x1fff).ram().w(FUNC(dec8_state::dec8_videoram_w)).share("videoram");
-	map(0x2000, 0x27ff).rw(FUNC(dec8_state::dec8_bg_data_r), FUNC(dec8_state::dec8_bg_data_w)).share("bg_data");
+	map(0x1800, 0x1fff).ram().w(FUNC(gondo_state::videoram_w)).share(m_videoram);
+	map(0x2000, 0x27ff).rw(FUNC(gondo_state::bg_ram_r), FUNC(gondo_state::bg_ram_w)).share("bg_ram");
 	map(0x2800, 0x2bff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x2c00, 0x2fff).ram().w(m_palette, FUNC(deco_rmc3_device::write8_ext)).share("palette_ext");
 	map(0x3000, 0x37ff).ram().share("spriteram");   /* Sprites */
 	map(0x3800, 0x3800).portr("DSW0");       /* Dip 1 */
 	map(0x3801, 0x3801).portr("DSW1");       /* Dip 2 */
-	map(0x380a, 0x380b).r(FUNC(dec8_state::gondo_player_1_r));  /* Player 1 rotary */
-	map(0x380c, 0x380d).r(FUNC(dec8_state::gondo_player_2_r));  /* Player 2 rotary */
+	map(0x380a, 0x380b).r(FUNC(gondo_state::player_io_r<0>));  /* Player 1 rotary */
+	map(0x380c, 0x380d).r(FUNC(gondo_state::player_io_r<1>));  /* Player 2 rotary */
 	map(0x380e, 0x380e).portr("IN3");        /* VBL */
 	map(0x380f, 0x380f).portr("IN2");        /* Fire buttons */
-	map(0x3810, 0x3810).w(FUNC(dec8_state::dec8_sound_w));
-	map(0x3818, 0x382f).w(FUNC(dec8_state::gondo_scroll_w));
-	map(0x3830, 0x3830).w(FUNC(dec8_state::ghostb_bank_w)); /* Bank + NMI enable */
-	map(0x3838, 0x3838).r(FUNC(dec8_state::i8751_h_r));
-	map(0x3839, 0x3839).r(FUNC(dec8_state::i8751_l_r));
-	map(0x383a, 0x383b).w(FUNC(dec8_state::dec8_i8751_w));
-	map(0x4000, 0x7fff).bankr("mainbank");
+	map(0x3810, 0x3810).w(FUNC(gondo_state::sound_w));
+	map(0x3818, 0x382f).w(FUNC(gondo_state::gondo_scroll_w));
+	map(0x3830, 0x3830).w(FUNC(gondo_state::ghostb_bank_w)); /* Bank + NMI enable */
+	map(0x3838, 0x3838).r(FUNC(gondo_state::i8751_h_r));
+	map(0x3839, 0x3839).r(FUNC(gondo_state::i8751_l_r));
+	map(0x383a, 0x383b).w(FUNC(gondo_state::i8751_w));
+	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
 
-void dec8_state::garyoret_map(address_map &map)
+void lastmisn_state::garyoret_map(address_map &map)
 {
 	map(0x0000, 0x17ff).ram();
-	map(0x1800, 0x1fff).ram().w(FUNC(dec8_state::dec8_videoram_w)).share("videoram");
-	map(0x2000, 0x27ff).rw(FUNC(dec8_state::dec8_bg_data_r), FUNC(dec8_state::dec8_bg_data_w)).share("bg_data");
+	map(0x1800, 0x1fff).ram().w(FUNC(lastmisn_state::videoram_w)).share(m_videoram);
+	map(0x2000, 0x27ff).rw(FUNC(lastmisn_state::bg_ram_r), FUNC(lastmisn_state::bg_ram_w)).share("bg_ram");
 	map(0x2800, 0x2bff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x2c00, 0x2fff).ram().w(m_palette, FUNC(deco_rmc3_device::write8_ext)).share("palette_ext");
-	map(0x3000, 0x37ff).ram().share("spriteram"); /* Sprites */
-	map(0x3800, 0x3800).portr("DSW0");   /* Dip 1 */
-	map(0x3801, 0x3801).portr("DSW1");   /* Dip 2 */
+	map(0x3000, 0x37ff).ram().share("spriteram");   /* Sprites */
+	map(0x3800, 0x3800).portr("DSW0");       /* Dip 1 */
+	map(0x3801, 0x3801).portr("DSW1");       /* Dip 2 */
 	map(0x3808, 0x3808).nopr();     /* ? */
 	map(0x380a, 0x380a).portr("IN1");    /* Player 2 + VBL */
 	map(0x380b, 0x380b).portr("IN0");    /* Player 1 */
-	map(0x3810, 0x3810).w(FUNC(dec8_state::dec8_sound_w));
-	map(0x3818, 0x382f).w(FUNC(dec8_state::gondo_scroll_w));
-	map(0x3830, 0x3830).w(FUNC(dec8_state::ghostb_bank_w)); /* Bank + NMI enable */
-	map(0x3838, 0x3839).w(FUNC(dec8_state::dec8_i8751_w));
-	map(0x383a, 0x383a).r(FUNC(dec8_state::i8751_h_r));
-	map(0x383b, 0x383b).r(FUNC(dec8_state::i8751_l_r));
-	map(0x4000, 0x7fff).bankr("mainbank");
+	map(0x3810, 0x3810).w(FUNC(lastmisn_state::sound_w));
+	map(0x3818, 0x382f).w(FUNC(lastmisn_state::gondo_scroll_w));
+	map(0x3830, 0x3830).w(FUNC(lastmisn_state::ghostb_bank_w)); /* Bank + NMI enable */
+	map(0x3838, 0x3839).w(FUNC(lastmisn_state::i8751_w));
+	map(0x383a, 0x383a).r(FUNC(lastmisn_state::i8751_h_r));
+	map(0x383b, 0x383b).r(FUNC(lastmisn_state::i8751_l_r));
+	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
 
-void dec8_state::meikyuh_map(address_map &map)
+void lastmisn_state::meikyuh_map(address_map &map)
 {
 	map(0x0000, 0x0fff).ram();
 	map(0x1000, 0x17ff).ram();
-	map(0x1800, 0x1fff).ram().w(FUNC(dec8_state::dec8_videoram_w)).share("videoram");
-	map(0x2000, 0x27ff).rw("tilegen1", FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
+	map(0x1800, 0x1fff).ram().w(FUNC(lastmisn_state::videoram_w)).share(m_videoram);
+	map(0x2000, 0x27ff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
 	map(0x2800, 0x2bff).ram(); // colscroll? mirror?
-	map(0x2c00, 0x2fff).rw("tilegen1", FUNC(deco_bac06_device::pf_rowscroll_8bit_r), FUNC(deco_bac06_device::pf_rowscroll_8bit_w));
+	map(0x2c00, 0x2fff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_rowscroll_8bit_r), FUNC(deco_bac06_device::pf_rowscroll_8bit_w));
 	map(0x3000, 0x37ff).ram().share("spriteram");
 	map(0x3800, 0x3800).portr("IN0");    /* Player 1 */
-	map(0x3800, 0x3800).w(FUNC(dec8_state::dec8_sound_w));
+	map(0x3800, 0x3800).w(FUNC(lastmisn_state::sound_w));
 	map(0x3801, 0x3801).portr("IN1");    /* Player 2 */
 	map(0x3802, 0x3802).portr("IN2");    /* Player 3 */
 	map(0x3803, 0x3803).portr("DSW0");   /* Start buttons + VBL */
 	map(0x3820, 0x3820).portr("DSW1");   /* Dip */
-	map(0x3820, 0x3827).w("tilegen1", FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x3830, 0x383f).rw("tilegen1", FUNC(deco_bac06_device::pf_control1_8bit_r), FUNC(deco_bac06_device::pf_control1_8bit_w));
-	map(0x3840, 0x3840).r(FUNC(dec8_state::i8751_h_r));
-	map(0x3840, 0x3840).w(FUNC(dec8_state::ghostb_bank_w));
-	map(0x3860, 0x3860).r(FUNC(dec8_state::i8751_l_r));
-	map(0x3860, 0x3861).w(FUNC(dec8_state::dec8_i8751_w));
-	map(0x4000, 0x7fff).bankr("mainbank");
+	map(0x3820, 0x3827).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control0_8bit_w));
+	map(0x3830, 0x383f).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_control1_8bit_r), FUNC(deco_bac06_device::pf_control1_8bit_w));
+	map(0x3840, 0x3840).r(FUNC(lastmisn_state::i8751_h_r));
+	map(0x3840, 0x3840).w(FUNC(lastmisn_state::ghostb_bank_w));
+	map(0x3860, 0x3860).r(FUNC(lastmisn_state::i8751_l_r));
+	map(0x3860, 0x3861).w(FUNC(lastmisn_state::i8751_w));
+	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
 
-void csilver_state::csilver_map(address_map &map)
+void csilver_state::main_map(address_map &map)
 {
 	map(0x0000, 0x0fff).ram().share("share1");
 	map(0x1000, 0x13ff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
@@ -459,23 +446,23 @@ void csilver_state::csilver_map(address_map &map)
 	map(0x1802, 0x1802).w(FUNC(csilver_state::main_firq_off_w));
 	map(0x1803, 0x1803).portr("IN2").w(FUNC(csilver_state::main_irq_on_w));
 	map(0x1804, 0x1804).portr("DSW1").w(FUNC(csilver_state::sub_irq_on_w));
-	map(0x1805, 0x1805).portr("DSW0").w(FUNC(csilver_state::dec8_mxc06_karn_buffer_spriteram_w)); /* Dip 1, DMA */
+	map(0x1805, 0x1805).portr("DSW0").w(FUNC(csilver_state::buffer_spriteram16_w)); /* Dip 1, DMA */
 	map(0x1807, 0x1807).w(FUNC(csilver_state::flip_screen_w));
-	map(0x1808, 0x180b).w(FUNC(csilver_state::dec8_scroll2_w));
-	map(0x180c, 0x180c).w(FUNC(csilver_state::dec8_sound_w));
-	map(0x180d, 0x180d).w(FUNC(csilver_state::csilver_control_w));
-	map(0x180e, 0x180f).w(FUNC(csilver_state::dec8_i8751_w));
+	map(0x1808, 0x180b).w(FUNC(csilver_state::scroll_w));
+	map(0x180c, 0x180c).w(FUNC(csilver_state::sound_w));
+	map(0x180d, 0x180d).w(FUNC(csilver_state::control_w));
+	map(0x180e, 0x180f).w(FUNC(csilver_state::i8751_w));
 	map(0x1c00, 0x1c00).r(FUNC(csilver_state::i8751_h_r));
 	map(0x1e00, 0x1e00).r(FUNC(csilver_state::i8751_l_r));
-	map(0x2000, 0x27ff).ram().w(FUNC(csilver_state::dec8_videoram_w));
+	map(0x2000, 0x27ff).ram().w(FUNC(csilver_state::videoram_w));
 	map(0x2800, 0x2fff).ram().share("spriteram");
 	map(0x3000, 0x37ff).ram().share("share2");
-	map(0x3800, 0x3fff).rw(FUNC(csilver_state::dec8_bg_data_r), FUNC(csilver_state::dec8_bg_data_w)).share("bg_data");
-	map(0x4000, 0x7fff).bankr("mainbank");
+	map(0x3800, 0x3fff).rw(FUNC(csilver_state::bg_ram_r), FUNC(csilver_state::bg_ram_w)).share("bg_ram");
+	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
 
-void csilver_state::csilver_sub_map(address_map &map)
+void csilver_state::sub_map(address_map &map)
 {
 	map(0x0000, 0x0fff).ram().share("share1");
 	map(0x1000, 0x13ff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
@@ -485,22 +472,22 @@ void csilver_state::csilver_sub_map(address_map &map)
 	map(0x1802, 0x1802).w(FUNC(csilver_state::main_firq_off_w));
 	map(0x1803, 0x1803).portr("IN2").w(FUNC(csilver_state::main_irq_on_w));
 	map(0x1804, 0x1804).portr("DSW1").w(FUNC(csilver_state::sub_irq_on_w));
-	map(0x1805, 0x1805).portr("DSW0").w(FUNC(csilver_state::dec8_mxc06_karn_buffer_spriteram_w)); /* DMA */
-	map(0x180c, 0x180c).w(FUNC(csilver_state::dec8_sound_w));
-	map(0x2000, 0x27ff).ram().w(FUNC(csilver_state::dec8_videoram_w)).share("videoram");
+	map(0x1805, 0x1805).portr("DSW0").w(FUNC(csilver_state::buffer_spriteram16_w)); /* DMA */
+	map(0x180c, 0x180c).w(FUNC(csilver_state::sound_w));
+	map(0x2000, 0x27ff).ram().w(FUNC(csilver_state::videoram_w)).share(m_videoram);
 	map(0x2800, 0x2fff).ram().share("spriteram");
 	map(0x3000, 0x37ff).ram().share("share2");
-	map(0x3800, 0x3fff).rw(FUNC(csilver_state::dec8_bg_data_r), FUNC(csilver_state::dec8_bg_data_w));
+	map(0x3800, 0x3fff).rw(FUNC(csilver_state::bg_ram_r), FUNC(csilver_state::bg_ram_w));
 	map(0x4000, 0xffff).rom();
 }
 
-void dec8_state::oscar_map(address_map &map)
+void oscar_state::oscar_map(address_map &map)
 {
 	map(0x0000, 0x0eff).ram().share("share1");
 	map(0x0f00, 0x0fff).ram();
 	map(0x1000, 0x1fff).ram().share("share2");
-	map(0x2000, 0x27ff).ram().w(FUNC(dec8_state::dec8_videoram_w)).share("videoram");
-	map(0x2800, 0x2fff).rw("tilegen1", FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
+	map(0x2000, 0x27ff).ram().w(FUNC(oscar_state::videoram_w)).share(m_videoram);
+	map(0x2800, 0x2fff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
 	map(0x3000, 0x37ff).ram().share("spriteram"); /* Sprites */
 	map(0x3800, 0x3bff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x3c00, 0x3c00).portr("IN0");
@@ -508,63 +495,63 @@ void dec8_state::oscar_map(address_map &map)
 	map(0x3c02, 0x3c02).portr("IN2");    /* VBL & coins */
 	map(0x3c03, 0x3c03).portr("DSW0");   /* Dip 1 */
 	map(0x3c04, 0x3c04).portr("DSW1");
-	map(0x3c00, 0x3c07).w("tilegen1", FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x3c10, 0x3c1f).w("tilegen1", FUNC(deco_bac06_device::pf_control1_8bit_w));
-	map(0x3c80, 0x3c80).w(FUNC(dec8_state::dec8_mxc06_karn_buffer_spriteram_w));   /* DMA */
-	map(0x3d00, 0x3d00).w(FUNC(dec8_state::dec8_bank_w));          /* BNKS */
+	map(0x3c00, 0x3c07).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control0_8bit_w));
+	map(0x3c10, 0x3c1f).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control1_8bit_w));
+	map(0x3c80, 0x3c80).w(FUNC(oscar_state::buffer_spriteram16_w));   /* DMA */
+	map(0x3d00, 0x3d00).w(FUNC(oscar_state::bank_w));          /* BNKS */
 	map(0x3d80, 0x3d80).w(m_soundlatch, FUNC(generic_latch_8_device::write));            /* SOUN */
-	map(0x3e00, 0x3e00).w(FUNC(dec8_state::oscar_coin_clear_w));   /* COINCL */
-	map(0x3e80, 0x3e80).w(FUNC(dec8_state::sub_irq_on_w));         /* IRQ 2 */
-	map(0x3e81, 0x3e81).w(FUNC(dec8_state::main_irq_off_w));       /* IRC 1 */
-	map(0x3e82, 0x3e82).w(FUNC(dec8_state::main_irq_on_w));        /* IRQ 1 */
-	map(0x3e83, 0x3e83).w(FUNC(dec8_state::sub_irq_off_w));        /* IRC 2 */
-	map(0x4000, 0x7fff).bankr("mainbank");
+	map(0x3e00, 0x3e00).w(FUNC(oscar_state::coin_clear_w));   /* COINCL */
+	map(0x3e80, 0x3e80).w(FUNC(oscar_state::sub_irq_on_w));         /* IRQ 2 */
+	map(0x3e81, 0x3e81).w(FUNC(oscar_state::main_irq_off_w));       /* IRC 1 */
+	map(0x3e82, 0x3e82).w(FUNC(oscar_state::main_irq_on_w));        /* IRQ 1 */
+	map(0x3e83, 0x3e83).w(FUNC(oscar_state::sub_irq_off_w));        /* IRC 2 */
+	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
 
-void dec8_state::oscar_sub_map(address_map &map)
+void oscar_state::oscar_sub_map(address_map &map)
 {
 	map(0x0000, 0x0eff).ram().share("share1");
 	map(0x0f00, 0x0fff).ram();
 	map(0x1000, 0x1fff).ram().share("share2");
-	map(0x3e80, 0x3e80).w(FUNC(dec8_state::sub_irq_on_w));         /* IRQ 2 */
-	map(0x3e81, 0x3e81).w(FUNC(dec8_state::main_irq_off_w));       /* IRC 1 */
-	map(0x3e82, 0x3e82).w(FUNC(dec8_state::main_irq_on_w));        /* IRQ 1 */
-	map(0x3e83, 0x3e83).w(FUNC(dec8_state::sub_irq_off_w));        /* IRC 2 */
+	map(0x3e80, 0x3e80).w(FUNC(oscar_state::sub_irq_on_w));         /* IRQ 2 */
+	map(0x3e81, 0x3e81).w(FUNC(oscar_state::main_irq_off_w));       /* IRC 1 */
+	map(0x3e82, 0x3e82).w(FUNC(oscar_state::main_irq_on_w));        /* IRQ 1 */
+	map(0x3e83, 0x3e83).w(FUNC(oscar_state::sub_irq_off_w));        /* IRC 2 */
 	map(0x4000, 0xffff).rom();
 }
 
-void dec8_state::srdarwin_map(address_map &map)
+void srdarwin_state::main_map(address_map &map)
 {
 	map(0x0000, 0x05ff).ram();
 	map(0x0600, 0x07ff).ram().share("spriteram");
-	map(0x0800, 0x0fff).ram().w(FUNC(dec8_state::srdarwin_videoram_w)).share("videoram");
+	map(0x0800, 0x0fff).ram().w(FUNC(srdarwin_state::srdarwin_videoram_w)).share(m_videoram);
 	map(0x1000, 0x13ff).ram();
-	map(0x1400, 0x17ff).rw(FUNC(dec8_state::dec8_bg_data_r), FUNC(dec8_state::dec8_bg_data_w)).share("bg_data");
-	map(0x1800, 0x1801).w(FUNC(dec8_state::dec8_i8751_w));
-	map(0x1802, 0x1802).w(FUNC(dec8_state::i8751_reset_w));        /* Maybe.. */
+	map(0x1400, 0x17ff).rw(FUNC(srdarwin_state::bg_ram_r), FUNC(srdarwin_state::bg_ram_w)).share("bg_ram");
+	map(0x1800, 0x1801).w(FUNC(srdarwin_state::i8751_w));
+	map(0x1802, 0x1802).w(FUNC(srdarwin_state::i8751_reset_w));        /* Maybe.. */
 	map(0x1803, 0x1803).nopw();            /* NMI ack */
 	map(0x1804, 0x1804).w(m_spriteram, FUNC(buffered_spriteram8_device::write)); /* DMA */
-	map(0x1805, 0x1806).w(FUNC(dec8_state::srdarwin_control_w)); /* Scroll & Bank */
-	map(0x2000, 0x2000).rw(FUNC(dec8_state::i8751_h_r), FUNC(dec8_state::dec8_sound_w));  /* Sound */
-	map(0x2001, 0x2001).rw(FUNC(dec8_state::i8751_l_r), FUNC(dec8_state::flip_screen_w));     /* Flipscreen */
+	map(0x1805, 0x1806).w(FUNC(srdarwin_state::control_w)); /* Scroll & Bank */
+	map(0x2000, 0x2000).rw(FUNC(srdarwin_state::i8751_h_r), FUNC(srdarwin_state::sound_w));  /* Sound */
+	map(0x2001, 0x2001).rw(FUNC(srdarwin_state::i8751_l_r), FUNC(srdarwin_state::flip_screen_w));     /* Flipscreen */
 	map(0x2800, 0x288f).w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x3000, 0x308f).w(m_palette, FUNC(deco_rmc3_device::write8_ext)).share("palette_ext");
 	map(0x3800, 0x3800).portr("DSW0");   /* Dip 1 */
 	map(0x3801, 0x3801).portr("IN0");    /* Player 1 */
 	map(0x3802, 0x3802).portr("IN1");    /* Player 2 (cocktail) + VBL */
 	map(0x3803, 0x3803).portr("DSW1");   /* Dip 2 */
-	map(0x4000, 0x7fff).bankr("mainbank");
+	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
 
-void dec8_state::cobra_map(address_map &map)
+void oscar_state::cobra_map(address_map &map)
 {
 	map(0x0000, 0x07ff).ram();
-	map(0x0800, 0x0fff).rw("tilegen1", FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
-	map(0x1000, 0x17ff).rw("tilegen2", FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
+	map(0x0800, 0x0fff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
+	map(0x1000, 0x17ff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
 	map(0x1800, 0x1fff).ram();
-	map(0x2000, 0x27ff).ram().w(FUNC(dec8_state::dec8_videoram_w)).share("videoram");
+	map(0x2000, 0x27ff).ram().w(FUNC(oscar_state::videoram_w)).share(m_videoram);
 	map(0x2800, 0x2fff).ram().share("spriteram");
 	map(0x3000, 0x31ff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x3200, 0x37ff).nopw(); /* Unused */
@@ -572,22 +559,22 @@ void dec8_state::cobra_map(address_map &map)
 	map(0x3801, 0x3801).portr("IN1");    /* Player 2 */
 	map(0x3802, 0x3802).portr("DSW0");   /* Dip 1 */
 	map(0x3803, 0x3803).portr("DSW1");   /* Dip 2 */
-	map(0x3800, 0x3807).w("tilegen1", FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x3810, 0x381f).w("tilegen1", FUNC(deco_bac06_device::pf_control1_8bit_w));
+	map(0x3800, 0x3807).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control0_8bit_w));
+	map(0x3810, 0x381f).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control1_8bit_w));
 	map(0x3a00, 0x3a00).portr("IN2");    /* VBL & coins */
-	map(0x3a00, 0x3a07).w("tilegen2", FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x3a10, 0x3a1f).w("tilegen2", FUNC(deco_bac06_device::pf_control1_8bit_w));
-	map(0x3c00, 0x3c00).w(FUNC(dec8_state::dec8_bank_w));
-	map(0x3c02, 0x3c02).w(FUNC(dec8_state::dec8_mxc06_karn_buffer_spriteram_w)); /* DMA */
-	map(0x3e00, 0x3e00).w(FUNC(dec8_state::dec8_sound_w));
-	map(0x4000, 0x7fff).bankr("mainbank");
+	map(0x3a00, 0x3a07).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control0_8bit_w));
+	map(0x3a10, 0x3a1f).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control1_8bit_w));
+	map(0x3c00, 0x3c00).w(FUNC(oscar_state::bank_w));
+	map(0x3c02, 0x3c02).w(FUNC(oscar_state::buffer_spriteram16_w)); /* DMA */
+	map(0x3e00, 0x3e00).w(FUNC(oscar_state::sound_w));
+	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
 
 /******************************************************************************/
 
 /* Used for Cobra Command, Maze Hunter, Super Real Darwin etc */
-void dec8_state::dec8_s_map(address_map &map)
+void base_state::dec8_s_map(address_map &map)
 {
 	map(0x0000, 0x05ff).ram();
 	map(0x2000, 0x2001).w("ym1", FUNC(ym2203_device::write));
@@ -597,7 +584,7 @@ void dec8_state::dec8_s_map(address_map &map)
 }
 
 /* Used by Gondomania, Psycho-Nics Oscar & Garyo Retsuden */
-void dec8_state::oscar_s_map(address_map &map)
+void base_state::oscar_s_map(address_map &map)
 {
 	map(0x0000, 0x05ff).ram();
 	map(0x2000, 0x2001).w("ym1", FUNC(ym2203_device::write));
@@ -607,13 +594,13 @@ void dec8_state::oscar_s_map(address_map &map)
 }
 
 // Used by the bootleg which has a standard M6502 with predecrypted opcodes
-void dec8_state::oscarbl_s_opcodes_map(address_map &map)
+void oscar_state::oscarbl_s_opcodes_map(address_map &map)
 {
 	map(0x8000, 0xffff).rom().region("audiocpu", 0x10000);
 }
 
 /* Used by Last Mission, Shackled & Breywood */
-void dec8_state::ym3526_s_map(address_map &map)
+void lastmisn_state::ym3526_s_map(address_map &map)
 {
 	map(0x0000, 0x05ff).ram();
 	map(0x0800, 0x0801).w("ym1", FUNC(ym2203_device::write));
@@ -623,15 +610,15 @@ void dec8_state::ym3526_s_map(address_map &map)
 }
 
 /* Captain Silver - same sound system as Pocket Gal */
-void csilver_state::csilver_s_map(address_map &map)
+void csilver_state::sound_map(address_map &map)
 {
 	map(0x0000, 0x07ff).ram();
 	map(0x0800, 0x0801).w("ym1", FUNC(ym2203_device::write));
 	map(0x1000, 0x1001).w("ym2", FUNC(ym3526_device::write));
-	map(0x1800, 0x1800).w(FUNC(csilver_state::csilver_adpcm_data_w)); /* ADPCM data for the MSM5205 chip */
-	map(0x2000, 0x2000).w(FUNC(csilver_state::csilver_sound_bank_w));
+	map(0x1800, 0x1800).w(FUNC(csilver_state::adpcm_data_w)); /* ADPCM data for the MSM5205 chip */
+	map(0x2000, 0x2000).w(FUNC(csilver_state::sound_bank_w));
 	map(0x3000, 0x3000).r(m_soundlatch, FUNC(generic_latch_8_device::read));
-	map(0x3400, 0x3400).r(FUNC(csilver_state::csilver_adpcm_reset_r)); /* ? not sure */
+	map(0x3400, 0x3400).r(FUNC(csilver_state::adpcm_reset_r)); /* ? not sure */
 	map(0x4000, 0x7fff).bankr("soundbank");
 	map(0x8000, 0xffff).rom();
 }
@@ -650,27 +637,27 @@ void csilver_state::csilver_s_map(address_map &map)
 
 */
 
-uint8_t dec8_state::i8751_port0_r()
+u8 mcu_state::i8751_port0_r()
 {
 	return m_i8751_port0;
 }
 
-void dec8_state::i8751_port0_w(uint8_t data)
+void mcu_state::i8751_port0_w(u8 data)
 {
 	m_i8751_port0 = data;
 }
 
-uint8_t dec8_state::i8751_port1_r()
+u8 mcu_state::i8751_port1_r()
 {
 	return m_i8751_port1;
 }
 
-void dec8_state::i8751_port1_w(uint8_t data)
+void mcu_state::i8751_port1_w(u8 data)
 {
 	m_i8751_port1 = data;
 }
 
-void dec8_state::gondo_mcu_to_main_w(uint8_t data)
+void lastmisn_state::gondo_mcu_to_main_w(u8 data)
 {
 	// P2 - controls latches for main CPU communication
 	if ((data&0x10)==0)
@@ -688,7 +675,7 @@ void dec8_state::gondo_mcu_to_main_w(uint8_t data)
 	m_i8751_p2 = data;
 }
 
-void dec8_state::shackled_mcu_to_main_w(uint8_t data)
+void lastmisn_state::shackled_mcu_to_main_w(u8 data)
 {
 	// P2 - controls latches for main CPU communication
 	if ((data&0x10)==0)
@@ -721,7 +708,7 @@ void dec8_state::shackled_mcu_to_main_w(uint8_t data)
     Super Real Darwin is similar but only appears to have a single port
 */
 
-void dec8_state::srdarwin_mcu_to_main_w(uint8_t data)
+void srdarwin_state::mcu_to_main_w(u8 data)
 {
 	// P2 - controls latches for main CPU communication
 	if ((data & 0x10) == 0)
@@ -747,7 +734,7 @@ void dec8_state::srdarwin_mcu_to_main_w(uint8_t data)
 }
 
 
-void csilver_state::csilver_mcu_to_main_w(uint8_t data)
+void csilver_state::mcu_to_main_w(u8 data)
 {
 	if (~data & 0x10)
 		m_i8751_port0 = m_i8751_value >> 8;
@@ -1769,19 +1756,19 @@ GFXDECODE_END
 /******************************************************************************/
 
 /* Coins generate NMI's */
-void dec8_state::oscar_coin_irq(int state)
+void oscar_state::coin_irq(int state)
 {
 	if (state && !m_coin_state)
 		m_maincpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE);
 	m_coin_state = bool(state);
 }
 
-void dec8_state::oscar_coin_clear_w(uint8_t data)
+void oscar_state::coin_clear_w(u8 data)
 {
 	m_maincpu->set_input_line(INPUT_LINE_NMI, CLEAR_LINE);
 }
 
-void dec8_state::shackled_coin_irq(int state)
+void lastmisn_state::shackled_coin_irq(int state)
 {
 	if (state && !m_coin_state)
 		m_mcu->set_input_line(MCS51_INT0_LINE, ASSERT_LINE);
@@ -1791,55 +1778,58 @@ void dec8_state::shackled_coin_irq(int state)
 /******************************************************************************/
 
 
-void dec8_state::machine_start()
+void base_state::machine_start()
 {
-	uint8_t *ROM = memregion("maincpu")->base();
+	u8 *ROM = memregion("maincpu")->base();
 	uint32_t max_bank = (memregion("maincpu")->bytes() - 0x10000) / 0x4000;
 	m_mainbank->configure_entries(0, max_bank, &ROM[0x10000], 0x4000);
 
-	m_i8751_timer = timer_alloc(FUNC(dec8_state::mcu_irq_clear), this);
-	m_m6502_timer = timer_alloc(FUNC(dec8_state::audiocpu_nmi_clear), this);
+	m_m6502_timer = timer_alloc(FUNC(base_state::audiocpu_nmi_clear), this);
 
-	m_i8751_p2 = 0xff;
-	m_latch = 0;
-
-	save_item(NAME(m_secclr));
-	save_item(NAME(m_i8751_p2));
-	save_item(NAME(m_latch));
 	save_item(NAME(m_coin_state));
+
+	save_item(NAME(m_scroll));
+}
+
+void base_state::machine_reset()
+{
+	m_scroll[0] = m_scroll[1] = m_scroll[2] = m_scroll[3] = 0;
+}
+
+
+void mcu_state::machine_start()
+{
+	base_state::machine_start();
+
+	m_i8751_timer = timer_alloc(FUNC(mcu_state::mcu_irq_clear), this);
+	m_i8751_p2 = 0xff;
+
+	save_item(NAME(m_i8751_p2));
 	save_item(NAME(m_i8751_port0));
 	save_item(NAME(m_i8751_port1));
 	save_item(NAME(m_i8751_return));
 	save_item(NAME(m_i8751_value));
-	save_item(NAME(m_coinage_id));
-	save_item(NAME(m_coin1));
-	save_item(NAME(m_coin2));
-	save_item(NAME(m_need1));
-	save_item(NAME(m_need2));
-	save_item(NAME(m_cred1));
-	save_item(NAME(m_cred2));
-	save_item(NAME(m_credits));
-	save_item(NAME(m_snd));
-
-	save_item(NAME(m_scroll2));
-	save_item(NAME(m_bg_control));
-	save_item(NAME(m_pf1_control));
 }
 
-void dec8_state::machine_reset()
+void mcu_state::machine_reset()
 {
+	base_state::machine_reset();
+
 	m_i8751_port0 = m_i8751_port1 = 0;
 	m_i8751_return = m_i8751_value = 0;
-	m_coinage_id = 0;
-	m_coin1 = m_coin2 = m_credits = m_snd = 0;
-	m_need1 = m_need2 = m_cred1 = m_cred2 = 1;
+}
 
-	m_scroll2[0] = m_scroll2[1] = m_scroll2[2] = m_scroll2[3] = 0;
-	for (int i = 0; i < 0x20; i++)
-	{
-		m_bg_control[i] = 0;
-		m_pf1_control[i] = 0;
-	}
+
+void lastmisn_state::machine_start()
+{
+	mcu_state::machine_start();
+
+	save_item(NAME(m_secclr));
+}
+
+void lastmisn_state::machine_reset()
+{
+	base_state::machine_reset();
 
 	// reset clears LS273 latch, which disables NMI
 	if (m_nmigate.found())
@@ -1849,9 +1839,9 @@ void dec8_state::machine_reset()
 
 void csilver_state::machine_start()
 {
-	dec8_state::machine_start();
+	lastmisn_state::machine_start();
 
-	uint8_t *RAM = memregion("audiocpu")->base();
+	u8 *RAM = memregion("audiocpu")->base();
 	m_soundbank->configure_entries(0, 2, &RAM[0], 0x4000);
 
 	save_item(NAME(m_msm5205next));
@@ -1860,7 +1850,7 @@ void csilver_state::machine_start()
 
 void csilver_state::machine_reset()
 {
-	dec8_state::machine_reset();
+	lastmisn_state::machine_reset();
 
 	m_msm5205next = 0;
 	m_toggle = 0;
@@ -1868,34 +1858,34 @@ void csilver_state::machine_reset()
 
 
 // DECO video CRTC, unverified
-void dec8_state::set_screen_raw_params_data_east(machine_config &config)
+void base_state::set_screen_raw_params_data_east(machine_config &config)
 {
 	m_screen->set_raw(XTAL(12'000'000)/2,384,0,256,272,8,248);
 }
 
-void dec8_state::lastmisn(machine_config &config)
+void lastmisn_state::lastmisn(machine_config &config)
 {
 	/* basic machine hardware */
 	MC6809E(config, m_maincpu, 2000000);
-	m_maincpu->set_addrmap(AS_PROGRAM, &dec8_state::lastmisn_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &lastmisn_state::lastmisn_map);
 
 	MC6809E(config, m_subcpu, 2000000);
-	m_subcpu->set_addrmap(AS_PROGRAM, &dec8_state::lastmisn_sub_map);
+	m_subcpu->set_addrmap(AS_PROGRAM, &lastmisn_state::lastmisn_sub_map);
 
 	M6502(config, m_audiocpu, 1500000);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &dec8_state::ym3526_s_map); /* NMIs are caused by the main CPU */
+	m_audiocpu->set_addrmap(AS_PROGRAM, &lastmisn_state::ym3526_s_map); /* NMIs are caused by the main CPU */
 
 	I8751(config, m_mcu, XTAL(8'000'000));
-	m_mcu->port_in_cb<0>().set(FUNC(dec8_state::i8751_port0_r));
-	m_mcu->port_out_cb<0>().set(FUNC(dec8_state::i8751_port0_w));
-	m_mcu->port_in_cb<1>().set(FUNC(dec8_state::i8751_port1_r));
-	m_mcu->port_out_cb<1>().set(FUNC(dec8_state::i8751_port1_w));
-	m_mcu->port_out_cb<2>().set(FUNC(dec8_state::shackled_mcu_to_main_w));
+	m_mcu->port_in_cb<0>().set(FUNC(lastmisn_state::i8751_port0_r));
+	m_mcu->port_out_cb<0>().set(FUNC(lastmisn_state::i8751_port0_w));
+	m_mcu->port_in_cb<1>().set(FUNC(lastmisn_state::i8751_port1_r));
+	m_mcu->port_out_cb<1>().set(FUNC(lastmisn_state::i8751_port1_w));
+	m_mcu->port_out_cb<2>().set(FUNC(lastmisn_state::shackled_mcu_to_main_w));
 	m_mcu->port_in_cb<3>().set_ioport("I8751");
 
 	config.set_maximum_quantum(attotime::from_hz(12000));
 
-	INPUT_MERGER_ANY_LOW(config, "coin").output_handler().set(FUNC(dec8_state::shackled_coin_irq));
+	INPUT_MERGER_ANY_LOW(config, "coin").output_handler().set(FUNC(lastmisn_state::shackled_coin_irq));
 
 	/* video hardware */
 	BUFFERED_SPRITERAM8(config, m_spriteram);
@@ -1908,13 +1898,13 @@ void dec8_state::lastmisn(machine_config &config)
 //  m_screen->set_size(32*8, 32*8);
 //  m_screen->set_visarea(0*8, 32*8-1, 1*8, 31*8-1);
 	set_screen_raw_params_data_east(config);
-	m_screen->set_screen_update(FUNC(dec8_state::screen_update_lastmisn));
+	m_screen->set_screen_update(FUNC(lastmisn_state::screen_update_lastmisn));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_shackled);
 	DECO_RMC3(config, m_palette, 0, 1024); // xxxxBBBBGGGGRRRR with custom weighting
 
-	MCFG_VIDEO_START_OVERRIDE(dec8_state,lastmisn)
+	MCFG_VIDEO_START_OVERRIDE(lastmisn_state,lastmisn)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -1932,30 +1922,30 @@ void dec8_state::lastmisn(machine_config &config)
 	ym2.add_route(ALL_OUTPUTS, "mono", 0.70);
 }
 
-void dec8_state::shackled(machine_config &config)
+void lastmisn_state::shackled(machine_config &config)
 {
 	/* basic machine hardware */
 	MC6809E(config, m_maincpu, 2000000);
-	m_maincpu->set_addrmap(AS_PROGRAM, &dec8_state::shackled_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &lastmisn_state::shackled_map);
 
 	MC6809E(config, m_subcpu, 2000000);
-	m_subcpu->set_addrmap(AS_PROGRAM, &dec8_state::shackled_sub_map);
+	m_subcpu->set_addrmap(AS_PROGRAM, &lastmisn_state::shackled_sub_map);
 
 	M6502(config, m_audiocpu, 1500000);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &dec8_state::ym3526_s_map); /* NMIs are caused by the main CPU */
+	m_audiocpu->set_addrmap(AS_PROGRAM, &lastmisn_state::ym3526_s_map); /* NMIs are caused by the main CPU */
 
 	I8751(config, m_mcu, XTAL(8'000'000));
-	m_mcu->port_in_cb<0>().set(FUNC(dec8_state::i8751_port0_r));
-	m_mcu->port_out_cb<0>().set(FUNC(dec8_state::i8751_port0_w));
-	m_mcu->port_in_cb<1>().set(FUNC(dec8_state::i8751_port1_r));
-	m_mcu->port_out_cb<1>().set(FUNC(dec8_state::i8751_port1_w));
-	m_mcu->port_out_cb<2>().set(FUNC(dec8_state::shackled_mcu_to_main_w));
+	m_mcu->port_in_cb<0>().set(FUNC(lastmisn_state::i8751_port0_r));
+	m_mcu->port_out_cb<0>().set(FUNC(lastmisn_state::i8751_port0_w));
+	m_mcu->port_in_cb<1>().set(FUNC(lastmisn_state::i8751_port1_r));
+	m_mcu->port_out_cb<1>().set(FUNC(lastmisn_state::i8751_port1_w));
+	m_mcu->port_out_cb<2>().set(FUNC(lastmisn_state::shackled_mcu_to_main_w));
 	m_mcu->port_in_cb<3>().set_ioport("I8751");
 
 //  config.set_maximum_quantum(attotime::from_hz(100000));
 	config.set_perfect_quantum(m_maincpu); // needs heavy sync, otherwise one of the two CPUs will miss an IRQ and cause the game to hang
 
-	INPUT_MERGER_ANY_LOW(config, "coin").output_handler().set(FUNC(dec8_state::shackled_coin_irq));
+	INPUT_MERGER_ANY_LOW(config, "coin").output_handler().set(FUNC(lastmisn_state::shackled_coin_irq));
 
 	/* video hardware */
 	BUFFERED_SPRITERAM8(config, m_spriteram);
@@ -1968,13 +1958,13 @@ void dec8_state::shackled(machine_config &config)
 //  m_screen->set_size(32*8, 32*8);
 //  m_screen->set_visarea(0*8, 32*8-1, 1*8, 31*8-1);
 	set_screen_raw_params_data_east(config);
-	m_screen->set_screen_update(FUNC(dec8_state::screen_update_shackled));
+	m_screen->set_screen_update(FUNC(lastmisn_state::screen_update_shackled));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_shackled);
 	DECO_RMC3(config, m_palette, 0, 1024); // xxxxBBBBGGGGRRRR with custom weighting
 
-	MCFG_VIDEO_START_OVERRIDE(dec8_state,shackled)
+	MCFG_VIDEO_START_OVERRIDE(lastmisn_state,shackled)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -1992,28 +1982,28 @@ void dec8_state::shackled(machine_config &config)
 	ym2.add_route(ALL_OUTPUTS, "mono", 0.70);
 }
 
-void dec8_state::gondo(machine_config &config)
+void gondo_state::gondo(machine_config &config)
 {
 	/* basic machine hardware */
 	HD6309E(config, m_maincpu, 3000000); /* HD63C09EP */
-	m_maincpu->set_addrmap(AS_PROGRAM, &dec8_state::gondo_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &gondo_state::gondo_map);
 
 	M6502(config, m_audiocpu, 1500000);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &dec8_state::oscar_s_map); /* NMIs are caused by the main CPU */
+	m_audiocpu->set_addrmap(AS_PROGRAM, &gondo_state::oscar_s_map); /* NMIs are caused by the main CPU */
 
 	I8751(config, m_mcu, XTAL(8'000'000));
-	m_mcu->port_in_cb<0>().set(FUNC(dec8_state::i8751_port0_r));
-	m_mcu->port_out_cb<0>().set(FUNC(dec8_state::i8751_port0_w));
-	m_mcu->port_in_cb<1>().set(FUNC(dec8_state::i8751_port1_r));
-	m_mcu->port_out_cb<1>().set(FUNC(dec8_state::i8751_port1_w));
-	m_mcu->port_out_cb<2>().set(FUNC(dec8_state::gondo_mcu_to_main_w));
+	m_mcu->port_in_cb<0>().set(FUNC(gondo_state::i8751_port0_r));
+	m_mcu->port_out_cb<0>().set(FUNC(gondo_state::i8751_port0_w));
+	m_mcu->port_in_cb<1>().set(FUNC(gondo_state::i8751_port1_r));
+	m_mcu->port_out_cb<1>().set(FUNC(gondo_state::i8751_port1_w));
+	m_mcu->port_out_cb<2>().set(FUNC(gondo_state::gondo_mcu_to_main_w));
 	m_mcu->port_in_cb<3>().set_ioport("I8751");
 
 	/* video hardware */
 	BUFFERED_SPRITERAM8(config, m_spriteram);
 
 	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0);
-	m_spritegen_krn->set_colpri_callback(FUNC(dec8_state::gondo_colpri_cb));
+	m_spritegen_krn->set_colpri_callback(FUNC(gondo_state::gondo_colpri_cb));
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 //  m_screen->set_refresh_hz(58);
@@ -2021,8 +2011,8 @@ void dec8_state::gondo(machine_config &config)
 //  m_screen->set_size(32*8, 32*8);
 //  m_screen->set_visarea(0*8, 32*8-1, 1*8, 31*8-1);
 	set_screen_raw_params_data_east(config);
-	m_screen->set_screen_update(FUNC(dec8_state::screen_update_gondo));
-	m_screen->screen_vblank().set(FUNC(dec8_state::screen_vblank_dec8));
+	m_screen->set_screen_update(FUNC(gondo_state::screen_update_gondo));
+	m_screen->screen_vblank().set(FUNC(gondo_state::screen_vblank));
 	m_screen->screen_vblank().append(m_nmigate, FUNC(input_merger_device::in_w<1>));
 	m_screen->set_palette(m_palette);
 
@@ -2031,8 +2021,6 @@ void dec8_state::gondo(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_gondo);
 	DECO_RMC3(config, m_palette, 0, 1024); // xxxxBBBBGGGGRRRR with custom weighting
 
-	MCFG_VIDEO_START_OVERRIDE(dec8_state,gondo)
-
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 
@@ -2049,21 +2037,21 @@ void dec8_state::gondo(machine_config &config)
 	ym2.add_route(ALL_OUTPUTS, "mono", 0.70);
 }
 
-void dec8_state::garyoret(machine_config &config)
+void lastmisn_state::garyoret(machine_config &config)
 {
 	/* basic machine hardware */
 	HD6309E(config, m_maincpu, 3000000); /* HD63C09EP */
-	m_maincpu->set_addrmap(AS_PROGRAM, &dec8_state::garyoret_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &lastmisn_state::garyoret_map);
 
 	M6502(config, m_audiocpu, 1500000);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &dec8_state::oscar_s_map); /* NMIs are caused by the main CPU */
+	m_audiocpu->set_addrmap(AS_PROGRAM, &lastmisn_state::oscar_s_map); /* NMIs are caused by the main CPU */
 
 	I8751(config, m_mcu, XTAL(8'000'000));
-	m_mcu->port_in_cb<0>().set(FUNC(dec8_state::i8751_port0_r));
-	m_mcu->port_out_cb<0>().set(FUNC(dec8_state::i8751_port0_w));
-	m_mcu->port_in_cb<1>().set(FUNC(dec8_state::i8751_port1_r));
-	m_mcu->port_out_cb<1>().set(FUNC(dec8_state::i8751_port1_w));
-	m_mcu->port_out_cb<2>().set(FUNC(dec8_state::gondo_mcu_to_main_w));
+	m_mcu->port_in_cb<0>().set(FUNC(lastmisn_state::i8751_port0_r));
+	m_mcu->port_out_cb<0>().set(FUNC(lastmisn_state::i8751_port0_w));
+	m_mcu->port_in_cb<1>().set(FUNC(lastmisn_state::i8751_port1_r));
+	m_mcu->port_out_cb<1>().set(FUNC(lastmisn_state::i8751_port1_w));
+	m_mcu->port_out_cb<2>().set(FUNC(lastmisn_state::gondo_mcu_to_main_w));
 	m_mcu->port_in_cb<3>().set_ioport("I8751");
 
 	/* video hardware */
@@ -2077,8 +2065,8 @@ void dec8_state::garyoret(machine_config &config)
 //  m_screen->set_size(32*8, 32*8);
 //  m_screen->set_visarea(0*8, 32*8-1, 1*8, 31*8-1);
 	set_screen_raw_params_data_east(config);
-	m_screen->set_screen_update(FUNC(dec8_state::screen_update_garyoret));
-	m_screen->screen_vblank().set(FUNC(dec8_state::screen_vblank_dec8));
+	m_screen->set_screen_update(FUNC(lastmisn_state::screen_update_garyoret));
+	m_screen->screen_vblank().set(FUNC(lastmisn_state::screen_vblank));
 	m_screen->screen_vblank().append(m_nmigate, FUNC(input_merger_device::in_w<1>));
 	m_screen->set_palette(m_palette);
 
@@ -2087,7 +2075,7 @@ void dec8_state::garyoret(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_gondo);
 	DECO_RMC3(config, m_palette, 0, 1024); // xxxxBBBBGGGGRRRR with custom weighting
 
-	MCFG_VIDEO_START_OVERRIDE(dec8_state,garyoret)
+	MCFG_VIDEO_START_OVERRIDE(lastmisn_state,garyoret)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -2105,21 +2093,21 @@ void dec8_state::garyoret(machine_config &config)
 	ym2.add_route(ALL_OUTPUTS, "mono", 0.70);
 }
 
-void dec8_state::ghostb(machine_config &config)
+void lastmisn_state::ghostb(machine_config &config)
 {
 	/* basic machine hardware */
 	HD6309E(config, m_maincpu, XTAL(12'000'000) / 4);  /* HD63C09EP, clock verified */
-	m_maincpu->set_addrmap(AS_PROGRAM, &dec8_state::meikyuh_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &lastmisn_state::meikyuh_map);
 
 	DECO_222(config, m_audiocpu, XTAL(12'000'000) / 8); /* also seen with stock M6502, clock verified */
-	m_audiocpu->set_addrmap(AS_PROGRAM, &dec8_state::dec8_s_map); /* NMIs are caused by the main CPU */
+	m_audiocpu->set_addrmap(AS_PROGRAM, &lastmisn_state::dec8_s_map); /* NMIs are caused by the main CPU */
 
 	I8751(config, m_mcu, XTAL(8'000'000)); /* 8.0MHz OSC next to MCU - clock verified */
-	m_mcu->port_in_cb<0>().set(FUNC(dec8_state::i8751_port0_r));
-	m_mcu->port_out_cb<0>().set(FUNC(dec8_state::i8751_port0_w));
-	m_mcu->port_in_cb<1>().set(FUNC(dec8_state::i8751_port1_r));
-	m_mcu->port_out_cb<1>().set(FUNC(dec8_state::i8751_port1_w));
-	m_mcu->port_out_cb<2>().set(FUNC(dec8_state::gondo_mcu_to_main_w));
+	m_mcu->port_in_cb<0>().set(FUNC(lastmisn_state::i8751_port0_r));
+	m_mcu->port_out_cb<0>().set(FUNC(lastmisn_state::i8751_port0_w));
+	m_mcu->port_in_cb<1>().set(FUNC(lastmisn_state::i8751_port1_r));
+	m_mcu->port_out_cb<1>().set(FUNC(lastmisn_state::i8751_port1_w));
+	m_mcu->port_out_cb<2>().set(FUNC(lastmisn_state::gondo_mcu_to_main_w));
 	m_mcu->port_in_cb<3>().set_ioport("I8751");
 
 	/* video hardware */
@@ -2137,8 +2125,8 @@ void dec8_state::ghostb(machine_config &config)
 //  m_screen->set_size(32*8, 32*8);
 //  m_screen->set_visarea(0*8, 32*8-1, 1*8, 31*8-1);
 	set_screen_raw_params_data_east(config);
-	m_screen->set_screen_update(FUNC(dec8_state::screen_update_ghostb));
-	m_screen->screen_vblank().set(FUNC(dec8_state::screen_vblank_dec8));
+	m_screen->set_screen_update(FUNC(lastmisn_state::screen_update_ghostb));
+	m_screen->screen_vblank().set(FUNC(lastmisn_state::screen_vblank));
 	m_screen->screen_vblank().append([this] (int state) { if (state && m_nmi_enable) m_maincpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE); });
 	m_screen->set_palette(m_palette);
 
@@ -2146,7 +2134,7 @@ void dec8_state::ghostb(machine_config &config)
 	DECO_RMC3(config, m_palette, 0, 1024); // xxxxBBBBGGGGRRRR with custom weighting
 	m_palette->set_prom_region("proms");
 	m_palette->set_init(m_palette, FUNC(deco_rmc3_device::palette_init_proms));
-	MCFG_VIDEO_START_OVERRIDE(dec8_state,ghostb)
+	MCFG_VIDEO_START_OVERRIDE(lastmisn_state,ghostb)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -2164,11 +2152,11 @@ void dec8_state::ghostb(machine_config &config)
 	ym2.add_route(ALL_OUTPUTS, "mono", 0.70);
 }
 
-void dec8_state::meikyuh(machine_config &config)
+void lastmisn_state::meikyuh(machine_config &config)
 {
 	ghostb(config);
 	M6502(config.replace(), m_audiocpu, 1500000);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &dec8_state::dec8_s_map);
+	m_audiocpu->set_addrmap(AS_PROGRAM, &lastmisn_state::dec8_s_map);
 }
 
 
@@ -2176,13 +2164,13 @@ void csilver_state::csilver(machine_config &config)
 {
 	/* basic machine hardware */
 	MC6809E(config, m_maincpu, XTAL(12'000'000)/8); /* verified on pcb */
-	m_maincpu->set_addrmap(AS_PROGRAM, &csilver_state::csilver_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &csilver_state::main_map);
 
 	MC6809E(config, m_subcpu, XTAL(12'000'000)/8); /* verified on pcb */
-	m_subcpu->set_addrmap(AS_PROGRAM, &csilver_state::csilver_sub_map);
+	m_subcpu->set_addrmap(AS_PROGRAM, &csilver_state::sub_map);
 
 	M6502(config, m_audiocpu, XTAL(12'000'000)/8); /* verified on pcb */
-	m_audiocpu->set_addrmap(AS_PROGRAM, &csilver_state::csilver_s_map); /* NMIs are caused by the main CPU */
+	m_audiocpu->set_addrmap(AS_PROGRAM, &csilver_state::sound_map); /* NMIs are caused by the main CPU */
 
 	config.set_maximum_quantum(attotime::from_hz(6000));
 
@@ -2191,7 +2179,7 @@ void csilver_state::csilver(machine_config &config)
 	m_mcu->port_out_cb<0>().set(FUNC(csilver_state::i8751_port0_w));
 	m_mcu->port_in_cb<1>().set(FUNC(csilver_state::i8751_port1_r));
 	m_mcu->port_out_cb<1>().set(FUNC(csilver_state::i8751_port1_w));
-	m_mcu->port_out_cb<2>().set(FUNC(csilver_state::csilver_mcu_to_main_w));
+	m_mcu->port_out_cb<2>().set(FUNC(csilver_state::mcu_to_main_w));
 	m_mcu->port_in_cb<3>().set_ioport("I8751");
 
 	config.set_perfect_quantum(m_maincpu);
@@ -2232,26 +2220,26 @@ void csilver_state::csilver(machine_config &config)
 	ym2.add_route(ALL_OUTPUTS, "mono", 0.70);
 
 	MSM5205(config, m_msm, XTAL(384'000)); /* verified on pcb */
-	m_msm->vck_legacy_callback().set(FUNC(csilver_state::csilver_adpcm_int));  /* interrupt function */
+	m_msm->vck_legacy_callback().set(FUNC(csilver_state::adpcm_int));  /* interrupt function */
 	m_msm->set_prescaler_selector(msm5205_device::S48_4B);      /* 8KHz */
 	m_msm->add_route(ALL_OUTPUTS, "mono", 0.88);
 }
 
-void dec8_state::oscar(machine_config &config)
+void oscar_state::oscar(machine_config &config)
 {
 	/* basic machine hardware */
 	HD6309(config, m_maincpu, XTAL(12'000'000)/2); /* PCB seen both HD6309EP or MC6809EP, clock verified on pcb */
-	m_maincpu->set_addrmap(AS_PROGRAM, &dec8_state::oscar_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &oscar_state::oscar_map);
 
 	HD6309(config, m_subcpu, XTAL(12'000'000)/2); /* PCB seen both HD6309EP or MC6809EP, clock verified on pcb */
-	m_subcpu->set_addrmap(AS_PROGRAM, &dec8_state::oscar_sub_map);
+	m_subcpu->set_addrmap(AS_PROGRAM, &oscar_state::oscar_sub_map);
 
 	DECO_222(config, m_audiocpu, XTAL(12'000'000)/8); // IC labeled "C10707-1"
-	m_audiocpu->set_addrmap(AS_PROGRAM, &dec8_state::oscar_s_map); /* NMIs are caused by the main CPU */
+	m_audiocpu->set_addrmap(AS_PROGRAM, &oscar_state::oscar_s_map); /* NMIs are caused by the main CPU */
 
 	config.set_maximum_quantum(attotime::from_hz(2400)); /* 40 CPU slices per frame */
 
-	INPUT_MERGER_ANY_LOW(config, "coin").output_handler().set(FUNC(dec8_state::oscar_coin_irq)); // 1S1588 x3 (D1-D3) + RCDM-I5
+	INPUT_MERGER_ANY_LOW(config, "coin").output_handler().set(FUNC(oscar_state::coin_irq)); // 1S1588 x3 (D1-D3) + RCDM-I5
 
 	/* video hardware */
 	BUFFERED_SPRITERAM8(config, m_spriteram);
@@ -2259,7 +2247,7 @@ void dec8_state::oscar(machine_config &config)
 	DECO_BAC06(config, m_tilegen[0], 0);
 	m_tilegen[0]->set_gfx_region_wide(2, 2, 0);
 	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
-	m_tilegen[0]->set_tile_callback(FUNC(dec8_state::oscar_tile_cb));
+	m_tilegen[0]->set_tile_callback(FUNC(oscar_state::oscar_tile_cb));
 
 	DECO_MXC06(config, m_spritegen_mxc, 0);
 
@@ -2269,13 +2257,13 @@ void dec8_state::oscar(machine_config &config)
 //  m_screen->set_size(32*8, 32*8);
 //  m_screen->set_visarea(0*8, 32*8-1, 1*8, 31*8-1);
 	set_screen_raw_params_data_east(config);
-	m_screen->set_screen_update(FUNC(dec8_state::screen_update_oscar));
+	m_screen->set_screen_update(FUNC(oscar_state::screen_update_oscar));
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_oscar);
 	DECO_RMC3(config, m_palette, 0, 1024); // xxxxBBBBGGGGRRRR with custom weighting
 
-	MCFG_VIDEO_START_OVERRIDE(dec8_state,oscar)
+	MCFG_VIDEO_START_OVERRIDE(oscar_state,oscar)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -2294,28 +2282,28 @@ void dec8_state::oscar(machine_config &config)
 	ym2.add_route(ALL_OUTPUTS, "mono", 0.70);
 }
 
-void dec8_state::oscarbl(machine_config &config)
+void oscar_state::oscarbl(machine_config &config)
 {
 	oscar(config);
 
 	M6502(config.replace(), m_audiocpu, XTAL(12'000'000)/8);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &dec8_state::oscar_s_map); /* NMIs are caused by the main CPU */
-	m_audiocpu->set_addrmap(AS_OPCODES, &dec8_state::oscarbl_s_opcodes_map);
+	m_audiocpu->set_addrmap(AS_PROGRAM, &oscar_state::oscar_s_map); /* NMIs are caused by the main CPU */
+	m_audiocpu->set_addrmap(AS_OPCODES, &oscar_state::oscarbl_s_opcodes_map);
 }
 
-void dec8_state::srdarwin(machine_config &config)
+void srdarwin_state::srdarwin(machine_config &config)
 {
 	/* basic machine hardware */
 	MC6809E(config, m_maincpu, 2000000);  /* MC68A09EP */
-	m_maincpu->set_addrmap(AS_PROGRAM, &dec8_state::srdarwin_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &srdarwin_state::main_map);
 
 	DECO_222(config, m_audiocpu, 1500000);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &dec8_state::dec8_s_map); /* NMIs are caused by the main CPU */
+	m_audiocpu->set_addrmap(AS_PROGRAM, &srdarwin_state::dec8_s_map); /* NMIs are caused by the main CPU */
 
 	I8751(config, m_mcu, XTAL(8'000'000)); /* unknown frequency */
-	m_mcu->port_in_cb<0>().set(FUNC(dec8_state::i8751_port0_r));
-	m_mcu->port_out_cb<0>().set(FUNC(dec8_state::i8751_port0_w));
-	m_mcu->port_out_cb<2>().set(FUNC(dec8_state::srdarwin_mcu_to_main_w));
+	m_mcu->port_in_cb<0>().set(FUNC(srdarwin_state::i8751_port0_r));
+	m_mcu->port_out_cb<0>().set(FUNC(srdarwin_state::i8751_port0_w));
+	m_mcu->port_out_cb<2>().set(FUNC(srdarwin_state::mcu_to_main_w));
 	m_mcu->port_in_cb<3>().set_ioport("I8751");
 
 	config.set_perfect_quantum(m_maincpu); /* needed for stability with emulated MCU or sometimes commands get missed and game crashes at bosses */
@@ -2329,14 +2317,12 @@ void dec8_state::srdarwin(machine_config &config)
 //  m_screen->set_size(32*8, 32*8);
 //  m_screen->set_visarea(0*8, 32*8-1, 1*8, 31*8-1);
 	set_screen_raw_params_data_east(config);
-	m_screen->set_screen_update(FUNC(dec8_state::screen_update_srdarwin));
+	m_screen->set_screen_update(FUNC(srdarwin_state::screen_update));
 	m_screen->set_palette(m_palette);
 	m_screen->screen_vblank().set_inputline(m_maincpu, INPUT_LINE_NMI);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_srdarwin);
 	DECO_RMC3(config, m_palette, 0, 144); // xxxxBBBBGGGGRRRR with custom weighting
-
-	MCFG_VIDEO_START_OVERRIDE(dec8_state,srdarwin)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -2354,14 +2340,14 @@ void dec8_state::srdarwin(machine_config &config)
 	ym2.add_route(ALL_OUTPUTS, "mono", 0.70);
 }
 
-void dec8_state::cobracom(machine_config &config)
+void oscar_state::cobracom(machine_config &config)
 {
 	/* basic machine hardware */
 	MC6809E(config, m_maincpu, 2000000);  /* MC68B09EP */
-	m_maincpu->set_addrmap(AS_PROGRAM, &dec8_state::cobra_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &oscar_state::cobra_map);
 
 	M6502(config, m_audiocpu, 1500000);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &dec8_state::dec8_s_map); /* NMIs are caused by the main CPU */
+	m_audiocpu->set_addrmap(AS_PROGRAM, &oscar_state::dec8_s_map); /* NMIs are caused by the main CPU */
 
 	/* video hardware */
 	BUFFERED_SPRITERAM8(config, m_spriteram);
@@ -2375,7 +2361,7 @@ void dec8_state::cobracom(machine_config &config)
 	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_MXC06(config, m_spritegen_mxc, 0);
-	m_spritegen_mxc->set_colpri_callback(FUNC(dec8_state::cobracom_colpri_cb));
+	m_spritegen_mxc->set_colpri_callback(FUNC(oscar_state::cobracom_colpri_cb));
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 //  m_screen->set_refresh_hz(58);
@@ -2383,14 +2369,14 @@ void dec8_state::cobracom(machine_config &config)
 //  m_screen->set_size(32*8, 32*8);
 //  m_screen->set_visarea(0*8, 32*8-1, 1*8, 31*8-1);
 	set_screen_raw_params_data_east(config);
-	m_screen->set_screen_update(FUNC(dec8_state::screen_update_cobracom));
+	m_screen->set_screen_update(FUNC(oscar_state::screen_update_cobracom));
 	m_screen->set_palette(m_palette);
 	m_screen->screen_vblank().set_inputline(m_maincpu, INPUT_LINE_NMI);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_cobracom);
 	DECO_RMC3(config, m_palette, 0, 256); // xxxxBBBBGGGGRRRR with custom weighting
 
-	MCFG_VIDEO_START_OVERRIDE(dec8_state,cobracom)
+	MCFG_VIDEO_START_OVERRIDE(oscar_state,cobracom)
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -3853,12 +3839,12 @@ ROM_START( cobracomjb )
 ROM_END
 
 
-void dec8_state::init_meikyuhbl()
+void lastmisn_state::init_meikyuhbl()
 {
 	// this bootleg has the high nibble of the first 0x400 bytes with reversed bits.
 	// Address it here instead of hacking the DECO RM-C3 device.
 
-	uint8_t *proms = memregion("proms")->base();
+	u8 *proms = memregion("proms")->base();
 
 	for (int i = 0; i < 0x400; i++)
 		proms[i] = bitswap<8>(proms[i], 4, 5, 6, 7, 3, 2, 1, 0);
@@ -3869,37 +3855,37 @@ void dec8_state::init_meikyuhbl()
 
 /******************************************************************************/
 
-GAME( 1986, lastmisn,   0,        lastmisn, lastmisn,  dec8_state,    empty_init,     ROT270, "Data East Corporation", "Last Mission (World revision 8)", MACHINE_SUPPORTS_SAVE )
-GAME( 1986, lastmisnu6, lastmisn, lastmisn, lastmisn,  dec8_state,    empty_init,     ROT270, "Data East USA",         "Last Mission (US revision 6)", MACHINE_SUPPORTS_SAVE )
-GAME( 1986, lastmisnu5, lastmisn, lastmisn, lastmisn,  dec8_state,    empty_init,     ROT270, "Data East USA",         "Last Mission (US revision 5)", MACHINE_SUPPORTS_SAVE )
-GAME( 1986, lastmisnj,  lastmisn, lastmisn, lastmisnj, dec8_state,    empty_init,     ROT270, "Data East Corporation", "Last Mission (Japan)", MACHINE_SUPPORTS_SAVE )
-GAME( 1986, shackled,   0,        shackled, shackled,  dec8_state,    empty_init,     ROT0,   "Data East USA",         "Shackled (US)", MACHINE_SUPPORTS_SAVE )
-GAME( 1986, breywood,   shackled, shackled, breywood,  dec8_state,    empty_init,     ROT0,   "Data East Corporation", "Breywood (Japan revision 2)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, gondo,      0,        gondo,    gondo,     dec8_state,    empty_init,     ROT270, "Data East Corporation", "Gondomania (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, gondou,     gondo,    gondo,    gondo,     dec8_state,    empty_init,     ROT270, "Data East USA",         "Gondomania (US)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, makyosen,   gondo,    gondo,    gondo,     dec8_state,    empty_init,     ROT270, "Data East Corporation", "Makyou Senshi (Japan)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, garyoret,   0,        garyoret, garyoret,  dec8_state,    empty_init,     ROT0,   "Data East Corporation", "Garyo Retsuden (Japan)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, ghostb,     0,        ghostb,   ghostb,    dec8_state,    empty_init,     ROT0,   "Data East USA",         "The Real Ghostbusters (US 2 Players, revision 2)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, ghostb2a,   ghostb,   ghostb,   ghostb2a,  dec8_state,    empty_init,     ROT0,   "Data East USA",         "The Real Ghostbusters (US 2 Players)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, ghostb3,    ghostb,   ghostb,   ghostb3,   dec8_state,    empty_init,     ROT0,   "Data East USA",         "The Real Ghostbusters (US 3 Players, revision 3B?)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, ghostb3a,   ghostb,   ghostb,   ghostb3,   dec8_state,    empty_init,     ROT0,   "Data East USA",         "The Real Ghostbusters (US 3 Players, revision 2)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // ROMs confirmed working on PCB - stalls in demo mode
-GAME( 1987, meikyuh,    ghostb,   meikyuh,  meikyuh,   dec8_state,    empty_init,     ROT0,   "Data East Corporation", "Meikyuu Hunter G (Japan)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, meikyuhbl,  ghostb,   meikyuh,  meikyuh,   dec8_state,    init_meikyuhbl, ROT0,   "Data East Corporation", "Meikyuu Hunter G (Japan, bootleg)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, csilver,    0,        csilver,  csilver,   csilver_state, empty_init,     ROT0,   "Data East Corporation", "Captain Silver (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, csilverj,   csilver,  csilver,  csilverj,  csilver_state, empty_init,     ROT0,   "Data East Corporation", "Captain Silver (Japan, revision 2)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, csilverja,  csilver,  csilver,  csilverj,  csilver_state, empty_init,     ROT0,   "Data East Corporation", "Captain Silver (Japan, revision 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, oscar,      0,        oscar,    oscar,     dec8_state,    empty_init,     ROT0,   "Data East Corporation", "Psycho-Nics Oscar (World revision 0)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, oscarbl,    oscar,    oscarbl,  oscar,     dec8_state,    empty_init,     ROT0,   "bootleg",               "Psycho-Nics Oscar (World revision 0, bootleg)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, oscaru,     oscar,    oscar,    oscarj,    dec8_state,    empty_init,     ROT0,   "Data East USA",         "Psycho-Nics Oscar (US)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, oscarj1,    oscar,    oscar,    oscarj,    dec8_state,    empty_init,     ROT0,   "Data East Corporation", "Psycho-Nics Oscar (Japan revision 1)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, oscarj2,    oscar,    oscar,    oscarj,    dec8_state,    empty_init,     ROT0,   "Data East Corporation", "Psycho-Nics Oscar (Japan revision 2)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, srdarwin,   0,        srdarwin, srdarwin,  dec8_state,    empty_init,     ROT270, "Data East Corporation", "Super Real Darwin (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1987, srdarwinj,  srdarwin, srdarwin, srdarwinj, dec8_state,    empty_init,     ROT270, "Data East Corporation", "Super Real Darwin (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1986, lastmisn,   0,        lastmisn, lastmisn,  lastmisn_state, empty_init,     ROT270, "Data East Corporation", "Last Mission (World revision 8)", MACHINE_SUPPORTS_SAVE )
+GAME( 1986, lastmisnu6, lastmisn, lastmisn, lastmisn,  lastmisn_state, empty_init,     ROT270, "Data East USA",         "Last Mission (US revision 6)", MACHINE_SUPPORTS_SAVE )
+GAME( 1986, lastmisnu5, lastmisn, lastmisn, lastmisn,  lastmisn_state, empty_init,     ROT270, "Data East USA",         "Last Mission (US revision 5)", MACHINE_SUPPORTS_SAVE )
+GAME( 1986, lastmisnj,  lastmisn, lastmisn, lastmisnj, lastmisn_state, empty_init,     ROT270, "Data East Corporation", "Last Mission (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1986, shackled,   0,        shackled, shackled,  lastmisn_state, empty_init,     ROT0,   "Data East USA",         "Shackled (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1986, breywood,   shackled, shackled, breywood,  lastmisn_state, empty_init,     ROT0,   "Data East Corporation", "Breywood (Japan revision 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, gondo,      0,        gondo,    gondo,     gondo_state,    empty_init,     ROT270, "Data East Corporation", "Gondomania (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, gondou,     gondo,    gondo,    gondo,     gondo_state,    empty_init,     ROT270, "Data East USA",         "Gondomania (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, makyosen,   gondo,    gondo,    gondo,     gondo_state,    empty_init,     ROT270, "Data East Corporation", "Makyou Senshi (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, garyoret,   0,        garyoret, garyoret,  lastmisn_state, empty_init,     ROT0,   "Data East Corporation", "Garyo Retsuden (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, ghostb,     0,        ghostb,   ghostb,    lastmisn_state, empty_init,     ROT0,   "Data East USA",         "The Real Ghostbusters (US 2 Players, revision 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, ghostb2a,   ghostb,   ghostb,   ghostb2a,  lastmisn_state, empty_init,     ROT0,   "Data East USA",         "The Real Ghostbusters (US 2 Players)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, ghostb3,    ghostb,   ghostb,   ghostb3,   lastmisn_state, empty_init,     ROT0,   "Data East USA",         "The Real Ghostbusters (US 3 Players, revision 3B?)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, ghostb3a,   ghostb,   ghostb,   ghostb3,   lastmisn_state, empty_init,     ROT0,   "Data East USA",         "The Real Ghostbusters (US 3 Players, revision 2)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // ROMs confirmed working on PCB - stalls in demo mode
+GAME( 1987, meikyuh,    ghostb,   meikyuh,  meikyuh,   lastmisn_state, empty_init,     ROT0,   "Data East Corporation", "Meikyuu Hunter G (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, meikyuhbl,  ghostb,   meikyuh,  meikyuh,   lastmisn_state, init_meikyuhbl, ROT0,   "Data East Corporation", "Meikyuu Hunter G (Japan, bootleg)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, csilver,    0,        csilver,  csilver,   csilver_state,  empty_init,     ROT0,   "Data East Corporation", "Captain Silver (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, csilverj,   csilver,  csilver,  csilverj,  csilver_state,  empty_init,     ROT0,   "Data East Corporation", "Captain Silver (Japan, revision 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, csilverja,  csilver,  csilver,  csilverj,  csilver_state,  empty_init,     ROT0,   "Data East Corporation", "Captain Silver (Japan, revision 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, oscar,      0,        oscar,    oscar,     oscar_state,    empty_init,     ROT0,   "Data East Corporation", "Psycho-Nics Oscar (World revision 0)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, oscarbl,    oscar,    oscarbl,  oscar,     oscar_state,    empty_init,     ROT0,   "bootleg",               "Psycho-Nics Oscar (World revision 0, bootleg)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, oscaru,     oscar,    oscar,    oscarj,    oscar_state,    empty_init,     ROT0,   "Data East USA",         "Psycho-Nics Oscar (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, oscarj1,    oscar,    oscar,    oscarj,    oscar_state,    empty_init,     ROT0,   "Data East Corporation", "Psycho-Nics Oscar (Japan revision 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, oscarj2,    oscar,    oscar,    oscarj,    oscar_state,    empty_init,     ROT0,   "Data East Corporation", "Psycho-Nics Oscar (Japan revision 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, srdarwin,   0,        srdarwin, srdarwin,  srdarwin_state, empty_init,     ROT270, "Data East Corporation", "Super Real Darwin (World)", MACHINE_SUPPORTS_SAVE )
+GAME( 1987, srdarwinj,  srdarwin, srdarwin, srdarwinj, srdarwin_state, empty_init,     ROT270, "Data East Corporation", "Super Real Darwin (Japan)", MACHINE_SUPPORTS_SAVE )
 
 // Unlike most Deco games of this period Cobra Command does not seem to have a Data East USA release.  Instead the Data East Corporation release
 // was used in the US as evidenced by boards with the EL romset bearing AAMA seal stickers (American Amusement Machine Association)
-GAME( 1988, cobracom,   0,        cobracom, cobracom,  dec8_state,    empty_init,     ROT0,   "Data East Corporation", "Cobra-Command (World/US revision 5)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, cobracoma,  cobracom, cobracom, cobracom,  dec8_state,    empty_init,     ROT0,   "Data East Corporation", "Cobra-Command (World/US revision 4)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, cobracomb,  cobracom, cobracom, cobracom,  dec8_state,    empty_init,     ROT0,   "Data East Corporation", "Cobra-Command (World/US)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, cobracomj,  cobracom, cobracom, cobracom,  dec8_state,    empty_init,     ROT0,   "Data East Corporation", "Cobra-Command (Japan)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, cobracomjb, cobracom, cobracom, cobracom,  dec8_state,    empty_init,     ROT0,   "bootleg",               "Cobra-Command (Japan, bootleg)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, cobracom,   0,        cobracom, cobracom,  oscar_state,    empty_init,     ROT0,   "Data East Corporation", "Cobra-Command (World/US revision 5)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, cobracoma,  cobracom, cobracom, cobracom,  oscar_state,    empty_init,     ROT0,   "Data East Corporation", "Cobra-Command (World/US revision 4)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, cobracomb,  cobracom, cobracom, cobracom,  oscar_state,    empty_init,     ROT0,   "Data East Corporation", "Cobra-Command (World/US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, cobracomj,  cobracom, cobracom, cobracom,  oscar_state,    empty_init,     ROT0,   "Data East Corporation", "Cobra-Command (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, cobracomjb, cobracom, cobracom, cobracom,  oscar_state,    empty_init,     ROT0,   "bootleg",               "Cobra-Command (Japan, bootleg)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/dataeast/dec8.cpp
+++ b/src/mame/dataeast/dec8.cpp
@@ -58,7 +58,7 @@ To do:
 /******************************************************************************/
 
 
-void base_state::buffer_spriteram16_w(u8 data)
+void dec8_state_base::buffer_spriteram16_w(u8 data)
 {
 	u8* spriteram = m_spriteram->live();
 	// copy to a 16-bit region for the sprite chip
@@ -78,17 +78,17 @@ void lastmisn_state::screen_vblank(int state)
 	}
 }
 
-u8 mcu_state::i8751_h_r()
+u8 dec8_mcu_state_base::i8751_h_r()
 {
 	return m_i8751_return >> 8; /* MSB */
 }
 
-u8 mcu_state::i8751_l_r()
+u8 dec8_mcu_state_base::i8751_l_r()
 {
 	return m_i8751_return & 0xff; /* LSB */
 }
 
-void mcu_state::i8751_reset_w(u8 data)
+void dec8_mcu_state_base::i8751_reset_w(u8 data)
 {
 	// ? reset the actual MCU?
 	//m_i8751_return = 0;
@@ -119,21 +119,21 @@ u8 gondo_state::player_io_r(offs_t offset)
 *
 ***************************************************/
 
-TIMER_CALLBACK_MEMBER(mcu_state::mcu_irq_clear)
+TIMER_CALLBACK_MEMBER(dec8_mcu_state_base::mcu_irq_clear)
 {
 	// The schematics show a clocked LS194 shift register (3A) is used to automatically
 	// clear the IRQ request.  The MCU does not clear it itself.
 	m_mcu->set_input_line(MCS51_INT1_LINE, CLEAR_LINE);
 }
 
-TIMER_CALLBACK_MEMBER(base_state::audiocpu_nmi_clear)
+TIMER_CALLBACK_MEMBER(dec8_state_base::audiocpu_nmi_clear)
 {
 	// Gondomania schematics show a LS194 for the sound IRQ, sharing the 6502 clock
 	// S1=H, S0=L, LSI=H, and QA is the only output connected (to NMI)
 	m_audiocpu->set_input_line(INPUT_LINE_NMI, CLEAR_LINE);
 }
 
-void mcu_state::i8751_w(offs_t offset, u8 data)
+void dec8_mcu_state_base::i8751_w(offs_t offset, u8 data)
 {
 	switch (offset)
 	{
@@ -196,7 +196,7 @@ void csilver_state::control_w(u8 data)
 	m_mainbank->set_entry(data & 0x0f);
 }
 
-void base_state::sound_w(u8 data)
+void dec8_state_base::sound_w(u8 data)
 {
 	m_soundlatch->write(data);
 	m_audiocpu->set_input_line(m6502_device::NMI_LINE, ASSERT_LINE);
@@ -231,39 +231,39 @@ void csilver_state::sound_bank_w(u8 data)
 
 /******************************************************************************/
 
-void base_state::main_irq_on_w(u8 data)
+void dec8_state_base::main_irq_on_w(u8 data)
 {
 	m_maincpu->set_input_line(M6809_IRQ_LINE, ASSERT_LINE);
 }
 
-void base_state::main_irq_off_w(u8 data)
+void dec8_state_base::main_irq_off_w(u8 data)
 {
 	m_maincpu->set_input_line(M6809_IRQ_LINE, CLEAR_LINE);
 }
 
-void base_state::main_firq_off_w(u8 data)
+void dec8_state_base::main_firq_off_w(u8 data)
 {
 	m_maincpu->set_input_line(M6809_FIRQ_LINE, CLEAR_LINE);
 }
 
-void base_state::sub_irq_on_w(u8 data)
+void dec8_state_base::sub_irq_on_w(u8 data)
 {
 	m_subcpu->set_input_line(M6809_IRQ_LINE, ASSERT_LINE);
 }
 
-void base_state::sub_irq_off_w(u8 data)
+void dec8_state_base::sub_irq_off_w(u8 data)
 {
 	m_subcpu->set_input_line(M6809_IRQ_LINE, CLEAR_LINE);
 }
 
-void base_state::sub_firq_off_w(u8 data)
+void dec8_state_base::sub_firq_off_w(u8 data)
 {
 	m_subcpu->set_input_line(M6809_FIRQ_LINE, CLEAR_LINE);
 }
 
 /******************************************************************************/
 
-void base_state::flip_screen_w(u8 data) { flip_screen_set(data); }
+void dec8_state_base::flip_screen_w(u8 data) { flip_screen_set(data); }
 
 /******************************************************************************/
 
@@ -288,7 +288,7 @@ void lastmisn_state::lastmisn_map(address_map &map)
 	map(0x2000, 0x27ff).ram().w(FUNC(lastmisn_state::videoram_w)).share(m_videoram);
 	map(0x2800, 0x2fff).ram().share("spriteram");
 	map(0x3000, 0x37ff).ram().share("share2");
-	map(0x3800, 0x3fff).rw(FUNC(lastmisn_state::bg_ram_r), FUNC(lastmisn_state::bg_ram_w)).share("bg_ram");
+	map(0x3800, 0x3fff).rw(FUNC(lastmisn_state::bg_ram_r), FUNC(lastmisn_state::bg_ram_w)).share(m_bg_ram);
 	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
@@ -574,7 +574,7 @@ void oscar_state::cobra_map(address_map &map)
 /******************************************************************************/
 
 /* Used for Cobra Command, Maze Hunter, Super Real Darwin etc */
-void base_state::dec8_s_map(address_map &map)
+void dec8_state_base::dec8_s_map(address_map &map)
 {
 	map(0x0000, 0x05ff).ram();
 	map(0x2000, 0x2001).w("ym1", FUNC(ym2203_device::write));
@@ -584,7 +584,7 @@ void base_state::dec8_s_map(address_map &map)
 }
 
 /* Used by Gondomania, Psycho-Nics Oscar & Garyo Retsuden */
-void base_state::oscar_s_map(address_map &map)
+void dec8_state_base::oscar_s_map(address_map &map)
 {
 	map(0x0000, 0x05ff).ram();
 	map(0x2000, 0x2001).w("ym1", FUNC(ym2203_device::write));
@@ -637,22 +637,22 @@ void csilver_state::sound_map(address_map &map)
 
 */
 
-u8 mcu_state::i8751_port0_r()
+u8 dec8_mcu_state_base::i8751_port0_r()
 {
 	return m_i8751_port0;
 }
 
-void mcu_state::i8751_port0_w(u8 data)
+void dec8_mcu_state_base::i8751_port0_w(u8 data)
 {
 	m_i8751_port0 = data;
 }
 
-u8 mcu_state::i8751_port1_r()
+u8 dec8_mcu_state_base::i8751_port1_r()
 {
 	return m_i8751_port1;
 }
 
-void mcu_state::i8751_port1_w(u8 data)
+void dec8_mcu_state_base::i8751_port1_w(u8 data)
 {
 	m_i8751_port1 = data;
 }
@@ -1778,30 +1778,30 @@ void lastmisn_state::shackled_coin_irq(int state)
 /******************************************************************************/
 
 
-void base_state::machine_start()
+void dec8_state_base::machine_start()
 {
 	u8 *ROM = memregion("maincpu")->base();
 	uint32_t max_bank = (memregion("maincpu")->bytes() - 0x10000) / 0x4000;
 	m_mainbank->configure_entries(0, max_bank, &ROM[0x10000], 0x4000);
 
-	m_m6502_timer = timer_alloc(FUNC(base_state::audiocpu_nmi_clear), this);
+	m_m6502_timer = timer_alloc(FUNC(dec8_state_base::audiocpu_nmi_clear), this);
 
 	save_item(NAME(m_coin_state));
 
 	save_item(NAME(m_scroll));
 }
 
-void base_state::machine_reset()
+void dec8_state_base::machine_reset()
 {
 	m_scroll[0] = m_scroll[1] = m_scroll[2] = m_scroll[3] = 0;
 }
 
 
-void mcu_state::machine_start()
+void dec8_mcu_state_base::machine_start()
 {
-	base_state::machine_start();
+	dec8_state_base::machine_start();
 
-	m_i8751_timer = timer_alloc(FUNC(mcu_state::mcu_irq_clear), this);
+	m_i8751_timer = timer_alloc(FUNC(dec8_mcu_state_base::mcu_irq_clear), this);
 	m_i8751_p2 = 0xff;
 
 	save_item(NAME(m_i8751_p2));
@@ -1811,9 +1811,9 @@ void mcu_state::machine_start()
 	save_item(NAME(m_i8751_value));
 }
 
-void mcu_state::machine_reset()
+void dec8_mcu_state_base::machine_reset()
 {
-	base_state::machine_reset();
+	dec8_state_base::machine_reset();
 
 	m_i8751_port0 = m_i8751_port1 = 0;
 	m_i8751_return = m_i8751_value = 0;
@@ -1822,14 +1822,14 @@ void mcu_state::machine_reset()
 
 void lastmisn_state::machine_start()
 {
-	mcu_state::machine_start();
+	dec8_mcu_state_base::machine_start();
 
 	save_item(NAME(m_secclr));
 }
 
 void lastmisn_state::machine_reset()
 {
-	base_state::machine_reset();
+	dec8_state_base::machine_reset();
 
 	// reset clears LS273 latch, which disables NMI
 	if (m_nmigate.found())
@@ -1858,7 +1858,7 @@ void csilver_state::machine_reset()
 
 
 // DECO video CRTC, unverified
-void base_state::set_screen_raw_params_data_east(machine_config &config)
+void dec8_state_base::set_screen_raw_params_data_east(machine_config &config)
 {
 	m_screen->set_raw(XTAL(12'000'000)/2,384,0,256,272,8,248);
 }

--- a/src/mame/dataeast/dec8.h
+++ b/src/mame/dataeast/dec8.h
@@ -17,74 +17,43 @@
 #include "screen.h"
 #include "tilemap.h"
 
-class dec8_state : public driver_device
+class base_state : public driver_device
 {
 public:
-	dec8_state(const machine_config &mconfig, device_type type, const char *tag) :
+	base_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
 		m_subcpu(*this, "sub"),
 		m_audiocpu(*this, "audiocpu"),
-		m_mcu(*this, "mcu"),
-		m_spritegen_krn(*this, "spritegen_krn"),
 		m_spriteram(*this, "spriteram") ,
 		m_screen(*this, "screen"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
 		m_soundlatch(*this, "soundlatch"),
-		m_mainbank(*this, "mainbank"),
-		m_nmigate(*this, "nmigate"),
 		m_tilegen(*this, "tilegen%u", 1),
-		m_spritegen_mxc(*this, "spritegen_mxc"),
+		m_mainbank(*this, "mainbank"),
 		m_videoram(*this, "videoram"),
-		m_bg_data(*this, "bg_data"),
-		m_coin_port(*this, "I8751")
+		m_bg_ram(*this, "bg_ram")
 	{ }
-
-	void shackled(machine_config &config);
-	void meikyuh(machine_config &config);
-	void lastmisn(machine_config &config);
-	void cobracom(machine_config &config);
-	void garyoret(machine_config &config);
-	void srdarwin(machine_config &config);
-	void ghostb(machine_config &config);
-	void oscar(machine_config &config);
-	void oscarbl(machine_config &config);
-	void gondo(machine_config &config);
-
-	void init_meikyuhbl();
 
 protected:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
-	TIMER_CALLBACK_MEMBER(mcu_irq_clear);
 	TIMER_CALLBACK_MEMBER(audiocpu_nmi_clear);
 
-	uint8_t i8751_h_r();
-	uint8_t i8751_l_r();
-	void dec8_i8751_w(offs_t offset, uint8_t data);
-
-	void dec8_mxc06_karn_buffer_spriteram_w(uint8_t data);
-	void dec8_sound_w(uint8_t data);
-	void main_irq_on_w(uint8_t data);
-	void main_irq_off_w(uint8_t data);
-	void main_firq_off_w(uint8_t data);
-	void sub_irq_on_w(uint8_t data);
-	void sub_irq_off_w(uint8_t data);
-	void flip_screen_w(uint8_t data);
-	void dec8_bg_data_w(offs_t offset, uint8_t data);
-	uint8_t dec8_bg_data_r(offs_t offset);
-	void dec8_videoram_w(offs_t offset, uint8_t data);
-	void dec8_scroll2_w(offs_t offset, uint8_t data);
-
-	uint8_t i8751_port0_r();
-	void i8751_port0_w(uint8_t data);
-	uint8_t i8751_port1_r();
-	void i8751_port1_w(uint8_t data);
-
-	DECLARE_VIDEO_START(lastmisn);
-	uint32_t screen_update_lastmisn(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void buffer_spriteram16_w(u8 data);
+	void sound_w(u8 data);
+	void main_irq_on_w(u8 data);
+	void main_irq_off_w(u8 data);
+	void main_firq_off_w(u8 data);
+	void sub_irq_on_w(u8 data);
+	void sub_irq_off_w(u8 data);
+	void sub_firq_off_w(u8 data);
+	void flip_screen_w(u8 data);
+	void bg_ram_w(offs_t offset, u8 data);
+	u8 bg_ram_r(offs_t offset);
+	void videoram_w(offs_t offset, u8 data);
 
 	void set_screen_raw_params_data_east(machine_config &config);
 
@@ -92,141 +61,255 @@ protected:
 	required_device<cpu_device> m_maincpu;
 	optional_device<cpu_device> m_subcpu;
 	required_device<cpu_device> m_audiocpu;
-	optional_device<i8751_device> m_mcu;
-	optional_device<deco_karnovsprites_device> m_spritegen_krn;
 	required_device<buffered_spriteram8_device> m_spriteram;
 	required_device<screen_device> m_screen;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<deco_rmc3_device> m_palette;
 	required_device<generic_latch_8_device> m_soundlatch;
+	optional_device_array<deco_bac06_device, 2> m_tilegen;
 
 	/* memory regions */
 	required_memory_bank m_mainbank;
 
-	// MCU communication
-	uint8_t  m_i8751_p2 = 0;
-	int      m_i8751_port0 = 0;
-	int      m_i8751_port1 = 0;
-	int      m_i8751_return = 0;
-	int      m_i8751_value = 0;
-
-private:
-	optional_device<input_merger_device> m_nmigate;
-	optional_device_array<deco_bac06_device, 2> m_tilegen;
-	optional_device<deco_mxc06_device> m_spritegen_mxc;
-
 	/* memory pointers */
-	required_shared_ptr<uint8_t> m_videoram;
-	optional_shared_ptr<uint8_t> m_bg_data;
+	required_shared_ptr<u8> m_videoram;
+	optional_shared_ptr<u8> m_bg_ram;
 
-	uint8_t *  m_pf1_data = nullptr;
-	uint8_t *  m_row = nullptr;
-	std::unique_ptr<uint16_t[]>   m_buffered_spriteram16; // for the mxc06 sprite chip emulation (oscar, cobra)
+	std::unique_ptr<u16[]>   m_buffered_spriteram16; // for the mxc06 sprite chip emulation (oscar, cobra)
 
 	/* video-related */
 	tilemap_t  *m_bg_tilemap = nullptr;
-	tilemap_t  *m_pf1_tilemap = nullptr;
 	tilemap_t  *m_fix_tilemap = nullptr;
-	//int      m_scroll1[4]{};
-	int      m_scroll2[4]{};
-	int      m_bg_control[0x20]{};
-	int      m_pf1_control[0x20]{};
+	int      m_scroll[4]{};
 	int      m_game_uses_priority = 0;
 
 	/* misc */
-	bool     m_secclr = false;
-	bool     m_nmi_enable = false;
-	int      m_coinage_id = 0;
-	int      m_coin1 = 0;
-	int      m_coin2 = 0;
-	int      m_need1 = 0;
-	int      m_need2 = 0;
-	int      m_cred1 = 0;
-	int      m_cred2 = 0;
-	int      m_credits = 0;
-	int      m_latch = 0;
 	bool     m_coin_state = false;
-	int      m_snd = 0;
 
-	emu_timer *m_i8751_timer = nullptr;
 	emu_timer *m_m6502_timer = nullptr;
 
-	void i8751_reset_w(uint8_t data);
-	uint8_t gondo_player_1_r(offs_t offset);
-	uint8_t gondo_player_2_r(offs_t offset);
-	void dec8_bank_w(uint8_t data);
-	void ghostb_bank_w(uint8_t data);
-	void sub_firq_off_w(uint8_t data);
-	void gondo_mcu_to_main_w(uint8_t data);
-	void shackled_mcu_to_main_w(uint8_t data);
-	void srdarwin_mcu_to_main_w(uint8_t data);
-	void srdarwin_videoram_w(offs_t offset, uint8_t data);
-	void srdarwin_control_w(offs_t offset, uint8_t data);
-	void lastmisn_control_w(uint8_t data);
-	void shackled_control_w(uint8_t data);
-	void lastmisn_scrollx_w(uint8_t data);
-	void lastmisn_scrolly_w(uint8_t data);
-	void gondo_scroll_w(offs_t offset, uint8_t data);
-	TILE_GET_INFO_MEMBER(get_cobracom_fix_tile_info);
-	TILE_GET_INFO_MEMBER(get_ghostb_fix_tile_info);
-	TILE_GET_INFO_MEMBER(get_oscar_fix_tile_info);
-	TILEMAP_MAPPER_MEMBER(lastmisn_scan_rows);
-	TILE_GET_INFO_MEMBER(get_lastmisn_tile_info);
-	TILE_GET_INFO_MEMBER(get_lastmisn_fix_tile_info);
-	TILE_GET_INFO_MEMBER(get_srdarwin_fix_tile_info);
-	TILE_GET_INFO_MEMBER(get_srdarwin_tile_info);
+	void allocate_buffered_spriteram16();
+	void dec8_s_map(address_map &map);
+	void oscar_s_map(address_map &map);
+
+};
+
+// with I8751 MCU
+class mcu_state : public base_state
+{
+public:
+	mcu_state(const machine_config &mconfig, device_type type, const char *tag) :
+		base_state(mconfig, type, tag),
+		m_mcu(*this, "mcu"),
+		m_coin_port(*this, "I8751")
+	{
+	}
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+	TIMER_CALLBACK_MEMBER(mcu_irq_clear);
+
+	required_device<i8751_device> m_mcu;
+
+	/* ports */
+	required_ioport m_coin_port;
+
+	u8 i8751_h_r();
+	u8 i8751_l_r();
+	void i8751_w(offs_t offset, u8 data);
+
+	u8 i8751_port0_r();
+	void i8751_port0_w(u8 data);
+	u8 i8751_port1_r();
+	void i8751_port1_w(u8 data);
+
+	void i8751_reset_w(u8 data);
+
+	// MCU communication
+	u8  m_i8751_p2 = 0;
+	int m_i8751_port0 = 0;
+	int m_i8751_port1 = 0;
+	int m_i8751_return = 0;
+	int m_i8751_value = 0;
+
+	emu_timer *m_i8751_timer = nullptr;
+};
+
+// with unique sprite hardware
+class srdarwin_state : public mcu_state
+{
+public:
+	srdarwin_state(const machine_config &mconfig, device_type type, const char *tag) :
+		mcu_state(mconfig, type, tag)
+	{
+	}
+	void srdarwin(machine_config &config);
+
+protected:
+	virtual void video_start() override;
+
+private:
+	void mcu_to_main_w(u8 data);
+	void srdarwin_videoram_w(offs_t offset, u8 data);
+	void control_w(offs_t offset, u8 data);
+
+	TILE_GET_INFO_MEMBER(get_fix_tile_info);
+	TILE_GET_INFO_MEMBER(get_tile_info);
+
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &primap);
+
+	void main_map(address_map &map);
+};
+
+// with 'karnov' sprite hardware
+class lastmisn_state : public mcu_state
+{
+public:
+	lastmisn_state(const machine_config &mconfig, device_type type, const char *tag) :
+		mcu_state(mconfig, type, tag),
+		m_spritegen_krn(*this, "spritegen_krn"),
+		m_nmigate(*this, "nmigate")
+	{
+	}
+
+	void garyoret(machine_config &config);
+	void ghostb(machine_config &config);
+	void lastmisn(machine_config &config);
+	void meikyuh(machine_config &config);
+	void shackled(machine_config &config);
+
+	void init_meikyuhbl();
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+	required_device<deco_karnovsprites_device> m_spritegen_krn;
+	optional_device<input_merger_device> m_nmigate;
+
+	void ghostb_bank_w(u8 data);
+	void gondo_scroll_w(offs_t offset, u8 data);
+	void gondo_mcu_to_main_w(u8 data);
+
 	TILE_GET_INFO_MEMBER(get_gondo_fix_tile_info);
 	TILE_GET_INFO_MEMBER(get_gondo_tile_info);
-	DECLARE_VIDEO_START(shackled);
-	DECLARE_VIDEO_START(gondo);
+
+	DECLARE_VIDEO_START(lastmisn);
+	uint32_t screen_update_lastmisn(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	void screen_vblank(int state);
+
+private:
+	bool     m_secclr = false;
+	bool     m_nmi_enable = false;
+
+	void lastmisn_control_w(u8 data);
+	void shackled_control_w(u8 data);
+	void lastmisn_scrollx_w(u8 data);
+	void lastmisn_scrolly_w(u8 data);
+	void shackled_mcu_to_main_w(u8 data);
+
+	TILEMAP_MAPPER_MEMBER(lastmisn_scan_rows);
+
+	TILE_GET_INFO_MEMBER(get_ghostb_fix_tile_info);
+	TILE_GET_INFO_MEMBER(get_lastmisn_tile_info);
+	TILE_GET_INFO_MEMBER(get_lastmisn_fix_tile_info);
+
 	DECLARE_VIDEO_START(garyoret);
 	DECLARE_VIDEO_START(ghostb);
-	DECLARE_VIDEO_START(oscar);
-	DECLARE_VIDEO_START(srdarwin);
-	DECLARE_VIDEO_START(cobracom);
-	void allocate_buffered_spriteram16();
-	uint32_t screen_update_shackled(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_gondo(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_garyoret(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	DECLARE_VIDEO_START(shackled);
+
 	uint32_t screen_update_ghostb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_oscar(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_srdarwin(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_cobracom(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void screen_vblank_dec8(int state);
-	void oscar_coin_irq(int state);
-	void oscar_coin_clear_w(uint8_t data);
+	uint32_t screen_update_garyoret(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update_shackled(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
 	void shackled_coin_irq(int state);
-	void srdarwin_draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &primap);
+
+	void lastmisn_map(address_map &map);
+	void lastmisn_sub_map(address_map &map);
+	void garyoret_map(address_map &map);
+	void meikyuh_map(address_map &map);
+	void shackled_map(address_map &map);
+	void shackled_sub_map(address_map &map);
+	void ym3526_s_map(address_map &map);
+};
+
+// with rotary joystick
+class gondo_state : public lastmisn_state
+{
+public:
+	gondo_state(const machine_config &mconfig, device_type type, const char *tag) :
+		lastmisn_state(mconfig, type, tag),
+		m_analog_io(*this, "AN%u", 0U),
+		m_in_io(*this, "IN%u", 0U)
+	{
+	}
+
+	void gondo(machine_config &config);
+
+protected:
+	virtual void video_start() override;
+
+private:
+	required_ioport_array<2> m_analog_io;
+	required_ioport_array<4> m_in_io;
+
+	template<unsigned Which> u8 player_io_r(offs_t offset);
+
+	uint32_t screen_update_gondo(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
 	void gondo_colpri_cb(u32 &colour, u32 &pri_mask);
+
+	void gondo_map(address_map &map);
+};
+
+// with MXC06 sprite hardware
+class oscar_state : public base_state
+{
+public:
+	oscar_state(const machine_config &mconfig, device_type type, const char *tag) :
+		base_state(mconfig, type, tag),
+		m_spritegen_mxc(*this, "spritegen_mxc")
+	{
+	}
+
+	void cobracom(machine_config &config);
+	void oscar(machine_config &config);
+	void oscarbl(machine_config &config);
+
+private:
+	required_device<deco_mxc06_device> m_spritegen_mxc;
+
+	void bank_w(u8 data);
+
+	TILE_GET_INFO_MEMBER(get_cobracom_fix_tile_info);
+	TILE_GET_INFO_MEMBER(get_oscar_fix_tile_info);
+
+	DECLARE_VIDEO_START(cobracom);
+	DECLARE_VIDEO_START(oscar);
+
+	uint32_t screen_update_cobracom(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update_oscar(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	void coin_irq(int state);
+	void coin_clear_w(u8 data);
 	void cobracom_colpri_cb(u32 &colour, u32 &pri_mask);
 	void oscar_tile_cb(tile_data &tileinfo, u32 &tile, u32 &colour, u32 &flags);
 
 	void cobra_map(address_map &map);
-	void dec8_s_map(address_map &map);
-	void garyoret_map(address_map &map);
-	void gondo_map(address_map &map);
-	void lastmisn_map(address_map &map);
-	void lastmisn_sub_map(address_map &map);
-	void meikyuh_map(address_map &map);
 	void oscar_map(address_map &map);
-	void oscar_s_map(address_map &map);
 	void oscarbl_s_opcodes_map(address_map &map);
 	void oscar_sub_map(address_map &map);
-	void shackled_map(address_map &map);
-	void shackled_sub_map(address_map &map);
-	void srdarwin_map(address_map &map);
-	void ym3526_s_map(address_map &map);
-
-	/* ports */
-	optional_ioport m_coin_port;
 };
 
-
-class csilver_state : public dec8_state
+// with MSM5205 ADPCM
+class csilver_state : public lastmisn_state
 {
 public:
 	csilver_state(const machine_config &mconfig, device_type type, const char *tag) :
-		dec8_state(mconfig, type, tag),
+		lastmisn_state(mconfig, type, tag),
 		m_msm(*this, "msm"),
 		m_soundbank(*this, "soundbank")
 	{
@@ -239,22 +322,23 @@ protected:
 	virtual void machine_reset() override;
 
 private:
-	void csilver_control_w(uint8_t data);
-	void csilver_adpcm_data_w(uint8_t data);
-	void csilver_sound_bank_w(uint8_t data);
-	void csilver_mcu_to_main_w(uint8_t data);
-	uint8_t csilver_adpcm_reset_r();
-	void csilver_adpcm_int(int state);
-
-	void csilver_map(address_map &map);
-	void csilver_s_map(address_map &map);
-	void csilver_sub_map(address_map &map);
-
 	required_device<msm5205_device> m_msm;
 	required_memory_bank m_soundbank;
 
 	int      m_toggle = 0;
 	int      m_msm5205next = 0;
+
+	void scroll_w(offs_t offset, u8 data);
+	void control_w(u8 data);
+	void adpcm_data_w(u8 data);
+	void sound_bank_w(u8 data);
+	void mcu_to_main_w(u8 data);
+	u8 adpcm_reset_r();
+	void adpcm_int(int state);
+
+	void main_map(address_map &map);
+	void sound_map(address_map &map);
+	void sub_map(address_map &map);
 };
 
 #endif // MAME_DATAEAST_DEC8_H

--- a/src/mame/dataeast/dec8.h
+++ b/src/mame/dataeast/dec8.h
@@ -5,17 +5,20 @@
 
 #pragma once
 
+#include "decbac06.h"
+#include "deckarn.h"
+#include "decmxc06.h"
+#include "decrmc3.h"
+
 #include "cpu/mcs51/mcs51.h"
 #include "machine/gen_latch.h"
 #include "machine/input_merger.h"
 #include "sound/msm5205.h"
 #include "video/bufsprite.h"
-#include "decbac06.h"
-#include "deckarn.h"
-#include "decmxc06.h"
-#include "decrmc3.h"
+
 #include "screen.h"
 #include "tilemap.h"
+
 
 class dec8_state_base : public driver_device
 {
@@ -35,26 +38,6 @@ protected:
 		m_videoram(*this, "videoram"),
 		m_bg_ram(*this, "bg_ram")
 	{ }
-
-	/* devices */
-	required_device<cpu_device> m_maincpu;
-	optional_device<cpu_device> m_subcpu;
-	required_device<cpu_device> m_audiocpu;
-	required_device<buffered_spriteram8_device> m_spriteram;
-	required_device<screen_device> m_screen;
-	required_device<gfxdecode_device> m_gfxdecode;
-	required_device<deco_rmc3_device> m_palette;
-	required_device<generic_latch_8_device> m_soundlatch;
-	optional_device_array<deco_bac06_device, 2> m_tilegen;
-
-	/* memory regions */
-	required_memory_bank m_mainbank;
-
-	/* memory pointers */
-	required_shared_ptr<u8> m_videoram;
-	optional_shared_ptr<u8> m_bg_ram;
-
-	std::unique_ptr<u16[]>   m_buffered_spriteram16; // for the mxc06 sprite chip emulation (oscar, cobra)
 
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
@@ -76,6 +59,30 @@ protected:
 
 	void set_screen_raw_params_data_east(machine_config &config);
 
+	void allocate_buffered_spriteram16();
+	void dec8_s_map(address_map &map);
+	void oscar_s_map(address_map &map);
+
+	/* devices */
+	required_device<cpu_device> m_maincpu;
+	optional_device<cpu_device> m_subcpu;
+	required_device<cpu_device> m_audiocpu;
+	required_device<buffered_spriteram8_device> m_spriteram;
+	required_device<screen_device> m_screen;
+	required_device<gfxdecode_device> m_gfxdecode;
+	required_device<deco_rmc3_device> m_palette;
+	required_device<generic_latch_8_device> m_soundlatch;
+	optional_device_array<deco_bac06_device, 2> m_tilegen;
+
+	/* memory regions */
+	required_memory_bank m_mainbank;
+
+	/* memory pointers */
+	required_shared_ptr<u8> m_videoram;
+	optional_shared_ptr<u8> m_bg_ram;
+
+	std::unique_ptr<u16[]>   m_buffered_spriteram16; // for the mxc06 sprite chip emulation (oscar, cobra)
+
 	/* video-related */
 	tilemap_t  *m_bg_tilemap = nullptr;
 	tilemap_t  *m_fix_tilemap = nullptr;
@@ -86,11 +93,6 @@ protected:
 	bool     m_coin_state = false;
 
 	emu_timer *m_m6502_timer = nullptr;
-
-	void allocate_buffered_spriteram16();
-	void dec8_s_map(address_map &map);
-	void oscar_s_map(address_map &map);
-
 };
 
 // with I8751 MCU
@@ -103,11 +105,6 @@ protected:
 		m_coin_port(*this, "I8751")
 	{
 	}
-
-	required_device<i8751_device> m_mcu;
-
-	/* ports */
-	required_ioport m_coin_port;
 
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
@@ -124,6 +121,11 @@ protected:
 	void i8751_port1_w(u8 data);
 
 	void i8751_reset_w(u8 data);
+
+	required_device<i8751_device> m_mcu;
+
+	/* ports */
+	required_ioport m_coin_port;
 
 	// MCU communication
 	u8  m_i8751_p2 = 0;
@@ -143,6 +145,7 @@ public:
 		dec8_mcu_state_base(mconfig, type, tag)
 	{
 	}
+
 	void srdarwin(machine_config &config);
 
 protected:
@@ -182,9 +185,6 @@ public:
 	void init_meikyuhbl();
 
 protected:
-	required_device<deco_karnovsprites_device> m_spritegen_krn;
-	optional_device<input_merger_device> m_nmigate;
-
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
@@ -200,10 +200,10 @@ protected:
 
 	void screen_vblank(int state);
 
-private:
-	bool     m_secclr = false;
-	bool     m_nmi_enable = false;
+	required_device<deco_karnovsprites_device> m_spritegen_krn;
+	optional_device<input_merger_device> m_nmigate;
 
+private:
 	void lastmisn_control_w(u8 data);
 	void shackled_control_w(u8 data);
 	void lastmisn_scrollx_w(u8 data);
@@ -233,6 +233,9 @@ private:
 	void shackled_map(address_map &map);
 	void shackled_sub_map(address_map &map);
 	void ym3526_s_map(address_map &map);
+
+	bool     m_secclr = false;
+	bool     m_nmi_enable = false;
 };
 
 // with rotary joystick
@@ -252,9 +255,6 @@ protected:
 	virtual void video_start() override;
 
 private:
-	required_ioport_array<2> m_analog_io;
-	required_ioport_array<4> m_in_io;
-
 	template<unsigned Which> u8 player_io_r(offs_t offset);
 
 	uint32_t screen_update_gondo(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
@@ -262,6 +262,9 @@ private:
 	void gondo_colpri_cb(u32 &colour, u32 &pri_mask);
 
 	void gondo_map(address_map &map);
+
+	required_ioport_array<2> m_analog_io;
+	required_ioport_array<4> m_in_io;
 };
 
 // with MXC06 sprite hardware
@@ -279,8 +282,6 @@ public:
 	void oscarbl(machine_config &config);
 
 private:
-	required_device<deco_mxc06_device> m_spritegen_mxc;
-
 	void bank_w(u8 data);
 
 	TILE_GET_INFO_MEMBER(get_cobracom_fix_tile_info);
@@ -301,6 +302,8 @@ private:
 	void oscar_map(address_map &map);
 	void oscarbl_s_opcodes_map(address_map &map);
 	void oscar_sub_map(address_map &map);
+
+	required_device<deco_mxc06_device> m_spritegen_mxc;
 };
 
 // with MSM5205 ADPCM
@@ -321,12 +324,6 @@ protected:
 	virtual void machine_reset() override;
 
 private:
-	required_device<msm5205_device> m_msm;
-	required_memory_bank m_soundbank;
-
-	int      m_toggle = 0;
-	int      m_msm5205next = 0;
-
 	void scroll_w(offs_t offset, u8 data);
 	void control_w(u8 data);
 	void adpcm_data_w(u8 data);
@@ -338,6 +335,12 @@ private:
 	void main_map(address_map &map);
 	void sound_map(address_map &map);
 	void sub_map(address_map &map);
+
+	required_device<msm5205_device> m_msm;
+	required_memory_bank m_soundbank;
+
+	int      m_toggle = 0;
+	int      m_msm5205next = 0;
 };
 
 #endif // MAME_DATAEAST_DEC8_H

--- a/src/mame/dataeast/dec8.h
+++ b/src/mame/dataeast/dec8.h
@@ -17,10 +17,10 @@
 #include "screen.h"
 #include "tilemap.h"
 
-class base_state : public driver_device
+class dec8_state_base : public driver_device
 {
-public:
-	base_state(const machine_config &mconfig, device_type type, const char *tag) :
+protected:
+	dec8_state_base(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
 		m_subcpu(*this, "sub"),
@@ -35,27 +35,6 @@ public:
 		m_videoram(*this, "videoram"),
 		m_bg_ram(*this, "bg_ram")
 	{ }
-
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-
-	TIMER_CALLBACK_MEMBER(audiocpu_nmi_clear);
-
-	void buffer_spriteram16_w(u8 data);
-	void sound_w(u8 data);
-	void main_irq_on_w(u8 data);
-	void main_irq_off_w(u8 data);
-	void main_firq_off_w(u8 data);
-	void sub_irq_on_w(u8 data);
-	void sub_irq_off_w(u8 data);
-	void sub_firq_off_w(u8 data);
-	void flip_screen_w(u8 data);
-	void bg_ram_w(offs_t offset, u8 data);
-	u8 bg_ram_r(offs_t offset);
-	void videoram_w(offs_t offset, u8 data);
-
-	void set_screen_raw_params_data_east(machine_config &config);
 
 	/* devices */
 	required_device<cpu_device> m_maincpu;
@@ -77,6 +56,26 @@ protected:
 
 	std::unique_ptr<u16[]>   m_buffered_spriteram16; // for the mxc06 sprite chip emulation (oscar, cobra)
 
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+	TIMER_CALLBACK_MEMBER(audiocpu_nmi_clear);
+
+	void buffer_spriteram16_w(u8 data);
+	void sound_w(u8 data);
+	void main_irq_on_w(u8 data);
+	void main_irq_off_w(u8 data);
+	void main_firq_off_w(u8 data);
+	void sub_irq_on_w(u8 data);
+	void sub_irq_off_w(u8 data);
+	void sub_firq_off_w(u8 data);
+	void flip_screen_w(u8 data);
+	void bg_ram_w(offs_t offset, u8 data);
+	u8 bg_ram_r(offs_t offset);
+	void videoram_w(offs_t offset, u8 data);
+
+	void set_screen_raw_params_data_east(machine_config &config);
+
 	/* video-related */
 	tilemap_t  *m_bg_tilemap = nullptr;
 	tilemap_t  *m_fix_tilemap = nullptr;
@@ -95,25 +94,25 @@ protected:
 };
 
 // with I8751 MCU
-class mcu_state : public base_state
+class dec8_mcu_state_base : public dec8_state_base
 {
-public:
-	mcu_state(const machine_config &mconfig, device_type type, const char *tag) :
-		base_state(mconfig, type, tag),
+protected:
+	dec8_mcu_state_base(const machine_config &mconfig, device_type type, const char *tag) :
+		dec8_state_base(mconfig, type, tag),
 		m_mcu(*this, "mcu"),
 		m_coin_port(*this, "I8751")
 	{
 	}
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-
-	TIMER_CALLBACK_MEMBER(mcu_irq_clear);
 
 	required_device<i8751_device> m_mcu;
 
 	/* ports */
 	required_ioport m_coin_port;
+
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+	TIMER_CALLBACK_MEMBER(mcu_irq_clear);
 
 	u8 i8751_h_r();
 	u8 i8751_l_r();
@@ -137,11 +136,11 @@ protected:
 };
 
 // with unique sprite hardware
-class srdarwin_state : public mcu_state
+class srdarwin_state : public dec8_mcu_state_base
 {
 public:
 	srdarwin_state(const machine_config &mconfig, device_type type, const char *tag) :
-		mcu_state(mconfig, type, tag)
+		dec8_mcu_state_base(mconfig, type, tag)
 	{
 	}
 	void srdarwin(machine_config &config);
@@ -164,11 +163,11 @@ private:
 };
 
 // with 'karnov' sprite hardware
-class lastmisn_state : public mcu_state
+class lastmisn_state : public dec8_mcu_state_base
 {
 public:
 	lastmisn_state(const machine_config &mconfig, device_type type, const char *tag) :
-		mcu_state(mconfig, type, tag),
+		dec8_mcu_state_base(mconfig, type, tag),
 		m_spritegen_krn(*this, "spritegen_krn"),
 		m_nmigate(*this, "nmigate")
 	{
@@ -183,11 +182,11 @@ public:
 	void init_meikyuhbl();
 
 protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-
 	required_device<deco_karnovsprites_device> m_spritegen_krn;
 	optional_device<input_merger_device> m_nmigate;
+
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
 
 	void ghostb_bank_w(u8 data);
 	void gondo_scroll_w(offs_t offset, u8 data);
@@ -266,11 +265,11 @@ private:
 };
 
 // with MXC06 sprite hardware
-class oscar_state : public base_state
+class oscar_state : public dec8_state_base
 {
 public:
 	oscar_state(const machine_config &mconfig, device_type type, const char *tag) :
-		base_state(mconfig, type, tag),
+		dec8_state_base(mconfig, type, tag),
 		m_spritegen_mxc(*this, "spritegen_mxc")
 	{
 	}

--- a/src/mame/dataeast/dec8_v.cpp
+++ b/src/mame/dataeast/dec8_v.cpp
@@ -46,52 +46,52 @@ sprites.
 #include "emu.h"
 #include "dec8.h"
 
-void dec8_state::dec8_bg_data_w(offs_t offset, uint8_t data)
+void base_state::bg_ram_w(offs_t offset, u8 data)
 {
-	m_bg_data[offset] = data;
+	m_bg_ram[offset] = data;
 	m_bg_tilemap->mark_tile_dirty(offset / 2);
 }
 
-uint8_t dec8_state::dec8_bg_data_r(offs_t offset)
+u8 base_state::bg_ram_r(offs_t offset)
 {
-	return m_bg_data[offset];
+	return m_bg_ram[offset];
 }
 
 
-void dec8_state::dec8_videoram_w(offs_t offset, uint8_t data)
+void base_state::videoram_w(offs_t offset, u8 data)
 {
 	m_videoram[offset] = data;
 	m_fix_tilemap->mark_tile_dirty(offset / 2);
 }
 
-void dec8_state::srdarwin_videoram_w(offs_t offset, uint8_t data)
+void srdarwin_state::srdarwin_videoram_w(offs_t offset, u8 data)
 {
 	m_videoram[offset] = data;
 	m_fix_tilemap->mark_tile_dirty(offset);
 }
 
 
-void dec8_state::dec8_scroll2_w(offs_t offset, uint8_t data)
+void csilver_state::scroll_w(offs_t offset, u8 data)
 {
-	m_scroll2[offset] = data;
+	m_scroll[offset] = data;
 }
 
-void dec8_state::srdarwin_control_w(offs_t offset, uint8_t data)
+void srdarwin_state::control_w(offs_t offset, u8 data)
 {
 	switch (offset)
 	{
 	case 0: /* Top 3 bits - bank switch, bottom 4 - scroll MSB */
 		m_mainbank->set_entry((data >> 5));
-		m_scroll2[0] = data & 0xf;
+		m_scroll[0] = data & 0xf;
 		return;
 
 	case 1:
-		m_scroll2[1] = data;
+		m_scroll[1] = data;
 		return;
 	}
 }
 
-void dec8_state::lastmisn_control_w(uint8_t data)
+void lastmisn_state::lastmisn_control_w(u8 data)
 {
 	/*
 	    Bit 0x0f - ROM bank switch.
@@ -102,8 +102,8 @@ void dec8_state::lastmisn_control_w(uint8_t data)
 	*/
 	m_mainbank->set_entry(data & 0x0f);
 
-	m_scroll2[0] = (data >> 5) & 1;
-	m_scroll2[2] = (data >> 6) & 1;
+	m_scroll[0] = (data >> 5) & 1;
+	m_scroll[2] = (data >> 6) & 1;
 
 	if (data & 0x80)
 		m_subcpu->set_input_line(INPUT_LINE_RESET, CLEAR_LINE);
@@ -111,55 +111,55 @@ void dec8_state::lastmisn_control_w(uint8_t data)
 		m_subcpu->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
 }
 
-void dec8_state::shackled_control_w(uint8_t data)
+void lastmisn_state::shackled_control_w(u8 data)
 {
 	/* Bottom 4 bits - bank switch, Bits 4 & 5 - Scroll MSBs */
 	m_mainbank->set_entry(data & 0x0f);
 
-	m_scroll2[0] = (data >> 5) & 1;
-	m_scroll2[2] = (data >> 6) & 1;
+	m_scroll[0] = (data >> 5) & 1;
+	m_scroll[2] = (data >> 6) & 1;
 }
 
-void dec8_state::lastmisn_scrollx_w(uint8_t data)
+void lastmisn_state::lastmisn_scrollx_w(u8 data)
 {
-	m_scroll2[1] = data;
+	m_scroll[1] = data;
 }
 
-void dec8_state::lastmisn_scrolly_w(uint8_t data)
+void lastmisn_state::lastmisn_scrolly_w(u8 data)
 {
-	m_scroll2[3] = data;
+	m_scroll[3] = data;
 }
 
-void dec8_state::gondo_scroll_w(offs_t offset, uint8_t data)
+void lastmisn_state::gondo_scroll_w(offs_t offset, u8 data)
 {
 	switch (offset)
 	{
 	case 0x0:
-		m_scroll2[1] = data; /* X LSB */
+		m_scroll[1] = data; /* X LSB */
 		break;
 	case 0x8:
-		m_scroll2[3] = data; /* Y LSB */
+		m_scroll[3] = data; /* Y LSB */
 		break;
 	case 0x10:
-		m_scroll2[0] = (data >> 0) & 1; /* Bit 0: X MSB */
-		m_scroll2[2] = (data >> 1) & 1; /* Bit 1: Y MSB */
+		m_scroll[0] = (data >> 0) & 1; /* Bit 0: X MSB */
+		m_scroll[2] = (data >> 1) & 1; /* Bit 1: Y MSB */
 		/* Bit 2 is also used in Gondo & Garyoret */
 		break;
 	}
 }
 
-void dec8_state::allocate_buffered_spriteram16()
+void base_state::allocate_buffered_spriteram16()
 {
-	m_buffered_spriteram16 = make_unique_clear<uint16_t[]>(0x800/2);
+	m_buffered_spriteram16 = make_unique_clear<u16[]>(0x800/2);
 	save_pointer(NAME(m_buffered_spriteram16), 0x800/2);
 }
 
 /******************************************************************************/
 
 
-void dec8_state::srdarwin_draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &primap)
+void srdarwin_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &primap)
 {
-	uint8_t *buffered_spriteram = m_spriteram->buffer();
+	u8 *buffered_spriteram = m_spriteram->buffer();
 
 	/* Sprites */
 	for (int offs = 0x200 - 4; offs >= 0; offs -= 4)
@@ -206,7 +206,7 @@ void dec8_state::srdarwin_draw_sprites(bitmap_ind16 &bitmap, const rectangle &cl
 
 /******************************************************************************/
 
-void dec8_state::cobracom_colpri_cb(u32 &colour, u32 &pri_mask)
+void oscar_state::cobracom_colpri_cb(u32 &colour, u32 &pri_mask)
 {
 	pri_mask = 0; // above foreground, background
 	if ((colour & 4) == 0)
@@ -215,7 +215,7 @@ void dec8_state::cobracom_colpri_cb(u32 &colour, u32 &pri_mask)
 	colour &= 3;
 }
 
-uint32_t dec8_state::screen_update_cobracom(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t oscar_state::screen_update_cobracom(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0,cliprect);
 	bool flip = m_tilegen[0]->get_flip_state();
@@ -234,7 +234,7 @@ uint32_t dec8_state::screen_update_cobracom(screen_device &screen, bitmap_ind16 
 /******************************************************************************/
 
 
-TILE_GET_INFO_MEMBER(dec8_state::get_cobracom_fix_tile_info)
+TILE_GET_INFO_MEMBER(oscar_state::get_cobracom_fix_tile_info)
 {
 	int offs = tile_index << 1;
 	int tile = m_videoram[offs + 1] + (m_videoram[offs] << 8);
@@ -246,10 +246,10 @@ TILE_GET_INFO_MEMBER(dec8_state::get_cobracom_fix_tile_info)
 			0);
 }
 
-VIDEO_START_MEMBER(dec8_state,cobracom)
+VIDEO_START_MEMBER(oscar_state,cobracom)
 {
 	allocate_buffered_spriteram16();
-	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_cobracom_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(oscar_state::get_cobracom_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 
 	m_fix_tilemap->set_transparent_pen(0);
 
@@ -258,7 +258,7 @@ VIDEO_START_MEMBER(dec8_state,cobracom)
 
 /******************************************************************************/
 
-uint32_t dec8_state::screen_update_ghostb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t lastmisn_state::screen_update_ghostb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 0);
 	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(1), m_buffered_spriteram16.get(), 0x400);
@@ -266,7 +266,7 @@ uint32_t dec8_state::screen_update_ghostb(screen_device &screen, bitmap_ind16 &b
 	return 0;
 }
 
-TILE_GET_INFO_MEMBER(dec8_state::get_ghostb_fix_tile_info)
+TILE_GET_INFO_MEMBER(lastmisn_state::get_ghostb_fix_tile_info)
 {
 	int offs = tile_index << 1;
 	int tile = m_videoram[offs + 1] + (m_videoram[offs] << 8);
@@ -278,10 +278,10 @@ TILE_GET_INFO_MEMBER(dec8_state::get_ghostb_fix_tile_info)
 			0);
 }
 
-VIDEO_START_MEMBER(dec8_state,ghostb)
+VIDEO_START_MEMBER(lastmisn_state,ghostb)
 {
 	allocate_buffered_spriteram16();
-	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_ghostb_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(lastmisn_state::get_ghostb_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 	m_fix_tilemap->set_transparent_pen(0);
 
 	m_game_uses_priority = 0;
@@ -293,13 +293,13 @@ VIDEO_START_MEMBER(dec8_state,ghostb)
 /******************************************************************************/
 
 // we mimic the priority scheme in dec0.cpp, this was originally a bit different, so this could be wrong
-void dec8_state::oscar_tile_cb(tile_data &tileinfo, u32 &tile, u32 &colour, u32 &flags)
+void oscar_state::oscar_tile_cb(tile_data &tileinfo, u32 &tile, u32 &colour, u32 &flags)
 {
 	tileinfo.group = BIT(colour, 3) ? 1 : 0;
 	colour &= 7;
 }
 
-uint32_t dec8_state::screen_update_oscar(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t oscar_state::screen_update_oscar(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bool flip = m_tilegen[0]->get_flip_state();
 	m_tilegen[0]->set_flip_screen(flip);
@@ -313,7 +313,7 @@ uint32_t dec8_state::screen_update_oscar(screen_device &screen, bitmap_ind16 &bi
 	return 0;
 }
 
-TILE_GET_INFO_MEMBER(dec8_state::get_oscar_fix_tile_info)
+TILE_GET_INFO_MEMBER(oscar_state::get_oscar_fix_tile_info)
 {
 	int offs = tile_index << 1;
 	int tile = m_videoram[offs + 1] + (m_videoram[offs] << 8);
@@ -325,10 +325,10 @@ TILE_GET_INFO_MEMBER(dec8_state::get_oscar_fix_tile_info)
 			0);
 }
 
-VIDEO_START_MEMBER(dec8_state,oscar)
+VIDEO_START_MEMBER(oscar_state,oscar)
 {
 	allocate_buffered_spriteram16();
-	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_oscar_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(oscar_state::get_oscar_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 
 	m_fix_tilemap->set_transparent_pen(0);
 	m_tilegen[0]->set_transmask(0, 0xffff, 0x0000);
@@ -339,10 +339,10 @@ VIDEO_START_MEMBER(dec8_state,oscar)
 
 /******************************************************************************/
 
-uint32_t dec8_state::screen_update_lastmisn(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t lastmisn_state::screen_update_lastmisn(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	m_bg_tilemap->set_scrollx(0, ((m_scroll2[0] << 8)+ m_scroll2[1]));
-	m_bg_tilemap->set_scrolly(0, ((m_scroll2[2] << 8)+ m_scroll2[3]));
+	m_bg_tilemap->set_scrollx(0, ((m_scroll[0] << 8)+ m_scroll[1]));
+	m_bg_tilemap->set_scrolly(0, ((m_scroll[2] << 8)+ m_scroll[3]));
 
 	m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(1), m_buffered_spriteram16.get(), 0x400);
@@ -350,10 +350,10 @@ uint32_t dec8_state::screen_update_lastmisn(screen_device &screen, bitmap_ind16 
 	return 0;
 }
 
-uint32_t dec8_state::screen_update_shackled(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t lastmisn_state::screen_update_shackled(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	m_bg_tilemap->set_scrollx(0, ((m_scroll2[0] << 8) + m_scroll2[1]));
-	m_bg_tilemap->set_scrolly(0, ((m_scroll2[2] << 8) + m_scroll2[3]));
+	m_bg_tilemap->set_scrollx(0, ((m_scroll[0] << 8) + m_scroll[1]));
+	m_bg_tilemap->set_scrolly(0, ((m_scroll[2] << 8) + m_scroll[3]));
 
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 0, 0);
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 1, 0);
@@ -364,16 +364,16 @@ uint32_t dec8_state::screen_update_shackled(screen_device &screen, bitmap_ind16 
 	return 0;
 }
 
-TILEMAP_MAPPER_MEMBER(dec8_state::lastmisn_scan_rows)
+TILEMAP_MAPPER_MEMBER(lastmisn_state::lastmisn_scan_rows)
 {
 	/* logical (col,row) -> memory offset */
 	return ((col & 0x0f) + ((row & 0x0f) << 4)) + ((col & 0x10) << 4) + ((row & 0x10) << 5);
 }
 
-TILE_GET_INFO_MEMBER(dec8_state::get_lastmisn_tile_info)
+TILE_GET_INFO_MEMBER(lastmisn_state::get_lastmisn_tile_info)
 {
 	int offs = tile_index * 2;
-	int tile = m_bg_data[offs + 1] + (m_bg_data[offs] << 8);
+	int tile = m_bg_ram[offs + 1] + (m_bg_ram[offs] << 8);
 	int color = tile >> 12;
 
 	if (color & 8 && m_game_uses_priority)
@@ -387,7 +387,7 @@ TILE_GET_INFO_MEMBER(dec8_state::get_lastmisn_tile_info)
 			0);
 }
 
-TILE_GET_INFO_MEMBER(dec8_state::get_lastmisn_fix_tile_info)
+TILE_GET_INFO_MEMBER(lastmisn_state::get_lastmisn_fix_tile_info)
 {
 	int offs = tile_index << 1;
 	int tile = m_videoram[offs + 1] + (m_videoram[offs] << 8);
@@ -399,21 +399,21 @@ TILE_GET_INFO_MEMBER(dec8_state::get_lastmisn_fix_tile_info)
 			0);
 }
 
-VIDEO_START_MEMBER(dec8_state,lastmisn)
+VIDEO_START_MEMBER(lastmisn_state,lastmisn)
 {
 	allocate_buffered_spriteram16();
-	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_lastmisn_tile_info)), tilemap_mapper_delegate(*this, FUNC(dec8_state::lastmisn_scan_rows)), 16, 16, 32, 32);
-	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_lastmisn_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(lastmisn_state::get_lastmisn_tile_info)), tilemap_mapper_delegate(*this, FUNC(lastmisn_state::lastmisn_scan_rows)), 16, 16, 32, 32);
+	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(lastmisn_state::get_lastmisn_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 
 	m_fix_tilemap->set_transparent_pen(0);
 	m_game_uses_priority = 0;
 }
 
-VIDEO_START_MEMBER(dec8_state,shackled)
+VIDEO_START_MEMBER(lastmisn_state,shackled)
 {
 	allocate_buffered_spriteram16();
-	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_lastmisn_tile_info)), tilemap_mapper_delegate(*this, FUNC(dec8_state::lastmisn_scan_rows)), 16, 16, 32, 32);
-	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_lastmisn_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(lastmisn_state::get_lastmisn_tile_info)), tilemap_mapper_delegate(*this, FUNC(lastmisn_state::lastmisn_scan_rows)), 16, 16, 32, 32);
+	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(lastmisn_state::get_lastmisn_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 
 	m_fix_tilemap->set_transparent_pen(0);
 	m_bg_tilemap->set_transmask(0, 0x000f, 0xfff0); // Bottom 12 pens
@@ -422,19 +422,19 @@ VIDEO_START_MEMBER(dec8_state,shackled)
 
 /******************************************************************************/
 
-uint32_t dec8_state::screen_update_srdarwin(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t srdarwin_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0, cliprect);
-	m_bg_tilemap->set_scrollx(0, (m_scroll2[0] << 8) + m_scroll2[1]);
+	m_bg_tilemap->set_scrollx(0, (m_scroll[0] << 8) + m_scroll[1]);
 
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1, 1);
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 2);
-	srdarwin_draw_sprites(bitmap, cliprect, screen.priority());
+	draw_sprites(bitmap, cliprect, screen.priority());
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
-TILE_GET_INFO_MEMBER(dec8_state::get_srdarwin_fix_tile_info)
+TILE_GET_INFO_MEMBER(srdarwin_state::get_fix_tile_info)
 {
 	int tile = m_videoram[tile_index];
 	int color = 0; /* ? */
@@ -447,9 +447,9 @@ TILE_GET_INFO_MEMBER(dec8_state::get_srdarwin_fix_tile_info)
 			0);
 }
 
-TILE_GET_INFO_MEMBER(dec8_state::get_srdarwin_tile_info)
+TILE_GET_INFO_MEMBER(srdarwin_state::get_tile_info)
 {
-	int tile = m_bg_data[2 * tile_index + 1] + (m_bg_data[2 * tile_index] << 8);
+	int tile = m_bg_ram[2 * tile_index + 1] + (m_bg_ram[2 * tile_index] << 8);
 	int color = tile >> 12 & 3;
 	int bank;
 
@@ -463,10 +463,10 @@ TILE_GET_INFO_MEMBER(dec8_state::get_srdarwin_tile_info)
 	tileinfo.group = color;
 }
 
-VIDEO_START_MEMBER(dec8_state,srdarwin)
+void srdarwin_state::video_start()
 {
-	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_srdarwin_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 16);
-	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_srdarwin_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(srdarwin_state::get_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 16);
+	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(srdarwin_state::get_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 
 	m_fix_tilemap->set_transparent_pen(0);
 	m_bg_tilemap->set_transmask(0, 0xffff, 0x0000); // draw as background only
@@ -477,18 +477,18 @@ VIDEO_START_MEMBER(dec8_state,srdarwin)
 
 /******************************************************************************/
 
-void dec8_state::gondo_colpri_cb(u32 &colour, u32 &pri_mask)
+void gondo_state::gondo_colpri_cb(u32 &colour, u32 &pri_mask)
 {
 	pri_mask = 0; // above foreground, background
 	if (colour & 8)
 		pri_mask |= GFX_PMASK_2; // behind foreground, above background
 }
 
-uint32_t dec8_state::screen_update_gondo(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t gondo_state::screen_update_gondo(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	screen.priority().fill(0, cliprect);
-	m_bg_tilemap->set_scrollx(0, ((m_scroll2[0] << 8) + m_scroll2[1]));
-	m_bg_tilemap->set_scrolly(0, ((m_scroll2[2] << 8) + m_scroll2[3]));
+	m_bg_tilemap->set_scrollx(0, ((m_scroll[0] << 8) + m_scroll[1]));
+	m_bg_tilemap->set_scrolly(0, ((m_scroll[2] << 8) + m_scroll[3]));
 
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1, 1);
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 2);
@@ -497,10 +497,10 @@ uint32_t dec8_state::screen_update_gondo(screen_device &screen, bitmap_ind16 &bi
 	return 0;
 }
 
-uint32_t dec8_state::screen_update_garyoret(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t lastmisn_state::screen_update_garyoret(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	m_bg_tilemap->set_scrollx(0, ((m_scroll2[0] << 8) + m_scroll2[1]));
-	m_bg_tilemap->set_scrolly(0, ((m_scroll2[2] << 8) + m_scroll2[3]));
+	m_bg_tilemap->set_scrollx(0, ((m_scroll[0] << 8) + m_scroll[1]));
+	m_bg_tilemap->set_scrolly(0, ((m_scroll[2] << 8) + m_scroll[3]));
 
 	m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(1), m_buffered_spriteram16.get(), 0x400);
@@ -509,7 +509,7 @@ uint32_t dec8_state::screen_update_garyoret(screen_device &screen, bitmap_ind16 
 	return 0;
 }
 
-TILE_GET_INFO_MEMBER(dec8_state::get_gondo_fix_tile_info)
+TILE_GET_INFO_MEMBER(lastmisn_state::get_gondo_fix_tile_info)
 {
 	int offs = tile_index * 2;
 	int tile = m_videoram[offs + 1] + (m_videoram[offs] << 8);
@@ -521,10 +521,10 @@ TILE_GET_INFO_MEMBER(dec8_state::get_gondo_fix_tile_info)
 			0);
 }
 
-TILE_GET_INFO_MEMBER(dec8_state::get_gondo_tile_info)
+TILE_GET_INFO_MEMBER(lastmisn_state::get_gondo_tile_info)
 {
 	int offs = tile_index * 2;
-	int tile = m_bg_data[offs + 1] + (m_bg_data[offs] << 8);
+	int tile = m_bg_ram[offs + 1] + (m_bg_ram[offs] << 8);
 	int color = tile>> 12;
 
 	if (color & 8 && m_game_uses_priority)
@@ -538,22 +538,22 @@ TILE_GET_INFO_MEMBER(dec8_state::get_gondo_tile_info)
 			0);
 }
 
-VIDEO_START_MEMBER(dec8_state,gondo)
+void gondo_state::video_start()
 {
 	allocate_buffered_spriteram16();
-	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_gondo_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
-	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_gondo_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gondo_state::get_gondo_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gondo_state::get_gondo_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
 
 	m_fix_tilemap->set_transparent_pen(0);
 	m_bg_tilemap->set_transmask(0, 0x00ff, 0xff00); /* Bottom 8 pens */
 	m_game_uses_priority = 0;
 }
 
-VIDEO_START_MEMBER(dec8_state,garyoret)
+VIDEO_START_MEMBER(lastmisn_state,garyoret)
 {
 	allocate_buffered_spriteram16();
-	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_gondo_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
-	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(dec8_state::get_gondo_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+	m_fix_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(lastmisn_state::get_gondo_fix_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(lastmisn_state::get_gondo_tile_info)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
 
 	m_fix_tilemap->set_transparent_pen(0);
 	m_game_uses_priority = 1;

--- a/src/mame/dataeast/dec8_v.cpp
+++ b/src/mame/dataeast/dec8_v.cpp
@@ -46,19 +46,19 @@ sprites.
 #include "emu.h"
 #include "dec8.h"
 
-void base_state::bg_ram_w(offs_t offset, u8 data)
+void dec8_state_base::bg_ram_w(offs_t offset, u8 data)
 {
 	m_bg_ram[offset] = data;
 	m_bg_tilemap->mark_tile_dirty(offset / 2);
 }
 
-u8 base_state::bg_ram_r(offs_t offset)
+u8 dec8_state_base::bg_ram_r(offs_t offset)
 {
 	return m_bg_ram[offset];
 }
 
 
-void base_state::videoram_w(offs_t offset, u8 data)
+void dec8_state_base::videoram_w(offs_t offset, u8 data)
 {
 	m_videoram[offset] = data;
 	m_fix_tilemap->mark_tile_dirty(offset / 2);
@@ -148,7 +148,7 @@ void lastmisn_state::gondo_scroll_w(offs_t offset, u8 data)
 	}
 }
 
-void base_state::allocate_buffered_spriteram16()
+void dec8_state_base::allocate_buffered_spriteram16()
 {
 	m_buffered_spriteram16 = make_unique_clear<u16[]>(0x800/2);
 	save_pointer(NAME(m_buffered_spriteram16), 0x800/2);


### PR DESCRIPTION
dataeast/dec0.h: remove unused address map