### PR TITLE
heathkit/tlb.cpp: fix coverity error

### DIFF
--- a/src/mame/heathkit/tlb.cpp
+++ b/src/mame/heathkit/tlb.cpp
@@ -1068,7 +1068,8 @@ ioport_constructor heath_super19_tlb_device::device_input_ports() const
  * Developed by TMSI
  */
 heath_superset_tlb_device::heath_superset_tlb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	heath_tlb_device(mconfig, HEATH_SUPERSET, tag, owner, clock)
+	heath_tlb_device(mconfig, HEATH_SUPERSET, tag, owner, clock),
+	m_selected_char_set(0)
 {
 }
 


### PR DESCRIPTION
Fix the following coverity error:
```
*** CID 465494:  Uninitialized members  (UNINIT_CTOR)
/src/mame/heathkit/tlb.cpp: 1073 in heath_superset_tlb_device::heath_superset_tlb_device(const machine_config &, const char *, device_t *, unsigned int)()
1067      *
1068      * Developed by TMSI
1069      */
1070     heath_superset_tlb_device::heath_superset_tlb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
1071            heath_tlb_device(mconfig, HEATH_SUPERSET, tag, owner, clock)
1072     {
     CID 465494:  Uninitialized members  (UNINIT_CTOR)
 >>>     Non-static class member "m_selected_char_set" is not initialized in this constructor nor in any functions that it calls.
 1073     }
```
