### PR TITLE
capcom/cps2.cpp: Support for CPS2 debug DIP switches

### DIFF
--- a/src/mame/capcom/cps2.cpp
+++ b/src/mame/capcom/cps2.cpp
@@ -668,7 +668,7 @@ public:
 		, m_output(*this, "output")
 		, m_io_in0(*this, "IN0")
 		, m_io_in1(*this, "IN1")
-		, m_dsw{ { *this, "DSWA" }, { *this, "DSWB" }, { *this, "DSWC" } }
+		, m_dsw(*this, "DSW%c", 'A')
 		, m_cps2_dial_type(0)
 		, m_ecofghtr_dial_direction0(0)
 		, m_ecofghtr_dial_direction1(0)
@@ -741,7 +741,7 @@ private:
 
 	optional_ioport m_io_in0;
 	optional_ioport m_io_in1;
-	optional_ioport m_dsw[3];
+	optional_ioport_array<3> m_dsw;
 
 	std::unique_ptr<uint16_t[]> m_cps2_buffered_obj;
 	std::unique_ptr<uint16_t[]> m_gigaman2_dummyqsound_ram;

--- a/src/mame/capcom/cps2.cpp
+++ b/src/mame/capcom/cps2.cpp
@@ -1314,8 +1314,8 @@ uint16_t cps2_state::cps2_qsound_volume_r()
  *  Read handlers
  *
  *************************************/
-uint16_t cps2_state::joy_or_paddle_r()
 
+uint16_t cps2_state::joy_or_paddle_r()
 {
 	if (m_readpaddle != 0)
 	{

--- a/src/mame/capcom/cps2.cpp
+++ b/src/mame/capcom/cps2.cpp
@@ -728,6 +728,8 @@ private:
 	void init_cps2_video();
 	void init_cps2crypt();
 
+	uint8_t cps2_dsw_r(offs_t offset);
+
 	optional_shared_ptr<uint16_t> m_decrypted_opcodes;
 	optional_memory_region m_region_key;
 
@@ -1312,8 +1314,8 @@ uint16_t cps2_state::cps2_qsound_volume_r()
  *  Read handlers
  *
  *************************************/
-
 uint16_t cps2_state::joy_or_paddle_r()
+
 {
 	if (m_readpaddle != 0)
 	{
@@ -1387,6 +1389,19 @@ uint16_t cps2_state::joy_or_paddle_ecofghtr_r()
 	}
 }
 
+/*************************************
+ *
+ *  DIP switches
+ *
+ *************************************/
+uint8_t cps2_state::cps2_dsw_r(offs_t offset)
+{
+	static const char *const dswname[] = { "DSWA", "DSWB", "DSWC" };
+	
+	int in = ioport(dswname[offset])->read();
+	// printf("dip offset %x, value %x\n", offset, in);
+	return in;
+}
 
 /*************************************
  *
@@ -1411,8 +1426,7 @@ void cps2_state::cps2_map(address_map &map)
 	map(0x804030, 0x804031).r(FUNC(cps2_state::cps2_qsound_volume_r));                                                                // Master volume. Also when bit 14=0 addon memory is present, when bit 15=0 network adapter present.
 	map(0x804040, 0x804041).w(FUNC(cps2_state::cps2_eeprom_port_w));                                                                  // EEPROM
 	map(0x8040a0, 0x8040a1).nopw();                                                                                                   // Unknown (reset once on startup)
-	map(0x8040b0, 0x8040b1).portr("DSW1");
-	map(0x8040b2, 0x8040b3).portr("DSW2");
+	// 0x8040b0 to 0x8040b2 are the debug DIPs present on development hardware, implemented as read handler cps2_dsw_r
 	map(0x8040e0, 0x8040e1).w(FUNC(cps2_state::cps2_objram_bank_w));                                                                  // bit 0 = Object ram bank swap
 	map(0x804100, 0x80413f).w(FUNC(cps2_state::cps1_cps_a_w)).share("cps_a_regs");                                                    // CPS-A custom
 	map(0x804140, 0x80417f).rw(FUNC(cps2_state::cps1_cps_b_r), FUNC(cps2_state::cps1_cps_b_w));                                       // CPS-B custom
@@ -1451,8 +1465,7 @@ void cps2_state::dead_cps2_map(address_map &map)
 	map(0x804030, 0x804031).r(FUNC(cps2_state::cps2_qsound_volume_r));                                                                // Master volume. Also when bit 14=0 addon memory is present, when bit 15=0 network adapter present.
 	map(0x804040, 0x804041).w(FUNC(cps2_state::cps2_eeprom_port_w));                                                                  // EEPROM
 	map(0x8040a0, 0x8040a1).nopw();                                                                                                   // Unknown (reset once on startup)
-	map(0x8040b0, 0x8040b3).portr("DSW1");
-	map(0x8040b2, 0x8040b3).portr("DSW2");
+	// 0x8040b0 to 0x8040b2 are the debug DIPs present on development hardware, implemented as read handler cps2_dsw_r
 	map(0x8040e0, 0x8040e1).w(FUNC(cps2_state::cps2_objram_bank_w));                                                                  // bit 0 = Object ram bank swap
 	map(0x804100, 0x80413f).w(FUNC(cps2_state::cps1_cps_a_w)).share("cps_a_regs");                                                    // CPS-A custom
 	map(0x804140, 0x80417f).rw(FUNC(cps2_state::cps1_cps_b_r), FUNC(cps2_state::cps1_cps_b_w));                                       // CPS-B custom
@@ -1540,88 +1553,89 @@ static INPUT_PORTS_START( cps2_4p4b )
 	PORT_BIT( 0x0001, IP_ACTIVE_HIGH, IPT_VOLUME_DOWN )
 	PORT_BIT( 0x0002, IP_ACTIVE_HIGH, IPT_VOLUME_UP )
 
+	// Machine configuration for dev hardware with DIPs
 	PORT_START("DEV_HW")
-	PORT_CONFNAME(0x01,0x00,"Dev hardware")
-	PORT_CONFSETTING(0x00, "Default Hardware")
-	PORT_CONFSETTING(0x01, "Debug DIP switches enable")
+	PORT_CONFNAME(0x01,0x00,"Hardware")
+	PORT_CONFSETTING(0x00, "Production")
+	PORT_CONFSETTING(0x01, "Development (Enable Debug DIPs)")
 
-// PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_START("DSW1") 
-	PORT_DIPNAME( 0x0001, 0x0001, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:1") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0001, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0002, 0x0002, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:2") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0002, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0004, 0x0004, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:3") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0004, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0008, 0x0008, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:4") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0008, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0010, 0x0010, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:5") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0010, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0020, 0x0020, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:6") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0020, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0040, 0x0040, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:7") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0040, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0080, 0x0080, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:8") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0080, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_START("DSWA") 
+	PORT_DIPNAME( 0x01, 0x01, "1-1" ) PORT_DIPLOCATION("SW1:1") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x01, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x02, 0x02, "1-2" ) PORT_DIPLOCATION("SW1:2") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x02, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x04, 0x04, "1-3" ) PORT_DIPLOCATION("SW1:3") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x04, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x08, 0x08, "1-4" ) PORT_DIPLOCATION("SW1:4") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x08, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x10, 0x10, "1-5" ) PORT_DIPLOCATION("SW1:5") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x10, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x20, 0x20, "1-6" ) PORT_DIPLOCATION("SW1:6") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x20, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x40, 0x40, "1-7" ) PORT_DIPLOCATION("SW1:7") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x40, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x80, 0x80, "1-8" ) PORT_DIPLOCATION("SW1:8") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x80, DEF_STR( Off ) )
 
-	PORT_DIPNAME( 0x0100, 0x0100, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:1") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0100, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0200, 0x0200, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:2") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0200, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0400, 0x0400, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:3") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0400, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0800, 0x0800, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:4") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0800, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x1000, 0x1000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:5") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x1000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x2000, 0x2000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:6") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x2000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x4000, 0x4000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:7") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x4000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x8000, 0x8000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:8") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x8000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_START("DSWB")
+	PORT_DIPNAME( 0x01, 0x01, "2-1" ) PORT_DIPLOCATION("SW2:1") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x01, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x02, 0x02, "2-2" ) PORT_DIPLOCATION("SW2:2") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x02, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x04, 0x04, "2-3" ) PORT_DIPLOCATION("SW2:3") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x04, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x08, 0x08, "2-4" ) PORT_DIPLOCATION("SW2:4") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x08, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x10, 0x10, "2-5" ) PORT_DIPLOCATION("SW2:5") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x10, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x20, 0x20, "2-6" ) PORT_DIPLOCATION("SW2:6") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x20, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x40, 0x40, "2-7" ) PORT_DIPLOCATION("SW2:7") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x40, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x80, 0x80, "2-8" ) PORT_DIPLOCATION("SW2:8") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x80, DEF_STR( Off ) )
 
-	PORT_START("DSW2") 
-	PORT_DIPNAME( 0x0100, 0x0100, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:1") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0100, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0200, 0x0200, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:2") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0200, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0400, 0x0400, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:3") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0400, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x0800, 0x0800, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:4") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0800, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x1000, 0x1000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:5") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x1000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x2000, 0x2000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:6") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x2000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x4000, 0x4000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:7") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x4000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPNAME( 0x8000, 0x8000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:8") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
-	PORT_DIPSETTING(      0x8000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_START("DSWC") 
+	PORT_DIPNAME( 0x01, 0x01, "3-1" ) PORT_DIPLOCATION("SW3:1") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x01, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x02, 0x02, "3-2" ) PORT_DIPLOCATION("SW3:2") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x02, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x04, 0x04, "3-3" ) PORT_DIPLOCATION("SW3:3") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x04, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x08, 0x08, "3-4" ) PORT_DIPLOCATION("SW3:4") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x08, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x10, 0x10, "3-5" ) PORT_DIPLOCATION("SW3:5") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x10, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x20, 0x20, "3-6" ) PORT_DIPLOCATION("SW3:6") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x20, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x40, 0x40, "3-7" ) PORT_DIPLOCATION("SW3:7") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x40, DEF_STR( Off ) )
+	PORT_DIPNAME( 0x80, 0x80, "3-8" ) PORT_DIPLOCATION("SW3:8") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPSETTING(    0x80, DEF_STR( Off ) )
 
 INPUT_PORTS_END
 
@@ -10901,6 +10915,8 @@ void cps2_state::init_cps2()
 	// Decrypt the game - see machine/cps2crypt.cpp
 	init_cps2crypt();
 	init_cps2nc();
+
+	m_maincpu->space(AS_PROGRAM).install_read_handler(0x8040b0, 0x8040b2, read8sm_delegate(*this, FUNC(cps2_state::cps2_dsw_r)));
 }
 
 void cps2_state::init_cps2nc()
@@ -10921,7 +10937,6 @@ void cps2_state::init_pzloop2()
 	m_cps2_dial_type = 1;
 
 	save_item(NAME(m_readpaddle));
-
 	m_maincpu->space(AS_PROGRAM).install_read_handler(0x804000, 0x804001, read16smo_delegate(*this, FUNC(cps2_state::joy_or_paddle_r)));
 }
 

--- a/src/mame/capcom/cps2.cpp
+++ b/src/mame/capcom/cps2.cpp
@@ -695,7 +695,6 @@ private:
 	void gigaman2_gfx_reorder();
 	void cps2_eeprom_port_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t cps2_qsound_volume_r();
-	uint16_t kludge_r();
 	uint16_t joy_or_paddle_r();
 	uint16_t joy_or_paddle_ecofghtr_r();
 	TIMER_DEVICE_CALLBACK_MEMBER(cps2_interrupt);
@@ -1314,11 +1313,6 @@ uint16_t cps2_state::cps2_qsound_volume_r()
  *
  *************************************/
 
-uint16_t cps2_state::kludge_r()
-{
-	return 0xffff;
-}
-
 uint16_t cps2_state::joy_or_paddle_r()
 {
 	if (m_readpaddle != 0)
@@ -1417,7 +1411,8 @@ void cps2_state::cps2_map(address_map &map)
 	map(0x804030, 0x804031).r(FUNC(cps2_state::cps2_qsound_volume_r));                                                                // Master volume. Also when bit 14=0 addon memory is present, when bit 15=0 network adapter present.
 	map(0x804040, 0x804041).w(FUNC(cps2_state::cps2_eeprom_port_w));                                                                  // EEPROM
 	map(0x8040a0, 0x8040a1).nopw();                                                                                                   // Unknown (reset once on startup)
-	map(0x8040b0, 0x8040b3).r(FUNC(cps2_state::kludge_r));                                                                            // Unknown (xmcotaj hangs if this is 0)
+	map(0x8040b0, 0x8040b1).portr("DSW1");
+	map(0x8040b2, 0x8040b3).portr("DSW2");
 	map(0x8040e0, 0x8040e1).w(FUNC(cps2_state::cps2_objram_bank_w));                                                                  // bit 0 = Object ram bank swap
 	map(0x804100, 0x80413f).w(FUNC(cps2_state::cps1_cps_a_w)).share("cps_a_regs");                                                    // CPS-A custom
 	map(0x804140, 0x80417f).rw(FUNC(cps2_state::cps1_cps_b_r), FUNC(cps2_state::cps1_cps_b_w));                                       // CPS-B custom
@@ -1456,7 +1451,8 @@ void cps2_state::dead_cps2_map(address_map &map)
 	map(0x804030, 0x804031).r(FUNC(cps2_state::cps2_qsound_volume_r));                                                                // Master volume. Also when bit 14=0 addon memory is present, when bit 15=0 network adapter present.
 	map(0x804040, 0x804041).w(FUNC(cps2_state::cps2_eeprom_port_w));                                                                  // EEPROM
 	map(0x8040a0, 0x8040a1).nopw();                                                                                                   // Unknown (reset once on startup)
-	map(0x8040b0, 0x8040b3).r(FUNC(cps2_state::kludge_r));                                                                            // Unknown (xmcotaj hangs if this is 0)
+	map(0x8040b0, 0x8040b3).portr("DSW1");
+	map(0x8040b2, 0x8040b3).portr("DSW2");
 	map(0x8040e0, 0x8040e1).w(FUNC(cps2_state::cps2_objram_bank_w));                                                                  // bit 0 = Object ram bank swap
 	map(0x804100, 0x80413f).w(FUNC(cps2_state::cps1_cps_a_w)).share("cps_a_regs");                                                    // CPS-A custom
 	map(0x804140, 0x80417f).rw(FUNC(cps2_state::cps1_cps_b_r), FUNC(cps2_state::cps1_cps_b_w));                                       // CPS-B custom
@@ -1543,6 +1539,90 @@ static INPUT_PORTS_START( cps2_4p4b )
 	PORT_START( "DIGITALVOL" )
 	PORT_BIT( 0x0001, IP_ACTIVE_HIGH, IPT_VOLUME_DOWN )
 	PORT_BIT( 0x0002, IP_ACTIVE_HIGH, IPT_VOLUME_UP )
+
+	PORT_START("DEV_HW")
+	PORT_CONFNAME(0x01,0x00,"Dev hardware")
+	PORT_CONFSETTING(0x00, "Default Hardware")
+	PORT_CONFSETTING(0x01, "Debug DIP switches enable")
+
+// PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_START("DSW1") 
+	PORT_DIPNAME( 0x0001, 0x0001, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:1") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0001, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0002, 0x0002, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:2") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0002, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0004, 0x0004, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:3") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0004, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0008, 0x0008, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:4") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0008, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0010, 0x0010, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:5") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0010, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0020, 0x0020, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:6") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0020, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0040, 0x0040, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:7") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0040, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0080, 0x0080, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW1:8") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0080, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+
+	PORT_DIPNAME( 0x0100, 0x0100, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:1") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0100, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0200, 0x0200, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:2") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0200, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0400, 0x0400, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:3") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0400, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0800, 0x0800, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:4") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0800, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x1000, 0x1000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:5") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x1000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x2000, 0x2000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:6") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x2000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x4000, 0x4000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:7") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x4000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x8000, 0x8000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW2:8") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x8000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+
+	PORT_START("DSW2") 
+	PORT_DIPNAME( 0x0100, 0x0100, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:1") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0100, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0200, 0x0200, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:2") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0200, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0400, 0x0400, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:3") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0400, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x0800, 0x0800, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:4") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0800, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x1000, 0x1000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:5") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x1000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x2000, 0x2000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:6") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x2000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x4000, 0x4000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:7") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x4000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPNAME( 0x8000, 0x8000, DEF_STR( Unknown ) ) PORT_DIPLOCATION("SW3:8") PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+	PORT_DIPSETTING(      0x8000, DEF_STR( Off ) ) PORT_CONDITION("DEV_HW", 0x01, EQUALS, 0x01)
+
 INPUT_PORTS_END
 
 // 4 players and 3 buttons


### PR DESCRIPTION
Adds support for the debugging DIP switches which are referenced in many CPS2 games and which apparently existed on dev boards thanks to images that have surfaced. Implemented as a machine configuration.

A write-up detailing the switches is posted here:
https://sudden-desu.net/entry/cps2-debug-switches-and-the-games-that-love-them

Note that in the article, I mentioned deciding against submitting a PR as it should technically be a whole new driver as it is different hardware, but given a conversation with @MooglyGuy on twitter, I've decided to go ahead and let the devs decide if it should be accepted.
https://twitter.com/TheMogMiner/status/1588881175309086730