### PR TITLE
BGFX : Fixed duplicate import of functions on Linux using gles20

### DIFF
--- a/3rdparty/bgfx/src/glimports.h
+++ b/3rdparty/bgfx/src/glimports.h
@@ -584,6 +584,7 @@ GL_IMPORT_____x(true,  PFNGLBLENDEQUATIONSEPARATEIPROC,            glBlendEquati
 GL_IMPORT_____x(true,  PFNGLBLENDFUNCIPROC,                        glBlendFunci);
 GL_IMPORT_____x(true,  PFNGLBLENDFUNCSEPARATEIPROC,                glBlendFuncSeparatei);
 
+#if !BGFX_USE_GL_DYNAMIC_LIB
 GL_IMPORT______(true,  PFNGLDRAWBUFFERPROC,                        glDrawBuffer);
 GL_IMPORT______(true,  PFNGLREADBUFFERPROC,                        glReadBuffer);
 GL_IMPORT______(true,  PFNGLGENSAMPLERSPROC,                       glGenSamplers);
@@ -592,6 +593,7 @@ GL_IMPORT______(true,  PFNGLBINDSAMPLERPROC,                       glBindSampler
 GL_IMPORT______(true,  PFNGLSAMPLERPARAMETERFPROC,                 glSamplerParameterf);
 GL_IMPORT______(true,  PFNGLSAMPLERPARAMETERIPROC,                 glSamplerParameteri);
 GL_IMPORT______(true,  PFNGLSAMPLERPARAMETERFVPROC,                glSamplerParameterfv);
+#endif // !BGFX_USE_GL_DYNAMIC_LIB
 
 GL_IMPORT_____x(true,  PFNGLBINDBUFFERBASEPROC,                    glBindBufferBase);
 GL_IMPORT_____x(true,  PFNGLBINDBUFFERRANGEPROC,                   glBindBufferRange);


### PR DESCRIPTION
Current MAME git master code breaks if trying to compile on Linux / GLES 2.0 with bgfx and Wayland enabled because of bgfx r recent commit which has not been cherry-picked.

So this PR is loosely based on the following upstream bgfx commit : https://github.com/bkaradzic/bgfx/commit/66d50eb721334d6538a7eccdfdabb997667af1db
