### PR TITLE
heathkit/tlb.cpp: fix nmi handling for H19

### DIFF
--- a/src/mame/heathkit/tlb.h
+++ b/src/mame/heathkit/tlb.h
@@ -86,6 +86,11 @@ private:
 	int mm5740_control_r();
 	void mm5740_data_ready_w(int state);
 
+	void crtc_addr_w(offs_t reg, uint8_t val);
+	uint8_t crtc_reg_r(offs_t reg);
+	void crtc_reg_w(offs_t reg, uint8_t val);
+	void crtc_vsync_w(int val);
+
 	TIMER_CALLBACK_MEMBER(key_click_off);
 	TIMER_CALLBACK_MEMBER(bell_off);
 
@@ -114,6 +119,7 @@ private:
 	bool     m_keyboard_irq_raised;
 	bool     m_serial_irq_raised;
 	bool     m_break_key_irq_raised;
+	bool     m_allow_vsync_nmi;
 };
 
 // Heath TLB with Super19 ROM


### PR DESCRIPTION
Fix NMI handling, to only trigger after the proper port is accessed.  Only when the ROM needs to update the CRTC registers does it write to the special port to allow the next VSYNC to trigger a NMI. 

The change fixes the Self-diagnostic test in the UltraROM. It was failing because the scratchpad memory is modified during the NMI interrupt routine, and that was conflicting with the memory test of the scratchpad.
<img width="349" alt="Screenshot 2023-08-15 at 8 44 35 PM" src="https://github.com/mamedev/mame/assets/8291090/5f6e6d7e-bf10-41ff-8728-f637bc3ed278">
