### PR TITLE
Fixed sinistarc audio routing and added comments

### DIFF
--- a/src/mame/midway/williams.cpp
+++ b/src/mame/midway/williams.cpp
@@ -1707,9 +1707,20 @@ void sinistar_state::cockpit(machine_config &config)
 	SPEAKER(config, "rspeaker").rear_center();
 	MC1408(config, "rdac").add_route(ALL_OUTPUTS, "rspeaker", 0.25); // unknown DAC
 
-	// uncomment this to route front/rear to left/right
-	//subdevice<speaker_device>("speaker")->front_left();
-	//subdevice<speaker_device>("rspeaker")->front_right();
+	// Williams "cheated" with the cockpit by treating stereo audio as a surround sound setup.
+	// While the speakers in the cockpit cabinet use center front/rear placement, the logical routing
+	// in MAME should be left/right for two reasons:
+	//
+	// 1) the current OSD code doesn't allow for re-routing speakers yet, but if the end-user
+	// desires accuracy then physically placing speakers in front and behind the player will work instead.
+	//
+	// 2) routing the sound to center front/rear actually duplicates the audio in both left/right
+	// channels, which ruins the stereo separation effect.  This effect is only audible when routing to
+	// left/right and is more accurate to what the developers originally intended.
+	//
+	// comment this code to re-route left/right to front/rear
+	subdevice<speaker_device>("speaker")->front_left();
+	subdevice<speaker_device>("rspeaker")->front_right();
 
 	// pia
 	INPUT_MERGER_ANY_HIGH(config, "soundirq_b").output_handler().set_inputline("soundcpu_b", M6808_IRQ_LINE);
@@ -3160,7 +3171,7 @@ There is known to be a "perfect" version of Sinistar, that being the original ve
 
 Sinistar's cockpit cabinet features two sound boards, one for the front speakers and another for the rear.  The rear
   sound board uses a different ROM, Video Sound ROM 10.  It adds a slight delay to some of the sound effects,
-  producing a reverberation effect, and ignores the extra ship and bounce effects.  It has no speech ROMs.
+  producing a stereo separation effect, and ignores the extra ship and bounce effects.  It has no speech ROMs.
 
 If you disconnect the speech ROMs from the upright sound board, Video Sound ROM 9 will play two replacement sound
   effects for the Sinistar's missing audio.  Any line of dialogue will be replaced by a generic alarm noise,


### PR DESCRIPTION
This is related to https://github.com/mamedev/mame/pull/11459/

First off, I want to thank Vas for rewriting my code and committing it to MAME, I don't want that to go unnoticed.

I've been doing extensive research on this game since March of this year.  As I mentioned in the last post of the previous pull request, it is apparent that the sound designer Mike Metz only used regular stereo audio, but placed the speakers in an unusual way (front = left, rear = right) to basically simulate a surround sound set up in the cockpit.  [Here's a scan of Mike's interview 
describing this](https://archive.org/details/Videogaming_and_Computer_Gaming_Illustrated_1983-11_Ion_International_US/page/n69/mode/2up?q=stereo+programming)

Yes, technically the cockpit speakers are in a center front and rear placement but the current routing to these center speakers completely ruins the stereo separation effect.  The code is essentially mixing down the two stereo audio channels and duplicating the sound in both speakers.  Therefore the logical routing should be left/right.  Routing left/right audio to two center speakers invalidates all the hard work and research I put in getting this to work.

https://youtu.be/-JXjx6J9Iog

Here's a video that I made a while back where I simulated the stereo sound before writing this code.  After a few seconds of gameplay, you can hear just how much more impressive the explosions are with this.  In the current code, they're in mono and are notably distorted.

Again, with this dual center speaker setup, the original intention that the developers had with the audio is lost and sounds even worst.  I feel that this is counter to MAME's mission in preserving video games as accurately as possible.

Also, I'm not sure why but my original comments were re-written.  I used the term "stereo separation" but it was replaced with "reverberation".  This is completely false as there is no reverb effect or any sort of effects-processing involved with the audio.  The second sound board slightly delays the GWAVE sound effects, which produces the stereo separation effect.  The explosions themselves are random enough in both channels that they sound immersive.

My reverse engineered source code of the sound rom breaks down how this works in further detail:
https://github.com/synamaxmusic/Sinistar-Sound-ROM/blob/6f7f19a74e167e9c85a92952118930ac8118c0ab/VSNDRM9.SRC#L656

Thank you for your time.

