### PR TITLE
apple/apple2video.cpp: Fix Apple II DHGR rendering in Color/Composite mode

### DIFF
--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -702,8 +702,9 @@ void a2_video_device::dhgr_update(screen_device &screen, bitmap_ind16 &bitmap, c
 				words[col] = (vaux_row[col] & 0x7f) + ((vram_row[col] & 0x7f) << 7);
 			}
 
-			if (rgbmode < 0 || monochrome)			// Composite or monochrome, use the renderer that supports artifact rendering.
+			if (rgbmode < 0 || monochrome)
 			{
+				// Composite or monochrome, use the renderer that supports artifact rendering.
 				render_line(p, words, startcol, stopcol, monochrome, true);
 			}
 			else

--- a/src/mame/apple/apple2video.cpp
+++ b/src/mame/apple/apple2video.cpp
@@ -655,7 +655,6 @@ void a2_video_device::dhgr_update(screen_device &screen, bitmap_ind16 &bitmap, c
 	endrow = (std::min)(endrow, cliprect.bottom());
 	int const startcol = (cliprect.left() / 14);
 	int const stopcol = (cliprect.right() / 14) + 1;
-	const bool bIsRGBMonitor = rgb_monitor();
 
 	uint8_t const *const vram = &m_ram_ptr[page];
 	uint8_t const *const vaux = (m_aux_ptr ? m_aux_ptr : vram) + page;
@@ -703,7 +702,7 @@ void a2_video_device::dhgr_update(screen_device &screen, bitmap_ind16 &bitmap, c
 				words[col] = (vaux_row[col] & 0x7f) + ((vram_row[col] & 0x7f) << 7);
 			}
 
-			if (monochrome)
+			if (rgbmode < 0 || monochrome)			// Composite or monochrome, use the renderer that supports artifact rendering.
 			{
 				render_line(p, words, startcol, stopcol, monochrome, true);
 			}
@@ -730,7 +729,7 @@ void a2_video_device::dhgr_update(screen_device &screen, bitmap_ind16 &bitmap, c
 				{
 					unsigned const w = words[col] + (words[col+1] << 14);
 
-					unsigned const color_mask = (rgbmode == 3 || !bIsRGBMonitor) ? -1u :
+					unsigned const color_mask = (rgbmode == 3) ? -1u :
 							(vaux_row[col] >> 7) * 0x7f + (vram_row[col] >> 7) * 0x3f80
 							+ (vaux_row[col+1] >> 7) * 0x1fc000 + (vram_row[col+1] >> 7) * 0xfe00000;
 


### PR DESCRIPTION
Fix DHGR rendering when in Color/Composite mode (rgbmode == -1, in this function), so it doesn't fall through to the Video-7 RBG rendering, where only rgbmode == 1 or rgbmode == 3 is expected.  DHGR graphics look much better when the color artifact emulation is applied, which the Video-7 rendering does not do.

This returns the rendering back to what it was like in the MAME 252.  The bIsRGBMonitor was removed, as it seems to just be a patch to try and fix the issue introduced in 253, where the monochrome flag was added.  The addition of bIsRGBMonitor just made it so that when rgbmode was -1 in the function, it acted like rgbmode == 3, but that is not ideal.

This was tested using a Total Replay image, and playing DHGR games, such as Airheart and Heavy Barrel.