### PR TITLE
heathkit/tlb.cpp - add back in gp19 fix TODOs

### DIFF
--- a/src/mame/heathkit/tlb.cpp
+++ b/src/mame/heathkit/tlb.cpp
@@ -17,7 +17,10 @@
   TODO:
     - INS8250 needs to implement "Set Break" (LCR, bit 6) before Break key
       will function as expected.
-
+    - 49/50 row mode does not work when DOT clocks are programmed as documented
+      in the manual. It does work when DOT clock is fixed at the 20.282 MHz
+      rate.
+    - In 49/50 row mode, character descenders are cut off.
 ****************************************************************************/
 /***************************************************************************
   Memory Layout


### PR DESCRIPTION
Add back in the TODO list, 2 issues with the GP-19 emulation that was inadvertently removed with https://github.com/mamedev/mame/pull/11534 since it looks like a fix proposed in https://github.com/mamedev/mame/pull/11504 is not going to be accepted.