### PR TITLE
t10mmc: Fix reading user data from mode 1 tracks using T10MMC_CMD_READ_CD

### DIFF
--- a/src/devices/machine/t10mmc.cpp
+++ b/src/devices/machine/t10mmc.cpp
@@ -960,12 +960,7 @@ void t10mmc::ReadData( uint8_t *data, int dataLength )
 						buffer_offset = 0;
 						data_len = 2352;
 					}
-					else if (track_type == cdrom_file::CD_TRACK_MODE1)
-					{
-						buffer_offset = 0;
-						data_len = 2048;
-					}
-					else if (track_type == cdrom_file::CD_TRACK_MODE1_RAW)
+					else if (track_type == cdrom_file::CD_TRACK_MODE1 || track_type == cdrom_file::CD_TRACK_MODE1_RAW)
 					{
 						buffer_offset = 16;
 						data_len = 2048;


### PR DESCRIPTION
Split off from previous PR (https://github.com/mamedev/mame/pull/11558#pullrequestreview-1636339911) because this regression needs to be fixed regardless of that PR.

The code reads CD_TRACK_MODE1 using CD_TRACK_MODE1_RAW because the CD-ROM code can generate a usable 16-byte header for non-raw tracks without the header. I forgot that when implementing the buffer_offset stuff so it's returning 16 bytes of header when user data is requested.  This PR fixes `taiko6` not loading currently.