### PR TITLE
Various Documentation fixes

### DIFF
--- a/docs/source/advanced/ctrlr_config.rst
+++ b/docs/source/advanced/ctrlr_config.rst
@@ -258,6 +258,6 @@ Here’s an example numbering two light guns and two XInput game controllers:
     </system>
 
 MAME applies ``mapdevice`` elements found inside the first applicable ``system``
-element only.  To avoid confusion, it’s simplest place the ``system`` element
-element applying to all systems (``name`` attribute set to ``default``) first
-in the file, and use it to assign input device numbers.
+element only.  To avoid confusion, it’s simplest to place the ``system`` element
+applying to all systems (``name`` attribute set to ``default``) first in the
+file, and use it to assign input device numbers.

--- a/docs/source/advanced/hlsl.rst
+++ b/docs/source/advanced/hlsl.rst
@@ -129,7 +129,7 @@ Configuration Settings
 |
 | **cubic_distortion** (*Cubic Distortion Amount*)
 |
-| 	This setting determines strength of the qubic distortion of the screen image.
+| 	This setting determines strength of the cubic distortion of the screen image.
 |
 |   Both distortion factors can be negative to compensate each other. e.g. distortion 0.5 and cubic_distortion -0.5
 |

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -40,7 +40,7 @@ File Names and Directory Paths
 ------------------------------
 
 A number of options for specifying directories support multiple paths (for
-for example to search for ROMs in multiple locations).  MAME expects multiple
+example to search for ROMs in multiple locations).  MAME expects multiple
 paths to be separated with semicolons ( ``;`` ).
 
 MAME expands environment variable expressions in paths.  The syntax used depends
@@ -1905,7 +1905,7 @@ Core Performance Options
 
 **-[no]throttle**
 
-   Enable or disable thottling emulation speed.  When throttling is enabled,
+   Enable or disable throttling emulation speed.  When throttling is enabled,
    MAME limits emulation speed to so the emulated system will not run faster
    than the original hardware.  When throttling is disabled, MAME runs the
    emulation as fast as possible. Depending on your settings and the
@@ -2334,7 +2334,7 @@ Core Video Options
 
     The default is ``1``.
 
-    This is supported with all video output types ( ``bgfx``, ``d3d``, etc) on
+    This is supported with all video output types ( ``bgfx``, ``d3d``, etc.) on
     Windows and is supported with BGFX and OpenGL on other platforms.
 
     Example:
@@ -2369,7 +2369,7 @@ Core Video Options
 **-[no]unevenstretch**
 
     Allow non-integer scaling factors allowing for great window sizing
-    flexability.
+    flexibility.
 
     The default is ON. (**-unevenstretch**)
 
@@ -2896,7 +2896,7 @@ Core Video OpenGL GLSL Options
 
 **-glsl_shader_mame9**
 
-    Set a custom OpenGL GLSL shader effect to the internal systcm screen in the
+    Set a custom OpenGL GLSL shader effect to the internal system screen in the
     given slot. MAME does not include a vast selection of shaders by default;
     more can be found online.
 
@@ -2917,7 +2917,7 @@ Core Video OpenGL GLSL Options
 
 
     Set a custom OpenGL GLSL shader effect to the whole scaled-up output screen
-    that will be rendered by your graphics card.MAME does not include a vast
+    that will be rendered by your graphics card. MAME does not include a vast
     selection of shaders by default; more can be found online.
 
     Example:
@@ -3458,7 +3458,7 @@ Core Input Options
 
     Allows user to specify whether or not to use a natural keyboard or not.
     This allows you to start your system in a 'native' mode, depending on your
-    region, allowing compatability for non-"QWERTY" style keyboards.
+    region, allowing compatibility for non-"QWERTY" style keyboards.
 
     The default is OFF (**-nonatural**)
 
@@ -4072,8 +4072,8 @@ Scripting Options
 **-autoboot_command** *"<command>"*
 
     Command string to execute after machine boot (in quotes " "). To issue a
-    quote to the emulation, use """ in the string. Using **\\n** will issue a
-    create a new line, issuing what was typed prior as a command.
+    quote to the emulation, use """ in the string. Using **\\n** will create
+    a new line, issuing what was typed prior as a command.
 
     This works only with systems that support natural keyboard mode.
 

--- a/docs/source/commandline/sdlconfig.rst
+++ b/docs/source/commandline/sdlconfig.rst
@@ -1,4 +1,4 @@
-SDL-Specific Commandline Options
+SDL-Specific Command-line Options
 ================================
 
 This section contains configuration options that are specific to any build

--- a/docs/source/debugger/execution.rst
+++ b/docs/source/debugger/execution.rst
@@ -186,7 +186,7 @@ or skip instruction is taken, following any delay slots.
 The optional **<condition>** parameter lets you specify an expression
 that will be evaluated each time a conditional branch is encountered.
 If the result of the expression is true (non-zero), execution will be
-haltedafter the branch if it is taken; otherwise, execution will
+halted after the branch if it is taken; otherwise, execution will
 continue with no notification.
 
 Examples:
@@ -269,7 +269,7 @@ gni
 
 Resumes execution.  Control will not be returned to the debugger until a
 breakpoint or watchpoint is triggered.  A temporary unconditional breakpoint
-is set at the prorgam address **<count>** instructions sequentially past the
+is set at the program address **<count>** instructions sequentially past the
 current one.  When this breakpoint is hit, it is automatically removed.
 
 The **<count>** parameter is optional and defaults to 1 if omitted.  If
@@ -440,7 +440,7 @@ trace
 Starts or stops tracing for execution of the specified **<CPU>**, or the
 currently visible CPU if no CPU is specified.  To enable tracing,
 specify the trace log file name in the **<filename>** parameter.  To
-disable tracing, use the keyword ``off`` for for the **<filename>**
+disable tracing, use the keyword ``off`` for the **<filename>**
 parameter.  If the **<filename>** argument begins with two right angle
 brackets (**>>**), it is treated as a directive to open the file for
 appending rather than overwriting.

--- a/docs/source/debugger/index.rst
+++ b/docs/source/debugger/index.rst
@@ -18,7 +18,7 @@ ROM hacking, or just investigating how software works.
 
 Use the ``-debug`` command line option to start MAME with the debugger
 activated.  By default, pressing the backtick/tilde (**~**) during
-emulation breaks into the debugger (this can by changed by reassigning
+emulation breaks into the debugger (this can be changed by reassigning
 the **Break in Debugger** input).
 
 The exact appearance of the debugger depends on your operating system
@@ -239,7 +239,7 @@ Examples:
 * ``0x123`` is 123 hexadecimal (291 decimal)
 * ``#123`` is 123 decimal
 * ``0o123`` is 123 octal (83 decimal)
-* ``0b1001`` is is 1001 binary (9 decimal)
+* ``0b1001`` is 1001 binary (9 decimal)
 * ``0b123`` is invalid
 
 
@@ -360,7 +360,7 @@ Adding access types gives additional possibilities:
     suppressing side effects
 ``id@400``
     Refers to the double word at 400 in the I/O space of the current CPU
-    CPU while suppressing side effects
+    while suppressing side effects
 ``ppd!<addr>``
     Refers to the double word at physical address **<addr>** in the
     program space of the current CPU while not suppressing side effects
@@ -418,8 +418,8 @@ abs(<x>)
     absolute value.
 bit(<x>, <n>[, <w>])
     Extracts and right-aligns a bit field **<w>** bits wide from **<x>**
-    with least significant bit position position **<n>**, counting from
-    the least significant bit.  If **<w>** is omitted, a single bit is
+    with least significant bit position **<n>**, counting from the
+    least significant bit.  If **<w>** is omitted, a single bit is
     extracted.
 s8(<x>)
     Sign-extends the argument from 8 bits to 64 bits (overwrites bits 8

--- a/docs/source/debugger/registerpoints.rst
+++ b/docs/source/debugger/registerpoints.rst
@@ -131,7 +131,7 @@ rplist
 **rplist [<CPU>]**
 
 List current registerpoints, along with their indices and conditions,
-and any associated actions actions.  If no **<CPU>** is specified,
+and any associated actions.  If no **<CPU>** is specified,
 registerpoints for all CPUs in the system will be listed; if a **<CPU>**
 is specified, only registerpoints for that CPU will be listed.  The
 **<CPU>** can be specified by tag or by debugger CPU number (see

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ MAME Documentation
 ==================
 
 .. note::
-    This documentation is a work in progress.  You can track the status of these topics through MAME's `issue tracker <https://github.com/mamedev/mame/issues>`_. Learn how you can `contribute <https://github.com/mamedev/mame/blob/master/docs/CONTRIBUTING.md>`_ on GitHub.
+    This documentation is a work in progress.  You can track the status of these topics through MAME's `issue tracker <https://github.com/mamedev/mame/issues>`_. Learn how you can `contribute <https://docs.mamedev.org/contributing/>`_.
 
 .. toctree::
     :titlesonly:

--- a/docs/source/initialsetup/configuringmame.rst
+++ b/docs/source/initialsetup/configuringmame.rst
@@ -64,8 +64,3 @@ Choose **Save Configuration** to create the ``mame.ini`` file with default
 settings. From here, you can either continue to configure things from the
 graphical user interface or edit the ``mame.ini`` file in your favorite
 text editor.
-
-
-Configuring MAME
-----------------
-

--- a/docs/source/luascript/ref-input.rst
+++ b/docs/source/luascript/ref-input.rst
@@ -572,7 +572,7 @@ poller:start([seq])
     the positive and negative portions of an axis; for switch inputs, an “or”
     code is appended and the user can add an alternate host input combination.
 poller:poll()
-    Polls for for user input and updates the sequence if appropriate.  Returns a
+    Polls for user input and updates the sequence if appropriate.  Returns a
     Boolean indicating whether sequence input is complete.  If this method
     returns false, you should continue polling.
 

--- a/docs/source/luascript/ref-mem.rst
+++ b/docs/source/luascript/ref-mem.rst
@@ -48,7 +48,7 @@ memory.regions[]
 Address space
 -------------
 
-Wraps MAME’s ``address_space`` class, which represent’s an address space
+Wraps MAME’s ``address_space`` class, which represents an address space
 belonging to a device.
 
 Instantiation

--- a/docs/source/luascript/ref-render.rst
+++ b/docs/source/luascript/ref-render.rst
@@ -48,7 +48,7 @@ bounds:set_xy(left, top, right, bottom)
 
     The arguments must all be floating-point numbers.
 bounds:set_wh(left, top, width, height)
-    Set the rectangle’s position and size in terms of the top top left corner
+    Set the rectangle’s position and size in terms of the top left corner
     position, and the width and height.
 
     The arguments must all be floating-point numbers.

--- a/docs/source/plugins/autofire.rst
+++ b/docs/source/plugins/autofire.rst
@@ -46,8 +46,8 @@ button are the same.
 Select **Input** to set the emulated button that you want to simulate pressing
 repeatedly.  Currently, only player buttons are supported.  Typically you’ll set
 this to the primary fire button for shooting games.  This is most often *P1
-Button 1* or the equivalent for another player, but it might have have a
-different name.  On Konami’s Gradius games, *P1 Button 2* is the primary fire
+Button 1* or the equivalent for another player, but it might have a
+different name. On Konami’s Gradius games, *P1 Button 2* is the primary fire
 button.
 
 Select **Hotkey** to set the control (or combination of controls) you’ll use to

--- a/docs/source/plugins/discord.rst
+++ b/docs/source/plugins/discord.rst
@@ -3,7 +3,7 @@
 Discord Presence Plugin
 =======================
 
-The Dicord presence plugin works with the Discord app for Windows, macOS or
+The Discord presence plugin works with the Discord app for Windows, macOS or
 Linux to set your activity to show what you’re doing in MAME.  The activity is
 set to *In menu* if you’re using the system or software selection menu,
 *Playing* if emulation is running, or *Paused* if emulation is paused.  The

--- a/docs/source/plugins/index.rst
+++ b/docs/source/plugins/index.rst
@@ -35,7 +35,7 @@ in an INI file or on the command line).
 Many plugins need to store settings and/or data.  The
 :ref:`homepath option <mame-commandline-homepath>` sets the folder where plugins
 should save data (defaults to the working directory).  You can change this by
-selecting **Configure Options** from the system selection menu, thens selecting
+selecting **Configure Options** from the system selection menu, then selecting
 **Configure Directories**, and then selecting **Plugin Data**.
 
 To turn individual plugins on or off, first make sure plugins are enabled, then

--- a/docs/source/plugins/inputmacro.rst
+++ b/docs/source/plugins/inputmacro.rst
@@ -224,7 +224,7 @@ pressing a single key:
   * **Duration (frames)**: 1
   * **Input 1**: P1 Jab Punch
 
-This macro has has involves steps that activate multiple inputs.  The macro will
+This macro involves steps that activate multiple inputs.  The macro will
 complete if the activation sequence is released early, allowing you to tap the
 key momentarily to perform the move.  Holding the activation sequence holds down
 the attack button.

--- a/docs/source/usingmame/assetsearch.rst
+++ b/docs/source/usingmame/assetsearch.rst
@@ -194,7 +194,7 @@ keyboard microcontroller ROM as follows:
   called **mackbd_m0110a_f.zip**, or a 7-Zip archive called
   **mackbd_m0110a_f.7z**.
 * The parent ROM device is the U.S. Macintosh Plus keyboard with integrated
-  numeric keypad, whcih has the short name ``mackbd_m0110a``, so MAME will look
+  numeric keypad, which has the short name ``mackbd_m0110a``, so MAME will look
   for a folder called **mackbd_m0110a**, a PKZIP archive called
   **mackbd_m0110a.zip**, or a 7-Zip archive called **mackbd_m0110a.7z**.
 * The short name of the Unitron 1024 system is ``utrn1024``, so MAME will look

--- a/docs/source/usingmame/mamemenus.rst
+++ b/docs/source/usingmame/mamemenus.rst
@@ -120,7 +120,7 @@ Crosshair Options
     Shows the Crosshair Options menu, where you can adjust the appearance of
     crosshairs used to show the location of emulated light guns and other
     absolute pointer inputs.  This item is not shown if the emulated system has
-    has no absolute pointer inputs.
+    no absolute pointer inputs.
 Cheat
     Shows the Cheat menu, for controlling the built-in cheat engine.  This item
     is only shown if the built-in chat engine is enabled.  Note that the cheat

--- a/docs/source/usingmame/usingmame.rst
+++ b/docs/source/usingmame/usingmame.rst
@@ -3,7 +3,7 @@ Using MAME
 
 If you want to dive right in and skip the command line, there's a nice graphical
 way to use MAME without the need to download and set up a front end. Simply
-start MAME with no parameters, by doubleclicking the **mame.exe** file or
+start MAME with no parameters, by double-clicking the **mame.exe** file or
 running it directly from the command line. If you're looking to harness the
 full power of MAME, keep reading further.
 
@@ -14,7 +14,7 @@ to missing glyphs.
 If you are a new MAME user, you could find this emulator a bit complex at
 first. Let's take a moment to talk about software lists, as they can simplify
 matters quite a bit. If the content you are trying to play is a documented
-entry on one of the MAME sotware lists, starting the content is as easy as
+entry on one of the MAME software lists, starting the content is as easy as
 
     **mame.exe** *<system>* *<software>*
 
@@ -86,7 +86,7 @@ of this manual.
     **mame.exe -showconfig**
 
 gives you a (quite long) list of available configuration options for MAME.
-These optons can always be modified at command line, or by editing them in
+These options can always be modified at command line, or by editing them in
 mame.ini which is the main configuration file for MAME. You can find a
 description of some configuration options in the
 :ref:`mame-commandline-universal` section of the manual (in most cases, each

--- a/docs/source/whatis.rst
+++ b/docs/source/whatis.rst
@@ -77,7 +77,7 @@ your derivative work.  In general, this means you must request
 permission, which requires that you follow the guidelines above.
 
 The version number of any derivative work should reflect the version
-number of the MAME release from which it was was derived.
+number of the MAME release from which it was derived.
 
 
 V. Official Contact Information


### PR DESCRIPTION
Fixes of various typos, misspellings, and other minor errors in the website Documentation.