### PR TITLE
Removed extra tick after gtime example in documentation

### DIFF
--- a/docs/source/debugger/execution.rst
+++ b/docs/source/debugger/execution.rst
@@ -301,7 +301,7 @@ specified in milliseconds.
 
 Example:
 
-``gtime #10000```
+``gtime #10000``
     Resume execution for ten seconds of emulated time.
 
 Back to :ref:`debugger-execution-list`


### PR DESCRIPTION
As reported [here](https://github.com/mamedev/www.mamedev.org/issues/28), there is a extra tick mark in the `gtime` example in `execution.rst`. This simply removes the extra tick mark.