### PR TITLE
apple/apple3.cpp: Add keyboard 2spd autorepeat

### DIFF
--- a/src/mame/apple/apple3.cpp
+++ b/src/mame/apple/apple3.cpp
@@ -90,6 +90,10 @@ void apple3_state::apple3(machine_config &config)
 	m_ay3600->shift().set(FUNC(apple3_state::ay3600_shift_r));
 	m_ay3600->control().set(FUNC(apple3_state::ay3600_control_r));
 	m_ay3600->data_ready().set(FUNC(apple3_state::ay3600_data_ready_w));
+	m_ay3600->ako().set(FUNC(apple3_state::ay3600_ako_w));
+
+	/* repeat timer */
+	TIMER(config, "repttimer").configure_generic(FUNC(apple3_state::ay3600_repeat));
 
 	/* slot bus */
 	A2BUS(config, m_a2bus, 0);

--- a/src/mame/apple/apple3.cpp
+++ b/src/mame/apple/apple3.cpp
@@ -93,7 +93,7 @@ void apple3_state::apple3(machine_config &config)
 	m_ay3600->ako().set(FUNC(apple3_state::ay3600_ako_w));
 
 	/* repeat timer */
-	TIMER(config, "repttimer").configure_generic(FUNC(apple3_state::ay3600_repeat));
+	TIMER(config, m_repttimer).configure_generic(FUNC(apple3_state::ay3600_repeat));
 
 	/* slot bus */
 	A2BUS(config, m_a2bus, 0);

--- a/src/mame/apple/apple3.h
+++ b/src/mame/apple/apple3.h
@@ -65,6 +65,7 @@ public:
 		floppy1(*this, "1"),
 		floppy2(*this, "2"),
 		floppy3(*this, "3"),
+		m_repttimer(*this, "repttimer"),
 		m_reset_latch(false),
 		m_nmi_latch(false)
 	{
@@ -89,6 +90,7 @@ public:
 	required_device<floppy_connector> floppy1;
 	required_device<floppy_connector> floppy2;
 	required_device<floppy_connector> floppy3;
+	required_device<timer_device> m_repttimer;
 
 	uint8_t apple3_memory_r(offs_t offset);
 	void apple3_memory_w(offs_t offset, uint8_t data);
@@ -122,6 +124,8 @@ public:
 	int ay3600_shift_r();
 	int ay3600_control_r();
 	void ay3600_data_ready_w(int state);
+	void ay3600_ako_w(int state);
+	TIMER_DEVICE_CALLBACK_MEMBER(ay3600_repeat);
 	virtual void device_post_load() override;
 	TIMER_DEVICE_CALLBACK_MEMBER(paddle_timer);
 	void pdl_handler(int offset);
@@ -162,6 +166,8 @@ private:
 	int m_c040_time = 0;
 	uint16_t m_lastchar = 0, m_strobe = 0;
 	uint8_t m_transchar = 0;
+	bool m_anykeydown;
+	int m_repeatdelay;
 	bool m_charwrt = false;
 
 	emu_timer *m_scanstart = nullptr, *m_scanend = nullptr;

--- a/src/mame/apple/apple3.h
+++ b/src/mame/apple/apple3.h
@@ -167,7 +167,6 @@ private:
 	uint16_t m_lastchar = 0, m_strobe = 0;
 	uint8_t m_transchar = 0;
 	bool m_anykeydown;
-	int m_repeatdelay;
 	bool m_charwrt = false;
 
 	emu_timer *m_scanstart = nullptr, *m_scanend = nullptr;

--- a/src/mame/apple/apple3_m.cpp
+++ b/src/mame/apple/apple3_m.cpp
@@ -1294,6 +1294,46 @@ void apple3_state::ay3600_data_ready_w(int state)
 	}
 }
 
+void apple3_state::ay3600_ako_w(int state)
+{
+	m_anykeydown = (state == ASSERT_LINE) ? true : false;
+
+	if (m_anykeydown)
+	{
+		m_repeatdelay = 5;
+		m_repttimer->adjust(attotime::from_hz(10));
+	}
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(apple3_state::ay3600_repeat)
+{
+	// is the key still down?
+	if (m_anykeydown)
+	{
+		if (m_repeatdelay)
+		{
+			m_repeatdelay--;
+			m_repttimer->adjust(attotime::from_hz(10));
+		}
+		else
+		{
+			// Closed Apple key
+			if (m_kbspecial->read() & 0x20)
+			{
+				m_repttimer->adjust(attotime::from_hz(30));
+			}
+			else
+			{
+				m_repttimer->adjust(attotime::from_hz(10));
+			}
+
+			m_strobe = 0x80;
+			m_via[1]->write_ca2(ASSERT_LINE);
+			m_via[1]->write_ca2(CLEAR_LINE);
+		}
+	}
+}
+
 void apple3_state::pdl_handler(int offset)
 {
 	uint8_t pdlread;

--- a/src/mame/apple/apple3_m.cpp
+++ b/src/mame/apple/apple3_m.cpp
@@ -1300,8 +1300,11 @@ void apple3_state::ay3600_ako_w(int state)
 
 	if (m_anykeydown)
 	{
-		m_repeatdelay = 5;
-		m_repttimer->adjust(attotime::from_hz(10));
+		m_repttimer->adjust(attotime::from_hz(2));
+	}
+	else
+	{
+		m_repttimer->adjust(attotime::never);
 	}
 }
 
@@ -1310,27 +1313,19 @@ TIMER_DEVICE_CALLBACK_MEMBER(apple3_state::ay3600_repeat)
 	// is the key still down?
 	if (m_anykeydown)
 	{
-		if (m_repeatdelay)
+		// Closed Apple key
+		if (m_kbspecial->read() & 0x20)
 		{
-			m_repeatdelay--;
-			m_repttimer->adjust(attotime::from_hz(10));
+			m_repttimer->adjust(attotime::from_hz(30));
 		}
 		else
 		{
-			// Closed Apple key
-			if (m_kbspecial->read() & 0x20)
-			{
-				m_repttimer->adjust(attotime::from_hz(30));
-			}
-			else
-			{
-				m_repttimer->adjust(attotime::from_hz(10));
-			}
-
-			m_strobe = 0x80;
-			m_via[1]->write_ca2(ASSERT_LINE);
-			m_via[1]->write_ca2(CLEAR_LINE);
+			m_repttimer->adjust(attotime::from_hz(10));
 		}
+
+		m_strobe = 0x80;
+		m_via[1]->write_ca2(ASSERT_LINE);
+		m_via[1]->write_ca2(CLEAR_LINE);
 	}
 }
 


### PR DESCRIPTION
Adding the keyboard auto repeat support. The Apple /// has a faster repeat speed that is invoked with the closed apple key. This is based on the Apple2 code.