### PR TITLE
Fix mingw/arm64 build issues

### DIFF
--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -1285,7 +1285,7 @@ project "bimg"
 		"BX_CONFIG_DEBUG=0",
 	}
 
-	configuration { "x64", "mingw*" }
+	configuration { "x64", "mingw*", "not arm64" }
 		defines {
 			"ASTCENC_AVX=0",
 			"ASTCENC_SSE=20",

--- a/src/osd/modules/diagnostics/diagnostics_win32.cpp
+++ b/src/osd/modules/diagnostics/diagnostics_win32.cpp
@@ -216,14 +216,18 @@ bool stack_walker::reset()
 	m_stackframe.AddrStack.Mode = AddrModeFlat;
 
 	// pull architecture-specific fields from the context
-#ifdef PTR64
+#if defined(__x86_64__) || defined(_M_X64)
 	m_stackframe.AddrPC.Offset = m_context.Rip;
 	m_stackframe.AddrFrame.Offset = m_context.Rsp;
 	m_stackframe.AddrStack.Offset = m_context.Rsp;
-#else
+#elif defined(__i386__) || defined(_M_IX86)
 	m_stackframe.AddrPC.Offset = m_context.Eip;
 	m_stackframe.AddrFrame.Offset = m_context.Ebp;
 	m_stackframe.AddrStack.Offset = m_context.Esp;
+#elif defined(__aarch64__) || defined(_M_ARM64)
+	m_stackframe.AddrPC.Offset = m_context.Pc;
+	m_stackframe.AddrFrame.Offset = m_context.Fp;
+	m_stackframe.AddrStack.Offset = m_context.Sp;
 #endif
 	return true;
 }
@@ -242,14 +246,18 @@ void stack_walker::reset(CONTEXT &initial, HANDLE thread)
 	m_stackframe.AddrStack.Mode = AddrModeFlat;
 
 	// pull architecture-specific fields from the context
-#ifdef PTR64
+#if defined(__x86_64__) || defined(_M_X64)
 	m_stackframe.AddrPC.Offset = m_context.Rip;
 	m_stackframe.AddrFrame.Offset = m_context.Rsp;
 	m_stackframe.AddrStack.Offset = m_context.Rsp;
-#else
+#elif defined(__i386__) || defined(_M_IX86)
 	m_stackframe.AddrPC.Offset = m_context.Eip;
 	m_stackframe.AddrFrame.Offset = m_context.Ebp;
 	m_stackframe.AddrStack.Offset = m_context.Esp;
+#elif defined(__aarch64__) || defined(_M_ARM64)
+	m_stackframe.AddrPC.Offset = m_context.Pc;
+	m_stackframe.AddrFrame.Offset = m_context.Fp;
+	m_stackframe.AddrStack.Offset = m_context.Sp;
 #endif
 }
 
@@ -263,10 +271,14 @@ bool stack_walker::unwind()
 	// if we were able to initialize, then we have everything we need
 	if (s_initialized)
 	{
-#ifdef PTR64
+#if defined(__x86_64__) || defined(_M_X64)
 		return (*m_stack_walk_64)(IMAGE_FILE_MACHINE_AMD64, m_process, m_thread, &m_stackframe, &m_context, nullptr, *m_sym_function_table_access_64, *m_sym_get_module_base_64, nullptr);
-#else
+#elif defined(__i386__) || defined(_M_IX86)
 		return (*m_stack_walk_64)(IMAGE_FILE_MACHINE_I386, m_process, m_thread, &m_stackframe, &m_context, nullptr, *m_sym_function_table_access_64, *m_sym_get_module_base_64, nullptr);
+#elif defined(__aarch64__) || defined(_M_ARM64)
+		return (*m_stack_walk_64)(IMAGE_FILE_MACHINE_ARM64, m_process, m_thread, &m_stackframe, &m_context, nullptr, *m_sym_function_table_access_64, *m_sym_get_module_base_64, nullptr);
+#else
+		return false;
 #endif
 	}
 
@@ -997,7 +1009,7 @@ private:
 
 		// print the state of the CPU
 		fprintf(stderr, "-----------------------------------------------------\n");
-#ifdef PTR64
+#if defined(__x86_64__) || defined(_M_X64)
 		fprintf(stderr, "RAX=%p RBX=%p RCX=%p RDX=%p\n",
 			(void *)info->ContextRecord->Rax,
 			(void *)info->ContextRecord->Rbx,
@@ -1018,7 +1030,7 @@ private:
 			(void *)info->ContextRecord->R13,
 			(void *)info->ContextRecord->R14,
 			(void *)info->ContextRecord->R15);
-#else
+#elif defined(__i386__) || defined(_M_IX86)
 		fprintf(stderr, "EAX=%p EBX=%p ECX=%p EDX=%p\n",
 			(void *)info->ContextRecord->Eax,
 			(void *)info->ContextRecord->Ebx,
@@ -1029,6 +1041,47 @@ private:
 			(void *)info->ContextRecord->Edi,
 			(void *)info->ContextRecord->Ebp,
 			(void *)info->ContextRecord->Esp);
+#elif defined(__aarch64__) || defined(_M_ARM64)
+		fprintf(stderr, " X0=%p  X1=%p  X2=%p  X3=%p\n",
+			(void *)info->ContextRecord->X0,
+			(void *)info->ContextRecord->X1,
+			(void *)info->ContextRecord->X2,
+			(void *)info->ContextRecord->X3);
+		fprintf(stderr, " X4=%p  X5=%p  X6=%p  X7=%p\n",
+			(void *)info->ContextRecord->X4,
+			(void *)info->ContextRecord->X5,
+			(void *)info->ContextRecord->X6,
+			(void *)info->ContextRecord->X7);
+		fprintf(stderr, " X8=%p  X9=%p X10=%p X11=%p\n",
+			(void *)info->ContextRecord->X8,
+			(void *)info->ContextRecord->X9,
+			(void *)info->ContextRecord->X10,
+			(void *)info->ContextRecord->X11);
+		fprintf(stderr, "X12=%p X13=%p X14=%p X15=%p\n",
+			(void *)info->ContextRecord->X12,
+			(void *)info->ContextRecord->X13,
+			(void *)info->ContextRecord->X14,
+			(void *)info->ContextRecord->X15);
+		fprintf(stderr, "X16=%p X17=%p X18=%p X19=%p\n",
+			(void *)info->ContextRecord->X16,
+			(void *)info->ContextRecord->X17,
+			(void *)info->ContextRecord->X18,
+			(void *)info->ContextRecord->X19);
+		fprintf(stderr, "X20=%p X21=%p X22=%p X23=%p\n",
+			(void *)info->ContextRecord->X20,
+			(void *)info->ContextRecord->X21,
+			(void *)info->ContextRecord->X22,
+			(void *)info->ContextRecord->X23);
+		fprintf(stderr, "X24=%p X25=%p X26=%p X27=%p\n",
+			(void *)info->ContextRecord->X24,
+			(void *)info->ContextRecord->X25,
+			(void *)info->ContextRecord->X26,
+			(void *)info->ContextRecord->X27);
+		fprintf(stderr, "X28=%p  FP=%p  LR=%p  SP=%p\n",
+			(void *)info->ContextRecord->X28,
+			(void *)info->ContextRecord->Fp,
+			(void *)info->ContextRecord->Lr,
+			(void *)info->ContextRecord->Sp);
 #endif
 
 		// reprint the actual exception address


### PR DESCRIPTION
I recently tried building MAME for Windows/arm64 with clang and mingw and it almost just worked, given the right build options. These are fixes for the couple of build issues I encountered.

These changes were tested by compiling natively with msys2/clangarm64 and also by cross-compiling with [llvm-mingw](https://github.com/mstorsjo/llvm-mingw). I booted a handful of machines without issue.

The crash diagnostic code is tested and working as well. Example:

```
-----------------------------------------------------
Exception at EIP=00007FF66C3144A8 (+0x6c3144a8): ACCESS VIOLATION
While attempting to write memory at 0000000000000000
-----------------------------------------------------
 X0=000001B05EAC9E10  X1=CDCDCDCDCDCDCDCD  X2=0000000000000018  X3=0000000000000040
 X4=0000000000000003  X5=0000000000000000  X6=0000000000000002  X7=0000000000000000
 X8=0000000000000000  X9=000000000000002A X10=000001B0612FA2C0 X11=0000000000000000
X12=00007FFFE07C7000 X13=0000000000000001 X14=0000000000000000 X15=0000000000000003
X16=00007FFFDC76B9A0 X17=0000D225CFE33B00 X18=0000000000000000 X19=000001B05EAC9E10
X20=000000000000053E X21=0000000000000001 X22=000001B05EAC9E10 X23=00007FF66E8232A0
X24=000000FF00000000 X25=00000092DCAF9D90 X26=00007FF66C45CC48 X27=00007FF66C45D238
X28=00007FF66C45D46C  FP=00000092DCAF9CA0  LR=00007FF66C3422E0  SP=00000092DCAF9C90
-----------------------------------------------------
Stack crawl:
  00000092DCAF9CA0: 00007FF66C3144A8 (`anonymous namespace'::wrally_state::machine_start+0x0014, mame\src\mame\gaelco\wrally.cpp:314)
  00000092DCAF9CB8: 00007FF66C3422E0 (driver_device::device_start+0x00f8, mame\src\emu\driver.cpp:221)
  00000092DCAF9D58: 00007FF66C410334 (device_t::start+0x0080, mame\src\emu\device.cpp:545)
  00000092DCAF9EA0: 00007FF66C4711B4 (running_machine::start_all_devices+0x0110, mame\src\emu\machine.cpp:1003)
  00000092DCAFA0E8: 00007FF66C470918 (running_machine::start+0x073c, mame\src\emu\machine.cpp:215)
  00000092DCAFA1F0: 00007FF66C4715FC (running_machine::run+0x0170, mame\src\emu\machine.cpp:288)
  00000092DCAFF580: 00007FF66C75D438 (mame_machine_manager::execute+0x01b0, mame\src\frontend\mame\mame.cpp:292)
  00000092DCAFF758: 00007FF66DD4E204 (cli_frontend::start_execution+0x01f4, mame\src\frontend\mame\clifront.cpp:277)
  00000092DCAFF888: 00007FF66DD4F3FC (cli_frontend::execute+0x004c, mame\src\frontend\mame\clifront.cpp:353)
  00000092DCAFF8C8: 00007FF66C75E3A8 (emulator_info::start_frontend+0x0030, mame\src\frontend\mame\mame.cpp:454)
  00000092DCAFFBF0: 00007FF66C31A5B8 (main+0x01c0, mame\src\osd\windows\winmain.cpp:210)
  00000092DCAFFC60: 00007FF66C3113AC (WinMainCRTStartup+0x0244)
  00000092DCAFFC60: 00007FF66C311404 (mainCRTStartup+0x0014)
  00000092DCAFFC60: 00007FFFDE4C23F0 (BaseThreadInitThunk+0x0030)
  00000092DCAFFCA0: 00007FFFE04F301C (RtlUserThreadStart+0x003c)
```