### PR TITLE
osd/sdl: Fixed interpretation of result of SDL_GetDesktopDisplayMode

### DIFF
--- a/src/osd/sdl/osdsdl.cpp
+++ b/src/osd/sdl/osdsdl.cpp
@@ -111,9 +111,9 @@ void osd_sdl_info()
 		SDL_DisplayMode mode;
 
 		osd_printf_verbose("\tDisplay #%d\n", i);
-		if (SDL_GetDesktopDisplayMode(i, &mode))
+		if (SDL_GetDesktopDisplayMode(i, &mode) == 0)
 			osd_printf_verbose("\t\tDesktop Mode:         %dx%d-%d@%d\n", mode.w, mode.h, SDL_BITSPERPIXEL(mode.format), mode.refresh_rate);
-		if (SDL_GetCurrentDisplayMode(i, &mode))
+		if (SDL_GetCurrentDisplayMode(i, &mode) == 0)
 			osd_printf_verbose("\t\tCurrent Display Mode: %dx%d-%d@%d\n", mode.w, mode.h, SDL_BITSPERPIXEL(mode.format), mode.refresh_rate);
 
 		osd_printf_verbose("\t\tRenderdrivers:\n");


### PR DESCRIPTION
SDL_GetDesktopDisplayMode returns 0 on success.  The current logic seems to assume that it returns true on success.  Updated the logic so that the lines printing the desktop mode and current display mode info can be reached.