### PR TITLE
Fix documentation compilation warning

### DIFF
--- a/docs/source/commandline/sdlconfig.rst
+++ b/docs/source/commandline/sdlconfig.rst
@@ -1,5 +1,5 @@
 SDL-Specific Command-line Options
-================================
+=================================
 
 This section contains configuration options that are specific to any build
 supported by SDL (including Windows when built with SDL instead of native).


### PR DESCRIPTION
While updating my toolset and getting things working again, I noticed there were four warnings in the documentation compilation process. Three of them are sections of the Lua scripting that haven't been written yet. This warning about ``sdlconfig.rst:2: WARNING: Title underline too short.`` could be fixed in one byte so I might as well just get it while I'm here.