### PR TITLE
removes SDL_WINDOW_BORDERLESS flag

### DIFF
--- a/src/osd/sdl/window.cpp
+++ b/src/osd/sdl/window.cpp
@@ -593,7 +593,7 @@ int sdl_window_info::complete_create()
 	// create the SDL window
 	// soft driver also used | SDL_WINDOW_INPUT_GRABBED | SDL_WINDOW_MOUSE_FOCUS
 	m_extra_flags |= (fullscreen() ?
-			SDL_WINDOW_BORDERLESS | SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_FULLSCREEN : SDL_WINDOW_RESIZABLE);
+			SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_FULLSCREEN : SDL_WINDOW_RESIZABLE);
 
 #if defined(SDLMAME_WIN32)
 	SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");


### PR DESCRIPTION
Meant to address the issue reported here:
https://github.com/mamedev/mame/issues/7532#issuecomment-1713880191 And possibly here:
https://github.com/mamedev/mame/issues/7922#issuecomment-1713887214