### PR TITLE
Renamed various Apple Macintosh software lists' description

### DIFF
--- a/hash/mac_cdrom.xml
+++ b/hash/mac_cdrom.xml
@@ -15,7 +15,7 @@ PPC603 - PowerPC 603/603E/603EV CPU
 PPC604 - PowerPC 604 CPU
 PPC750 - PowerPC 750 (G3) CPU
 -->
-<softwarelist name="mac_cdrom" description="Mac CD-ROMs">
+<softwarelist name="mac_cdrom" description="Apple Macintosh CD-ROMs">
 	<software name="aplegrec">
 		<description>Apple Legacy Recovery</description>
 		<year>1998</year>

--- a/hash/mac_flop.xml
+++ b/hash/mac_flop.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="mac_flop" description="Macintosh 400K/800K Disk images">
+<softwarelist name="mac_flop" description="Apple Macintosh 400K/800K disk images">
 
 	<software name="airborne">
 		<description>Airborne!</description>

--- a/hash/mac_flop_clcracked.xml
+++ b/hash/mac_flop_clcracked.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="mac_flop_clcracked" description="Macintosh 400K/800K cleanly cracked disks">
+<softwarelist name="mac_flop_clcracked" description="Apple Macintosh 400K/800K cleanly cracked disks">
 
 	<software name="dlxmuscset10">
 		<description>Deluxe Music Construction Set (version 1.0) (san inc crack)</description>

--- a/hash/mac_flop_orig.xml
+++ b/hash/mac_flop_orig.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="mac_flop_orig" description="Macintosh 400K/800K Original disk images">
+<softwarelist name="mac_flop_orig" description="Apple Macintosh 400K/800K original disk images">
 
 	<software name="lodrun10">
 		<description>Lode Runner (version 1.0)</description>

--- a/hash/mac_hdd.xml
+++ b/hash/mac_hdd.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="mac_hdd" description="Mac Harddisks">
+<softwarelist name="mac_hdd" description="Apple Macintosh hard disk images">
 	<software name="mac608">
 		<description>System Software 6.0.8</description>
 		<year>1988</year>

--- a/hash/mac_hdflop.xml
+++ b/hash/mac_hdflop.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="mac_hdflop" description="Macintosh High Density Disk images">
+<softwarelist name="mac_hdflop" description="Apple Macintosh high density disk images">
 
 <!-- Operating system disks -->
 


### PR DESCRIPTION
Added the manufacturer's name.
Lowercase on the storage medias' name.
Renamed "Mac" abbreviation to "Macintosh".