### PR TITLE
konami/twin16.cpp: Dumped priority PROM for The Final Round/Hard Puncher

### DIFF
--- a/src/mame/konami/twin16.cpp
+++ b/src/mame/konami/twin16.cpp
@@ -1103,6 +1103,9 @@ ROM_START( fround )
 
 	ROM_REGION( 0x20000, "upd", 0 )     // samples
 	ROM_LOAD( "870_c02.7c", 0x00000, 0x20000, CRC(54e12c6d) SHA1(8171441aeb1a1dc4d65fae59c7c217f992f70cbc) )
+
+	ROM_REGION( 0x0100, "proms", 0 ) // from a GX870 PWB351311A board
+	ROM_LOAD( "63s141n.e16", 0x0100, 0x0100, CRC(ed87c1f1) SHA1(08ddbdeeccbfc2c61129946653016d2e56c8bd4e) )  // priority (not used)
 ROM_END
 
 ROM_START( froundl )
@@ -1129,6 +1132,9 @@ ROM_START( froundl )
 
 	ROM_REGION( 0x20000, "upd", 0 ) // samples
 	ROM_LOAD( "870_c02.7c", 0x00000, 0x20000, CRC(54e12c6d) SHA1(8171441aeb1a1dc4d65fae59c7c217f992f70cbc) )
+
+	ROM_REGION( 0x0100, "proms", 0 ) // from a GX870 PWB351311A board
+	ROM_LOAD( "63s141n.e16", 0x0100, 0x0100, CRC(ed87c1f1) SHA1(08ddbdeeccbfc2c61129946653016d2e56c8bd4e) )  // priority (not used)
 ROM_END
 
 ROM_START( hpuncher )
@@ -1161,6 +1167,9 @@ ROM_START( hpuncher )
 
 	ROM_REGION( 0x20000, "upd", 0 )     // samples
 	ROM_LOAD( "870_c02.7c", 0x00000, 0x20000, CRC(54e12c6d) SHA1(8171441aeb1a1dc4d65fae59c7c217f992f70cbc) )
+
+	ROM_REGION( 0x0100, "proms", 0 ) // from a GX870 PWB351311A board
+	ROM_LOAD( "63s141n.e16", 0x0100, 0x0100, CRC(ed87c1f1) SHA1(08ddbdeeccbfc2c61129946653016d2e56c8bd4e) )  // priority (not used)
 ROM_END
 
 ROM_START( miaj )

--- a/src/mame/konami/twin16.cpp
+++ b/src/mame/konami/twin16.cpp
@@ -1105,7 +1105,7 @@ ROM_START( fround )
 	ROM_LOAD( "870_c02.7c", 0x00000, 0x20000, CRC(54e12c6d) SHA1(8171441aeb1a1dc4d65fae59c7c217f992f70cbc) )
 
 	ROM_REGION( 0x0100, "proms", 0 ) // from a GX870 PWB351311A board
-	ROM_LOAD( "63s141n.e16", 0x0100, 0x0100, CRC(ed87c1f1) SHA1(08ddbdeeccbfc2c61129946653016d2e56c8bd4e) )  // priority (not used)
+	ROM_LOAD( "63s141n.e16", 0x0000, 0x0100, CRC(ed87c1f1) SHA1(08ddbdeeccbfc2c61129946653016d2e56c8bd4e) )  // priority (not used)
 ROM_END
 
 ROM_START( froundl )
@@ -1134,7 +1134,7 @@ ROM_START( froundl )
 	ROM_LOAD( "870_c02.7c", 0x00000, 0x20000, CRC(54e12c6d) SHA1(8171441aeb1a1dc4d65fae59c7c217f992f70cbc) )
 
 	ROM_REGION( 0x0100, "proms", 0 ) // from a GX870 PWB351311A board
-	ROM_LOAD( "63s141n.e16", 0x0100, 0x0100, CRC(ed87c1f1) SHA1(08ddbdeeccbfc2c61129946653016d2e56c8bd4e) )  // priority (not used)
+	ROM_LOAD( "63s141n.e16", 0x0000, 0x0100, CRC(ed87c1f1) SHA1(08ddbdeeccbfc2c61129946653016d2e56c8bd4e) )  // priority (not used)
 ROM_END
 
 ROM_START( hpuncher )
@@ -1169,7 +1169,7 @@ ROM_START( hpuncher )
 	ROM_LOAD( "870_c02.7c", 0x00000, 0x20000, CRC(54e12c6d) SHA1(8171441aeb1a1dc4d65fae59c7c217f992f70cbc) )
 
 	ROM_REGION( 0x0100, "proms", 0 ) // from a GX870 PWB351311A board
-	ROM_LOAD( "63s141n.e16", 0x0100, 0x0100, CRC(ed87c1f1) SHA1(08ddbdeeccbfc2c61129946653016d2e56c8bd4e) )  // priority (not used)
+	ROM_LOAD( "63s141n.e16", 0x0000, 0x0100, CRC(ed87c1f1) SHA1(08ddbdeeccbfc2c61129946653016d2e56c8bd4e) )  // priority (not used)
 ROM_END
 
 ROM_START( miaj )


### PR DESCRIPTION
We have dumped and measured PROM E16 used for priority encoding from a GX870 PWB351311A board. I have added the information to the driver.