### PR TITLE
ioprocs.h: Add read_stream::alloc_read and random_read::alloc_read_at…

### DIFF
--- a/src/devices/bus/adam/exp.cpp
+++ b/src/devices/bus/adam/exp.cpp
@@ -76,13 +76,18 @@ void adam_expansion_slot_device::device_start()
 
 std::pair<std::error_condition, std::string> adam_expansion_slot_device::call_load()
 {
+	std::error_condition err;
+
 	if (m_card)
 	{
 		if (!loaded_through_softlist())
 		{
 			size_t const size = length();
 
-			fread(m_card->m_rom, size);
+			size_t actual;
+			err = image_core_file().alloc_read(m_card->m_rom, size, actual);
+			if (!err && actual != size)
+				err = std::errc::io_error;
 		}
 		else
 		{
@@ -90,7 +95,7 @@ std::pair<std::error_condition, std::string> adam_expansion_slot_device::call_lo
 		}
 	}
 
-	return std::make_pair(std::error_condition(), std::string());
+	return std::make_pair(err, std::string());
 }
 
 

--- a/src/devices/bus/cbm2/exp.cpp
+++ b/src/devices/bus/cbm2/exp.cpp
@@ -85,26 +85,34 @@ void cbm2_expansion_slot_device::device_start()
 
 std::pair<std::error_condition, std::string> cbm2_expansion_slot_device::call_load()
 {
+	std::error_condition err;
 	if (m_card)
 	{
 		if (!loaded_through_softlist())
 		{
+			util::core_file &file = image_core_file();
 			size_t const size = length();
 
 			if (is_filetype("20"))
 			{
-				m_card->m_bank1 = std::make_unique<uint8_t[]>(size);
-				fread(m_card->m_bank1, size);
+				size_t actual;
+				err = file.alloc_read(m_card->m_bank1, size, actual);
+				if (!err && actual != size)
+					err = std::errc::io_error;
 			}
 			else if (is_filetype("40"))
 			{
-				m_card->m_bank2 = std::make_unique<uint8_t[]>(size);
-				fread(m_card->m_bank2, size);
+				size_t actual;
+				err = file.alloc_read(m_card->m_bank2, size, actual);
+				if (!err && actual != size)
+					err = std::errc::io_error;
 			}
 			else if (is_filetype("60"))
 			{
-				m_card->m_bank3 = std::make_unique<uint8_t[]>(size);
-				fread(m_card->m_bank3, size);
+				size_t actual;
+				err = file.alloc_read(m_card->m_bank3, size, actual);
+				if (!err && actual != size)
+					err = std::errc::io_error;
 			}
 		}
 		else
@@ -115,7 +123,7 @@ std::pair<std::error_condition, std::string> cbm2_expansion_slot_device::call_lo
 		}
 	}
 
-	return std::make_pair(std::error_condition(), std::string());
+	return std::make_pair(err, std::string());
 }
 
 

--- a/src/devices/bus/cpc/cpc_rom.cpp
+++ b/src/devices/bus/cpc/cpc_rom.cpp
@@ -105,18 +105,12 @@ std::pair<std::error_condition, std::string> cpc_rom_image_device::call_load()
 {
 	uint64_t const size = length();
 
-	m_base = std::make_unique<uint8_t[]>(16384);
-	if(size <= 16384)
-	{
-		fread(m_base, size);
-	}
-	else
-	{
-		fseek(size - 16384, SEEK_SET);
-		fread(m_base, 16384);
-	}
+	size_t actual;
+	std::error_condition err = image_core_file().alloc_read_at(size <= 16384 ? 0 : size - 16384, m_base, 16384, actual);
+	if (!err && actual != std::min<size_t>(size, 16384))
+		err = std::errc::io_error;
 
-	return std::make_pair(std::error_condition(), std::string());
+	return std::make_pair(err, std::string());
 }
 
 

--- a/src/devices/bus/gameboy/gbslot.cpp
+++ b/src/devices/bus/gameboy/gbslot.cpp
@@ -1136,10 +1136,8 @@ std::pair<std::error_condition, std::string> gb_cart_slot_device::load_image_fil
 	if (read_gbx_footer_trailer(file, len, gbxtrailer))
 	{
 		// try reading the GBX footer into temporary space before more checks
-		std::unique_ptr<u8 []> const footer(new (std::nothrow) u8 [gbxtrailer.size]);
-		if (!footer)
-			return std::make_pair(std::errc::not_enough_memory, "Error allocating memory to read GBX file footer");
-		std::error_condition const err = file.read_at(len - gbxtrailer.size, footer.get(), gbxtrailer.size, actual);
+		std::unique_ptr<u8 []> footer;
+		std::error_condition const err = file.alloc_read_at(len - gbxtrailer.size, footer, gbxtrailer.size, actual);
 		if (err || (gbxtrailer.size != actual))
 			return std::make_pair(err ? err : std::errc::io_error, "Error reading GBX file footer");
 		if (1 != gbxtrailer.ver_maj)

--- a/src/devices/bus/megadrive/md_slot.cpp
+++ b/src/devices/bus/megadrive/md_slot.cpp
@@ -458,10 +458,16 @@ std::error_condition base_md_cart_slot_device::load_nonlist()
 	unsigned char *ROM;
 	bool is_smd, is_md;
 	uint32_t tmplen = length(), offset, len;
-	std::vector<uint8_t> tmpROM(tmplen);
+
+	std::unique_ptr<uint8_t []> tmpROM;
 
 	// STEP 1: store a (possibly headered) copy of the file and determine its type (SMD? MD? BIN?)
-	fread(&tmpROM[0], tmplen);
+	size_t actual;
+	std::error_condition const err = image_core_file().alloc_read(tmpROM, tmplen, actual);
+	if (err)
+		return err;
+	else if (actual != tmplen)
+		return std::errc::io_error;
 	is_smd = genesis_is_SMD(&tmpROM[0x200], tmplen - 0x200);
 	is_md = (tmpROM[0x80] == 'E') && (tmpROM[0x81] == 'A') && (tmpROM[0x82] == 'M' || tmpROM[0x82] == 'G');
 

--- a/src/devices/bus/nubus/nubus_image.cpp
+++ b/src/devices/bus/nubus/nubus_image.cpp
@@ -98,15 +98,14 @@ std::pair<std::error_condition, std::string> nubus_image_device::messimg_disk_im
 		return std::make_pair(image_error::INVALIDLENGTH, "Image file is too large (must be no more than 256MB)");
 	}
 
-	m_data.reset(new (std::nothrow) uint8_t [m_size]);
-	if (!m_data)
-		return std::make_pair(std::errc::not_enough_memory, "Error allocating memory for volume image");
+	size_t actual;
+	std::error_condition err = image_core_file().alloc_read(m_data, m_size, actual);
+	if (!err && actual != m_size)
+		err = std::errc::io_error;
 
-	fseek(0, SEEK_SET);
-	fread(m_data.get(), m_size);
 	m_ejected = false;
 
-	return std::make_pair(std::error_condition(), std::string());
+	return std::make_pair(err, std::string());
 }
 
 void nubus_image_device::messimg_disk_image_device::call_unload()

--- a/src/devices/bus/pofo/ccm.cpp
+++ b/src/devices/bus/pofo/ccm.cpp
@@ -70,15 +70,24 @@ void portfolio_memory_card_slot_device::device_start()
 
 std::pair<std::error_condition, std::string> portfolio_memory_card_slot_device::call_load()
 {
+	std::error_condition err;
+
 	if (m_card)
 	{
 		if (!loaded_through_softlist())
-			fread(m_card->m_rom, length());
+		{
+			size_t const size = length();
+
+			size_t actual;
+			err = image_core_file().alloc_read(m_card->m_rom, size, actual);
+			if (!err && actual != size)
+				err = std::errc::io_error;
+		}
 		else
 			load_software_region("rom", m_card->m_rom);
 	}
 
-	return std::make_pair(std::error_condition(), std::string());
+	return std::make_pair(err, std::string());
 }
 
 

--- a/src/devices/bus/ql/rom.cpp
+++ b/src/devices/bus/ql/rom.cpp
@@ -87,11 +87,16 @@ void ql_rom_cartridge_slot_device::device_start()
 
 std::pair<std::error_condition, std::string> ql_rom_cartridge_slot_device::call_load()
 {
+	std::error_condition err;
 	if (m_card)
 	{
 		if (!loaded_through_softlist())
 		{
-			fread(m_card->m_rom, length());
+			size_t const size = length();
+			size_t actual;
+			err = image_core_file().alloc_read(m_card->m_rom, size, actual);
+			if (!err && actual != size)
+				err = std::errc::io_error;
 		}
 		else
 		{
@@ -99,7 +104,7 @@ std::pair<std::error_condition, std::string> ql_rom_cartridge_slot_device::call_
 		}
 	}
 
-	return std::make_pair(std::error_condition(), std::string());
+	return std::make_pair(err, std::string());
 }
 
 

--- a/src/devices/bus/snes/snes_slot.cpp
+++ b/src/devices/bus/snes/snes_slot.cpp
@@ -655,8 +655,11 @@ std::pair<std::error_condition, std::string> base_sns_cart_slot_device::call_loa
 		if (!loaded_through_softlist())
 		{
 			uint32_t tmplen = length();
-			std::vector<uint8_t> tmpROM(tmplen);
-			fread(&tmpROM[0], tmplen);
+			std::unique_ptr<uint8_t []> tmpROM;
+			size_t actual;
+			std::error_condition const err = image_core_file().alloc_read(tmpROM, tmplen, actual);
+			if (err || actual != tmplen)
+				return std::make_pair(err ? err : std::errc::io_error, std::string());
 			offset = snes_skip_header(&tmpROM[0], tmplen);
 			fseek(offset, SEEK_SET);
 		}

--- a/src/devices/bus/vic10/exp.cpp
+++ b/src/devices/bus/vic10/exp.cpp
@@ -82,24 +82,34 @@ void vic10_expansion_slot_device::device_start()
 
 std::pair<std::error_condition, std::string> vic10_expansion_slot_device::call_load()
 {
+	std::error_condition err;
 	if (m_card)
 	{
 		if (!loaded_through_softlist())
 		{
+			util::core_file &file = image_core_file();
 			size_t const size = length();
 
 			if (is_filetype("80"))
 			{
-				fread(m_card->m_lorom, 0x2000);
+				size_t actual;
+				err = file.alloc_read(m_card->m_lorom, 0x2000, actual);
+				if (!err && actual != 0x2000)
+					err = std::errc::io_error;
 
-				if (size == 0x4000)
+				if (!err && size == 0x4000)
 				{
-					fread(m_card->m_uprom, 0x2000);
+					err = file.alloc_read(m_card->m_uprom, 0x2000, actual);
+					if (!err && actual != 0x2000)
+						err = std::errc::io_error;
 				}
 			}
 			else if (is_filetype("e0"))
 			{
-				fread(m_card->m_uprom, size);
+				size_t actual;
+				err = file.alloc_read(m_card->m_uprom, size, actual);
+				if (!err && actual != size)
+					err = std::errc::io_error;
 			}
 			else if (is_filetype("crt"))
 			{
@@ -108,7 +118,7 @@ std::pair<std::error_condition, std::string> vic10_expansion_slot_device::call_l
 				int exrom = 1;
 				int game = 1;
 
-				if (cbm_crt_read_header(image_core_file(), &roml_size, &romh_size, &exrom, &game))
+				if (cbm_crt_read_header(file, &roml_size, &romh_size, &exrom, &game))
 				{
 					uint8_t *roml = nullptr;
 					uint8_t *romh = nullptr;
@@ -119,7 +129,7 @@ std::pair<std::error_condition, std::string> vic10_expansion_slot_device::call_l
 					if (roml_size) roml = m_card->m_lorom.get();
 					if (romh_size) romh = m_card->m_lorom.get();
 
-					cbm_crt_read_data(image_core_file(), roml, romh);
+					cbm_crt_read_data(file, roml, romh);
 				}
 			}
 		}
@@ -131,7 +141,7 @@ std::pair<std::error_condition, std::string> vic10_expansion_slot_device::call_l
 		}
 	}
 
-	return std::make_pair(std::error_condition(), std::string());
+	return std::make_pair(err, std::string());
 }
 
 

--- a/src/devices/machine/psion_ssd.cpp
+++ b/src/devices/machine/psion_ssd.cpp
@@ -163,8 +163,10 @@ std::pair<std::error_condition, std::string> psion_ssd_device::call_load()
 	if (size < 0x10000 || size > 0x800000 || (size & (size - 1)) != 0)
 		return std::make_pair(image_error::INVALIDLENGTH, "Invalid size, must be 64K, 128K, 256K, 512K, 1M, 2M, 4M, 8M");
 
-	if (fread(m_ssd_data, size) != size)
-		return std::make_pair(std::errc::io_error, std::string());
+	size_t actual;
+	std::error_condition const err = image_core_file().alloc_read(m_ssd_data, size, actual);
+	if (err || actual != size)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	// check for Flash header
 	if ((m_ssd_data[0] | (m_ssd_data[1] << 8)) == 0xf1a5) // Flash

--- a/src/devices/machine/smartmed.cpp
+++ b/src/devices/machine/smartmed.cpp
@@ -116,7 +116,11 @@ std::error_condition smartmedia_image_device::smartmedia_format_1()
 		fread(&m_mp_opcode, 1);
 		fread(m_data_uid_ptr.get(), 256 + 16);
 	}
-	fread(m_feeprom_data, m_page_total_size*m_num_pages);
+
+	size_t actual;
+	std::error_condition const err = image_core_file().alloc_read(m_feeprom_data, m_page_total_size*m_num_pages, actual);
+	if (err || actual != m_page_total_size*m_num_pages)
+		return err ? err : std::errc::io_error;
 
 #ifdef SMARTMEDIA_IMAGE_SAVE
 	m_image_format = 1;
@@ -207,7 +211,10 @@ std::error_condition smartmedia_image_device::smartmedia_format_2()
 	}
 	memcpy(m_data_uid_ptr.get() + 256, custom_header.data3, 16);
 
-	fread(m_feeprom_data, m_page_total_size*m_num_pages);
+	size_t actual;
+	std::error_condition const err = image_core_file().alloc_read(m_feeprom_data, m_page_total_size*m_num_pages, actual);
+	if (err || actual != m_page_total_size*m_num_pages)
+		return err ? err : std::errc::io_error;
 
 #ifdef SMARTMEDIA_IMAGE_SAVE
 	m_image_format = 2;

--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -158,15 +158,6 @@ public:
 		m_file->tell(result);
 		return result;
 	}
-	bool image_feof()
-	{
-		check_for_file();
-		return m_file->eof();
-	}
-
-	// allocate and read into buffers
-	u32 fread(std::unique_ptr<u8 []> &ptr, u32 length) { ptr = std::make_unique<u8 []>(length); return fread(ptr.get(), length); }
-	u32 fread(std::unique_ptr<u8 []> &ptr, u32 length, offs_t offset) { ptr = std::make_unique<u8 []>(length); return fread(ptr.get() + offset, length - offset); }
 
 	// access to software list item information
 	const software_info *software_entry() const noexcept;

--- a/src/lib/formats/ap2_dsk.cpp
+++ b/src/lib/formats/ap2_dsk.cpp
@@ -1049,12 +1049,10 @@ bool a2_edd_format::load(util::random_read &io, uint32_t form_factor, const std:
 	uint8_t nibble[16384], stream[16384];
 	int npos[16384];
 
-	std::unique_ptr<uint8_t []> img(new (std::nothrow) uint8_t[2244608]);
-	if (!img)
-		return false;
-
+	std::unique_ptr<uint8_t []> img;
 	size_t actual;
-	io.read_at(0, img.get(), 2244608, actual);
+	if (io.alloc_read_at(0, img, 2244608, actual))
+		return false;
 
 	for(int i=0; i<137; i++) {
 		uint8_t const *const trk = &img[16384*i];

--- a/src/lib/formats/ccvf_dsk.cpp
+++ b/src/lib/formats/ccvf_dsk.cpp
@@ -96,9 +96,10 @@ bool ccvf_format::load(util::random_read &io, uint32_t form_factor, const std::v
 	if (io.length(size))
 		return false;
 
-	std::vector<uint8_t> img(size);
+	std::unique_ptr<uint8_t []> img;
 	size_t actual;
-	io.read_at(0, &img[0], size, actual);
+	if (io.alloc_read_at(0, img, size, actual) || actual != size)
+		return false;
 
 	std::string ccvf = std::string((const char *)&img[0], size);
 	std::vector<uint8_t> bytes(78720);

--- a/src/lib/formats/cqm_dsk.cpp
+++ b/src/lib/formats/cqm_dsk.cpp
@@ -317,8 +317,9 @@ bool cqm_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	uint64_t cqm_size;
 	if (io.length(cqm_size))
 		return false;
-	std::vector<uint8_t> cqmbuf(cqm_size);
-	io.read_at(0, &cqmbuf[0], cqm_size, actual);
+	std::unique_ptr<uint8_t []> cqmbuf;
+	if (io.alloc_read_at(0, cqmbuf, cqm_size, actual) || actual != cqm_size)
+		return false;
 
 	// decode the RLE data
 	for (int s = 0, pos = CQM_HEADER_SIZE + comment_size; pos < cqm_size; )

--- a/src/lib/formats/fsd_dsk.cpp
+++ b/src/lib/formats/fsd_dsk.cpp
@@ -111,9 +111,10 @@ bool fsd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	uint64_t size;
 	if(io.length(size))
 		return false;
-	std::vector<uint8_t> img(size);
+	std::unique_ptr<uint8_t []> img;
 	size_t actual;
-	io.read_at(0, &img[0], size, actual);
+	if(io.alloc_read_at(0, img, size, actual) || actual != size)
+		return false;
 
 	uint64_t pos;
 	std::string title;

--- a/src/lib/formats/g64_dsk.cpp
+++ b/src/lib/formats/g64_dsk.cpp
@@ -51,9 +51,10 @@ bool g64_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	if (io.length(size))
 		return false;
 
-	std::vector<uint8_t> img(size);
+	std::unique_ptr<uint8_t []> img;
 	size_t actual;
-	io.read_at(0, &img[0], size, actual);
+	if (io.alloc_read_at(0, img, size, actual) || actual != size)
+		return false;
 
 	if (img[POS_VERSION])
 	{

--- a/src/lib/formats/hpi_dsk.cpp
+++ b/src/lib/formats/hpi_dsk.cpp
@@ -162,9 +162,10 @@ bool hpi_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	image->set_variant(heads == 2 ? floppy_image::DSDD : floppy_image::SSDD);
 
 	// Suck in the whole image
-	std::vector<uint8_t> image_data(size);
+	std::unique_ptr<uint8_t []> image_data;
 	size_t actual;
-	io.read_at(0, image_data.data(), size, actual);
+	if (io.alloc_read_at(0, image_data, size, actual) || actual != size)
+		return false;
 
 	// Get interleave factor from image
 	unsigned il = (unsigned)image_data[ IL_OFFSET ] * 256 + image_data[ IL_OFFSET + 1 ];

--- a/src/lib/formats/imd_dsk.cpp
+++ b/src/lib/formats/imd_dsk.cpp
@@ -442,9 +442,10 @@ bool imd_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	uint64_t size;
 	if(io.length(size))
 		return false;
-	std::vector<uint8_t> img(size);
+	std::unique_ptr<uint8_t []> img;
 	size_t actual;
-	io.read_at(0, &img[0], size, actual);
+	if(io.alloc_read_at(0, img, size, actual) || actual != size)
+		return false;
 
 	uint64_t pos, savepos;
 	for(pos=0; pos < size && img[pos] != 0x1a; pos++) { }

--- a/src/lib/formats/oric_dsk.cpp
+++ b/src/lib/formats/oric_dsk.cpp
@@ -157,9 +157,10 @@ bool oric_jasmin_format::load(util::random_read &io, uint32_t form_factor, const
 
 	int const heads = size == 41*17*256 ? 1 : 2;
 
-	std::vector<uint8_t> data(size);
+	std::unique_ptr<uint8_t []> data;
 	size_t actual;
-	io.read_at(0, data.data(), size, actual);
+	if(io.alloc_read_at(0, data, size, actual) || actual != size)
+		return false;
 
 	for(int head = 0; head != heads; head++)
 		for(int track = 0; track != 41; track++) {
@@ -171,7 +172,7 @@ bool oric_jasmin_format::load(util::random_read &io, uint32_t form_factor, const
 				sdesc[s].sector = sector + 1;
 				sdesc[s].size = 1;
 				sdesc[s].actual_size = 256;
-				sdesc[s].data = data.data() + 256 * (sector + track*17 + head*17*41);
+				sdesc[s].data = data.get() + 256 * (sector + track*17 + head*17*41);
 				sdesc[s].deleted = false;
 				sdesc[s].bad_crc = false;
 			}

--- a/src/lib/formats/victor9k_dsk.cpp
+++ b/src/lib/formats/victor9k_dsk.cpp
@@ -303,12 +303,10 @@ bool victor9k_format::load(util::random_read &io, uint32_t form_factor, const st
 	if(io.length(size))
 		return false;
 
-	std::vector<uint8_t> img;
-	try { img.resize(size); }
-	catch (...) { return false; }
-
+	std::unique_ptr<uint8_t []> img;
 	size_t actual;
-	io.read_at(0, &img[0], size, actual);
+	if(io.alloc_read_at(0, img, size, actual) || actual != size)
+		return false;
 
 	log_boot_sector(&img[0]);
 

--- a/src/lib/formats/vt_dsk.h
+++ b/src/lib/formats/vt_dsk.h
@@ -19,7 +19,7 @@ public:
 	virtual bool supports_save() const override { return true; }
 
 protected:
-	static void image_to_flux(const std::vector<uint8_t> &bdata, floppy_image *image);
+	static void image_to_flux(const uint8_t *bdata, floppy_image *image);
 	static std::vector<uint8_t> flux_to_image(floppy_image *image);
 
 	static void wbit(std::vector<uint32_t> &buffer, uint32_t &pos, bool bit);

--- a/src/lib/util/png.cpp
+++ b/src/lib/util/png.cpp
@@ -477,13 +477,8 @@ private:
 		// read the chunk itself into an allocated memory buffer
 		if (length)
 		{
-			// allocate memory for this chunk
-			data.reset(new (std::nothrow) std::uint8_t [length]);
-			if (!data)
-				return std::errc::not_enough_memory;
-
-			// read the data from the file
-			err = fp.read(data.get(), length, actual);
+			// allocate memory and read the data from the file
+			err = fp.alloc_read(data, length, actual);
 			if (err)
 			{
 				data.reset();

--- a/src/mame/apple/apple1.cpp
+++ b/src/mame/apple/apple1.cpp
@@ -189,9 +189,11 @@ SNAPSHOT_LOAD_MEMBER(apple1_state::snapshot_cb)
 	if ((snapsize - 12) > 65535)
 		return std::make_pair(image_error::INVALIDLENGTH, "Snapshot is too long");
 
-	auto data = std::make_unique<uint8_t []>(snapsize);
-	if (image.fread(data.get(), snapsize) != snapsize)
-		return std::make_pair(image_error::UNSPECIFIED, "Internal error loading snapshot");
+	std::unique_ptr<uint8_t []> data;
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(data, snapsize, actual);
+	if (err || actual != snapsize)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	if ((memcmp(hd1, &data[0], 5)) || (memcmp(hd2, &data[7], 5)))
 		return std::make_pair(image_error::INVALIDIMAGE, "Snapshot is invalid");

--- a/src/mame/atari/lynx.cpp
+++ b/src/mame/atari/lynx.cpp
@@ -163,9 +163,12 @@ QUICKLOAD_LOAD_MEMBER(lynx_state::quickload_cb)
 	uint16_t const start = header[3] | (header[2]<<8); //! big endian format in file format for little endian cpu
 	uint16_t const length = (header[5] | (header[4]<<8)) - 10;
 
-	std::vector<u8> data;
-	data.resize(length);
-	if (image.fread(&data[0], length) != length)
+	std::unique_ptr<u8 []> data;
+	size_t actual;
+	std::error_condition const error = image.image_core_file().alloc_read(data, length, actual);
+	if (error)
+		return std::make_pair(error, std::string());
+	if (actual != length)
 		return std::make_pair(image_error::INVALIDIMAGE, "Invalid length in file header");
 
 	address_space &space = m_maincpu->space(AS_PROGRAM);

--- a/src/mame/ausnz/binbug.cpp
+++ b/src/mame/ausnz/binbug.cpp
@@ -189,12 +189,12 @@ QUICKLOAD_LOAD_MEMBER(binbug_state::quickload_cb)
 		return std::make_pair(image_error::INVALIDLENGTH, "File too long");
 	}
 
-	std::vector<u8> quick_data;
-	quick_data.resize(quick_length);
-	int const read_ = image.fread( &quick_data[0], quick_length);
-	if (read_ != quick_length)
+	std::unique_ptr<u8 []> quick_data;
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(quick_data, quick_length, actual);
+	if (err || actual != quick_length)
 	{
-		return std::make_pair(image_error::UNSPECIFIED, "Cannot read the file");
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 	}
 	else if (quick_data[0] != 0xc4)
 	{
@@ -211,7 +211,7 @@ QUICKLOAD_LOAD_MEMBER(binbug_state::quickload_cb)
 
 	address_space &space = m_maincpu->space(AS_PROGRAM);
 	constexpr int QUICK_ADDR = 0x440;
-	for (int i = QUICK_ADDR; i < read_; i++)
+	for (int i = QUICK_ADDR; i < quick_length; i++)
 		space.write_byte(i, quick_data[i]);
 
 	// display a message about the loaded quickload

--- a/src/mame/ausnz/eti660.cpp
+++ b/src/mame/ausnz/eti660.cpp
@@ -317,11 +317,11 @@ void eti660_state::machine_start()
 QUICKLOAD_LOAD_MEMBER(eti660_state::quickload_cb)
 {
 	int const quick_length = image.length();
-	std::vector<u8> quick_data;
-	quick_data.resize(quick_length);
-	int const read_ = image.fread( &quick_data[0], quick_length);
-	if (read_ != quick_length)
-		return std::make_pair(image_error::INVALIDIMAGE, "Cannot read the file");
+	std::unique_ptr<u8 []> quick_data;
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(quick_data, quick_length, actual);
+	if (err || actual != quick_length)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	constexpr int QUICK_ADDR = 0x600;
 	address_space &space = m_maincpu->space(AS_PROGRAM);

--- a/src/mame/ausnz/pipbug.cpp
+++ b/src/mame/ausnz/pipbug.cpp
@@ -160,12 +160,12 @@ QUICKLOAD_LOAD_MEMBER(pipbug_state::quickload_cb)
 		return std::make_pair(image_error::INVALIDLENGTH, "File too long");
 	}
 
-	std::vector<u8> quick_data;
-	quick_data.resize(quick_length);
-	int const read_ = image.fread(&quick_data[0], quick_length);
-	if (read_ != quick_length)
+	std::unique_ptr<u8 []> quick_data;
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(quick_data, quick_length, actual);
+	if (err || actual != quick_length)
 	{
-		return std::make_pair(image_error::UNSPECIFIED, "Cannot read the file");
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 	}
 	else if (quick_data[0] != 0xc4)
 	{
@@ -184,7 +184,7 @@ QUICKLOAD_LOAD_MEMBER(pipbug_state::quickload_cb)
 	constexpr int QUICK_ADDR = 0x440;
 
 	address_space &space = m_maincpu->space(AS_PROGRAM);
-	for (int i = QUICK_ADDR; i < read_; i++)
+	for (int i = QUICK_ADDR; i < quick_length; i++)
 		space.write_byte(i, quick_data[i]);
 
 	// display a message about the loaded quickload

--- a/src/mame/cybiko/cybiko_m.cpp
+++ b/src/mame/cybiko/cybiko_m.cpp
@@ -53,8 +53,12 @@ QUICKLOAD_LOAD_MEMBER(cybiko_state::quickload_cybikoxt)
 	address_space &dest = m_maincpu->space(AS_PROGRAM);
 	uint32_t size = std::min(image.length(), uint64_t(RAMDISK_SIZE));
 
-	std::vector<uint8_t> buffer(size);
-	image.fread(&buffer[0], size);
+	std::unique_ptr<uint8_t []> buffer;
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(buffer, size, actual);
+	if (err || actual != size)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
+
 	for (int byte = 0; byte < size; byte++)
 		dest.write_byte(0x400000 + byte, buffer[byte]);
 

--- a/src/mame/homebrew/uzebox.cpp
+++ b/src/mame/homebrew/uzebox.cpp
@@ -259,8 +259,11 @@ DEVICE_IMAGE_LOAD_MEMBER(uzebox_state::cart_load)
 
 	if (!image.loaded_through_softlist())
 	{
-		std::vector<uint8_t> data(size);
-		image.fread(&data[0], size);
+		std::unique_ptr<uint8_t []> data;
+		size_t actual;
+		std::error_condition const err = image.image_core_file().alloc_read(data, size, actual);
+		if (err || actual != size)
+			return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 		if (image.is_filetype("uze"))
 			memcpy(m_cart->get_rom_base(), &data[0x200], size - 0x200);

--- a/src/mame/luxor/abc80.cpp
+++ b/src/mame/luxor/abc80.cpp
@@ -667,9 +667,13 @@ QUICKLOAD_LOAD_MEMBER(abc80_state::quickload_cb)
 	offs_t address = space.read_byte(BOFA + 1) << 8 | space.read_byte(BOFA);
 	if (LOG) logerror("BOFA %04x\n",address);
 
-	int quickload_size = image.length();
-	std::vector<u8> data(quickload_size);
-	image.fread(&data[0], quickload_size);
+	const int quickload_size = image.length();
+	std::unique_ptr<u8 []> data;
+	size_t actual;
+	const std::error_condition err = image.image_core_file().alloc_read(data, quickload_size, actual);
+	if (err || actual != quickload_size)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
+
 	for (int i = 1; i < quickload_size; i++)
 		space.write_byte(address++, data[i]);
 

--- a/src/mame/luxor/abc80x.cpp
+++ b/src/mame/luxor/abc80x.cpp
@@ -1969,9 +1969,12 @@ QUICKLOAD_LOAD_MEMBER(abc800_state::quickload_cb)
 {
 	address_space &space = m_maincpu->space(AS_PROGRAM);
 
-	size_t quickload_size = image.length();
-	std::vector<uint8_t> data(quickload_size);
-	image.fread(&data[0], quickload_size);
+	const size_t quickload_size = image.length();
+	std::unique_ptr<uint8_t []> data;
+	size_t actual;
+	const std::error_condition err = image.image_core_file().alloc_read(data, quickload_size, actual);
+	if (err || actual != quickload_size)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	uint8_t prstat = data[2];
 	uint16_t prgsz = (data[5] << 8) | data[4];

--- a/src/mame/memotech/mtx_m.cpp
+++ b/src/mame/memotech/mtx_m.cpp
@@ -426,9 +426,11 @@ SNAPSHOT_LOAD_MEMBER(mtx_state::snapshot_cb)
 	if (length >= 0x10000 - 0x4000 + 18)
 		return std::make_pair(image_error::INVALIDLENGTH, "File too long (must be at no more than 48K data)");
 
-	auto data = std::make_unique<uint8_t []>(length);
-	if (image.fread(data.get(), length) != length)
-		return std::make_pair(image_error::UNSPECIFIED, "Error reading file");
+	std::unique_ptr<uint8_t []> data;
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(data, length, actual);
+	if (err || actual != length)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	// verify first byte
 	if (data[0] != 0xff)
@@ -481,9 +483,11 @@ QUICKLOAD_LOAD_MEMBER(mtx_state::quickload_cb)
 	else if (length >= 0x10000 - 0x4000 + 4)
 		return std::make_pair(image_error::INVALIDLENGTH, "File too long (must be at no more than 48K data)");
 
-	auto data = std::make_unique<uint8_t []>(length);
-	if (image.fread(data.get(), length) != length)
-		return std::make_pair(image_error::UNSPECIFIED, "Error reading file");
+	std::unique_ptr<uint8_t []> data;
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(data, length, actual);
+	if (err || actual != length)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	uint16_t const code_base = get_u16le(&data[0]);
 	uint16_t const code_length = get_u16le(&data[2]);

--- a/src/mame/poly88/poly88_m.cpp
+++ b/src/mame/poly88/poly88_m.cpp
@@ -251,8 +251,11 @@ SNAPSHOT_LOAD_MEMBER(poly88_state::snapshot_cb)
 	int i = 0;
 	int theend = 0;
 
-	std::vector<uint8_t> data(snapshot_size);
-	image.fread(&data[0], snapshot_size);
+	std::unique_ptr<uint8_t []> data;
+	size_t actual;
+	const std::error_condition err = image.image_core_file().alloc_read(data, snapshot_size, actual);
+	if (err || actual != snapshot_size)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	while (pos<snapshot_size) {
 		for(i=0;i<9;i++) {

--- a/src/mame/sfrj/galaxy.cpp
+++ b/src/mame/sfrj/galaxy.cpp
@@ -208,8 +208,11 @@ SNAPSHOT_LOAD_MEMBER(galaxy_state::snapshot_cb)
 					util::string_format("Unsupported image size (must be %u or %u bytes)", GALAXY_SNAPSHOT_V1_SIZE, GALAXY_SNAPSHOT_V2_SIZE));
 	}
 
-	std::vector<uint8_t> snapshot_data(snapshot_size);
-	image.fread(&snapshot_data[0], snapshot_size);
+	std::unique_ptr<uint8_t []> snapshot_data;
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(snapshot_data, snapshot_size, actual);
+	if (err || actual == snapshot_size)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	setup_snapshot(&snapshot_data[0], snapshot_size);
 

--- a/src/mame/sinclair/spec_snqk.cpp
+++ b/src/mame/sinclair/spec_snqk.cpp
@@ -116,10 +116,13 @@ void spectrum_state::page_basicrom()
 
 SNAPSHOT_LOAD_MEMBER(spectrum_state::snapshot_cb)
 {
-	size_t snapshot_size = image.length();
-	std::vector<uint8_t> snapshot_data(snapshot_size);
+	size_t const snapshot_size = image.length();
+	std::unique_ptr<uint8_t []> snapshot_data;
 
-	image.fread(&snapshot_data[0], snapshot_size);
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(snapshot_data, snapshot_size, actual);
+	if (err || actual != snapshot_size)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	if (image.is_filetype("sna"))
 	{
@@ -2399,10 +2402,13 @@ void spectrum_state::setup_z80(uint8_t *snapdata, uint32_t snapsize)
 
 QUICKLOAD_LOAD_MEMBER(spectrum_state::quickload_cb)
 {
-	size_t quickload_size = image.length();
-	std::vector<uint8_t> quickload_data(quickload_size);
+	size_t const quickload_size = image.length();
+	std::unique_ptr<uint8_t []> quickload_data;
 
-	image.fread(&quickload_data[0], quickload_size);
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(quickload_data, quickload_size, actual);
+	if (err || actual != quickload_size)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	if (image.is_filetype("scr"))
 	{

--- a/src/mame/ti/ti85_m.cpp
+++ b/src/mame/ti/ti85_m.cpp
@@ -1199,8 +1199,11 @@ SNAPSHOT_LOAD_MEMBER(ti85_state::snapshot_cb)
 				util::string_format("Incorrect snapshot file length (expected %u bytes)", expected_snapshot_size));
 	}
 
-	std::vector<uint8_t> ti8x_snapshot_data(image.length());
-	image.fread(&ti8x_snapshot_data[0], image.length());
+	std::unique_ptr<uint8_t []> ti8x_snapshot_data;
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(ti8x_snapshot_data, expected_snapshot_size, actual);
+	if (err || actual != expected_snapshot_size)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	if (!strncmp(machine().system().name, "ti85", 4))
 		ti85_setup_snapshot(&ti8x_snapshot_data[0]);

--- a/src/mame/tvgames/spg29x.cpp
+++ b/src/mame/tvgames/spg29x.cpp
@@ -435,8 +435,10 @@ QUICKLOAD_LOAD_MEMBER(spg29x_game_state::quickload_hyper_exe)
 	const uint32_t length = image.length();
 
 	std::unique_ptr<u8 []> ptr;
-	if (image.fread(ptr, length) != length)
-		return std::make_pair(image_error::UNSPECIFIED, std::string());
+	size_t actual;
+	const std::error_condition err = image.image_core_file().alloc_read(ptr, length, actual);
+	if (err || actual != length)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 
 	auto &space = m_maincpu->space(AS_PROGRAM);
 	for (uint32_t i = 0; i < length; i++)

--- a/src/mame/ussr/lviv_m.cpp
+++ b/src/mame/ussr/lviv_m.cpp
@@ -286,9 +286,12 @@ std::pair<std::error_condition, std::string> lviv_state::verify_snapshot(const u
 
 SNAPSHOT_LOAD_MEMBER(lviv_state::snapshot_cb)
 {
-	std::vector<uint8_t> snapshot_data(LVIV_SNAPSHOT_SIZE);
+	std::unique_ptr<uint8_t []> snapshot_data;
 
-	image.fread(&snapshot_data[0], LVIV_SNAPSHOT_SIZE);
+	size_t actual;
+	std::error_condition const error = image.image_core_file().alloc_read(snapshot_data, LVIV_SNAPSHOT_SIZE, actual);
+	if (error)
+		return std::make_pair(error, std::string());
 
 	auto err = verify_snapshot(&snapshot_data[0], image.length());
 	if (err.first)

--- a/src/mame/vtech/vtech1.cpp
+++ b/src/mame/vtech/vtech1.cpp
@@ -181,11 +181,11 @@ SNAPSHOT_LOAD_MEMBER(vtech1_base_state::snapshot_cb)
 	uint16_t const size = end - start;
 
 	// write it to RAM
-	auto buf = std::make_unique<uint8_t []>(size);
-	if (image.fread(buf.get(), size) != size)
-	{
-		return std::make_pair(image_error::UNSPECIFIED, std::string());
-	}
+	std::unique_ptr<uint8_t []> buf;
+	size_t actual;
+	std::error_condition const err = image.image_core_file().alloc_read(buf, size, actual);
+	if (err || actual != size)
+		return std::make_pair(err ? err : std::errc::io_error, std::string());
 	uint8_t *ptr = &buf[0];
 
 	// check for supported format before overwriting memory


### PR DESCRIPTION
…. These work just like read and read_at, but take a std::unique_ptr to a uint8_t buffer and attempt to newly allocate it with the requested length. If the allocation fails, these return an error code instead of throwing an exception.

* formats/trs80_dsk.cpp: Test the JV3 writable byte without slurping in the entire file.

* diimage.h: Retire image_feof and the pointer-allocating versions of fread.