### PR TITLE
Optimizations for Atmel AVR-8 core

### DIFF
--- a/src/devices/bus/sms_ctrl/diypaddle.cpp
+++ b/src/devices/bus/sms_ctrl/diypaddle.cpp
@@ -76,7 +76,7 @@ private:
 	TIMER_CALLBACK_MEMBER(set_lines);
 	TIMER_CALLBACK_MEMBER(set_portd);
 
-	required_device<avr8_device> m_mcu;
+	required_device<atmega168_device> m_mcu;
 	required_ioport m_button;
 	required_ioport m_paddle;
 	required_ioport m_mode;
@@ -132,12 +132,12 @@ void sms_diy_paddle_device::device_add_mconfig(machine_config &config)
 	m_mcu->set_low_fuses(0xe2);
 	m_mcu->set_high_fuses(0xdd);
 	m_mcu->set_extended_fuses(0xf9);
-	m_mcu->gpio_in<AVR8_IO_PORTB>().set(FUNC(sms_diy_paddle_device::portb_in));
-	m_mcu->gpio_in<AVR8_IO_PORTC>().set(FUNC(sms_diy_paddle_device::portc_in));
-	m_mcu->gpio_in<AVR8_IO_PORTD>().set(FUNC(sms_diy_paddle_device::portd_in));
-	m_mcu->gpio_out<AVR8_IO_PORTB>().set(FUNC(sms_diy_paddle_device::portb_out));
-	m_mcu->gpio_out<AVR8_IO_PORTC>().set(FUNC(sms_diy_paddle_device::portc_out));
-	m_mcu->adc_in<AVR8_ADC_ADC0>().set_ioport("PADDLE");
+	m_mcu->gpio_in<atmega168_device::GPIOB>().set(FUNC(sms_diy_paddle_device::portb_in));
+	m_mcu->gpio_in<atmega168_device::GPIOC>().set(FUNC(sms_diy_paddle_device::portc_in));
+	m_mcu->gpio_in<atmega168_device::GPIOD>().set(FUNC(sms_diy_paddle_device::portd_in));
+	m_mcu->gpio_out<atmega168_device::GPIOB>().set(FUNC(sms_diy_paddle_device::portb_out));
+	m_mcu->gpio_out<atmega168_device::GPIOC>().set(FUNC(sms_diy_paddle_device::portc_out));
+	m_mcu->adc_in<atmega168_device::ADC0>().set_ioport("PADDLE");
 }
 
 

--- a/src/devices/cpu/avr8/avr8.cpp
+++ b/src/devices/cpu/avr8/avr8.cpp
@@ -104,23 +104,23 @@
 
 enum
 {
-	AVR8_SREG_C = 0,
-	AVR8_SREG_Z,
-	AVR8_SREG_N,
-	AVR8_SREG_V,
-	AVR8_SREG_S,
-	AVR8_SREG_H,
-	AVR8_SREG_T,
-	AVR8_SREG_I,
+	SREG_C = 0,
+	SREG_Z,
+	SREG_N,
+	SREG_V,
+	SREG_S,
+	SREG_H,
+	SREG_T,
+	SREG_I,
 
-	AVR8_SREG_MASK_C = 0x01,
-	AVR8_SREG_MASK_Z = 0x02,
-	AVR8_SREG_MASK_N = 0x04,
-	AVR8_SREG_MASK_V = 0x08,
-	AVR8_SREG_MASK_S = 0x10,
-	AVR8_SREG_MASK_H = 0x20,
-	AVR8_SREG_MASK_T = 0x40,
-	AVR8_SREG_MASK_I = 0x80
+	SREG_MASK_C = 0x01,
+	SREG_MASK_Z = 0x02,
+	SREG_MASK_N = 0x04,
+	SREG_MASK_V = 0x08,
+	SREG_MASK_S = 0x10,
+	SREG_MASK_H = 0x20,
+	SREG_MASK_T = 0x40,
+	SREG_MASK_I = 0x80
 };
 
 // I/O Enums
@@ -176,12 +176,6 @@ enum
 	WGM5_FAST_PWM_OCR
 };
 
-static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
-
-#define SREG_R(b)   ((m_r[SREG] & (1 << (b))) >> (b))
-#define SREG_W(b,v) m_r[SREG] = (m_r[SREG] & ~(1 << (b))) | ((v) << (b))
-#define NOT(x) (1 - (x))
-
 // Opcode-Parsing Defines
 #define RD2(op)         (((op) >> 4) & 0x0003)
 #define RD3(op)         (((op) >> 4) & 0x0007)
@@ -207,398 +201,328 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define SPREG           ((m_r[SPH] << 8) | m_r[SPL])
 
 // I/O Defines
-#define AVR8_OCR1CH             (m_r[OCR1CH])
-#define AVR8_OCR1CL             (m_r[OCR1CL])
-#define AVR8_OCR1BH             (m_r[OCR1BH])
-#define AVR8_OCR1BL             (m_r[OCR1BL])
-#define AVR8_OCR1AH             (m_r[OCR1AH])
-#define AVR8_OCR1AL             (m_r[OCR1AL])
-#define AVR8_ICR1H              (m_r[ICR1H])
-#define AVR8_ICR1L              (m_r[ICR1L])
-#define AVR8_TCNT1H             (m_r[TCNT1H])
-#define AVR8_TCNT1L             (m_r[TCNT1L])
+#define TCCR0B_CS_SHIFT			0
+#define TCCR0B_CS_MASK			0x07
+#define TCCR0B_WGM0_2_SHIFT		3
+#define TCCR0B_WGM0_2_MASK		0x08
+#define TCCR0B_FOC0B_SHIFT		6
+#define TCCR0B_FOC0B_MASK		0x40
+#define TCCR0B_FOC0A_SHIFT		7
+#define TCCR0B_FOC0A_MASK		0x80
+#define TIMER0_CLOCK_SELECT		(m_r[TCCR0B] & TCCR0B_CS_MASK)
 
-#define AVR8_OCR3CH             (m_r[OCR3CH])
-#define AVR8_OCR3CL             (m_r[OCR3CL])
-#define AVR8_OCR3BH             (m_r[OCR3BH])
-#define AVR8_OCR3BL             (m_r[OCR3BL])
-#define AVR8_OCR3AH             (m_r[OCR3AH])
-#define AVR8_OCR3AL             (m_r[OCR3AL])
-#define AVR8_ICR3H              (m_r[ICR3H])
-#define AVR8_ICR3L              (m_r[ICR3L])
-#define AVR8_TCNT3H             (m_r[TCNT3H])
-#define AVR8_TCNT3L             (m_r[TCNT3L])
+#define TCCR0A_WGM0_10_SHIFT	0
+#define TCCR0A_WGM0_10_MASK		0x03
+#define TCCR0A_COM0B_SHIFT		4
+#define TCCR0A_COM0B_MASK		0x30
+#define TCCR0A_COM0A_SHIFT		6
+#define TCCR0A_COM0A_MASK		0xc0
+#define TCCR0A_COM0A			((m_r[TCCR0A] & TCCR0A_COM0A_MASK) >> TCCR0A_COM0A_SHIFT)
+#define TCCR0A_COM0B			((m_r[TCCR0A] & TCCR0A_COM0B_MASK) >> TCCR0A_COM0B_SHIFT)
+#define TCCR0A_WGM0_10			(m_r[TCCR0A] & TCCR0A_WGM0_10_MASK)
 
-#define AVR8_OCR4CH             (m_r[OCR4CH])
-#define AVR8_OCR4CL             (m_r[OCR4CL])
-#define AVR8_OCR4BH             (m_r[OCR4BH])
-#define AVR8_OCR4BL             (m_r[OCR4BL])
-#define AVR8_OCR4AH             (m_r[OCR4AH])
-#define AVR8_OCR4AL             (m_r[OCR4AL])
-#define AVR8_ICR4H              (m_r[ICR4H])
-#define AVR8_ICR4L              (m_r[ICR4L])
-#define AVR8_TCNT4H             (m_r[TCNT4H])
-#define AVR8_TCNT4L             (m_r[TCNT4L])
+#define TIMSK0_TOIE0_BIT	0
+#define TIMSK0_OCIE0A_BIT	1
+#define TIMSK0_OCIE0B_BIT	2
+#define TIMSK0_TOIE0_MASK	(1 << TIMSK0_TOIE0_BIT)
+#define TIMSK0_OCIE0A_MASK	(1 << TIMSK0_OCIE0A_BIT)
+#define TIMSK0_OCIE0B_MASK	(1 << TIMSK0_OCIE0B_BIT)
+#define TIMSK0_TOIE0		(BIT(m_r[TIMSK0], TIMSK0_TOIE0_BIT))
+#define TIMSK0_OCIE0A		(BIT(m_r[TIMSK0], TIMSK0_OCIE0A_BIT))
+#define TIMSK0_OCIE0B		(BIT(m_r[TIMSK0], TIMSK0_OCIE0B_BIT))
 
-#define AVR8_OCR5CH             (m_r[OCR5CH])
-#define AVR8_OCR5CL             (m_r[OCR5CL])
-#define AVR8_OCR5BH             (m_r[OCR5BH])
-#define AVR8_OCR5BL             (m_r[OCR5BL])
-#define AVR8_OCR5AH             (m_r[OCR5AH])
-#define AVR8_OCR5AL             (m_r[OCR5AL])
-#define AVR8_ICR5H              (m_r[ICR5H])
-#define AVR8_ICR5L              (m_r[ICR5L])
-#define AVR8_TCNT5H             (m_r[TCNT5H])
-#define AVR8_TCNT5L             (m_r[TCNT5L])
+#define TIFR0_TOV0_SHIFT	0
+#define TIFR0_TOV0_MASK		0x01
+#define TIFR0_OCF0A_SHIFT	1
+#define TIFR0_OCF0A_MASK	0x02
+#define TIFR0_OCF0B_SHIFT	2
+#define TIFR0_OCF0B_MASK	0x04
+#define TIFR0_MASK			(TIFR0_TOV0_MASK | TIFR0_OCF0B_MASK | TIFR0_OCF0A_MASK)
 
-#define AVR8_TCCR0B                 (m_r[TCCR0B])
-#define AVR8_TCCR0B_FOC0A_MASK      0x80
-#define AVR8_TCCR0B_FOC0A_SHIFT     7
-#define AVR8_TCCR0B_FOC0B_MASK      0x40
-#define AVR8_TCCR0B_FOC0B_SHIFT     6
-#define AVR8_TCCR0B_WGM0_2_MASK     0x08
-#define AVR8_TCCR0B_WGM0_2_SHIFT    3
-#define AVR8_TCCR0B_CS_MASK         0x07
-#define AVR8_TCCR0B_CS_SHIFT        0
-#define AVR8_TIMER0_CLOCK_SELECT    (m_r[TCCR0B] & AVR8_TCCR0B_CS_MASK)
+#define TCCR1B_CS_SHIFT			0
+#define TCCR1B_CS_MASK			0x07
+#define TCCR1B_WGM1_32_SHIFT	3
+#define TCCR1B_WGM1_32_MASK		0x18
+#define TCCR1B_ICES1_SHIFT		6
+#define TCCR1B_ICES1_MASK		0x40
+#define TCCR1B_ICNC1_SHIFT		7
+#define TCCR1B_ICNC1_MASK		0x80
+#define TIMER1_CLOCK_SELECT		(m_r[TCCR1B] & TCCR1B_CS_MASK)
 
-#define AVR8_TCCR0A                 (m_r[TCCR0A])
-#define AVR8_TCCR0A_COM0A_MASK      0xc0
-#define AVR8_TCCR0A_COM0A_SHIFT     6
-#define AVR8_TCCR0A_COM0B_MASK      0x30
-#define AVR8_TCCR0A_COM0B_SHIFT     4
-#define AVR8_TCCR0A_WGM0_10_MASK    0x03
-#define AVR8_TCCR0A_WGM0_10_SHIFT   0
-#define AVR8_TCCR0A_COM0A           ((AVR8_TCCR0A & AVR8_TCCR0A_COM0A_MASK) >> AVR8_TCCR0A_COM0A_SHIFT)
-#define AVR8_TCCR0A_COM0B           ((AVR8_TCCR0A & AVR8_TCCR0A_COM0B_MASK) >> AVR8_TCCR0A_COM0B_SHIFT)
-#define AVR8_TCCR0A_WGM0_10         (AVR8_TCCR0A & AVR8_TCCR0A_WGM0_10_MASK)
+#define TCCR1A_WGM1_10_SHIFT	0
+#define TCCR1A_WGM1_10_MASK		0x03
+#define TCCR1A_COM1AB_SHIFT		4
+#define TCCR1A_COM1AB_MASK		0xf0
+#define TCCR1A_COM1B_SHIFT		4
+#define TCCR1A_COM1B_MASK		0x30
+#define TCCR1A_COM1A_SHIFT		6
+#define TCCR1A_COM1A_MASK		0xc0
+#define TCCR1A_COM1A			((m_r[TCCR1A] & TCCR1A_COM1A_MASK) >> TCCR1A_COM1A_SHIFT)
+#define TCCR1A_COM1B			((m_r[TCCR1A] & TCCR1A_COM1B_MASK) >> TCCR1A_COM1B_SHIFT)
+#define TCCR1A_WGM1_10			(m_r[TCCR1A] & TCCR1A_WGM1_10_MASK)
 
-#define AVR8_TIMSK0             (m_r[TIMSK0])
-#define AVR8_TIMSK0_OCIE0B_MASK 0x04
-#define AVR8_TIMSK0_OCIE0A_MASK 0x02
-#define AVR8_TIMSK0_TOIE0_MASK  0x01
-#define AVR8_TIMSK0_OCIE0B      ((AVR8_TIMSK0 & AVR8_TIMSK0_OCIE0B_MASK) >> 2)
-#define AVR8_TIMSK0_OCIE0A      ((AVR8_TIMSK0 & AVR8_TIMSK0_OCIE0A_MASK) >> 1)
-#define AVR8_TIMSK0_TOIE0       (AVR8_TIMSK0 & AVR8_TIMSK0_TOIE0_MASK)
+#define TIMSK1_TOIE1_BIT	0
+#define TIMSK1_OCIE1A_BIT	1
+#define TIMSK1_OCIE1B_BIT	2
+#define TIMSK1_ICIE1_BIT	5
+#define TIMSK1_TOIE1_MASK	(1 << TIMSK1_TOIE1_BIT)
+#define TIMSK1_OCIE1A_MASK	(1 << TIMSK1_OCIE1A_BIT)
+#define TIMSK1_OCIE1B_MASK	(1 << TIMSK1_OCIE1B_BIT)
+#define TIMSK1_ICIE1_MASK	(1 << TIMSK1_ICIE1_BIT)
+#define TIMSK1_TOIE1		(BIT(m_r[TIMSK1], TIMSK1_TOIE1_BIT))
+#define TIMSK1_OCIE1A		(BIT(m_r[TIMSK1], TIMSK1_OCIE1A_BIT))
+#define TIMSK1_OCIE1B		(BIT(m_r[TIMSK1], TIMSK1_OCIE1B_BIT))
+#define TIMSK1_ICIE1		(BIT(m_r[TIMSK1], TIMSK1_ICIE1_BIT))
 
-#define AVR8_TIFR0              (m_r[TIFR0])
-#define AVR8_TIFR0_OCF0B_MASK   0x04
-#define AVR8_TIFR0_OCF0B_SHIFT  2
-#define AVR8_TIFR0_OCF0A_MASK   0x02
-#define AVR8_TIFR0_OCF0A_SHIFT  1
-#define AVR8_TIFR0_TOV0_MASK    0x01
-#define AVR8_TIFR0_TOV0_SHIFT   0
-#define AVR8_TIFR0_MASK         (AVR8_TIFR0_TOV0_MASK | AVR8_TIFR0_OCF0B_MASK | AVR8_TIFR0_OCF0A_MASK)
+#define TIFR1_TOV1_SHIFT	0
+#define TIFR1_TOV1_MASK		0x01
+#define TIFR1_OCF1A_SHIFT	1
+#define TIFR1_OCF1A_MASK	0x02
+#define TIFR1_OCF1B_SHIFT	2
+#define TIFR1_OCF1B_MASK	0x04
+#define TIFR1_ICF1_SHIFT	5
+#define TIFR1_ICF1_MASK		0x20
+#define TIFR1_MASK			(TIFR1_ICF1_MASK | TIFR1_TOV1_MASK | TIFR1_OCF1B_MASK | TIFR1_OCF1A_MASK)
 
-#define AVR8_TCCR1B                 (m_r[TCCR1B])
-#define AVR8_TCCR1B_ICNC1_MASK      0x80
-#define AVR8_TCCR1B_ICNC1_SHIFT     7
-#define AVR8_TCCR1B_ICES1_MASK      0x40
-#define AVR8_TCCR1B_ICES1_SHIFT     6
-#define AVR8_TCCR1B_WGM1_32_MASK    0x18
-#define AVR8_TCCR1B_WGM1_32_SHIFT   3
-#define AVR8_TCCR1B_CS_MASK         0x07
-#define AVR8_TCCR1B_CS_SHIFT        0
-#define AVR8_TIMER1_CLOCK_SELECT    (AVR8_TCCR1B & AVR8_TCCR1B_CS_MASK)
+#define TCCR2B_CS_SHIFT			0
+#define TCCR2B_CS_MASK			0x07
+#define TCCR2B_WGM2_2_SHIFT		3
+#define TCCR2B_WGM2_2_MASK		0x08
+#define TCCR2B_FOC2B_SHIFT		6
+#define TCCR2B_FOC2B_MASK		0x40
+#define TCCR2B_FOC2A_SHIFT		7
+#define TCCR2B_FOC2A_MASK		0x80
+#define TIMER2_CLOCK_SELECT		(m_r[TCCR2B] & TCCR2B_CS_MASK)
 
-#define AVR8_TCCR1A                 (m_r[TCCR1A])
-#define AVR8_TCCR1A_COM1A_MASK      0xc0
-#define AVR8_TCCR1A_COM1A_SHIFT     6
-#define AVR8_TCCR1A_COM1B_MASK      0x30
-#define AVR8_TCCR1A_COM1B_SHIFT     4
-#define AVR8_TCCR1A_COM1AB_MASK     0xf0
-#define AVR8_TCCR1A_COM1AB_SHIFT    4
-#define AVR8_TCCR1A_WGM1_10_MASK    0x03
-#define AVR8_TCCR1A_WGM1_10_SHIFT   0
-#define AVR8_TCCR1A_COM1A           ((AVR8_TCCR1A & AVR8_TCCR1A_COM1A_MASK) >> AVR8_TCCR1A_COM1A_SHIFT)
-#define AVR8_TCCR1A_COM1B           ((AVR8_TCCR1A & AVR8_TCCR1A_COM1B_MASK) >> AVR8_TCCR1A_COM1B_SHIFT)
-#define AVR8_TCCR1A_WGM1_10         (AVR8_TCCR1A & AVR8_TCCR1A_WGM1_10_MASK)
+#define TCCR2A_WGM2_10_SHIFT	0
+#define TCCR2A_WGM2_10_MASK		0x03
+#define TCCR2A_COM2B_SHIFT		4
+#define TCCR2A_COM2B_MASK		0x30
+#define TCCR2A_COM2A_SHIFT		6
+#define TCCR2A_COM2A_MASK		0xc0
+#define TCCR2A_COM2A			((m_r[TCCR2A] & TCCR2A_COM2A_MASK) >> TCCR2A_COM2A_SHIFT)
+#define TCCR2A_COM2B			((m_r[TCCR2A] & TCCR2A_COM2B_MASK) >> TCCR2A_COM2B_SHIFT)
+#define TCCR2A_WGM2_10			(m_r[TCCR2A] & TCCR2A_WGM2_10_MASK)
 
-#define AVR8_TIMSK1             (m_r[TIMSK1])
-#define AVR8_TIMSK1_ICIE1_MASK  0x20
-#define AVR8_TIMSK1_OCIE1B_MASK 0x04
-#define AVR8_TIMSK1_OCIE1A_MASK 0x02
-#define AVR8_TIMSK1_TOIE1_MASK  0x01
-#define AVR8_TIMSK1_ICIE1       ((AVR8_TIMSK1 & AVR8_TIMSK1_ICIE1_MASK) >> 5)
-#define AVR8_TIMSK1_OCIE1B      ((AVR8_TIMSK1 & AVR8_TIMSK1_OCIE1B_MASK) >> 2)
-#define AVR8_TIMSK1_OCIE1A      ((AVR8_TIMSK1 & AVR8_TIMSK1_OCIE1A_MASK) >> 1)
-#define AVR8_TIMSK1_TOIE1       (AVR8_TIMSK1 & AVR8_TIMSK1_TOIE1_MASK)
+#define TIMSK2_TOIE2_BIT	0
+#define TIMSK2_OCIE2A_BIT	1
+#define TIMSK2_OCIE2B_BIT	2
+#define TIMSK2_TOIE2_MASK	(1 << TIMSK2_TOIE2_BIT)
+#define TIMSK2_OCIE2A_MASK	(1 << TIMSK2_OCIE2A_BIT)
+#define TIMSK2_OCIE2B_MASK	(1 << TIMSK2_OCIE2B_BIT)
+#define TIMSK2_TOIE2		(BIT(m_r[TIMSK2], TIMSK2_TOIE2_BIT))
+#define TIMSK2_OCIE2A		(BIT(m_r[TIMSK2], TIMSK2_OCIE2A_BIT))
+#define TIMSK2_OCIE2B		(BIT(m_r[TIMSK2], TIMSK2_OCIE2B_BIT))
 
-#define AVR8_TIFR1              (m_r[TIFR1])
-#define AVR8_TIFR1_ICF1_MASK    0x20
-#define AVR8_TIFR1_ICF1_SHIFT   5
-#define AVR8_TIFR1_OCF1B_MASK   0x04
-#define AVR8_TIFR1_OCF1B_SHIFT  2
-#define AVR8_TIFR1_OCF1A_MASK   0x02
-#define AVR8_TIFR1_OCF1A_SHIFT  1
-#define AVR8_TIFR1_TOV1_MASK    0x01
-#define AVR8_TIFR1_TOV1_SHIFT   0
-#define AVR8_TIFR1_MASK         (AVR8_TIFR1_ICF1_MASK | AVR8_TIFR1_TOV1_MASK | \
-									AVR8_TIFR1_OCF1B_MASK | AVR8_TIFR1_OCF1A_MASK)
+#define TIFR2_TOV2_SHIFT	0
+#define TIFR2_TOV2_MASK		0x01
+#define TIFR2_OCF2A_SHIFT	1
+#define TIFR2_OCF2A_MASK	0x02
+#define TIFR2_OCF2B_SHIFT	2
+#define TIFR2_OCF2B_MASK	0x04
+#define TIFR2_MASK			(TIFR2_TOV2_MASK | TIFR2_OCF2B_MASK | TIFR2_OCF2A_MASK)
 
-#define AVR8_TCCR2B                 (m_r[TCCR2B])
-#define AVR8_TCCR2B_FOC2A_MASK      0x80
-#define AVR8_TCCR2B_FOC2A_SHIFT     7
-#define AVR8_TCCR2B_FOC2B_MASK      0x40
-#define AVR8_TCCR2B_FOC2B_SHIFT     6
-#define AVR8_TCCR2B_WGM2_2_MASK     0x08
-#define AVR8_TCCR2B_WGM2_2_SHIFT    3
-#define AVR8_TCCR2B_CS_MASK         0x07
-#define AVR8_TCCR2B_CS_SHIFT        0
-#define AVR8_TIMER2_CLOCK_SELECT    (AVR8_TCCR2B & AVR8_TCCR2B_CS_MASK)
+#define TIMSK3_TOIE3_BIT	0
+#define TIMSK3_OCIE3A_BIT	1
+#define TIMSK3_OCIE3B_BIT	2
+#define TIMSK3_OCIE3C_BIT	3
+#define TIMSK3_TOIE3		(BIT(m_r[TIMSK3], TIMSK3_TOIE3_BIT))
+#define TIMSK3_OCIE3A		(BIT(m_r[TIMSK3], TIMSK3_OCIE3A_BIT))
+#define TIMSK3_OCIE3B		(BIT(m_r[TIMSK3], TIMSK3_OCIE3B_BIT))
+#define TIMSK3_OCIE3C		(BIT(m_r[TIMSK3], TIMSK3_OCIE3C_BIT))
 
-#define AVR8_TCCR2A                 (m_r[TCCR2A])
-#define AVR8_TCCR2A_COM2A_MASK      0xc0
-#define AVR8_TCCR2A_COM2A_SHIFT     6
-#define AVR8_TCCR2A_COM2B_MASK      0x30
-#define AVR8_TCCR2A_COM2B_SHIFT     4
-#define AVR8_TCCR2A_WGM2_10_MASK    0x03
-#define AVR8_TCCR2A_WGM2_10_SHIFT   0
-#define AVR8_TCCR2A_COM2A           ((AVR8_TCCR2A & AVR8_TCCR2A_COM2A_MASK) >> AVR8_TCCR2A_COM2A_SHIFT)
-#define AVR8_TCCR2A_COM2B           ((AVR8_TCCR2A & AVR8_TCCR2A_COM2B_MASK) >> AVR8_TCCR2A_COM2B_SHIFT)
-#define AVR8_TCCR2A_WGM2_10         (AVR8_TCCR2A & AVR8_TCCR2A_WGM2_10_MASK)
+#define TCCR4B_CS_SHIFT			0
+#define TCCR4B_CS_MASK			0x07
+#define TCCR4B_WGM4_32_SHIFT	3
+#define TCCR4B_WGM4_32_MASK		0x18
+#define TCCR4B_FOC4C_SHIFT		5
+#define TCCR4B_FOC4C_MASK		0x20
+#define TCCR4B_FOC4B_SHIFT		6
+#define TCCR4B_FOC4B_MASK		0x40
+#define TCCR4B_FOC4A_SHIFT		7
+#define TCCR4B_FOC4A_MASK		0x80
+#define TIMER4_CLOCK_SELECT		((m_r[TCCR4B] & TCCR4B_CS_MASK) >> TCCR4B_CS_SHIFT)
 
-#define AVR8_TIMSK2             (m_r[TIMSK2])
-#define AVR8_TIMSK2_OCIE2B_MASK 0x04
-#define AVR8_TIMSK2_OCIE2A_MASK 0x02
-#define AVR8_TIMSK2_TOIE2_MASK  0x01
-#define AVR8_TIMSK2_OCIE2B      ((AVR8_TIMSK2 & AVR8_TIMSK2_OCIE2B_MASK) >> 2)
-#define AVR8_TIMSK2_OCIE2A      ((AVR8_TIMSK2 & AVR8_TIMSK2_OCIE2A_MASK) >> 1)
-#define AVR8_TIMSK2_TOIE2       (AVR8_TIMSK2 & AVR8_TIMSK2_TOIE2_MASK)
+#define TCCR4A_WGM4_10_SHIFT	0
+#define TCCR4A_WGM4_10_MASK		0x03
+#define TCCR4A_COM4C_SHIFT		2
+#define TCCR4A_COM4C_MASK		0x0c
+#define TCCR4A_COM4B_SHIFT		4
+#define TCCR4A_COM4B_MASK		0x30
+#define TCCR4A_COM4A_SHIFT		6
+#define TCCR4A_COM4A_MASK		0xc0
+#define TCCR4A_COM4A			((m_r[TCCR4A] & TCCR4A_COM4A_MASK) >> TCCR4A_COM4A_SHIFT)
+#define TCCR4A_COM4B			((m_r[TCCR4A] & TCCR4A_COM4B_MASK) >> TCCR4A_COM4B_SHIFT)
+#define TCCR4A_COM4C			((m_r[TCCR4A] & TCCR4A_COM4C_MASK) >> TCCR4A_COM4C_SHIFT)
+#define TCCR4A_WGM2_10			(m_r[TCCR4A] & TCCR4A_WGM2_10_MASK)
 
-#define AVR8_TIFR2              (m_r[TIFR2])
-#define AVR8_TIFR2_OCF2B_MASK   0x04
-#define AVR8_TIFR2_OCF2B_SHIFT  2
-#define AVR8_TIFR2_OCF2A_MASK   0x02
-#define AVR8_TIFR2_OCF2A_SHIFT  1
-#define AVR8_TIFR2_TOV2_MASK    0x01
-#define AVR8_TIFR2_TOV2_SHIFT   0
-#define AVR8_TIFR2_MASK         (AVR8_TIFR2_TOV2_MASK | AVR8_TIFR2_OCF2B_MASK | AVR8_TIFR2_OCF2A_MASK)
+#define WGM4_32		((m_r[TCCR4B] & TCCR4B_WGM4_32_MASK) >> TCCR4B_WGM4_32_SHIFT)
+#define WGM4_10		((m_r[TCCR4A] & TCCR4A_WGM4_10_MASK) >> TCCR4A_WGM4_10_SHIFT)
+#define WGM4		((WGM4_32 << 2) | WGM4_10)
 
-#define AVR8_TIMSK3             (m_r[TIMSK3])
-#define AVR8_TIMSK3_OCIE3C_MASK 0x08
-#define AVR8_TIMSK3_OCIE3B_MASK 0x04
-#define AVR8_TIMSK3_OCIE3A_MASK 0x02
-#define AVR8_TIMSK3_TOIE3_MASK  0x01
-#define AVR8_TIMSK3_OCIE3C      ((AVR8_TIMSK3 & AVR8_TIMSK3_OCIE3C_MASK) >> 3)
-#define AVR8_TIMSK3_OCIE3B      ((AVR8_TIMSK3 & AVR8_TIMSK3_OCIE3B_MASK) >> 2)
-#define AVR8_TIMSK3_OCIE3A      ((AVR8_TIMSK3 & AVR8_TIMSK3_OCIE3A_MASK) >> 1)
-#define AVR8_TIMSK3_TOIE3       ((AVR8_TIMSK3 &  AVR8_TIMSK3_TOIE3_MASK) >> 0)
+#define TIMSK4_TOIE4_BIT	0
+#define TIMSK4_OCIE4A_BIT	1
+#define TIMSK4_OCIE4B_BIT	2
+#define TIMSK4_TOIE4		(BIT(m_r[TIMSK4], TIMSK4_TOIE4_BIT))
+#define TIMSK4_OCIE4A		(BIT(m_r[TIMSK4], TIMSK4_OCIE4A_BIT))
+#define TIMSK4_OCIE4B		(BIT(m_r[TIMSK4], TIMSK4_OCIE4B_BIT))
 
-#define AVR8_TCCR4C                 (m_r[TCCR4C])
+#define TIFR4_TOV4_SHIFT	0
+#define TIFR4_TOV4_MASK		0x01
+#define TIFR4_OCF4A_SHIFT	1
+#define TIFR4_OCF4A_MASK	0x02
+#define TIFR4_OCF4B_SHIFT	2
+#define TIFR4_OCF4B_MASK	0x04
+#define TIFR4_MASK			(TIFR4_TOV4_MASK | TIFR4_OCF4B_MASK | TIFR4_OCF4A_MASK)
 
-#define AVR8_TCCR4B                 (m_r[TCCR4B])
-#define AVR8_TCCR4B_FOC4A_MASK      0x80
-#define AVR8_TCCR4B_FOC4A_SHIFT     7
-#define AVR8_TCCR4B_FOC4B_MASK      0x40
-#define AVR8_TCCR4B_FOC4B_SHIFT     6
-#define AVR8_TCCR4B_FOC4C_MASK      0x20
-#define AVR8_TCCR4B_FOC4C_SHIFT     5
-#define AVR8_TCCR4B_WGM4_32_MASK    0x18
-#define AVR8_TCCR4B_WGM4_32_SHIFT   3
-#define AVR8_TCCR4B_CS_MASK         0x07
-#define AVR8_TCCR4B_CS_SHIFT        0
-#define AVR8_TIMER4_CLOCK_SELECT    ((AVR8_TCCR4B & AVR8_TCCR4B_CS_MASK) >> AVR8_TCCR4B_CS_SHIFT)
+#define TCCR5C_FOC5C_SHIFT	5
+#define TCCR5C_FOC5C_MASK	0x20
+#define TCCR5C_FOC5B_SHIFT	6
+#define TCCR5C_FOC5B_MASK	0x40
+#define TCCR5C_FOC5A_SHIFT	7
+#define TCCR5C_FOC5A_MASK	0x80
 
-#define AVR8_TCCR4A                 (m_r[TCCR4A])
-#define AVR8_TCCR4A_COM4A_MASK      0xc0
-#define AVR8_TCCR4A_COM4A_SHIFT     6
-#define AVR8_TCCR4A_COM4B_MASK      0x30
-#define AVR8_TCCR4A_COM4B_SHIFT     4
-#define AVR8_TCCR4A_COM4C_MASK      0x0c
-#define AVR8_TCCR4A_COM4C_SHIFT     2
-#define AVR8_TCCR4A_WGM4_10_MASK    0x03
-#define AVR8_TCCR4A_WGM4_10_SHIFT   0
-#define AVR8_TCCR4A_COM4A           ((AVR8_TCCR4A & AVR8_TCCR4A_COM4A_MASK) >> AVR8_TCCR4A_COM4A_SHIFT)
-#define AVR8_TCCR4A_COM4B           ((AVR8_TCCR4A & AVR8_TCCR4A_COM4B_MASK) >> AVR8_TCCR4A_COM4B_SHIFT)
-#define AVR8_TCCR4A_COM4C           ((AVR8_TCCR4A & AVR8_TCCR4A_COM4C_MASK) >> AVR8_TCCR4A_COM4C_SHIFT)
-#define AVR8_TCCR4A_WGM2_10         (AVR8_TCCR4A & AVR8_TCCR4A_WGM2_10_MASK)
+#define TCCR5B_CS_SHIFT			0
+#define TCCR5B_CS_MASK			0x07
+#define TCCR5B_WGM5_32_SHIFT	3
+#define TCCR5B_WGM5_32_MASK		0x18
+#define TCCR5B_ICES5_SHIFT		6
+#define TCCR5B_ICES5_MASK		0x40
+#define TCCR5B_ICNC5_SHIFT		7
+#define TCCR5B_ICNC5_MASK		0x80
+#define TIMER5_CLOCK_SELECT		((m_r[TCCR5B] & TCCR5B_CS_MASK) >> TCCR5B_CS_SHIFT)
 
-#define AVR8_WGM4_32 ((AVR8_TCCR4B & AVR8_TCCR4B_WGM4_32_MASK) >> AVR8_TCCR4B_WGM4_32_SHIFT)
-#define AVR8_WGM4_10 ((AVR8_TCCR4A & AVR8_TCCR4A_WGM4_10_MASK) >> AVR8_TCCR4A_WGM4_10_SHIFT)
-#define AVR8_WGM4 ((AVR8_WGM4_32 << 2) | AVR8_WGM4_10)
+#define TCCR5A_WGM5_10_SHIFT	0
+#define TCCR5A_WGM5_10_MASK		0x03
+#define TCCR5A_COM5C_SHIFT		2
+#define TCCR5A_COM5C_MASK		0x0c
+#define TCCR5A_COM5B_SHIFT		4
+#define TCCR5A_COM5B_MASK		0x30
+#define TCCR5A_COM5A_SHIFT		6
+#define TCCR5A_COM5A_MASK		0xc0
+#define TCCR5A_COM5A			((m_r[TCCR5A] & TCCR5A_COM5A_MASK) >> TCCR5A_COM5A_SHIFT)
+#define TCCR5A_COM5B			((m_r[TCCR5A] & TCCR5A_COM5B_MASK) >> TCCR5A_COM5B_SHIFT)
+#define TCCR5A_COM5C			((m_r[TCCR5A] & TCCR5A_COM5C_MASK) >> TCCR5A_COM5C_SHIFT)
+#define TCCR5A_WGM5_10			(m_r[TCCR5A] & TCCR5A_WGM5_10_MASK)
 
-#define AVR8_TIMSK4             (m_r[TIMSK4])
-#define AVR8_TIMSK4_OCIE4B_MASK 0x04
-#define AVR8_TIMSK4_OCIE4A_MASK 0x02
-#define AVR8_TIMSK4_TOIE4_MASK  0x01
-#define AVR8_TIMSK4_OCIE4B      ((AVR8_TIMSK4 & AVR8_TIMSK4_OCIE4B_MASK) >> 2)
-#define AVR8_TIMSK4_OCIE4A      ((AVR8_TIMSK4 & AVR8_TIMSK4_OCIE4A_MASK) >> 1)
-#define AVR8_TIMSK4_TOIE4       (AVR8_TIMSK4 & AVR8_TIMSK4_TOIE4_MASK)
+#define WGM5_32		((m_r[TCCR5B] & TCCR5B_WGM5_32_MASK) >> TCCR5B_WGM5_32_SHIFT)
+#define WGM5_10		((m_r[TCCR5A] & TCCR5A_WGM5_10_MASK) >> TCCR5A_WGM5_10_SHIFT)
+#define WGM5		((WGM5_32 << 2) | WGM5_10)
 
-#define AVR8_TIFR4              (m_r[TIFR4])
-#define AVR8_TIFR4_OCF4B_MASK   0x04
-#define AVR8_TIFR4_OCF4B_SHIFT  2
-#define AVR8_TIFR4_OCF4A_MASK   0x02
-#define AVR8_TIFR4_OCF4A_SHIFT  1
-#define AVR8_TIFR4_TOV4_MASK    0x01
-#define AVR8_TIFR4_TOV4_SHIFT   0
-#define AVR8_TIFR4_MASK         (AVR8_TIFR4_TOV4_MASK | AVR8_TIFR4_OCF4B_MASK | AVR8_TIFR4_OCF4A_MASK)
+#define TIMSK5_TOIE5_BIT	0
+#define TIMSK5_OCIE5A_BIT	1
+#define TIMSK5_OCIE5B_BIT	2
+#define TIMSK5_OCIE5C_BIT	3
+#define TIMSK5_ICIE5_BIT	5
+#define TIMSK5_TOIE5_MASK	(1 << TIMSK5_TOIE5_BIT)
+#define TIMSK5_OCIE5A_MASK	(1 << TIMSK5_OCIE5A_BIT)
+#define TIMSK5_OCIE5B_MASK	(1 << TIMSK5_OCIE5B_BIT)
+#define TIMSK5_OCIE5C_MASK	(1 << TIMSK5_OCIE5C_BIT)
+#define TIMSK5_ICIE5_MASK	(1 << TIMSK5_ICIE5_BIT)
+#define TIMSK5_TOIE5		(BIT(m_r[TIMSK5], TIMSK5_TOIE5_BIT))
+#define TIMSK5_OCIE5A		(BIT(m_r[TIMSK5], TIMSK5_OCIE5A_BIT))
+#define TIMSK5_OCIE5B		(BIT(m_r[TIMSK5], TIMSK5_OCIE5B_BIT))
+#define TIMSK5_OCIE5C		(BIT(m_r[TIMSK5], TIMSK5_OCIE5C_BIT))
+#define TIMSK5_ICIE5C		(BIT(m_r[TIMSK5], TIMSK5_ICIE5C_BIT))
 
-//---------------------------------------------------------------
-#define AVR8_TCCR5C                 (m_r[TCCR5C])
-#define AVR8_TCCR5C_FOC5A_MASK      0x80
-#define AVR8_TCCR5C_FOC5A_SHIFT     7
-#define AVR8_TCCR5C_FOC5B_MASK      0x40
-#define AVR8_TCCR5C_FOC5B_SHIFT     6
-#define AVR8_TCCR5C_FOC5C_MASK      0x20
-#define AVR8_TCCR5C_FOC5C_SHIFT     5
-
-#define AVR8_TCCR5B                 (m_r[TCCR5B])
-#define AVR8_TCCR5B_ICNC5_MASK      0x80
-#define AVR8_TCCR5B_ICNC5_SHIFT     7
-#define AVR8_TCCR5B_ICES5_MASK      0x40
-#define AVR8_TCCR5B_ICES5_SHIFT     6
-#define AVR8_TCCR5B_WGM5_32_MASK    0x18
-#define AVR8_TCCR5B_WGM5_32_SHIFT   3
-#define AVR8_TCCR5B_CS_MASK         0x07
-#define AVR8_TCCR5B_CS_SHIFT        0
-#define AVR8_TIMER5_CLOCK_SELECT    ((AVR8_TCCR5B & AVR8_TCCR5B_CS_MASK) >> AVR8_TCCR5B_CS_SHIFT)
-
-#define AVR8_TCCR5A                 (m_r[TCCR4A])
-#define AVR8_TCCR5A_COM5A_MASK      0xc0
-#define AVR8_TCCR5A_COM5A_SHIFT     6
-#define AVR8_TCCR5A_COM5B_MASK      0x30
-#define AVR8_TCCR5A_COM5B_SHIFT     4
-#define AVR8_TCCR5A_COM5C_MASK      0x0c
-#define AVR8_TCCR5A_COM5C_SHIFT     2
-#define AVR8_TCCR5A_WGM5_10_MASK    0x03
-#define AVR8_TCCR5A_WGM5_10_SHIFT   0
-#define AVR8_TCCR5A_COM5A           ((AVR8_TCCR5A & AVR8_TCCR5A_COM5A_MASK) >> AVR8_TCCR5A_COM5A_SHIFT)
-#define AVR8_TCCR5A_COM5B           ((AVR8_TCCR5A & AVR8_TCCR5A_COM5B_MASK) >> AVR8_TCCR5A_COM5B_SHIFT)
-#define AVR8_TCCR5A_COM5C           ((AVR8_TCCR5A & AVR8_TCCR5A_COM5C_MASK) >> AVR8_TCCR5A_COM5C_SHIFT)
-#define AVR8_TCCR5A_WGM5_10         (AVR8_TCCR5A & AVR8_TCCR5A_WGM5_10_MASK)
-
-#define AVR8_WGM5_32 ((AVR8_TCCR5B & AVR8_TCCR5B_WGM5_32_MASK) >> AVR8_TCCR5B_WGM5_32_SHIFT)
-#define AVR8_WGM5_10 ((AVR8_TCCR5A & AVR8_TCCR5A_WGM5_10_MASK) >> AVR8_TCCR5A_WGM5_10_SHIFT)
-#define AVR8_WGM5 ((AVR8_WGM5_32 << 2) | AVR8_WGM5_10)
-
-#define AVR8_TIMSK5             (m_r[TIMSK5])
-#define AVR8_TIMSK5_ICIE5_MASK  0x20
-#define AVR8_TIMSK5_OCIE5C_MASK 0x08
-#define AVR8_TIMSK5_OCIE5B_MASK 0x04
-#define AVR8_TIMSK5_OCIE5A_MASK 0x02
-#define AVR8_TIMSK5_TOIE5_MASK  0x01
-
-#define AVR8_TIMSK5_ICIE5C      ((AVR8_TIMSK5 & AVR8_TIMSK5_ICIE5C_MASK) >> 5)
-#define AVR8_TIMSK5_OCIE5C      ((AVR8_TIMSK5 & AVR8_TIMSK5_OCIE5C_MASK) >> 3)
-#define AVR8_TIMSK5_OCIE5B      ((AVR8_TIMSK5 & AVR8_TIMSK5_OCIE5B_MASK) >> 2)
-#define AVR8_TIMSK5_OCIE5A      ((AVR8_TIMSK5 & AVR8_TIMSK5_OCIE5A_MASK) >> 1)
-#define AVR8_TIMSK5_TOIE5       (AVR8_TIMSK5 & AVR8_TIMSK5_TOIE5_MASK)
-
-#define AVR8_TIFR5              (m_r[TIFR5])
-#define AVR8_TIFR5_ICF5_MASK   0x20
-#define AVR8_TIFR5_ICF5_SHIFT  5
-#define AVR8_TIFR5_OCF5C_MASK   0x08
-#define AVR8_TIFR5_OCF5C_SHIFT  3
-#define AVR8_TIFR5_OCF5B_MASK   0x04
-#define AVR8_TIFR5_OCF5B_SHIFT  2
-#define AVR8_TIFR5_OCF5A_MASK   0x02
-#define AVR8_TIFR5_OCF5A_SHIFT  1
-#define AVR8_TIFR5_TOV5_MASK    0x01
-#define AVR8_TIFR5_TOV5_SHIFT   0
-#define AVR8_TIFR5_MASK         (AVR8_TIFR5_ICF5_MASK | AVR8_TIFR5_OCF5C_MASK | AVR8_TIFR5_OCF5B_MASK | AVR8_TIFR5_OCF5A_MASK | AVR8_TIFR5_TOV5_MASK)
-
-
-#define AVR8_TIFR5_ICF5 ((AVR8_TIFR5 & AVR8_TIFR5_ICF5_MASK) >> AVR8_TIFR5_ICF5_SHIFT)
-#define AVR8_TIFR5_OCF5C ((AVR8_TIFR5 & AVR8_TIFR5_OCF5C_MASK) >> AVR8_TIFR5_OCF5C_SHIFT)
-#define AVR8_TIFR5_OCF5B ((AVR8_TIFR5 & AVR8_TIFR5_OCF5B_MASK) >> AVR8_TIFR5_OCF5B_SHIFT)
-#define AVR8_TIFR5_OCF5A ((AVR8_TIFR5 & AVR8_TIFR5_OCF5A_MASK) >> AVR8_TIFR5_OCF5A_SHIFT)
-#define AVR8_TIFR5_TOV5 ((AVR8_TIFR5 & AVR8_TIFR5_TOV5_MASK) >> AVR8_TIFR5_TOV5_SHIFT)
+#define TIFR5_ICF5_MASK		0x20
+#define TIFR5_ICF5_SHIFT	5
+#define TIFR5_OCF5C_MASK	0x08
+#define TIFR5_OCF5C_SHIFT	3
+#define TIFR5_OCF5B_MASK	0x04
+#define TIFR5_OCF5B_SHIFT	2
+#define TIFR5_OCF5A_MASK	0x02
+#define TIFR5_OCF5A_SHIFT	1
+#define TIFR5_TOV5_MASK		0x01
+#define TIFR5_TOV5_SHIFT	0
+#define TIFR5_MASK			(TIFR5_ICF5_MASK | TIFR5_OCF5C_MASK | TIFR5_OCF5B_MASK | TIFR5_OCF5A_MASK | TIFR5_TOV5_MASK)
+#define TIFR5_ICF5			((m_r[TIFR5] & TIFR5_ICF5_MASK) >> TIFR5_ICF5_SHIFT)
+#define TIFR5_OCF5C			((m_r[TIFR5] & TIFR5_OCF5C_MASK) >> TIFR5_OCF5C_SHIFT)
+#define TIFR5_OCF5B			((m_r[TIFR5] & TIFR5_OCF5B_MASK) >> TIFR5_OCF5B_SHIFT)
+#define TIFR5_OCF5A			((m_r[TIFR5] & TIFR5_OCF5A_MASK) >> TIFR5_OCF5A_SHIFT)
+#define TIFR5_TOV5			((m_r[TIFR5] & TIFR5_TOV5_MASK) >> TIFR5_TOV5_SHIFT)
 
 //---------------------------------------------------------------
 
-#define AVR8_OCR0A              m_r[OCR0A]
-#define AVR8_OCR0B              m_r[OCR0B]
-#define AVR8_TCNT0              m_r[TCNT0]
-#define AVR8_WGM0               (((m_r[TCCR0B] & 0x08) >> 1) | (m_r[TCCR0A] & 0x03))
+#define WGM0				(((m_r[TCCR0B] & 0x08) >> 1) | (m_r[TCCR0A] & 0x03))
 
-#define AVR8_OCR1A              ((AVR8_OCR1AH << 8) | AVR8_OCR1AL)
-#define AVR8_OCR1B              ((AVR8_OCR1BH << 8) | AVR8_OCR1BL)
-#define AVR8_OCR1C              ((AVR8_OCR1CH << 8) | AVR8_OCR1CL)
-#define AVR8_ICR1               ((AVR8_ICR1H  << 8) | AVR8_ICR1L)
-#define AVR8_TCNT1              ((AVR8_TCNT1H << 8) | AVR8_TCNT1L)
-#define AVR8_WGM1               (((AVR8_TCCR1B & 0x18) >> 1) | (AVR8_TCCR1A & 0x03))
-#define AVR8_TCNT1_DIR          (state->m_tcnt1_direction)
+#define OCR1A				((m_r[OCR1AH] << 8) | m_r[OCR1AL])
+#define OCR1B				((m_r[OCR1BH] << 8) | m_r[OCR1BL])
+#define OCR1C				((m_r[OCR1CH] << 8) | m_r[OCR1CL])
+#define ICR1				((m_r[ICR1H]  << 8) | m_r[ICR1L])
+#define WGM1				(((m_r[TCCR1B] & 0x18) >> 1) | (m_r[TCCR1A] & 0x03))
 
-#define AVR8_OCR2A              m_r[OCR2A]
-#define AVR8_OCR2B              m_r[OCR2B]
-#define AVR8_TCNT2              m_r[TCNT2]
-#define AVR8_WGM2               (((AVR8_TCCR2B & 0x08) >> 1) | (AVR8_TCCR2A & 0x03))
+#define WGM2				(((m_r[TCCR2B] & 0x08) >> 1) | (m_r[TCCR2A] & 0x03))
 
-#define AVR8_ICR3               ((AVR8_ICR3H  << 8) | AVR8_ICR3L)
-#define AVR8_OCR3A              ((AVR8_OCR3AH << 8) | AVR8_OCR3AL)
+#define ICR3				((m_r[ICR3H]  << 8) | m_r[ICR3L])
+#define OCR3A				((m_r[OCR3AH] << 8) | m_r[OCR3AL])
 
-#define AVR8_ICR4               ((AVR8_ICR4H  << 8) | AVR8_ICR4L)
-#define AVR8_ICR4H              (m_r[ICR4H])
-#define AVR8_ICR4L              (m_r[ICR4L])
-#define AVR8_OCR4A              ((AVR8_OCR4AH << 8) | AVR8_OCR4AL)
-#define AVR8_OCR4B              m_r[OCR4B]
-#define AVR8_TCNT4              m_r[TCNT4]
+#define ICR4				((m_r[ICR4H]  << 8) | m_r[ICR4L])
+#define OCR4A				((m_r[OCR4AH] << 8) | m_r[OCR4AL])
 
-#define AVR8_ICR5               ((AVR8_ICR5H  << 8) | AVR8_ICR5L)
-#define AVR8_OCR5A              ((AVR8_OCR5AH << 8) | AVR8_OCR5AL)
+#define ICR5				((m_r[ICR5H]  << 8) | m_r[ICR5L])
+#define OCR5A				((m_r[OCR5AH] << 8) | m_r[OCR5AL])
 
-#define AVR8_GTCCR_PSRASY_MASK  0x02
-#define AVR8_GTCCR_PSRASY_SHIFT 1
+#define GTCCR_PSRASY_MASK	0x02
+#define GTCCR_PSRASY_SHIFT	1
 
-#define AVR8_SPSR               (m_r[SPSR])
-#define AVR8_SPSR_SPR2X         (AVR8_SPSR & AVR8_SPSR_SPR2X_MASK)
+#define SPSR_SPR2X			(m_r[SPSR] & SPSR_SPR2X_MASK)
 
-#define AVR8_SPCR               (m_r[SPCR])
-#define AVR8_SPCR_SPIE          ((AVR8_SPCR & AVR8_SPCR_SPIE_MASK) >> 7)
-#define AVR8_SPCR_SPE           ((AVR8_SPCR & AVR8_SPCR_SPE_MASK) >> 6)
-#define AVR8_SPCR_DORD          ((AVR8_SPCR & AVR8_SPCR_DORD_MASK) >> 5)
-#define AVR8_SPCR_MSTR          ((AVR8_SPCR & AVR8_SPCR_MSTR_MASK) >> 4)
-#define AVR8_SPCR_CPOL          ((AVR8_SPCR & AVR8_SPCR_CPOL_MASK) >> 3)
-#define AVR8_SPCR_CPHA          ((AVR8_SPCR & AVR8_SPCR_CPHA_MASK) >> 2)
-#define AVR8_SPCR_SPR           (AVR8_SPCR & AVR8_SPCR_SPR_MASK)
+#define SPCR_SPIE			((m_r[SPCR] & SPCR_SPIE_MASK) >> 7)
+#define SPCR_SPE			((m_r[SPCR] & SPCR_SPE_MASK) >> 6)
+#define SPCR_DORD			((m_r[SPCR] & SPCR_DORD_MASK) >> 5)
+#define SPCR_MSTR			((m_r[SPCR] & SPCR_MSTR_MASK) >> 4)
+#define SPCR_CPOL			((m_r[SPCR] & SPCR_CPOL_MASK) >> 3)
+#define SPCR_CPHA			((m_r[SPCR] & SPCR_CPHA_MASK) >> 2)
+#define SPCR_SPR			(m_r[SPCR] & SPCR_SPR_MASK)
 
-#define AVR8_SPI_RATE           ((AVR8_SPSR_SPR2X << 2) | AVR8_SPCR_SPR)
+#define SPI_RATE			((SPSR_SPR2X << 2) | SPCR_SPR)
 
-#define AVR8_PORTB_MOSI         0x08
+#define PORTB_MOSI			0x08
 
-#define AVR8_EECR               m_r[EECR] & 0x3F; //bits 6 and 7 are reserved and will always read as zero
-#define AVR8_EECR_EEPM_MASK     0x30
-#define AVR8_EECR_EERIE_MASK    0x08
-#define AVR8_EECR_EEMPE_MASK    0x04
-#define AVR8_EECR_EEPE_MASK     0x02
-#define AVR8_EECR_EERE_MASK     0x01
-#define AVR8_EECR_EEPM          ((AVR8_EECR & AVR8_EECR_EEPM_MASK) >> 4)
-#define AVR8_EECR_EERIE         ((AVR8_EECR & AVR8_EECR_EERIE_MASK) >> 3)
-#define AVR8_EECR_EEMPE         ((AVR8_EECR & AVR8_EECR_EEMPE_MASK) >> 2)
-#define AVR8_EECR_EEPE          ((AVR8_EECR & AVR8_EECR_EEPE_MASK) >> 1)
-#define AVR8_EECR_EERE          ((AVR8_EECR & AVR8_EECR_EERE_MASK) >> 0)
+#define EECR_MASK			0x3f
+#define EECR_EERE_BIT		0
+#define EECR_EEPE_BIT		1
+#define EECR_EEMPE_BIT		2
+#define EECR_EERIE_BIT		3
+#define EECR_EEPM_BIT		4
+#define EECR_EERE_MASK		(1 << EECR_EERE_BIT)
+#define EECR_EEPE_MASK		(1 << EECR_EEPE_BIT)
+#define EECR_EEMPE_MASK		(1 << EECR_EEMPE_BIT)
+#define EECR_EERIE_MASK		(1 << EECR_EERIE_BIT)
+#define EECR_EEPM_MASK		(3 << EECR_EEPM_BIT)
+#define EECR_EERE			(BIT(m_r[EECR], EECR_EERE_BIT))
+#define EECR_EEPE			(BIT(m_r[EECR], EECR_EEPE_BIT))
+#define EECR_EEMPE			(BIT(m_r[EECR], EECR_EEMPE_BIT))
+#define EECR_EERIE			(BIT(m_r[EECR], EECR_EERIE_BIT))
+#define EECR_EEPM			((m_r[EECR] & EECR_EEPM_MASK) >> EECR_EEPM_BIT)
 
 //---------------------------------------------------------------
 
-#define AVR8_ADMUX              (m_r[ADMUX])
-#define AVR8_ADMUX_REFS_MASK    0xc0
-#define AVR8_ADMUX_ADLAR_MASK   0x20
-#define AVR8_ADMUX_MUX_MASK     0x0f
-#define AVR8_ADMUX_REFS         ((AVR8_ADMUX & AVR8_ADMUX_REFS_MASK) >> 6)
-#define AVR8_ADMUX_ADLAR        ((AVR8_ADMUX & AVR8_ADMUX_ADLAR_MASK) >> 5)
-#define AVR8_ADMUX_MUX          ((AVR8_ADMUX & AVR8_ADMUX_MUX_MASK) >> 0)
+#define ADMUX_MUX_MASK		0x0f
+#define ADMUX_ADLAR_MASK	0x20
+#define ADMUX_REFS_MASK		0xc0
+#define ADMUX_MUX			((m_r[ADMUX] & ADMUX_MUX_MASK) >> 0)
+#define ADMUX_ADLAR			((m_r[ADMUX] & ADMUX_ADLAR_MASK) >> 5)
+#define ADMUX_REFS			((m_r[ADMUX] & ADMUX_REFS_MASK) >> 6)
 
-#define AVR8_ADCSRB             (m_r[ADCSRB])
-#define AVR8_ADCSRB_ACME_MASK   0x40
-#define AVR8_ADCSRB_ADTS_MASK   0x07
-#define AVR8_ADCSRB_ACME        ((AVR8_ADCSRB & AVR8_ADCSRB_ACME_MASK) >> 6)
-#define AVR8_ADCSRB_ADTS        ((AVR8_ADCSRB & AVR8_ADCSRB_ADTS_MASK) >> 0)
+#define ADCSRB_ACME_MASK	0x40
+#define ADCSRB_ADTS_MASK	0x07
+#define ADCSRB_ACME			((m_r[ADCSRB] & ADCSRB_ACME_MASK) >> 6)
+#define ADCSRB_ADTS			((m_r[ADCSRB] & ADCSRB_ADTS_MASK) >> 0)
 
-#define AVR8_ADCSRA             (m_r[ADCSRA])
-#define AVR8_ADCSRA_ADEN_MASK   0x80
-#define AVR8_ADCSRA_ADSC_MASK   0x40
-#define AVR8_ADCSRA_ADATE_MASK  0x20
-#define AVR8_ADCSRA_ADIF_MASK   0x10
-#define AVR8_ADCSRA_ADIE_MASK   0x08
-#define AVR8_ADCSRA_ADPS_MASK   0x07
-#define AVR8_ADCSRA_ADEN        ((AVR8_ADCSRA & AVR8_ADCSRA_ADEN_MASK) >> 7)
-#define AVR8_ADCSRA_ADSC        ((AVR8_ADCSRA & AVR8_ADCSRA_ADSC_MASK) >> 6)
-#define AVR8_ADCSRA_ADATE       ((AVR8_ADCSRA & AVR8_ADCSRA_ADATE_MASK) >> 5)
-#define AVR8_ADCSRA_ADIF        ((AVR8_ADCSRA & AVR8_ADCSRA_ADIF_MASK) >> 4)
-#define AVR8_ADCSRA_ADIE        ((AVR8_ADCSRA & AVR8_ADCSRA_ADIE_MASK) >> 3)
-#define AVR8_ADCSRA_ADPS        ((AVR8_ADCSRA & AVR8_ADCSRA_ADPS_MASK) >> 0)
+#define ADCSRA_ADPS_MASK	0x07
+#define ADCSRA_ADIE_MASK	0x08
+#define ADCSRA_ADIF_MASK	0x10
+#define ADCSRA_ADATE_MASK	0x20
+#define ADCSRA_ADSC_MASK	0x40
+#define ADCSRA_ADEN_MASK	0x80
+#define ADCSRA_ADPS			(m_r[ADCSRA] & ADCSRA_ADPS_MASK)
+#define ADCSRA_ADIE			((m_r[ADCSRA] & ADCSRA_ADIE_MASK) >> 3)
+#define ADCSRA_ADIF			((m_r[ADCSRA] & ADCSRA_ADIF_MASK) >> 4)
+#define ADCSRA_ADATE		((m_r[ADCSRA] & ADCSRA_ADATE_MASK) >> 5)
+#define ADCSRA_ADSC			((m_r[ADCSRA] & ADCSRA_ADSC_MASK) >> 6)
+#define ADCSRA_ADEN			((m_r[ADCSRA] & ADCSRA_ADEN_MASK) >> 7)
 
 
 //**************************************************************************
@@ -786,7 +710,7 @@ void attiny15_device::attiny15_internal_map(address_map &map)
 //-------------------------------------------------
 
 atmega88_device::atmega88_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA88, 0x0fff, address_map_constructor(FUNC(atmega88_device::atmega88_internal_map), this))
+	: avr8_device<3>(mconfig, tag, owner, clock, ATMEGA88, 0x0fff, address_map_constructor(FUNC(atmega88_device::atmega88_internal_map), this))
 {
 }
 
@@ -795,7 +719,7 @@ atmega88_device::atmega88_device(const machine_config &mconfig, const char *tag,
 //-------------------------------------------------
 
 atmega168_device::atmega168_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA168, 0x1fff, address_map_constructor(FUNC(atmega168_device::atmega168_internal_map), this))
+	: avr8_device<3>(mconfig, tag, owner, clock, ATMEGA168, 0x1fff, address_map_constructor(FUNC(atmega168_device::atmega168_internal_map), this))
 {
 }
 
@@ -804,7 +728,7 @@ atmega168_device::atmega168_device(const machine_config &mconfig, const char *ta
 //-------------------------------------------------
 
 atmega328_device::atmega328_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA328, 0x7fff, address_map_constructor(FUNC(atmega328_device::atmega328_internal_map), this))
+	: avr8_device<3>(mconfig, tag, owner, clock, ATMEGA328, 0x7fff, address_map_constructor(FUNC(atmega328_device::atmega328_internal_map), this))
 {
 }
 
@@ -813,7 +737,7 @@ atmega328_device::atmega328_device(const machine_config &mconfig, const char *ta
 //-------------------------------------------------
 
 atmega644_device::atmega644_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA644, 0xffff, address_map_constructor(FUNC(atmega644_device::atmega644_internal_map), this))
+	: avr8_device<3>(mconfig, tag, owner, clock, ATMEGA644, 0xffff, address_map_constructor(FUNC(atmega644_device::atmega644_internal_map), this))
 {
 }
 
@@ -822,7 +746,7 @@ atmega644_device::atmega644_device(const machine_config &mconfig, const char *ta
 //-------------------------------------------------
 
 atmega1280_device::atmega1280_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA1280, 0x1ffff, address_map_constructor(FUNC(atmega1280_device::atmega1280_internal_map), this))
+	: avr8_device<6>(mconfig, tag, owner, clock, ATMEGA1280, 0x1ffff, address_map_constructor(FUNC(atmega1280_device::atmega1280_internal_map), this))
 {
 }
 
@@ -831,7 +755,7 @@ atmega1280_device::atmega1280_device(const machine_config &mconfig, const char *
 //-------------------------------------------------
 
 atmega2560_device::atmega2560_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA2560, 0x1ffff, address_map_constructor(FUNC(atmega2560_device::atmega2560_internal_map), this))
+	: avr8_device<6>(mconfig, tag, owner, clock, ATMEGA2560, 0x1ffff, address_map_constructor(FUNC(atmega2560_device::atmega2560_internal_map), this))
 {
 }
 
@@ -840,16 +764,15 @@ atmega2560_device::atmega2560_device(const machine_config &mconfig, const char *
 //-------------------------------------------------
 
 attiny15_device::attiny15_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATTINY15, 0x03ff, address_map_constructor(FUNC(attiny15_device::attiny15_internal_map), this))
+	: avr8_device<2>(mconfig, tag, owner, clock, ATTINY15, 0x03ff, address_map_constructor(FUNC(attiny15_device::attiny15_internal_map), this))
 {
 }
 
 //-------------------------------------------------
-//  avr8_device - constructor
+//  avr8_base_device - constructor
 //-------------------------------------------------
 
-template <int NumTimers>
-avr8_device<NumTimers>::avr8_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, const device_type type, uint32_t addr_mask, address_map_constructor internal_map)
+avr8_base_device::avr8_base_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, const device_type type, uint32_t addr_mask, address_map_constructor internal_map)
 	: cpu_device(mconfig, type, tag, owner, clock)
 	, m_program_config("program", ENDIANNESS_LITTLE, 8, 22)
 	, m_data_config("data", ENDIANNESS_LITTLE, 8, 16, 0, internal_map)
@@ -860,6 +783,14 @@ avr8_device<NumTimers>::avr8_device(const machine_config &mconfig, const char *t
 	, m_lock_bits(0xff)
 	, m_r(*this, "regs")
 	, m_pc(0)
+	, m_addr_mask((addr_mask << 1) | 1)
+	, m_interrupt_pending(false)
+{
+}
+
+template <int NumTimers>
+avr8_device<NumTimers>::avr8_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, const device_type type, uint32_t addr_mask, address_map_constructor internal_map)
+	: avr8_base_device(mconfig, tag, owner, clock, type, addr_mask, internal_map)
 	, m_gpio_out_cb(*this)
 	, m_gpio_in_cb(*this, 0)
 	, m_adc_in_cb(*this, 0)
@@ -867,17 +798,15 @@ avr8_device<NumTimers>::avr8_device(const machine_config &mconfig, const char *t
 	, m_spi_active(false)
 	, m_spi_prescale(0)
 	, m_spi_prescale_count(0)
-	, m_addr_mask((addr_mask << 1) | 1)
-	, m_interrupt_pending(false)
 {
 	// Fill in default callbacks
 	for (int i = 0; i < 8*4; i++)
 	{
-		m_timer0_ticks[i] = &avr8_device<NumTimers>::timer0_tick_default;
+		m_timer0_ticks[i] = timer_func(&avr8_device<NumTimers>::timer0_tick_default, this);
 	}
 	for (int i = 0; i < 8; i++)
 	{
-		m_timer2_ticks[i] = &avr8_device<NumTimers>::timer2_tick_default;
+		m_timer2_ticks[i] = timer_func(&avr8_device<NumTimers>::timer2_tick_default, this);
 	}
 
 	// Fill in the mode-specific callbacks
@@ -888,105 +817,105 @@ avr8_device<NumTimers>::avr8_device(const machine_config &mconfig, const char *t
 			switch (i)
 			{
 				case 0:
-					m_timer0_ticks[(i << 2) + j] = &avr8_device<NumTimers>::timer0_tick_norm;
+					m_timer0_ticks[(i << 2) + j] = timer_func(&avr8_device<NumTimers>::timer0_tick_norm, this);
 					break;
 				case 1:
-					m_timer0_ticks[(i << 2) + j] = &avr8_device<NumTimers>::timer0_tick_pwm_pc;
+					m_timer0_ticks[(i << 2) + j] = timer_func(&avr8_device<NumTimers>::timer0_tick_pwm_pc, this);
 					break;
 				case 3:
-					m_timer0_ticks[(i << 2) + j] = &avr8_device<NumTimers>::timer0_tick_fast_pwm;
+					m_timer0_ticks[(i << 2) + j] = timer_func(&avr8_device<NumTimers>::timer0_tick_fast_pwm, this);
 					break;
 				case 5:
-					m_timer0_ticks[(i << 2) + j] = &avr8_device<NumTimers>::timer0_tick_pwm_pc_cmp;
+					m_timer0_ticks[(i << 2) + j] = timer_func(&avr8_device<NumTimers>::timer0_tick_pwm_pc_cmp, this);
 					break;
 				case 7:
-					m_timer0_ticks[(i << 2) + j] = &avr8_device<NumTimers>::timer0_tick_fast_pwm_cmp;
+					m_timer0_ticks[(i << 2) + j] = timer_func(&avr8_device<NumTimers>::timer0_tick_fast_pwm_cmp, this);
 					break;
 			}
 		}
 	}
 
-	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 0] = &avr8_device<NumTimers>::timer0_tick_ctc_norm;
-	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 1] = &avr8_device<NumTimers>::timer0_tick_ctc_toggle;
-	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 2] = &avr8_device<NumTimers>::timer0_tick_ctc_clear;
-	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 3] = &avr8_device<NumTimers>::timer0_tick_ctc_set;
+	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 0] = timer_func(&avr8_device<NumTimers>::timer0_tick_ctc_norm, this);
+	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 1] = timer_func(&avr8_device<NumTimers>::timer0_tick_ctc_toggle, this);
+	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 2] = timer_func(&avr8_device<NumTimers>::timer0_tick_ctc_clear, this);
+	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 3] = timer_func(&avr8_device<NumTimers>::timer0_tick_ctc_set, this);
 
 	for (int i = 0; i < 16; i++)
 	{
-		m_timer1_ticks[(WGM1_NORMAL << 4) | i] = &avr8_device<NumTimers>::timer1_tick_normal;
-		m_timer1_ticks[(WGM1_PWM_8_PC << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm8_pc;
-		m_timer1_ticks[(WGM1_PWM_9_PC << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm9_pc;
-		m_timer1_ticks[(WGM1_PWM_10_PC << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm10_pc;
-		m_timer1_ticks[(WGM1_FAST_PWM_8 << 4) | i] = &avr8_device<NumTimers>::timer1_tick_fast_pwm8;
-		m_timer1_ticks[(WGM1_FAST_PWM_9 << 4) | i] = &avr8_device<NumTimers>::timer1_tick_fast_pwm9;
-		m_timer1_ticks[(WGM1_FAST_PWM_10 << 4) | i] = &avr8_device<NumTimers>::timer1_tick_fast_pwm10;
-		m_timer1_ticks[(WGM1_PWM_PFC_ICR << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm_pfc_icr;
-		m_timer1_ticks[(WGM1_PWM_PFC_OCR << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm_pfc_ocr;
-		m_timer1_ticks[(WGM1_PWM_PC_ICR << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm_pc_icr;
-		m_timer1_ticks[(WGM1_PWM_PC_OCR << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm_pc_ocr;
-		m_timer1_ticks[(WGM1_CTC_ICR << 4) | i] = &avr8_device<NumTimers>::timer1_tick_ctc_icr;
-		m_timer1_ticks[(WGM1_RESERVED << 4) | i] = &avr8_device<NumTimers>::timer1_tick_resv;
+		m_timer1_ticks[(WGM1_NORMAL << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_normal, this);
+		m_timer1_ticks[(WGM1_PWM_8_PC << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_pwm8_pc, this);
+		m_timer1_ticks[(WGM1_PWM_9_PC << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_pwm9_pc, this);
+		m_timer1_ticks[(WGM1_PWM_10_PC << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_pwm10_pc, this);
+		m_timer1_ticks[(WGM1_FAST_PWM_8 << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm8, this);
+		m_timer1_ticks[(WGM1_FAST_PWM_9 << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm9, this);
+		m_timer1_ticks[(WGM1_FAST_PWM_10 << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm10, this);
+		m_timer1_ticks[(WGM1_PWM_PFC_ICR << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_pwm_pfc_icr, this);
+		m_timer1_ticks[(WGM1_PWM_PFC_OCR << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_pwm_pfc_ocr, this);
+		m_timer1_ticks[(WGM1_PWM_PC_ICR << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_pwm_pc_icr, this);
+		m_timer1_ticks[(WGM1_PWM_PC_OCR << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_pwm_pc_ocr, this);
+		m_timer1_ticks[(WGM1_CTC_ICR << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_icr, this);
+		m_timer1_ticks[(WGM1_RESERVED << 4) | i] = timer_func(&avr8_device<NumTimers>::timer1_tick_resv, this);
 	}
 
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  0] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_norm;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  1] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_toggle;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  2] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_clear;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  3] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_set;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  4] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_norm;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  5] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_toggle;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  6] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_clear;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  7] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_set;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  8] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_norm;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  9] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_toggle;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 10] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_clear;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 11] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_set;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 12] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_norm;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 13] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_toggle;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 14] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_clear;
-	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 15] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_set;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  0] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_norm, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  1] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_toggle, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  2] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_clear, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  3] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_set, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  4] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_norm, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  5] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_toggle, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  6] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_clear, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  7] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_set, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  8] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_norm, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  9] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_toggle, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 10] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_clear, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 11] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_set, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 12] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_norm, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 13] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_toggle, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 14] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_clear, this);
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 15] = timer_func(&avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_set, this);
 
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  0] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_norm;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  1] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_toggle;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  2] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_clear;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  3] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_set;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  4] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_norm;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  5] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_toggle;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  6] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_clear;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  7] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_set;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  8] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_norm;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  9] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_toggle;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 10] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_clear;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 11] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_set;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 12] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_norm;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 13] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_toggle;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 14] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_clear;
-	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 15] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_set;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  0] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_norm, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  1] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_toggle, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  2] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_clear, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  3] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_set, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  4] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_norm, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  5] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_toggle, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  6] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_clear, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  7] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_set, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  8] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_norm, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  9] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_toggle, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 10] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_clear, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 11] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_set, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 12] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_norm, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 13] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_toggle, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 14] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_clear, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 15] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_set, this);
 
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  0] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_norm;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  1] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_toggle;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  2] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_clear;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  3] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_set;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  4] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_norm;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  5] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_toggle;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  6] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_clear;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  7] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_set;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  8] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_norm;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  9] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_toggle;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 10] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_clear;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 11] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_set;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 12] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_norm;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 13] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_toggle;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 14] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_clear;
-	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 15] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_set;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  0] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_norm, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  1] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_toggle, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  2] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_clear, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  3] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_set, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  4] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_norm, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  5] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_toggle, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  6] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_clear, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  7] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_set, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  8] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_norm, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  9] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_toggle, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 10] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_clear, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 11] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_set, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 12] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_norm, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 13] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_toggle, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 14] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_clear, this);
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 15] = timer_func(&avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_set, this);
 
-	m_timer2_ticks[WGM02_NORMAL] = &avr8_device<NumTimers>::timer2_tick_norm;
-	m_timer2_ticks[WGM02_PWM_PC] = &avr8_device<NumTimers>::timer2_tick_default;
-	m_timer2_ticks[WGM02_CTC_CMP] = &avr8_device<NumTimers>::timer2_tick_default;
-	m_timer2_ticks[WGM02_FAST_PWM] = &avr8_device<NumTimers>::timer2_tick_fast_pwm;
-	m_timer2_ticks[WGM02_RESERVED0] = &avr8_device<NumTimers>::timer2_tick_default;
-	m_timer2_ticks[WGM02_PWM_PC_CMP] = &avr8_device<NumTimers>::timer2_tick_default;
-	m_timer2_ticks[WGM02_RESERVED1] = &avr8_device<NumTimers>::timer2_tick_default;
-	m_timer2_ticks[WGM02_FAST_PWM_CMP] = &avr8_device<NumTimers>::timer2_tick_fast_pwm_cmp;
+	m_timer2_ticks[WGM02_NORMAL] = timer_func(&avr8_device<NumTimers>::timer2_tick_norm, this);
+	m_timer2_ticks[WGM02_PWM_PC] = timer_func(&avr8_device<NumTimers>::timer2_tick_default, this);
+	m_timer2_ticks[WGM02_CTC_CMP] = timer_func(&avr8_device<NumTimers>::timer2_tick_default, this);
+	m_timer2_ticks[WGM02_FAST_PWM] = timer_func(&avr8_device<NumTimers>::timer2_tick_fast_pwm, this);
+	m_timer2_ticks[WGM02_RESERVED0] = timer_func(&avr8_device<NumTimers>::timer2_tick_default, this);
+	m_timer2_ticks[WGM02_PWM_PC_CMP] = timer_func(&avr8_device<NumTimers>::timer2_tick_default, this);
+	m_timer2_ticks[WGM02_RESERVED1] = timer_func(&avr8_device<NumTimers>::timer2_tick_default, this);
+	m_timer2_ticks[WGM02_FAST_PWM_CMP] = timer_func(&avr8_device<NumTimers>::timer2_tick_fast_pwm_cmp, this);
 
 	m_timer0_tick = m_timer0_ticks[0];
 	m_timer1_tick = m_timer1_ticks[0];
@@ -994,55 +923,37 @@ avr8_device<NumTimers>::avr8_device(const machine_config &mconfig, const char *t
 }
 
 //-------------------------------------------------
-//  avr8_device - constructor
-//-------------------------------------------------
-template class avr8_device<2>;
-template class avr8_device<3>;
-template class avr8_device<6>;
-
-//-------------------------------------------------
-//  static_set_low_fuses
+//  set_low_fuses
 //-------------------------------------------------
 
-//template <int NumTimers> void avr8_device<2>::set_low_fuses(const uint32_t, const uint32_t);
-//template <int NumTimers> void avr8_device<3>::set_low_fuses(const uint32_t, const uint32_t);
-//template <int NumTimers> void avr8_device<6>::set_low_fuses(const uint32_t, const uint32_t);
-//template <int NumTimers> void avr8_device<2>::set_low_fuses(const uint32_t, const uint32_t);
-//template <int NumTimers> void avr8_device<3>::set_low_fuses(const uint32_t, const uint32_t);
-//template <int NumTimers> void avr8_device<6>::set_low_fuses(const uint32_t, const uint32_t);
-
-template <int NumTimers>
-void avr8_device<NumTimers>::set_low_fuses(const uint8_t byte)
+void avr8_base_device::set_low_fuses(const uint8_t byte)
 {
 	m_lfuses = byte;
 }
 
 //-------------------------------------------------
-//  static_set_high_fuses
+//  set_high_fuses
 //-------------------------------------------------
 
-template <int NumTimers>
-void avr8_device<NumTimers>::set_high_fuses(const uint8_t byte)
+void avr8_base_device::set_high_fuses(const uint8_t byte)
 {
 	m_hfuses = byte;
 }
 
 //-------------------------------------------------
-//  static_set_extended_fuses
+//  set_extended_fuses
 //-------------------------------------------------
 
-template <int NumTimers>
-void avr8_device<NumTimers>::set_extended_fuses(const uint8_t byte)
+void avr8_base_device::set_extended_fuses(const uint8_t byte)
 {
 	m_efuses = byte;
 }
 
 //-------------------------------------------------
-//  static_set_lock_bits
+//  set_lock_bits
 //-------------------------------------------------
 
-template <int NumTimers>
-void avr8_device<NumTimers>::set_lock_bits(const uint8_t byte)
+void avr8_base_device::set_lock_bits(const uint8_t byte)
 {
 	m_lock_bits = byte;
 }
@@ -1052,8 +963,7 @@ void avr8_device<NumTimers>::set_lock_bits(const uint8_t byte)
 //  instruction
 //-------------------------------------------------
 
-template <int NumTimers>
-void avr8_device<NumTimers>::unimplemented_opcode(uint32_t op)
+void avr8_base_device::unimplemented_opcode(uint32_t op)
 {
 //  machine().debug_break();
 	fatalerror("AVR8: unknown opcode (%08x) at %08x\n", op, m_pc);
@@ -1065,8 +975,7 @@ void avr8_device<NumTimers>::unimplemented_opcode(uint32_t op)
 //  bytes long
 //-------------------------------------------------
 
-template <int NumTimers>
-inline bool avr8_device<NumTimers>::is_long_opcode(uint16_t op)
+inline bool avr8_base_device::is_long_opcode(uint16_t op)
 {
 	if ((op & 0xf000) == 0x9000)
 	{
@@ -1092,15 +1001,12 @@ inline bool avr8_device<NumTimers>::is_long_opcode(uint16_t op)
 //  device_start - start up the device
 //-------------------------------------------------
 
-template <int NumTimers>
-void avr8_device<NumTimers>::device_start()
+void avr8_base_device::device_start()
 {
 	m_pc = 0;
 
 	m_program = &space(AS_PROGRAM);
 	m_data = &space(AS_DATA);
-
-	m_adc_timer = timer_alloc(FUNC(avr8_device<NumTimers>::adc_conversion_complete), this);
 
 	// register our state for the debugger
 	state_add(STATE_GENPC,     "GENPC",     m_pc).callexport().noshow();
@@ -1151,28 +1057,6 @@ void avr8_device<NumTimers>::device_start()
 	save_item(NAME(m_lock_bits));
 	save_item(NAME(m_pc));
 
-	// Timers
-	save_item(NAME(m_timer_top));
-	save_item(NAME(m_timer_prescale));
-	save_item(NAME(m_timer_prescale_count));
-	save_item(NAME(m_ocr2_not_reached_yet));
-	save_item(NAME(m_wgm1));
-	save_item(NAME(m_timer1_compare_mode));
-	save_item(NAME(m_ocr1));
-
-	// ADC
-	save_item(NAME(m_adc_sample));
-	save_item(NAME(m_adc_result));
-	save_item(NAME(m_adc_data));
-	save_item(NAME(m_adc_first));
-	save_item(NAME(m_adc_hold));
-
-	// SPI
-	save_item(NAME(m_spi_active));
-	save_item(NAME(m_spi_prescale));
-	save_item(NAME(m_spi_prescale_count));
-	save_item(NAME(m_spi_prescale_countdown));
-
 	// Misc.
 	save_item(NAME(m_addr_mask));
 	save_item(NAME(m_interrupt_pending));
@@ -1197,12 +1081,39 @@ void avr8_device<NumTimers>::device_start()
 	populate_shift_flag_cache();
 }
 
+template <int NumTimers>
+void avr8_device<NumTimers>::device_start()
+{
+	avr8_base_device::device_start();
+
+	m_adc_timer = timer_alloc(FUNC(avr8_device<NumTimers>::adc_conversion_complete), this);
+
+	// Timers
+	save_item(NAME(m_timer_top));
+	save_item(NAME(m_timer_prescale));
+	save_item(NAME(m_timer_prescale_count));
+	save_item(NAME(m_ocr2_not_reached_yet));
+	save_item(NAME(m_ocr1));
+
+	// ADC
+	save_item(NAME(m_adc_sample));
+	save_item(NAME(m_adc_result));
+	save_item(NAME(m_adc_data));
+	save_item(NAME(m_adc_first));
+	save_item(NAME(m_adc_hold));
+
+	// SPI
+	save_item(NAME(m_spi_active));
+	save_item(NAME(m_spi_prescale));
+	save_item(NAME(m_spi_prescale_count));
+	save_item(NAME(m_spi_prescale_countdown));
+}
+
 //-------------------------------------------------
 //  device_reset - reset the device
 //-------------------------------------------------
 
-template <int NumTimers>
-void avr8_device<NumTimers>::device_reset()
+void avr8_base_device::device_reset()
 {
 	logerror("AVR low fuse bits: 0x%02X\n", m_lfuses);
 	logerror("AVR high fuse bits: 0x%02X\n", m_hfuses);
@@ -1249,6 +1160,12 @@ void avr8_device<NumTimers>::device_reset()
 		m_r[i] = 0;
 	}
 
+	m_interrupt_pending = false;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::device_reset()
+{
 	m_adc_sample = 0;
 	m_adc_result = 0;
 	m_adc_data = 0;
@@ -1266,16 +1183,12 @@ void avr8_device<NumTimers>::device_reset()
 		m_timer_prescale_count[t] = 0;
 	}
 
-	m_wgm1 = 0;
-	m_timer1_compare_mode[0] = 0;
-	m_timer1_compare_mode[1] = 0;
 	for (int reg = AVR8_REG_A; reg <= AVR8_REG_C; reg++)
 	{
 		m_ocr1[reg] = 0;
 	}
 
 	m_ocr2_not_reached_yet = true;
-	m_interrupt_pending = false;
 }
 
 //-------------------------------------------------
@@ -1283,8 +1196,7 @@ void avr8_device<NumTimers>::device_reset()
 //  of the CPU's address spaces
 //-------------------------------------------------
 
-template <int NumTimers>
-device_memory_interface::space_config_vector avr8_device<NumTimers>::memory_space_config() const
+device_memory_interface::space_config_vector avr8_base_device::memory_space_config() const
 {
 	return space_config_vector {
 		std::make_pair(AS_PROGRAM, &m_program_config),
@@ -1298,8 +1210,7 @@ device_memory_interface::space_config_vector avr8_device<NumTimers>::memory_spac
 //  for the debugger
 //-------------------------------------------------
 
-template <int NumTimers>
-void avr8_device<NumTimers>::state_string_export(const device_state_entry &entry, std::string &str) const
+void avr8_base_device::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{
@@ -1322,8 +1233,7 @@ void avr8_device<NumTimers>::state_string_export(const device_state_entry &entry
 	}
 }
 
-template <int NumTimers>
-std::unique_ptr<util::disasm_interface> avr8_device<NumTimers>::create_disassembler()
+std::unique_ptr<util::disasm_interface> avr8_base_device::create_disassembler()
 {
 	return std::make_unique<avr8_disassembler>();
 }
@@ -1333,8 +1243,7 @@ std::unique_ptr<util::disasm_interface> avr8_device<NumTimers>::create_disassemb
 //  MEMORY ACCESSORS
 //**************************************************************************
 
-template <int NumTimers>
-inline void avr8_device<NumTimers>::push(uint8_t val)
+inline void avr8_base_device::push(uint8_t val)
 {
 	uint16_t sp = SPREG;
 	m_data->write_byte(sp, val);
@@ -1343,8 +1252,7 @@ inline void avr8_device<NumTimers>::push(uint8_t val)
 	m_r[SPH] = (sp >> 8) & 0x00ff;
 }
 
-template <int NumTimers>
-inline uint8_t avr8_device<NumTimers>::pop()
+inline uint8_t avr8_base_device::pop()
 {
 	uint16_t sp = SPREG;
 	sp++;
@@ -1357,14 +1265,13 @@ inline uint8_t avr8_device<NumTimers>::pop()
 //  IRQ HANDLING
 //**************************************************************************
 
-template <int NumTimers>
-void avr8_device<NumTimers>::set_irq_line(uint16_t vector, int state)
+void avr8_base_device::set_irq_line(uint16_t vector, int state)
 {
 	if (state)
 	{
-		if (SREG_R(AVR8_SREG_I))
+		if (BIT(m_r[SREG], SREG_I))
 		{
-			SREG_W(AVR8_SREG_I, 0);
+			m_r[SREG] &= ~SREG_MASK_I;
 			push((m_pc >> 1) & 0x00ff);
 			push((m_pc >> 9) & 0x00ff);
 			m_pc = vector << 1;
@@ -1376,32 +1283,22 @@ void avr8_device<NumTimers>::set_irq_line(uint16_t vector, int state)
 	}
 }
 
-struct interrupt_condition
+const avr8_base_device::interrupt_condition avr8_base_device::s_int_conditions[avr8_base_device::INTIDX_COUNT] =
 {
-	uint8_t m_intindex;
-	uint8_t m_intreg;
-	uint8_t m_intmask;
-	uint8_t m_regindex;
-	uint8_t m_regmask;
+	{ AVR8_INT_SPI_STC, SPCR,   SPCR_SPIE_MASK,     SPSR,    SPSR_SPIF_MASK },
+	{ AVR8_INT_T0COMPB, TIMSK0, TIMSK0_OCIE0B_MASK, TIFR0,   TIFR0_OCF0B_MASK },
+	{ AVR8_INT_T0COMPA, TIMSK0, TIMSK0_OCIE0A_MASK, TIFR0,   TIFR0_OCF0A_MASK },
+	{ AVR8_INT_T0OVF,   TIMSK0, TIMSK0_TOIE0_MASK,  TIFR0,   TIFR0_TOV0_MASK },
+	{ AVR8_INT_T1CAPT,  TIMSK1, TIMSK1_ICIE1_MASK,  TIFR1,   TIFR1_ICF1_MASK },
+	{ AVR8_INT_T1COMPB, TIMSK1, TIMSK1_OCIE1B_MASK, TIFR1,   TIFR1_OCF1B_MASK },
+	{ AVR8_INT_T1COMPA, TIMSK1, TIMSK1_OCIE1A_MASK, TIFR1,   TIFR1_OCF1A_MASK },
+	{ AVR8_INT_T1OVF,   TIMSK1, TIMSK1_TOIE1_MASK,  TIFR1,   TIFR1_TOV1_MASK },
+	{ AVR8_INT_T2COMPB, TIMSK2, TIMSK2_OCIE2B_MASK, TIFR2,   TIFR2_OCF2B_MASK },
+	{ AVR8_INT_T2COMPA, TIMSK2, TIMSK2_OCIE2A_MASK, TIFR2,   TIFR2_OCF2A_MASK },
+	{ AVR8_INT_T2OVF,   TIMSK2, TIMSK2_TOIE2_MASK,  TIFR2,   TIFR2_TOV2_MASK }
 };
 
-static const interrupt_condition s_int_conditions[AVR8_INTIDX_COUNT] =
-{
-	{ AVR8_INT_SPI_STC, SPCR,   AVR8_SPCR_SPIE_MASK,     SPSR,    AVR8_SPSR_SPIF_MASK },
-	{ AVR8_INT_T0COMPB, TIMSK0, AVR8_TIMSK0_OCIE0B_MASK, TIFR0,   AVR8_TIFR0_OCF0B_MASK },
-	{ AVR8_INT_T0COMPA, TIMSK0, AVR8_TIMSK0_OCIE0A_MASK, TIFR0,   AVR8_TIFR0_OCF0A_MASK },
-	{ AVR8_INT_T0OVF,   TIMSK0, AVR8_TIMSK0_TOIE0_MASK,  TIFR0,   AVR8_TIFR0_TOV0_MASK },
-	{ AVR8_INT_T1CAPT,  TIMSK1, AVR8_TIMSK1_ICIE1_MASK,  TIFR1,   AVR8_TIFR1_ICF1_MASK },
-	{ AVR8_INT_T1COMPB, TIMSK1, AVR8_TIMSK1_OCIE1B_MASK, TIFR1,   AVR8_TIFR1_OCF1B_MASK },
-	{ AVR8_INT_T1COMPA, TIMSK1, AVR8_TIMSK1_OCIE1A_MASK, TIFR1,   AVR8_TIFR1_OCF1A_MASK },
-	{ AVR8_INT_T1OVF,   TIMSK1, AVR8_TIMSK1_TOIE1_MASK,  TIFR1,   AVR8_TIFR1_TOV1_MASK },
-	{ AVR8_INT_T2COMPB, TIMSK2, AVR8_TIMSK2_OCIE2B_MASK, TIFR2,   AVR8_TIFR2_OCF2B_MASK },
-	{ AVR8_INT_T2COMPA, TIMSK2, AVR8_TIMSK2_OCIE2A_MASK, TIFR2,   AVR8_TIFR2_OCF2A_MASK },
-	{ AVR8_INT_T2OVF,   TIMSK2, AVR8_TIMSK2_TOIE2_MASK,  TIFR2,   AVR8_TIFR2_TOV2_MASK }
-};
-
-template <int NumTimers>
-void avr8_device<NumTimers>::update_interrupt(int source)
+void avr8_base_device::update_interrupt(int source)
 {
 	const interrupt_condition &condition = s_int_conditions[source];
 
@@ -1450,19 +1347,19 @@ void atmega328_device::update_interrupt(int source)
 	}
 }
 
-static const interrupt_condition s_mega644_int_conditions[AVR8_INTIDX_COUNT] =
+const avr8_base_device::interrupt_condition avr8_base_device::s_mega644_int_conditions[avr8_base_device::INTIDX_COUNT] =
 {
-	{ ATMEGA644_INT_SPI_STC, SPCR,   AVR8_SPCR_SPIE_MASK,     SPSR,    AVR8_SPSR_SPIF_MASK },
-	{ ATMEGA644_INT_T0COMPB, TIMSK0, AVR8_TIMSK0_OCIE0B_MASK, TIFR0,   AVR8_TIFR0_OCF0B_MASK },
-	{ ATMEGA644_INT_T0COMPA, TIMSK0, AVR8_TIMSK0_OCIE0A_MASK, TIFR0,   AVR8_TIFR0_OCF0A_MASK },
-	{ ATMEGA644_INT_T0OVF,   TIMSK0, AVR8_TIMSK0_TOIE0_MASK,  TIFR0,   AVR8_TIFR0_TOV0_MASK },
-	{ ATMEGA644_INT_T1CAPT,  TIMSK1, AVR8_TIMSK1_ICIE1_MASK,  TIFR1,   AVR8_TIFR1_ICF1_MASK },
-	{ ATMEGA644_INT_T1COMPB, TIMSK1, AVR8_TIMSK1_OCIE1B_MASK, TIFR1,   AVR8_TIFR1_OCF1B_MASK },
-	{ ATMEGA644_INT_T1COMPA, TIMSK1, AVR8_TIMSK1_OCIE1A_MASK, TIFR1,   AVR8_TIFR1_OCF1A_MASK },
-	{ ATMEGA644_INT_T1OVF,   TIMSK1, AVR8_TIMSK1_TOIE1_MASK,  TIFR1,   AVR8_TIFR1_TOV1_MASK },
-	{ ATMEGA644_INT_T2COMPB, TIMSK2, AVR8_TIMSK2_OCIE2B_MASK, TIFR2,   AVR8_TIFR2_OCF2B_MASK },
-	{ ATMEGA644_INT_T2COMPA, TIMSK2, AVR8_TIMSK2_OCIE2A_MASK, TIFR2,   AVR8_TIFR2_OCF2A_MASK },
-	{ ATMEGA644_INT_T2OVF,   TIMSK2, AVR8_TIMSK2_TOIE2_MASK,  TIFR2,   AVR8_TIFR2_TOV2_MASK }
+	{ ATMEGA644_INT_SPI_STC, SPCR,   SPCR_SPIE_MASK,     SPSR,    SPSR_SPIF_MASK },
+	{ ATMEGA644_INT_T0COMPB, TIMSK0, TIMSK0_OCIE0B_MASK, TIFR0,   TIFR0_OCF0B_MASK },
+	{ ATMEGA644_INT_T0COMPA, TIMSK0, TIMSK0_OCIE0A_MASK, TIFR0,   TIFR0_OCF0A_MASK },
+	{ ATMEGA644_INT_T0OVF,   TIMSK0, TIMSK0_TOIE0_MASK,  TIFR0,   TIFR0_TOV0_MASK },
+	{ ATMEGA644_INT_T1CAPT,  TIMSK1, TIMSK1_ICIE1_MASK,  TIFR1,   TIFR1_ICF1_MASK },
+	{ ATMEGA644_INT_T1COMPB, TIMSK1, TIMSK1_OCIE1B_MASK, TIFR1,   TIFR1_OCF1B_MASK },
+	{ ATMEGA644_INT_T1COMPA, TIMSK1, TIMSK1_OCIE1A_MASK, TIFR1,   TIFR1_OCF1A_MASK },
+	{ ATMEGA644_INT_T1OVF,   TIMSK1, TIMSK1_TOIE1_MASK,  TIFR1,   TIFR1_TOV1_MASK },
+	{ ATMEGA644_INT_T2COMPB, TIMSK2, TIMSK2_OCIE2B_MASK, TIFR2,   TIFR2_OCF2B_MASK },
+	{ ATMEGA644_INT_T2COMPA, TIMSK2, TIMSK2_OCIE2A_MASK, TIFR2,   TIFR2_OCF2A_MASK },
+	{ ATMEGA644_INT_T2OVF,   TIMSK2, TIMSK2_TOIE2_MASK,  TIFR2,   TIFR2_TOV2_MASK }
 };
 
 void atmega644_device::update_interrupt(int source)
@@ -1473,7 +1370,6 @@ void atmega644_device::update_interrupt(int source)
 	if (m_r[condition.m_intreg] & condition.m_intmask)
 		intstate = (m_r[condition.m_regindex] & condition.m_regmask) ? 1 : 0;
 
-	if (intstate) logerror("interrupt %d is 1\n", source);
 	set_irq_line(condition.m_intindex << 1, intstate);
 
 	if (intstate)
@@ -1520,7 +1416,7 @@ void atmega2560_device::update_interrupt(int source)
 
 
 //**************************************************************************
-//  REGISTER HANDLING
+//  PERIPHERAL HANDLING
 //**************************************************************************
 
 template <int NumTimers>
@@ -1528,10 +1424,10 @@ void avr8_device<NumTimers>::spi_tick()
 {
 	const uint8_t out_bit = (m_r[SPDR] & (1 << m_spi_prescale_countdown)) >> m_spi_prescale_countdown;
 	m_spi_prescale_countdown--;
-	const uint8_t data = (m_r[PORTB] &~ AVR8_PORTB_MOSI) | (out_bit ? AVR8_PORTB_MOSI : 0);
+	const uint8_t data = (m_r[PORTB] &~ PORTB_MOSI) | (out_bit ? PORTB_MOSI : 0);
 	m_r[PORTB] = data;
 	m_gpio_out_cb[GPIOB](data);
-	m_r[PORTB] = (m_r[PORTB] &~ AVR8_PORTB_MOSI) | (out_bit ? AVR8_PORTB_MOSI : 0);
+	m_r[PORTB] = (m_r[PORTB] &~ PORTB_MOSI) | (out_bit ? PORTB_MOSI : 0);
 }
 
 // Timer 0 Handling
@@ -1555,16 +1451,16 @@ void avr8_device<NumTimers>::timer0_tick_pwm_pc()
 template <int NumTimers>
 void avr8_device<NumTimers>::timer0_tick_ctc_norm()
 {
-	static const uint8_t s_ocf0[2] = { (1 << AVR8_TIFR0_OCF0A_SHIFT), (1 << AVR8_TIFR0_OCF0B_SHIFT) };
-	static const uint8_t s_int0[2] = { AVR8_INTIDX_OCF0A, AVR8_INTIDX_OCF0B };
+	static const uint8_t s_ocf0[2] = { (1 << TIFR0_OCF0A_SHIFT), (1 << TIFR0_OCF0B_SHIFT) };
+	static const uint8_t s_int0[2] = { INTIDX_OCF0A, INTIDX_OCF0B };
 
-	if (m_r[TCNT0] == AVR8_OCR0A - 1)
+	if (m_r[TCNT0] == m_r[OCR0A] - 1)
 	{
 		m_r[TIFR0] |= s_ocf0[AVR8_REG_A];
 		update_interrupt(s_int0[AVR8_REG_A]);
 		m_r[TCNT0] = 0;
 	}
-	else if (m_r[TCNT0] == AVR8_OCR0B - 1)
+	else if (m_r[TCNT0] == m_r[OCR0B] - 1)
 	{
 		m_r[TIFR0] |= s_ocf0[AVR8_REG_B];
 		update_interrupt(s_int0[AVR8_REG_B]);
@@ -1646,7 +1542,7 @@ void avr8_device<NumTimers>::timer0_tick_fast_pwm_cmp()
 template <int NumTimers>
 void avr8_device<NumTimers>::timer0_tick_default()
 {
-	LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: timer0_tick_default: Unknown waveform generation mode: %02x\n", machine().describe_context(), AVR8_WGM0);
+	LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: timer0_tick_default: Unknown waveform generation mode: %02x\n", machine().describe_context(), WGM0);
 	m_r[TCNT0]++;
 	m_timer_prescale_count[0] -= m_timer_prescale[0];
 }
@@ -1654,7 +1550,7 @@ void avr8_device<NumTimers>::timer0_tick_default()
 template <int NumTimers>
 void avr8_device<NumTimers>::timer0_force_output_compare(int reg)
 {
-	LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: timer0_force_output_compare: TODO; should be forcing OC0%c\n", machine().describe_context(), avr8_reg_name[reg]);
+	LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: timer0_force_output_compare: TODO; should be forcing OC0%c\n", machine().describe_context(), 'A' + reg);
 	m_timer_prescale_count[0] -= m_timer_prescale[0];
 }
 
@@ -1670,9 +1566,9 @@ template <int NumTimers>
 template <int TimerMode, int ChannelModeA, int ChannelModeB>
 inline void avr8_device<NumTimers>::timer1_tick()
 {
-	static const uint8_t s_ocf1[2] = { (1 << AVR8_TIFR1_OCF1A_SHIFT), (1 << AVR8_TIFR1_OCF1B_SHIFT) };
-	static const uint8_t s_int1[2] = { AVR8_INTIDX_OCF1A, AVR8_INTIDX_OCF1B };
-	const uint16_t icr1 = AVR8_ICR1;
+	static const uint8_t s_ocf1[2] = { (1 << TIFR1_OCF1A_SHIFT), (1 << TIFR1_OCF1B_SHIFT) };
+	static const uint8_t s_int1[2] = { INTIDX_OCF1A, INTIDX_OCF1B };
+	const uint16_t icr1 = ICR1;
 	uint16_t timer1_count = (m_r[TCNT1H] << 8) | m_r[TCNT1L];
 	int32_t increment = 1;
 
@@ -1682,8 +1578,8 @@ inline void avr8_device<NumTimers>::timer1_tick()
 		if (timer1_count == 0xffff)
 		{
 			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 CTC_OCR, TOP, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
-			m_r[TIFR1] |= AVR8_TIFR1_TOV1_MASK;
-			update_interrupt(AVR8_INTIDX_TOV1);
+			m_r[TIFR1] |= TIFR1_TOV1_MASK;
+			update_interrupt(INTIDX_TOV1);
 			timer1_count = 0;
 			increment = 0;
 		}
@@ -1724,8 +1620,8 @@ inline void avr8_device<NumTimers>::timer1_tick()
 		else if (timer1_count == 0)
 		{
 			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 CTC_OCR, BOTTOM, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
-			m_r[TIFR1] &= ~AVR8_TIFR1_TOV1_MASK;
-			update_interrupt(AVR8_INTIDX_TOV1);
+			m_r[TIFR1] &= ~TIFR1_TOV1_MASK;
+			update_interrupt(INTIDX_TOV1);
 		}
 
 		if (timer1_count == m_ocr1[AVR8_REG_B])
@@ -1759,8 +1655,8 @@ inline void avr8_device<NumTimers>::timer1_tick()
 		if (timer1_count == m_ocr1[AVR8_REG_A])
 		{
 			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 FAST_PWM_OCR, OCR1A, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
-			m_r[TIFR1] |= AVR8_TIFR1_TOV1_MASK;
-			update_interrupt(AVR8_INTIDX_TOV1);
+			m_r[TIFR1] |= TIFR1_TOV1_MASK;
+			update_interrupt(INTIDX_TOV1);
 			timer1_count = 0;
 			increment = 0;
 
@@ -1794,8 +1690,8 @@ inline void avr8_device<NumTimers>::timer1_tick()
 		else if (timer1_count == 0)
 		{
 			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 FAST_PWM_OCR, BOTTOM A, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
-			m_r[TIFR1] &= ~AVR8_TIFR1_TOV1_MASK;
-			update_interrupt(AVR8_INTIDX_TOV1);
+			m_r[TIFR1] &= ~TIFR1_TOV1_MASK;
+			update_interrupt(INTIDX_TOV1);
 
 			switch (ChannelModeA)
 			{
@@ -1905,8 +1801,8 @@ inline void avr8_device<NumTimers>::timer1_tick()
 		else if (timer1_count == 0)
 		{
 			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 FAST_PWM_ICR, BOTTOM A, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
-			m_r[TIFR1] &= ~AVR8_TIFR1_TOV1_MASK;
-			update_interrupt(AVR8_INTIDX_TOV1);
+			m_r[TIFR1] &= ~TIFR1_TOV1_MASK;
+			update_interrupt(INTIDX_TOV1);
 
 			switch (ChannelModeA)
 			{
@@ -1981,15 +1877,15 @@ inline void avr8_device<NumTimers>::timer1_tick()
 
 		if (timer1_count == icr1)
 		{
-			m_r[TIFR1] |= AVR8_TIFR1_TOV1_MASK;
-			update_interrupt(AVR8_INTIDX_TOV1);
+			m_r[TIFR1] |= TIFR1_TOV1_MASK;
+			update_interrupt(INTIDX_TOV1);
 			timer1_count = 0;
 			increment = 0;
 		}
 		break;
 
 	default:
-		LOGMASKED(LOG_TIMER1 | LOG_UNKNOWN, "%s: timer1_tick: Unknown waveform generation mode: %02x\n", machine().describe_context(), m_wgm1);
+		LOGMASKED(LOG_TIMER1 | LOG_UNKNOWN, "%s: timer1_tick: Unknown waveform generation mode: %02x\n", machine().describe_context(), WGM1);
 		break;
 	}
 
@@ -2007,28 +1903,28 @@ void avr8_device<NumTimers>::update_timer_waveform_gen_mode(uint8_t t, uint8_t m
 	switch (t)
 	{
 	case 0:
-		oc_val = AVR8_OCR0A;
+		oc_val = m_r[OCR0A];
 		ic_val = -1;
 		break;
 	case 1:
-		oc_val = AVR8_OCR1A;
-		ic_val = AVR8_ICR1;
+		oc_val = OCR1A;
+		ic_val = ICR1;
 		break;
 	case 2:
-		oc_val = AVR8_OCR2A;
+		oc_val = OCR2A;
 		ic_val = -1;
 		break;
 	case 3:
-		oc_val = AVR8_OCR3A;
-		ic_val = AVR8_ICR3;
+		oc_val = OCR3A;
+		ic_val = ICR3;
 		break;
 	case 4:
-		oc_val = AVR8_OCR4A;
-		ic_val = AVR8_ICR4;
+		oc_val = OCR4A;
+		ic_val = ICR4;
 		break;
 	case 5:
-		oc_val = AVR8_OCR5A;
-		ic_val = AVR8_ICR5;
+		oc_val = OCR5A;
+		ic_val = ICR5;
 		break;
 	}
 
@@ -2059,10 +1955,6 @@ void avr8_device<NumTimers>::update_timer_waveform_gen_mode(uint8_t t, uint8_t m
 		break;
 	}
 
-	if (t == 1)
-	{
-		m_wgm1 = ((m_r[TCCR1B] & AVR8_TCCR1B_WGM1_32_MASK) >> 1) | (m_r[TCCR1A] & AVR8_TCCR1A_WGM1_10_MASK);
-	}
 	if (m_timer_top[t] == -1)
 	{
 		m_timer_top[t] = 0;
@@ -2097,7 +1989,7 @@ void avr8_device<NumTimers>::update_ocr1(uint16_t newval, uint8_t reg)
 template <int NumTimers>
 void avr8_device<NumTimers>::timer2_tick_default()
 {
-	LOGMASKED(LOG_TIMER2, "%s: WGM02_PWM_PC: Unimplemented timer#2 waveform generation mode %d\n", machine().describe_context(), AVR8_WGM2);
+	LOGMASKED(LOG_TIMER2, "%s: WGM02_PWM_PC: Unimplemented timer#2 waveform generation mode %d\n", machine().describe_context(), WGM2);
 	m_r[TCNT2]++;
 	m_timer_prescale_count[2] -= m_timer_prescale[2];
 }
@@ -2108,10 +2000,10 @@ void avr8_device<NumTimers>::timer2_tick_norm()
 	LOGMASKED(LOG_TIMER2, "%s: timer2_tick_norm; WGM02_NORMAL\n", machine().describe_context());
 	if (m_r[TCNT2] == 0xff)
 	{
-		m_r[TIFR2] |= AVR8_TIFR2_TOV2_MASK;
+		m_r[TIFR2] |= TIFR2_TOV2_MASK;
 	}
 	m_r[TCNT2]++;
-	update_interrupt(AVR8_INTIDX_TOV2);
+	update_interrupt(INTIDX_TOV2);
 	m_timer_prescale_count[2] -= m_timer_prescale[2];
 }
 
@@ -2147,21 +2039,21 @@ void avr8_device<NumTimers>::timer2_tick_fast_pwm()
 template <int NumTimers>
 void avr8_device<NumTimers>::timer2_tick_fast_pwm_cmp()
 {
-	const uint8_t ocf2[2] = { (1 << AVR8_TIFR2_OCF2A_SHIFT), (1 << AVR8_TIFR2_OCF2B_SHIFT) };
+	const uint8_t ocf2[2] = { (1 << TIFR2_OCF2A_SHIFT), (1 << TIFR2_OCF2B_SHIFT) };
 	uint16_t count = m_r[TCNT2];
 
 	int32_t increment = 1;
 
 	if (count == m_r[OCR2A])
 	{
-		m_r[TIFR2] |= AVR8_TIFR2_TOV2_MASK;
+		m_r[TIFR2] |= TIFR2_TOV2_MASK;
 		count = 0;
 		increment = 0;
 		m_r[TIFR2] |= ocf2[AVR8_REG_A];
 	}
 	else if (count == 0)
 	{
-		m_r[TIFR2] &= ~AVR8_TIFR2_TOV2_MASK;
+		m_r[TIFR2] &= ~TIFR2_TOV2_MASK;
 	}
 
 	if (count == m_r[OCR2B])
@@ -2171,7 +2063,7 @@ void avr8_device<NumTimers>::timer2_tick_fast_pwm_cmp()
 
 	count += increment;
 
-	update_interrupt(AVR8_INTIDX_TOV2);
+	update_interrupt(INTIDX_TOV2);
 	m_r[TCNT2] = count;
 	m_timer_prescale_count[2] -= m_timer_prescale[2];
 }
@@ -2179,7 +2071,7 @@ void avr8_device<NumTimers>::timer2_tick_fast_pwm_cmp()
 template <int NumTimers>
 void avr8_device<NumTimers>::timer2_force_output_compare(int reg)
 {
-	LOGMASKED(LOG_TIMER2 | LOG_UNKNOWN, "%s: force_output_compare: TODO; should be forcing OC2%c\n", machine().describe_context(), avr8_reg_name[reg]);
+	LOGMASKED(LOG_TIMER2 | LOG_UNKNOWN, "%s: force_output_compare: TODO; should be forcing OC2%c\n", machine().describe_context(), 'A' + reg);
 }
 
 template <int NumTimers>
@@ -2204,26 +2096,18 @@ template <int NumTimers>
 void avr8_device<NumTimers>::timer4_tick()
 {
 	/* TODO: Handle comparison, setting OC1x pins, detection of BOTTOM and TOP */
-	LOGMASKED(LOG_TIMER4_TICK, "%s: AVR8_WGM4: %d\n", machine().describe_context(), AVR8_WGM4);
-	LOGMASKED(LOG_TIMER4_TICK, "%s: AVR8_TCCR4A_COM4B: %d\n", machine().describe_context(), AVR8_TCCR4A_COM4B);
+	LOGMASKED(LOG_TIMER4_TICK, "%s: WGM4: %d\n", machine().describe_context(), WGM4);
+	LOGMASKED(LOG_TIMER4_TICK, "%s: TCCR4A_COM4B: %d\n", machine().describe_context(), TCCR4A_COM4B);
 
 	uint16_t count = (m_r[TCNT4H] << 8) | m_r[TCNT4L];
-
-	// Cache things in array form to avoid a compare+branch inside a potentially high-frequency timer
-	// uint8_t compare_mode[2] = { (m_r[TCCR1A] & AVR8_TCCR1A_COM1A_MASK) >> AVR8_TCCR1A_COM1A_SHIFT,
-	//                             (m_r[TCCR1A] & AVR8_TCCR1A_COM1B_MASK) >> AVR8_TCCR1A_COM1B_SHIFT };
-	// uint16_t ocr4[2] = { static_cast<uint16_t>((m_r[OCR4AH] << 8) | m_r[OCR4AL]),
-							// static_cast<uint16_t>((m_r[OCR4BH] << 8) | m_r[OCR4BL]) };
-	// TODO  uint8_t ocf4[2] = { (1 << AVR8_TIFR4_OCF4A_SHIFT), (1 << AVR8_TIFR4_OCF4B_SHIFT) };
-	// TODO  uint8_t int4[2] = { AVR8_INTIDX_OCF4A, AVR8_INTIDX_OCF4B };
 	int32_t increment = 1;
 
-	switch (AVR8_WGM4)
+	switch (WGM4)
 	{
 	case WGM4_FAST_PWM_8:
 	case WGM4_FAST_PWM_9:
 	case WGM4_FAST_PWM_10:
-		switch (AVR8_TCCR4A_COM4B)
+		switch (TCCR4A_COM4B)
 		{
 		case 0: /* Normal Operation */
 			break;
@@ -2268,8 +2152,8 @@ void avr8_device<NumTimers>::timer4_tick()
 		LOGMASKED(LOG_TIMER4, "%s: timer4: tick WGM4_CTC_OCR: %d\n", machine().describe_context(), count);
 		if (count == 0xffff)
 		{
-			m_r[TIFR4] |= AVR8_TIFR4_TOV4_MASK;
-			update_interrupt(AVR8_INTIDX_TOV4);
+			m_r[TIFR4] |= TIFR4_TOV4_MASK;
+			update_interrupt(INTIDX_TOV4);
 			count = 0;
 			increment = 0;
 		}
@@ -2282,7 +2166,7 @@ void avr8_device<NumTimers>::timer4_tick()
 		break;
 
 	default:
-		LOGMASKED(LOG_TIMER4 | LOG_UNKNOWN, "%s: timer4_tick: Unknown waveform generation mode: %02x\n", machine().describe_context(), AVR8_WGM4);
+		LOGMASKED(LOG_TIMER4 | LOG_UNKNOWN, "%s: timer4_tick: Unknown waveform generation mode: %02x\n", machine().describe_context(), WGM4);
 		break;
 	}
 
@@ -2325,13 +2209,13 @@ void avr8_device<NumTimers>::update_timer_clock_source(uint8_t clock_select, con
 template <int NumTimers>
 void avr8_device<NumTimers>::timer5_tick()
 {
-	LOGMASKED(LOG_TIMER5_TICK, "%s: AVR8_WGM5: %d\n", machine().describe_context(), AVR8_WGM5);
-	LOGMASKED(LOG_TIMER5_TICK, "%s: AVR8_TCCR5A_COM5B: %d\n", machine().describe_context(), AVR8_TCCR5A_COM5B);
+	LOGMASKED(LOG_TIMER5_TICK, "%s: WGM5: %d\n", machine().describe_context(), WGM5);
+	LOGMASKED(LOG_TIMER5_TICK, "%s: TCCR5A_COM5B: %d\n", machine().describe_context(), TCCR5A_COM5B);
 
-	uint16_t count = (AVR8_TCNT5H << 8) + AVR8_TCNT5L;
+	uint16_t count = (m_r[TCNT5H] << 8) + m_r[TCNT5L];
 	int32_t increment = 1;
 
-	switch (AVR8_WGM5)
+	switch (WGM5)
 	{
 	case WGM5_NORMAL:
 	case WGM5_PWM_8_PC:
@@ -2348,12 +2232,12 @@ void avr8_device<NumTimers>::timer5_tick()
 	case WGM5_CTC_ICR:
 	case WGM5_FAST_PWM_ICR:
 	case WGM5_FAST_PWM_OCR:
-		LOGMASKED(LOG_TIMER5 | LOG_UNKNOWN, "%s: Unimplemented timer5 waveform generation mode: AVR8_WGM5 = 0x%02X\n", machine().describe_context(), AVR8_WGM5);
+		LOGMASKED(LOG_TIMER5 | LOG_UNKNOWN, "%s: Unimplemented timer5 waveform generation mode: WGM5 = 0x%02X\n", machine().describe_context(), WGM5);
 		break;
 
 	case WGM5_CTC_OCR:
 		// TODO: Please verify, might be wrong
-		switch (AVR8_TCCR5A_COM5B)
+		switch (TCCR5A_COM5B)
 		{
 		case 0: /* Normal Operation */
 			if (count == m_timer_top[5])
@@ -2393,7 +2277,7 @@ void avr8_device<NumTimers>::timer5_tick()
 		break;
 
 	default:
-		LOGMASKED(LOG_TIMER5 | LOG_UNKNOWN, "%s: timer5: Unknown waveform generation mode: %02x\n", machine().describe_context(), AVR8_WGM5);
+		LOGMASKED(LOG_TIMER5 | LOG_UNKNOWN, "%s: timer5: Unknown waveform generation mode: %02x\n", machine().describe_context(), WGM5);
 		break;
 	}
 
@@ -2413,33 +2297,33 @@ template <int NumTimers>
 void avr8_device<NumTimers>::adc_start_conversion()
 {
 	// set capture in progress flag
-	AVR8_ADCSRA |= AVR8_ADCSRA_ADSC_MASK;
+	m_r[ADCSRA] |= ADCSRA_ADSC_MASK;
 
 	// get a sample - the sample-and-hold circuit will hold this for the duration of the conversion
-	if (AVR8_ADMUX_MUX < 0x8)
+	if (ADMUX_MUX < 0x8)
 	{
-		m_adc_sample = m_adc_in_cb[AVR8_ADMUX_MUX]() & 0x3ff;
+		m_adc_sample = m_adc_in_cb[ADMUX_MUX]() & 0x3ff;
 	}
-	else if (AVR8_ADMUX_MUX == 0xe)
+	else if (ADMUX_MUX == 0xe)
 	{
 		// 1.1V (Vbg)
 		// FIXME: the value this acquires depends on what the reference source is set to
 		logerror("%s: Using unimplemented 1.1V reference voltage as ADC input\n", machine().describe_context());
 		m_adc_sample = 0x3ff;
 	}
-	else if (AVR8_ADMUX_MUX == 0x0f)
+	else if (ADMUX_MUX == 0x0f)
 	{
 		// 0V (GND)
 		m_adc_sample = 0;
 	}
 	else
 	{
-		logerror("%s: Using reserved ADC input 0x%X\n", machine().describe_context(), AVR8_ADMUX_MUX);
+		logerror("%s: Using reserved ADC input 0x%X\n", machine().describe_context(), ADMUX_MUX);
 		m_adc_sample = 0;
 	}
 
 	// wait for conversion to complete
-	int const scale = 1 << std::max(AVR8_ADCSRA_ADPS, 1);
+	int const scale = 1 << std::max(ADCSRA_ADPS, 1);
 	m_adc_timer->adjust(attotime::from_ticks((m_adc_first ? 25 : 13) * scale, clock()));
 }
 
@@ -2452,11 +2336,11 @@ TIMER_CALLBACK_MEMBER(avr8_device<NumTimers>::adc_conversion_complete)
 		m_adc_data = m_adc_result;
 
 	// clear conversion in progress flag, set conversion interrupt flag
-	AVR8_ADCSRA &= ~AVR8_ADCSRA_ADSC_MASK;
-	AVR8_ADCSRA |= AVR8_ADCSRA_ADIF_MASK;
+	m_r[ADCSRA] &= ~ADCSRA_ADSC_MASK;
+	m_r[ADCSRA] |= ADCSRA_ADIF_MASK;
 
 	// trigger another conversion if appropriate
-	if (AVR8_ADCSRA_ADATE && (AVR8_ADCSRB_ADTS == 0))
+	if (ADCSRA_ADATE && (ADCSRB_ADTS == 0))
 		adc_start_conversion();
 }
 
@@ -2503,52 +2387,52 @@ void avr8_device<NumTimers>::spi_update_clock_rate()
 	{
 		4, 16, 64, 128, 2, 8, 32, 64
 	};
-	m_spi_prescale = s_spi_clock_divisor[AVR8_SPI_RATE];
+	m_spi_prescale = s_spi_clock_divisor[SPI_RATE];
 	m_spi_prescale_count &= m_spi_prescale - 1;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::change_spcr(uint8_t data)
 {
-	uint8_t oldspcr = AVR8_SPCR;
+	uint8_t oldspcr = m_r[SPCR];
 	uint8_t newspcr = data;
 	uint8_t changed = newspcr ^ oldspcr;
 	uint8_t high_to_low = ~newspcr & oldspcr;
 	uint8_t low_to_high = newspcr & ~oldspcr;
 
-	AVR8_SPCR = data;
+	m_r[SPCR] = data;
 
-	if (changed & AVR8_SPCR_SPIE_MASK)
+	if (changed & SPCR_SPIE_MASK)
 	{
 		// Check for SPI interrupt condition
-		update_interrupt(AVR8_INTIDX_SPI);
+		update_interrupt(INTIDX_SPI);
 	}
 
-	if (low_to_high & AVR8_SPCR_SPE_MASK)
+	if (low_to_high & SPCR_SPE_MASK)
 	{
 		enable_spi();
 	}
-	else if (high_to_low & AVR8_SPCR_SPE_MASK)
+	else if (high_to_low & SPCR_SPE_MASK)
 	{
 		disable_spi();
 	}
 
-	if (changed & AVR8_SPCR_MSTR_MASK)
+	if (changed & SPCR_MSTR_MASK)
 	{
 		spi_update_masterslave_select();
 	}
 
-	if (changed & AVR8_SPCR_CPOL_MASK)
+	if (changed & SPCR_CPOL_MASK)
 	{
 		spi_update_clock_polarity();
 	}
 
-	if (changed & AVR8_SPCR_CPHA_MASK)
+	if (changed & SPCR_CPHA_MASK)
 	{
 		spi_update_clock_phase();
 	}
 
-	if (changed & AVR8_SPCR_SPR_MASK)
+	if (changed & SPCR_SPR_MASK)
 	{
 		spi_update_clock_rate();
 	}
@@ -2557,14 +2441,14 @@ void avr8_device<NumTimers>::change_spcr(uint8_t data)
 template <int NumTimers>
 void avr8_device<NumTimers>::change_spsr(uint8_t data)
 {
-	uint8_t oldspsr = AVR8_SPSR;
+	uint8_t oldspsr = m_r[SPSR];
 	uint8_t newspsr = data;
 	uint8_t changed = newspsr ^ oldspsr;
 
-	AVR8_SPSR &= ~1;
-	AVR8_SPSR |= data & 1;
+	m_r[SPSR] &= ~1;
+	m_r[SPSR] |= data & 1;
 
-	if (changed & AVR8_SPSR_SPR2X_MASK)
+	if (changed & SPSR_SPR2X_MASK)
 	{
 		spi_update_clock_rate();
 	}
@@ -2641,12 +2525,12 @@ void avr8_device<NumTimers>::tccr0a_w(uint8_t data)
 	const uint8_t changed = newtccr ^ oldtccr;
 	m_r[TCCR0A] = data;
 
-	if (changed & AVR8_TCCR0A_WGM0_10_MASK)
+	if (changed & TCCR0A_WGM0_10_MASK)
 	{
-		update_timer_waveform_gen_mode(0, AVR8_WGM0);
+		update_timer_waveform_gen_mode(0, WGM0);
 	}
 
-	m_timer0_tick = m_timer0_ticks[(AVR8_WGM0 << 2) | AVR8_TCCR0A_COM0B];
+	m_timer0_tick = m_timer0_ticks[(WGM0 << 2) | TCCR0A_COM0B];
 }
 
 template <int NumTimers>
@@ -2656,33 +2540,33 @@ void avr8_device<NumTimers>::tccr0b_w(uint8_t data)
 	const uint8_t oldtccr = m_r[TCCR0B];
 	const uint8_t newtccr = data;
 	const uint8_t changed = newtccr ^ oldtccr;
-	const uint8_t oldcs = m_r[TCCR0B] & AVR8_TCCR0B_CS_MASK;
+	const uint8_t oldcs = m_r[TCCR0B] & TCCR0B_CS_MASK;
 
 	m_r[TCCR0B] = data;
 
-	if (changed & AVR8_TCCR0B_FOC0A_MASK)
+	if (changed & TCCR0B_FOC0A_MASK)
 	{
 		// TODO
 		timer0_force_output_compare(AVR8_REG_A);
 	}
 
-	if (changed & AVR8_TCCR0B_FOC0B_MASK)
+	if (changed & TCCR0B_FOC0B_MASK)
 	{
 		// TODO
 		timer0_force_output_compare(AVR8_REG_B);
 	}
 
-	if (changed & AVR8_TCCR0B_WGM0_2_MASK)
+	if (changed & TCCR0B_WGM0_2_MASK)
 	{
-		update_timer_waveform_gen_mode(0, AVR8_WGM0);
+		update_timer_waveform_gen_mode(0, WGM0);
 	}
 
-	if (changed & AVR8_TCCR0B_CS_MASK)
+	if (changed & TCCR0B_CS_MASK)
 	{
-		update_timer_clock_source<0>(AVR8_TIMER0_CLOCK_SELECT, oldcs);
+		update_timer_clock_source<0>(TIMER0_CLOCK_SELECT, oldcs);
 	}
 
-	m_timer0_tick = m_timer0_ticks[(AVR8_WGM0 << 2) | AVR8_TCCR0A_COM0B];
+	m_timer0_tick = m_timer0_ticks[(WGM0 << 2) | TCCR0A_COM0B];
 }
 
 template <int NumTimers>
@@ -2703,39 +2587,39 @@ template <int NumTimers>
 void avr8_device<NumTimers>::tifr0_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER0, "%s: TIFR0 = %02x\n", machine().describe_context(), data);
-	m_r[TIFR0] &= ~(data & AVR8_TIFR0_MASK);
-	update_interrupt(AVR8_INTIDX_OCF0A);
-	update_interrupt(AVR8_INTIDX_OCF0B);
-	update_interrupt(AVR8_INTIDX_TOV0);
+	m_r[TIFR0] &= ~(data & TIFR0_MASK);
+	update_interrupt(INTIDX_OCF0A);
+	update_interrupt(INTIDX_OCF0B);
+	update_interrupt(INTIDX_TOV0);
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::tifr1_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER1, "%s: TIFR1 = %02x\n", machine().describe_context(), data);
-	m_r[TIFR1] &= ~(data & AVR8_TIFR1_MASK);
-	update_interrupt(AVR8_INTIDX_ICF1);
-	update_interrupt(AVR8_INTIDX_OCF1A);
-	update_interrupt(AVR8_INTIDX_OCF1B);
-	update_interrupt(AVR8_INTIDX_TOV1);
+	m_r[TIFR1] &= ~(data & TIFR1_MASK);
+	update_interrupt(INTIDX_ICF1);
+	update_interrupt(INTIDX_OCF1A);
+	update_interrupt(INTIDX_OCF1B);
+	update_interrupt(INTIDX_TOV1);
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::tifr2_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER2, "%s: TIFR2 = %02x\n", machine().describe_context(), data);
-	m_r[TIFR2] &= ~(data & AVR8_TIFR2_MASK);
-	update_interrupt(AVR8_INTIDX_OCF2A);
-	update_interrupt(AVR8_INTIDX_OCF2B);
-	update_interrupt(AVR8_INTIDX_TOV2);
+	m_r[TIFR2] &= ~(data & TIFR2_MASK);
+	update_interrupt(INTIDX_OCF2A);
+	update_interrupt(INTIDX_OCF2B);
+	update_interrupt(INTIDX_TOV2);
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::gtccr_w(uint8_t data)
 {
-	if (data & AVR8_GTCCR_PSRASY_MASK)
+	if (data & GTCCR_PSRASY_MASK)
 	{
-		data &= ~AVR8_GTCCR_PSRASY_MASK;
+		data &= ~GTCCR_PSRASY_MASK;
 		m_timer_prescale_count[2] = 0;
 	}
 }
@@ -2743,25 +2627,25 @@ void avr8_device<NumTimers>::gtccr_w(uint8_t data)
 template <int NumTimers>
 void avr8_device<NumTimers>::eecr_w(uint8_t data)
 {
-	m_r[EECR] = data;
+	m_r[EECR] = data & EECR_MASK;
 
-	if (data & AVR8_EECR_EERE_MASK)
+	if (data & EECR_EERE_MASK)
 	{
-		uint16_t addr = (m_r[EEARH] & AVR8_EEARH_MASK) << 8;
+		uint16_t addr = (m_r[EEARH] & EEARH_MASK) << 8;
 		addr |= m_r[EEARL];
 		m_r[EEDR] = m_eeprom[addr];
 		LOGMASKED(LOG_EEPROM, "%s: EEPROM read @ %04x data = %02x\n", machine().describe_context(), addr, m_eeprom[addr]);
 	}
-	if ((data & AVR8_EECR_EEPE_MASK) && (data & AVR8_EECR_EEMPE_MASK))
+	if ((data & EECR_EEPE_MASK) && (data & EECR_EEMPE_MASK))
 	{
-		uint16_t addr = (m_r[EEARH] & AVR8_EEARH_MASK) << 8;
+		uint16_t addr = (m_r[EEARH] & EEARH_MASK) << 8;
 		addr |= m_r[EEARL];
 		m_eeprom[addr] = m_r[EEDR];
 		LOGMASKED(LOG_EEPROM, "%s: EEPROM write @ %04x data = %02x ('%c')\n", machine().describe_context(), addr, m_eeprom[addr], m_eeprom[addr] >= 0x21 ? m_eeprom[addr] : ' ');
 
 		// Indicate that we've finished writing a value to the EEPROM.
 		// TODO: this should only happen after a certain dalay.
-		m_r[EECR] = data & ~AVR8_EECR_EEPE_MASK;
+		m_r[EECR] = data & ~EECR_EEPE_MASK;
 	}
 }
 
@@ -2878,9 +2762,9 @@ void avr8_device<NumTimers>::timsk0_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER0, "%s: TIMSK0 = %02x\n", machine().describe_context(), data);
 	m_r[TIMSK0] = data;
-	update_interrupt(AVR8_INTIDX_OCF0A);
-	update_interrupt(AVR8_INTIDX_OCF0B);
-	update_interrupt(AVR8_INTIDX_TOV0);
+	update_interrupt(INTIDX_OCF0A);
+	update_interrupt(INTIDX_OCF0B);
+	update_interrupt(INTIDX_TOV0);
 }
 
 template <int NumTimers>
@@ -2888,10 +2772,10 @@ void avr8_device<NumTimers>::timsk1_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER1, "%s: TIMSK1 = %02x\n", machine().describe_context(), data);
 	m_r[TIMSK1] = data;
-	update_interrupt(AVR8_INTIDX_ICF1);
-	update_interrupt(AVR8_INTIDX_OCF1A);
-	update_interrupt(AVR8_INTIDX_OCF1B);
-	update_interrupt(AVR8_INTIDX_TOV1);
+	update_interrupt(INTIDX_ICF1);
+	update_interrupt(INTIDX_OCF1A);
+	update_interrupt(INTIDX_OCF1B);
+	update_interrupt(INTIDX_TOV1);
 }
 
 template <int NumTimers>
@@ -2899,9 +2783,9 @@ void avr8_device<NumTimers>::timsk2_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER2, "%s: TIMSK2 = %02x\n", machine().describe_context(), data);
 	m_r[TIMSK2] = data;
-	update_interrupt(AVR8_INTIDX_OCF2A);
-	update_interrupt(AVR8_INTIDX_OCF2B);
-	update_interrupt(AVR8_INTIDX_TOV2);
+	update_interrupt(INTIDX_OCF2A);
+	update_interrupt(INTIDX_OCF2B);
+	update_interrupt(INTIDX_TOV2);
 }
 
 template <int NumTimers>
@@ -2909,9 +2793,9 @@ void avr8_device<NumTimers>::timsk3_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER3, "%s: TIMSK3 = %02x\n", machine().describe_context(), data);
 	m_r[TIMSK3] = data;
-	update_interrupt(AVR8_INTIDX_OCF3A);
-	update_interrupt(AVR8_INTIDX_OCF3B);
-	update_interrupt(AVR8_INTIDX_TOV3);
+	update_interrupt(INTIDX_OCF3A);
+	update_interrupt(INTIDX_OCF3B);
+	update_interrupt(INTIDX_TOV3);
 }
 
 template <int NumTimers>
@@ -2919,9 +2803,9 @@ void avr8_device<NumTimers>::timsk4_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER4, "%s: TIMSK4 = %02x\n", machine().describe_context(), data);
 	m_r[TIMSK4] = data;
-	update_interrupt(AVR8_INTIDX_OCF4A);
-	update_interrupt(AVR8_INTIDX_OCF4B);
-	update_interrupt(AVR8_INTIDX_TOV4);
+	update_interrupt(INTIDX_OCF4A);
+	update_interrupt(INTIDX_OCF4B);
+	update_interrupt(INTIDX_TOV4);
 }
 
 template <int NumTimers>
@@ -2929,9 +2813,9 @@ void avr8_device<NumTimers>::timsk5_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER5, "%s: TIMSK5 = %02x\n", machine().describe_context(), data);
 	m_r[TIMSK5] = data;
-	update_interrupt(AVR8_INTIDX_OCF5A);
-	update_interrupt(AVR8_INTIDX_OCF5B);
-	update_interrupt(AVR8_INTIDX_TOV5);
+	update_interrupt(INTIDX_OCF5A);
+	update_interrupt(INTIDX_OCF5B);
+	update_interrupt(INTIDX_TOV5);
 }
 
 template <int NumTimers>
@@ -2951,7 +2835,7 @@ uint8_t avr8_device<NumTimers>::adcl_r()
 {
 	if (!machine().side_effects_disabled())
 		m_adc_hold = true;
-	if (AVR8_ADMUX_ADLAR)
+	if (ADMUX_ADLAR)
 		return (m_adc_data & 0x03) << 6;
 	else
 		return uint8_t(m_adc_data);
@@ -2966,7 +2850,7 @@ void avr8_device<NumTimers>::adcl_w(uint8_t data)
 template <int NumTimers>
 uint8_t avr8_device<NumTimers>::adch_r()
 {
-	uint8_t const result = AVR8_ADMUX_ADLAR ? BIT(m_adc_data, 2, 8) : BIT(m_adc_data, 8, 2);
+	uint8_t const result = ADMUX_ADLAR ? BIT(m_adc_data, 2, 8) : BIT(m_adc_data, 8, 2);
 	if (!machine().side_effects_disabled())
 	{
 		m_adc_data = m_adc_result;
@@ -2987,34 +2871,35 @@ void avr8_device<NumTimers>::adcsra_w(uint8_t data)
 	LOGMASKED(LOG_ADC, "%s: ADCSRA = %02x\n", machine().describe_context(), data);
 
 	// set auto trigger enable, interrupt enable, and prescaler directly
-	AVR8_ADCSRA = (AVR8_ADCSRA & ~(AVR8_ADCSRA_ADATE_MASK | AVR8_ADCSRA_ADIE_MASK | AVR8_ADCSRA_ADPS_MASK)) | (data & (AVR8_ADCSRA_ADATE_MASK | AVR8_ADCSRA_ADIE_MASK | AVR8_ADCSRA_ADPS_MASK));
+	m_r[ADCSRA] &= ~(ADCSRA_ADATE_MASK | ADCSRA_ADIE_MASK | ADCSRA_ADPS_MASK);
+	m_r[ADCSRA] |= data & (ADCSRA_ADATE_MASK | ADCSRA_ADIE_MASK | ADCSRA_ADPS_MASK);
 
 	// check enable bit
-	if (!(data & AVR8_ADCSRA_ADEN_MASK))
+	if (!(data & ADCSRA_ADEN_MASK))
 	{
 		// disable ADC, terminate any conversion in progress
-		AVR8_ADCSRA &= ~(AVR8_ADCSRA_ADEN_MASK | AVR8_ADCSRA_ADSC_MASK);
+		m_r[ADCSRA] &= ~(ADCSRA_ADEN_MASK | ADCSRA_ADSC_MASK);
 		m_adc_timer->reset();
 	}
 	else
 	{
 		// first conversion after initial enable takes longer
-		if (!AVR8_ADCSRA_ADEN)
+		if (!ADCSRA_ADEN)
 		{
 			m_adc_first = true;
-			AVR8_ADCSRA |= AVR8_ADCSRA_ADEN_MASK;
+			m_r[ADCSRA] |= ADCSRA_ADEN_MASK;
 		}
 
 		// trigger conversion if necessary
-		if (!AVR8_ADCSRA_ADSC && (data & AVR8_ADCSRA_ADSC_MASK))
+		if (!ADCSRA_ADSC && (data & ADCSRA_ADSC_MASK))
 			adc_start_conversion();
 	}
 
 	// writing with ADIF set clears the interrupt flag manually
-	if (data & AVR8_ADCSRA_ADIF_MASK)
-		AVR8_ADCSRA &= ~AVR8_ADCSRA_ADIF_MASK;
+	if (data & ADCSRA_ADIF_MASK)
+		m_r[ADCSRA] &= ~ADCSRA_ADIF_MASK;
 
-	if (AVR8_ADCSRA_ADIE)
+	if (ADCSRA_ADIE)
 		logerror("%s: Unimplemented ADC interrupt enabled\n");
 }
 
@@ -3022,16 +2907,16 @@ template <int NumTimers>
 void avr8_device<NumTimers>::adcsrb_w(uint8_t data)
 {
 	LOGMASKED(LOG_ADC, "%s: ADCSRB = %02x\n", machine().describe_context(), data);
-	AVR8_ADCSRB = data & (AVR8_ADCSRB_ACME_MASK | AVR8_ADCSRB_ADTS_MASK);
-	if (AVR8_ADCSRB_ADTS != 0x00)
-		logerror("%s: Unimplemented ADC auto trigger source %X selected\n", machine().describe_context(), AVR8_ADCSRB_ADTS);
+	m_r[ADCSRB] = data & (ADCSRB_ACME_MASK | ADCSRB_ADTS_MASK);
+	if (ADCSRB_ADTS != 0)
+		logerror("%s: Unimplemented ADC auto trigger source %X selected\n", machine().describe_context(), ADCSRB_ADTS);
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::admux_w(uint8_t data)
 {
 	LOGMASKED(LOG_ADC, "%s: ADMUX = %02x\n", machine().describe_context(), data);
-	AVR8_ADMUX = data & (AVR8_ADMUX_REFS_MASK | AVR8_ADMUX_ADLAR_MASK | AVR8_ADMUX_MUX_MASK);
+	m_r[ADMUX] = data & (ADMUX_REFS_MASK | ADMUX_ADLAR_MASK | ADMUX_MUX_MASK);
 }
 
 template <int NumTimers>
@@ -3061,12 +2946,12 @@ void avr8_device<NumTimers>::tccr1a_w(uint8_t data)
 	const uint8_t changed = newtccr ^ oldtccr;
 	m_r[TCCR1A] = newtccr;
 
-	if (changed & AVR8_TCCR1A_WGM1_10_MASK)
+	if (changed & TCCR1A_WGM1_10_MASK)
 	{
-		update_timer_waveform_gen_mode(1, AVR8_WGM1);
+		update_timer_waveform_gen_mode(1, WGM1);
 	}
 
-	m_timer1_tick = m_timer1_ticks[(AVR8_WGM1 << 4) | ((m_r[TCCR1A] & AVR8_TCCR1A_COM1AB_MASK) >> AVR8_TCCR1A_COM1AB_SHIFT)];
+	m_timer1_tick = m_timer1_ticks[(WGM1 << 4) | ((m_r[TCCR1A] & TCCR1A_COM1AB_MASK) >> TCCR1A_COM1AB_SHIFT)];
 }
 
 template <int NumTimers>
@@ -3076,31 +2961,31 @@ void avr8_device<NumTimers>::tccr1b_w(uint8_t data)
 	const uint8_t oldtccr = m_r[TCCR1B];
 	const uint8_t newtccr = data;
 	const uint8_t changed = newtccr ^ oldtccr;
-	const uint8_t oldcs = m_r[TCCR1B] & AVR8_TCCR1B_CS_MASK;
+	const uint8_t oldcs = m_r[TCCR1B] & TCCR1B_CS_MASK;
 
 	m_r[TCCR1B] = newtccr;
 
-	if (changed & AVR8_TCCR1B_ICNC1_MASK)
+	if (changed & TCCR1B_ICNC1_MASK)
 	{
 		update_timer1_input_noise_canceler();
 	}
 
-	if (changed & AVR8_TCCR1B_ICES1_MASK)
+	if (changed & TCCR1B_ICES1_MASK)
 	{
 		update_timer1_input_edge_select();
 	}
 
-	if (changed & AVR8_TCCR1B_WGM1_32_MASK)
+	if (changed & TCCR1B_WGM1_32_MASK)
 	{
-		update_timer_waveform_gen_mode(1, AVR8_WGM1);
+		update_timer_waveform_gen_mode(1, WGM1);
 	}
 
-	if (changed & AVR8_TCCR1B_CS_MASK)
+	if (changed & TCCR1B_CS_MASK)
 	{
-		update_timer_clock_source<1>(AVR8_TIMER1_CLOCK_SELECT, oldcs);
+		update_timer_clock_source<1>(TIMER1_CLOCK_SELECT, oldcs);
 	}
 
-	m_timer1_tick = m_timer1_ticks[(AVR8_WGM1 << 4) | ((m_r[TCCR1A] & AVR8_TCCR1A_COM1AB_MASK) >> AVR8_TCCR1A_COM1AB_SHIFT)];
+	m_timer1_tick = m_timer1_ticks[(WGM1 << 4) | ((m_r[TCCR1A] & TCCR1A_COM1AB_MASK) >> TCCR1A_COM1AB_SHIFT)];
 }
 
 template <int NumTimers>
@@ -3112,73 +2997,73 @@ void avr8_device<NumTimers>::tccr1c_w(uint8_t data)
 template <int NumTimers>
 void avr8_device<NumTimers>::icr1l_w(uint8_t data)
 {
-	AVR8_ICR1L = data;
+	m_r[ICR1L] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::icr1h_w(uint8_t data)
 {
-	AVR8_ICR1H = data;
+	m_r[ICR1H] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr1al_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER1, "%s: OCR1AL = %02x\n", machine().describe_context(), data);
-	update_ocr1((AVR8_OCR1A & 0xff00) | data, AVR8_REG_A);
+	update_ocr1((OCR1A & 0xff00) | data, AVR8_REG_A);
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr1ah_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER1, "%s: OCR1AH = %02x\n", machine().describe_context(), data);
-	update_ocr1((AVR8_OCR1A & 0x00ff) | (data << 8), AVR8_REG_A);
+	update_ocr1((OCR1A & 0x00ff) | (data << 8), AVR8_REG_A);
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr1bl_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER1, "%s: OCR1BL = %02x\n", machine().describe_context(), data);
-	update_ocr1((AVR8_OCR1B & 0xff00) | data, AVR8_REG_B);
+	update_ocr1((OCR1B & 0xff00) | data, AVR8_REG_B);
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr1bh_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER1, "%s: OCR1BH = %02x\n", machine().describe_context(), data);
-	update_ocr1((AVR8_OCR1B & 0x00ff) | (data << 8), AVR8_REG_B);
+	update_ocr1((OCR1B & 0x00ff) | (data << 8), AVR8_REG_B);
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr1cl_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER1, "%s: OCR1CL = %02x\n", machine().describe_context(), data);
-	update_ocr1((AVR8_OCR1C & 0xff00) | data, AVR8_REG_C);
+	update_ocr1((OCR1C & 0xff00) | data, AVR8_REG_C);
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr1ch_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER1, "%s: OCR1CH = %02x\n", machine().describe_context(), data);
-	update_ocr1((AVR8_OCR1C & 0x00ff) | (data << 8), AVR8_REG_C);
+	update_ocr1((OCR1C & 0x00ff) | (data << 8), AVR8_REG_C);
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::tccr2a_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER2, "%s: TCCR2A = %02x\n", machine().describe_context(), data);
-	const uint8_t oldtccr = AVR8_TCCR2A;
+	const uint8_t oldtccr = m_r[TCCR2A];
 	const uint8_t newtccr = data;
 	const uint8_t changed = newtccr ^ oldtccr;
 
-	AVR8_TCCR2A = data;
+	m_r[TCCR2A] = data;
 
-	if (changed & AVR8_TCCR2A_WGM2_10_MASK)
+	if (changed & TCCR2A_WGM2_10_MASK)
 	{
-		update_timer_waveform_gen_mode(2, AVR8_WGM2);
+		update_timer_waveform_gen_mode(2, WGM2);
 	}
 
-	m_timer2_tick = m_timer2_ticks[((m_r[TCCR2B] & AVR8_TCCR2B_WGM2_2_MASK) >> 1) | (m_r[TCCR2A] & AVR8_TCCR2A_WGM2_10_MASK)];
+	m_timer2_tick = m_timer2_ticks[((m_r[TCCR2B] & TCCR2B_WGM2_2_MASK) >> 1) | (m_r[TCCR2A] & TCCR2A_WGM2_10_MASK)];
 }
 
 template <int NumTimers>
@@ -3188,37 +3073,37 @@ void avr8_device<NumTimers>::tccr2b_w(uint8_t data)
 	const uint8_t oldtccr = m_r[TCCR2B];
 	const uint8_t newtccr = data;
 	const uint8_t changed = newtccr ^ oldtccr;
-	const uint8_t oldcs = m_r[TCCR2B] & AVR8_TCCR2B_CS_MASK;
+	const uint8_t oldcs = m_r[TCCR2B] & TCCR2B_CS_MASK;
 
 	m_r[TCCR2B] = data;
 
-	if (changed & AVR8_TCCR2B_FOC2A_MASK)
+	if (changed & TCCR2B_FOC2A_MASK)
 	{
 		timer2_force_output_compare(AVR8_REG_A);
 	}
 
-	if (changed & AVR8_TCCR2B_FOC2B_MASK)
+	if (changed & TCCR2B_FOC2B_MASK)
 	{
 		timer2_force_output_compare(AVR8_REG_B);
 	}
 
-	if (changed & AVR8_TCCR2B_WGM2_2_MASK)
+	if (changed & TCCR2B_WGM2_2_MASK)
 	{
-		update_timer_waveform_gen_mode(2, AVR8_WGM2);
+		update_timer_waveform_gen_mode(2, WGM2);
 	}
 
-	if (changed & AVR8_TCCR2B_CS_MASK)
+	if (changed & TCCR2B_CS_MASK)
 	{
-		update_timer_clock_source<2>(AVR8_TIMER2_CLOCK_SELECT, oldcs);
+		update_timer_clock_source<2>(TIMER2_CLOCK_SELECT, oldcs);
 	}
 
-	m_timer2_tick = m_timer2_ticks[((m_r[TCCR2B] & AVR8_TCCR2B_WGM2_2_MASK) >> 1) | (m_r[TCCR2A] & AVR8_TCCR2A_WGM2_10_MASK)];
+	m_timer2_tick = m_timer2_ticks[((m_r[TCCR2B] & TCCR2B_WGM2_2_MASK) >> 1) | (m_r[TCCR2A] & TCCR2A_WGM2_10_MASK)];
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::tcnt2_w(uint8_t data)
 {
-	AVR8_TCNT2 = data;
+	m_r[TCNT2] = data;
 }
 
 template <int NumTimers>
@@ -3256,64 +3141,64 @@ void avr8_device<NumTimers>::tccr3c_w(uint8_t data)
 template <int NumTimers>
 void avr8_device<NumTimers>::icr3l_w(uint8_t data)
 {
-	AVR8_ICR3L = data;
+	m_r[ICR3L] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::icr3h_w(uint8_t data)
 {
-	AVR8_ICR3H = data;
+	m_r[ICR3H] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr3al_w(uint8_t data)
 {
-	AVR8_OCR3AL = data;
+	m_r[OCR3AL] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr3ah_w(uint8_t data)
 {
-	AVR8_OCR3AH = data;
+	m_r[OCR3AH] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr3bl_w(uint8_t data)
 {
-	AVR8_OCR3BL = data;
+	m_r[OCR3BL] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr3bh_w(uint8_t data)
 {
-	AVR8_OCR3BH = data;
+	m_r[OCR3BH] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr3cl_w(uint8_t data)
 {
-	AVR8_OCR3CL = data;
+	m_r[OCR3CL] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr3ch_w(uint8_t data)
 {
-	AVR8_OCR3CH = data;
+	m_r[OCR3CH] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::tccr4a_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER4, "%s: TCCR4A = %02x\n", machine().describe_context(), data);
-	const uint8_t oldtccr = AVR8_TCCR4A;
+	const uint8_t oldtccr = m_r[TCCR4A];
 	const uint8_t newtccr = data;
 	const uint8_t changed = newtccr ^ oldtccr;
 
-	AVR8_TCCR4A = data;
+	m_r[TCCR4A] = data;
 
-	if (changed & AVR8_TCCR4A_WGM4_10_MASK)
+	if (changed & TCCR4A_WGM4_10_MASK)
 	{
-		update_timer_waveform_gen_mode(4, AVR8_WGM4);
+		update_timer_waveform_gen_mode(4, WGM4);
 	}
 }
 
@@ -3324,30 +3209,30 @@ void avr8_device<NumTimers>::tccr4b_w(uint8_t data)
 	const uint8_t oldtccr = m_r[TCCR4B];
 	const uint8_t newtccr = data;
 	const uint8_t changed = newtccr ^ oldtccr;
-	const uint8_t oldcs = (m_r[TCCR4B] & AVR8_TCCR4B_CS_MASK) >> AVR8_TCCR4B_CS_SHIFT;
+	const uint8_t oldcs = (m_r[TCCR4B] & TCCR4B_CS_MASK) >> TCCR4B_CS_SHIFT;
 
 	m_r[TCCR4B] = data;
 
-	if (changed & AVR8_TCCR4B_FOC4A_MASK)
+	if (changed & TCCR4B_FOC4A_MASK)
 	{
 		// TODO
 		// timer4_force_output_compare(AVR8_REG_A);
 	}
 
-	if (changed & AVR8_TCCR4B_FOC4B_MASK)
+	if (changed & TCCR4B_FOC4B_MASK)
 	{
 		// TODO
 		// timer4_force_output_compare(AVR8_REG_B);
 	}
 
-	if (changed & AVR8_TCCR4B_WGM4_32_MASK)
+	if (changed & TCCR4B_WGM4_32_MASK)
 	{
-		update_timer_waveform_gen_mode(4, AVR8_WGM4);
+		update_timer_waveform_gen_mode(4, WGM4);
 	}
 
-	if (changed & AVR8_TCCR4B_CS_MASK)
+	if (changed & TCCR4B_CS_MASK)
 	{
-		update_timer_clock_source<4>(AVR8_TIMER4_CLOCK_SELECT, oldcs);
+		update_timer_clock_source<4>(TIMER4_CLOCK_SELECT, oldcs);
 	}
 }
 
@@ -3355,86 +3240,86 @@ template <int NumTimers>
 void avr8_device<NumTimers>::tccr4c_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER4, "%s: TCCR4C = %02x\n", machine().describe_context(), data);
-	//  uint8_t oldtccr = AVR8_TCCR4C;
+	//  uint8_t oldtccr = m_r[TCCR4C];
 	//  uint8_t newtccr = data;
 	//  uint8_t changed = newtccr ^ oldtccr;
 
-	AVR8_TCCR4C = data;
+	m_r[TCCR4C] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::tcnt4l_w(uint8_t data)
 {
-	AVR8_TCNT4L = data;
+	m_r[TCNT4L] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::tcnt4h_w(uint8_t data)
 {
-	AVR8_TCNT4H = data;
+	m_r[TCNT4H] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::icr4l_w(uint8_t data)
 {
-	AVR8_ICR4L = data;
+	m_r[ICR4L] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::icr4h_w(uint8_t data)
 {
-	AVR8_ICR4H = data;
+	m_r[ICR4H] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr4al_w(uint8_t data)
 {
-	AVR8_OCR4AL = data;
+	m_r[OCR4AL] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr4ah_w(uint8_t data)
 {
-	AVR8_OCR4AH = data;
+	m_r[OCR4AH] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr4bl_w(uint8_t data)
 {
-	AVR8_OCR4BL = data;
+	m_r[OCR4BL] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr4bh_w(uint8_t data)
 {
-	AVR8_OCR4BH = data;
+	m_r[OCR4BH] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr4cl_w(uint8_t data)
 {
-	AVR8_OCR4CL = data;
+	m_r[OCR4CL] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::ocr4ch_w(uint8_t data)
 {
-	AVR8_OCR4CH = data;
+	m_r[OCR4CH] = data;
 }
 
 template <int NumTimers>
 void avr8_device<NumTimers>::tccr5a_w(uint8_t data)
 {
 	LOGMASKED(LOG_TIMER5, "%s: TCCR5A = %02x\n", machine().describe_context(), data);
-	const uint8_t oldtccr = AVR8_TCCR5A;
+	const uint8_t oldtccr = m_r[TCCR5A];
 	const uint8_t newtccr = data;
 	const uint8_t changed = newtccr ^ oldtccr;
 
-	AVR8_TCCR5A = data;
+	m_r[TCCR5A] = data;
 
-	if (changed & AVR8_TCCR5A_WGM5_10_MASK)
+	if (changed & TCCR5A_WGM5_10_MASK)
 	{
-		update_timer_waveform_gen_mode(5, AVR8_WGM5);
+		update_timer_waveform_gen_mode(5, WGM5);
 	}
 }
 
@@ -3445,36 +3330,36 @@ void avr8_device<NumTimers>::tccr5b_w(uint8_t data)
 	const uint8_t oldtccr = m_r[TCCR5B];
 	const uint8_t newtccr = data;
 	const uint8_t changed = newtccr ^ oldtccr;
-	const uint8_t oldcs = (m_r[TCCR5B] & AVR8_TCCR5B_CS_MASK) >> AVR8_TCCR5B_CS_SHIFT;
+	const uint8_t oldcs = (m_r[TCCR5B] & TCCR5B_CS_MASK) >> TCCR5B_CS_SHIFT;
 
 	m_r[TCCR5B] = data;
 
-	if (changed & AVR8_TCCR5C_FOC5A_MASK)
+	if (changed & TCCR5C_FOC5A_MASK)
 	{
 		// TODO
 		// timer5_force_output_compare(AVR8_REG_A);
 	}
 
-	if (changed & AVR8_TCCR5C_FOC5B_MASK)
+	if (changed & TCCR5C_FOC5B_MASK)
 	{
 		// TODO
 		// timer5_force_output_compare(AVR8_REG_B);
 	}
 
-	if (changed & AVR8_TCCR5C_FOC5C_MASK)
+	if (changed & TCCR5C_FOC5C_MASK)
 	{
 		// TODO
 		// timer5_force_output_compare(AVR8_REG_C);
 	}
 
-	if (changed & AVR8_TCCR5B_WGM5_32_MASK)
+	if (changed & TCCR5B_WGM5_32_MASK)
 	{
-		update_timer_waveform_gen_mode(5, AVR8_WGM5);
+		update_timer_waveform_gen_mode(5, WGM5);
 	}
 
-	if (changed & AVR8_TCCR5B_CS_MASK)
+	if (changed & TCCR5B_CS_MASK)
 	{
-		update_timer_clock_source<5>(AVR8_TIMER5_CLOCK_SELECT, oldcs);
+		update_timer_clock_source<5>(TIMER5_CLOCK_SELECT, oldcs);
 	}
 }
 
@@ -3554,47 +3439,6 @@ void avr8_device<NumTimers>::ucsr0c_w(uint8_t data)
 //  CORE EXECUTION LOOP
 //**************************************************************************
 
-//-------------------------------------------------
-//  execute_min_cycles - return minimum number of
-//  cycles it takes for one instruction to execute
-//-------------------------------------------------
-
-template <int NumTimers>
-uint32_t avr8_device<NumTimers>::execute_min_cycles() const noexcept
-{
-	return 1;
-}
-
-
-//-------------------------------------------------
-//  execute_max_cycles - return maximum number of
-//  cycles it takes for one instruction to execute
-//-------------------------------------------------
-
-template <int NumTimers>
-uint32_t avr8_device<NumTimers>::execute_max_cycles() const noexcept
-{
-	return 4;
-}
-
-
-//-------------------------------------------------
-//  execute_input_lines - return the number of
-//  input/interrupt lines
-//-------------------------------------------------
-
-template <int NumTimers>
-uint32_t avr8_device<NumTimers>::execute_input_lines() const noexcept
-{
-	return 0;
-}
-
-
-template <int NumTimers>
-void avr8_device<NumTimers>::execute_set_input(int inputnum, int state)
-{
-}
-
 #include "avr8ops.hxx"
 
 //-------------------------------------------------
@@ -3634,21 +3478,15 @@ void avr8_device<NumTimers>::execute_run()
 
 			m_timer_prescale_count[0]++;
 			if (m_timer_prescale_count[0] > m_timer_prescale[0])
-			{
-				((this)->*(m_timer0_tick))();
-			}
+				m_timer0_tick();
 
 			m_timer_prescale_count[1]++;
 			if (m_timer_prescale_count[1] > m_timer_prescale[1])
-			{
-				((this)->*(m_timer1_tick))();
-			}
+				m_timer1_tick();
 
 			m_timer_prescale_count[2]++;
 			if (m_timer_prescale_count[2] > m_timer_prescale[2])
-			{
-				((this)->*(m_timer1_tick))();
-			}
+				m_timer2_tick();
 
 			if (NumTimers > 5)
 			{
@@ -3676,3 +3514,7 @@ void avr8_device<NumTimers>::execute_run()
 		}
 	}
 }
+
+template class avr8_device<2>;
+template class avr8_device<3>;
+template class avr8_device<6>;

--- a/src/devices/cpu/avr8/avr8.cpp
+++ b/src/devices/cpu/avr8/avr8.cpp
@@ -90,7 +90,7 @@
 #define LOG_UART            (1U << 27)
 #define LOG_TIMERS          (LOG_TIMER0 | LOG_TIMER1 | LOG_TIMER2 | LOG_TIMER3 | LOG_TIMER4 | LOG_TIMER5)
 #define LOG_TIMER_TICKS     (LOG_TIMER0_TICK | LOG_TIMER1_TICK | LOG_TIMER2_TICK | LOG_TIMER3_TICK | LOG_TIMER4_TICK | LOG_TIMER5_TICK)
-#define LOG_ALL             (LOG_UNKNOWN | LOG_BOOT | LOG_TIMERS | LOG_TIMER_TICKS | LOG_EEPROM | LOG_GPIO | LOG_WDOG | LOG_CLOCK | LOG_POWER \
+#define LOG_ALL             (LOG_UNKNOWN | LOG_BOOT | LOG_TIMERS | LOG_EEPROM | LOG_GPIO | LOG_WDOG | LOG_CLOCK | LOG_POWER \
 							 | LOG_OSC | LOG_PINCHG | LOG_EXTMEM | LOG_ADC | LOG_DIGINPUT | LOG_ASYNC | LOG_TWI | LOG_UART)
 
 #define VERBOSE             (0)
@@ -124,26 +124,6 @@ enum
 };
 
 // I/O Enums
-enum
-{
-	WGM1_NORMAL = 0,
-	WGM1_PWM_8_PC,
-	WGM1_PWM_9_PC,
-	WGM1_PWM_10_PC,
-	WGM1_CTC_OCR,
-	WGM1_FAST_PWM_8,
-	WGM1_FAST_PWM_9,
-	WGM1_FAST_PWM_10,
-	WGM1_PWM_PFC_ICR,
-	WGM1_PWM_PFC_OCR,
-	WGM1_PWM_PC_ICR,
-	WGM1_PWM_PC_OCR,
-	WGM1_CTC_ICR,
-	WGM1_RESERVED,
-	WGM1_FAST_PWM_ICR,
-	WGM1_FAST_PWM_OCR
-};
-
 enum
 {
 	WGM02_NORMAL = 0,
@@ -198,9 +178,8 @@ enum
 
 static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 
-#define SREG_R(b)   ((m_r[AVR8_REGIDX_SREG] & (1 << (b))) >> (b))
-#define SREG_W(b,v) m_r[AVR8_REGIDX_SREG] = (m_r[AVR8_REGIDX_SREG] & ~(1 << (b))) | ((v) << (b))
-#define SREG        m_r[AVR8_REGIDX_SREG]
+#define SREG_R(b)   ((m_r[SREG] & (1 << (b))) >> (b))
+#define SREG_W(b,v) m_r[SREG] = (m_r[SREG] & ~(1 << (b))) | ((v) << (b))
 #define NOT(x) (1 - (x))
 
 // Opcode-Parsing Defines
@@ -225,54 +204,54 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define XREG            ((m_r[27] << 8) | m_r[26])
 #define YREG            ((m_r[29] << 8) | m_r[28])
 #define ZREG            ((m_r[31] << 8) | m_r[30])
-#define SPREG           ((m_r[AVR8_REGIDX_SPH] << 8) | m_r[AVR8_REGIDX_SPL])
+#define SPREG           ((m_r[SPH] << 8) | m_r[SPL])
 
 // I/O Defines
-#define AVR8_OCR1CH             (m_r[AVR8_REGIDX_OCR1CH])
-#define AVR8_OCR1CL             (m_r[AVR8_REGIDX_OCR1CL])
-#define AVR8_OCR1BH             (m_r[AVR8_REGIDX_OCR1BH])
-#define AVR8_OCR1BL             (m_r[AVR8_REGIDX_OCR1BL])
-#define AVR8_OCR1AH             (m_r[AVR8_REGIDX_OCR1AH])
-#define AVR8_OCR1AL             (m_r[AVR8_REGIDX_OCR1AL])
-#define AVR8_ICR1H              (m_r[AVR8_REGIDX_ICR1H])
-#define AVR8_ICR1L              (m_r[AVR8_REGIDX_ICR1L])
-#define AVR8_TCNT1H             (m_r[AVR8_REGIDX_TCNT1H])
-#define AVR8_TCNT1L             (m_r[AVR8_REGIDX_TCNT1L])
+#define AVR8_OCR1CH             (m_r[OCR1CH])
+#define AVR8_OCR1CL             (m_r[OCR1CL])
+#define AVR8_OCR1BH             (m_r[OCR1BH])
+#define AVR8_OCR1BL             (m_r[OCR1BL])
+#define AVR8_OCR1AH             (m_r[OCR1AH])
+#define AVR8_OCR1AL             (m_r[OCR1AL])
+#define AVR8_ICR1H              (m_r[ICR1H])
+#define AVR8_ICR1L              (m_r[ICR1L])
+#define AVR8_TCNT1H             (m_r[TCNT1H])
+#define AVR8_TCNT1L             (m_r[TCNT1L])
 
-#define AVR8_OCR3CH             (m_r[AVR8_REGIDX_OCR3CH])
-#define AVR8_OCR3CL             (m_r[AVR8_REGIDX_OCR3CL])
-#define AVR8_OCR3BH             (m_r[AVR8_REGIDX_OCR3BH])
-#define AVR8_OCR3BL             (m_r[AVR8_REGIDX_OCR3BL])
-#define AVR8_OCR3AH             (m_r[AVR8_REGIDX_OCR3AH])
-#define AVR8_OCR3AL             (m_r[AVR8_REGIDX_OCR3AL])
-#define AVR8_ICR3H              (m_r[AVR8_REGIDX_ICR3H])
-#define AVR8_ICR3L              (m_r[AVR8_REGIDX_ICR3L])
-#define AVR8_TCNT3H             (m_r[AVR8_REGIDX_TCNT3H])
-#define AVR8_TCNT3L             (m_r[AVR8_REGIDX_TCNT3L])
+#define AVR8_OCR3CH             (m_r[OCR3CH])
+#define AVR8_OCR3CL             (m_r[OCR3CL])
+#define AVR8_OCR3BH             (m_r[OCR3BH])
+#define AVR8_OCR3BL             (m_r[OCR3BL])
+#define AVR8_OCR3AH             (m_r[OCR3AH])
+#define AVR8_OCR3AL             (m_r[OCR3AL])
+#define AVR8_ICR3H              (m_r[ICR3H])
+#define AVR8_ICR3L              (m_r[ICR3L])
+#define AVR8_TCNT3H             (m_r[TCNT3H])
+#define AVR8_TCNT3L             (m_r[TCNT3L])
 
-#define AVR8_OCR4CH             (m_r[AVR8_REGIDX_OCR4CH])
-#define AVR8_OCR4CL             (m_r[AVR8_REGIDX_OCR4CL])
-#define AVR8_OCR4BH             (m_r[AVR8_REGIDX_OCR4BH])
-#define AVR8_OCR4BL             (m_r[AVR8_REGIDX_OCR4BL])
-#define AVR8_OCR4AH             (m_r[AVR8_REGIDX_OCR4AH])
-#define AVR8_OCR4AL             (m_r[AVR8_REGIDX_OCR4AL])
-#define AVR8_ICR4H              (m_r[AVR8_REGIDX_ICR4H])
-#define AVR8_ICR4L              (m_r[AVR8_REGIDX_ICR4L])
-#define AVR8_TCNT4H             (m_r[AVR8_REGIDX_TCNT4H])
-#define AVR8_TCNT4L             (m_r[AVR8_REGIDX_TCNT4L])
+#define AVR8_OCR4CH             (m_r[OCR4CH])
+#define AVR8_OCR4CL             (m_r[OCR4CL])
+#define AVR8_OCR4BH             (m_r[OCR4BH])
+#define AVR8_OCR4BL             (m_r[OCR4BL])
+#define AVR8_OCR4AH             (m_r[OCR4AH])
+#define AVR8_OCR4AL             (m_r[OCR4AL])
+#define AVR8_ICR4H              (m_r[ICR4H])
+#define AVR8_ICR4L              (m_r[ICR4L])
+#define AVR8_TCNT4H             (m_r[TCNT4H])
+#define AVR8_TCNT4L             (m_r[TCNT4L])
 
-#define AVR8_OCR5CH             (m_r[AVR8_REGIDX_OCR5CH])
-#define AVR8_OCR5CL             (m_r[AVR8_REGIDX_OCR5CL])
-#define AVR8_OCR5BH             (m_r[AVR8_REGIDX_OCR5BH])
-#define AVR8_OCR5BL             (m_r[AVR8_REGIDX_OCR5BL])
-#define AVR8_OCR5AH             (m_r[AVR8_REGIDX_OCR5AH])
-#define AVR8_OCR5AL             (m_r[AVR8_REGIDX_OCR5AL])
-#define AVR8_ICR5H              (m_r[AVR8_REGIDX_ICR5H])
-#define AVR8_ICR5L              (m_r[AVR8_REGIDX_ICR5L])
-#define AVR8_TCNT5H             (m_r[AVR8_REGIDX_TCNT5H])
-#define AVR8_TCNT5L             (m_r[AVR8_REGIDX_TCNT5L])
+#define AVR8_OCR5CH             (m_r[OCR5CH])
+#define AVR8_OCR5CL             (m_r[OCR5CL])
+#define AVR8_OCR5BH             (m_r[OCR5BH])
+#define AVR8_OCR5BL             (m_r[OCR5BL])
+#define AVR8_OCR5AH             (m_r[OCR5AH])
+#define AVR8_OCR5AL             (m_r[OCR5AL])
+#define AVR8_ICR5H              (m_r[ICR5H])
+#define AVR8_ICR5L              (m_r[ICR5L])
+#define AVR8_TCNT5H             (m_r[TCNT5H])
+#define AVR8_TCNT5L             (m_r[TCNT5L])
 
-#define AVR8_TCCR0B                 (m_r[AVR8_REGIDX_TCCR0B])
+#define AVR8_TCCR0B                 (m_r[TCCR0B])
 #define AVR8_TCCR0B_FOC0A_MASK      0x80
 #define AVR8_TCCR0B_FOC0A_SHIFT     7
 #define AVR8_TCCR0B_FOC0B_MASK      0x40
@@ -281,9 +260,9 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TCCR0B_WGM0_2_SHIFT    3
 #define AVR8_TCCR0B_CS_MASK         0x07
 #define AVR8_TCCR0B_CS_SHIFT        0
-#define AVR8_TIMER0_CLOCK_SELECT    (AVR8_TCCR0B & AVR8_TCCR0B_CS_MASK)
+#define AVR8_TIMER0_CLOCK_SELECT    (m_r[TCCR0B] & AVR8_TCCR0B_CS_MASK)
 
-#define AVR8_TCCR0A                 (m_r[AVR8_REGIDX_TCCR0A])
+#define AVR8_TCCR0A                 (m_r[TCCR0A])
 #define AVR8_TCCR0A_COM0A_MASK      0xc0
 #define AVR8_TCCR0A_COM0A_SHIFT     6
 #define AVR8_TCCR0A_COM0B_MASK      0x30
@@ -294,7 +273,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TCCR0A_COM0B           ((AVR8_TCCR0A & AVR8_TCCR0A_COM0B_MASK) >> AVR8_TCCR0A_COM0B_SHIFT)
 #define AVR8_TCCR0A_WGM0_10         (AVR8_TCCR0A & AVR8_TCCR0A_WGM0_10_MASK)
 
-#define AVR8_TIMSK0             (m_r[AVR8_REGIDX_TIMSK0])
+#define AVR8_TIMSK0             (m_r[TIMSK0])
 #define AVR8_TIMSK0_OCIE0B_MASK 0x04
 #define AVR8_TIMSK0_OCIE0A_MASK 0x02
 #define AVR8_TIMSK0_TOIE0_MASK  0x01
@@ -302,7 +281,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TIMSK0_OCIE0A      ((AVR8_TIMSK0 & AVR8_TIMSK0_OCIE0A_MASK) >> 1)
 #define AVR8_TIMSK0_TOIE0       (AVR8_TIMSK0 & AVR8_TIMSK0_TOIE0_MASK)
 
-#define AVR8_TIFR0              (m_r[AVR8_REGIDX_TIFR0])
+#define AVR8_TIFR0              (m_r[TIFR0])
 #define AVR8_TIFR0_OCF0B_MASK   0x04
 #define AVR8_TIFR0_OCF0B_SHIFT  2
 #define AVR8_TIFR0_OCF0A_MASK   0x02
@@ -311,7 +290,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TIFR0_TOV0_SHIFT   0
 #define AVR8_TIFR0_MASK         (AVR8_TIFR0_TOV0_MASK | AVR8_TIFR0_OCF0B_MASK | AVR8_TIFR0_OCF0A_MASK)
 
-#define AVR8_TCCR1B                 (m_r[AVR8_REGIDX_TCCR1B])
+#define AVR8_TCCR1B                 (m_r[TCCR1B])
 #define AVR8_TCCR1B_ICNC1_MASK      0x80
 #define AVR8_TCCR1B_ICNC1_SHIFT     7
 #define AVR8_TCCR1B_ICES1_MASK      0x40
@@ -322,18 +301,20 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TCCR1B_CS_SHIFT        0
 #define AVR8_TIMER1_CLOCK_SELECT    (AVR8_TCCR1B & AVR8_TCCR1B_CS_MASK)
 
-#define AVR8_TCCR1A                 (m_r[AVR8_REGIDX_TCCR1A])
+#define AVR8_TCCR1A                 (m_r[TCCR1A])
 #define AVR8_TCCR1A_COM1A_MASK      0xc0
 #define AVR8_TCCR1A_COM1A_SHIFT     6
 #define AVR8_TCCR1A_COM1B_MASK      0x30
 #define AVR8_TCCR1A_COM1B_SHIFT     4
+#define AVR8_TCCR1A_COM1AB_MASK     0xf0
+#define AVR8_TCCR1A_COM1AB_SHIFT    4
 #define AVR8_TCCR1A_WGM1_10_MASK    0x03
 #define AVR8_TCCR1A_WGM1_10_SHIFT   0
 #define AVR8_TCCR1A_COM1A           ((AVR8_TCCR1A & AVR8_TCCR1A_COM1A_MASK) >> AVR8_TCCR1A_COM1A_SHIFT)
 #define AVR8_TCCR1A_COM1B           ((AVR8_TCCR1A & AVR8_TCCR1A_COM1B_MASK) >> AVR8_TCCR1A_COM1B_SHIFT)
 #define AVR8_TCCR1A_WGM1_10         (AVR8_TCCR1A & AVR8_TCCR1A_WGM1_10_MASK)
 
-#define AVR8_TIMSK1             (m_r[AVR8_REGIDX_TIMSK1])
+#define AVR8_TIMSK1             (m_r[TIMSK1])
 #define AVR8_TIMSK1_ICIE1_MASK  0x20
 #define AVR8_TIMSK1_OCIE1B_MASK 0x04
 #define AVR8_TIMSK1_OCIE1A_MASK 0x02
@@ -343,7 +324,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TIMSK1_OCIE1A      ((AVR8_TIMSK1 & AVR8_TIMSK1_OCIE1A_MASK) >> 1)
 #define AVR8_TIMSK1_TOIE1       (AVR8_TIMSK1 & AVR8_TIMSK1_TOIE1_MASK)
 
-#define AVR8_TIFR1              (m_r[AVR8_REGIDX_TIFR1])
+#define AVR8_TIFR1              (m_r[TIFR1])
 #define AVR8_TIFR1_ICF1_MASK    0x20
 #define AVR8_TIFR1_ICF1_SHIFT   5
 #define AVR8_TIFR1_OCF1B_MASK   0x04
@@ -355,7 +336,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TIFR1_MASK         (AVR8_TIFR1_ICF1_MASK | AVR8_TIFR1_TOV1_MASK | \
 									AVR8_TIFR1_OCF1B_MASK | AVR8_TIFR1_OCF1A_MASK)
 
-#define AVR8_TCCR2B                 (m_r[AVR8_REGIDX_TCCR2B])
+#define AVR8_TCCR2B                 (m_r[TCCR2B])
 #define AVR8_TCCR2B_FOC2A_MASK      0x80
 #define AVR8_TCCR2B_FOC2A_SHIFT     7
 #define AVR8_TCCR2B_FOC2B_MASK      0x40
@@ -366,7 +347,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TCCR2B_CS_SHIFT        0
 #define AVR8_TIMER2_CLOCK_SELECT    (AVR8_TCCR2B & AVR8_TCCR2B_CS_MASK)
 
-#define AVR8_TCCR2A                 (m_r[AVR8_REGIDX_TCCR2A])
+#define AVR8_TCCR2A                 (m_r[TCCR2A])
 #define AVR8_TCCR2A_COM2A_MASK      0xc0
 #define AVR8_TCCR2A_COM2A_SHIFT     6
 #define AVR8_TCCR2A_COM2B_MASK      0x30
@@ -377,7 +358,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TCCR2A_COM2B           ((AVR8_TCCR2A & AVR8_TCCR2A_COM2B_MASK) >> AVR8_TCCR2A_COM2B_SHIFT)
 #define AVR8_TCCR2A_WGM2_10         (AVR8_TCCR2A & AVR8_TCCR2A_WGM2_10_MASK)
 
-#define AVR8_TIMSK2             (m_r[AVR8_REGIDX_TIMSK2])
+#define AVR8_TIMSK2             (m_r[TIMSK2])
 #define AVR8_TIMSK2_OCIE2B_MASK 0x04
 #define AVR8_TIMSK2_OCIE2A_MASK 0x02
 #define AVR8_TIMSK2_TOIE2_MASK  0x01
@@ -385,7 +366,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TIMSK2_OCIE2A      ((AVR8_TIMSK2 & AVR8_TIMSK2_OCIE2A_MASK) >> 1)
 #define AVR8_TIMSK2_TOIE2       (AVR8_TIMSK2 & AVR8_TIMSK2_TOIE2_MASK)
 
-#define AVR8_TIFR2              (m_r[AVR8_REGIDX_TIFR2])
+#define AVR8_TIFR2              (m_r[TIFR2])
 #define AVR8_TIFR2_OCF2B_MASK   0x04
 #define AVR8_TIFR2_OCF2B_SHIFT  2
 #define AVR8_TIFR2_OCF2A_MASK   0x02
@@ -394,7 +375,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TIFR2_TOV2_SHIFT   0
 #define AVR8_TIFR2_MASK         (AVR8_TIFR2_TOV2_MASK | AVR8_TIFR2_OCF2B_MASK | AVR8_TIFR2_OCF2A_MASK)
 
-#define AVR8_TIMSK3             (m_r[AVR8_REGIDX_TIMSK3])
+#define AVR8_TIMSK3             (m_r[TIMSK3])
 #define AVR8_TIMSK3_OCIE3C_MASK 0x08
 #define AVR8_TIMSK3_OCIE3B_MASK 0x04
 #define AVR8_TIMSK3_OCIE3A_MASK 0x02
@@ -404,9 +385,9 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TIMSK3_OCIE3A      ((AVR8_TIMSK3 & AVR8_TIMSK3_OCIE3A_MASK) >> 1)
 #define AVR8_TIMSK3_TOIE3       ((AVR8_TIMSK3 &  AVR8_TIMSK3_TOIE3_MASK) >> 0)
 
-#define AVR8_TCCR4C                 (m_r[AVR8_REGIDX_TCCR4C])
+#define AVR8_TCCR4C                 (m_r[TCCR4C])
 
-#define AVR8_TCCR4B                 (m_r[AVR8_REGIDX_TCCR4B])
+#define AVR8_TCCR4B                 (m_r[TCCR4B])
 #define AVR8_TCCR4B_FOC4A_MASK      0x80
 #define AVR8_TCCR4B_FOC4A_SHIFT     7
 #define AVR8_TCCR4B_FOC4B_MASK      0x40
@@ -419,7 +400,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TCCR4B_CS_SHIFT        0
 #define AVR8_TIMER4_CLOCK_SELECT    ((AVR8_TCCR4B & AVR8_TCCR4B_CS_MASK) >> AVR8_TCCR4B_CS_SHIFT)
 
-#define AVR8_TCCR4A                 (m_r[AVR8_REGIDX_TCCR4A])
+#define AVR8_TCCR4A                 (m_r[TCCR4A])
 #define AVR8_TCCR4A_COM4A_MASK      0xc0
 #define AVR8_TCCR4A_COM4A_SHIFT     6
 #define AVR8_TCCR4A_COM4B_MASK      0x30
@@ -437,7 +418,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_WGM4_10 ((AVR8_TCCR4A & AVR8_TCCR4A_WGM4_10_MASK) >> AVR8_TCCR4A_WGM4_10_SHIFT)
 #define AVR8_WGM4 ((AVR8_WGM4_32 << 2) | AVR8_WGM4_10)
 
-#define AVR8_TIMSK4             (m_r[AVR8_REGIDX_TIMSK4])
+#define AVR8_TIMSK4             (m_r[TIMSK4])
 #define AVR8_TIMSK4_OCIE4B_MASK 0x04
 #define AVR8_TIMSK4_OCIE4A_MASK 0x02
 #define AVR8_TIMSK4_TOIE4_MASK  0x01
@@ -445,7 +426,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TIMSK4_OCIE4A      ((AVR8_TIMSK4 & AVR8_TIMSK4_OCIE4A_MASK) >> 1)
 #define AVR8_TIMSK4_TOIE4       (AVR8_TIMSK4 & AVR8_TIMSK4_TOIE4_MASK)
 
-#define AVR8_TIFR4              (m_r[AVR8_REGIDX_TIFR4])
+#define AVR8_TIFR4              (m_r[TIFR4])
 #define AVR8_TIFR4_OCF4B_MASK   0x04
 #define AVR8_TIFR4_OCF4B_SHIFT  2
 #define AVR8_TIFR4_OCF4A_MASK   0x02
@@ -455,7 +436,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TIFR4_MASK         (AVR8_TIFR4_TOV4_MASK | AVR8_TIFR4_OCF4B_MASK | AVR8_TIFR4_OCF4A_MASK)
 
 //---------------------------------------------------------------
-#define AVR8_TCCR5C                 (m_r[AVR8_REGIDX_TCCR5C])
+#define AVR8_TCCR5C                 (m_r[TCCR5C])
 #define AVR8_TCCR5C_FOC5A_MASK      0x80
 #define AVR8_TCCR5C_FOC5A_SHIFT     7
 #define AVR8_TCCR5C_FOC5B_MASK      0x40
@@ -463,7 +444,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TCCR5C_FOC5C_MASK      0x20
 #define AVR8_TCCR5C_FOC5C_SHIFT     5
 
-#define AVR8_TCCR5B                 (m_r[AVR8_REGIDX_TCCR5B])
+#define AVR8_TCCR5B                 (m_r[TCCR5B])
 #define AVR8_TCCR5B_ICNC5_MASK      0x80
 #define AVR8_TCCR5B_ICNC5_SHIFT     7
 #define AVR8_TCCR5B_ICES5_MASK      0x40
@@ -474,7 +455,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TCCR5B_CS_SHIFT        0
 #define AVR8_TIMER5_CLOCK_SELECT    ((AVR8_TCCR5B & AVR8_TCCR5B_CS_MASK) >> AVR8_TCCR5B_CS_SHIFT)
 
-#define AVR8_TCCR5A                 (m_r[AVR8_REGIDX_TCCR4A])
+#define AVR8_TCCR5A                 (m_r[TCCR4A])
 #define AVR8_TCCR5A_COM5A_MASK      0xc0
 #define AVR8_TCCR5A_COM5A_SHIFT     6
 #define AVR8_TCCR5A_COM5B_MASK      0x30
@@ -492,7 +473,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_WGM5_10 ((AVR8_TCCR5A & AVR8_TCCR5A_WGM5_10_MASK) >> AVR8_TCCR5A_WGM5_10_SHIFT)
 #define AVR8_WGM5 ((AVR8_WGM5_32 << 2) | AVR8_WGM5_10)
 
-#define AVR8_TIMSK5             (m_r[AVR8_REGIDX_TIMSK5])
+#define AVR8_TIMSK5             (m_r[TIMSK5])
 #define AVR8_TIMSK5_ICIE5_MASK  0x20
 #define AVR8_TIMSK5_OCIE5C_MASK 0x08
 #define AVR8_TIMSK5_OCIE5B_MASK 0x04
@@ -505,7 +486,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_TIMSK5_OCIE5A      ((AVR8_TIMSK5 & AVR8_TIMSK5_OCIE5A_MASK) >> 1)
 #define AVR8_TIMSK5_TOIE5       (AVR8_TIMSK5 & AVR8_TIMSK5_TOIE5_MASK)
 
-#define AVR8_TIFR5              (m_r[AVR8_REGIDX_TIFR5])
+#define AVR8_TIFR5              (m_r[TIFR5])
 #define AVR8_TIFR5_ICF5_MASK   0x20
 #define AVR8_TIFR5_ICF5_SHIFT  5
 #define AVR8_TIFR5_OCF5C_MASK   0x08
@@ -527,10 +508,10 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 
 //---------------------------------------------------------------
 
-#define AVR8_OCR0A              m_r[AVR8_REGIDX_OCR0A]
-#define AVR8_OCR0B              m_r[AVR8_REGIDX_OCR0B]
-#define AVR8_TCNT0              m_r[AVR8_REGIDX_TCNT0]
-#define AVR8_WGM0               (((AVR8_TCCR0B & 0x08) >> 1) | (AVR8_TCCR0A & 0x03))
+#define AVR8_OCR0A              m_r[OCR0A]
+#define AVR8_OCR0B              m_r[OCR0B]
+#define AVR8_TCNT0              m_r[TCNT0]
+#define AVR8_WGM0               (((m_r[TCCR0B] & 0x08) >> 1) | (m_r[TCCR0A] & 0x03))
 
 #define AVR8_OCR1A              ((AVR8_OCR1AH << 8) | AVR8_OCR1AL)
 #define AVR8_OCR1B              ((AVR8_OCR1BH << 8) | AVR8_OCR1BL)
@@ -540,20 +521,20 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_WGM1               (((AVR8_TCCR1B & 0x18) >> 1) | (AVR8_TCCR1A & 0x03))
 #define AVR8_TCNT1_DIR          (state->m_tcnt1_direction)
 
-#define AVR8_OCR2A              m_r[AVR8_REGIDX_OCR2A]
-#define AVR8_OCR2B              m_r[AVR8_REGIDX_OCR2B]
-#define AVR8_TCNT2              m_r[AVR8_REGIDX_TCNT2]
+#define AVR8_OCR2A              m_r[OCR2A]
+#define AVR8_OCR2B              m_r[OCR2B]
+#define AVR8_TCNT2              m_r[TCNT2]
 #define AVR8_WGM2               (((AVR8_TCCR2B & 0x08) >> 1) | (AVR8_TCCR2A & 0x03))
 
 #define AVR8_ICR3               ((AVR8_ICR3H  << 8) | AVR8_ICR3L)
 #define AVR8_OCR3A              ((AVR8_OCR3AH << 8) | AVR8_OCR3AL)
 
 #define AVR8_ICR4               ((AVR8_ICR4H  << 8) | AVR8_ICR4L)
-#define AVR8_ICR4H              (m_r[AVR8_REGIDX_ICR4H])
-#define AVR8_ICR4L              (m_r[AVR8_REGIDX_ICR4L])
+#define AVR8_ICR4H              (m_r[ICR4H])
+#define AVR8_ICR4L              (m_r[ICR4L])
 #define AVR8_OCR4A              ((AVR8_OCR4AH << 8) | AVR8_OCR4AL)
-#define AVR8_OCR4B              m_r[AVR8_REGIDX_OCR4B]
-#define AVR8_TCNT4              m_r[AVR8_REGIDX_TCNT4]
+#define AVR8_OCR4B              m_r[OCR4B]
+#define AVR8_TCNT4              m_r[TCNT4]
 
 #define AVR8_ICR5               ((AVR8_ICR5H  << 8) | AVR8_ICR5L)
 #define AVR8_OCR5A              ((AVR8_OCR5AH << 8) | AVR8_OCR5AL)
@@ -561,10 +542,10 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_GTCCR_PSRASY_MASK  0x02
 #define AVR8_GTCCR_PSRASY_SHIFT 1
 
-#define AVR8_SPSR               (m_r[AVR8_REGIDX_SPSR])
+#define AVR8_SPSR               (m_r[SPSR])
 #define AVR8_SPSR_SPR2X         (AVR8_SPSR & AVR8_SPSR_SPR2X_MASK)
 
-#define AVR8_SPCR               (m_r[AVR8_REGIDX_SPCR])
+#define AVR8_SPCR               (m_r[SPCR])
 #define AVR8_SPCR_SPIE          ((AVR8_SPCR & AVR8_SPCR_SPIE_MASK) >> 7)
 #define AVR8_SPCR_SPE           ((AVR8_SPCR & AVR8_SPCR_SPE_MASK) >> 6)
 #define AVR8_SPCR_DORD          ((AVR8_SPCR & AVR8_SPCR_DORD_MASK) >> 5)
@@ -577,7 +558,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 
 #define AVR8_PORTB_MOSI         0x08
 
-#define AVR8_EECR               m_r[AVR8_REGIDX_EECR] & 0x3F; //bits 6 and 7 are reserved and will always read as zero
+#define AVR8_EECR               m_r[EECR] & 0x3F; //bits 6 and 7 are reserved and will always read as zero
 #define AVR8_EECR_EEPM_MASK     0x30
 #define AVR8_EECR_EERIE_MASK    0x08
 #define AVR8_EECR_EEMPE_MASK    0x04
@@ -591,7 +572,7 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 
 //---------------------------------------------------------------
 
-#define AVR8_ADMUX              (m_r[AVR8_REGIDX_ADMUX])
+#define AVR8_ADMUX              (m_r[ADMUX])
 #define AVR8_ADMUX_REFS_MASK    0xc0
 #define AVR8_ADMUX_ADLAR_MASK   0x20
 #define AVR8_ADMUX_MUX_MASK     0x0f
@@ -599,13 +580,13 @@ static const char avr8_reg_name[4] = { 'A', 'B', 'C', 'D' };
 #define AVR8_ADMUX_ADLAR        ((AVR8_ADMUX & AVR8_ADMUX_ADLAR_MASK) >> 5)
 #define AVR8_ADMUX_MUX          ((AVR8_ADMUX & AVR8_ADMUX_MUX_MASK) >> 0)
 
-#define AVR8_ADCSRB             (m_r[AVR8_REGIDX_ADCSRB])
+#define AVR8_ADCSRB             (m_r[ADCSRB])
 #define AVR8_ADCSRB_ACME_MASK   0x40
 #define AVR8_ADCSRB_ADTS_MASK   0x07
 #define AVR8_ADCSRB_ACME        ((AVR8_ADCSRB & AVR8_ADCSRB_ACME_MASK) >> 6)
 #define AVR8_ADCSRB_ADTS        ((AVR8_ADCSRB & AVR8_ADCSRB_ADTS_MASK) >> 0)
 
-#define AVR8_ADCSRA             (m_r[AVR8_REGIDX_ADCSRA])
+#define AVR8_ADCSRA             (m_r[ADCSRA])
 #define AVR8_ADCSRA_ADEN_MASK   0x80
 #define AVR8_ADCSRA_ADSC_MASK   0x40
 #define AVR8_ADCSRA_ADATE_MASK  0x20
@@ -636,39 +617,168 @@ DEFINE_DEVICE_TYPE(ATTINY15,   attiny15_device,   "attiny15",   "Atmel ATtiny15"
 //  INTERNAL ADDRESS MAP
 //**************************************************************************
 
+template <int NumTimers>
+void avr8_device<NumTimers>::base_internal_map(address_map &map)
+{
+	map(0x0000, 0x01ff).ram().share(m_r);
+	map(0x0020, 0x0020).r(FUNC(avr8_device::pin_r<0>));
+	map(0x0022, 0x0022).rw(FUNC(avr8_device::gpio_r<GPIOA>), FUNC(avr8_device::port_w<GPIOA>));
+	map(0x0023, 0x0023).r(FUNC(avr8_device::pin_r<1>));
+	map(0x0025, 0x0025).rw(FUNC(avr8_device::gpio_r<GPIOB>), FUNC(avr8_device::port_w<GPIOB>));
+	map(0x0026, 0x0026).r(FUNC(avr8_device::pin_r<2>));
+	map(0x0028, 0x0028).rw(FUNC(avr8_device::gpio_r<GPIOC>), FUNC(avr8_device::port_w<GPIOC>));
+	map(0x0029, 0x0029).r(FUNC(avr8_device::pin_r<3>));
+	map(0x002b, 0x002b).rw(FUNC(avr8_device::gpio_r<GPIOD>), FUNC(avr8_device::port_w<GPIOD>));
+	map(0x002c, 0x002c).r(FUNC(avr8_device::pin_r<4>));
+	map(0x002e, 0x002e).rw(FUNC(avr8_device::gpio_r<GPIOE>), FUNC(avr8_device::port_w<GPIOE>));
+	map(0x002f, 0x002f).r(FUNC(avr8_device::pin_r<5>));
+	map(0x0031, 0x0031).rw(FUNC(avr8_device::gpio_r<GPIOF>), FUNC(avr8_device::port_w<GPIOF>));
+	map(0x0032, 0x0032).r(FUNC(avr8_device::pin_r<6>));
+	map(0x0034, 0x0034).rw(FUNC(avr8_device::gpio_r<GPIOG>), FUNC(avr8_device::port_w<GPIOG>));
+	map(0x0035, 0x0035).w(FUNC(avr8_device::tifr0_w));
+	map(0x0036, 0x0036).w(FUNC(avr8_device::tifr1_w));
+	map(0x0037, 0x0037).w(FUNC(avr8_device::tifr2_w));
+	map(0x003e, 0x003e).w(FUNC(avr8_device::gpior0_w));
+	map(0x003f, 0x003f).w(FUNC(avr8_device::eecr_w));
+	map(0x0043, 0x0043).w(FUNC(avr8_device::gtccr_w));
+	map(0x0044, 0x0044).w(FUNC(avr8_device::tccr0a_w));
+	map(0x004a, 0x004a).w(FUNC(avr8_device::gpior1_w));
+	map(0x004b, 0x004b).w(FUNC(avr8_device::gpior2_w));
+	map(0x004c, 0x004c).w(FUNC(avr8_device::spcr_w));
+	map(0x004d, 0x004d).w(FUNC(avr8_device::spsr_w));
+	map(0x004e, 0x004e).w(FUNC(avr8_device::spdr_w));
+	map(0x0060, 0x0060).w(FUNC(avr8_device::wdtcsr_w));
+	map(0x0061, 0x0061).w(FUNC(avr8_device::clkpr_w));
+	map(0x0064, 0x0064).w(FUNC(avr8_device::prr0_w));
+	map(0x0065, 0x0065).w(FUNC(avr8_device::prr1_w));
+	map(0x0066, 0x0066).w(FUNC(avr8_device::osccal_w));
+	map(0x0068, 0x0068).w(FUNC(avr8_device::pcicr_w));
+	map(0x0069, 0x0069).w(FUNC(avr8_device::eicra_w));
+	map(0x006a, 0x006a).w(FUNC(avr8_device::eicrb_w));
+	map(0x006b, 0x006b).w(FUNC(avr8_device::pcmsk0_w));
+	map(0x006c, 0x006c).w(FUNC(avr8_device::pcmsk1_w));
+	map(0x006d, 0x006d).w(FUNC(avr8_device::pcmsk2_w));
+	map(0x006e, 0x006e).w(FUNC(avr8_device::timsk0_w));
+	map(0x006f, 0x006f).w(FUNC(avr8_device::timsk1_w));
+	map(0x0070, 0x0070).w(FUNC(avr8_device::timsk2_w));
+	map(0x0071, 0x0071).w(FUNC(avr8_device::timsk3_w));
+	map(0x0072, 0x0072).w(FUNC(avr8_device::timsk4_w));
+	map(0x0073, 0x0073).w(FUNC(avr8_device::timsk5_w));
+	map(0x0074, 0x0074).w(FUNC(avr8_device::xmcra_w));
+	map(0x0075, 0x0075).w(FUNC(avr8_device::xmcrb_w));
+	map(0x0078, 0x0078).rw(FUNC(avr8_device::adcl_r), FUNC(avr8_device::adcl_w));
+	map(0x0079, 0x0079).rw(FUNC(avr8_device::adch_r), FUNC(avr8_device::adch_w));
+	map(0x007a, 0x007a).w(FUNC(avr8_device::adcsra_w));
+	map(0x007b, 0x007b).w(FUNC(avr8_device::adcsrb_w));
+	map(0x007c, 0x007c).w(FUNC(avr8_device::admux_w));
+	map(0x007d, 0x007d).w(FUNC(avr8_device::didr2_w));
+	map(0x007e, 0x007e).w(FUNC(avr8_device::didr0_w));
+	map(0x007f, 0x007f).w(FUNC(avr8_device::didr1_w));
+	map(0x0080, 0x0080).w(FUNC(avr8_device::tccr1a_w));
+	map(0x0081, 0x0081).w(FUNC(avr8_device::tccr1b_w));
+	map(0x0082, 0x0082).w(FUNC(avr8_device::tccr1c_w));
+	map(0x0086, 0x0086).w(FUNC(avr8_device::icr1l_w));
+	map(0x0087, 0x0087).w(FUNC(avr8_device::icr1h_w));
+	map(0x0088, 0x0088).w(FUNC(avr8_device::ocr1al_w));
+	map(0x0089, 0x0089).w(FUNC(avr8_device::ocr1ah_w));
+	map(0x008a, 0x008a).w(FUNC(avr8_device::ocr1bl_w));
+	map(0x008b, 0x008b).w(FUNC(avr8_device::ocr1bh_w));
+	map(0x008c, 0x008c).w(FUNC(avr8_device::ocr1cl_w));
+	map(0x008d, 0x008d).w(FUNC(avr8_device::ocr1ch_w));
+	map(0x0090, 0x0090).w(FUNC(avr8_device::tccr3a_w));
+	map(0x0091, 0x0091).w(FUNC(avr8_device::tccr3b_w));
+	map(0x0092, 0x0092).w(FUNC(avr8_device::tccr3c_w));
+	map(0x0096, 0x0096).w(FUNC(avr8_device::icr3l_w));
+	map(0x0097, 0x0097).w(FUNC(avr8_device::icr3h_w));
+	map(0x0098, 0x0098).w(FUNC(avr8_device::ocr3al_w));
+	map(0x0099, 0x0099).w(FUNC(avr8_device::ocr3ah_w));
+	map(0x009a, 0x009a).w(FUNC(avr8_device::ocr3bl_w));
+	map(0x009b, 0x009b).w(FUNC(avr8_device::ocr3bh_w));
+	map(0x009c, 0x009c).w(FUNC(avr8_device::ocr3cl_w));
+	map(0x009d, 0x009d).w(FUNC(avr8_device::ocr3ch_w));
+	map(0x00a0, 0x00a0).w(FUNC(avr8_device::tccr4a_w));
+	map(0x00a1, 0x00a1).w(FUNC(avr8_device::tccr4b_w));
+	map(0x00a2, 0x00a2).w(FUNC(avr8_device::tccr4c_w));
+	map(0x00a4, 0x00a4).w(FUNC(avr8_device::tcnt4l_w));
+	map(0x00a5, 0x00a5).w(FUNC(avr8_device::tcnt4h_w));
+	map(0x00a6, 0x00a6).w(FUNC(avr8_device::icr4l_w));
+	map(0x00a7, 0x00a7).w(FUNC(avr8_device::icr4h_w));
+	map(0x00a8, 0x00a8).w(FUNC(avr8_device::ocr4al_w));
+	map(0x00a9, 0x00a9).w(FUNC(avr8_device::ocr4ah_w));
+	map(0x00aa, 0x00aa).w(FUNC(avr8_device::ocr4bl_w));
+	map(0x00ab, 0x00ab).w(FUNC(avr8_device::ocr4bh_w));
+	map(0x00ac, 0x00ac).w(FUNC(avr8_device::ocr4cl_w));
+	map(0x00ad, 0x00ad).w(FUNC(avr8_device::ocr4ch_w));
+	map(0x00b0, 0x00b0).w(FUNC(avr8_device::tccr2a_w));
+	map(0x00b1, 0x00b1).w(FUNC(avr8_device::tccr2b_w));
+	map(0x00b2, 0x00b2).w(FUNC(avr8_device::tcnt2_w));
+	map(0x00b3, 0x00b3).w(FUNC(avr8_device::ocr2a_w));
+	map(0x00b4, 0x00b4).w(FUNC(avr8_device::ocr2b_w));
+	map(0x00b6, 0x00b6).w(FUNC(avr8_device::assr_w));
+	map(0x00b8, 0x00b8).w(FUNC(avr8_device::twbr_w));
+	map(0x00b9, 0x00b9).rw(FUNC(avr8_device::twsr_r), FUNC(avr8_device::twsr_w));
+	map(0x00ba, 0x00ba).w(FUNC(avr8_device::twar_w));
+	map(0x00bb, 0x00bb).w(FUNC(avr8_device::twdr_w));
+	map(0x00bc, 0x00bc).w(FUNC(avr8_device::twcr_w));
+	map(0x00bd, 0x00bd).w(FUNC(avr8_device::twamr_w));
+	map(0x00c0, 0x00c0).w(FUNC(avr8_device::ucsr0a_w));
+	map(0x00c1, 0x00c1).w(FUNC(avr8_device::ucsr0b_w));
+	map(0x00c2, 0x00c2).w(FUNC(avr8_device::ucsr0c_w));
+}
+
 void atmega88_device::atmega88_internal_map(address_map &map)
 {
-	map(0x0000, 0x00ff).rw(FUNC(atmega88_device::regs_r), FUNC(atmega88_device::regs_w));
+	avr8_device::base_internal_map(map);
 }
 
 void atmega168_device::atmega168_internal_map(address_map &map)
 {
-	map(0x0000, 0x00ff).rw(FUNC(atmega168_device::regs_r), FUNC(atmega168_device::regs_w));
+	avr8_device::base_internal_map(map);
 }
 
 void atmega328_device::atmega328_internal_map(address_map &map)
 {
-	map(0x0000, 0x00ff).rw(FUNC(atmega328_device::regs_r), FUNC(atmega328_device::regs_w));
+	avr8_device::base_internal_map(map);
 }
 
 void atmega644_device::atmega644_internal_map(address_map &map)
 {
-	map(0x0000, 0x00ff).rw(FUNC(atmega644_device::regs_r), FUNC(atmega644_device::regs_w));
+	avr8_device::base_internal_map(map);
 }
 
 void atmega1280_device::atmega1280_internal_map(address_map &map)
 {
-	map(0x0000, 0x01ff).rw(FUNC(atmega1280_device::regs_r), FUNC(atmega1280_device::regs_w));
+	avr8_device::base_internal_map(map);
+	map(0x0100, 0x0100).r(FUNC(atmega1280_device::pin_r<7>));
+	map(0x0102, 0x0102).rw(FUNC(atmega1280_device::gpio_r<GPIOH>), FUNC(atmega1280_device::port_w<GPIOH>));
+	map(0x0103, 0x0103).r(FUNC(atmega1280_device::pin_r<8>));
+	map(0x0105, 0x0105).rw(FUNC(atmega1280_device::gpio_r<GPIOJ>),FUNC(atmega1280_device::port_w<GPIOJ>));
+	map(0x0106, 0x0106).r(FUNC(atmega1280_device::pin_r<9>));
+	map(0x0108, 0x0108).rw(FUNC(atmega1280_device::gpio_r<GPIOK>),FUNC(atmega1280_device::port_w<GPIOK>));
+	map(0x0109, 0x0109).r(FUNC(atmega1280_device::pin_r<10>));
+	map(0x010b, 0x010b).rw(FUNC(atmega1280_device::gpio_r<GPIOL>),FUNC(atmega1280_device::port_w<GPIOL>));
+	map(0x0120, 0x0120).w(FUNC(atmega1280_device::tccr5a_w));
+	map(0x0121, 0x0121).w(FUNC(atmega1280_device::tccr5b_w));
 }
 
 void atmega2560_device::atmega2560_internal_map(address_map &map)
 {
-	map(0x0000, 0x01ff).rw(FUNC(atmega2560_device::regs_r), FUNC(atmega2560_device::regs_w));
+	avr8_device::base_internal_map(map);
+	map(0x0100, 0x0100).r(FUNC(atmega2560_device::pin_r<7>));
+	map(0x0102, 0x0102).rw(FUNC(atmega2560_device::gpio_r<GPIOH>), FUNC(atmega2560_device::port_w<GPIOH>));
+	map(0x0103, 0x0103).r(FUNC(atmega2560_device::pin_r<8>));
+	map(0x0105, 0x0105).rw(FUNC(atmega2560_device::gpio_r<GPIOJ>),FUNC(atmega2560_device::port_w<GPIOJ>));
+	map(0x0106, 0x0106).r(FUNC(atmega2560_device::pin_r<9>));
+	map(0x0108, 0x0108).rw(FUNC(atmega2560_device::gpio_r<GPIOK>),FUNC(atmega2560_device::port_w<GPIOK>));
+	map(0x0109, 0x0109).r(FUNC(atmega2560_device::pin_r<10>));
+	map(0x010b, 0x010b).rw(FUNC(atmega2560_device::gpio_r<GPIOL>),FUNC(atmega2560_device::port_w<GPIOL>));
+	map(0x0120, 0x0120).w(FUNC(atmega2560_device::tccr5a_w));
+	map(0x0121, 0x0121).w(FUNC(atmega2560_device::tccr5b_w));
 }
 
 void attiny15_device::attiny15_internal_map(address_map &map)
 {
-	map(0x00, 0x1f).rw(FUNC(attiny15_device::regs_r), FUNC(attiny15_device::regs_w));
+	avr8_device::base_internal_map(map);
 }
 
 //-------------------------------------------------
@@ -676,7 +786,7 @@ void attiny15_device::attiny15_internal_map(address_map &map)
 //-------------------------------------------------
 
 atmega88_device::atmega88_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA88, 0x0fff, address_map_constructor(FUNC(atmega88_device::atmega88_internal_map), this), 3)
+	: avr8_device(mconfig, tag, owner, clock, ATMEGA88, 0x0fff, address_map_constructor(FUNC(atmega88_device::atmega88_internal_map), this))
 {
 }
 
@@ -685,7 +795,7 @@ atmega88_device::atmega88_device(const machine_config &mconfig, const char *tag,
 //-------------------------------------------------
 
 atmega168_device::atmega168_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA168, 0x1fff, address_map_constructor(FUNC(atmega168_device::atmega168_internal_map), this), 3)
+	: avr8_device(mconfig, tag, owner, clock, ATMEGA168, 0x1fff, address_map_constructor(FUNC(atmega168_device::atmega168_internal_map), this))
 {
 }
 
@@ -694,7 +804,7 @@ atmega168_device::atmega168_device(const machine_config &mconfig, const char *ta
 //-------------------------------------------------
 
 atmega328_device::atmega328_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA328, 0x7fff, address_map_constructor(FUNC(atmega328_device::atmega328_internal_map), this), 3)
+	: avr8_device(mconfig, tag, owner, clock, ATMEGA328, 0x7fff, address_map_constructor(FUNC(atmega328_device::atmega328_internal_map), this))
 {
 }
 
@@ -703,7 +813,7 @@ atmega328_device::atmega328_device(const machine_config &mconfig, const char *ta
 //-------------------------------------------------
 
 atmega644_device::atmega644_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA644, 0xffff, address_map_constructor(FUNC(atmega644_device::atmega644_internal_map), this), 3)
+	: avr8_device(mconfig, tag, owner, clock, ATMEGA644, 0xffff, address_map_constructor(FUNC(atmega644_device::atmega644_internal_map), this))
 {
 }
 
@@ -712,7 +822,7 @@ atmega644_device::atmega644_device(const machine_config &mconfig, const char *ta
 //-------------------------------------------------
 
 atmega1280_device::atmega1280_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA1280, 0x1ffff, address_map_constructor(FUNC(atmega1280_device::atmega1280_internal_map), this), 6)
+	: avr8_device(mconfig, tag, owner, clock, ATMEGA1280, 0x1ffff, address_map_constructor(FUNC(atmega1280_device::atmega1280_internal_map), this))
 {
 }
 
@@ -721,7 +831,7 @@ atmega1280_device::atmega1280_device(const machine_config &mconfig, const char *
 //-------------------------------------------------
 
 atmega2560_device::atmega2560_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATMEGA2560, 0x1ffff, address_map_constructor(FUNC(atmega2560_device::atmega2560_internal_map), this), 6)
+	: avr8_device(mconfig, tag, owner, clock, ATMEGA2560, 0x1ffff, address_map_constructor(FUNC(atmega2560_device::atmega2560_internal_map), this))
 {
 }
 
@@ -730,7 +840,7 @@ atmega2560_device::atmega2560_device(const machine_config &mconfig, const char *
 //-------------------------------------------------
 
 attiny15_device::attiny15_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: avr8_device(mconfig, tag, owner, clock, ATTINY15, 0x03ff, address_map_constructor(FUNC(attiny15_device::attiny15_internal_map), this), 2)
+	: avr8_device(mconfig, tag, owner, clock, ATTINY15, 0x03ff, address_map_constructor(FUNC(attiny15_device::attiny15_internal_map), this))
 {
 }
 
@@ -738,9 +848,9 @@ attiny15_device::attiny15_device(const machine_config &mconfig, const char *tag,
 //  avr8_device - constructor
 //-------------------------------------------------
 
-avr8_device::avr8_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, const device_type type, uint32_t addr_mask, address_map_constructor internal_map, int32_t num_timers)
+template <int NumTimers>
+avr8_device<NumTimers>::avr8_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, const device_type type, uint32_t addr_mask, address_map_constructor internal_map)
 	: cpu_device(mconfig, type, tag, owner, clock)
-	, m_shifted_pc(0)
 	, m_program_config("program", ENDIANNESS_LITTLE, 8, 22)
 	, m_data_config("data", ENDIANNESS_LITTLE, 8, 16, 0, internal_map)
 	, m_eeprom(*this, finder_base::DUMMY_TAG)
@@ -748,8 +858,8 @@ avr8_device::avr8_device(const machine_config &mconfig, const char *tag, device_
 	, m_hfuses(0x99)
 	, m_efuses(0xff)
 	, m_lock_bits(0xff)
+	, m_r(*this, "regs")
 	, m_pc(0)
-	, m_num_timers(num_timers)
 	, m_gpio_out_cb(*this)
 	, m_gpio_in_cb(*this, 0)
 	, m_adc_in_cb(*this, 0)
@@ -757,17 +867,152 @@ avr8_device::avr8_device(const machine_config &mconfig, const char *tag, device_
 	, m_spi_active(false)
 	, m_spi_prescale(0)
 	, m_spi_prescale_count(0)
-	, m_addr_mask(addr_mask)
+	, m_addr_mask((addr_mask << 1) | 1)
 	, m_interrupt_pending(false)
 {
+	// Fill in default callbacks
+	for (int i = 0; i < 8*4; i++)
+	{
+		m_timer0_ticks[i] = &avr8_device<NumTimers>::timer0_tick_default;
+	}
+	for (int i = 0; i < 8; i++)
+	{
+		m_timer2_ticks[i] = &avr8_device<NumTimers>::timer2_tick_default;
+	}
+
+	// Fill in the mode-specific callbacks
+	for (int i = 0; i < 8; i++)
+	{
+		for (int j = 1; j < 4; j++)
+		{
+			switch (i)
+			{
+				case 0:
+					m_timer0_ticks[(i << 2) + j] = &avr8_device<NumTimers>::timer0_tick_norm;
+					break;
+				case 1:
+					m_timer0_ticks[(i << 2) + j] = &avr8_device<NumTimers>::timer0_tick_pwm_pc;
+					break;
+				case 3:
+					m_timer0_ticks[(i << 2) + j] = &avr8_device<NumTimers>::timer0_tick_fast_pwm;
+					break;
+				case 5:
+					m_timer0_ticks[(i << 2) + j] = &avr8_device<NumTimers>::timer0_tick_pwm_pc_cmp;
+					break;
+				case 7:
+					m_timer0_ticks[(i << 2) + j] = &avr8_device<NumTimers>::timer0_tick_fast_pwm_cmp;
+					break;
+			}
+		}
+	}
+
+	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 0] = &avr8_device<NumTimers>::timer0_tick_ctc_norm;
+	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 1] = &avr8_device<NumTimers>::timer0_tick_ctc_toggle;
+	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 2] = &avr8_device<NumTimers>::timer0_tick_ctc_clear;
+	m_timer0_ticks[(WGM02_CTC_CMP << 2) | 3] = &avr8_device<NumTimers>::timer0_tick_ctc_set;
+
+	for (int i = 0; i < 16; i++)
+	{
+		m_timer1_ticks[(WGM1_NORMAL << 4) | i] = &avr8_device<NumTimers>::timer1_tick_normal;
+		m_timer1_ticks[(WGM1_PWM_8_PC << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm8_pc;
+		m_timer1_ticks[(WGM1_PWM_9_PC << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm9_pc;
+		m_timer1_ticks[(WGM1_PWM_10_PC << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm10_pc;
+		m_timer1_ticks[(WGM1_FAST_PWM_8 << 4) | i] = &avr8_device<NumTimers>::timer1_tick_fast_pwm8;
+		m_timer1_ticks[(WGM1_FAST_PWM_9 << 4) | i] = &avr8_device<NumTimers>::timer1_tick_fast_pwm9;
+		m_timer1_ticks[(WGM1_FAST_PWM_10 << 4) | i] = &avr8_device<NumTimers>::timer1_tick_fast_pwm10;
+		m_timer1_ticks[(WGM1_PWM_PFC_ICR << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm_pfc_icr;
+		m_timer1_ticks[(WGM1_PWM_PFC_OCR << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm_pfc_ocr;
+		m_timer1_ticks[(WGM1_PWM_PC_ICR << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm_pc_icr;
+		m_timer1_ticks[(WGM1_PWM_PC_OCR << 4) | i] = &avr8_device<NumTimers>::timer1_tick_pwm_pc_ocr;
+		m_timer1_ticks[(WGM1_CTC_ICR << 4) | i] = &avr8_device<NumTimers>::timer1_tick_ctc_icr;
+		m_timer1_ticks[(WGM1_RESERVED << 4) | i] = &avr8_device<NumTimers>::timer1_tick_resv;
+	}
+
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  0] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_norm;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  1] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_toggle;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  2] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_clear;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  3] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_norm_set;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  4] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_norm;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  5] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_toggle;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  6] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_clear;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  7] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_toggle_set;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  8] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_norm;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) |  9] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_toggle;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 10] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_clear;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 11] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_clear_set;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 12] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_norm;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 13] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_toggle;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 14] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_clear;
+	m_timer1_ticks[(WGM1_CTC_OCR << 4) | 15] = &avr8_device<NumTimers>::timer1_tick_ctc_ocr_set_set;
+
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  0] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_norm;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  1] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_toggle;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  2] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_clear;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  3] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_norm_set;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  4] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_norm;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  5] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_toggle;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  6] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_clear;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  7] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_toggle_set;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  8] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_norm;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) |  9] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_toggle;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 10] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_clear;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 11] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_clear_set;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 12] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_norm;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 13] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_toggle;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 14] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_clear;
+	m_timer1_ticks[(WGM1_FAST_PWM_ICR << 4) | 15] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_icr_set_set;
+
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  0] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_norm;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  1] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_toggle;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  2] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_clear;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  3] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_norm_set;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  4] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_norm;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  5] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_toggle;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  6] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_clear;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  7] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_toggle_set;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  8] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_norm;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) |  9] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_toggle;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 10] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_clear;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 11] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_clear_set;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 12] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_norm;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 13] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_toggle;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 14] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_clear;
+	m_timer1_ticks[(WGM1_FAST_PWM_OCR << 4) | 15] = &avr8_device<NumTimers>::timer1_tick_fast_pwm_ocr_set_set;
+
+	m_timer2_ticks[WGM02_NORMAL] = &avr8_device<NumTimers>::timer2_tick_norm;
+	m_timer2_ticks[WGM02_PWM_PC] = &avr8_device<NumTimers>::timer2_tick_default;
+	m_timer2_ticks[WGM02_CTC_CMP] = &avr8_device<NumTimers>::timer2_tick_default;
+	m_timer2_ticks[WGM02_FAST_PWM] = &avr8_device<NumTimers>::timer2_tick_fast_pwm;
+	m_timer2_ticks[WGM02_RESERVED0] = &avr8_device<NumTimers>::timer2_tick_default;
+	m_timer2_ticks[WGM02_PWM_PC_CMP] = &avr8_device<NumTimers>::timer2_tick_default;
+	m_timer2_ticks[WGM02_RESERVED1] = &avr8_device<NumTimers>::timer2_tick_default;
+	m_timer2_ticks[WGM02_FAST_PWM_CMP] = &avr8_device<NumTimers>::timer2_tick_fast_pwm_cmp;
+
+	m_timer0_tick = m_timer0_ticks[0];
+	m_timer1_tick = m_timer1_ticks[0];
+	m_timer2_tick = m_timer2_ticks[0];
 }
 
+//-------------------------------------------------
+//  avr8_device - constructor
+//-------------------------------------------------
+template class avr8_device<2>;
+template class avr8_device<3>;
+template class avr8_device<6>;
 
 //-------------------------------------------------
 //  static_set_low_fuses
 //-------------------------------------------------
 
-void avr8_device::set_low_fuses(const uint8_t byte)
+//template <int NumTimers> void avr8_device<2>::set_low_fuses(const uint32_t, const uint32_t);
+//template <int NumTimers> void avr8_device<3>::set_low_fuses(const uint32_t, const uint32_t);
+//template <int NumTimers> void avr8_device<6>::set_low_fuses(const uint32_t, const uint32_t);
+//template <int NumTimers> void avr8_device<2>::set_low_fuses(const uint32_t, const uint32_t);
+//template <int NumTimers> void avr8_device<3>::set_low_fuses(const uint32_t, const uint32_t);
+//template <int NumTimers> void avr8_device<6>::set_low_fuses(const uint32_t, const uint32_t);
+
+template <int NumTimers>
+void avr8_device<NumTimers>::set_low_fuses(const uint8_t byte)
 {
 	m_lfuses = byte;
 }
@@ -776,7 +1021,8 @@ void avr8_device::set_low_fuses(const uint8_t byte)
 //  static_set_high_fuses
 //-------------------------------------------------
 
-void avr8_device::set_high_fuses(const uint8_t byte)
+template <int NumTimers>
+void avr8_device<NumTimers>::set_high_fuses(const uint8_t byte)
 {
 	m_hfuses = byte;
 }
@@ -785,7 +1031,8 @@ void avr8_device::set_high_fuses(const uint8_t byte)
 //  static_set_extended_fuses
 //-------------------------------------------------
 
-void avr8_device::set_extended_fuses(const uint8_t byte)
+template <int NumTimers>
+void avr8_device<NumTimers>::set_extended_fuses(const uint8_t byte)
 {
 	m_efuses = byte;
 }
@@ -794,7 +1041,8 @@ void avr8_device::set_extended_fuses(const uint8_t byte)
 //  static_set_lock_bits
 //-------------------------------------------------
 
-void avr8_device::set_lock_bits(const uint8_t byte)
+template <int NumTimers>
+void avr8_device<NumTimers>::set_lock_bits(const uint8_t byte)
 {
 	m_lock_bits = byte;
 }
@@ -804,10 +1052,11 @@ void avr8_device::set_lock_bits(const uint8_t byte)
 //  instruction
 //-------------------------------------------------
 
-void avr8_device::unimplemented_opcode(uint32_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::unimplemented_opcode(uint32_t op)
 {
 //  machine().debug_break();
-	fatalerror("AVR8: unknown opcode (%08x) at %08x\n", op, m_shifted_pc);
+	fatalerror("AVR8: unknown opcode (%08x) at %08x\n", op, m_pc);
 }
 
 
@@ -816,7 +1065,8 @@ void avr8_device::unimplemented_opcode(uint32_t op)
 //  bytes long
 //-------------------------------------------------
 
-inline bool avr8_device::is_long_opcode(uint16_t op)
+template <int NumTimers>
+inline bool avr8_device<NumTimers>::is_long_opcode(uint16_t op)
 {
 	if ((op & 0xf000) == 0x9000)
 	{
@@ -842,23 +1092,24 @@ inline bool avr8_device::is_long_opcode(uint16_t op)
 //  device_start - start up the device
 //-------------------------------------------------
 
-void avr8_device::device_start()
+template <int NumTimers>
+void avr8_device<NumTimers>::device_start()
 {
 	m_pc = 0;
 
 	m_program = &space(AS_PROGRAM);
 	m_data = &space(AS_DATA);
 
-	m_adc_timer = timer_alloc(FUNC(avr8_device::adc_conversion_complete), this);
+	m_adc_timer = timer_alloc(FUNC(avr8_device<NumTimers>::adc_conversion_complete), this);
 
 	// register our state for the debugger
-	state_add(STATE_GENPC,     "GENPC",     m_shifted_pc).noshow();
-	state_add(STATE_GENPCBASE, "CURPC",     m_shifted_pc).noshow();
-	state_add(STATE_GENFLAGS,  "GENFLAGS",  m_r[AVR8_REGIDX_SREG]).callimport().callexport().formatstr("%8s").noshow();
-	state_add(AVR8_SREG,       "STATUS",    m_r[AVR8_REGIDX_SREG]).mask(0xff);
-	state_add(AVR8_PC,         "PC",        m_shifted_pc).mask(m_addr_mask);
-	state_add(AVR8_SPH,        "SPH",       m_r[AVR8_REGIDX_SPH]).mask(0xff);
-	state_add(AVR8_SPL,        "SPL",       m_r[AVR8_REGIDX_SPL]).mask(0xff);
+	state_add(STATE_GENPC,     "GENPC",     m_pc).callexport().noshow();
+	state_add(STATE_GENPCBASE, "CURPC",     m_pc).callexport().noshow();
+	state_add(STATE_GENFLAGS,  "GENFLAGS",  m_r[SREG]).callimport().callexport().formatstr("%8s").noshow();
+	state_add(AVR8_SREG,       "STATUS",    m_r[SREG]).mask(0xff);
+	state_add(AVR8_PC,         "PC",        m_pc).mask(m_addr_mask).callexport();
+	state_add(AVR8_SPH,        "SPH",       m_r[SPH]).mask(0xff);
+	state_add(AVR8_SPL,        "SPL",       m_r[SPL]).mask(0xff);
 	state_add(AVR8_R0,         "R0",        m_r[ 0]).mask(0xff);
 	state_add(AVR8_R1,         "R1",        m_r[ 1]).mask(0xff);
 	state_add(AVR8_R2,         "R2",        m_r[ 2]).mask(0xff);
@@ -899,18 +1150,15 @@ void avr8_device::device_start()
 	save_item(NAME(m_efuses));
 	save_item(NAME(m_lock_bits));
 	save_item(NAME(m_pc));
-	save_item(NAME(m_r));
 
 	// Timers
 	save_item(NAME(m_timer_top));
-	save_item(NAME(m_timer_increment));
 	save_item(NAME(m_timer_prescale));
 	save_item(NAME(m_timer_prescale_count));
 	save_item(NAME(m_ocr2_not_reached_yet));
 	save_item(NAME(m_wgm1));
 	save_item(NAME(m_timer1_compare_mode));
 	save_item(NAME(m_ocr1));
-	save_item(NAME(m_timer1_count));
 
 	// ADC
 	save_item(NAME(m_adc_sample));
@@ -953,7 +1201,8 @@ void avr8_device::device_start()
 //  device_reset - reset the device
 //-------------------------------------------------
 
-void avr8_device::device_reset()
+template <int NumTimers>
+void avr8_device<NumTimers>::device_reset()
 {
 	logerror("AVR low fuse bits: 0x%02X\n", m_lfuses);
 	logerror("AVR high fuse bits: 0x%02X\n", m_hfuses);
@@ -963,23 +1212,23 @@ void avr8_device::device_reset()
 	switch ((m_hfuses & (BOOTSZ1 | BOOTSZ0)) >> 1)
 	{
 	case 0:
-		if (m_addr_mask <= 0x0fff) { m_boot_size = 1024; }
-		else if (m_addr_mask <= 0x7fff) { m_boot_size = 2048; }
+		if (m_addr_mask <= 0x1fff) { m_boot_size = 1024; }
+		else if (m_addr_mask <= 0xffff) { m_boot_size = 2048; }
 		else { m_boot_size = 4096; }
 		break;
 	case 1:
-		if (m_addr_mask <= 0x0fff) { m_boot_size = 512; }
-		else if (m_addr_mask <= 0x7fff) { m_boot_size = 1024; }
+		if (m_addr_mask <= 0x1fff) { m_boot_size = 512; }
+		else if (m_addr_mask <= 0xffff) { m_boot_size = 1024; }
 		else { m_boot_size = 2048; }
 		break;
 	case 2:
-		if (m_addr_mask <= 0x0fff) { m_boot_size = 256; }
-		else if (m_addr_mask <= 0x7fff) { m_boot_size = 512; }
+		if (m_addr_mask <= 0x1fff) { m_boot_size = 256; }
+		else if (m_addr_mask <= 0xffff) { m_boot_size = 512; }
 		else { m_boot_size = 1024; }
 		break;
 	case 3:
-		if (m_addr_mask <= 0x0fff) { m_boot_size = 128; }
-		else if (m_addr_mask <= 0x7fff) { m_boot_size = 256; }
+		if (m_addr_mask <= 0x1fff) { m_boot_size = 128; }
+		else if (m_addr_mask <= 0xffff) { m_boot_size = 256; }
 		else { m_boot_size = 512; }
 		break;
 	default:
@@ -988,11 +1237,10 @@ void avr8_device::device_reset()
 
 	if (m_hfuses & BOOTRST)
 	{
-		m_shifted_pc = 0x0000;
+		m_pc = 0x0000;
 		LOGMASKED(LOG_BOOT, "Booting AVR core from address 0x0000\n");
 	} else {
-		m_shifted_pc = (m_addr_mask + 1) - 2*m_boot_size;
-		m_pc = m_shifted_pc >> 1;
+		m_pc = (m_addr_mask + 1) - 2 * m_boot_size;
 		LOGMASKED(LOG_BOOT, "AVR Boot loader section size: %d words\n", m_boot_size);
 	}
 
@@ -1011,11 +1259,10 @@ void avr8_device::device_reset()
 	m_spi_prescale = 0;
 	m_spi_prescale_count = 0;
 
-	for (int t = 0; t < m_num_timers; t++)
+	for (int t = 0; t < NumTimers; t++)
 	{
 		m_timer_top[t] = 0;
-		m_timer_increment[t] = 1;
-		m_timer_prescale[t] = 0;
+		m_timer_prescale[t] = 0xffff;
 		m_timer_prescale_count[t] = 0;
 	}
 
@@ -1026,7 +1273,6 @@ void avr8_device::device_reset()
 	{
 		m_ocr1[reg] = 0;
 	}
-	m_timer1_count = 0;
 
 	m_ocr2_not_reached_yet = true;
 	m_interrupt_pending = false;
@@ -1037,7 +1283,8 @@ void avr8_device::device_reset()
 //  of the CPU's address spaces
 //-------------------------------------------------
 
-device_memory_interface::space_config_vector avr8_device::memory_space_config() const
+template <int NumTimers>
+device_memory_interface::space_config_vector avr8_device<NumTimers>::memory_space_config() const
 {
 	return space_config_vector {
 		std::make_pair(AS_PROGRAM, &m_program_config),
@@ -1051,26 +1298,32 @@ device_memory_interface::space_config_vector avr8_device::memory_space_config() 
 //  for the debugger
 //-------------------------------------------------
 
-void avr8_device::state_string_export(const device_state_entry &entry, std::string &str) const
+template <int NumTimers>
+void avr8_device<NumTimers>::state_string_export(const device_state_entry &entry, std::string &str) const
 {
 	switch (entry.index())
 	{
+	case STATE_GENPC:
+	case STATE_GENPCBASE:
+	case AVR8_PC:
+		str = string_format("%05x", m_pc << 1);
+		break;
 	case STATE_GENFLAGS:
 		str = string_format("%c%c%c%c%c%c%c%c",
-			(m_r[AVR8_REGIDX_SREG] & 0x80) ? 'I' : '-',
-			(m_r[AVR8_REGIDX_SREG] & 0x40) ? 'T' : '-',
-			(m_r[AVR8_REGIDX_SREG] & 0x20) ? 'H' : '-',
-			(m_r[AVR8_REGIDX_SREG] & 0x10) ? 'S' : '-',
-			(m_r[AVR8_REGIDX_SREG] & 0x08) ? 'V' : '-',
-			(m_r[AVR8_REGIDX_SREG] & 0x04) ? 'N' : '-',
-			(m_r[AVR8_REGIDX_SREG] & 0x02) ? 'Z' : '-',
-			(m_r[AVR8_REGIDX_SREG] & 0x01) ? 'C' : '-');
+			(m_r[SREG] & 0x80) ? 'I' : '-',
+			(m_r[SREG] & 0x40) ? 'T' : '-',
+			(m_r[SREG] & 0x20) ? 'H' : '-',
+			(m_r[SREG] & 0x10) ? 'S' : '-',
+			(m_r[SREG] & 0x08) ? 'V' : '-',
+			(m_r[SREG] & 0x04) ? 'N' : '-',
+			(m_r[SREG] & 0x02) ? 'Z' : '-',
+			(m_r[SREG] & 0x01) ? 'C' : '-');
 		break;
 	}
 }
 
-
-std::unique_ptr<util::disasm_interface> avr8_device::create_disassembler()
+template <int NumTimers>
+std::unique_ptr<util::disasm_interface> avr8_device<NumTimers>::create_disassembler()
 {
 	return std::make_unique<avr8_disassembler>();
 }
@@ -1080,21 +1333,23 @@ std::unique_ptr<util::disasm_interface> avr8_device::create_disassembler()
 //  MEMORY ACCESSORS
 //**************************************************************************
 
-inline void avr8_device::push(uint8_t val)
+template <int NumTimers>
+inline void avr8_device<NumTimers>::push(uint8_t val)
 {
 	uint16_t sp = SPREG;
 	m_data->write_byte(sp, val);
 	sp--;
-	m_r[AVR8_REGIDX_SPL] = sp & 0x00ff;
-	m_r[AVR8_REGIDX_SPH] = (sp >> 8) & 0x00ff;
+	m_r[SPL] = sp & 0x00ff;
+	m_r[SPH] = (sp >> 8) & 0x00ff;
 }
 
-inline uint8_t avr8_device::pop()
+template <int NumTimers>
+inline uint8_t avr8_device<NumTimers>::pop()
 {
 	uint16_t sp = SPREG;
 	sp++;
-	m_r[AVR8_REGIDX_SPL] = sp & 0x00ff;
-	m_r[AVR8_REGIDX_SPH] = (sp >> 8) & 0x00ff;
+	m_r[SPL] = sp & 0x00ff;
+	m_r[SPH] = (sp >> 8) & 0x00ff;
 	return m_data->read_byte(sp);
 }
 
@@ -1102,17 +1357,17 @@ inline uint8_t avr8_device::pop()
 //  IRQ HANDLING
 //**************************************************************************
 
-void avr8_device::set_irq_line(uint16_t vector, int state)
+template <int NumTimers>
+void avr8_device<NumTimers>::set_irq_line(uint16_t vector, int state)
 {
 	if (state)
 	{
 		if (SREG_R(AVR8_SREG_I))
 		{
 			SREG_W(AVR8_SREG_I, 0);
-			push(m_pc & 0x00ff);
-			push((m_pc >> 8) & 0x00ff);
-			m_pc = vector;
-			m_shifted_pc = vector << 1;
+			push((m_pc >> 1) & 0x00ff);
+			push((m_pc >> 9) & 0x00ff);
+			m_pc = vector << 1;
 		}
 		else
 		{
@@ -1132,20 +1387,21 @@ struct interrupt_condition
 
 static const interrupt_condition s_int_conditions[AVR8_INTIDX_COUNT] =
 {
-	{ AVR8_INT_SPI_STC, AVR8_REGIDX_SPCR,   AVR8_SPCR_SPIE_MASK,     AVR8_REGIDX_SPSR,    AVR8_SPSR_SPIF_MASK },
-	{ AVR8_INT_T0COMPB, AVR8_REGIDX_TIMSK0, AVR8_TIMSK0_OCIE0B_MASK, AVR8_REGIDX_TIFR0,   AVR8_TIFR0_OCF0B_MASK },
-	{ AVR8_INT_T0COMPA, AVR8_REGIDX_TIMSK0, AVR8_TIMSK0_OCIE0A_MASK, AVR8_REGIDX_TIFR0,   AVR8_TIFR0_OCF0A_MASK },
-	{ AVR8_INT_T0OVF,   AVR8_REGIDX_TIMSK0, AVR8_TIMSK0_TOIE0_MASK,  AVR8_REGIDX_TIFR0,   AVR8_TIFR0_TOV0_MASK },
-	{ AVR8_INT_T1CAPT,  AVR8_REGIDX_TIMSK1, AVR8_TIMSK1_ICIE1_MASK,  AVR8_REGIDX_TIFR1,   AVR8_TIFR1_ICF1_MASK },
-	{ AVR8_INT_T1COMPB, AVR8_REGIDX_TIMSK1, AVR8_TIMSK1_OCIE1B_MASK, AVR8_REGIDX_TIFR1,   AVR8_TIFR1_OCF1B_MASK },
-	{ AVR8_INT_T1COMPA, AVR8_REGIDX_TIMSK1, AVR8_TIMSK1_OCIE1A_MASK, AVR8_REGIDX_TIFR1,   AVR8_TIFR1_OCF1A_MASK },
-	{ AVR8_INT_T1OVF,   AVR8_REGIDX_TIMSK1, AVR8_TIMSK1_TOIE1_MASK,  AVR8_REGIDX_TIFR1,   AVR8_TIFR1_TOV1_MASK },
-	{ AVR8_INT_T2COMPB, AVR8_REGIDX_TIMSK2, AVR8_TIMSK2_OCIE2B_MASK, AVR8_REGIDX_TIFR2,   AVR8_TIFR2_OCF2B_MASK },
-	{ AVR8_INT_T2COMPA, AVR8_REGIDX_TIMSK2, AVR8_TIMSK2_OCIE2A_MASK, AVR8_REGIDX_TIFR2,   AVR8_TIFR2_OCF2A_MASK },
-	{ AVR8_INT_T2OVF,   AVR8_REGIDX_TIMSK2, AVR8_TIMSK2_TOIE2_MASK,  AVR8_REGIDX_TIFR2,   AVR8_TIFR2_TOV2_MASK }
+	{ AVR8_INT_SPI_STC, SPCR,   AVR8_SPCR_SPIE_MASK,     SPSR,    AVR8_SPSR_SPIF_MASK },
+	{ AVR8_INT_T0COMPB, TIMSK0, AVR8_TIMSK0_OCIE0B_MASK, TIFR0,   AVR8_TIFR0_OCF0B_MASK },
+	{ AVR8_INT_T0COMPA, TIMSK0, AVR8_TIMSK0_OCIE0A_MASK, TIFR0,   AVR8_TIFR0_OCF0A_MASK },
+	{ AVR8_INT_T0OVF,   TIMSK0, AVR8_TIMSK0_TOIE0_MASK,  TIFR0,   AVR8_TIFR0_TOV0_MASK },
+	{ AVR8_INT_T1CAPT,  TIMSK1, AVR8_TIMSK1_ICIE1_MASK,  TIFR1,   AVR8_TIFR1_ICF1_MASK },
+	{ AVR8_INT_T1COMPB, TIMSK1, AVR8_TIMSK1_OCIE1B_MASK, TIFR1,   AVR8_TIFR1_OCF1B_MASK },
+	{ AVR8_INT_T1COMPA, TIMSK1, AVR8_TIMSK1_OCIE1A_MASK, TIFR1,   AVR8_TIFR1_OCF1A_MASK },
+	{ AVR8_INT_T1OVF,   TIMSK1, AVR8_TIMSK1_TOIE1_MASK,  TIFR1,   AVR8_TIFR1_TOV1_MASK },
+	{ AVR8_INT_T2COMPB, TIMSK2, AVR8_TIMSK2_OCIE2B_MASK, TIFR2,   AVR8_TIFR2_OCF2B_MASK },
+	{ AVR8_INT_T2COMPA, TIMSK2, AVR8_TIMSK2_OCIE2A_MASK, TIFR2,   AVR8_TIFR2_OCF2A_MASK },
+	{ AVR8_INT_T2OVF,   TIMSK2, AVR8_TIMSK2_TOIE2_MASK,  TIFR2,   AVR8_TIFR2_TOV2_MASK }
 };
 
-void avr8_device::update_interrupt(int source)
+template <int NumTimers>
+void avr8_device<NumTimers>::update_interrupt(int source)
 {
 	const interrupt_condition &condition = s_int_conditions[source];
 
@@ -1196,17 +1452,17 @@ void atmega328_device::update_interrupt(int source)
 
 static const interrupt_condition s_mega644_int_conditions[AVR8_INTIDX_COUNT] =
 {
-	{ ATMEGA644_INT_SPI_STC, AVR8_REGIDX_SPCR,   AVR8_SPCR_SPIE_MASK,     AVR8_REGIDX_SPSR,    AVR8_SPSR_SPIF_MASK },
-	{ ATMEGA644_INT_T0COMPB, AVR8_REGIDX_TIMSK0, AVR8_TIMSK0_OCIE0B_MASK, AVR8_REGIDX_TIFR0,   AVR8_TIFR0_OCF0B_MASK },
-	{ ATMEGA644_INT_T0COMPA, AVR8_REGIDX_TIMSK0, AVR8_TIMSK0_OCIE0A_MASK, AVR8_REGIDX_TIFR0,   AVR8_TIFR0_OCF0A_MASK },
-	{ ATMEGA644_INT_T0OVF,   AVR8_REGIDX_TIMSK0, AVR8_TIMSK0_TOIE0_MASK,  AVR8_REGIDX_TIFR0,   AVR8_TIFR0_TOV0_MASK },
-	{ ATMEGA644_INT_T1CAPT,  AVR8_REGIDX_TIMSK1, AVR8_TIMSK1_ICIE1_MASK,  AVR8_REGIDX_TIFR1,   AVR8_TIFR1_ICF1_MASK },
-	{ ATMEGA644_INT_T1COMPB, AVR8_REGIDX_TIMSK1, AVR8_TIMSK1_OCIE1B_MASK, AVR8_REGIDX_TIFR1,   AVR8_TIFR1_OCF1B_MASK },
-	{ ATMEGA644_INT_T1COMPA, AVR8_REGIDX_TIMSK1, AVR8_TIMSK1_OCIE1A_MASK, AVR8_REGIDX_TIFR1,   AVR8_TIFR1_OCF1A_MASK },
-	{ ATMEGA644_INT_T1OVF,   AVR8_REGIDX_TIMSK1, AVR8_TIMSK1_TOIE1_MASK,  AVR8_REGIDX_TIFR1,   AVR8_TIFR1_TOV1_MASK },
-	{ ATMEGA644_INT_T2COMPB, AVR8_REGIDX_TIMSK2, AVR8_TIMSK2_OCIE2B_MASK, AVR8_REGIDX_TIFR2,   AVR8_TIFR2_OCF2B_MASK },
-	{ ATMEGA644_INT_T2COMPA, AVR8_REGIDX_TIMSK2, AVR8_TIMSK2_OCIE2A_MASK, AVR8_REGIDX_TIFR2,   AVR8_TIFR2_OCF2A_MASK },
-	{ ATMEGA644_INT_T2OVF,   AVR8_REGIDX_TIMSK2, AVR8_TIMSK2_TOIE2_MASK,  AVR8_REGIDX_TIFR2,   AVR8_TIFR2_TOV2_MASK }
+	{ ATMEGA644_INT_SPI_STC, SPCR,   AVR8_SPCR_SPIE_MASK,     SPSR,    AVR8_SPSR_SPIF_MASK },
+	{ ATMEGA644_INT_T0COMPB, TIMSK0, AVR8_TIMSK0_OCIE0B_MASK, TIFR0,   AVR8_TIFR0_OCF0B_MASK },
+	{ ATMEGA644_INT_T0COMPA, TIMSK0, AVR8_TIMSK0_OCIE0A_MASK, TIFR0,   AVR8_TIFR0_OCF0A_MASK },
+	{ ATMEGA644_INT_T0OVF,   TIMSK0, AVR8_TIMSK0_TOIE0_MASK,  TIFR0,   AVR8_TIFR0_TOV0_MASK },
+	{ ATMEGA644_INT_T1CAPT,  TIMSK1, AVR8_TIMSK1_ICIE1_MASK,  TIFR1,   AVR8_TIFR1_ICF1_MASK },
+	{ ATMEGA644_INT_T1COMPB, TIMSK1, AVR8_TIMSK1_OCIE1B_MASK, TIFR1,   AVR8_TIFR1_OCF1B_MASK },
+	{ ATMEGA644_INT_T1COMPA, TIMSK1, AVR8_TIMSK1_OCIE1A_MASK, TIFR1,   AVR8_TIFR1_OCF1A_MASK },
+	{ ATMEGA644_INT_T1OVF,   TIMSK1, AVR8_TIMSK1_TOIE1_MASK,  TIFR1,   AVR8_TIFR1_TOV1_MASK },
+	{ ATMEGA644_INT_T2COMPB, TIMSK2, AVR8_TIMSK2_OCIE2B_MASK, TIFR2,   AVR8_TIFR2_OCF2B_MASK },
+	{ ATMEGA644_INT_T2COMPA, TIMSK2, AVR8_TIMSK2_OCIE2A_MASK, TIFR2,   AVR8_TIFR2_OCF2A_MASK },
+	{ ATMEGA644_INT_T2OVF,   TIMSK2, AVR8_TIMSK2_TOIE2_MASK,  TIFR2,   AVR8_TIFR2_TOV2_MASK }
 };
 
 void atmega644_device::update_interrupt(int source)
@@ -1217,6 +1473,7 @@ void atmega644_device::update_interrupt(int source)
 	if (m_r[condition.m_intreg] & condition.m_intmask)
 		intstate = (m_r[condition.m_regindex] & condition.m_regmask) ? 1 : 0;
 
+	if (intstate) logerror("interrupt %d is 1\n", source);
 	set_irq_line(condition.m_intindex << 1, intstate);
 
 	if (intstate)
@@ -1234,6 +1491,7 @@ void atmega1280_device::update_interrupt(int source)
 	if (m_r[condition.m_intreg] & condition.m_intmask)
 		intstate = (m_r[condition.m_regindex] & condition.m_regmask) ? 1 : 0;
 
+	if (intstate) logerror("interrupt %d is 1\n", source);
 	set_irq_line(condition.m_intindex << 1, intstate);
 
 	if (intstate)
@@ -1251,6 +1509,7 @@ void atmega2560_device::update_interrupt(int source)
 	if (m_r[condition.m_intreg] & condition.m_intmask)
 		intstate = (m_r[condition.m_regindex] & condition.m_regmask) ? 1 : 0;
 
+	if (intstate) logerror("interrupt %d is 1\n", source);
 	set_irq_line(condition.m_intindex << 1, intstate);
 
 	if (intstate)
@@ -1263,419 +1522,488 @@ void atmega2560_device::update_interrupt(int source)
 //**************************************************************************
 //  REGISTER HANDLING
 //**************************************************************************
-void avr8_device::timer_tick()
-{
-	for (int count = 0; count < m_opcycles; count++)
-	{
-		if (m_spi_active && m_spi_prescale > 0 && m_spi_prescale_countdown >= 0)
-		{
-			m_spi_prescale_count++;
-			if (m_spi_prescale_count >= m_spi_prescale)
-			{
-				uint8_t out_bit = (m_r[AVR8_REGIDX_SPDR] & (1 << m_spi_prescale_countdown)) >> m_spi_prescale_countdown;
-				m_spi_prescale_countdown--;
-				write_gpio(AVR8_IO_PORTB, (m_r[AVR8_REGIDX_PORTB] &~ AVR8_PORTB_MOSI) | (out_bit ? AVR8_PORTB_MOSI : 0));
-				m_r[AVR8_REGIDX_PORTB] = (m_r[AVR8_REGIDX_PORTB] &~ AVR8_PORTB_MOSI) | (out_bit ? AVR8_PORTB_MOSI : 0);
-				m_spi_prescale_count -= m_spi_prescale;
-			}
-		}
 
-		for (int t = 0; t < m_num_timers; t++)
-		{
-			if (m_timer_prescale[t] != 0)
-			{
-				m_timer_prescale_count[t]++;
-				if (m_timer_prescale_count[t] >= m_timer_prescale[t])
-				{
-					switch (t)
-					{
-					case 0: timer0_tick(); break;
-					case 1: timer1_tick(); break;
-					case 2: timer2_tick(); break;
-					case 3: timer3_tick(); break;
-					case 4: timer4_tick(); break;
-					case 5: timer5_tick(); break;
-					}
-					m_timer_prescale_count[t] -= m_timer_prescale[t];
-				}
-			}
-		}
-	}
+template <int NumTimers>
+void avr8_device<NumTimers>::spi_tick()
+{
+	const uint8_t out_bit = (m_r[SPDR] & (1 << m_spi_prescale_countdown)) >> m_spi_prescale_countdown;
+	m_spi_prescale_countdown--;
+	const uint8_t data = (m_r[PORTB] &~ AVR8_PORTB_MOSI) | (out_bit ? AVR8_PORTB_MOSI : 0);
+	m_r[PORTB] = data;
+	m_gpio_out_cb[GPIOB](data);
+	m_r[PORTB] = (m_r[PORTB] &~ AVR8_PORTB_MOSI) | (out_bit ? AVR8_PORTB_MOSI : 0);
 }
 
 // Timer 0 Handling
-void avr8_device::timer0_tick()
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timer0_tick_norm()
+{
+	LOGMASKED(LOG_TIMER0, "%s: WGM02_NORMAL: Unimplemented timer#0 waveform generation mode\n", machine().describe_context());
+	m_r[TCNT0]++;
+	m_timer_prescale_count[0] -= m_timer_prescale[0];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timer0_tick_pwm_pc()
+{
+	LOGMASKED(LOG_TIMER0, "%s: WGM02_PWM_PC: Unimplemented timer#0 waveform generation mode\n", machine().describe_context());
+	m_r[TCNT0]++;
+	m_timer_prescale_count[0] -= m_timer_prescale[0];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timer0_tick_ctc_norm()
 {
 	static const uint8_t s_ocf0[2] = { (1 << AVR8_TIFR0_OCF0A_SHIFT), (1 << AVR8_TIFR0_OCF0B_SHIFT) };
 	static const uint8_t s_int0[2] = { AVR8_INTIDX_OCF0A, AVR8_INTIDX_OCF0B };
 
-	LOGMASKED(LOG_TIMER0_TICK, "%s: AVR8_WGM0: %d\n", machine().describe_context(), AVR8_WGM0);
-	LOGMASKED(LOG_TIMER0_TICK, "%s: AVR8_TCCR0A_COM0B: %d\n", machine().describe_context(), AVR8_TCCR0A_COM0B);
-
-	uint8_t count = m_r[AVR8_REGIDX_TCNT0];
-	count++;
-
-	switch (AVR8_WGM0)
+	if (m_r[TCNT0] == AVR8_OCR0A - 1)
 	{
-	case WGM02_NORMAL:
-		LOGMASKED(LOG_TIMER0, "%s: WGM02_NORMAL: Unimplemented timer#0 waveform generation mode\n", machine().describe_context());
-		break;
-
-	case WGM02_PWM_PC:
-		LOGMASKED(LOG_TIMER0, "%s: WGM02_PWM_PC: Unimplemented timer0 waveform generation mode\n", machine().describe_context());
-		break;
-
-	case WGM02_CTC_CMP:
-		switch (AVR8_TCCR0A_COM0B)
-		{
-		case 0: /* Normal Operation */
-			if (count == AVR8_OCR0A)
-			{
-				m_r[AVR8_REGIDX_TIFR0] |= s_ocf0[AVR8_REG_A];
-				update_interrupt(s_int0[AVR8_REG_A]);
-				count = 0;
-			}
-			else if (count == AVR8_OCR0B)
-			{
-				m_r[AVR8_REGIDX_TIFR0] |= s_ocf0[AVR8_REG_B];
-				update_interrupt(s_int0[AVR8_REG_B]);
-			}
-			break;
-
-		case 1: /* Toggle OC0B on compare match */
-			if (count == m_timer_top[0])
-			{
-				m_timer_top[0] = 0;
-				LOGMASKED(LOG_TIMER0, "%s: timer0: Toggle OC0B on match\n", machine().describe_context());
-				write_gpio(AVR8_IO_PORTG, m_r[AVR8_REGIDX_PORTG] ^ (1 << 5));
-			}
-			break;
-
-		case 2: /* Clear OC0B on compare match */
-			if (count == m_timer_top[0])
-			{
-				m_timer_top[0] = 0;
-				LOGMASKED(LOG_TIMER0, "[0] timer0: Clear OC0B on match\n", machine().describe_context());
-				write_gpio(AVR8_IO_PORTG, m_r[AVR8_REGIDX_PORTG] & ~(1 << 5));
-			}
-			break;
-
-		case 3: /* Set OC0B on compare match */
-			if (count == m_timer_top[0])
-			{
-				m_timer_top[0] = 0;
-				LOGMASKED(LOG_TIMER0, "%s: timer0: Set OC0B on match\n", machine().describe_context());
-				write_gpio(AVR8_IO_PORTG, m_r[AVR8_REGIDX_PORTG] | (1 << 5));
-			}
-			break;
-		}
-		break;
-
-	case WGM02_FAST_PWM:
-		LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: WGM02_FAST_PWM: Unimplemented timer0 waveform generation mode\n", machine().describe_context());
-		break;
-
-	case WGM02_PWM_PC_CMP:
-		LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: WGM02_PWM_PC_CMP: Unimplemented timer0 waveform generation mode\n", machine().describe_context());
-		break;
-
-	case WGM02_FAST_PWM_CMP:
-		LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: WGM02_FAST_PWM_CMP: Unimplemented timer0 waveform generation mode\n", machine().describe_context());
-		break;
-
-	default:
-		LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: update_timer0_compare_mode: Unknown waveform generation mode: %02x\n", machine().describe_context(), AVR8_WGM0);
-		break;
+		m_r[TIFR0] |= s_ocf0[AVR8_REG_A];
+		update_interrupt(s_int0[AVR8_REG_A]);
+		m_r[TCNT0] = 0;
 	}
-
-	m_r[AVR8_REGIDX_TCNT0] = count;
+	else if (m_r[TCNT0] == AVR8_OCR0B - 1)
+	{
+		m_r[TIFR0] |= s_ocf0[AVR8_REG_B];
+		update_interrupt(s_int0[AVR8_REG_B]);
+		m_r[TCNT0]++;
+	}
+	else
+	{
+		m_r[TCNT0]++;
+	}
+	m_timer_prescale_count[0] -= m_timer_prescale[0];
 }
 
-void avr8_device::changed_tccr0a(uint8_t data)
+template <int NumTimers>
+void avr8_device<NumTimers>::timer0_tick_ctc_toggle()
 {
-	uint8_t oldtccr = AVR8_TCCR0A;
-	uint8_t newtccr = data;
-	uint8_t changed = newtccr ^ oldtccr;
-
-	AVR8_TCCR0A = data;
-
-	if (changed & AVR8_TCCR0A_WGM0_10_MASK)
+	if (m_r[TCNT0] == m_timer_top[0] - 1)
 	{
-		update_timer_waveform_gen_mode(0, AVR8_WGM0);
+		m_timer_top[0] = 0;
+		LOGMASKED(LOG_TIMER0, "%s: timer0: Toggle OC0B on match\n", machine().describe_context());
+		m_r[PORTG] ^= (1 << 5);
+		m_gpio_out_cb[PORTG](m_r[PORTG]);
 	}
+	m_r[TCNT0]++;
+	m_timer_prescale_count[0] -= m_timer_prescale[0];
 }
 
-void avr8_device::timer0_force_output_compare(int reg)
+template <int NumTimers>
+void avr8_device<NumTimers>::timer0_tick_ctc_clear()
+{
+	if (m_r[TCNT0] == m_timer_top[0])
+	{
+		m_timer_top[0] = 0;
+		LOGMASKED(LOG_TIMER0, "[0] timer0: Clear OC0B on match\n", machine().describe_context());
+		m_r[PORTG] &= ~(1 << 5);
+		m_gpio_out_cb[PORTG](m_r[PORTG]);
+	}
+	m_r[TCNT0]++;
+	m_timer_prescale_count[0] -= m_timer_prescale[0];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timer0_tick_ctc_set()
+{
+	if (m_r[TCNT0] == m_timer_top[0])
+	{
+		m_timer_top[0] = 0;
+		LOGMASKED(LOG_TIMER0, "%s: timer0: Set OC0B on match\n", machine().describe_context());
+		m_r[PORTG] |= (1 << 5);
+		m_gpio_out_cb[PORTG](m_r[PORTG]);
+	}
+	m_r[TCNT0]++;
+	m_timer_prescale_count[0] -= m_timer_prescale[0];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timer0_tick_fast_pwm()
+{
+	LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: WGM02_FAST_PWM: Unimplemented timer0 waveform generation mode\n", machine().describe_context());
+	m_r[TCNT0]++;
+	m_timer_prescale_count[0] -= m_timer_prescale[0];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timer0_tick_pwm_pc_cmp()
+{
+	LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: WGM02_PWM_PC_CMP: Unimplemented timer0 waveform generation mode\n", machine().describe_context());
+	m_r[TCNT0]++;
+	m_timer_prescale_count[0] -= m_timer_prescale[0];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timer0_tick_fast_pwm_cmp()
+{
+	LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: WGM02_FAST_PWM_CMP: Unimplemented timer0 waveform generation mode\n", machine().describe_context());
+	m_r[TCNT0]++;
+	m_timer_prescale_count[0] -= m_timer_prescale[0];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timer0_tick_default()
+{
+	LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: timer0_tick_default: Unknown waveform generation mode: %02x\n", machine().describe_context(), AVR8_WGM0);
+	m_r[TCNT0]++;
+	m_timer_prescale_count[0] -= m_timer_prescale[0];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timer0_force_output_compare(int reg)
 {
 	LOGMASKED(LOG_TIMER0 | LOG_UNKNOWN, "%s: timer0_force_output_compare: TODO; should be forcing OC0%c\n", machine().describe_context(), avr8_reg_name[reg]);
+	m_timer_prescale_count[0] -= m_timer_prescale[0];
 }
 
-void avr8_device::changed_tccr0b(uint8_t data)
+template <int NumTimers>
+void avr8_device<NumTimers>::update_ocr0(uint8_t newval, uint8_t reg)
 {
-	LOGMASKED(LOG_TIMER0, "%s: changed_tccr0b: data = 0x%02X\n", machine().describe_context(), data);
-
-	uint8_t oldtccr = AVR8_TCCR0B;
-	uint8_t newtccr = data;
-	uint8_t changed = newtccr ^ oldtccr;
-
-	AVR8_TCCR0B = data;
-
-	if (changed & AVR8_TCCR0B_FOC0A_MASK)
-	{
-		// TODO
-		timer0_force_output_compare(AVR8_REG_A);
-	}
-
-	if (changed & AVR8_TCCR0B_FOC0B_MASK)
-	{
-		// TODO
-		timer0_force_output_compare(AVR8_REG_B);
-	}
-
-	if (changed & AVR8_TCCR0B_WGM0_2_MASK)
-	{
-		update_timer_waveform_gen_mode(0, AVR8_WGM0);
-	}
-
-	if (changed & AVR8_TCCR0B_CS_MASK)
-	{
-		update_timer_clock_source(0, AVR8_TIMER0_CLOCK_SELECT);
-	}
-}
-
-void avr8_device::update_ocr0(uint8_t newval, uint8_t reg)
-{
-	m_r[(reg == AVR8_REG_A) ? AVR8_REGIDX_OCR0A : AVR8_REGIDX_OCR0B] = newval;
+	m_r[(reg == AVR8_REG_A) ? OCR0A : OCR0B] = newval;
 }
 
 // Timer 1 Handling
 
-inline void avr8_device::timer1_tick()
+template <int NumTimers>
+template <int TimerMode, int ChannelModeA, int ChannelModeB>
+inline void avr8_device<NumTimers>::timer1_tick()
 {
-	/* TODO: Handle comparison, setting OC1A pin, detection of BOTTOM and TOP */
-
 	static const uint8_t s_ocf1[2] = { (1 << AVR8_TIFR1_OCF1A_SHIFT), (1 << AVR8_TIFR1_OCF1B_SHIFT) };
 	static const uint8_t s_int1[2] = { AVR8_INTIDX_OCF1A, AVR8_INTIDX_OCF1B };
 	const uint16_t icr1 = AVR8_ICR1;
-	int32_t increment = m_timer_increment[1];
+	uint16_t timer1_count = (m_r[TCNT1H] << 8) | m_r[TCNT1L];
+	int32_t increment = 1;
 
-	for (int32_t reg = AVR8_REG_A; reg <= AVR8_REG_B; reg++)
+	switch (TimerMode)
 	{
-		switch (m_wgm1)
+	case WGM1_CTC_OCR:
+		if (timer1_count == 0xffff)
 		{
-		case WGM1_CTC_OCR:
-			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1_count: %04x\n", machine().describe_context(), m_timer1_count);
-			LOGMASKED(LOG_TIMER1_TICK, "%s: OCR1%c: %04x\n", machine().describe_context(), reg ? 'A' : 'B', m_ocr1[reg]);
-			if (m_timer1_count == 0xffff)
-			{
-				m_r[AVR8_REGIDX_TIFR1] |= AVR8_TIFR1_TOV1_MASK;
-				update_interrupt(AVR8_INTIDX_TOV1);
-				m_timer1_count = 0;
-				increment = 0;
-			}
-
-			if (m_timer1_count == m_ocr1[reg])
-			{
-				if (reg == AVR8_REG_A)
-				{
-					m_timer1_count = 0;
-					increment = 0;
-				}
-
-				switch (m_timer1_compare_mode[reg] & 3)
-				{
-				case 0: /* Normal Operation; OC1A/B disconnected */
-					break;
-
-				case 1: /* Toggle OC1A on compare match */
-					if (reg == AVR8_REG_A)
-					{
-						LOGMASKED(LOG_TIMER1, "%s: timer1: Toggle OC1%c on match\n", machine().describe_context());
-						write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] ^ 2);
-					}
-					break;
-
-				case 2: /* Clear OC1A/B on compare match */
-					LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1%c on match\n", machine().describe_context(), reg ? 'B' : 'A');
-					write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] & ~(2 << reg));
-					break;
-
-				case 3: /* Set OC1A/B on compare match */
-					LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1%c on match\n", machine().describe_context(), reg ? 'B' : 'A');
-					write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] | (2 << reg));
-					break;
-				}
-
-				m_r[AVR8_REGIDX_TIFR1] |= s_ocf1[reg];
-				update_interrupt(s_int1[reg]);
-			}
-			else if (m_timer1_count == 0)
-			{
-				if (reg == AVR8_REG_A)
-				{
-					m_r[AVR8_REGIDX_TIFR1] &= ~AVR8_TIFR1_TOV1_MASK;
-					update_interrupt(AVR8_INTIDX_TOV1);
-				}
-			}
-			break;
-
-		case WGM1_FAST_PWM_OCR:
-			if (m_timer1_count == m_ocr1[reg])
-			{
-				if (reg == AVR8_REG_A)
-				{
-					m_r[AVR8_REGIDX_TIFR1] |= AVR8_TIFR1_TOV1_MASK;
-					update_interrupt(AVR8_INTIDX_TOV1);
-					m_timer1_count = 0;
-					increment = 0;
-				}
-
-				switch (m_timer1_compare_mode[reg] & 3)
-				{
-				case 0: /* Normal Operation; OC1A/B disconnected */
-					break;
-
-				case 1: /* Toggle OC1A on compare match */
-					if (reg == AVR8_REG_A)
-					{
-						LOGMASKED(LOG_TIMER1, "%s: timer1: Toggle OC1%c on match\n", machine().describe_context());
-						write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] ^ 2);
-					}
-					break;
-
-				case 2: /* Clear OC1A/B on compare match */
-					LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1%c on match\n", machine().describe_context(), reg ? 'B' : 'A');
-					write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] & ~(2 << reg));
-					break;
-
-				case 3: /* Set OC1A/B on compare match */
-					LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1%c on match\n", machine().describe_context(), reg ? 'B' : 'A');
-					write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] | (2 << reg));
-					break;
-				}
-
-				m_r[AVR8_REGIDX_TIFR1] |= s_ocf1[reg];
-				update_interrupt(s_int1[reg]);
-			}
-			else if (m_timer1_count == 0)
-			{
-				if (reg == AVR8_REG_A)
-				{
-					m_r[AVR8_REGIDX_TIFR1] &= ~AVR8_TIFR1_TOV1_MASK;
-					update_interrupt(AVR8_INTIDX_TOV1);
-				}
-
-				switch (m_timer1_compare_mode[reg] & 3)
-				{
-				case 0: /* Normal Operation; OC1A/B disconnected */
-					break;
-
-				case 1: /* Toggle OC1A at BOTTOM*/
-					if (reg == AVR8_REG_A)
-					{
-						LOGMASKED(LOG_TIMER1, "%s: timer1: Toggle OC1A at BOTTOM\n", machine().describe_context());
-						write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] ^ 2);
-					}
-					break;
-
-				case 2: /* Set OC1A/B at BOTTOM*/
-					LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1%c at BOTTOM\n", machine().describe_context(), reg ? 'B' : 'A');
-					write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] | (2 << reg));
-					break;
-
-				case 3: /* Clear OC1A/B at BOTTOM */
-					LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1%c at BOTTOM\n", machine().describe_context(), reg ? 'B' : 'A');
-					write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] & ~(2 << reg));
-					break;
-				}
-			}
-			break;
-
-		case WGM1_FAST_PWM_ICR:
-			if (m_timer1_count == m_ocr1[reg])
-			{
-				switch (m_timer1_compare_mode[reg] & 3)
-				{
-				case 0: /* Normal Operation; OC1A/B disconnected */
-					break;
-
-				case 1: /* Toggle OC1A on compare match */
-					if (reg == AVR8_REG_A)
-					{
-						LOGMASKED(LOG_TIMER1, "%s: timer1: Toggle OC1%c on match\n", machine().describe_context());
-						write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] ^ 2);
-					}
-					break;
-
-				case 2: /* Clear OC1A/B on compare match */
-					LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1%c on match\n", machine().describe_context(), reg ? 'B' : 'A');
-					write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] & ~(2 << reg));
-					break;
-
-				case 3: /* Set OC1A/B on compare match */
-					LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1%c on match\n", machine().describe_context(), reg ? 'B' : 'A');
-					write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] | (2 << reg));
-					break;
-				}
-
-				m_r[AVR8_REGIDX_TIFR1] |= s_ocf1[reg];
-				update_interrupt(s_int1[reg]);
-			}
-			else if (m_timer1_count == 0)
-			{
-				if (reg == AVR8_REG_A)
-				{
-					m_r[AVR8_REGIDX_TIFR1] &= ~AVR8_TIFR1_TOV1_MASK;
-					update_interrupt(AVR8_INTIDX_TOV1);
-				}
-
-				switch (m_timer1_compare_mode[reg] & 3)
-				{
-				case 0: /* Normal Operation; OC1A/B disconnected */
-					break;
-
-				case 1: /* Toggle OC1A at BOTTOM*/
-					if (reg == AVR8_REG_A)
-					{
-						LOGMASKED(LOG_TIMER1, "%s: timer1: Toggle OC1A at BOTTOM\n", machine().describe_context());
-						write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] ^ 2);
-					}
-					break;
-
-				case 2: /* Set OC1A/B at BOTTOM*/
-					LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1%c at BOTTOM\n", machine().describe_context(), reg ? 'B' : 'A');
-					write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] | (2 << reg));
-					break;
-
-				case 3: /* Clear OC1A/B at BOTTOM */
-					LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1%c at BOTTOM\n", machine().describe_context(), reg ? 'B' : 'A');
-					write_gpio(AVR8_IO_PORTB, m_r[AVR8_REGIDX_PORTB] & ~(2 << reg));
-					break;
-				}
-			}
-
-			if (m_timer1_count == icr1 && reg == 1)
-			{
-				m_r[AVR8_REGIDX_TIFR1] |= AVR8_TIFR1_TOV1_MASK;
-				update_interrupt(AVR8_INTIDX_TOV1);
-				m_timer1_count = 0;
-				increment = 0;
-			}
-			break;
-
-		default:
-			LOGMASKED(LOG_TIMER1 | LOG_UNKNOWN, "%s: timer1_tick: Unknown waveform generation mode: %02x\n", machine().describe_context(), m_wgm1);
-			break;
+			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 CTC_OCR, TOP, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
+			m_r[TIFR1] |= AVR8_TIFR1_TOV1_MASK;
+			update_interrupt(AVR8_INTIDX_TOV1);
+			timer1_count = 0;
+			increment = 0;
 		}
+
+		if (timer1_count == m_ocr1[AVR8_REG_A])
+		{
+			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 CTC_OCR, OCR1A, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
+			timer1_count = 0;
+			increment = 0;
+
+			switch (ChannelModeA)
+			{
+			case 0: /* Normal Operation; OC1A/B disconnected */
+				break;
+
+			case 1: /* Toggle OC1A on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Toggle OC1A on match\n", machine().describe_context());
+				m_r[PORTB] ^= 2;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 2: /* Clear OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1A on match\n", machine().describe_context());
+				m_r[PORTB] &= ~(2 << AVR8_REG_A);
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 3: /* Set OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1A on match\n", machine().describe_context());
+				m_r[PORTB] |= 2 << AVR8_REG_A;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+			}
+
+			m_r[TIFR1] |= s_ocf1[AVR8_REG_A];
+			update_interrupt(s_int1[AVR8_REG_A]);
+		}
+		else if (timer1_count == 0)
+		{
+			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 CTC_OCR, BOTTOM, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
+			m_r[TIFR1] &= ~AVR8_TIFR1_TOV1_MASK;
+			update_interrupt(AVR8_INTIDX_TOV1);
+		}
+
+		if (timer1_count == m_ocr1[AVR8_REG_B])
+		{
+			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 CTC_OCR, OCR1B, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
+			switch (ChannelModeB)
+			{
+			case 0: /* Normal Operation; OC1A/B disconnected */
+			case 1: /* Toggle OC1A on compare match */
+				break;
+
+			case 2: /* Clear OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1B on match\n", machine().describe_context());
+				m_r[PORTB] &= ~(2 << AVR8_REG_B);
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 3: /* Set OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1B on match\n", machine().describe_context());
+				m_r[PORTB] |= 2 << AVR8_REG_B;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+			}
+
+			m_r[TIFR1] |= s_ocf1[AVR8_REG_B];
+			update_interrupt(s_int1[AVR8_REG_B]);
+		}
+		break;
+
+	case WGM1_FAST_PWM_OCR:
+		if (timer1_count == m_ocr1[AVR8_REG_A])
+		{
+			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 FAST_PWM_OCR, OCR1A, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
+			m_r[TIFR1] |= AVR8_TIFR1_TOV1_MASK;
+			update_interrupt(AVR8_INTIDX_TOV1);
+			timer1_count = 0;
+			increment = 0;
+
+			switch (ChannelModeA)
+			{
+			case 0: /* Normal Operation; OC1A/B disconnected */
+				break;
+
+			case 1: /* Toggle OC1A on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Toggle OC1A on match\n", machine().describe_context());
+				m_r[PORTB] ^= 2;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 2: /* Clear OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1A on match\n", machine().describe_context());
+				m_r[PORTB] &= ~(2 << AVR8_REG_A);
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 3: /* Set OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1A on match\n", machine().describe_context());
+				m_r[PORTB] |= 2 << AVR8_REG_A;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+			}
+
+			m_r[TIFR1] |= s_ocf1[AVR8_REG_A];
+			update_interrupt(s_int1[AVR8_REG_A]);
+		}
+		else if (timer1_count == 0)
+		{
+			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 FAST_PWM_OCR, BOTTOM A, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
+			m_r[TIFR1] &= ~AVR8_TIFR1_TOV1_MASK;
+			update_interrupt(AVR8_INTIDX_TOV1);
+
+			switch (ChannelModeA)
+			{
+			case 0: /* Normal Operation; OC1A/B disconnected */
+				break;
+
+			case 1: /* Toggle OC1A at BOTTOM*/
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Toggle OC1A at BOTTOM\n", machine().describe_context());
+				m_r[PORTB] ^= 2;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 2: /* Set OC1A/B at BOTTOM*/
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1A at BOTTOM\n", machine().describe_context());
+				m_r[PORTB] |= 2 << AVR8_REG_A;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 3: /* Clear OC1A/B at BOTTOM */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1A at BOTTOM\n", machine().describe_context());
+				m_r[PORTB] &= ~(2 << AVR8_REG_A);
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+			}
+		}
+
+		if (timer1_count == m_ocr1[AVR8_REG_B])
+		{
+			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 FAST_PWM_OCR, OCR1B, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
+			switch (ChannelModeB)
+			{
+			case 0: /* Normal Operation; OC1A/B disconnected */
+			case 1: /* Toggle OC1A on compare match */
+				break;
+
+			case 2: /* Clear OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1B on match\n", machine().describe_context());
+				m_r[PORTB] &= ~(2 << AVR8_REG_B);
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 3: /* Set OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1B on match\n", machine().describe_context());
+				m_r[PORTB] |= 2 << AVR8_REG_B;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+			}
+
+			m_r[TIFR1] |= s_ocf1[AVR8_REG_B];
+			update_interrupt(s_int1[AVR8_REG_B]);
+		}
+		else if (timer1_count == 0)
+		{
+			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 FAST_PWM_OCR, BOTTOM B, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
+			switch (ChannelModeB)
+			{
+			case 0: /* Normal Operation; OC1A/B disconnected */
+			case 1: /* Toggle OC1A at BOTTOM*/
+				break;
+
+			case 2: /* Set OC1A/B at BOTTOM*/
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1B at BOTTOM\n", machine().describe_context());
+				m_r[PORTB] |= 2 << AVR8_REG_B;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 3: /* Clear OC1A/B at BOTTOM */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1B at BOTTOM\n", machine().describe_context());
+				m_r[PORTB] &= ~(2 << AVR8_REG_B);
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+			}
+		}
+		break;
+
+	case WGM1_FAST_PWM_ICR:
+		if (timer1_count == m_ocr1[AVR8_REG_A])
+		{
+			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 FAST_PWM_ICR, OCR1A, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
+			switch (ChannelModeA)
+			{
+			case 0: /* Normal Operation; OC1A/B disconnected */
+				break;
+
+			case 1: /* Toggle OC1A on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Toggle OC1A on match\n", machine().describe_context());
+				m_r[PORTB] ^= 2;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 2: /* Clear OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1A on match\n", machine().describe_context());
+				m_r[PORTB] &= ~(2 << AVR8_REG_A);
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 3: /* Set OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1A on match\n", machine().describe_context());
+				m_r[PORTB] |= 2 << AVR8_REG_A;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+			}
+
+			m_r[TIFR1] |= s_ocf1[AVR8_REG_A];
+			update_interrupt(s_int1[AVR8_REG_A]);
+		}
+		else if (timer1_count == 0)
+		{
+			LOGMASKED(LOG_TIMER1_TICK, "%s: timer1 WGM1 FAST_PWM_ICR, BOTTOM A, new count %04x, OCR1A/B %04x/%04x, ICR1 %04x\n", machine().describe_context(), timer1_count, m_ocr1[AVR8_REG_A], m_ocr1[AVR8_REG_B], icr1);
+			m_r[TIFR1] &= ~AVR8_TIFR1_TOV1_MASK;
+			update_interrupt(AVR8_INTIDX_TOV1);
+
+			switch (ChannelModeA)
+			{
+			case 0: /* Normal Operation; OC1A/B disconnected */
+				break;
+
+			case 1: /* Toggle OC1A at BOTTOM*/
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Toggle OC1A at BOTTOM\n", machine().describe_context());
+				m_r[PORTB] ^= 2;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 2: /* Set OC1A/B at BOTTOM*/
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1A at BOTTOM\n", machine().describe_context());
+				m_r[PORTB] |= 2 << AVR8_REG_A;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 3: /* Clear OC1A/B at BOTTOM */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1A at BOTTOM\n", machine().describe_context());
+				m_r[PORTB] &= ~(2 << AVR8_REG_A);
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+			}
+		}
+
+		if (timer1_count == m_ocr1[AVR8_REG_B])
+		{
+			switch (ChannelModeB)
+			{
+			case 0: /* Normal Operation; OC1A/B disconnected */
+			case 1: /* Toggle OC1A on compare match */
+				break;
+
+			case 2: /* Clear OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1B on match\n", machine().describe_context());
+				m_r[PORTB] &= ~(2 << AVR8_REG_B);
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 3: /* Set OC1A/B on compare match */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1B on match\n", machine().describe_context());
+				m_r[PORTB] |= 2 << AVR8_REG_B;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+			}
+
+			m_r[TIFR1] |= s_ocf1[AVR8_REG_B];
+			update_interrupt(s_int1[AVR8_REG_B]);
+		}
+		else if (timer1_count == 0)
+		{
+			switch (ChannelModeB)
+			{
+			case 0: /* Normal Operation; OC1A/B disconnected */
+			case 1: /* Toggle OC1A at BOTTOM*/
+				break;
+
+			case 2: /* Set OC1A/B at BOTTOM*/
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Set OC1B at BOTTOM\n", machine().describe_context());
+				m_r[PORTB] |= 2 << AVR8_REG_B;
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+
+			case 3: /* Clear OC1A/B at BOTTOM */
+				LOGMASKED(LOG_TIMER1, "%s: timer1: Clear OC1B at BOTTOM\n", machine().describe_context());
+				m_r[PORTB] &= ~(2 << AVR8_REG_B);
+				m_gpio_out_cb[GPIOB](m_r[PORTB]);
+				break;
+			}
+		}
+
+		if (timer1_count == icr1)
+		{
+			m_r[TIFR1] |= AVR8_TIFR1_TOV1_MASK;
+			update_interrupt(AVR8_INTIDX_TOV1);
+			timer1_count = 0;
+			increment = 0;
+		}
+		break;
+
+	default:
+		LOGMASKED(LOG_TIMER1 | LOG_UNKNOWN, "%s: timer1_tick: Unknown waveform generation mode: %02x\n", machine().describe_context(), m_wgm1);
+		break;
 	}
 
-	m_timer1_count += increment;
+	timer1_count += increment;
+	m_timer_prescale_count[1] -= m_timer_prescale[1];
+
+	m_r[TCNT1H] = timer1_count >> 8;
+	m_r[TCNT1L] = (uint8_t)timer1_count;
 }
 
-void avr8_device::update_timer_waveform_gen_mode(uint8_t t, uint8_t mode)
+template <int NumTimers>
+void avr8_device<NumTimers>::update_timer_waveform_gen_mode(uint8_t t, uint8_t mode)
 {
 	int32_t oc_val = -1, ic_val = -1;
-
 	switch (t)
 	{
 	case 0:
@@ -1733,7 +2061,7 @@ void avr8_device::update_timer_waveform_gen_mode(uint8_t t, uint8_t mode)
 
 	if (t == 1)
 	{
-		m_wgm1 = ((m_r[AVR8_REGIDX_TCCR1B] & AVR8_TCCR1B_WGM1_32_MASK) >> 1) | (m_r[AVR8_REGIDX_TCCR1A] & AVR8_TCCR1A_WGM1_10_MASK);
+		m_wgm1 = ((m_r[TCCR1B] & AVR8_TCCR1B_WGM1_32_MASK) >> 1) | (m_r[TCCR1A] & AVR8_TCCR1A_WGM1_10_MASK);
 	}
 	if (m_timer_top[t] == -1)
 	{
@@ -1742,68 +2070,23 @@ void avr8_device::update_timer_waveform_gen_mode(uint8_t t, uint8_t mode)
 	}
 }
 
-void avr8_device::changed_tccr1a(uint8_t data)
-{
-	uint8_t oldtccr = AVR8_TCCR1A;
-	uint8_t newtccr = data;
-	uint8_t changed = newtccr ^ oldtccr;
-
-	m_r[AVR8_REGIDX_TCCR1A] = newtccr;
-
-	if (changed & AVR8_TCCR1A_WGM1_10_MASK)
-	{
-		update_timer_waveform_gen_mode(1, AVR8_WGM1);
-	}
-
-	m_timer1_compare_mode[AVR8_REG_A] = (m_r[AVR8_REGIDX_TCCR1A] & AVR8_TCCR1A_COM1A_MASK) >> AVR8_TCCR1A_COM1A_SHIFT;
-	m_timer1_compare_mode[AVR8_REG_B] = (m_r[AVR8_REGIDX_TCCR1A] & AVR8_TCCR1A_COM1B_MASK) >> AVR8_TCCR1A_COM1B_SHIFT;
-}
-
-void avr8_device::update_timer1_input_noise_canceler()
+template <int NumTimers>
+void avr8_device<NumTimers>::update_timer1_input_noise_canceler()
 {
 	LOGMASKED(LOG_TIMER1 | LOG_UNKNOWN, "%s: update_timer1_input_noise_canceler: TODO\n", machine().describe_context());
 }
 
-void avr8_device::update_timer1_input_edge_select()
+template <int NumTimers>
+void avr8_device<NumTimers>::update_timer1_input_edge_select()
 {
 	LOGMASKED(LOG_TIMER1 | LOG_UNKNOWN, "%s: update_timer1_input_edge_select: TODO\n", machine().describe_context());
 }
 
-void avr8_device::changed_tccr1b(uint8_t data)
+template <int NumTimers>
+void avr8_device<NumTimers>::update_ocr1(uint16_t newval, uint8_t reg)
 {
-	LOGMASKED(LOG_TIMER1, "%s: changed_tccr1b: data = 0x%02X\n", machine().describe_context(), data);
-
-	uint8_t oldtccr = AVR8_TCCR1B;
-	uint8_t newtccr = data;
-	uint8_t changed = newtccr ^ oldtccr;
-
-	m_r[AVR8_REGIDX_TCCR1B] = newtccr;
-
-	if (changed & AVR8_TCCR1B_ICNC1_MASK)
-	{
-		update_timer1_input_noise_canceler();
-	}
-
-	if (changed & AVR8_TCCR1B_ICES1_MASK)
-	{
-		update_timer1_input_edge_select();
-	}
-
-	if (changed & AVR8_TCCR1B_WGM1_32_MASK)
-	{
-		update_timer_waveform_gen_mode(1, AVR8_WGM1);
-	}
-
-	if (changed & AVR8_TCCR1B_CS_MASK)
-	{
-		update_timer_clock_source(1, AVR8_TIMER1_CLOCK_SELECT);
-	}
-}
-
-void avr8_device::update_ocr1(uint16_t newval, uint8_t reg)
-{
-	static const int32_t s_high_indices[3] = { AVR8_REGIDX_OCR1AH, AVR8_REGIDX_OCR1BH, AVR8_REGIDX_OCR1CH };
-	static const int32_t s_low_indices[3] =  { AVR8_REGIDX_OCR1AL, AVR8_REGIDX_OCR1BL, AVR8_REGIDX_OCR1CL };
+	static const int32_t s_high_indices[3] = { OCR1AH, OCR1BH, OCR1CH };
+	static const int32_t s_low_indices[3] =  { OCR1AL, OCR1BL, OCR1CL };
 	m_r[s_high_indices[reg]] = (uint8_t)(newval >> 8);
 	m_r[s_low_indices[reg]]  = (uint8_t)newval;
 	m_ocr1[reg] = newval;
@@ -1811,142 +2094,98 @@ void avr8_device::update_ocr1(uint16_t newval, uint8_t reg)
 
 // Timer 2 Handling
 
-void avr8_device::timer2_tick()
+template <int NumTimers>
+void avr8_device<NumTimers>::timer2_tick_default()
 {
-	uint16_t count = m_r[AVR8_REGIDX_TCNT2];
-	int32_t wgm2 = ((m_r[AVR8_REGIDX_TCCR2B] & AVR8_TCCR2B_WGM2_2_MASK) >> 1) |
-					(m_r[AVR8_REGIDX_TCCR2A] & AVR8_TCCR2A_WGM2_10_MASK);
+	LOGMASKED(LOG_TIMER2, "%s: WGM02_PWM_PC: Unimplemented timer#2 waveform generation mode %d\n", machine().describe_context(), AVR8_WGM2);
+	m_r[TCNT2]++;
+	m_timer_prescale_count[2] -= m_timer_prescale[2];
+}
 
-	// Cache things in array form to avoid a compare+branch inside a potentially high-frequency timer
-	//uint8_t compare_mode[2] = { (m_r[AVR8_REGIDX_TCCR2A] & AVR8_TCCR2A_COM2A_MASK) >> AVR8_TCCR2A_COM2A_SHIFT,
-								//(m_r[AVR8_REGIDX_TCCR2A] & AVR8_TCCR2A_COM2B_MASK) >> AVR8_TCCR2A_COM2B_SHIFT };
-	uint8_t ocr2[2] = { m_r[AVR8_REGIDX_OCR2A], m_r[AVR8_REGIDX_OCR2B] };
-	uint8_t ocf2[2] = { (1 << AVR8_TIFR2_OCF2A_SHIFT), (1 << AVR8_TIFR2_OCF2B_SHIFT) };
-	int32_t increment = m_timer_increment[2];
-
-	for (int32_t reg = AVR8_REG_A; reg <= AVR8_REG_B; reg++)
+template <int NumTimers>
+void avr8_device<NumTimers>::timer2_tick_norm()
+{
+	LOGMASKED(LOG_TIMER2, "%s: timer2_tick_norm; WGM02_NORMAL\n", machine().describe_context());
+	if (m_r[TCNT2] == 0xff)
 	{
-		switch (wgm2)
+		m_r[TIFR2] |= AVR8_TIFR2_TOV2_MASK;
+	}
+	m_r[TCNT2]++;
+	update_interrupt(AVR8_INTIDX_TOV2);
+	m_timer_prescale_count[2] -= m_timer_prescale[2];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timer2_tick_fast_pwm()
+{
+	if (m_r[TCNT2] >= m_r[OCR2A])
+	{
+		if (m_r[TCNT2] >= 0xff)
 		{
-		case WGM02_NORMAL:
-			if (count == 0xff)
+			// Turn on
+			m_r[PORTD] |= 1 << 7;
+			m_gpio_out_cb[GPIOD](m_r[PORTD]);
+			m_r[TCNT2] = 0;
+			m_ocr2_not_reached_yet = true;
+		}
+		else
+		{
+			if (m_ocr2_not_reached_yet)
 			{
-				m_r[AVR8_REGIDX_TIFR2] |= AVR8_TIFR2_TOV2_MASK;
+				// Turn off
+				m_r[PORTD] |= 1 << 7;
+				m_gpio_out_cb[GPIOD](m_r[PORTD]);
+				m_ocr2_not_reached_yet = false;
 			}
-			break;
-
-		case WGM02_FAST_PWM:
-			if (reg == AVR8_REG_A)
-			{
-				if (count >= m_r[AVR8_REGIDX_OCR2A])
-				{
-					if (count >= 0xff)
-					{
-						// Turn on
-						write_gpio(AVR8_IO_PORTD, m_r[AVR8_REGIDX_PORTD] | (1 << 7));
-						m_r[AVR8_REGIDX_TCNT2] = 0;
-						m_ocr2_not_reached_yet = true;
-					}
-					else
-					{
-						if (m_ocr2_not_reached_yet)
-						{
-							// Turn off
-							write_gpio(AVR8_IO_PORTD, m_r[AVR8_REGIDX_PORTD] & ~(1 << 7));
-							m_ocr2_not_reached_yet = false;
-						}
-					}
-				}
-			}
-			break;
-
-		case WGM02_FAST_PWM_CMP:
-			if (count == ocr2[reg])
-			{
-				if (reg == AVR8_REG_A)
-				{
-					m_r[AVR8_REGIDX_TIFR2] |= AVR8_TIFR2_TOV2_MASK;
-					count = 0;
-					increment = 0;
-				}
-
-				m_r[AVR8_REGIDX_TIFR2] |= ocf2[reg];
-			}
-			else if (count == 0)
-			{
-				if (reg == AVR8_REG_A)
-				{
-					m_r[AVR8_REGIDX_TIFR2] &= ~AVR8_TIFR2_TOV2_MASK;
-				}
-			}
-			break;
-
-		default:
-			LOGMASKED(LOG_TIMER2 | LOG_UNKNOWN, "%s: timer2_tick: Unknown waveform generation mode: %02x\n", machine().describe_context(), wgm2);
-			break;
 		}
 	}
 
-	m_r[AVR8_REGIDX_TCNT2] += increment;
-
-	update_interrupt(AVR8_INTIDX_OCF2A);
-	update_interrupt(AVR8_INTIDX_OCF2B);
-	update_interrupt(AVR8_INTIDX_TOV2);
+	m_r[TCNT2]++;
+	m_timer_prescale_count[2] -= m_timer_prescale[2];
 }
 
-void avr8_device::changed_tccr2a(uint8_t data)
+template <int NumTimers>
+void avr8_device<NumTimers>::timer2_tick_fast_pwm_cmp()
 {
-	uint8_t oldtccr = AVR8_TCCR2A;
-	uint8_t newtccr = data;
-	uint8_t changed = newtccr ^ oldtccr;
+	const uint8_t ocf2[2] = { (1 << AVR8_TIFR2_OCF2A_SHIFT), (1 << AVR8_TIFR2_OCF2B_SHIFT) };
+	uint16_t count = m_r[TCNT2];
 
-	AVR8_TCCR2A = data;
+	int32_t increment = 1;
 
-	if (changed & AVR8_TCCR2A_WGM2_10_MASK)
+	if (count == m_r[OCR2A])
 	{
-		update_timer_waveform_gen_mode(2, AVR8_WGM2);
+		m_r[TIFR2] |= AVR8_TIFR2_TOV2_MASK;
+		count = 0;
+		increment = 0;
+		m_r[TIFR2] |= ocf2[AVR8_REG_A];
 	}
+	else if (count == 0)
+	{
+		m_r[TIFR2] &= ~AVR8_TIFR2_TOV2_MASK;
+	}
+
+	if (count == m_r[OCR2B])
+	{
+		m_r[TIFR2] |= ocf2[AVR8_REG_B];
+	}
+
+	count += increment;
+
+	update_interrupt(AVR8_INTIDX_TOV2);
+	m_r[TCNT2] = count;
+	m_timer_prescale_count[2] -= m_timer_prescale[2];
 }
 
-void avr8_device::timer2_force_output_compare(int reg)
+template <int NumTimers>
+void avr8_device<NumTimers>::timer2_force_output_compare(int reg)
 {
 	LOGMASKED(LOG_TIMER2 | LOG_UNKNOWN, "%s: force_output_compare: TODO; should be forcing OC2%c\n", machine().describe_context(), avr8_reg_name[reg]);
 }
 
-void avr8_device::changed_tccr2b(uint8_t data)
+template <int NumTimers>
+void avr8_device<NumTimers>::update_ocr2(uint8_t newval, uint8_t reg)
 {
-	LOGMASKED(LOG_TIMER2, "%s: changed_tccr2b: data = 0x%02X\n", machine().describe_context(), data);
-
-	uint8_t oldtccr = AVR8_TCCR2B;
-	uint8_t newtccr = data;
-	uint8_t changed = newtccr ^ oldtccr;
-
-	AVR8_TCCR2B = data;
-
-	if (changed & AVR8_TCCR2B_FOC2A_MASK)
-	{
-		timer2_force_output_compare(AVR8_REG_A);
-	}
-
-	if (changed & AVR8_TCCR2B_FOC2B_MASK)
-	{
-		timer2_force_output_compare(AVR8_REG_B);
-	}
-
-	if (changed & AVR8_TCCR2B_WGM2_2_MASK)
-	{
-		update_timer_waveform_gen_mode(2, AVR8_WGM2);
-	}
-
-	if (changed & AVR8_TCCR2B_CS_MASK)
-	{
-		update_timer_clock_source(2, AVR8_TIMER2_CLOCK_SELECT);
-	}
-}
-
-void avr8_device::update_ocr2(uint8_t newval, uint8_t reg)
-{
-	m_r[(reg == AVR8_REG_A) ? AVR8_REGIDX_OCR2A : AVR8_REGIDX_OCR2B] = newval;
+	m_r[(reg == AVR8_REG_A) ? OCR2A : OCR2B] = newval;
 
 	// Nothing needs to be done? All handled in timer callback
 }
@@ -1954,28 +2193,30 @@ void avr8_device::update_ocr2(uint8_t newval, uint8_t reg)
 /************************************************************************************************/
 
 // Timer 3 Handling
-void avr8_device::timer3_tick()
+template <int NumTimers>
+void avr8_device<NumTimers>::timer3_tick()
 {
 }
 
 /************************************************************************************************/
 
-void avr8_device::timer4_tick()
+template <int NumTimers>
+void avr8_device<NumTimers>::timer4_tick()
 {
 	/* TODO: Handle comparison, setting OC1x pins, detection of BOTTOM and TOP */
 	LOGMASKED(LOG_TIMER4_TICK, "%s: AVR8_WGM4: %d\n", machine().describe_context(), AVR8_WGM4);
 	LOGMASKED(LOG_TIMER4_TICK, "%s: AVR8_TCCR4A_COM4B: %d\n", machine().describe_context(), AVR8_TCCR4A_COM4B);
 
-	uint16_t count = (m_r[AVR8_REGIDX_TCNT4H] << 8) | m_r[AVR8_REGIDX_TCNT4L];
+	uint16_t count = (m_r[TCNT4H] << 8) | m_r[TCNT4L];
 
 	// Cache things in array form to avoid a compare+branch inside a potentially high-frequency timer
-	// uint8_t compare_mode[2] = { (m_r[AVR8_REGIDX_TCCR1A] & AVR8_TCCR1A_COM1A_MASK) >> AVR8_TCCR1A_COM1A_SHIFT,
-	//                             (m_r[AVR8_REGIDX_TCCR1A] & AVR8_TCCR1A_COM1B_MASK) >> AVR8_TCCR1A_COM1B_SHIFT };
-	// uint16_t ocr4[2] = { static_cast<uint16_t>((m_r[AVR8_REGIDX_OCR4AH] << 8) | m_r[AVR8_REGIDX_OCR4AL]),
-							// static_cast<uint16_t>((m_r[AVR8_REGIDX_OCR4BH] << 8) | m_r[AVR8_REGIDX_OCR4BL]) };
+	// uint8_t compare_mode[2] = { (m_r[TCCR1A] & AVR8_TCCR1A_COM1A_MASK) >> AVR8_TCCR1A_COM1A_SHIFT,
+	//                             (m_r[TCCR1A] & AVR8_TCCR1A_COM1B_MASK) >> AVR8_TCCR1A_COM1B_SHIFT };
+	// uint16_t ocr4[2] = { static_cast<uint16_t>((m_r[OCR4AH] << 8) | m_r[OCR4AL]),
+							// static_cast<uint16_t>((m_r[OCR4BH] << 8) | m_r[OCR4BL]) };
 	// TODO  uint8_t ocf4[2] = { (1 << AVR8_TIFR4_OCF4A_SHIFT), (1 << AVR8_TIFR4_OCF4B_SHIFT) };
 	// TODO  uint8_t int4[2] = { AVR8_INTIDX_OCF4A, AVR8_INTIDX_OCF4B };
-	int32_t increment = m_timer_increment[4];
+	int32_t increment = 1;
 
 	switch (AVR8_WGM4)
 	{
@@ -1993,13 +2234,15 @@ void avr8_device::timer4_tick()
 			{
 				// Clear OC0B
 				LOGMASKED(LOG_TIMER4, "%s: timer4: non-inverting mode, Clear OC0B\n", machine().describe_context());
-				write_gpio(AVR8_IO_PORTG, m_r[AVR8_REGIDX_PORTG] & ~(1 << 5));
+				m_r[PORTG] &= ~(1 << 5);
+				m_gpio_out_cb[GPIOG](m_r[PORTG]);
 			}
 			else if (count == 0)
 			{
 				// Set OC0B
 				LOGMASKED(LOG_TIMER4, "%s: timer4: non-inverting mode, Set OC0B\n", machine().describe_context());
-				write_gpio(AVR8_IO_PORTG, m_r[AVR8_REGIDX_PORTG] | (1 << 5));
+				m_r[PORTG] |= 1 << 5;
+				m_gpio_out_cb[GPIOG](m_r[PORTG]);
 			}
 			break;
 		case 3: /* Inverting mode */
@@ -2007,13 +2250,15 @@ void avr8_device::timer4_tick()
 			{
 				// Set OC0B
 				LOGMASKED(LOG_TIMER4, "%s: timer4: inverting mode, Clear OC0B\n", machine().describe_context());
-				write_gpio(AVR8_IO_PORTG, m_r[AVR8_REGIDX_PORTG] | (1 << 5));
+				m_r[PORTG] |= 1 << 5;
+				m_gpio_out_cb[GPIOG](m_r[PORTG]);
 			}
 			else if (count == 0)
 			{
 				// Clear OC0B
 				LOGMASKED(LOG_TIMER4, "%s: timer4: inverting mode, Set OC0B\n", machine().describe_context());
-				write_gpio(AVR8_IO_PORTG, m_r[AVR8_REGIDX_PORTG] & ~(1 << 5));
+				m_r[PORTG] &= ~(1 << 5);
+				m_gpio_out_cb[GPIOG](m_r[PORTG]);
 			}
 			break;
 		}
@@ -2023,7 +2268,7 @@ void avr8_device::timer4_tick()
 		LOGMASKED(LOG_TIMER4, "%s: timer4: tick WGM4_CTC_OCR: %d\n", machine().describe_context(), count);
 		if (count == 0xffff)
 		{
-			m_r[AVR8_REGIDX_TIFR4] |= AVR8_TIFR4_TOV4_MASK;
+			m_r[TIFR4] |= AVR8_TIFR4_TOV4_MASK;
 			update_interrupt(AVR8_INTIDX_TOV4);
 			count = 0;
 			increment = 0;
@@ -2042,120 +2287,49 @@ void avr8_device::timer4_tick()
 	}
 
 	count += increment;
-	m_r[AVR8_REGIDX_TCNT4H] = (count >> 8) & 0xff;
-	m_r[AVR8_REGIDX_TCNT4L] = count & 0xff;
+	m_r[TCNT4H] = (count >> 8) & 0xff;
+	m_r[TCNT4L] = count & 0xff;
 }
 
-void avr8_device::update_timer_clock_source(uint8_t t, uint8_t clock_select)
+template <int NumTimers>
+template <int Timer>
+void avr8_device<NumTimers>::update_timer_clock_source(uint8_t clock_select, const uint8_t old_clock_select)
 {
-	static const int s_prescale_values[2][8] =
+	static const int32_t s_prescale_values[2][8] =
 	{
-		{ 0, 1, 8, 64, 256, 1024, -1, -1 }, // T0/T1/T3/T4/T5
-		{ 0, 1, 8, 32, 64, 128, 256, 1024 } // T2
+		{ 0x0000ffff, 1, 8, 64, 256, 1024, -1, -1 }, // T0/T1/T3/T4/T5
+		{ 0x0000ffff, 1, 8, 32, 64, 128, 256, 1024 } // T2
 	};
-	m_timer_prescale[t] = s_prescale_values[(t == 2) ? 1 : 0][clock_select];
+	const int32_t prescale_divisor = s_prescale_values[(Timer == 2) ? 1 : 0][clock_select];
+	const uint16_t old_prescale = s_prescale_values[(Timer == 2) ? 1 : 0][old_clock_select];
+	m_timer_prescale[Timer] = (uint16_t)prescale_divisor;
 
-	LOGMASKED((LOG_TIMER0 + t), "%s: update_timer_clock_source: t = %d, cs = %d\n", machine().describe_context(), t, clock_select);
+	LOGMASKED(LOG_TIMER0 + Timer, "%s: update_timer_clock_source: t = %d, cs = %d\n", machine().describe_context(), Timer, clock_select);
 
-	if (m_timer_prescale[t] == 0xffff)
+	if (prescale_divisor == -1)
 	{
-		LOGMASKED((LOG_TIMER0 + t), "%s: timer%d: update_timer_clock_source: External trigger mode not implemented yet\n", machine().describe_context(), t);
-		m_timer_prescale[t] = 0;
+		LOGMASKED(LOG_TIMER0 + Timer, "%s: timer%d: update_timer_clock_source: External trigger mode not implemented yet\n", machine().describe_context(), Timer);
+		m_timer_prescale[Timer] = 0xffff;
 	}
 
-	if (m_timer_prescale_count[t] > m_timer_prescale[t])
+	if (old_prescale == 0xffff || m_timer_prescale_count[Timer] > m_timer_prescale[Timer])
 	{
-		m_timer_prescale_count[t] = m_timer_prescale[t] - 1;
+		m_timer_prescale_count[Timer] = m_timer_prescale[Timer];
 	}
-}
-
-void avr8_device::changed_tccr3a(uint8_t data)
-{
-	// TODO
-	//  AVR8_TCCR3A = data;
-}
-
-void avr8_device::changed_tccr3b(uint8_t data)
-{
-	LOGMASKED(LOG_TIMER3 | LOG_UNKNOWN, "%s: (not yet implemented) changed_tccr3b: data = %02X\n", machine().describe_context(), data);
-}
-
-void avr8_device::changed_tccr3c(uint8_t data)
-{
-	//  uint8_t oldtccr = AVR8_TCCR3C;
-	//  uint8_t newtccr = data;
-	//  uint8_t changed = newtccr ^ oldtccr;
-	LOGMASKED(LOG_TIMER3 | LOG_UNKNOWN, "%s: (not yet implemented) changed_tccr3c: data = %02X\n", machine().describe_context(), data);
-
-	//  AVR8_TCCR3C = data;
-}
-
-void avr8_device::changed_tccr4a(uint8_t data)
-{
-	uint8_t oldtccr = AVR8_TCCR4A;
-	uint8_t newtccr = data;
-	uint8_t changed = newtccr ^ oldtccr;
-
-	AVR8_TCCR4A = data;
-
-	if (changed & AVR8_TCCR4A_WGM4_10_MASK)
-	{
-		update_timer_waveform_gen_mode(4, AVR8_WGM4);
-	}
-}
-
-void avr8_device::changed_tccr4b(uint8_t data)
-{
-	LOGMASKED(LOG_TIMER4, "%s: changed_tccr4b: data = %02X\n", machine().describe_context(), data);
-
-	uint8_t oldtccr = AVR8_TCCR4B;
-	uint8_t newtccr = data;
-	uint8_t changed = newtccr ^ oldtccr;
-
-	AVR8_TCCR4B = data;
-
-	if (changed & AVR8_TCCR4B_FOC4A_MASK)
-	{
-		// TODO
-		// timer4_force_output_compare(AVR8_REG_A);
-	}
-
-	if (changed & AVR8_TCCR4B_FOC4B_MASK)
-	{
-		// TODO
-		// timer4_force_output_compare(AVR8_REG_B);
-	}
-
-	if (changed & AVR8_TCCR4B_WGM4_32_MASK)
-	{
-		update_timer_waveform_gen_mode(4, AVR8_WGM4);
-	}
-
-	if (changed & AVR8_TCCR4B_CS_MASK)
-	{
-		update_timer_clock_source(4, AVR8_TIMER4_CLOCK_SELECT);
-	}
-}
-
-void avr8_device::changed_tccr4c(uint8_t data)
-{
-	//  uint8_t oldtccr = AVR8_TCCR4C;
-	//  uint8_t newtccr = data;
-	//  uint8_t changed = newtccr ^ oldtccr;
-
-	AVR8_TCCR4C = data;
 }
 
 /************************************************************************************************/
 
 // Timer 5 Handling
-void avr8_device::timer5_tick()
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timer5_tick()
 {
 	LOGMASKED(LOG_TIMER5_TICK, "%s: AVR8_WGM5: %d\n", machine().describe_context(), AVR8_WGM5);
 	LOGMASKED(LOG_TIMER5_TICK, "%s: AVR8_TCCR5A_COM5B: %d\n", machine().describe_context(), AVR8_TCCR5A_COM5B);
 
 	uint16_t count = (AVR8_TCNT5H << 8) + AVR8_TCNT5L;
-	int32_t increment = m_timer_increment[5];
+	int32_t increment = 1;
 
 	switch (AVR8_WGM5)
 	{
@@ -2192,7 +2366,8 @@ void avr8_device::timer5_tick()
 			{
 				m_timer_top[5] = 0;
 				LOGMASKED(LOG_TIMER5, "%s: timer5: Toggle OC5B on compare match\n", machine().describe_context());
-				write_gpio(AVR8_IO_PORTL, m_r[AVR8_REGIDX_PORTL] ^ (1 << 4));
+				m_r[PORTL] ^= 1 << 4;
+				m_gpio_out_cb[PORTL](m_r[PORTL]);
 			}
 			break;
 		case 2: /* Clear OC5B on compare match */
@@ -2201,7 +2376,8 @@ void avr8_device::timer5_tick()
 				m_timer_top[5] = 0;
 				// Clear OC5B
 				LOGMASKED(LOG_TIMER5, "%s: timer5: Clear OC5B on compare match\n", machine().describe_context());
-				write_gpio(AVR8_IO_PORTL, m_r[AVR8_REGIDX_PORTL] & ~(1 << 4));
+				m_r[PORTL] &= ~(1 << 4);
+				m_gpio_out_cb[PORTL](m_r[PORTL]);
 			}
 			break;
 		case 3: /* Set OC5B on compare match */
@@ -2209,7 +2385,8 @@ void avr8_device::timer5_tick()
 			{
 				m_timer_top[5] = 0;
 				LOGMASKED(LOG_TIMER5, "%s: timer5: Set OC5B on compare match\n", machine().describe_context());
-				write_gpio(AVR8_IO_PORTL, m_r[AVR8_REGIDX_PORTL] | (1 << 4));
+				m_r[PORTL] |= 1 << 4;
+				m_gpio_out_cb[PORTL](m_r[PORTL]);
 			}
 			break;
 		}
@@ -2221,61 +2398,8 @@ void avr8_device::timer5_tick()
 	}
 
 	count += increment;
-	m_r[AVR8_REGIDX_TCNT5H] = (count >> 8) & 0xff;
-	m_r[AVR8_REGIDX_TCNT5L] = count & 0xff;
-}
-
-void avr8_device::changed_tccr5a(uint8_t data)
-{
-	uint8_t oldtccr = AVR8_TCCR5A;
-	uint8_t newtccr = data;
-	uint8_t changed = newtccr ^ oldtccr;
-
-	AVR8_TCCR5A = data;
-
-	if (changed & AVR8_TCCR5A_WGM5_10_MASK)
-	{
-		update_timer_waveform_gen_mode(5, AVR8_WGM5);
-	}
-}
-
-void avr8_device::changed_tccr5b(uint8_t data)
-{
-	LOGMASKED(LOG_TIMER5, "%s: changed_tccr5b: data = %02X\n", machine().describe_context(), data);
-
-	uint8_t oldtccr = AVR8_TCCR5B;
-	uint8_t newtccr = data;
-	uint8_t changed = newtccr ^ oldtccr;
-
-	AVR8_TCCR5B = data;
-
-	if (changed & AVR8_TCCR5C_FOC5A_MASK)
-	{
-		// TODO
-		// timer5_force_output_compare(AVR8_REG_A);
-	}
-
-	if (changed & AVR8_TCCR5C_FOC5B_MASK)
-	{
-		// TODO
-		// timer5_force_output_compare(AVR8_REG_B);
-	}
-
-	if (changed & AVR8_TCCR5C_FOC5C_MASK)
-	{
-		// TODO
-		// timer5_force_output_compare(AVR8_REG_C);
-	}
-
-	if (changed & AVR8_TCCR5B_WGM5_32_MASK)
-	{
-		update_timer_waveform_gen_mode(5, AVR8_WGM5);
-	}
-
-	if (changed & AVR8_TCCR5B_CS_MASK)
-	{
-		update_timer_clock_source(5, AVR8_TIMER5_CLOCK_SELECT);
-	}
+	m_r[TCNT5H] = (count >> 8) & 0xff;
+	m_r[TCNT5L] = count & 0xff;
 }
 
 /************************************************************************************************/
@@ -2285,7 +2409,8 @@ void avr8_device::changed_tccr5b(uint8_t data)
 /* ADC Handling */
 /****************/
 
-void avr8_device::adc_start_conversion()
+template <int NumTimers>
+void avr8_device<NumTimers>::adc_start_conversion()
 {
 	// set capture in progress flag
 	AVR8_ADCSRA |= AVR8_ADCSRA_ADSC_MASK;
@@ -2318,7 +2443,8 @@ void avr8_device::adc_start_conversion()
 	m_adc_timer->adjust(attotime::from_ticks((m_adc_first ? 25 : 13) * scale, clock()));
 }
 
-TIMER_CALLBACK_MEMBER(avr8_device::adc_conversion_complete)
+template <int NumTimers>
+TIMER_CALLBACK_MEMBER(avr8_device<NumTimers>::adc_conversion_complete)
 {
 	// set conversion result
 	m_adc_result = m_adc_sample;
@@ -2334,80 +2460,44 @@ TIMER_CALLBACK_MEMBER(avr8_device::adc_conversion_complete)
 		adc_start_conversion();
 }
 
-void avr8_device::change_adcsra(uint8_t data)
-{
-	// set auto trigger enable, interrupt enable, and prescaler directly
-	AVR8_ADCSRA = (AVR8_ADCSRA & ~(AVR8_ADCSRA_ADATE_MASK | AVR8_ADCSRA_ADIE_MASK | AVR8_ADCSRA_ADPS_MASK)) | (data & (AVR8_ADCSRA_ADATE_MASK | AVR8_ADCSRA_ADIE_MASK | AVR8_ADCSRA_ADPS_MASK));
-
-	// check enable bit
-	if (!(data & AVR8_ADCSRA_ADEN_MASK))
-	{
-		// disable ADC, terminate any conversion in progress
-		AVR8_ADCSRA &= ~(AVR8_ADCSRA_ADEN_MASK | AVR8_ADCSRA_ADSC_MASK);
-		m_adc_timer->reset();
-	}
-	else
-	{
-		// first conversion after initial enable takes longer
-		if (!AVR8_ADCSRA_ADEN)
-		{
-			m_adc_first = true;
-			AVR8_ADCSRA |= AVR8_ADCSRA_ADEN_MASK;
-		}
-
-		// trigger conversion if necessary
-		if (!AVR8_ADCSRA_ADSC && (data & AVR8_ADCSRA_ADSC_MASK))
-			adc_start_conversion();
-	}
-
-	// writing with ADIF set clears the interrupt flag manually
-	if (data & AVR8_ADCSRA_ADIF_MASK)
-		AVR8_ADCSRA &= ~AVR8_ADCSRA_ADIF_MASK;
-
-	if (AVR8_ADCSRA_ADIE)
-		logerror("%s: Unimplemented ADC interrupt enabled\n");
-}
-
-void avr8_device::change_adcsrb(uint8_t data)
-{
-	AVR8_ADCSRB = data & (AVR8_ADCSRB_ACME_MASK | AVR8_ADCSRB_ADTS_MASK);
-	if (AVR8_ADCSRB_ADTS != 0x00)
-		logerror("%s: Unimplemented ADC auto trigger source %X selected\n", machine().describe_context(), AVR8_ADCSRB_ADTS);
-}
-
 /************************************************************************************************/
-
 
 /****************/
 /* SPI Handling */
 /****************/
 
-void avr8_device::enable_spi()
+template <int NumTimers>
+void avr8_device<NumTimers>::enable_spi()
 {
 	// TODO
 }
 
-void avr8_device::disable_spi()
+template <int NumTimers>
+void avr8_device<NumTimers>::disable_spi()
 {
 	// TODO
 }
 
-void avr8_device::spi_update_masterslave_select()
+template <int NumTimers>
+void avr8_device<NumTimers>::spi_update_masterslave_select()
 {
 	// TODO
 }
 
-void avr8_device::spi_update_clock_polarity()
+template <int NumTimers>
+void avr8_device<NumTimers>::spi_update_clock_polarity()
 {
 	// TODO
 }
 
-void avr8_device::spi_update_clock_phase()
+template <int NumTimers>
+void avr8_device<NumTimers>::spi_update_clock_phase()
 {
 	// TODO
 }
 
-void avr8_device::spi_update_clock_rate()
+template <int NumTimers>
+void avr8_device<NumTimers>::spi_update_clock_rate()
 {
 	static const uint8_t s_spi_clock_divisor[8] =
 	{
@@ -2417,7 +2507,8 @@ void avr8_device::spi_update_clock_rate()
 	m_spi_prescale_count &= m_spi_prescale - 1;
 }
 
-void avr8_device::change_spcr(uint8_t data)
+template <int NumTimers>
+void avr8_device<NumTimers>::change_spcr(uint8_t data)
 {
 	uint8_t oldspcr = AVR8_SPCR;
 	uint8_t newspcr = data;
@@ -2463,7 +2554,8 @@ void avr8_device::change_spcr(uint8_t data)
 	}
 }
 
-void avr8_device::change_spsr(uint8_t data)
+template <int NumTimers>
+void avr8_device<NumTimers>::change_spsr(uint8_t data)
 {
 	uint8_t oldspsr = AVR8_SPSR;
 	uint8_t newspsr = data;
@@ -2480,846 +2572,981 @@ void avr8_device::change_spsr(uint8_t data)
 
 /*****************************************************************************/
 
-void avr8_device::write_gpio(const uint8_t port, const uint8_t data)
+template <int NumTimers>
+template <int Port>
+uint8_t avr8_device<NumTimers>::gpio_r()
 {
-	static const uint16_t s_port_to_reg[11] =
+	static constexpr uint16_t PORT_TO_REG[11] =
 	{
-		AVR8_REGIDX_PORTA,
-		AVR8_REGIDX_PORTB,
-		AVR8_REGIDX_PORTC,
-		AVR8_REGIDX_PORTD,
-		AVR8_REGIDX_PORTE,
-		AVR8_REGIDX_PORTF,
-		AVR8_REGIDX_PORTG,
-		AVR8_REGIDX_PORTH,
-		AVR8_REGIDX_PORTJ,
-		AVR8_REGIDX_PORTK,
-		AVR8_REGIDX_PORTL
+		PORTA,
+		PORTB,
+		PORTC,
+		PORTD,
+		PORTE,
+		PORTF,
+		PORTG,
+		PORTH,
+		PORTJ,
+		PORTK,
+		PORTL
+	};
+	static constexpr char PORT_CHARS[GPIO_COUNT] = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L' };
+	LOGMASKED(LOG_GPIO, "%s: Huh%c(%d) Read: %02x\n", machine().describe_context(), PORT_CHARS[Port], Port, m_r[PORT_TO_REG[Port]]);
+	return m_r[PORT_TO_REG[Port]];
+}
+
+template <int NumTimers>
+template <int Port>
+uint8_t avr8_device<NumTimers>::pin_r()
+{
+	static constexpr char PORT_CHARS[GPIO_COUNT] = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L' };
+	// TODO: account for DDRH
+	const uint8_t data = m_gpio_in_cb[Port]();
+	LOGMASKED(LOG_GPIO, "%s: PIN%c(%d) Read: %02x\n", machine().describe_context(), PORT_CHARS[Port], Port, data);
+	return data;
+}
+
+template <int NumTimers>
+template <int Port>
+void avr8_device<NumTimers>::port_w(uint8_t data)
+{
+	static constexpr char PORT_CHARS[GPIO_COUNT] = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L' };
+	static constexpr uint16_t PORT_TO_REG[11] =
+	{
+		PORTA,
+		PORTB,
+		PORTC,
+		PORTD,
+		PORTE,
+		PORTF,
+		PORTG,
+		PORTH,
+		PORTJ,
+		PORTK,
+		PORTL
 	};
 
-	m_r[s_port_to_reg[port]] = data;
-	m_gpio_out_cb[port](data);
+	LOGMASKED(LOG_GPIO, "%s: PORT%c Write: %02x\n", machine().describe_context(), PORT_CHARS[Port], data);
+	m_r[PORT_TO_REG[Port]] = data;
+	LOGMASKED(LOG_GPIO, "%s: PORT%c Write, XYZ m_r[%d[%d]] = %02x\n", machine().describe_context(), PORT_CHARS[Port], PORT_TO_REG[Port], Port, data);
+	m_gpio_out_cb[Port](data);
 }
 
-uint8_t avr8_device::read_gpio(const uint8_t port)
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr0a_w(uint8_t data)
 {
-	return m_gpio_in_cb[port]();
-}
+	LOGMASKED(LOG_TIMER0, "%s: TCCR0A = %02x\n", machine().describe_context(), data);
+	const uint8_t oldtccr = m_r[TCCR0A];
+	const uint8_t newtccr = data;
+	const uint8_t changed = newtccr ^ oldtccr;
+	m_r[TCCR0A] = data;
 
-/*****************************************************************************/
-
-void avr8_device::regs_w(offs_t offset, uint8_t data)
-{
-	switch (offset)
+	if (changed & AVR8_TCCR0A_WGM0_10_MASK)
 	{
-	case AVR8_REGIDX_R0:
-	case AVR8_REGIDX_R1:
-	case AVR8_REGIDX_R2:
-	case AVR8_REGIDX_R3:
-	case AVR8_REGIDX_R4:
-	case AVR8_REGIDX_R5:
-	case AVR8_REGIDX_R6:
-	case AVR8_REGIDX_R7:
-	case AVR8_REGIDX_R8:
-	case AVR8_REGIDX_R9:
-	case AVR8_REGIDX_R10:
-	case AVR8_REGIDX_R11:
-	case AVR8_REGIDX_R12:
-	case AVR8_REGIDX_R13:
-	case AVR8_REGIDX_R14:
-	case AVR8_REGIDX_R15:
-	case AVR8_REGIDX_R16:
-	case AVR8_REGIDX_R17:
-	case AVR8_REGIDX_R18:
-	case AVR8_REGIDX_R19:
-	case AVR8_REGIDX_R20:
-	case AVR8_REGIDX_R21:
-	case AVR8_REGIDX_R22:
-	case AVR8_REGIDX_R23:
-	case AVR8_REGIDX_R24:
-	case AVR8_REGIDX_R25:
-	case AVR8_REGIDX_R26:
-	case AVR8_REGIDX_R27:
-	case AVR8_REGIDX_R28:
-	case AVR8_REGIDX_R29:
-	case AVR8_REGIDX_R30:
-	case AVR8_REGIDX_R31:
-		m_r[offset] = data;
-		break;
-
-	case AVR8_REGIDX_PORTA:
-		LOGMASKED(LOG_GPIO, "%s: PORTA Write: %02x\n", machine().describe_context(), data);
-		write_gpio(AVR8_IO_PORTA, data);
-		break;
-
-	case AVR8_REGIDX_PORTB:
-		LOGMASKED(LOG_GPIO, "%s: PORTB Write: %02x\n", machine().describe_context(), data);
-		write_gpio(AVR8_IO_PORTB, data);
-		break;
-
-	case AVR8_REGIDX_PORTC:
-		LOGMASKED(LOG_GPIO, "%s: PORTC Write: %02x\n", machine().describe_context(), data);
-		write_gpio(AVR8_IO_PORTC, data);
-		break;
-
-	case AVR8_REGIDX_PORTD:
-		LOGMASKED(LOG_GPIO, "%s: PORTD Write: %02x\n", machine().describe_context(), data);
-		write_gpio(AVR8_IO_PORTD, data);
-		break;
-
-	case AVR8_REGIDX_PORTE:
-		LOGMASKED(LOG_GPIO, "%s: PORTE Write: %02x\n", machine().describe_context(), data);
-		write_gpio(AVR8_IO_PORTE, data);
-		break;
-
-	case AVR8_REGIDX_PORTF:
-		LOGMASKED(LOG_GPIO, "%s: PORTF Write: %02x\n", machine().describe_context(), data);
-		write_gpio(AVR8_IO_PORTF, data);
-		break;
-
-	case AVR8_REGIDX_PORTG:
-		LOGMASKED(LOG_GPIO, "%s: PORTG Write: %02x\n", machine().describe_context(), data);
-		write_gpio(AVR8_IO_PORTG, data);
-		break;
-
-	case AVR8_REGIDX_PORTH:
-		LOGMASKED(LOG_GPIO, "%s: PORTH Write: %02x\n", machine().describe_context(), data);
-		write_gpio(AVR8_IO_PORTH, data);
-		break;
-
-	case AVR8_REGIDX_PORTJ:
-		LOGMASKED(LOG_GPIO, "%s: PORTJ Write: %02x\n", machine().describe_context(), data);
-		write_gpio(AVR8_IO_PORTJ, data);
-		break;
-
-	case AVR8_REGIDX_PORTK:
-		LOGMASKED(LOG_GPIO, "%s: PORTK Write: %02x\n", machine().describe_context(), data);
-		write_gpio(AVR8_IO_PORTK, data);
-		break;
-
-	case AVR8_REGIDX_PORTL:
-		LOGMASKED(LOG_GPIO, "%s: PORTL Write: %02x\n", machine().describe_context(), data);
-		write_gpio(AVR8_IO_PORTL, data);
-		break;
-
-	case AVR8_REGIDX_DDRA:
-	case AVR8_REGIDX_DDRB:
-	case AVR8_REGIDX_DDRC:
-	case AVR8_REGIDX_DDRD:
-	case AVR8_REGIDX_SREG:
-	case AVR8_REGIDX_RAMPZ:
-	case AVR8_REGIDX_SPH:
-	case AVR8_REGIDX_SPL:
-		m_r[offset] = data;
-		break;
-
-	case AVR8_REGIDX_TCCR0B:
-		LOGMASKED(LOG_TIMER0, "%s: TCCR0B = %02x\n", machine().describe_context(), data);
-		changed_tccr0b(data);
-		break;
-
-	case AVR8_REGIDX_TCCR0A:
-		LOGMASKED(LOG_TIMER0, "%s: TCCR0A = %02x\n", machine().describe_context(), data);
-		changed_tccr0a(data);
-		break;
-
-	case AVR8_REGIDX_OCR0A:
-		LOGMASKED(LOG_TIMER0, "%s: OCR0A = %02x\n", machine().describe_context(), data);
-		update_ocr0(data, AVR8_REG_A);
-		break;
-
-	case AVR8_REGIDX_OCR0B:
-		LOGMASKED(LOG_TIMER0, "%s: OCR0B = %02x\n", machine().describe_context(), data);
-		update_ocr0(data, AVR8_REG_B);
-		break;
-
-	case AVR8_REGIDX_TIFR0:
-		LOGMASKED(LOG_TIMER0, "%s: TIFR0 = %02x\n", machine().describe_context(), data);
-		m_r[AVR8_REGIDX_TIFR0] &= ~(data & AVR8_TIFR0_MASK);
-		update_interrupt(AVR8_INTIDX_OCF0A);
-		update_interrupt(AVR8_INTIDX_OCF0B);
-		update_interrupt(AVR8_INTIDX_TOV0);
-		break;
-
-	case AVR8_REGIDX_TCNT0:
-		AVR8_TCNT0 = data;
-		break;
-
-	case AVR8_REGIDX_TIFR1:
-		LOGMASKED(LOG_TIMER1, "%s: TIFR1 = %02x\n", machine().describe_context(), data);
-		m_r[AVR8_REGIDX_TIFR1] &= ~(data & AVR8_TIFR1_MASK);
-		update_interrupt(AVR8_INTIDX_ICF1);
-		update_interrupt(AVR8_INTIDX_OCF1A);
-		update_interrupt(AVR8_INTIDX_OCF1B);
-		update_interrupt(AVR8_INTIDX_TOV1);
-		break;
-
-	case AVR8_REGIDX_TIFR2:
-		LOGMASKED(LOG_TIMER2, "%s: TIFR2 = %02x\n", machine().describe_context(), data);
-		m_r[AVR8_REGIDX_TIFR2] &= ~(data & AVR8_TIFR2_MASK);
-		update_interrupt(AVR8_INTIDX_OCF2A);
-		update_interrupt(AVR8_INTIDX_OCF2B);
-		update_interrupt(AVR8_INTIDX_TOV2);
-		break;
-
-	case AVR8_REGIDX_GTCCR:
-		if (data & AVR8_GTCCR_PSRASY_MASK)
-		{
-			data &= ~AVR8_GTCCR_PSRASY_MASK;
-			m_timer_prescale_count[2] = 0;
-		}
-		break;
-
-	// EEPROM registers
-	case AVR8_REGIDX_EEARL:
-	case AVR8_REGIDX_EEARH:
-	case AVR8_REGIDX_EEDR:
-		m_r[offset] = data;
-		break;
-
-	case AVR8_REGIDX_EECR:
-		m_r[offset] = data;
-
-		if (data & AVR8_EECR_EERE_MASK)
-		{
-			uint16_t addr = (m_r[AVR8_REGIDX_EEARH] & AVR8_EEARH_MASK) << 8;
-			addr |= m_r[AVR8_REGIDX_EEARL];
-			m_r[AVR8_REGIDX_EEDR] = m_eeprom[addr];
-			LOGMASKED(LOG_EEPROM, "%s: EEPROM read @ %04x data = %02x\n", machine().describe_context(), addr, m_eeprom[addr]);
-		}
-		if ((data & AVR8_EECR_EEPE_MASK) && (data & AVR8_EECR_EEMPE_MASK))
-		{
-			uint16_t addr = (m_r[AVR8_REGIDX_EEARH] & AVR8_EEARH_MASK) << 8;
-			addr |= m_r[AVR8_REGIDX_EEARL];
-			m_eeprom[addr] = m_r[AVR8_REGIDX_EEDR];
-			LOGMASKED(LOG_EEPROM, "%s: EEPROM write @ %04x data = %02x ('%c')\n", machine().describe_context(), addr, m_eeprom[addr], m_eeprom[addr]);
-
-			// Indicate that we've finished writing a value to the EEPROM.
-			// TODO: this should only happen after a certain dalay.
-			m_r[offset] = data & ~AVR8_EECR_EEPE_MASK;
-		}
-		break;
-
-	case AVR8_REGIDX_GPIOR0:
-		LOGMASKED(LOG_GPIO, "%s: GPIOR0 Write: %02x\n", machine().describe_context(), data);
-		m_r[AVR8_REGIDX_GPIOR0] = data;
-		break;
-
-	case AVR8_REGIDX_GPIOR1:
-		LOGMASKED(LOG_GPIO, "%s: GPIOR1 Write: %02x\n", machine().describe_context(), data);
-		m_r[offset] = data;
-		break;
-
-	case AVR8_REGIDX_GPIOR2:
-		LOGMASKED(LOG_GPIO, "%s: GPIOR2 Write: %02x\n", machine().describe_context(), data);
-		m_r[offset] = data;
-		break;
-
-	case AVR8_REGIDX_SPSR:
-		change_spsr(data);
-		break;
-
-	case AVR8_REGIDX_SPCR:
-		change_spcr(data);
-		break;
-
-	case AVR8_REGIDX_SPDR:
-	{
-		m_r[AVR8_REGIDX_SPDR] = data;
-		m_spi_active = true;
-		m_spi_prescale_countdown = 7;
-		m_spi_prescale_count = 0;
-		break;
+		update_timer_waveform_gen_mode(0, AVR8_WGM0);
 	}
 
-	case AVR8_REGIDX_WDTCSR:
-		LOGMASKED(LOG_WDOG, "%s: (not yet implemented) WDTCSR = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_CLKPR:
-		LOGMASKED(LOG_CLOCK, "%s: (not yet implemented) CLKPR = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_PRR0:
-		LOGMASKED(LOG_POWER, "%s: (not yet implemented) PRR0 = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_PRR1:
-		LOGMASKED(LOG_POWER, "%s: (not yet implemented) PRR1 = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_OSCCAL:
-		LOGMASKED(LOG_OSC, "%s: (not yet implemented) OSCCAL = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_PCICR:
-		LOGMASKED(LOG_PINCHG, "%s: (not yet implemented) PCICR = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_EICRA:
-		LOGMASKED(LOG_GPIO, "%s: (not yet implemented) EICRA = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_EICRB:
-		LOGMASKED(LOG_GPIO, "%s: (not yet implemented) EICRB = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_PCMSK0:
-		LOGMASKED(LOG_PINCHG, "%s: (not yet implemented) PCMSK0 = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_PCMSK1:
-		LOGMASKED(LOG_PINCHG, "%s: (not yet implemented) PCMSK1 = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_PCMSK2:
-		LOGMASKED(LOG_PINCHG, "%s: (not yet implemented) PCMSK2 = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_TIMSK0:
-		LOGMASKED(LOG_TIMER0, "%s: TIMSK0 = %02x\n", machine().describe_context(), data);
-		m_r[AVR8_REGIDX_TIMSK0] = data;
-		update_interrupt(AVR8_INTIDX_OCF0A);
-		update_interrupt(AVR8_INTIDX_OCF0B);
-		update_interrupt(AVR8_INTIDX_TOV0);
-		break;
-
-	case AVR8_REGIDX_TIMSK1:
-		LOGMASKED(LOG_TIMER1, "%s: TIMSK1 = %02x\n", machine().describe_context(), data);
-		m_r[AVR8_REGIDX_TIMSK1] = data;
-		update_interrupt(AVR8_INTIDX_ICF1);
-		update_interrupt(AVR8_INTIDX_OCF1A);
-		update_interrupt(AVR8_INTIDX_OCF1B);
-		update_interrupt(AVR8_INTIDX_TOV1);
-		break;
-
-	case AVR8_REGIDX_TIMSK2:
-		LOGMASKED(LOG_TIMER2, "%s: TIMSK2 = %02x\n", machine().describe_context(), data);
-		m_r[AVR8_REGIDX_TIMSK2] = data;
-		update_interrupt(AVR8_INTIDX_OCF2A);
-		update_interrupt(AVR8_INTIDX_OCF2B);
-		update_interrupt(AVR8_INTIDX_TOV2);
-		break;
-
-	case AVR8_REGIDX_TIMSK3:
-		LOGMASKED(LOG_TIMER3, "%s: TIMSK3 = %02x\n", machine().describe_context(), data);
-		m_r[AVR8_REGIDX_TIMSK3] = data;
-		update_interrupt(AVR8_INTIDX_OCF3A);
-		update_interrupt(AVR8_INTIDX_OCF3B);
-		update_interrupt(AVR8_INTIDX_TOV3);
-		break;
-
-	case AVR8_REGIDX_TIMSK4:
-		LOGMASKED(LOG_TIMER4, "%s: TIMSK4 = %02x\n", machine().describe_context(), data);
-		m_r[AVR8_REGIDX_TIMSK4] = data;
-		update_interrupt(AVR8_INTIDX_OCF4A);
-		update_interrupt(AVR8_INTIDX_OCF4B);
-		update_interrupt(AVR8_INTIDX_TOV4);
-		break;
-
-	case AVR8_REGIDX_TIMSK5:
-		LOGMASKED(LOG_TIMER5, "%s: TIMSK5 = %02x\n", machine().describe_context(), data);
-		m_r[AVR8_REGIDX_TIMSK5] = data;
-		update_interrupt(AVR8_INTIDX_OCF5A);
-		update_interrupt(AVR8_INTIDX_OCF5B);
-		update_interrupt(AVR8_INTIDX_TOV5);
-		break;
-
-	case AVR8_REGIDX_XMCRA:
-		LOGMASKED(LOG_EXTMEM, "%s: (not yet implemented) XMCRA = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_XMCRB:
-		LOGMASKED(LOG_EXTMEM, "%s: (not yet implemented) XMCRB = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_ADCL:
-		LOGMASKED(LOG_ADC, "%s: ADCL = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_ADCH:
-		LOGMASKED(LOG_ADC, "%s: ADCH = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_ADCSRA:
-		LOGMASKED(LOG_ADC, "%s: ADCSRA = %02x\n", machine().describe_context(), data);
-		change_adcsra(data);
-		break;
-
-	case AVR8_REGIDX_ADCSRB:
-		LOGMASKED(LOG_ADC, "%s: ADCSRB = %02x\n", machine().describe_context(), data);
-		change_adcsrb(data);
-		break;
-
-	case AVR8_REGIDX_ADMUX:
-		LOGMASKED(LOG_ADC, "%s: ADMUX = %02x\n", machine().describe_context(), data);
-		AVR8_ADMUX = data & (AVR8_ADMUX_REFS_MASK | AVR8_ADMUX_ADLAR_MASK | AVR8_ADMUX_MUX_MASK);
-		break;
-
-	case AVR8_REGIDX_DIDR0:
-		LOGMASKED(LOG_DIGINPUT, "%s: (not yet implemented) DIDR0 = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_DIDR1:
-		LOGMASKED(LOG_DIGINPUT, "%s: (not yet implemented) DIDR1 = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_DIDR2:
-		LOGMASKED(LOG_DIGINPUT, "%s: (not yet implemented) DIDR2 = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_TCCR1A:
-		LOGMASKED(LOG_TIMER1, "%s: TCCR1A = %02x\n", machine().describe_context(), data);
-		changed_tccr1a(data);
-		break;
-
-	case AVR8_REGIDX_TCCR1B:
-		LOGMASKED(LOG_TIMER1, "%s: TCCR1B = %02x\n", machine().describe_context(), data);
-		changed_tccr1b(data);
-		break;
-
-	case AVR8_REGIDX_TCCR1C:
-		LOGMASKED(LOG_TIMER1, "%s: (not yet implemented) TCCR1C = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_TCNT1L:
-		m_timer1_count = (m_timer1_count & 0xff00) | data;
-		break;
-
-	case AVR8_REGIDX_TCNT1H:
-		m_timer1_count = (m_timer1_count & 0x00ff) | (data << 8);
-		break;
-
-	case AVR8_REGIDX_ICR1L:
-		AVR8_ICR1L = data;
-		break;
-
-	case AVR8_REGIDX_ICR1H:
-		AVR8_ICR1H = data;
-		break;
-
-	case AVR8_REGIDX_OCR1AL:
-		LOGMASKED(LOG_TIMER1, "%s: OCR1AL = %02x\n", machine().describe_context(), data);
-		update_ocr1((AVR8_OCR1A & 0xff00) | data, AVR8_REG_A);
-		break;
-
-	case AVR8_REGIDX_OCR1AH:
-		LOGMASKED(LOG_TIMER1, "%s: OCR1AH = %02x\n", machine().describe_context(), data);
-		update_ocr1((AVR8_OCR1A & 0x00ff) | (data << 8), AVR8_REG_A);
-		break;
-
-	case AVR8_REGIDX_OCR1BL:
-		LOGMASKED(LOG_TIMER1, "%s: OCR1BL = %02x\n", machine().describe_context(), data);
-		update_ocr1((AVR8_OCR1B & 0xff00) | data, AVR8_REG_B);
-		break;
-
-	case AVR8_REGIDX_OCR1BH:
-		LOGMASKED(LOG_TIMER1, "%s: OCR1BH = %02x\n", machine().describe_context(), data);
-		update_ocr1((AVR8_OCR1B & 0x00ff) | (data << 8), AVR8_REG_B);
-		break;
-
-	case AVR8_REGIDX_OCR1CL:
-		LOGMASKED(LOG_TIMER1, "%s: OCR1CL = %02x\n", machine().describe_context(), data);
-		update_ocr1((AVR8_OCR1C & 0xff00) | data, AVR8_REG_C);
-		break;
-
-	case AVR8_REGIDX_OCR1CH:
-		LOGMASKED(LOG_TIMER1, "%s: OCR1CH = %02x\n", machine().describe_context(), data);
-		update_ocr1((AVR8_OCR1C & 0x00ff) | (data << 8), AVR8_REG_C);
-		break;
-
-	case AVR8_REGIDX_TCCR2A:
-		LOGMASKED(LOG_TIMER2, "%s: TCCR2A = %02x\n", machine().describe_context(), data);
-		changed_tccr2a(data);
-		break;
-
-	case AVR8_REGIDX_TCCR2B:
-		LOGMASKED(LOG_TIMER2, "%s: TCCR2B = %02x\n", machine().describe_context(), data);
-		changed_tccr2b(data);
-		break;
-
-	case AVR8_REGIDX_TCNT2:
-		AVR8_TCNT2 = data;
-		break;
-
-	case AVR8_REGIDX_OCR2A:
-		update_ocr2(data, AVR8_REG_A);
-		break;
-
-	case AVR8_REGIDX_OCR2B:
-		update_ocr2(data, AVR8_REG_B);
-		break;
-
-	case AVR8_REGIDX_TCCR3A:
-		LOGMASKED(LOG_TIMER3, "%s: TCCR3A = %02x\n", machine().describe_context(), data);
-		changed_tccr3a(data);
-		break;
-
-	case AVR8_REGIDX_TCCR3B:
-		LOGMASKED(LOG_TIMER3, "%s: TCCR3B = %02x\n", machine().describe_context(), data);
-		changed_tccr3b(data);
-		break;
-
-	case AVR8_REGIDX_TCCR3C:
-		LOGMASKED(LOG_TIMER3, "%s: TCCR3C = %02x\n", machine().describe_context(), data);
-		changed_tccr3c(data);
-		break;
-
-	case AVR8_REGIDX_TCNT3L:
-		AVR8_TCNT3L = data;
-		break;
-
-	case AVR8_REGIDX_TCNT3H:
-		AVR8_TCNT3H = data;
-		break;
-
-	case AVR8_REGIDX_ICR3L:
-		AVR8_ICR3L = data;
-		break;
-
-	case AVR8_REGIDX_ICR3H:
-		AVR8_ICR3H = data;
-		break;
-
-	case AVR8_REGIDX_OCR3AL:
-		AVR8_OCR3AL = data;
-		break;
-
-	case AVR8_REGIDX_OCR3AH:
-		AVR8_OCR3AH = data;
-		break;
-
-	case AVR8_REGIDX_OCR3BL:
-		AVR8_OCR3BL = data;
-		break;
-
-	case AVR8_REGIDX_OCR3BH:
-		AVR8_OCR3BH = data;
-		break;
-
-	case AVR8_REGIDX_OCR3CL:
-		AVR8_OCR3CL = data;
-		break;
-
-	case AVR8_REGIDX_OCR3CH:
-		AVR8_OCR3CH = data;
-		break;
-
-	case AVR8_REGIDX_TCCR4A:
-		LOGMASKED(LOG_TIMER4, "%s: TCCR4A = %02x\n", machine().describe_context(), data);
-		changed_tccr4a(data);
-		break;
-
-	case AVR8_REGIDX_TCCR4B:
-		LOGMASKED(LOG_TIMER4, "%s: TCCR4B = %02x\n", machine().describe_context(), data);
-		changed_tccr4b(data);
-		break;
-
-	case AVR8_REGIDX_TCCR4C:
-		LOGMASKED(LOG_TIMER4, "%s: TCCR4C = %02x\n", machine().describe_context(), data);
-		changed_tccr4c(data);
-		break;
-
-	case AVR8_REGIDX_TCNT4L:
-		AVR8_TCNT4L = data;
-		break;
-
-	case AVR8_REGIDX_TCNT4H:
-		AVR8_TCNT4H = data;
-		break;
-
-	case AVR8_REGIDX_ICR4L:
-		AVR8_ICR4L = data;
-		break;
-
-	case AVR8_REGIDX_ICR4H:
-		AVR8_ICR4H = data;
-		break;
-
-	case AVR8_REGIDX_OCR4AL:
-		AVR8_OCR4AL = data;
-		break;
-
-	case AVR8_REGIDX_OCR4AH:
-		AVR8_OCR4AH = data;
-		break;
-
-	case AVR8_REGIDX_OCR4BL:
-		AVR8_OCR4BL = data;
-		break;
-
-	case AVR8_REGIDX_OCR4BH:
-		AVR8_OCR4BH = data;
-		break;
-
-	case AVR8_REGIDX_OCR4CL:
-		AVR8_OCR4CL = data;
-		break;
-
-	case AVR8_REGIDX_OCR4CH:
-		AVR8_OCR4CH = data;
-		break;
-
-	case AVR8_REGIDX_TCCR5A:
-		LOGMASKED(LOG_TIMER5, "%s: TCCR5A = %02x\n", machine().describe_context(), data);
-		changed_tccr5a(data);
-		break;
-
-	case AVR8_REGIDX_TCCR5B:
-		LOGMASKED(LOG_TIMER5, "%s: TCCR5B = %02x\n", machine().describe_context(), data);
-		changed_tccr5b(data);
-		break;
-
-	case AVR8_REGIDX_ASSR:
-		LOGMASKED(LOG_ASYNC, "%s: (not yet implemented) ASSR = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_TWBR:
-		LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWBR = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_TWSR:
-		LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWSR = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_TWAR:
-		LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWAR = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_TWDR:
-		LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWDR = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_TWCR:
-		LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWCR = %02x\n", machine().describe_context(), data);
-		m_r[AVR8_REGIDX_TWCR] = data;
-		break;
-
-	case AVR8_REGIDX_TWAMR:
-		LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWAMR = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_UCSR0A:
-		LOGMASKED(LOG_UART, "%s: (not yet implemented) UCSR0A = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_UCSR0B:
-		LOGMASKED(LOG_UART, "%s: (not yet implemented) UCSR0B = %02x\n", machine().describe_context(), data);
-		break;
-
-	case AVR8_REGIDX_UCSR0C:
-		LOGMASKED(LOG_UART, "%s: (not yet implemented) UCSR0C = %02x\n", machine().describe_context(), data);
-		break;
-
-	default:
-		LOGMASKED(LOG_UNKNOWN, "%s: Unknown Register Write: %03x = %02x\n", machine().describe_context(), offset, data);
-		break;
+	m_timer0_tick = m_timer0_ticks[(AVR8_WGM0 << 2) | AVR8_TCCR0A_COM0B];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr0b_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER0, "%s: TCCR0B = %02x\n", machine().describe_context(), data);
+	const uint8_t oldtccr = m_r[TCCR0B];
+	const uint8_t newtccr = data;
+	const uint8_t changed = newtccr ^ oldtccr;
+	const uint8_t oldcs = m_r[TCCR0B] & AVR8_TCCR0B_CS_MASK;
+
+	m_r[TCCR0B] = data;
+
+	if (changed & AVR8_TCCR0B_FOC0A_MASK)
+	{
+		// TODO
+		timer0_force_output_compare(AVR8_REG_A);
+	}
+
+	if (changed & AVR8_TCCR0B_FOC0B_MASK)
+	{
+		// TODO
+		timer0_force_output_compare(AVR8_REG_B);
+	}
+
+	if (changed & AVR8_TCCR0B_WGM0_2_MASK)
+	{
+		update_timer_waveform_gen_mode(0, AVR8_WGM0);
+	}
+
+	if (changed & AVR8_TCCR0B_CS_MASK)
+	{
+		update_timer_clock_source<0>(AVR8_TIMER0_CLOCK_SELECT, oldcs);
+	}
+
+	m_timer0_tick = m_timer0_ticks[(AVR8_WGM0 << 2) | AVR8_TCCR0A_COM0B];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr0a_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER0, "%s: OCR0A = %02x\n", machine().describe_context(), data);
+	update_ocr0(data, AVR8_REG_A);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr0b_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER0, "%s: OCR0B = %02x\n", machine().describe_context(), data);
+	update_ocr0(data, AVR8_REG_B);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tifr0_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER0, "%s: TIFR0 = %02x\n", machine().describe_context(), data);
+	m_r[TIFR0] &= ~(data & AVR8_TIFR0_MASK);
+	update_interrupt(AVR8_INTIDX_OCF0A);
+	update_interrupt(AVR8_INTIDX_OCF0B);
+	update_interrupt(AVR8_INTIDX_TOV0);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tifr1_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER1, "%s: TIFR1 = %02x\n", machine().describe_context(), data);
+	m_r[TIFR1] &= ~(data & AVR8_TIFR1_MASK);
+	update_interrupt(AVR8_INTIDX_ICF1);
+	update_interrupt(AVR8_INTIDX_OCF1A);
+	update_interrupt(AVR8_INTIDX_OCF1B);
+	update_interrupt(AVR8_INTIDX_TOV1);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tifr2_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER2, "%s: TIFR2 = %02x\n", machine().describe_context(), data);
+	m_r[TIFR2] &= ~(data & AVR8_TIFR2_MASK);
+	update_interrupt(AVR8_INTIDX_OCF2A);
+	update_interrupt(AVR8_INTIDX_OCF2B);
+	update_interrupt(AVR8_INTIDX_TOV2);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::gtccr_w(uint8_t data)
+{
+	if (data & AVR8_GTCCR_PSRASY_MASK)
+	{
+		data &= ~AVR8_GTCCR_PSRASY_MASK;
+		m_timer_prescale_count[2] = 0;
 	}
 }
 
-uint8_t avr8_device::regs_r(offs_t offset)
+template <int NumTimers>
+void avr8_device<NumTimers>::eecr_w(uint8_t data)
 {
-	uint8_t data = m_r[offset];
+	m_r[EECR] = data;
 
-	switch (offset)
+	if (data & AVR8_EECR_EERE_MASK)
 	{
-	case AVR8_REGIDX_R0:
-	case AVR8_REGIDX_R1:
-	case AVR8_REGIDX_R2:
-	case AVR8_REGIDX_R3:
-	case AVR8_REGIDX_R4:
-	case AVR8_REGIDX_R5:
-	case AVR8_REGIDX_R6:
-	case AVR8_REGIDX_R7:
-	case AVR8_REGIDX_R8:
-	case AVR8_REGIDX_R9:
-	case AVR8_REGIDX_R10:
-	case AVR8_REGIDX_R11:
-	case AVR8_REGIDX_R12:
-	case AVR8_REGIDX_R13:
-	case AVR8_REGIDX_R14:
-	case AVR8_REGIDX_R15:
-	case AVR8_REGIDX_R16:
-	case AVR8_REGIDX_R17:
-	case AVR8_REGIDX_R18:
-	case AVR8_REGIDX_R19:
-	case AVR8_REGIDX_R20:
-	case AVR8_REGIDX_R21:
-	case AVR8_REGIDX_R22:
-	case AVR8_REGIDX_R23:
-	case AVR8_REGIDX_R24:
-	case AVR8_REGIDX_R25:
-	case AVR8_REGIDX_R26:
-	case AVR8_REGIDX_R27:
-	case AVR8_REGIDX_R28:
-	case AVR8_REGIDX_R29:
-	case AVR8_REGIDX_R30:
-	case AVR8_REGIDX_R31:
-		return data;
-
-	case AVR8_REGIDX_PINA:
-		// TODO: account for DDRA
-		return read_gpio(AVR8_IO_PORTA);
-
-	case AVR8_REGIDX_PINB:
-		// TODO: account for DDRB
-		return read_gpio(AVR8_IO_PORTB);
-
-	case AVR8_REGIDX_PINC:
-		// TODO: account for DDRC
-		return read_gpio(AVR8_IO_PORTC);
-
-	case AVR8_REGIDX_PIND:
-		// TODO: account for DDRD
-		return read_gpio(AVR8_IO_PORTD);
-
-	case AVR8_REGIDX_PINE:
-		// TODO: account for DDRE
-		return read_gpio(AVR8_IO_PORTE);
-
-	case AVR8_REGIDX_PINF:
-		// TODO: account for DDRF
-		return read_gpio(AVR8_IO_PORTF);
-
-	case AVR8_REGIDX_PING:
-		// TODO: account for DDRG
-		return read_gpio(AVR8_IO_PORTG);
-
-	case AVR8_REGIDX_PINH:
-		// TODO: account for DDRH
-		return read_gpio(AVR8_IO_PORTH);
-
-	case AVR8_REGIDX_PINJ:
-		// TODO: account for DDRJ
-		return read_gpio(AVR8_IO_PORTJ);
-
-	case AVR8_REGIDX_PINK:
-		// TODO: account for DDRK
-		return read_gpio(AVR8_IO_PORTK);
-
-	case AVR8_REGIDX_PINL:
-		// TODO: account for DDRL
-		return read_gpio(AVR8_IO_PORTL);
-
-	case AVR8_REGIDX_PORTA:
-	case AVR8_REGIDX_PORTB:
-	case AVR8_REGIDX_PORTC:
-	case AVR8_REGIDX_PORTD:
-	case AVR8_REGIDX_PORTE:
-	case AVR8_REGIDX_PORTF:
-	case AVR8_REGIDX_PORTG:
-	case AVR8_REGIDX_PORTH:
-	case AVR8_REGIDX_PORTJ:
-	case AVR8_REGIDX_PORTK:
-	case AVR8_REGIDX_PORTL:
-		return data;
-
-	case AVR8_REGIDX_DDRA:
-	case AVR8_REGIDX_DDRB:
-	case AVR8_REGIDX_DDRC:
-	case AVR8_REGIDX_DDRD:
-	case AVR8_REGIDX_DDRE:
-	case AVR8_REGIDX_DDRF:
-	case AVR8_REGIDX_DDRG:
-	case AVR8_REGIDX_DDRH:
-	case AVR8_REGIDX_DDRJ:
-	case AVR8_REGIDX_DDRK:
-	case AVR8_REGIDX_DDRL:
-		return data;
-
-	// EEPROM registers
-	case AVR8_REGIDX_EECR:
-	case AVR8_REGIDX_EEDR:
-		return data;
-
-	// Miscellaneous registers
-	// TODO: Implement readback for all applicable registers.
-
-	case AVR8_REGIDX_GPIOR0:
-		LOGMASKED(LOG_GPIO, "%s: GPIOR0 Read: %02x\n", machine().describe_context(), data);
-		return data;
-	case AVR8_REGIDX_GPIOR1:
-		LOGMASKED(LOG_GPIO, "%s: GPIOR1 Read: %02x\n", machine().describe_context(), data);
-		return data;
-	case AVR8_REGIDX_GPIOR2:
-		LOGMASKED(LOG_GPIO, "%s: GPIOR2 Read: %02x\n", machine().describe_context(), data);
-		return data;
-//    case AVR8_REGIDX_UCSR0B:   // TODO: needed for Replicator 1
-	case AVR8_REGIDX_SPDR:   // TODO: needed for Replicator 1
-	case AVR8_REGIDX_SPSR:   // TODO: needed for Replicator 1
-//    case AVR8_REGIDX_ADCSRA:   // TODO: needed for Replicator 1
-//    case AVR8_REGIDX_ADCSRB:   // TODO: needed for Replicator 1
-	case AVR8_REGIDX_SPL:
-	case AVR8_REGIDX_SPH:
-	case AVR8_REGIDX_SREG:
-	case AVR8_REGIDX_TIMSK0:
-		LOGMASKED(LOG_TIMER0, "%s: TIMSK0 Read: %02x\n", machine().describe_context(), data);
-		return data;
-	case AVR8_REGIDX_TIMSK1:
-		LOGMASKED(LOG_TIMER1, "%s: TIMSK1 Read: %02x\n", machine().describe_context(), data);
-		return data;
-	case AVR8_REGIDX_TIMSK2:
-		LOGMASKED(LOG_TIMER2, "%s: TIMSK2 Read: %02x\n", machine().describe_context(), data);
-		return data;
-	case AVR8_REGIDX_TIMSK3:
-		LOGMASKED(LOG_TIMER3, "%s: TIMSK3 Read: %02x\n", machine().describe_context(), data);
-		return data;
-	case AVR8_REGIDX_TIMSK4:
-		LOGMASKED(LOG_TIMER4, "%s: TIMSK4 Read: %02x\n", machine().describe_context(), data);
-		return data;
-	case AVR8_REGIDX_TIMSK5:
-		LOGMASKED(LOG_TIMER5, "%s: TIMSK5 Read: %02x\n", machine().describe_context(), data);
-		return data;
-	case AVR8_REGIDX_TIFR1:
-		//LOGMASKED(LOG_TIMER0, "%s: TIFR1 Read: %02x\n", machine().describe_context(), data);
-		return data;
-
-	// Two-wire registers
-	case AVR8_REGIDX_TWCR:
-		// TODO: needed for Replicator 1
-		return m_r[offset];
-
-	case AVR8_REGIDX_TWSR:
-		// HACK for Replicator 1:
-		//   By returning a value != 0x08, we induce an error state that makes the object code jump out of the wait loop,
-		//   and continue execution failing the 2-wire write operation.
-		return 0x00;
-
-
-	case AVR8_REGIDX_TCNT1L:
-		return (uint8_t)m_timer1_count;
-	case AVR8_REGIDX_TCNT1H:
-		return (uint8_t)(m_timer1_count >> 8);
-	case AVR8_REGIDX_TCNT2:
-	case AVR8_REGIDX_UCSR0A:
-		return m_r[offset];
-
-	case AVR8_REGIDX_ADCL:
-		if (!machine().side_effects_disabled())
-			m_adc_hold = true;
-		if (AVR8_ADMUX_ADLAR)
-			return (m_adc_data & 0x03) << 6;
-		else
-			return uint8_t(m_adc_data);
-	case AVR8_REGIDX_ADCH:
-		{
-			uint8_t const result = AVR8_ADMUX_ADLAR ? BIT(m_adc_data, 2, 8) : BIT(m_adc_data, 8, 2);
-			if (!machine().side_effects_disabled())
-			{
-				m_adc_data = m_adc_result;
-				m_adc_hold = false;
-			}
-			return result;
-		}
-	case AVR8_REGIDX_ADCSRA:
-	case AVR8_REGIDX_ADCSRB:
-	case AVR8_REGIDX_ADMUX:
-		return m_r[offset];
-
-	default:
-		LOGMASKED(LOG_UNKNOWN, "%s: Unknown Register Read: %03X\n", machine().describe_context(), offset);
-		return 0;
+		uint16_t addr = (m_r[EEARH] & AVR8_EEARH_MASK) << 8;
+		addr |= m_r[EEARL];
+		m_r[EEDR] = m_eeprom[addr];
+		LOGMASKED(LOG_EEPROM, "%s: EEPROM read @ %04x data = %02x\n", machine().describe_context(), addr, m_eeprom[addr]);
 	}
+	if ((data & AVR8_EECR_EEPE_MASK) && (data & AVR8_EECR_EEMPE_MASK))
+	{
+		uint16_t addr = (m_r[EEARH] & AVR8_EEARH_MASK) << 8;
+		addr |= m_r[EEARL];
+		m_eeprom[addr] = m_r[EEDR];
+		LOGMASKED(LOG_EEPROM, "%s: EEPROM write @ %04x data = %02x ('%c')\n", machine().describe_context(), addr, m_eeprom[addr], m_eeprom[addr] >= 0x21 ? m_eeprom[addr] : ' ');
+
+		// Indicate that we've finished writing a value to the EEPROM.
+		// TODO: this should only happen after a certain dalay.
+		m_r[EECR] = data & ~AVR8_EECR_EEPE_MASK;
+	}
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::gpior0_w(uint8_t data)
+{
+	LOGMASKED(LOG_GPIO, "%s: GPIOR0 Write: %02x\n", machine().describe_context(), data);
+	m_r[GPIOR0] = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::gpior1_w(uint8_t data)
+{
+	LOGMASKED(LOG_GPIO, "%s: GPIOR1 Write: %02x\n", machine().describe_context(), data);
+	m_r[GPIOR1] = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::gpior2_w(uint8_t data)
+{
+	LOGMASKED(LOG_GPIO, "%s: GPIOR2 Write: %02x\n", machine().describe_context(), data);
+	m_r[GPIOR2] = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::spsr_w(uint8_t data)
+{
+	change_spsr(data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::spcr_w(uint8_t data)
+{
+	change_spcr(data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::spdr_w(uint8_t data)
+{
+	m_r[SPDR] = data;
+	m_spi_active = true;
+	m_spi_prescale_countdown = 7;
+	m_spi_prescale_count = 0;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::wdtcsr_w(uint8_t data)
+{
+	LOGMASKED(LOG_WDOG, "%s: (not yet implemented) WDTCSR = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::clkpr_w(uint8_t data)
+{
+	LOGMASKED(LOG_CLOCK, "%s: (not yet implemented) CLKPR = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::prr0_w(uint8_t data)
+{
+	LOGMASKED(LOG_POWER, "%s: (not yet implemented) PRR0 = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::prr1_w(uint8_t data)
+{
+	LOGMASKED(LOG_POWER, "%s: (not yet implemented) PRR1 = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::osccal_w(uint8_t data)
+{
+	LOGMASKED(LOG_POWER, "%s: (not yet implemented) OSCCAL = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::pcicr_w(uint8_t data)
+{
+	LOGMASKED(LOG_POWER, "%s: (not yet implemented) PCICR = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::eicra_w(uint8_t data)
+{
+	LOGMASKED(LOG_POWER, "%s: (not yet implemented) EICRA = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::eicrb_w(uint8_t data)
+{
+	LOGMASKED(LOG_POWER, "%s: (not yet implemented) EICRB = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::pcmsk0_w(uint8_t data)
+{
+	LOGMASKED(LOG_POWER, "%s: (not yet implemented) PCMSK0 = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::pcmsk1_w(uint8_t data)
+{
+	LOGMASKED(LOG_POWER, "%s: (not yet implemented) PCMSK1 = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::pcmsk2_w(uint8_t data)
+{
+	LOGMASKED(LOG_POWER, "%s: (not yet implemented) PCMSK2 = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timsk0_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER0, "%s: TIMSK0 = %02x\n", machine().describe_context(), data);
+	m_r[TIMSK0] = data;
+	update_interrupt(AVR8_INTIDX_OCF0A);
+	update_interrupt(AVR8_INTIDX_OCF0B);
+	update_interrupt(AVR8_INTIDX_TOV0);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timsk1_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER1, "%s: TIMSK1 = %02x\n", machine().describe_context(), data);
+	m_r[TIMSK1] = data;
+	update_interrupt(AVR8_INTIDX_ICF1);
+	update_interrupt(AVR8_INTIDX_OCF1A);
+	update_interrupt(AVR8_INTIDX_OCF1B);
+	update_interrupt(AVR8_INTIDX_TOV1);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timsk2_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER2, "%s: TIMSK2 = %02x\n", machine().describe_context(), data);
+	m_r[TIMSK2] = data;
+	update_interrupt(AVR8_INTIDX_OCF2A);
+	update_interrupt(AVR8_INTIDX_OCF2B);
+	update_interrupt(AVR8_INTIDX_TOV2);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timsk3_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER3, "%s: TIMSK3 = %02x\n", machine().describe_context(), data);
+	m_r[TIMSK3] = data;
+	update_interrupt(AVR8_INTIDX_OCF3A);
+	update_interrupt(AVR8_INTIDX_OCF3B);
+	update_interrupt(AVR8_INTIDX_TOV3);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timsk4_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER4, "%s: TIMSK4 = %02x\n", machine().describe_context(), data);
+	m_r[TIMSK4] = data;
+	update_interrupt(AVR8_INTIDX_OCF4A);
+	update_interrupt(AVR8_INTIDX_OCF4B);
+	update_interrupt(AVR8_INTIDX_TOV4);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::timsk5_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER5, "%s: TIMSK5 = %02x\n", machine().describe_context(), data);
+	m_r[TIMSK5] = data;
+	update_interrupt(AVR8_INTIDX_OCF5A);
+	update_interrupt(AVR8_INTIDX_OCF5B);
+	update_interrupt(AVR8_INTIDX_TOV5);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::xmcra_w(uint8_t data)
+{
+	LOGMASKED(LOG_EXTMEM, "%s: (not yet implemented) XMCRA = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::xmcrb_w(uint8_t data)
+{
+	LOGMASKED(LOG_EXTMEM, "%s: (not yet implemented) XMCRB = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+uint8_t avr8_device<NumTimers>::adcl_r()
+{
+	if (!machine().side_effects_disabled())
+		m_adc_hold = true;
+	if (AVR8_ADMUX_ADLAR)
+		return (m_adc_data & 0x03) << 6;
+	else
+		return uint8_t(m_adc_data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::adcl_w(uint8_t data)
+{
+	LOGMASKED(LOG_ADC, "%s: ADCL = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+uint8_t avr8_device<NumTimers>::adch_r()
+{
+	uint8_t const result = AVR8_ADMUX_ADLAR ? BIT(m_adc_data, 2, 8) : BIT(m_adc_data, 8, 2);
+	if (!machine().side_effects_disabled())
+	{
+		m_adc_data = m_adc_result;
+		m_adc_hold = false;
+	}
+	return result;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::adch_w(uint8_t data)
+{
+	LOGMASKED(LOG_ADC, "%s: ADCH = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::adcsra_w(uint8_t data)
+{
+	LOGMASKED(LOG_ADC, "%s: ADCSRA = %02x\n", machine().describe_context(), data);
+
+	// set auto trigger enable, interrupt enable, and prescaler directly
+	AVR8_ADCSRA = (AVR8_ADCSRA & ~(AVR8_ADCSRA_ADATE_MASK | AVR8_ADCSRA_ADIE_MASK | AVR8_ADCSRA_ADPS_MASK)) | (data & (AVR8_ADCSRA_ADATE_MASK | AVR8_ADCSRA_ADIE_MASK | AVR8_ADCSRA_ADPS_MASK));
+
+	// check enable bit
+	if (!(data & AVR8_ADCSRA_ADEN_MASK))
+	{
+		// disable ADC, terminate any conversion in progress
+		AVR8_ADCSRA &= ~(AVR8_ADCSRA_ADEN_MASK | AVR8_ADCSRA_ADSC_MASK);
+		m_adc_timer->reset();
+	}
+	else
+	{
+		// first conversion after initial enable takes longer
+		if (!AVR8_ADCSRA_ADEN)
+		{
+			m_adc_first = true;
+			AVR8_ADCSRA |= AVR8_ADCSRA_ADEN_MASK;
+		}
+
+		// trigger conversion if necessary
+		if (!AVR8_ADCSRA_ADSC && (data & AVR8_ADCSRA_ADSC_MASK))
+			adc_start_conversion();
+	}
+
+	// writing with ADIF set clears the interrupt flag manually
+	if (data & AVR8_ADCSRA_ADIF_MASK)
+		AVR8_ADCSRA &= ~AVR8_ADCSRA_ADIF_MASK;
+
+	if (AVR8_ADCSRA_ADIE)
+		logerror("%s: Unimplemented ADC interrupt enabled\n");
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::adcsrb_w(uint8_t data)
+{
+	LOGMASKED(LOG_ADC, "%s: ADCSRB = %02x\n", machine().describe_context(), data);
+	AVR8_ADCSRB = data & (AVR8_ADCSRB_ACME_MASK | AVR8_ADCSRB_ADTS_MASK);
+	if (AVR8_ADCSRB_ADTS != 0x00)
+		logerror("%s: Unimplemented ADC auto trigger source %X selected\n", machine().describe_context(), AVR8_ADCSRB_ADTS);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::admux_w(uint8_t data)
+{
+	LOGMASKED(LOG_ADC, "%s: ADMUX = %02x\n", machine().describe_context(), data);
+	AVR8_ADMUX = data & (AVR8_ADMUX_REFS_MASK | AVR8_ADMUX_ADLAR_MASK | AVR8_ADMUX_MUX_MASK);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::didr0_w(uint8_t data)
+{
+	LOGMASKED(LOG_DIGINPUT, "%s: (not yet implemented) DIDR0 = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::didr1_w(uint8_t data)
+{
+	LOGMASKED(LOG_DIGINPUT, "%s: (not yet implemented) DIDR1 = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::didr2_w(uint8_t data)
+{
+	LOGMASKED(LOG_DIGINPUT, "%s: (not yet implemented) DIDR2 = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr1a_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER1, "%s: TCCR1A = %02x\n", machine().describe_context(), data);
+	const uint8_t oldtccr = m_r[TCCR1A];
+	const uint8_t newtccr = data;
+	const uint8_t changed = newtccr ^ oldtccr;
+	m_r[TCCR1A] = newtccr;
+
+	if (changed & AVR8_TCCR1A_WGM1_10_MASK)
+	{
+		update_timer_waveform_gen_mode(1, AVR8_WGM1);
+	}
+
+	m_timer1_tick = m_timer1_ticks[(AVR8_WGM1 << 4) | ((m_r[TCCR1A] & AVR8_TCCR1A_COM1AB_MASK) >> AVR8_TCCR1A_COM1AB_SHIFT)];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr1b_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER1, "%s: TCCR1B = %02x\n", machine().describe_context(), data);
+	const uint8_t oldtccr = m_r[TCCR1B];
+	const uint8_t newtccr = data;
+	const uint8_t changed = newtccr ^ oldtccr;
+	const uint8_t oldcs = m_r[TCCR1B] & AVR8_TCCR1B_CS_MASK;
+
+	m_r[TCCR1B] = newtccr;
+
+	if (changed & AVR8_TCCR1B_ICNC1_MASK)
+	{
+		update_timer1_input_noise_canceler();
+	}
+
+	if (changed & AVR8_TCCR1B_ICES1_MASK)
+	{
+		update_timer1_input_edge_select();
+	}
+
+	if (changed & AVR8_TCCR1B_WGM1_32_MASK)
+	{
+		update_timer_waveform_gen_mode(1, AVR8_WGM1);
+	}
+
+	if (changed & AVR8_TCCR1B_CS_MASK)
+	{
+		update_timer_clock_source<1>(AVR8_TIMER1_CLOCK_SELECT, oldcs);
+	}
+
+	m_timer1_tick = m_timer1_ticks[(AVR8_WGM1 << 4) | ((m_r[TCCR1A] & AVR8_TCCR1A_COM1AB_MASK) >> AVR8_TCCR1A_COM1AB_SHIFT)];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr1c_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER1, "%s: (not yet implemented) TCCR1C = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::icr1l_w(uint8_t data)
+{
+	AVR8_ICR1L = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::icr1h_w(uint8_t data)
+{
+	AVR8_ICR1H = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr1al_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER1, "%s: OCR1AL = %02x\n", machine().describe_context(), data);
+	update_ocr1((AVR8_OCR1A & 0xff00) | data, AVR8_REG_A);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr1ah_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER1, "%s: OCR1AH = %02x\n", machine().describe_context(), data);
+	update_ocr1((AVR8_OCR1A & 0x00ff) | (data << 8), AVR8_REG_A);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr1bl_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER1, "%s: OCR1BL = %02x\n", machine().describe_context(), data);
+	update_ocr1((AVR8_OCR1B & 0xff00) | data, AVR8_REG_B);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr1bh_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER1, "%s: OCR1BH = %02x\n", machine().describe_context(), data);
+	update_ocr1((AVR8_OCR1B & 0x00ff) | (data << 8), AVR8_REG_B);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr1cl_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER1, "%s: OCR1CL = %02x\n", machine().describe_context(), data);
+	update_ocr1((AVR8_OCR1C & 0xff00) | data, AVR8_REG_C);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr1ch_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER1, "%s: OCR1CH = %02x\n", machine().describe_context(), data);
+	update_ocr1((AVR8_OCR1C & 0x00ff) | (data << 8), AVR8_REG_C);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr2a_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER2, "%s: TCCR2A = %02x\n", machine().describe_context(), data);
+	const uint8_t oldtccr = AVR8_TCCR2A;
+	const uint8_t newtccr = data;
+	const uint8_t changed = newtccr ^ oldtccr;
+
+	AVR8_TCCR2A = data;
+
+	if (changed & AVR8_TCCR2A_WGM2_10_MASK)
+	{
+		update_timer_waveform_gen_mode(2, AVR8_WGM2);
+	}
+
+	m_timer2_tick = m_timer2_ticks[((m_r[TCCR2B] & AVR8_TCCR2B_WGM2_2_MASK) >> 1) | (m_r[TCCR2A] & AVR8_TCCR2A_WGM2_10_MASK)];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr2b_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER2, "%s: TCCR2B = %02x\n", machine().describe_context(), data);
+	const uint8_t oldtccr = m_r[TCCR2B];
+	const uint8_t newtccr = data;
+	const uint8_t changed = newtccr ^ oldtccr;
+	const uint8_t oldcs = m_r[TCCR2B] & AVR8_TCCR2B_CS_MASK;
+
+	m_r[TCCR2B] = data;
+
+	if (changed & AVR8_TCCR2B_FOC2A_MASK)
+	{
+		timer2_force_output_compare(AVR8_REG_A);
+	}
+
+	if (changed & AVR8_TCCR2B_FOC2B_MASK)
+	{
+		timer2_force_output_compare(AVR8_REG_B);
+	}
+
+	if (changed & AVR8_TCCR2B_WGM2_2_MASK)
+	{
+		update_timer_waveform_gen_mode(2, AVR8_WGM2);
+	}
+
+	if (changed & AVR8_TCCR2B_CS_MASK)
+	{
+		update_timer_clock_source<2>(AVR8_TIMER2_CLOCK_SELECT, oldcs);
+	}
+
+	m_timer2_tick = m_timer2_ticks[((m_r[TCCR2B] & AVR8_TCCR2B_WGM2_2_MASK) >> 1) | (m_r[TCCR2A] & AVR8_TCCR2A_WGM2_10_MASK)];
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tcnt2_w(uint8_t data)
+{
+	AVR8_TCNT2 = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr2a_w(uint8_t data)
+{
+	update_ocr2(data, AVR8_REG_A);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr2b_w(uint8_t data)
+{
+	update_ocr2(data, AVR8_REG_B);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr3a_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER3, "%s: (not yet implemented) TCCR3A = %02x\n", machine().describe_context(), data);
+	// TODO
+	//  AVR8_TCCR3A = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr3b_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER3, "%s: (not yet implemented) TCCR3B = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr3c_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER3, "%s: (not yet implemented) TCCR3C = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::icr3l_w(uint8_t data)
+{
+	AVR8_ICR3L = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::icr3h_w(uint8_t data)
+{
+	AVR8_ICR3H = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr3al_w(uint8_t data)
+{
+	AVR8_OCR3AL = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr3ah_w(uint8_t data)
+{
+	AVR8_OCR3AH = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr3bl_w(uint8_t data)
+{
+	AVR8_OCR3BL = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr3bh_w(uint8_t data)
+{
+	AVR8_OCR3BH = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr3cl_w(uint8_t data)
+{
+	AVR8_OCR3CL = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr3ch_w(uint8_t data)
+{
+	AVR8_OCR3CH = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr4a_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER4, "%s: TCCR4A = %02x\n", machine().describe_context(), data);
+	const uint8_t oldtccr = AVR8_TCCR4A;
+	const uint8_t newtccr = data;
+	const uint8_t changed = newtccr ^ oldtccr;
+
+	AVR8_TCCR4A = data;
+
+	if (changed & AVR8_TCCR4A_WGM4_10_MASK)
+	{
+		update_timer_waveform_gen_mode(4, AVR8_WGM4);
+	}
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr4b_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER4, "%s: TCCR4B = %02x\n", machine().describe_context(), data);
+	const uint8_t oldtccr = m_r[TCCR4B];
+	const uint8_t newtccr = data;
+	const uint8_t changed = newtccr ^ oldtccr;
+	const uint8_t oldcs = (m_r[TCCR4B] & AVR8_TCCR4B_CS_MASK) >> AVR8_TCCR4B_CS_SHIFT;
+
+	m_r[TCCR4B] = data;
+
+	if (changed & AVR8_TCCR4B_FOC4A_MASK)
+	{
+		// TODO
+		// timer4_force_output_compare(AVR8_REG_A);
+	}
+
+	if (changed & AVR8_TCCR4B_FOC4B_MASK)
+	{
+		// TODO
+		// timer4_force_output_compare(AVR8_REG_B);
+	}
+
+	if (changed & AVR8_TCCR4B_WGM4_32_MASK)
+	{
+		update_timer_waveform_gen_mode(4, AVR8_WGM4);
+	}
+
+	if (changed & AVR8_TCCR4B_CS_MASK)
+	{
+		update_timer_clock_source<4>(AVR8_TIMER4_CLOCK_SELECT, oldcs);
+	}
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr4c_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER4, "%s: TCCR4C = %02x\n", machine().describe_context(), data);
+	//  uint8_t oldtccr = AVR8_TCCR4C;
+	//  uint8_t newtccr = data;
+	//  uint8_t changed = newtccr ^ oldtccr;
+
+	AVR8_TCCR4C = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tcnt4l_w(uint8_t data)
+{
+	AVR8_TCNT4L = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tcnt4h_w(uint8_t data)
+{
+	AVR8_TCNT4H = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::icr4l_w(uint8_t data)
+{
+	AVR8_ICR4L = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::icr4h_w(uint8_t data)
+{
+	AVR8_ICR4H = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr4al_w(uint8_t data)
+{
+	AVR8_OCR4AL = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr4ah_w(uint8_t data)
+{
+	AVR8_OCR4AH = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr4bl_w(uint8_t data)
+{
+	AVR8_OCR4BL = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr4bh_w(uint8_t data)
+{
+	AVR8_OCR4BH = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr4cl_w(uint8_t data)
+{
+	AVR8_OCR4CL = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ocr4ch_w(uint8_t data)
+{
+	AVR8_OCR4CH = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr5a_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER5, "%s: TCCR5A = %02x\n", machine().describe_context(), data);
+	const uint8_t oldtccr = AVR8_TCCR5A;
+	const uint8_t newtccr = data;
+	const uint8_t changed = newtccr ^ oldtccr;
+
+	AVR8_TCCR5A = data;
+
+	if (changed & AVR8_TCCR5A_WGM5_10_MASK)
+	{
+		update_timer_waveform_gen_mode(5, AVR8_WGM5);
+	}
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::tccr5b_w(uint8_t data)
+{
+	LOGMASKED(LOG_TIMER5, "%s: TCCR5B = %02x\n", machine().describe_context(), data);
+	const uint8_t oldtccr = m_r[TCCR5B];
+	const uint8_t newtccr = data;
+	const uint8_t changed = newtccr ^ oldtccr;
+	const uint8_t oldcs = (m_r[TCCR5B] & AVR8_TCCR5B_CS_MASK) >> AVR8_TCCR5B_CS_SHIFT;
+
+	m_r[TCCR5B] = data;
+
+	if (changed & AVR8_TCCR5C_FOC5A_MASK)
+	{
+		// TODO
+		// timer5_force_output_compare(AVR8_REG_A);
+	}
+
+	if (changed & AVR8_TCCR5C_FOC5B_MASK)
+	{
+		// TODO
+		// timer5_force_output_compare(AVR8_REG_B);
+	}
+
+	if (changed & AVR8_TCCR5C_FOC5C_MASK)
+	{
+		// TODO
+		// timer5_force_output_compare(AVR8_REG_C);
+	}
+
+	if (changed & AVR8_TCCR5B_WGM5_32_MASK)
+	{
+		update_timer_waveform_gen_mode(5, AVR8_WGM5);
+	}
+
+	if (changed & AVR8_TCCR5B_CS_MASK)
+	{
+		update_timer_clock_source<5>(AVR8_TIMER5_CLOCK_SELECT, oldcs);
+	}
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::assr_w(uint8_t data)
+{
+	LOGMASKED(LOG_ASYNC, "%s: (not yet implemented) ASSR = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::twbr_w(uint8_t data)
+{
+	LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWBR = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+uint8_t avr8_device<NumTimers>::twsr_r()
+{
+	LOGMASKED(LOG_TWI, "%s: (not yet implemented) Read TWSR: %02x\n", machine().describe_context(), 0);
+	// HACK for Replicator 1:
+	//   By returning a value != 0x08, we induce an error state that makes the object code jump out of the wait loop,
+	//   and continue execution failing the 2-wire write operation.
+	return 0x00;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::twsr_w(uint8_t data)
+{
+	LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWSR = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::twar_w(uint8_t data)
+{
+	LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWAR = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::twdr_w(uint8_t data)
+{
+	LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWDR = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::twcr_w(uint8_t data)
+{
+	LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWCR = %02x\n", machine().describe_context(), data);
+	m_r[TWCR] = data;
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::twamr_w(uint8_t data)
+{
+	LOGMASKED(LOG_TWI, "%s: (not yet implemented) TWAMR = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ucsr0a_w(uint8_t data)
+{
+	LOGMASKED(LOG_UART, "%s: (not yet implemented) UCSR0A = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ucsr0b_w(uint8_t data)
+{
+	LOGMASKED(LOG_UART, "%s: (not yet implemented) UCSR0B = %02x\n", machine().describe_context(), data);
+}
+
+template <int NumTimers>
+void avr8_device<NumTimers>::ucsr0c_w(uint8_t data)
+{
+	LOGMASKED(LOG_UART, "%s: (not yet implemented) UCSR0C = %02x\n", machine().describe_context(), data);
 }
 
 
@@ -3332,7 +3559,8 @@ uint8_t avr8_device::regs_r(offs_t offset)
 //  cycles it takes for one instruction to execute
 //-------------------------------------------------
 
-uint32_t avr8_device::execute_min_cycles() const noexcept
+template <int NumTimers>
+uint32_t avr8_device<NumTimers>::execute_min_cycles() const noexcept
 {
 	return 1;
 }
@@ -3343,7 +3571,8 @@ uint32_t avr8_device::execute_min_cycles() const noexcept
 //  cycles it takes for one instruction to execute
 //-------------------------------------------------
 
-uint32_t avr8_device::execute_max_cycles() const noexcept
+template <int NumTimers>
+uint32_t avr8_device<NumTimers>::execute_max_cycles() const noexcept
 {
 	return 4;
 }
@@ -3354,13 +3583,15 @@ uint32_t avr8_device::execute_max_cycles() const noexcept
 //  input/interrupt lines
 //-------------------------------------------------
 
-uint32_t avr8_device::execute_input_lines() const noexcept
+template <int NumTimers>
+uint32_t avr8_device<NumTimers>::execute_input_lines() const noexcept
 {
 	return 0;
 }
 
 
-void avr8_device::execute_set_input(int inputnum, int state)
+template <int NumTimers>
+void avr8_device<NumTimers>::execute_set_input(int inputnum, int state)
 {
 }
 
@@ -3371,24 +3602,77 @@ void avr8_device::execute_set_input(int inputnum, int state)
 //  opcodes
 //-------------------------------------------------
 
-void avr8_device::execute_run()
+template <int NumTimers>
+void avr8_device<NumTimers>::execute_run()
 {
 	while (m_icount > 0)
 	{
 		m_pc &= m_addr_mask;
-		m_shifted_pc &= (m_addr_mask << 1) | 1;
+		debugger_instruction_hook(m_pc);
 
-		debugger_instruction_hook(m_shifted_pc);
-
-		const uint16_t op = (uint32_t)m_program->read_word(m_shifted_pc);
+		const uint16_t op = (uint32_t)m_program->read_word(m_pc);
 		m_opcycles = m_op_cycles[op];
 		((this)->*(m_op_funcs[op]))(op);
-		m_pc++;
-
-		m_shifted_pc = m_pc << 1;
+		m_pc += 2;
 
 		m_icount -= m_opcycles;
 
-		timer_tick();
+		for (int i = 0; i < m_opcycles; i++)
+		{
+			if (m_spi_active && m_spi_prescale > 0)
+			{
+				if (m_spi_prescale_countdown >= 0)
+				{
+					m_spi_prescale_count++;
+					if (m_spi_prescale_count >= m_spi_prescale)
+					{
+						spi_tick();
+						m_spi_prescale_count -= m_spi_prescale;
+					}
+				}
+			}
+
+			m_timer_prescale_count[0]++;
+			if (m_timer_prescale_count[0] > m_timer_prescale[0])
+			{
+				((this)->*(m_timer0_tick))();
+			}
+
+			m_timer_prescale_count[1]++;
+			if (m_timer_prescale_count[1] > m_timer_prescale[1])
+			{
+				((this)->*(m_timer1_tick))();
+			}
+
+			m_timer_prescale_count[2]++;
+			if (m_timer_prescale_count[2] > m_timer_prescale[2])
+			{
+				((this)->*(m_timer1_tick))();
+			}
+
+			if (NumTimers > 5)
+			{
+				m_timer_prescale_count[3]++;
+				if (m_timer_prescale_count[3] > m_timer_prescale[3])
+				{
+					timer3_tick();
+					m_timer_prescale_count[3] -= m_timer_prescale[3];
+				}
+
+				m_timer_prescale_count[4]++;
+				if (m_timer_prescale_count[4] > m_timer_prescale[4])
+				{
+					timer4_tick();
+					m_timer_prescale_count[4] -= m_timer_prescale[4];
+				}
+
+				m_timer_prescale_count[5]++;
+				if (m_timer_prescale_count[5] > m_timer_prescale[5])
+				{
+					timer5_tick();
+					m_timer_prescale_count[5] -= m_timer_prescale[5];
+				}
+			}
+		}
 	}
 }

--- a/src/devices/cpu/avr8/avr8.h
+++ b/src/devices/cpu/avr8/avr8.h
@@ -15,13 +15,25 @@
 //  TYPE DEFINITIONS
 //**************************************************************************
 
-// ======================> avr8_device
+// ======================> avr8_base_device
 
 // Used by core CPU interface
-template <int NumTimers>
-class avr8_device : public cpu_device
+class avr8_base_device : public cpu_device
 {
 public:
+	// inline configuration helpers
+	void set_eeprom_tag(const char *tag) { m_eeprom.set_tag(tag); }
+
+	// fuse configs
+	void set_low_fuses(uint8_t byte);
+	void set_high_fuses(uint8_t byte);
+	void set_extended_fuses(uint8_t byte);
+	void set_lock_bits(uint8_t byte);
+
+	// public interfaces
+	virtual void update_interrupt(int source);
+
+	// GPIO
 	enum gpio_t : int
 	{
 		GPIOA,
@@ -51,33 +63,530 @@ public:
 		ADC7
 	};
 
-	// inline configuration helpers
-	void set_eeprom_tag(const char *tag) { m_eeprom.set_tag(tag); }
-
-	// fuse configs
-	void set_low_fuses(uint8_t byte);
-	void set_high_fuses(uint8_t byte);
-	void set_extended_fuses(uint8_t byte);
-	void set_lock_bits(uint8_t byte);
-
-	// public interfaces
-	virtual void update_interrupt(int source);
-
-	// GPIO
-	template <gpio_t Port> auto gpio_out() { return m_gpio_out_cb[Port].bind(); }
-	template <gpio_t Port> auto gpio_in() { return m_gpio_in_cb[Port].bind(); }
-	template <int Port> uint8_t pin_r();
-	template <int Port> void port_w(uint8_t data);
-	template <int Port> uint8_t gpio_r();
-
-	// ADC
-	template<uint8_t Pin> auto adc_in() { return m_adc_in_cb[Pin].bind(); }
-
 protected:
-	avr8_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, const device_type type, uint32_t address_mask, address_map_constructor internal_map);
+	avr8_base_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, const device_type type, uint32_t address_mask, address_map_constructor internal_map);
 
-	typedef void (avr8_device::*timer_func) ();
-	typedef void (avr8_device::*op_func) (uint16_t op);
+	typedef void (avr8_base_device::*op_func) (uint16_t op);
+
+	enum : uint8_t
+	{
+		AVR8_INT_RESET = 0,
+		AVR8_INT_INT0,
+		AVR8_INT_INT1,
+		AVR8_INT_PCINT0,
+		AVR8_INT_PCINT1,
+		AVR8_INT_PCINT2,
+		AVR8_INT_WDT,
+		AVR8_INT_T2COMPA,
+		AVR8_INT_T2COMPB,
+		AVR8_INT_T2OVF,
+		AVR8_INT_T1CAPT,
+		AVR8_INT_T1COMPA,
+		AVR8_INT_T1COMPB,
+		AVR8_INT_T1OVF,
+		AVR8_INT_T0COMPA,
+		AVR8_INT_T0COMPB,
+		AVR8_INT_T0OVF,
+		AVR8_INT_SPI_STC,
+		AVR8_INT_USART_RX,
+		AVR8_INT_USART_UDRE,
+		AVR8_INT_USART_TX,
+		AVR8_INT_ADC,
+		AVR8_INT_EE_RDY,
+		AVR8_INT_ANALOG_COMP,
+		AVR8_INT_TWI,
+		AVR8_INT_SPM_RDY,
+	};
+
+	// Used by I/O register handling
+	enum : uint16_t
+	{
+		R0 = 0x00,
+		R1,
+		R2,
+		R3,
+		R4,
+		R5,
+		R6,
+		R7,
+		R8,
+		R9,
+		R10,
+		R11,
+		R12,
+		R13,
+		R14,
+		R15,
+		R16,
+		R17,
+		R18,
+		R19,
+		R20,
+		R21,
+		R22,
+		R23,
+		R24,
+		R25,
+		R26,
+		R27,
+		R28,
+		R29,
+		R30,
+		R31,
+		PINA = 0x20,
+		DDRA,
+		PORTA,
+		PINB,
+		DDRB,
+		PORTB,
+		PINC,
+		DDRC,
+		PORTC,
+		PIND,
+		DDRD,
+		PORTD,
+		PINE,
+		DDRE,
+		PORTE,
+		PINF,
+		DDRF,
+		PORTF,
+		PING,
+		DDRG,
+		PORTG,
+		TIFR0 = 0x35,
+		TIFR1,
+		TIFR2,
+		TIFR3,
+		TIFR4,
+		TIFR5,
+		PCIFR = 0x3B,
+		EIFR,
+		EIMSK,
+		GPIOR0,
+		EECR,
+		EEDR,
+		EEARL,
+		EEARH,
+		GTCCR,
+		TCCR0A,
+		TCCR0B,
+		TCNT0,
+		OCR0A,
+		OCR0B,
+		//0x49: Reserved
+		GPIOR1 = 0x4A,
+		GPIOR2,
+		SPCR,
+		SPSR,
+		SPDR,
+		//0x4F: Reserved
+		ACSR = 0x50,
+		OCDR,
+		//0x52: Reserved
+		SMCR = 0x53,
+		MCUSR,
+		MCUCR,
+		//0x56: Reserved
+		SPMCSR = 0x57,
+		//0x58: Reserved
+		//0x59: Reserved
+		//0x5A: Reserved
+		RAMPZ = 0x5B,
+		EIND,
+		SPL,
+		SPH,
+		SREG,
+	//--------------------------
+		WDTCSR = 0x60,
+		CLKPR,
+		//0x62: Reserved
+		//0x63: Reserved
+		PRR0 = 0x64,
+		PRR1,
+		OSCCAL,
+		//0x67: Reserved
+		PCICR = 0x68,
+		EICRA,
+		EICRB,
+		PCMSK0,
+		PCMSK1,
+		PCMSK2,
+		TIMSK0,
+		TIMSK1,
+		TIMSK2,
+		TIMSK3,
+		TIMSK4,
+		TIMSK5,
+		XMCRA,
+		XMCRB,
+		//0x76: Reserved
+		//0x77: Reserved
+		ADCL = 0x78,
+		ADCH,
+		ADCSRA,
+		ADCSRB,
+		ADMUX,
+		DIDR2,
+		DIDR0,
+		DIDR1,
+		TCCR1A,
+		TCCR1B,
+		TCCR1C,
+		//0x83: Reserved
+		TCNT1L = 0x84,
+		TCNT1H,
+		ICR1L,
+		ICR1H,
+		OCR1AL,
+		OCR1AH,
+		OCR1BL,
+		OCR1BH,
+		OCR1CL,
+		OCR1CH,
+		//0x8E: Reserved
+		//0x8F: Reserved
+		TCCR3A = 0x90,
+		TCCR3B,
+		TCCR3C,
+		//0x93: Reserved
+		TCNT3L = 0x94,
+		TCNT3H,
+		ICR3L,
+		ICR3H,
+		OCR3AL,
+		OCR3AH,
+		OCR3BL,
+		OCR3BH,
+		OCR3CL,
+		OCR3CH,
+		//0x9E: Reserved
+		//0x9F: Reserved
+		TCCR4A = 0xA0,
+		TCCR4B,
+		TCCR4C,
+		//0xA3: Reserved
+		TCNT4L = 0xA4,
+		TCNT4H,
+		ICR4L,
+		ICR4H,
+		OCR4AL,
+		OCR4AH,
+		OCR4BL,
+		OCR4BH,
+		OCR4CL,
+		OCR4CH,
+		//0xAE: Reserved
+		//0xAF: Reserved
+		TCCR2A = 0xB0,
+		TCCR2B,
+		TCNT2,
+		OCR2A,
+		OCR2B,
+		//0xB5: Reserved
+		ASSR = 0xB6,
+		//0xB7: Reserved
+		TWBR = 0xB8,
+		TWSR,
+		TWAR,
+		TWDR,
+		TWCR,
+		TWAMR,
+		//0xBE: Reserved
+		//0xBF: Reserved
+		UCSR0A = 0xC0,
+		UCSR0B,
+		UCSR0C,
+		//0xC3: Reserved
+		UBRR0L = 0xC4,
+		UBRR0H,
+		UDR0,
+		//0xC7: Reserved
+		UCSR1A = 0xC8,
+		UCSR1B,
+		UCSR1C,
+		//0xCB: Reserved
+		UBRR1L = 0xCC,
+		UBRR1H,
+		UDR1,
+		//0xCF: Reserved
+		UCSR2A = 0xD0,
+		UCSR2B,
+		UCSR2C,
+		//0xD3: Reserved
+		UBRR2L = 0xD4,
+		UBRR2H,
+		UDR2,
+		//0xD7: Reserved
+		//0xD8: Reserved
+		//0xD9: Reserved
+		//0xDA: Reserved
+		//0xDB: Reserved
+		//0xDC: Reserved
+		//0xDD: Reserved
+		//0xDE: Reserved
+		//0xDF: Reserved
+		//0xE0: Reserved
+		//0xE1: Reserved
+		//0xE2: Reserved
+		//0xE3: Reserved
+		//0xE4: Reserved
+		//0xE5: Reserved
+		//0xE6: Reserved
+		//0xE7: Reserved
+		//0xE8: Reserved
+		//0xE9: Reserved
+		//0xEA: Reserved
+		//0xEB: Reserved
+		//0xEC: Reserved
+		//0xED: Reserved
+		//0xEE: Reserved
+		//0xEF: Reserved
+		//0xF0: Reserved
+		//0xF1: Reserved
+		//0xF2: Reserved
+		//0xF3: Reserved
+		//0xF4: Reserved
+		//0xF5: Reserved
+		//0xF6: Reserved
+		//0xF7: Reserved
+		//0xF8: Reserved
+		//0xF9: Reserved
+		//0xFA: Reserved
+		//0xFB: Reserved
+		//0xFC: Reserved
+		//0xFD: Reserved
+		//0xFE: Reserved
+		//0xFF: Reserved
+		PINH = 0x100,
+		DDRH,
+		PORTH,
+		PINJ,
+		DDRJ,
+		PORTJ,
+		PINK,
+		DDRK,
+		PORTK,
+		PINL,
+		DDRL,
+		PORTL,
+		//0x10C: Reserved
+		//0x10D: Reserved
+		//0x10E: Reserved
+		//0x10F: Reserved
+		//0x110: Reserved
+		//0x111: Reserved
+		//0x112: Reserved
+		//0x113: Reserved
+		//0x114: Reserved
+		//0x115: Reserved
+		//0x116: Reserved
+		//0x117: Reserved
+		//0x118: Reserved
+		//0x119: Reserved
+		//0x11A: Reserved
+		//0x11B: Reserved
+		//0x11C: Reserved
+		//0x11D: Reserved
+		//0x11E: Reserved
+		//0x11F: Reserved
+		TCCR5A = 0x120,
+		TCCR5B,
+		TCCR5C,
+		//0x123: Reserved
+		TCNT5L = 0x124,
+		TCNT5H,
+		ICR5L,
+		ICR5H,
+		OCR5AL,
+		OCR5AH,
+		OCR5BL,
+		OCR5BH,
+		OCR5CL,
+		OCR5CH,
+		//0x12E: Reserved
+		//0x12F: Reserved
+		UCSR3A = 0x130,
+		UCSR3B,
+		UCSR3C,
+		//0x133: Reserved
+		UBRR3L = 0x134,
+		UBRR3H,
+		UDR3
+		//0x137: Reserved
+		//  .
+		//  . up to
+		//  .
+		//0x1FF: Reserved
+	};
+
+	enum : uint8_t
+	{
+		AVR8_IO_PORTA = 0,
+		AVR8_IO_PORTB,
+		AVR8_IO_PORTC,
+		AVR8_IO_PORTD,
+		AVR8_IO_PORTE,
+		AVR8_IO_PORTF,
+		AVR8_IO_PORTG,
+		AVR8_IO_PORTH,
+		AVR8_IO_PORTJ,
+		AVR8_IO_PORTK,
+		AVR8_IO_PORTL
+	};
+
+	enum : uint8_t
+	{
+		AVR8_REG_A = 0,
+		AVR8_REG_B,
+		AVR8_REG_C,
+		AVR8_REG_D,
+		AVR8_REG_E,
+		AVR8_REG_F,
+		AVR8_REG_G,
+		AVR8_REG_H,
+		AVR8_REG_J,
+		AVR8_REG_K,
+		AVR8_REG_L
+	};
+
+	enum : uint8_t
+	{
+		INTIDX_SPI,
+
+		INTIDX_OCF0B,
+		INTIDX_OCF0A,
+		INTIDX_TOV0,
+
+		INTIDX_ICF1,
+
+		INTIDX_OCF1B,
+		INTIDX_OCF1A,
+		INTIDX_TOV1,
+
+		INTIDX_OCF2B,
+		INTIDX_OCF2A,
+		INTIDX_TOV2,
+
+	//------ TODO: review this --------
+		INTIDX_OCF3B,
+		INTIDX_OCF3A,
+		INTIDX_TOV3,
+
+		INTIDX_OCF4B,
+		INTIDX_OCF4A,
+		INTIDX_TOV4,
+
+		INTIDX_OCF5B,
+		INTIDX_OCF5A,
+		INTIDX_TOV5,
+	//---------------------------------
+
+		INTIDX_COUNT
+	};
+
+	enum : uint8_t
+	{
+		ATMEGA644_INT_RESET = 0,
+		ATMEGA644_INT_INT0,
+		ATMEGA644_INT_INT1,
+		ATMEGA644_INT_INT2,
+		ATMEGA644_INT_PCINT0,
+		ATMEGA644_INT_PCINT1,
+		ATMEGA644_INT_PCINT2,
+		ATMEGA644_INT_PCINT3,
+		ATMEGA644_INT_WDT,
+		ATMEGA644_INT_T2COMPA,
+		ATMEGA644_INT_T2COMPB,
+		ATMEGA644_INT_T2OVF,
+		ATMEGA644_INT_T1CAPT,
+		ATMEGA644_INT_T1COMPA,
+		ATMEGA644_INT_T1COMPB,
+		ATMEGA644_INT_T1OVF,
+		ATMEGA644_INT_T0COMPA,
+		ATMEGA644_INT_T0COMPB,
+		ATMEGA644_INT_T0OVF,
+		ATMEGA644_INT_SPI_STC,
+		ATMEGA644_INT_USART_RX,
+		ATMEGA644_INT_USART_UDRE,
+		ATMEGA644_INT_USART_TX,
+		ATMEGA644_INT_ADC,
+		ATMEGA644_INT_EE_RDY,
+		ATMEGA644_INT_ANALOG_COMP,
+		ATMEGA644_INT_TWI,
+		ATMEGA644_INT_SPM_RDY
+	};
+
+	// lock bit masks
+	enum : uint8_t
+	{
+		LB1		= (1 << 0),
+		LB2		= (1 << 1),
+		BLB01	= (1 << 2),
+		BLB02	= (1 << 3),
+		BLB11	= (1 << 4),
+		BLB12	= (1 << 5)
+	};
+
+	// extended fuses bit masks
+	enum : uint8_t
+	{
+		BODLEVEL0 = (1 << 0),
+		BODLEVEL1 = (1 << 1),
+		BODLEVEL2 = (1 << 2)
+	};
+
+	// high fuses bit masks
+	enum : uint8_t
+	{
+		BOOTRST	= (1 << 0),
+		BOOTSZ0 = (1 << 1),
+		BOOTSZ1 = (1 << 2),
+		EESAVE	= (1 << 3),
+		WDTON	= (1 << 4),
+		SPIEN	= (1 << 5),
+		JTAGEN	= (1 << 6),
+		OCDEN	= (1 << 7)
+	};
+
+	// low fuses bit masks
+	enum : uint8_t
+	{
+		CKSEL0	= (1 << 0),
+		CKSEL1	= (1 << 1),
+		CKSEL2	= (1 << 2),
+		CKSEL3	= (1 << 3),
+		SUT0	= (1 << 4),
+		SUT1	= (1 << 5),
+		CKOUT	= (1 << 6),
+		CKDIV8	= (1 << 7)
+	};
+
+	enum : uint8_t
+	{
+		EEARH_MASK = (1 << 0),
+
+		SPSR_SPR2X_MASK = (1 << 0),
+		SPSR_SPIF_SHIFT = 7,
+		SPSR_SPIF_MASK = (1 << SPSR_SPIF_SHIFT),
+
+		SPCR_SPR_MASK = (3 << 0),
+		SPCR_CPHA_MASK = (1 << 2),
+		SPCR_CPOL_MASK = (1 << 3),
+		SPCR_MSTR_MASK = (1 << 4),
+		SPCR_DORD_MASK = (1 << 5),
+		SPCR_SPE_MASK = (1 << 6),
+		SPCR_SPIE_MASK = (1 << 7)
+	};
+
+	struct interrupt_condition
+	{
+		uint8_t m_intindex;
+		uint8_t m_intreg;
+		uint8_t m_intmask;
+		uint8_t m_regindex;
+		uint8_t m_regmask;
+	};
 
 	op_func m_op_funcs[0x10000];
 	int m_op_cycles[0x10000];
@@ -94,11 +603,9 @@ protected:
 	virtual void device_reset() override;
 
 	// device_execute_interface overrides
-	virtual uint32_t execute_min_cycles() const noexcept override;
-	virtual uint32_t execute_max_cycles() const noexcept override;
-	virtual uint32_t execute_input_lines() const noexcept override;
-	virtual void execute_run() override;
-	virtual void execute_set_input(int inputnum, int state) override;
+	virtual uint32_t execute_min_cycles() const noexcept override { return 1; }
+	virtual uint32_t execute_max_cycles() const noexcept override { return 4; }
+	virtual uint32_t execute_input_lines() const noexcept override { return 0; }
 
 	// device_memory_interface overrides
 	virtual space_config_vector memory_space_config() const override;
@@ -110,7 +617,6 @@ protected:
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	// address spaces
-	void base_internal_map(address_map &map);
 	const address_space_config m_program_config;
 	const address_space_config m_data_config;
 	required_region_ptr<uint8_t> m_eeprom;
@@ -127,152 +633,6 @@ protected:
 	// CPU registers
 	required_shared_ptr<uint8_t> m_r;
 	uint32_t m_pc;
-
-	void tccr0a_w(uint8_t data);
-	void tccr0b_w(uint8_t data);
-	void ocr0a_w(uint8_t data);
-	void ocr0b_w(uint8_t data);
-	void tifr0_w(uint8_t data);
-	void tifr1_w(uint8_t data);
-	void tifr2_w(uint8_t data);
-	void gtccr_w(uint8_t data);
-	void eecr_w(uint8_t data);
-	void gpior0_w(uint8_t data);
-	void gpior1_w(uint8_t data);
-	void gpior2_w(uint8_t data);
-	void spsr_w(uint8_t data);
-	void spcr_w(uint8_t data);
-	void spdr_w(uint8_t data);
-	void wdtcsr_w(uint8_t data);
-	void clkpr_w(uint8_t data);
-	void prr0_w(uint8_t data);
-	void prr1_w(uint8_t data);
-	void osccal_w(uint8_t data);
-	void pcicr_w(uint8_t data);
-	void eicra_w(uint8_t data);
-	void eicrb_w(uint8_t data);
-	void pcmsk0_w(uint8_t data);
-	void pcmsk1_w(uint8_t data);
-	void pcmsk2_w(uint8_t data);
-	void timsk0_w(uint8_t data);
-	void timsk1_w(uint8_t data);
-	void timsk2_w(uint8_t data);
-	void timsk3_w(uint8_t data);
-	void timsk4_w(uint8_t data);
-	void timsk5_w(uint8_t data);
-	void xmcra_w(uint8_t data);
-	void xmcrb_w(uint8_t data);
-	uint8_t adcl_r();
-	void adcl_w(uint8_t data);
-	uint8_t adch_r();
-	void adch_w(uint8_t data);
-	void adcsra_w(uint8_t data);
-	void adcsrb_w(uint8_t data);
-	void admux_w(uint8_t data);
-	void didr0_w(uint8_t data);
-	void didr1_w(uint8_t data);
-	void didr2_w(uint8_t data);
-	void tccr1a_w(uint8_t data);
-	void tccr1b_w(uint8_t data);
-	void tccr1c_w(uint8_t data);
-	void tcnt1l_w(uint8_t data);
-	void tcnt1h_w(uint8_t data);
-	void icr1l_w(uint8_t data);
-	void icr1h_w(uint8_t data);
-	void ocr1al_w(uint8_t data);
-	void ocr1ah_w(uint8_t data);
-	void ocr1bl_w(uint8_t data);
-	void ocr1bh_w(uint8_t data);
-	void ocr1cl_w(uint8_t data);
-	void ocr1ch_w(uint8_t data);
-	void tccr2a_w(uint8_t data);
-	void tccr2b_w(uint8_t data);
-	void tcnt2_w(uint8_t data);
-	void ocr2a_w(uint8_t data);
-	void ocr2b_w(uint8_t data);
-	void tccr3a_w(uint8_t data);
-	void tccr3b_w(uint8_t data);
-	void tccr3c_w(uint8_t data);
-	void tcnt3l_w(uint8_t data);
-	void tcnt3h_w(uint8_t data);
-	void icr3l_w(uint8_t data);
-	void icr3h_w(uint8_t data);
-	void ocr3al_w(uint8_t data);
-	void ocr3ah_w(uint8_t data);
-	void ocr3bl_w(uint8_t data);
-	void ocr3bh_w(uint8_t data);
-	void ocr3cl_w(uint8_t data);
-	void ocr3ch_w(uint8_t data);
-	void tccr4a_w(uint8_t data);
-	void tccr4b_w(uint8_t data);
-	void tccr4c_w(uint8_t data);
-	void tcnt4l_w(uint8_t data);
-	void tcnt4h_w(uint8_t data);
-	void icr4l_w(uint8_t data);
-	void icr4h_w(uint8_t data);
-	void ocr4al_w(uint8_t data);
-	void ocr4ah_w(uint8_t data);
-	void ocr4bl_w(uint8_t data);
-	void ocr4bh_w(uint8_t data);
-	void ocr4cl_w(uint8_t data);
-	void ocr4ch_w(uint8_t data);
-	void tccr5a_w(uint8_t data);
-	void tccr5b_w(uint8_t data);
-	void assr_w(uint8_t data);
-	void twbr_w(uint8_t data);
-	uint8_t twsr_r();
-	void twsr_w(uint8_t data);
-	void twar_w(uint8_t data);
-	void twdr_w(uint8_t data);
-	void twcr_w(uint8_t data);
-	void twamr_w(uint8_t data);
-	void ucsr0a_w(uint8_t data);
-	void ucsr0b_w(uint8_t data);
-	void ucsr0c_w(uint8_t data);
-
-	timer_func m_timer0_ticks[8*4];
-	timer_func m_timer1_ticks[16*16];
-	timer_func m_timer2_ticks[8];
-	timer_func m_timer0_tick;
-	timer_func m_timer1_tick;
-	timer_func m_timer2_tick;
-	int32_t m_num_timers;
-	int32_t m_timer_top[6];
-	uint16_t m_timer_prescale[6];
-	uint16_t m_timer_prescale_count[6];
-	int32_t m_wgm1;
-	int32_t m_timer1_compare_mode[2];
-	uint16_t m_ocr1[3];
-	bool m_ocr2_not_reached_yet;
-
-	// GPIO
-	devcb_write8::array<11> m_gpio_out_cb;
-	devcb_read8::array<11> m_gpio_in_cb;
-
-	// ADC
-	devcb_read16::array<8> m_adc_in_cb;
-	emu_timer *m_adc_timer;
-	uint16_t m_adc_sample;
-	uint16_t m_adc_result;
-	uint16_t m_adc_data;
-	bool m_adc_first;
-	bool m_adc_hold;
-	void adc_start_conversion();
-	TIMER_CALLBACK_MEMBER(adc_conversion_complete);
-
-	// SPI
-	bool m_spi_active;
-	uint8_t m_spi_prescale;
-	uint8_t m_spi_prescale_count;
-	int8_t m_spi_prescale_countdown;
-	void enable_spi();
-	void disable_spi();
-	void spi_update_masterslave_select();
-	void spi_update_clock_polarity();
-	void spi_update_clock_phase();
-	void spi_update_clock_rate();
-	void change_spcr(uint8_t data);
-	void change_spsr(uint8_t data);
 
 	// internal CPU state
 	uint32_t m_addr_mask;
@@ -291,138 +651,6 @@ protected:
 
 	// interrupts
 	void set_irq_line(uint16_t vector, int state);
-
-	// timers
-	void spi_tick();
-	template <int Timer> void update_timer_clock_source(uint8_t selection, const uint8_t old_clock_select);
-	void update_timer_waveform_gen_mode(uint8_t timer, uint8_t mode);
-
-	// timer 0
-	void timer0_tick_norm();
-	void timer0_tick_pwm_pc();
-	void timer0_tick_ctc_norm();
-	void timer0_tick_ctc_toggle();
-	void timer0_tick_ctc_clear();
-	void timer0_tick_ctc_set();
-	void timer0_tick_fast_pwm();
-	void timer0_tick_pwm_pc_cmp();
-	void timer0_tick_fast_pwm_cmp();
-	void timer0_tick_default();
-
-	void update_ocr0(uint8_t newval, uint8_t reg);
-	void timer0_force_output_compare(int reg);
-
-	enum ocr_mode_t : uint8_t
-	{
-		OCR_NORM,
-		OCR_TOGGLE,
-		OCR_CLEAR,
-		OCR_SET
-	};
-
-	enum wgm1_mode_t : uint8_t
-	{
-		WGM1_NORMAL = 0,
-		WGM1_PWM_8_PC,
-		WGM1_PWM_9_PC,
-		WGM1_PWM_10_PC,
-		WGM1_CTC_OCR,
-		WGM1_FAST_PWM_8,
-		WGM1_FAST_PWM_9,
-		WGM1_FAST_PWM_10,
-		WGM1_PWM_PFC_ICR,
-		WGM1_PWM_PFC_OCR,
-		WGM1_PWM_PC_ICR,
-		WGM1_PWM_PC_OCR,
-		WGM1_CTC_ICR,
-		WGM1_RESERVED,
-		WGM1_FAST_PWM_ICR,
-		WGM1_FAST_PWM_OCR
-	};
-
-	// timer 1
-	template <int TimerMode, int ChannelModeA, int ChannelModeB> void timer1_tick();
-	void timer1_tick_normal() { timer1_tick<WGM1_NORMAL, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_pwm8_pc() { timer1_tick<WGM1_PWM_8_PC, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_pwm9_pc() { timer1_tick<WGM1_PWM_9_PC, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_pwm10_pc() { timer1_tick<WGM1_PWM_10_PC, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_ctc_ocr_norm_norm() { timer1_tick<WGM1_CTC_OCR, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_ctc_ocr_norm_toggle() { timer1_tick<WGM1_CTC_OCR, OCR_NORM, OCR_TOGGLE>(); };
-	void timer1_tick_ctc_ocr_norm_clear() { timer1_tick<WGM1_CTC_OCR, OCR_NORM, OCR_CLEAR>(); };
-	void timer1_tick_ctc_ocr_norm_set() { timer1_tick<WGM1_CTC_OCR, OCR_NORM, OCR_SET>(); };
-	void timer1_tick_ctc_ocr_toggle_norm() { timer1_tick<WGM1_CTC_OCR, OCR_TOGGLE, OCR_NORM>(); };
-	void timer1_tick_ctc_ocr_toggle_toggle() { timer1_tick<WGM1_CTC_OCR, OCR_TOGGLE, OCR_TOGGLE>(); };
-	void timer1_tick_ctc_ocr_toggle_clear() { timer1_tick<WGM1_CTC_OCR, OCR_TOGGLE, OCR_CLEAR>(); };
-	void timer1_tick_ctc_ocr_toggle_set() { timer1_tick<WGM1_CTC_OCR, OCR_TOGGLE, OCR_SET>(); };
-	void timer1_tick_ctc_ocr_clear_norm() { timer1_tick<WGM1_CTC_OCR, OCR_CLEAR, OCR_NORM>(); };
-	void timer1_tick_ctc_ocr_clear_toggle() { timer1_tick<WGM1_CTC_OCR, OCR_CLEAR, OCR_TOGGLE>(); };
-	void timer1_tick_ctc_ocr_clear_clear() { timer1_tick<WGM1_CTC_OCR, OCR_CLEAR, OCR_CLEAR>(); };
-	void timer1_tick_ctc_ocr_clear_set() { timer1_tick<WGM1_CTC_OCR, OCR_CLEAR, OCR_SET>(); };
-	void timer1_tick_ctc_ocr_set_norm() { timer1_tick<WGM1_CTC_OCR, OCR_SET, OCR_NORM>(); };
-	void timer1_tick_ctc_ocr_set_toggle() { timer1_tick<WGM1_CTC_OCR, OCR_SET, OCR_TOGGLE>(); };
-	void timer1_tick_ctc_ocr_set_clear() { timer1_tick<WGM1_CTC_OCR, OCR_SET, OCR_CLEAR>(); };
-	void timer1_tick_ctc_ocr_set_set() { timer1_tick<WGM1_CTC_OCR, OCR_SET, OCR_SET>(); };
-	void timer1_tick_fast_pwm8() { timer1_tick<WGM1_FAST_PWM_8, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_fast_pwm9() { timer1_tick<WGM1_FAST_PWM_9, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_fast_pwm10() { timer1_tick<WGM1_FAST_PWM_10, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_pwm_pfc_icr() { timer1_tick<WGM1_PWM_PFC_ICR, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_pwm_pfc_ocr() { timer1_tick<WGM1_PWM_PFC_OCR, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_pwm_pc_icr() { timer1_tick<WGM1_PWM_PC_ICR, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_pwm_pc_ocr() { timer1_tick<WGM1_PWM_PC_OCR, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_ctc_icr() { timer1_tick<WGM1_CTC_ICR, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_resv() { timer1_tick<WGM1_RESERVED, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_fast_pwm_icr_norm_norm() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_fast_pwm_icr_norm_toggle() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_NORM, OCR_TOGGLE>(); };
-	void timer1_tick_fast_pwm_icr_norm_clear() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_NORM, OCR_CLEAR>(); };
-	void timer1_tick_fast_pwm_icr_norm_set() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_NORM, OCR_SET>(); };
-	void timer1_tick_fast_pwm_icr_toggle_norm() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_TOGGLE, OCR_NORM>(); };
-	void timer1_tick_fast_pwm_icr_toggle_toggle() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_TOGGLE, OCR_TOGGLE>(); };
-	void timer1_tick_fast_pwm_icr_toggle_clear() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_TOGGLE, OCR_CLEAR>(); };
-	void timer1_tick_fast_pwm_icr_toggle_set() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_TOGGLE, OCR_SET>(); };
-	void timer1_tick_fast_pwm_icr_clear_norm() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_CLEAR, OCR_NORM>(); };
-	void timer1_tick_fast_pwm_icr_clear_toggle() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_CLEAR, OCR_TOGGLE>(); };
-	void timer1_tick_fast_pwm_icr_clear_clear() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_CLEAR, OCR_CLEAR>(); };
-	void timer1_tick_fast_pwm_icr_clear_set() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_CLEAR, OCR_SET>(); };
-	void timer1_tick_fast_pwm_icr_set_norm() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_SET, OCR_NORM>(); };
-	void timer1_tick_fast_pwm_icr_set_toggle() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_SET, OCR_TOGGLE>(); };
-	void timer1_tick_fast_pwm_icr_set_clear() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_SET, OCR_CLEAR>(); };
-	void timer1_tick_fast_pwm_icr_set_set() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_SET, OCR_SET>(); };
-	void timer1_tick_fast_pwm_ocr_norm_norm() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_NORM, OCR_NORM>(); };
-	void timer1_tick_fast_pwm_ocr_norm_toggle() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_NORM, OCR_TOGGLE>(); };
-	void timer1_tick_fast_pwm_ocr_norm_clear() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_NORM, OCR_CLEAR>(); };
-	void timer1_tick_fast_pwm_ocr_norm_set() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_NORM, OCR_SET>(); };
-	void timer1_tick_fast_pwm_ocr_toggle_norm() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_TOGGLE, OCR_NORM>(); };
-	void timer1_tick_fast_pwm_ocr_toggle_toggle() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_TOGGLE, OCR_TOGGLE>(); };
-	void timer1_tick_fast_pwm_ocr_toggle_clear() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_TOGGLE, OCR_CLEAR>(); };
-	void timer1_tick_fast_pwm_ocr_toggle_set() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_TOGGLE, OCR_SET>(); };
-	void timer1_tick_fast_pwm_ocr_clear_norm() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_CLEAR, OCR_NORM>(); };
-	void timer1_tick_fast_pwm_ocr_clear_toggle() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_CLEAR, OCR_TOGGLE>(); };
-	void timer1_tick_fast_pwm_ocr_clear_clear() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_CLEAR, OCR_CLEAR>(); };
-	void timer1_tick_fast_pwm_ocr_clear_set() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_CLEAR, OCR_SET>(); };
-	void timer1_tick_fast_pwm_ocr_set_norm() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_SET, OCR_NORM>(); };
-	void timer1_tick_fast_pwm_ocr_set_toggle() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_SET, OCR_TOGGLE>(); };
-	void timer1_tick_fast_pwm_ocr_set_clear() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_SET, OCR_CLEAR>(); };
-	void timer1_tick_fast_pwm_ocr_set_set() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_SET, OCR_SET>(); };
-	void update_timer1_input_noise_canceler();
-	void update_timer1_input_edge_select();
-	void update_ocr1(uint16_t newval, uint8_t reg);
-
-	// timer 2
-	void timer2_tick_default();
-	void timer2_tick_norm();
-	void timer2_tick_fast_pwm();
-	void timer2_tick_fast_pwm_cmp();
-	void update_ocr2(uint8_t newval, uint8_t reg);
-	void timer2_force_output_compare(int reg);
-
-	// timer 3
-	void timer3_tick();
-
-	// timer 4
-	void timer4_tick();
-
-	// timer 5
-	void timer5_tick();
 
 	// ops
 	void populate_ops();
@@ -529,6 +757,333 @@ protected:
 	// address spaces
 	address_space *m_program;
 	address_space *m_data;
+
+	static const interrupt_condition s_int_conditions[INTIDX_COUNT];
+	static const interrupt_condition s_mega644_int_conditions[INTIDX_COUNT];
+};
+
+// ======================> avr8_device
+
+template <int NumTimers>
+class avr8_device : public avr8_base_device
+{
+public:
+	// GPIO
+	template <gpio_t Port> auto gpio_out() { return m_gpio_out_cb[Port].bind(); }
+	template <gpio_t Port> auto gpio_in() { return m_gpio_in_cb[Port].bind(); }
+	template <int Port> uint8_t pin_r();
+	template <int Port> void port_w(uint8_t data);
+	template <int Port> uint8_t gpio_r();
+
+	// ADC
+	template<uint8_t Pin> auto adc_in() { return m_adc_in_cb[Pin].bind(); }
+
+protected:
+	avr8_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, const device_type type, uint32_t address_mask, address_map_constructor internal_map);
+
+	typedef delegate<void (void)> timer_func;
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// device_execute_interface overrides
+	virtual void execute_run() override;
+
+	// address maps
+	void base_internal_map(address_map &map);
+
+	// Miscellaneous registers
+	void wdtcsr_w(uint8_t data);
+	void clkpr_w(uint8_t data);
+	void prr0_w(uint8_t data);
+	void prr1_w(uint8_t data);
+	void osccal_w(uint8_t data);
+	void pcicr_w(uint8_t data);
+	void eicra_w(uint8_t data);
+	void eicrb_w(uint8_t data);
+	void pcmsk0_w(uint8_t data);
+	void pcmsk1_w(uint8_t data);
+	void pcmsk2_w(uint8_t data);
+	void xmcra_w(uint8_t data);
+	void xmcrb_w(uint8_t data);
+	void didr0_w(uint8_t data);
+	void didr1_w(uint8_t data);
+	void didr2_w(uint8_t data);
+	void assr_w(uint8_t data);
+	void twbr_w(uint8_t data);
+	uint8_t twsr_r();
+	void twsr_w(uint8_t data);
+	void twar_w(uint8_t data);
+	void twdr_w(uint8_t data);
+	void twcr_w(uint8_t data);
+	void twamr_w(uint8_t data);
+	void ucsr0a_w(uint8_t data);
+	void ucsr0b_w(uint8_t data);
+	void ucsr0c_w(uint8_t data);
+
+	// EEPROM
+	void eecr_w(uint8_t data);
+
+	void gpior0_w(uint8_t data);
+	void gpior1_w(uint8_t data);
+	void gpior2_w(uint8_t data);
+
+	devcb_write8::array<11> m_gpio_out_cb;
+	devcb_read8::array<11> m_gpio_in_cb;
+
+	// ADC
+	uint8_t adcl_r();
+	void adcl_w(uint8_t data);
+	uint8_t adch_r();
+	void adch_w(uint8_t data);
+	void adcsra_w(uint8_t data);
+	void adcsrb_w(uint8_t data);
+	void admux_w(uint8_t data);
+
+	void adc_start_conversion();
+	TIMER_CALLBACK_MEMBER(adc_conversion_complete);
+
+	devcb_read16::array<8> m_adc_in_cb;
+	emu_timer *m_adc_timer;
+	uint16_t m_adc_sample;
+	uint16_t m_adc_result;
+	uint16_t m_adc_data;
+	bool m_adc_first;
+	bool m_adc_hold;
+
+	// SPI
+	void spsr_w(uint8_t data);
+	void spcr_w(uint8_t data);
+	void spdr_w(uint8_t data);
+
+	void spi_tick();
+	void enable_spi();
+	void disable_spi();
+	void spi_update_masterslave_select();
+	void spi_update_clock_polarity();
+	void spi_update_clock_phase();
+	void spi_update_clock_rate();
+	void change_spcr(uint8_t data);
+	void change_spsr(uint8_t data);
+
+	bool m_spi_active;
+	uint8_t m_spi_prescale;
+	uint8_t m_spi_prescale_count;
+	int8_t m_spi_prescale_countdown;
+
+	// timers
+	void gtccr_w(uint8_t data);
+
+	template <int Timer> void update_timer_clock_source(uint8_t selection, const uint8_t old_clock_select);
+	void update_timer_waveform_gen_mode(uint8_t timer, uint8_t mode);
+
+	int32_t m_timer_top[6];
+	uint16_t m_timer_prescale[6];
+	uint16_t m_timer_prescale_count[6];
+
+	// timer 0
+	void tccr0a_w(uint8_t data);
+	void tccr0b_w(uint8_t data);
+	void ocr0a_w(uint8_t data);
+	void ocr0b_w(uint8_t data);
+	void tifr0_w(uint8_t data);
+	void timsk0_w(uint8_t data);
+
+	void timer0_tick_norm();
+	void timer0_tick_pwm_pc();
+	void timer0_tick_ctc_norm();
+	void timer0_tick_ctc_toggle();
+	void timer0_tick_ctc_clear();
+	void timer0_tick_ctc_set();
+	void timer0_tick_fast_pwm();
+	void timer0_tick_pwm_pc_cmp();
+	void timer0_tick_fast_pwm_cmp();
+	void timer0_tick_default();
+
+	void update_ocr0(uint8_t newval, uint8_t reg);
+	void timer0_force_output_compare(int reg);
+
+	timer_func m_timer0_ticks[8*4];
+	timer_func m_timer0_tick;
+
+	// timer 1
+	enum wgm1_mode_t
+	{
+		WGM1_NORMAL = 0,
+		WGM1_PWM_8_PC,
+		WGM1_PWM_9_PC,
+		WGM1_PWM_10_PC,
+		WGM1_CTC_OCR,
+		WGM1_FAST_PWM_8,
+		WGM1_FAST_PWM_9,
+		WGM1_FAST_PWM_10,
+		WGM1_PWM_PFC_ICR,
+		WGM1_PWM_PFC_OCR,
+		WGM1_PWM_PC_ICR,
+		WGM1_PWM_PC_OCR,
+		WGM1_CTC_ICR,
+		WGM1_RESERVED,
+		WGM1_FAST_PWM_ICR,
+		WGM1_FAST_PWM_OCR
+	};
+
+	enum ocr_mode_t
+	{
+		OCR_NORM = 0,
+		OCR_TOGGLE,
+		OCR_CLEAR,
+		OCR_SET
+	};
+
+	void tccr1a_w(uint8_t data);
+	void tccr1b_w(uint8_t data);
+	void tccr1c_w(uint8_t data);
+	void tcnt1l_w(uint8_t data);
+	void tcnt1h_w(uint8_t data);
+	void icr1l_w(uint8_t data);
+	void icr1h_w(uint8_t data);
+	void ocr1al_w(uint8_t data);
+	void ocr1ah_w(uint8_t data);
+	void ocr1bl_w(uint8_t data);
+	void ocr1bh_w(uint8_t data);
+	void ocr1cl_w(uint8_t data);
+	void ocr1ch_w(uint8_t data);
+	void tifr1_w(uint8_t data);
+	void timsk1_w(uint8_t data);
+
+	template <int TimerMode, int ChannelModeA, int ChannelModeB> void timer1_tick();
+	void timer1_tick_normal() { timer1_tick<WGM1_NORMAL, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_pwm8_pc() { timer1_tick<WGM1_PWM_8_PC, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_pwm9_pc() { timer1_tick<WGM1_PWM_9_PC, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_pwm10_pc() { timer1_tick<WGM1_PWM_10_PC, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_ctc_ocr_norm_norm() { timer1_tick<WGM1_CTC_OCR, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_ctc_ocr_norm_toggle() { timer1_tick<WGM1_CTC_OCR, OCR_NORM, OCR_TOGGLE>(); };
+	void timer1_tick_ctc_ocr_norm_clear() { timer1_tick<WGM1_CTC_OCR, OCR_NORM, OCR_CLEAR>(); };
+	void timer1_tick_ctc_ocr_norm_set() { timer1_tick<WGM1_CTC_OCR, OCR_NORM, OCR_SET>(); };
+	void timer1_tick_ctc_ocr_toggle_norm() { timer1_tick<WGM1_CTC_OCR, OCR_TOGGLE, OCR_NORM>(); };
+	void timer1_tick_ctc_ocr_toggle_toggle() { timer1_tick<WGM1_CTC_OCR, OCR_TOGGLE, OCR_TOGGLE>(); };
+	void timer1_tick_ctc_ocr_toggle_clear() { timer1_tick<WGM1_CTC_OCR, OCR_TOGGLE, OCR_CLEAR>(); };
+	void timer1_tick_ctc_ocr_toggle_set() { timer1_tick<WGM1_CTC_OCR, OCR_TOGGLE, OCR_SET>(); };
+	void timer1_tick_ctc_ocr_clear_norm() { timer1_tick<WGM1_CTC_OCR, OCR_CLEAR, OCR_NORM>(); };
+	void timer1_tick_ctc_ocr_clear_toggle() { timer1_tick<WGM1_CTC_OCR, OCR_CLEAR, OCR_TOGGLE>(); };
+	void timer1_tick_ctc_ocr_clear_clear() { timer1_tick<WGM1_CTC_OCR, OCR_CLEAR, OCR_CLEAR>(); };
+	void timer1_tick_ctc_ocr_clear_set() { timer1_tick<WGM1_CTC_OCR, OCR_CLEAR, OCR_SET>(); };
+	void timer1_tick_ctc_ocr_set_norm() { timer1_tick<WGM1_CTC_OCR, OCR_SET, OCR_NORM>(); };
+	void timer1_tick_ctc_ocr_set_toggle() { timer1_tick<WGM1_CTC_OCR, OCR_SET, OCR_TOGGLE>(); };
+	void timer1_tick_ctc_ocr_set_clear() { timer1_tick<WGM1_CTC_OCR, OCR_SET, OCR_CLEAR>(); };
+	void timer1_tick_ctc_ocr_set_set() { timer1_tick<WGM1_CTC_OCR, OCR_SET, OCR_SET>(); };
+	void timer1_tick_fast_pwm8() { timer1_tick<WGM1_FAST_PWM_8, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_fast_pwm9() { timer1_tick<WGM1_FAST_PWM_9, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_fast_pwm10() { timer1_tick<WGM1_FAST_PWM_10, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_pwm_pfc_icr() { timer1_tick<WGM1_PWM_PFC_ICR, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_pwm_pfc_ocr() { timer1_tick<WGM1_PWM_PFC_OCR, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_pwm_pc_icr() { timer1_tick<WGM1_PWM_PC_ICR, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_pwm_pc_ocr() { timer1_tick<WGM1_PWM_PC_OCR, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_ctc_icr() { timer1_tick<WGM1_CTC_ICR, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_resv() { timer1_tick<WGM1_RESERVED, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_fast_pwm_icr_norm_norm() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_fast_pwm_icr_norm_toggle() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_NORM, OCR_TOGGLE>(); };
+	void timer1_tick_fast_pwm_icr_norm_clear() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_NORM, OCR_CLEAR>(); };
+	void timer1_tick_fast_pwm_icr_norm_set() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_NORM, OCR_SET>(); };
+	void timer1_tick_fast_pwm_icr_toggle_norm() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_TOGGLE, OCR_NORM>(); };
+	void timer1_tick_fast_pwm_icr_toggle_toggle() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_TOGGLE, OCR_TOGGLE>(); };
+	void timer1_tick_fast_pwm_icr_toggle_clear() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_TOGGLE, OCR_CLEAR>(); };
+	void timer1_tick_fast_pwm_icr_toggle_set() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_TOGGLE, OCR_SET>(); };
+	void timer1_tick_fast_pwm_icr_clear_norm() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_CLEAR, OCR_NORM>(); };
+	void timer1_tick_fast_pwm_icr_clear_toggle() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_CLEAR, OCR_TOGGLE>(); };
+	void timer1_tick_fast_pwm_icr_clear_clear() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_CLEAR, OCR_CLEAR>(); };
+	void timer1_tick_fast_pwm_icr_clear_set() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_CLEAR, OCR_SET>(); };
+	void timer1_tick_fast_pwm_icr_set_norm() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_SET, OCR_NORM>(); };
+	void timer1_tick_fast_pwm_icr_set_toggle() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_SET, OCR_TOGGLE>(); };
+	void timer1_tick_fast_pwm_icr_set_clear() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_SET, OCR_CLEAR>(); };
+	void timer1_tick_fast_pwm_icr_set_set() { timer1_tick<WGM1_FAST_PWM_ICR, OCR_SET, OCR_SET>(); };
+	void timer1_tick_fast_pwm_ocr_norm_norm() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_NORM, OCR_NORM>(); };
+	void timer1_tick_fast_pwm_ocr_norm_toggle() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_NORM, OCR_TOGGLE>(); };
+	void timer1_tick_fast_pwm_ocr_norm_clear() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_NORM, OCR_CLEAR>(); };
+	void timer1_tick_fast_pwm_ocr_norm_set() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_NORM, OCR_SET>(); };
+	void timer1_tick_fast_pwm_ocr_toggle_norm() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_TOGGLE, OCR_NORM>(); };
+	void timer1_tick_fast_pwm_ocr_toggle_toggle() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_TOGGLE, OCR_TOGGLE>(); };
+	void timer1_tick_fast_pwm_ocr_toggle_clear() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_TOGGLE, OCR_CLEAR>(); };
+	void timer1_tick_fast_pwm_ocr_toggle_set() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_TOGGLE, OCR_SET>(); };
+	void timer1_tick_fast_pwm_ocr_clear_norm() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_CLEAR, OCR_NORM>(); };
+	void timer1_tick_fast_pwm_ocr_clear_toggle() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_CLEAR, OCR_TOGGLE>(); };
+	void timer1_tick_fast_pwm_ocr_clear_clear() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_CLEAR, OCR_CLEAR>(); };
+	void timer1_tick_fast_pwm_ocr_clear_set() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_CLEAR, OCR_SET>(); };
+	void timer1_tick_fast_pwm_ocr_set_norm() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_SET, OCR_NORM>(); };
+	void timer1_tick_fast_pwm_ocr_set_toggle() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_SET, OCR_TOGGLE>(); };
+	void timer1_tick_fast_pwm_ocr_set_clear() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_SET, OCR_CLEAR>(); };
+	void timer1_tick_fast_pwm_ocr_set_set() { timer1_tick<WGM1_FAST_PWM_OCR, OCR_SET, OCR_SET>(); };
+	void update_timer1_input_noise_canceler();
+	void update_timer1_input_edge_select();
+	void update_ocr1(uint16_t newval, uint8_t reg);
+
+	timer_func m_timer1_ticks[16*16];
+	timer_func m_timer1_tick;
+	uint16_t m_ocr1[3];
+
+	// timer 2
+	void tccr2a_w(uint8_t data);
+	void tccr2b_w(uint8_t data);
+	void tcnt2_w(uint8_t data);
+	void ocr2a_w(uint8_t data);
+	void ocr2b_w(uint8_t data);
+	void tifr2_w(uint8_t data);
+	void timsk2_w(uint8_t data);
+
+	void timer2_tick_default();
+	void timer2_tick_norm();
+	void timer2_tick_fast_pwm();
+	void timer2_tick_fast_pwm_cmp();
+	void update_ocr2(uint8_t newval, uint8_t reg);
+	void timer2_force_output_compare(int reg);
+
+	timer_func m_timer2_ticks[8];
+	timer_func m_timer2_tick;
+	bool m_ocr2_not_reached_yet;
+
+	// timer 3
+	void tccr3a_w(uint8_t data);
+	void tccr3b_w(uint8_t data);
+	void tccr3c_w(uint8_t data);
+	void tcnt3l_w(uint8_t data);
+	void tcnt3h_w(uint8_t data);
+	void icr3l_w(uint8_t data);
+	void icr3h_w(uint8_t data);
+	void ocr3al_w(uint8_t data);
+	void ocr3ah_w(uint8_t data);
+	void ocr3bl_w(uint8_t data);
+	void ocr3bh_w(uint8_t data);
+	void ocr3cl_w(uint8_t data);
+	void ocr3ch_w(uint8_t data);
+	void timsk3_w(uint8_t data);
+
+	void timer3_tick();
+
+	// timer 4
+	void tccr4a_w(uint8_t data);
+	void tccr4b_w(uint8_t data);
+	void tccr4c_w(uint8_t data);
+	void tcnt4l_w(uint8_t data);
+	void tcnt4h_w(uint8_t data);
+	void icr4l_w(uint8_t data);
+	void icr4h_w(uint8_t data);
+	void ocr4al_w(uint8_t data);
+	void ocr4ah_w(uint8_t data);
+	void ocr4bl_w(uint8_t data);
+	void ocr4bh_w(uint8_t data);
+	void ocr4cl_w(uint8_t data);
+	void ocr4ch_w(uint8_t data);
+	void timsk4_w(uint8_t data);
+
+	void timer4_tick();
+
+	// timer 5
+	void tccr5a_w(uint8_t data);
+	void tccr5b_w(uint8_t data);
+	void timsk5_w(uint8_t data);
+
+	void timer5_tick();
 };
 
 // device type definition
@@ -666,511 +1221,5 @@ enum : uint8_t
 	AVR8_SPH,
 	AVR8_SPL
 };
-
-enum : uint8_t
-{
-	AVR8_INT_RESET = 0,
-	AVR8_INT_INT0,
-	AVR8_INT_INT1,
-	AVR8_INT_PCINT0,
-	AVR8_INT_PCINT1,
-	AVR8_INT_PCINT2,
-	AVR8_INT_WDT,
-	AVR8_INT_T2COMPA,
-	AVR8_INT_T2COMPB,
-	AVR8_INT_T2OVF,
-	AVR8_INT_T1CAPT,
-	AVR8_INT_T1COMPA,
-	AVR8_INT_T1COMPB,
-	AVR8_INT_T1OVF,
-	AVR8_INT_T0COMPA,
-	AVR8_INT_T0COMPB,
-	AVR8_INT_T0OVF,
-	AVR8_INT_SPI_STC,
-	AVR8_INT_USART_RX,
-	AVR8_INT_USART_UDRE,
-	AVR8_INT_USART_TX,
-	AVR8_INT_ADC,
-	AVR8_INT_EE_RDY,
-	AVR8_INT_ANALOG_COMP,
-	AVR8_INT_TWI,
-	AVR8_INT_SPM_RDY,
-
-	// ATMEGA644
-	ATMEGA644_INT_RESET = 0,
-	ATMEGA644_INT_INT0,
-	ATMEGA644_INT_INT1,
-	ATMEGA644_INT_INT2,
-	ATMEGA644_INT_PCINT0,
-	ATMEGA644_INT_PCINT1,
-	ATMEGA644_INT_PCINT2,
-	ATMEGA644_INT_PCINT3,
-	ATMEGA644_INT_WDT,
-	ATMEGA644_INT_T2COMPA,
-	ATMEGA644_INT_T2COMPB,
-	ATMEGA644_INT_T2OVF,
-	ATMEGA644_INT_T1CAPT,
-	ATMEGA644_INT_T1COMPA,
-	ATMEGA644_INT_T1COMPB,
-	ATMEGA644_INT_T1OVF,
-	ATMEGA644_INT_T0COMPA,
-	ATMEGA644_INT_T0COMPB,
-	ATMEGA644_INT_T0OVF,
-	ATMEGA644_INT_SPI_STC,
-	ATMEGA644_INT_USART_RX,
-	ATMEGA644_INT_USART_UDRE,
-	ATMEGA644_INT_USART_TX,
-	ATMEGA644_INT_ADC,
-	ATMEGA644_INT_EE_RDY,
-	ATMEGA644_INT_ANALOG_COMP,
-	ATMEGA644_INT_TWI,
-	ATMEGA644_INT_SPM_RDY
-};
-
-// Used by I/O register handling
-enum : uint16_t
-{
-	R0 = 0x00,
-	R1,
-	R2,
-	R3,
-	R4,
-	R5,
-	R6,
-	R7,
-	R8,
-	R9,
-	R10,
-	R11,
-	R12,
-	R13,
-	R14,
-	R15,
-	R16,
-	R17,
-	R18,
-	R19,
-	R20,
-	R21,
-	R22,
-	R23,
-	R24,
-	R25,
-	R26,
-	R27,
-	R28,
-	R29,
-	R30,
-	R31,
-	PINA = 0x20,
-	DDRA,
-	PORTA,
-	PINB,
-	DDRB,
-	PORTB,
-	PINC,
-	DDRC,
-	PORTC,
-	PIND,
-	DDRD,
-	PORTD,
-	PINE,
-	DDRE,
-	PORTE,
-	PINF,
-	DDRF,
-	PORTF,
-	PING,
-	DDRG,
-	PORTG,
-	TIFR0 = 0x35,
-	TIFR1,
-	TIFR2,
-	TIFR3,
-	TIFR4,
-	TIFR5,
-	PCIFR = 0x3B,
-	EIFR,
-	EIMSK,
-	GPIOR0,
-	EECR,
-	EEDR,
-	EEARL,
-	EEARH,
-	GTCCR,
-	TCCR0A,
-	TCCR0B,
-	TCNT0,
-	OCR0A,
-	OCR0B,
-	//0x49: Reserved
-	GPIOR1 = 0x4A,
-	GPIOR2,
-	SPCR,
-	SPSR,
-	SPDR,
-	//0x4F: Reserved
-	ACSR = 0x50,
-	OCDR,
-	//0x52: Reserved
-	SMCR = 0x53,
-	MCUSR,
-	MCUCR,
-	//0x56: Reserved
-	SPMCSR = 0x57,
-	//0x58: Reserved
-	//0x59: Reserved
-	//0x5A: Reserved
-	RAMPZ = 0x5B,
-	EIND,
-	SPL,
-	SPH,
-	SREG,
-//--------------------------
-	WDTCSR = 0x60,
-	CLKPR,
-	//0x62: Reserved
-	//0x63: Reserved
-	PRR0 = 0x64,
-	PRR1,
-	OSCCAL,
-	//0x67: Reserved
-	PCICR = 0x68,
-	EICRA,
-	EICRB,
-	PCMSK0,
-	PCMSK1,
-	PCMSK2,
-	TIMSK0,
-	TIMSK1,
-	TIMSK2,
-	TIMSK3,
-	TIMSK4,
-	TIMSK5,
-	XMCRA,
-	XMCRB,
-	//0x76: Reserved
-	//0x77: Reserved
-	ADCL = 0x78,
-	ADCH,
-	ADCSRA,
-	ADCSRB,
-	ADMUX,
-	DIDR2,
-	DIDR0,
-	DIDR1,
-	TCCR1A,
-	TCCR1B,
-	TCCR1C,
-	//0x83: Reserved
-	TCNT1L = 0x84,
-	TCNT1H,
-	ICR1L,
-	ICR1H,
-	OCR1AL,
-	OCR1AH,
-	OCR1BL,
-	OCR1BH,
-	OCR1CL,
-	OCR1CH,
-	//0x8E: Reserved
-	//0x8F: Reserved
-	TCCR3A = 0x90,
-	TCCR3B,
-	TCCR3C,
-	//0x93: Reserved
-	TCNT3L = 0x94,
-	TCNT3H,
-	ICR3L,
-	ICR3H,
-	OCR3AL,
-	OCR3AH,
-	OCR3BL,
-	OCR3BH,
-	OCR3CL,
-	OCR3CH,
-	//0x9E: Reserved
-	//0x9F: Reserved
-	TCCR4A = 0xA0,
-	TCCR4B,
-	TCCR4C,
-	//0xA3: Reserved
-	TCNT4L = 0xA4,
-	TCNT4H,
-	ICR4L,
-	ICR4H,
-	OCR4AL,
-	OCR4AH,
-	OCR4BL,
-	OCR4BH,
-	OCR4CL,
-	OCR4CH,
-	//0xAE: Reserved
-	//0xAF: Reserved
-	TCCR2A = 0xB0,
-	TCCR2B,
-	TCNT2,
-	OCR2A,
-	OCR2B,
-	//0xB5: Reserved
-	ASSR = 0xB6,
-	//0xB7: Reserved
-	TWBR = 0xB8,
-	TWSR,
-	TWAR,
-	TWDR,
-	TWCR,
-	TWAMR,
-	//0xBE: Reserved
-	//0xBF: Reserved
-	UCSR0A = 0xC0,
-	UCSR0B,
-	UCSR0C,
-	//0xC3: Reserved
-	UBRR0L = 0xC4,
-	UBRR0H,
-	UDR0,
-	//0xC7: Reserved
-	UCSR1A = 0xC8,
-	UCSR1B,
-	UCSR1C,
-	//0xCB: Reserved
-	UBRR1L = 0xCC,
-	UBRR1H,
-	UDR1,
-	//0xCF: Reserved
-	UCSR2A = 0xD0,
-	UCSR2B,
-	UCSR2C,
-	//0xD3: Reserved
-	UBRR2L = 0xD4,
-	UBRR2H,
-	UDR2,
-	//0xD7: Reserved
-	//0xD8: Reserved
-	//0xD9: Reserved
-	//0xDA: Reserved
-	//0xDB: Reserved
-	//0xDC: Reserved
-	//0xDD: Reserved
-	//0xDE: Reserved
-	//0xDF: Reserved
-	//0xE0: Reserved
-	//0xE1: Reserved
-	//0xE2: Reserved
-	//0xE3: Reserved
-	//0xE4: Reserved
-	//0xE5: Reserved
-	//0xE6: Reserved
-	//0xE7: Reserved
-	//0xE8: Reserved
-	//0xE9: Reserved
-	//0xEA: Reserved
-	//0xEB: Reserved
-	//0xEC: Reserved
-	//0xED: Reserved
-	//0xEE: Reserved
-	//0xEF: Reserved
-	//0xF0: Reserved
-	//0xF1: Reserved
-	//0xF2: Reserved
-	//0xF3: Reserved
-	//0xF4: Reserved
-	//0xF5: Reserved
-	//0xF6: Reserved
-	//0xF7: Reserved
-	//0xF8: Reserved
-	//0xF9: Reserved
-	//0xFA: Reserved
-	//0xFB: Reserved
-	//0xFC: Reserved
-	//0xFD: Reserved
-	//0xFE: Reserved
-	//0xFF: Reserved
-	PINH = 0x100,
-	DDRH,
-	PORTH,
-	PINJ,
-	DDRJ,
-	PORTJ,
-	PINK,
-	DDRK,
-	PORTK,
-	PINL,
-	DDRL,
-	PORTL,
-	//0x10C: Reserved
-	//0x10D: Reserved
-	//0x10E: Reserved
-	//0x10F: Reserved
-	//0x110: Reserved
-	//0x111: Reserved
-	//0x112: Reserved
-	//0x113: Reserved
-	//0x114: Reserved
-	//0x115: Reserved
-	//0x116: Reserved
-	//0x117: Reserved
-	//0x118: Reserved
-	//0x119: Reserved
-	//0x11A: Reserved
-	//0x11B: Reserved
-	//0x11C: Reserved
-	//0x11D: Reserved
-	//0x11E: Reserved
-	//0x11F: Reserved
-	TCCR5A = 0x120,
-	TCCR5B,
-	TCCR5C,
-	//0x123: Reserved
-	TCNT5L = 0x124,
-	TCNT5H,
-	ICR5L,
-	ICR5H,
-	OCR5AL,
-	OCR5AH,
-	OCR5BL,
-	OCR5BH,
-	OCR5CL,
-	OCR5CH,
-	//0x12E: Reserved
-	//0x12F: Reserved
-	UCSR3A = 0x130,
-	UCSR3B,
-	UCSR3C,
-	//0x133: Reserved
-	UBRR3L = 0x134,
-	UBRR3H,
-	UDR3
-	//0x137: Reserved
-	//  .
-	//  . up to
-	//  .
-	//0x1FF: Reserved
-};
-
-enum : uint8_t
-{
-	AVR8_IO_PORTA = 0,
-	AVR8_IO_PORTB,
-	AVR8_IO_PORTC,
-	AVR8_IO_PORTD,
-	AVR8_IO_PORTE,
-	AVR8_IO_PORTF,
-	AVR8_IO_PORTG,
-	AVR8_IO_PORTH,
-	AVR8_IO_PORTJ,
-	AVR8_IO_PORTK,
-	AVR8_IO_PORTL
-};
-
-enum : uint8_t
-{
-	AVR8_REG_A = 0,
-	AVR8_REG_B,
-	AVR8_REG_C,
-	AVR8_REG_D,
-	AVR8_REG_E,
-	AVR8_REG_F,
-	AVR8_REG_G,
-	AVR8_REG_H,
-	AVR8_REG_J,
-	AVR8_REG_K,
-	AVR8_REG_L
-};
-
-enum : uint8_t
-{
-	AVR8_INTIDX_SPI,
-
-	AVR8_INTIDX_OCF0B,
-	AVR8_INTIDX_OCF0A,
-	AVR8_INTIDX_TOV0,
-
-	AVR8_INTIDX_ICF1,
-
-	AVR8_INTIDX_OCF1B,
-	AVR8_INTIDX_OCF1A,
-	AVR8_INTIDX_TOV1,
-
-	AVR8_INTIDX_OCF2B,
-	AVR8_INTIDX_OCF2A,
-	AVR8_INTIDX_TOV2,
-
-//------ TODO: review this --------
-	AVR8_INTIDX_OCF3B,
-	AVR8_INTIDX_OCF3A,
-	AVR8_INTIDX_TOV3,
-
-	AVR8_INTIDX_OCF4B,
-	AVR8_INTIDX_OCF4A,
-	AVR8_INTIDX_TOV4,
-
-	AVR8_INTIDX_OCF5B,
-	AVR8_INTIDX_OCF5A,
-	AVR8_INTIDX_TOV5,
-//---------------------------------
-
-	AVR8_INTIDX_COUNT
-};
-
-// lock bit masks
-enum : uint8_t
-{
-	LB1 = (1 << 0),
-	LB2 = (1 << 1),
-	BLB01 = (1 << 2),
-	BLB02 = (1 << 3),
-	BLB11 = (1 << 4),
-	BLB12 = (1 << 5)
-};
-
-// extended fuses bit masks
-enum : uint8_t
-{
-	BODLEVEL0 = (1 << 0),
-	BODLEVEL1 = (1 << 1),
-	BODLEVEL2 = (1 << 2)
-};
-
-// high fuses bit masks
-enum : uint8_t
-{
-	BOOTRST = (1 << 0),
-	BOOTSZ0 = (1 << 1),
-	BOOTSZ1 = (1 << 2),
-	EESAVE = (1 << 3),
-	WDTON = (1 << 4),
-	SPIEN = (1 << 5),
-	JTAGEN = (1 << 6),
-	OCDEN = (1 << 7)
-};
-
-// low fuses bit masks
-enum : uint8_t
-{
-	CKSEL0 = (1 << 0),
-	CKSEL1 = (1 << 1),
-	CKSEL2 = (1 << 2),
-	CKSEL3 = (1 << 3),
-	SUT0 = (1 << 4),
-	SUT1 = (1 << 5),
-	CKOUT = (1 << 6),
-	CKDIV8 = (1 << 7)
-};
-
-#define AVR8_EEARH_MASK         0x01
-
-#define AVR8_SPSR_SPIF_MASK     0x80
-#define AVR8_SPSR_SPIF_SHIFT    7
-#define AVR8_SPSR_SPR2X_MASK    0x01
-
-#define AVR8_SPCR_SPIE_MASK     0x80
-#define AVR8_SPCR_SPE_MASK      0x40
-#define AVR8_SPCR_DORD_MASK     0x20
-#define AVR8_SPCR_MSTR_MASK     0x10
-#define AVR8_SPCR_CPOL_MASK     0x08
-#define AVR8_SPCR_CPHA_MASK     0x04
-#define AVR8_SPCR_SPR_MASK      0x03
 
 #endif /* MAME_CPU_AVR8_AVR8_H */

--- a/src/devices/cpu/avr8/avr8ops.hxx
+++ b/src/devices/cpu/avr8/avr8ops.hxx
@@ -8,7 +8,8 @@
 
 ***************************************************************************/
 
-void avr8_device::populate_ops()
+template <int NumTimers>
+void avr8_device<NumTimers>::populate_ops()
 {
 	for (uint32_t op = 0; op < 0x10000; op++)
 	{
@@ -512,7 +513,8 @@ void avr8_device::populate_ops()
 	}
 }
 
-void avr8_device::populate_add_flag_cache()
+template <int NumTimers>
+void avr8_device<NumTimers>::populate_add_flag_cache()
 {
 	for (uint16_t rd = 0; rd < 0x100; rd++)
 	{
@@ -531,7 +533,8 @@ void avr8_device::populate_add_flag_cache()
 	}
 }
 
-void avr8_device::populate_adc_flag_cache()
+template <int NumTimers>
+void avr8_device<NumTimers>::populate_adc_flag_cache()
 {
 	for (uint16_t rd = 0; rd < 0x100; rd++)
 	{
@@ -553,7 +556,8 @@ void avr8_device::populate_adc_flag_cache()
 	}
 }
 
-void avr8_device::populate_sub_flag_cache()
+template <int NumTimers>
+void avr8_device<NumTimers>::populate_sub_flag_cache()
 {
 	for (uint16_t rd = 0; rd < 0x100; rd++)
 	{
@@ -572,7 +576,8 @@ void avr8_device::populate_sub_flag_cache()
 	}
 }
 
-void avr8_device::populate_sbc_flag_cache()
+template <int NumTimers>
+void avr8_device<NumTimers>::populate_sbc_flag_cache()
 {
 	for (uint16_t rd = 0; rd < 0x100; rd++)
 	{
@@ -597,7 +602,8 @@ void avr8_device::populate_sbc_flag_cache()
 	}
 }
 
-void avr8_device::populate_bool_flag_cache()
+template <int NumTimers>
+void avr8_device<NumTimers>::populate_bool_flag_cache()
 {
 	for (uint16_t res = 0; res < 0x100; res++)
 	{
@@ -609,7 +615,8 @@ void avr8_device::populate_bool_flag_cache()
 	}
 }
 
-void avr8_device::populate_shift_flag_cache()
+template <int NumTimers>
+void avr8_device<NumTimers>::populate_shift_flag_cache()
 {
 	for (uint16_t rd = 0; rd < 0x100; rd++)
 	{
@@ -626,17 +633,20 @@ void avr8_device::populate_shift_flag_cache()
 	}
 }
 
-void avr8_device::op_nop(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_nop(uint16_t op)
 {
 }
 
-void avr8_device::op_movw(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_movw(uint16_t op)
 {
 	m_r[(RD4(op) << 1) + 1] = m_r[(RR4(op) << 1) + 1];
 	m_r[RD4(op) << 1] = m_r[RR4(op) << 1];
 }
 
-void avr8_device::op_muls(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_muls(uint16_t op)
 {
 	const int16_t sd = (int8_t)m_r[16 + RD4(op)] * (int8_t)m_r[16 + RR4(op)];
 	m_r[1] = (sd >> 8) & 0x00ff;
@@ -645,7 +655,8 @@ void avr8_device::op_muls(uint16_t op)
 	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
 }
 
-void avr8_device::op_mulsu(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_mulsu(uint16_t op)
 {
 	const int16_t sd = (int8_t)m_r[16 + RD3(op)] * (uint8_t)m_r[16 + RR3(op)];
 	m_r[1] = (sd >> 8) & 0x00ff;
@@ -654,7 +665,8 @@ void avr8_device::op_mulsu(uint16_t op)
 	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
 }
 
-void avr8_device::op_fmul(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_fmul(uint16_t op)
 {
 	const int16_t sd = ((uint8_t)m_r[16 + RD3(op)] * (uint8_t)m_r[16 + RR3(op)]) << 1;
 	m_r[1] = (sd >> 8) & 0x00ff;
@@ -663,7 +675,8 @@ void avr8_device::op_fmul(uint16_t op)
 	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
 }
 
-void avr8_device::op_fmuls(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_fmuls(uint16_t op)
 {
 	const int16_t sd = ((int8_t)m_r[16 + RD3(op)] * (int8_t)m_r[16 + RR3(op)]) << 1;
 	m_r[1] = (sd >> 8) & 0x00ff;
@@ -672,7 +685,8 @@ void avr8_device::op_fmuls(uint16_t op)
 	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
 }
 
-void avr8_device::op_fmulsu(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_fmulsu(uint16_t op)
 {
 	const int16_t sd = ((int8_t)m_r[16 + RD3(op)] * (uint8_t)m_r[16 + RR3(op)]) << 1;
 	m_r[1] = (sd >> 8) & 0x00ff;
@@ -681,183 +695,204 @@ void avr8_device::op_fmulsu(uint16_t op)
 	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
 }
 
-void avr8_device::op_cpc(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_cpc(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
-	const uint8_t c = SREG & AVR8_SREG_MASK_C;
-	const uint32_t z = (SREG & AVR8_SREG_MASK_Z) ? (1 << 17) : 0;
-	SREG &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
-	SREG |= m_sbc_flag_cache[z | (c << 16) | (rd << 8) | rr];
+	const uint8_t c = m_r[SREG] & AVR8_SREG_MASK_C;
+	const uint32_t z = (m_r[SREG] & AVR8_SREG_MASK_Z) ? (1 << 17) : 0;
+	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] |= m_sbc_flag_cache[z | (c << 16) | (rd << 8) | rr];
 }
 
-void avr8_device::op_sbc(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_sbc(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
-	const uint8_t c = SREG & AVR8_SREG_MASK_C;
+	const uint8_t c = m_r[SREG] & AVR8_SREG_MASK_C;
 	const uint8_t res = rd - (rr + c);
 	m_r[RD5(op)] = res;
-	const uint32_t z = (SREG & AVR8_SREG_MASK_Z) ? (1 << 17) : 0;
-	SREG &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
-	SREG |= m_sbc_flag_cache[z | (c << 16) | (rd << 8) | rr];
+	const uint32_t z = (m_r[SREG] & AVR8_SREG_MASK_Z) ? (1 << 17) : 0;
+	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] |= m_sbc_flag_cache[z | (c << 16) | (rd << 8) | rr];
 }
 
-void avr8_device::op_add(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_add(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
 	const uint8_t res = rd + rr;
 	m_r[RD5(op)] = res;
-	SREG &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
-	SREG |= m_add_flag_cache[(rd << 8) | rr];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] |= m_add_flag_cache[(rd << 8) | rr];
 }
 
-void avr8_device::op_cpse(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_cpse(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
 	if (rd == rr)
 	{
-		const uint16_t data = (uint32_t)m_program->read_word(m_shifted_pc + 2);
+		const uint16_t data = (uint32_t)m_program->read_word(m_pc + 2);
 		m_opcycles += is_long_opcode(data) ? 2 : 1;
-		m_pc += is_long_opcode(data) ? 2 : 1;
+		m_pc += is_long_opcode(data) ? 4 : 2;
 	}
 }
 
-void avr8_device::op_cp(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_cp(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
-	SREG &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
-	SREG |= m_sub_flag_cache[(rd << 8) | rr];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] |= m_sub_flag_cache[(rd << 8) | rr];
 }
 
-void avr8_device::op_sub(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_sub(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
 	const uint8_t res = rd - rr;
 	m_r[RD5(op)] = res;
-	SREG &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
-	SREG |= m_sub_flag_cache[(rd << 8) | rr];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] |= m_sub_flag_cache[(rd << 8) | rr];
 }
 
-void avr8_device::op_adc(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_adc(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
-	const uint8_t c = SREG & AVR8_SREG_MASK_C;
+	const uint8_t c = m_r[SREG] & AVR8_SREG_MASK_C;
 	const uint8_t res = rd + rr + c;
 	m_r[RD5(op)] = res;
-	SREG &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
-	SREG |= m_adc_flag_cache[(c << 16) | (rd << 8) | rr];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] |= m_adc_flag_cache[(c << 16) | (rd << 8) | rr];
 }
 
-void avr8_device::op_and(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_and(uint16_t op)
 {
 	const uint8_t res = m_r[RD5(op)] & m_r[RR5(op)];
 	m_r[RD5(op)] = res;
-	SREG &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
-	SREG |= m_bool_flag_cache[res];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
+	m_r[SREG] |= m_bool_flag_cache[res];
 }
 
-void avr8_device::op_eor(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_eor(uint16_t op)
 {
 	const uint8_t res = m_r[RD5(op)] ^ m_r[RR5(op)];
 	m_r[RD5(op)] = res;
-	SREG &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
-	SREG |= m_bool_flag_cache[res];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
+	m_r[SREG] |= m_bool_flag_cache[res];
 }
 
-void avr8_device::op_or(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_or(uint16_t op)
 {
 	const uint8_t res = m_r[RD5(op)] | m_r[RR5(op)];
 	m_r[RD5(op)] = res;
-	SREG &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
-	SREG |= m_bool_flag_cache[res];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
+	m_r[SREG] |= m_bool_flag_cache[res];
 }
 
-void avr8_device::op_mov(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_mov(uint16_t op)
 {
 	m_r[RD5(op)] = m_r[RR5(op)];
 }
 
-void avr8_device::op_cpi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_cpi(uint16_t op)
 {
 	const uint8_t rd = m_r[16 + RD4(op)];
 	const uint8_t rr = KCONST8(op);
-	SREG &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
-	SREG |= m_sub_flag_cache[(rd << 8) | rr];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] |= m_sub_flag_cache[(rd << 8) | rr];
 }
 
-void avr8_device::op_sbci(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_sbci(uint16_t op)
 {
 	const uint8_t rd = m_r[16 + RD4(op)];
 	const uint8_t rr = KCONST8(op);
-	const uint8_t c = SREG & AVR8_SREG_MASK_C;
+	const uint8_t c = m_r[SREG] & AVR8_SREG_MASK_C;
 	const uint8_t res = rd - (rr + c);
 	m_r[16 + RD4(op)] = res;
-	const uint32_t z = (SREG & AVR8_SREG_MASK_Z) ? (1 << 17) : 0;
-	SREG &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
-	SREG |= m_sbc_flag_cache[z | (c << 16) | (rd << 8) | rr];
+	const uint32_t z = (m_r[SREG] & AVR8_SREG_MASK_Z) ? (1 << 17) : 0;
+	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] |= m_sbc_flag_cache[z | (c << 16) | (rd << 8) | rr];
 }
 
-void avr8_device::op_subi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_subi(uint16_t op)
 {
 	const uint8_t rd = m_r[16 + RD4(op)];
 	const uint8_t rr = KCONST8(op);
 	const uint8_t res = rd - rr;
 	m_r[16 + RD4(op)] = res;
-	SREG &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
-	SREG |= m_sub_flag_cache[(rd << 8) | rr];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] |= m_sub_flag_cache[(rd << 8) | rr];
 }
 
-void avr8_device::op_ori(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ori(uint16_t op)
 {
 	const uint8_t res = m_r[16 + RD4(op)] | KCONST8(op);
 	m_r[16 + RD4(op)] = res;
-	SREG &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
-	SREG |= m_bool_flag_cache[res];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
+	m_r[SREG] |= m_bool_flag_cache[res];
 }
 
-void avr8_device::op_andi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_andi(uint16_t op)
 {
 	const uint8_t res = m_r[16 + RD4(op)] & KCONST8(op);
 	m_r[16 + RD4(op)] = res;
-	SREG &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
-	SREG |= m_bool_flag_cache[res];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
+	m_r[SREG] |= m_bool_flag_cache[res];
 }
 
-void avr8_device::op_lddz(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_lddz(uint16_t op)
 {
 	m_r[RD5(op)] = m_data->read_byte(ZREG + QCONST6(op));
 }
 
-void avr8_device::op_lddy(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_lddy(uint16_t op)
 {
 	m_r[RD5(op)] = m_data->read_byte(YREG + QCONST6(op));
 }
 
-void avr8_device::op_stdz(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_stdz(uint16_t op)
 {
 	m_data->write_byte(ZREG + QCONST6(op), m_r[RD5(op)]);
 }
 
-void avr8_device::op_stdy(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_stdy(uint16_t op)
 {
 	m_data->write_byte(YREG + QCONST6(op), m_r[RD5(op)]);
 }
 
-void avr8_device::op_lds(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_lds(uint16_t op)
 {
-	m_pc++;
-	m_shifted_pc += 2;
-	const uint16_t addr = m_program->read_word(m_shifted_pc);
+	m_pc += 2;
+	const uint16_t addr = m_program->read_word(m_pc);
 	m_r[RD5(op)] = m_data->read_byte(addr);
 }
 
-void avr8_device::op_ldzi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ldzi(uint16_t op)
 {
 	uint16_t pd = ZREG;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -866,7 +901,8 @@ void avr8_device::op_ldzi(uint16_t op)
 	m_r[30] = pd & 0x00ff;
 }
 
-void avr8_device::op_ldzd(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ldzd(uint16_t op)
 {
 	const uint16_t pd = ZREG - 1;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -874,12 +910,14 @@ void avr8_device::op_ldzd(uint16_t op)
 	m_r[30] = pd & 0x00ff;
 }
 
-void avr8_device::op_lpmz(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_lpmz(uint16_t op)
 {
 	m_r[RD5(op)] = m_program->read_byte(ZREG);
 }
 
-void avr8_device::op_lpmzi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_lpmzi(uint16_t op)
 {
 	uint16_t pd = ZREG;
 	m_r[RD5(op)] = m_program->read_byte(pd);
@@ -888,22 +926,25 @@ void avr8_device::op_lpmzi(uint16_t op)
 	m_r[30] = pd & 0x00ff;
 }
 
-void avr8_device::op_elpmz(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_elpmz(uint16_t op)
 {
-	m_r[RD5(op)] = m_program->read_byte((m_r[AVR8_REGIDX_RAMPZ] << 16) | ZREG);
+	m_r[RD5(op)] = m_program->read_byte((m_r[RAMPZ] << 16) | ZREG);
 }
 
-void avr8_device::op_elpmzi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_elpmzi(uint16_t op)
 {
-	uint32_t pd32 = (m_r[AVR8_REGIDX_RAMPZ] << 16) | ZREG;
+	uint32_t pd32 = (m_r[RAMPZ] << 16) | ZREG;
 	m_r[RD5(op)] = m_program->read_byte(pd32);
 	pd32++;
-	m_r[AVR8_REGIDX_RAMPZ] = (pd32 >> 16) & 0x00ff;
+	m_r[RAMPZ] = (pd32 >> 16) & 0x00ff;
 	m_r[31] = (pd32 >> 8) & 0x00ff;
 	m_r[30] = pd32 & 0x00ff;
 }
 
-void avr8_device::op_ldyi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ldyi(uint16_t op)
 {
 	uint16_t pd = YREG;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -912,7 +953,8 @@ void avr8_device::op_ldyi(uint16_t op)
 	m_r[28] = pd & 0x00ff;
 }
 
-void avr8_device::op_ldyd(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ldyd(uint16_t op)
 {
 	const uint16_t pd = YREG - 1;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -920,12 +962,14 @@ void avr8_device::op_ldyd(uint16_t op)
 	m_r[28] = pd & 0x00ff;
 }
 
-void avr8_device::op_ldx(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ldx(uint16_t op)
 {
 	m_r[RD5(op)] = m_data->read_byte(XREG);
 }
 
-void avr8_device::op_ldxi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ldxi(uint16_t op)
 {
 	uint16_t pd = XREG;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -934,7 +978,8 @@ void avr8_device::op_ldxi(uint16_t op)
 	m_r[26] = pd & 0x00ff;
 }
 
-void avr8_device::op_ldxd(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ldxd(uint16_t op)
 {
 	const uint16_t pd = XREG - 1;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -942,20 +987,22 @@ void avr8_device::op_ldxd(uint16_t op)
 	m_r[26] = pd & 0x00ff;
 }
 
-void avr8_device::op_pop(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_pop(uint16_t op)
 {
 	m_r[RD5(op)] = pop();
 }
 
-void avr8_device::op_sts(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_sts(uint16_t op)
 {
-	m_pc++;
-	m_shifted_pc += 2;
-	const uint16_t addr = m_program->read_word(m_shifted_pc);
+	m_pc += 2;
+	const uint16_t addr = m_program->read_word(m_pc);
 	m_data->write_byte(addr, m_r[RD5(op)]);
 }
 
-void avr8_device::op_stzi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_stzi(uint16_t op)
 {
 	uint16_t pd = ZREG;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -964,7 +1011,8 @@ void avr8_device::op_stzi(uint16_t op)
 	m_r[30] = pd & 0x00ff;
 }
 
-void avr8_device::op_stzd(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_stzd(uint16_t op)
 {
 	const uint16_t pd = ZREG - 1;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -972,7 +1020,8 @@ void avr8_device::op_stzd(uint16_t op)
 	m_r[30] = pd & 0x00ff;
 }
 
-void avr8_device::op_styi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_styi(uint16_t op)
 {
 	uint16_t pd = YREG;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -981,7 +1030,8 @@ void avr8_device::op_styi(uint16_t op)
 	m_r[28] = pd & 0x00ff;
 }
 
-void avr8_device::op_styd(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_styd(uint16_t op)
 {
 	const uint16_t pd = YREG - 1;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -989,12 +1039,14 @@ void avr8_device::op_styd(uint16_t op)
 	m_r[28] = pd & 0x00ff;
 }
 
-void avr8_device::op_stx(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_stx(uint16_t op)
 {
 	m_data->write_byte(XREG, m_r[RD5(op)]);
 }
 
-void avr8_device::op_stxi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_stxi(uint16_t op)
 {
 	uint16_t pd = XREG;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -1003,7 +1055,8 @@ void avr8_device::op_stxi(uint16_t op)
 	m_r[26] = pd & 0x00ff;
 }
 
-void avr8_device::op_stxd(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_stxd(uint16_t op)
 {
 	const uint16_t pd = XREG - 1;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -1011,12 +1064,14 @@ void avr8_device::op_stxd(uint16_t op)
 	m_r[26] = pd & 0x00ff;
 }
 
-void avr8_device::op_push(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_push(uint16_t op)
 {
 	push(m_r[RD5(op)]);
 }
 
-void avr8_device::op_com(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_com(uint16_t op)
 {
 	const uint8_t res = ~m_r[RD5(op)];
 	SREG_W(AVR8_SREG_C, 1);
@@ -1027,7 +1082,8 @@ void avr8_device::op_com(uint16_t op)
 	m_r[RD5(op)] = res;
 }
 
-void avr8_device::op_neg(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_neg(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t res = 0 - rd;
@@ -1040,13 +1096,15 @@ void avr8_device::op_neg(uint16_t op)
 	m_r[RD5(op)] = res;
 }
 
-void avr8_device::op_swap(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_swap(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	m_r[RD5(op)] = (rd >> 4) | (rd << 4);
 }
 
-void avr8_device::op_inc(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_inc(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t res = rd + 1;
@@ -1057,54 +1115,62 @@ void avr8_device::op_inc(uint16_t op)
 	m_r[RD5(op)] = res;
 }
 
-void avr8_device::op_asr(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_asr(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t res = (rd & 0x80) | (rd >> 1);
-	SREG &= ~(AVR8_SREG_MASK_C | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_N | AVR8_SREG_MASK_V | AVR8_SREG_MASK_S);
-	SREG |= m_shift_flag_cache[(rd << 8) | res];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_C | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_N | AVR8_SREG_MASK_V | AVR8_SREG_MASK_S);
+	m_r[SREG] |= m_shift_flag_cache[(rd << 8) | res];
 	m_r[RD5(op)] = res;
 }
 
-void avr8_device::op_lsr(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_lsr(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t res = rd >> 1;
-	SREG &= ~(AVR8_SREG_MASK_C | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_N | AVR8_SREG_MASK_V | AVR8_SREG_MASK_S);
-	SREG |= m_shift_flag_cache[(rd << 8) | res];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_C | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_N | AVR8_SREG_MASK_V | AVR8_SREG_MASK_S);
+	m_r[SREG] |= m_shift_flag_cache[(rd << 8) | res];
 	m_r[RD5(op)] = res;
 }
 
-void avr8_device::op_ror(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ror(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t res = (rd >> 1) | (SREG_R(AVR8_SREG_C) << 7);
-	SREG &= ~(AVR8_SREG_MASK_C | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_N | AVR8_SREG_MASK_V | AVR8_SREG_MASK_S);
-	SREG |= m_shift_flag_cache[(rd << 8) | res];
+	m_r[SREG] &= ~(AVR8_SREG_MASK_C | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_N | AVR8_SREG_MASK_V | AVR8_SREG_MASK_S);
+	m_r[SREG] |= m_shift_flag_cache[(rd << 8) | res];
 	m_r[RD5(op)] = res;
 }
 
-void avr8_device::op_setf(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_setf(uint16_t op)
 {
 	SREG_W((op >> 4) & 0x07, 1);
 }
 
-void avr8_device::op_clrf(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_clrf(uint16_t op)
 {
 	SREG_W((op >> 4) & 0x07, 0);
 }
 
-void avr8_device::op_ijmp(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ijmp(uint16_t op)
 {
-	m_pc = ZREG - 1;
+	m_pc = (ZREG - 1) << 1;
 }
 
-void avr8_device::op_eijmp(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_eijmp(uint16_t op)
 {
-	m_pc = (m_r[AVR8_REGIDX_EIND] << 16 | ZREG) - 1;
+	m_pc = ((m_r[EIND] << 16 | ZREG) << 1) - 2;
 }
 
-void avr8_device::op_dec(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_dec(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t res = rd - 1;
@@ -1115,93 +1181,105 @@ void avr8_device::op_dec(uint16_t op)
 	m_r[RD5(op)] = res;
 }
 
-void avr8_device::op_jmp(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_jmp(uint16_t op)
 {
 	uint32_t offs = KCONST22(op) << 16;
-	m_pc++;
-	m_shifted_pc += 2;
-	offs |= m_program->read_word(m_shifted_pc);
-	m_pc = offs;
-	m_pc--;
+	m_pc += 2;
+	uint16_t wordval = m_program->read_word(m_pc);
+	offs |= wordval;
+	m_pc = offs << 1;
+	m_pc -= 2;
 }
 
-void avr8_device::op_call(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_call(uint16_t op)
 {
-	push((m_pc + 2) & 0x00ff);
-	push(((m_pc + 2) >> 8) & 0x00ff);
+	push(((m_pc >> 1) + 2) & 0x00ff);
+	push((((m_pc >> 1) + 2) >> 8) & 0x00ff);
 	uint32_t offs = KCONST22(op) << 16;
-	m_pc++;
-	m_shifted_pc += 2;
-	offs |= m_program->read_word(m_shifted_pc);
-	m_pc = offs;
-	m_pc--;
+	m_pc += 2;
+	offs |= m_program->read_word(m_pc);
+	m_pc = offs << 1;
+	m_pc -= 2;
 }
 
-void avr8_device::op_ret(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ret(uint16_t op)
 {
 	m_pc = pop() << 8;
 	m_pc |= pop();
-	m_pc--;
+	m_pc = (m_pc << 1) - 2;
 }
 
-void avr8_device::op_reti(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_reti(uint16_t op)
 {
 	m_pc = pop() << 8;
 	m_pc |= pop();
-	m_pc--;
+	m_pc = (m_pc << 1) - 2;
 	SREG_W(AVR8_SREG_I, 1);
 }
 
-void avr8_device::op_sleep(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_sleep(uint16_t op)
 {
-	m_pc--;
+	m_pc = (m_pc << 1) - 2;
 }
 
-void avr8_device::op_break(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_break(uint16_t op)
 {
 	op_unimpl(op);
 }
 
-void avr8_device::op_wdr(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_wdr(uint16_t op)
 {
 	LOGMASKED(LOG_WDOG, "%s: Watchdog reset opcode\n", machine().describe_context());
 	//op_unimpl(op);
 }
 
-void avr8_device::op_lpm(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_lpm(uint16_t op)
 {
 	m_r[0] = m_program->read_byte(ZREG);
 }
 
-void avr8_device::op_elpm(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_elpm(uint16_t op)
 {
 	op_unimpl(op);
 }
 
-void avr8_device::op_spm(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_spm(uint16_t op)
 {
 	op_unimpl(op);
 }
 
-void avr8_device::op_spmzi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_spmzi(uint16_t op)
 {
 	op_unimpl(op);
 }
 
-void avr8_device::op_icall(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_icall(uint16_t op)
 {
-	push((m_pc + 1) & 0x00ff);
-	push(((m_pc + 1) >> 8) & 0x00ff);
-	m_pc = ZREG;
-	m_pc--;
+	push(((m_pc >> 1) + 1) & 0x00ff);
+	push((((m_pc >> 1) + 1) >> 8) & 0x00ff);
+	m_pc = (ZREG << 1) - 2;
 }
 
-void avr8_device::op_eicall(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_eicall(uint16_t op)
 {
 	op_unimpl(op);
 }
 
-void avr8_device::op_adiw(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_adiw(uint16_t op)
 {
 	const uint8_t rd = m_r[24 + (DCONST(op) << 1)];
 	const uint8_t rr = m_r[25 + (DCONST(op) << 1)];
@@ -1215,7 +1293,8 @@ void avr8_device::op_adiw(uint16_t op)
 	m_r[25 + (DCONST(op) << 1)] = (pd >> 8) & 0x00ff;
 }
 
-void avr8_device::op_sbiw(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_sbiw(uint16_t op)
 {
 	const uint8_t rd = m_r[24 + (DCONST(op) << 1)];
 	const uint8_t rr = m_r[25 + (DCONST(op) << 1)];
@@ -1229,37 +1308,42 @@ void avr8_device::op_sbiw(uint16_t op)
 	m_r[25 + (DCONST(op) << 1)] = (pd >> 8) & 0x00ff;
 }
 
-void avr8_device::op_cbi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_cbi(uint16_t op)
 {
 	m_data->write_byte(32 + ACONST5(op), m_data->read_byte(32 + ACONST5(op)) &~ (1 << RR3(op)));
 }
 
-void avr8_device::op_sbic(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_sbic(uint16_t op)
 {
 	if (!BIT(m_data->read_byte(32 + ACONST5(op)), RR3(op)))
 	{
-		const uint16_t data = (uint32_t)m_program->read_word(m_shifted_pc + 2);
+		const uint16_t data = (uint32_t)m_program->read_word(m_pc + 2);
 		m_opcycles += is_long_opcode(data) ? 2 : 1;
-		m_pc += is_long_opcode(data) ? 2 : 1;
+		m_pc += is_long_opcode(data) ? 4 : 2;
 	}
 }
 
-void avr8_device::op_sbi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_sbi(uint16_t op)
 {
 	m_data->write_byte(32 + ACONST5(op), m_data->read_byte(32 + ACONST5(op)) | (1 << RR3(op)));
 }
 
-void avr8_device::op_sbis(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_sbis(uint16_t op)
 {
 	if (BIT(m_data->read_byte(32 + ACONST5(op)), RR3(op)))
 	{
-		const uint16_t data = (uint32_t)m_program->read_word(m_shifted_pc + 2);
+		const uint16_t data = (uint32_t)m_program->read_word(m_pc + 2);
 		m_opcycles += is_long_opcode(data) ? 2 : 1;
-		m_pc += is_long_opcode(data) ? 2 : 1;
+		m_pc += is_long_opcode(data) ? 4 : 2;
 	}
 }
 
-void avr8_device::op_mul(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_mul(uint16_t op)
 {
 	const int16_t sd = (uint8_t)m_r[RD5(op)] * (uint8_t)m_r[RR5(op)];
 	m_r[1] = (sd >> 8) & 0x00ff;
@@ -1268,58 +1352,67 @@ void avr8_device::op_mul(uint16_t op)
 	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
 }
 
-void avr8_device::op_out(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_out(uint16_t op)
 {
 	m_data->write_byte(32 + ACONST6(op), m_r[RD5(op)]);
 }
 
-void avr8_device::op_in(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_in(uint16_t op)
 {
 	m_r[RD5(op)] = m_data->read_byte(0x20 + ACONST6(op));
 }
 
-void avr8_device::op_rjmp(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_rjmp(uint16_t op)
 {
-	m_pc += (int32_t)((op & 0x0800) ? ((op & 0x0fff) | 0xfffff000) : (op & 0x0fff));
+	m_pc += (int32_t)((op & 0x0800) ? ((op & 0x0fff) | 0xfffff000) : (op & 0x0fff)) << 1;
 }
 
-void avr8_device::op_rcall(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_rcall(uint16_t op)
 {
-	const int32_t offs = (int32_t)((op & 0x0800) ? ((op & 0x0fff) | 0xfffff000) : (op & 0x0fff));
-	push((m_pc + 1) & 0x00ff);
-	push(((m_pc + 1) >> 8) & 0x00ff);
+	const int32_t offs = (int32_t)((op & 0x0800) ? ((op & 0x0fff) | 0xfffff000) : (op & 0x0fff)) << 1;
+	push(((m_pc >> 1) + 1) & 0x00ff);
+	push((((m_pc >> 1) + 1) >> 8) & 0x00ff);
 	m_pc += offs;
 }
 
-void avr8_device::op_ldi(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_ldi(uint16_t op)
 {
 	m_r[16 + RD4(op)] = KCONST8(op);
 }
 
-void avr8_device::op_brset(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_brset(uint16_t op)
 {
 	if (SREG_R(op & 0x0007))
 	{
-		m_pc += util::sext(KCONST7(op), 7);
+		m_pc += util::sext(KCONST7(op), 7) << 1;
 		m_opcycles++;
 	}
 }
 
-void avr8_device::op_brclr(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_brclr(uint16_t op)
 {
 	if (SREG_R(op & 0x0007) == 0)
 	{
-		m_pc += util::sext(KCONST7(op), 7);
+		m_pc += util::sext(KCONST7(op), 7) << 1;
 		m_opcycles++;
 	}
 }
 
-void avr8_device::op_bst(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_bst(uint16_t op)
 {
 	SREG_W(AVR8_SREG_T, (BIT(m_r[RD5(op)], RR3(op))) ? 1 : 0);
 }
 
-void avr8_device::op_bld(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_bld(uint16_t op)
 {
 	if (SREG_R(AVR8_SREG_T))
 	{
@@ -1331,27 +1424,30 @@ void avr8_device::op_bld(uint16_t op)
 	}
 }
 
-void avr8_device::op_sbrs(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_sbrs(uint16_t op)
 {
 	if (BIT(m_r[RD5(op)], RR3(op)))
 	{
-		const uint16_t data = (uint32_t)m_program->read_word(m_shifted_pc + 2);
+		const uint16_t data = (uint32_t)m_program->read_word(m_pc + 2);
 		m_opcycles += is_long_opcode(data) ? 2 : 1;
-		m_pc += is_long_opcode(data) ? 2 : 1;
+		m_pc += is_long_opcode(data) ? 4 : 2;
 	}
 }
 
-void avr8_device::op_sbrc(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_sbrc(uint16_t op)
 {
 	if (!BIT(m_r[RD5(op)], RR3(op)))
 	{
-		const uint16_t data = (uint32_t)m_program->read_word(m_shifted_pc + 2);
+		const uint16_t data = (uint32_t)m_program->read_word(m_pc + 2);
 		m_opcycles += is_long_opcode(data) ? 2 : 1;
-		m_pc += is_long_opcode(data) ? 2 : 1;
+		m_pc += is_long_opcode(data) ? 4 : 2;
 	}
 }
 
-void avr8_device::op_unimpl(uint16_t op)
+template <int NumTimers>
+void avr8_device<NumTimers>::op_unimpl(uint16_t op)
 {
 	unimplemented_opcode(op);
 }

--- a/src/devices/cpu/avr8/avr8ops.hxx
+++ b/src/devices/cpu/avr8/avr8ops.hxx
@@ -8,8 +8,7 @@
 
 ***************************************************************************/
 
-template <int NumTimers>
-void avr8_device<NumTimers>::populate_ops()
+void avr8_base_device::populate_ops()
 {
 	for (uint32_t op = 0; op < 0x10000; op++)
 	{
@@ -21,32 +20,32 @@ void avr8_device<NumTimers>::populate_ops()
 			switch (op & 0x0f00)
 			{
 			case 0x0000:    // NOP
-				m_op_funcs[op] = &avr8_device::op_nop;
+				m_op_funcs[op] = &avr8_base_device::op_nop;
 				break;
 			case 0x0100:    // MOVW Rd+1:Rd,Rr+1:Rd
-				m_op_funcs[op] = &avr8_device::op_movw;
+				m_op_funcs[op] = &avr8_base_device::op_movw;
 				break;
 			case 0x0200:    // MULS Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_muls;
+				m_op_funcs[op] = &avr8_base_device::op_muls;
 				m_op_cycles[op] = 2;
 				break;
 			case 0x0300:    // Multiplication
 				switch (MULCONST2(op))
 				{
 				case 0x0000: // MULSU Rd,Rr
-					m_op_funcs[op] = &avr8_device::op_mulsu;
+					m_op_funcs[op] = &avr8_base_device::op_mulsu;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x0001: // FMUL Rd,Rr
-					m_op_funcs[op] = &avr8_device::op_fmul;
+					m_op_funcs[op] = &avr8_base_device::op_fmul;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x0002: // FMULS Rd,Rr
-					m_op_funcs[op] = &avr8_device::op_fmuls;
+					m_op_funcs[op] = &avr8_base_device::op_fmuls;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x0003: // FMULSU Rd,Rr
-					m_op_funcs[op] = &avr8_device::op_fmulsu;
+					m_op_funcs[op] = &avr8_base_device::op_fmulsu;
 					m_op_cycles[op] = 2;
 					break;
 				}
@@ -55,19 +54,19 @@ void avr8_device<NumTimers>::populate_ops()
 			case 0x0500:
 			case 0x0600:
 			case 0x0700:    // CPC Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_cpc;
+				m_op_funcs[op] = &avr8_base_device::op_cpc;
 				break;
 			case 0x0800:
 			case 0x0900:
 			case 0x0a00:
 			case 0x0b00:    // SBC Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_sbc;
+				m_op_funcs[op] = &avr8_base_device::op_sbc;
 				break;
 			case 0x0c00:
 			case 0x0d00:
 			case 0x0e00:
 			case 0x0f00:    // ADD Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_add;
+				m_op_funcs[op] = &avr8_base_device::op_add;
 				break;
 			}
 			break;
@@ -75,16 +74,16 @@ void avr8_device<NumTimers>::populate_ops()
 			switch (op & 0x0c00)
 			{
 			case 0x0000:    // CPSE Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_cpse;
+				m_op_funcs[op] = &avr8_base_device::op_cpse;
 				break;
 			case 0x0400:    // CP Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_cp;
+				m_op_funcs[op] = &avr8_base_device::op_cp;
 				break;
 			case 0x0800:    // SUB Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_sub;
+				m_op_funcs[op] = &avr8_base_device::op_sub;
 				break;
 			case 0x0c00:    // ADC Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_adc;
+				m_op_funcs[op] = &avr8_base_device::op_adc;
 				break;
 			}
 			break;
@@ -92,52 +91,52 @@ void avr8_device<NumTimers>::populate_ops()
 			switch (op & 0x0c00)
 			{
 			case 0x0000:    // AND Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_and;
+				m_op_funcs[op] = &avr8_base_device::op_and;
 				break;
 			case 0x0400:    // EOR Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_eor;
+				m_op_funcs[op] = &avr8_base_device::op_eor;
 				break;
 			case 0x0800:    // OR Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_or;
+				m_op_funcs[op] = &avr8_base_device::op_or;
 				break;
 			case 0x0c00:    // MOV Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_mov;
+				m_op_funcs[op] = &avr8_base_device::op_mov;
 				break;
 			}
 			break;
 		case 0x3000:    // CPI Rd,K
-			m_op_funcs[op] = &avr8_device::op_cpi;
+			m_op_funcs[op] = &avr8_base_device::op_cpi;
 			break;
 		case 0x4000:    // SBCI Rd,K
-			m_op_funcs[op] = &avr8_device::op_sbci;
+			m_op_funcs[op] = &avr8_base_device::op_sbci;
 			break;
 		case 0x5000:    // SUBI Rd,K
-			m_op_funcs[op] = &avr8_device::op_subi;
+			m_op_funcs[op] = &avr8_base_device::op_subi;
 			break;
 		case 0x6000:    // ORI Rd,K
-			m_op_funcs[op] = &avr8_device::op_ori;
+			m_op_funcs[op] = &avr8_base_device::op_ori;
 			break;
 		case 0x7000:    // ANDI Rd,K
-			m_op_funcs[op] = &avr8_device::op_andi;
+			m_op_funcs[op] = &avr8_base_device::op_andi;
 			break;
 		case 0x8000:
 		case 0xa000:
 			switch (op & 0x0208)
 			{
 			case 0x0000:    // LDD Rd,Z+q
-				m_op_funcs[op] = &avr8_device::op_lddz;
+				m_op_funcs[op] = &avr8_base_device::op_lddz;
 				m_op_cycles[op] = 2;
 				break;
 			case 0x0008:    // LDD Rd,Y+q
-				m_op_funcs[op] = &avr8_device::op_lddy;
+				m_op_funcs[op] = &avr8_base_device::op_lddy;
 				m_op_cycles[op] = 2;
 				break;
 			case 0x0200:    // STD Z+q,Rr
-				m_op_funcs[op] = &avr8_device::op_stdz;
+				m_op_funcs[op] = &avr8_base_device::op_stdz;
 				m_op_cycles[op] = 2;
 				break;
 			case 0x0208:    // STD Y+q,Rr
-				m_op_funcs[op] = &avr8_device::op_stdy;
+				m_op_funcs[op] = &avr8_base_device::op_stdy;
 				m_op_cycles[op] = 2;
 				break;
 			}
@@ -150,59 +149,59 @@ void avr8_device<NumTimers>::populate_ops()
 				switch (op & 0x000f)
 				{
 				case 0x0000:    // LDS Rd,k
-					m_op_funcs[op] = &avr8_device::op_lds;
+					m_op_funcs[op] = &avr8_base_device::op_lds;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x0001:    // LD Rd,Z+
-					m_op_funcs[op] = &avr8_device::op_ldzi;
+					m_op_funcs[op] = &avr8_base_device::op_ldzi;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x0002:    // LD Rd,-Z
-					m_op_funcs[op] = &avr8_device::op_ldzd;
+					m_op_funcs[op] = &avr8_base_device::op_ldzd;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x0004:    // LPM Rd,Z
-					m_op_funcs[op] = &avr8_device::op_lpmz;
+					m_op_funcs[op] = &avr8_base_device::op_lpmz;
 					m_op_cycles[op] = 3;
 					break;
 				case 0x0005:    // LPM Rd,Z+
-					m_op_funcs[op] = &avr8_device::op_lpmzi;
+					m_op_funcs[op] = &avr8_base_device::op_lpmzi;
 					m_op_cycles[op] = 3;
 					break;
 				case 0x0006:    // ELPM Rd,Z
-					m_op_funcs[op] = &avr8_device::op_elpmz;
+					m_op_funcs[op] = &avr8_base_device::op_elpmz;
 					m_op_cycles[op] = 3;
 					break;
 				case 0x0007:    // ELPM Rd,Z+
-					m_op_funcs[op] = &avr8_device::op_elpmzi;
+					m_op_funcs[op] = &avr8_base_device::op_elpmzi;
 					m_op_cycles[op] = 3;
 					break;
 				case 0x0009:    // LD Rd,Y+
-					m_op_funcs[op] = &avr8_device::op_ldyi;
+					m_op_funcs[op] = &avr8_base_device::op_ldyi;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x000a:    // LD Rd,-Y
-					m_op_funcs[op] = &avr8_device::op_ldyd;
+					m_op_funcs[op] = &avr8_base_device::op_ldyd;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x000c:    // LD Rd,X
-					m_op_funcs[op] = &avr8_device::op_ldx;
+					m_op_funcs[op] = &avr8_base_device::op_ldx;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x000d:    // LD Rd,X+
-					m_op_funcs[op] = &avr8_device::op_ldxi;
+					m_op_funcs[op] = &avr8_base_device::op_ldxi;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x000e:    // LD Rd,-X
-					m_op_funcs[op] = &avr8_device::op_ldxd;
+					m_op_funcs[op] = &avr8_base_device::op_ldxd;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x000f:    // POP Rd
-					m_op_funcs[op] = &avr8_device::op_pop;
+					m_op_funcs[op] = &avr8_base_device::op_pop;
 					m_op_cycles[op] = 2;
 					break;
 				default:
-					m_op_funcs[op] = &avr8_device::op_unimpl;
+					m_op_funcs[op] = &avr8_base_device::op_unimpl;
 					break;
 				}
 				break;
@@ -211,42 +210,42 @@ void avr8_device<NumTimers>::populate_ops()
 				switch (op & 0x000f)
 				{
 				case 0x0000:    // STS k,Rr
-					m_op_funcs[op] = &avr8_device::op_sts;
+					m_op_funcs[op] = &avr8_base_device::op_sts;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x0001:    // ST Z+,Rd
-					m_op_funcs[op] = &avr8_device::op_stzi;
+					m_op_funcs[op] = &avr8_base_device::op_stzi;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x0002:    // ST -Z,Rd
-					m_op_funcs[op] = &avr8_device::op_stzd;
+					m_op_funcs[op] = &avr8_base_device::op_stzd;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x0009:    // ST Y+,Rd
-					m_op_funcs[op] = &avr8_device::op_styi;
+					m_op_funcs[op] = &avr8_base_device::op_styi;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x000a:    // ST -Y,Rd
-					m_op_funcs[op] = &avr8_device::op_styd;
+					m_op_funcs[op] = &avr8_base_device::op_styd;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x000c:    // ST X,Rd
-					m_op_funcs[op] = &avr8_device::op_stx;
+					m_op_funcs[op] = &avr8_base_device::op_stx;
 					break;
 				case 0x000d:    // ST X+,Rd
-					m_op_funcs[op] = &avr8_device::op_stxi;
+					m_op_funcs[op] = &avr8_base_device::op_stxi;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x000e:    // ST -X,Rd
-					m_op_funcs[op] = &avr8_device::op_stxd;
+					m_op_funcs[op] = &avr8_base_device::op_stxd;
 					m_op_cycles[op] = 2;
 					break;
 				case 0x000f:    // PUSH Rd
-					m_op_funcs[op] = &avr8_device::op_push;
+					m_op_funcs[op] = &avr8_base_device::op_push;
 					m_op_cycles[op] = 2;
 					break;
 				default:
-					m_op_funcs[op] = &avr8_device::op_unimpl;
+					m_op_funcs[op] = &avr8_base_device::op_unimpl;
 					break;
 				}
 				break;
@@ -254,25 +253,25 @@ void avr8_device<NumTimers>::populate_ops()
 				switch (op & 0x000f)
 				{
 				case 0x0000:    // COM Rd
-					m_op_funcs[op] = &avr8_device::op_com;
+					m_op_funcs[op] = &avr8_base_device::op_com;
 					break;
 				case 0x0001:    // NEG Rd
-					m_op_funcs[op] = &avr8_device::op_neg;
+					m_op_funcs[op] = &avr8_base_device::op_neg;
 					break;
 				case 0x0002:    // SWAP Rd
-					m_op_funcs[op] = &avr8_device::op_swap;
+					m_op_funcs[op] = &avr8_base_device::op_swap;
 					break;
 				case 0x0003:    // INC Rd
-					m_op_funcs[op] = &avr8_device::op_inc;
+					m_op_funcs[op] = &avr8_base_device::op_inc;
 					break;
 				case 0x0005:    // ASR Rd
-					m_op_funcs[op] = &avr8_device::op_asr;
+					m_op_funcs[op] = &avr8_base_device::op_asr;
 					break;
 				case 0x0006:    // LSR Rd
-					m_op_funcs[op] = &avr8_device::op_lsr;
+					m_op_funcs[op] = &avr8_base_device::op_lsr;
 					break;
 				case 0x0007:    // ROR Rd
-					m_op_funcs[op] = &avr8_device::op_ror;
+					m_op_funcs[op] = &avr8_base_device::op_ror;
 					break;
 				case 0x0008:
 					switch (op & 0x00f0)
@@ -285,7 +284,7 @@ void avr8_device<NumTimers>::populate_ops()
 					case 0x0050:    // SEH
 					case 0x0060:    // SET
 					case 0x0070:    // SEI
-						m_op_funcs[op] = &avr8_device::op_setf;
+						m_op_funcs[op] = &avr8_base_device::op_setf;
 						break;
 					case 0x0080:    // CLC
 					case 0x0090:    // CLZ
@@ -295,7 +294,7 @@ void avr8_device<NumTimers>::populate_ops()
 					case 0x00d0:    // CLH
 					case 0x00e0:    // CLT
 					case 0x00f0:    // CLI
-						m_op_funcs[op] = &avr8_device::op_clrf;
+						m_op_funcs[op] = &avr8_base_device::op_clrf;
 						break;
 					}
 					break;
@@ -303,33 +302,33 @@ void avr8_device<NumTimers>::populate_ops()
 					switch (op & 0x00f0)
 					{
 					case 0x0000:    // IJMP
-						m_op_funcs[op] = &avr8_device::op_ijmp;
+						m_op_funcs[op] = &avr8_base_device::op_ijmp;
 						m_op_cycles[op] = 2;
 						break;
 					case 0x0010:    // EIJMP
-						m_op_funcs[op] = &avr8_device::op_eijmp;
+						m_op_funcs[op] = &avr8_base_device::op_eijmp;
 						m_op_cycles[op] = 2;
 						break;
 					default:
-						m_op_funcs[op] = &avr8_device::op_unimpl;
+						m_op_funcs[op] = &avr8_base_device::op_unimpl;
 						break;
 					}
 					break;
 				case 0x000a:    // DEC Rd
-					m_op_funcs[op] = &avr8_device::op_dec;
+					m_op_funcs[op] = &avr8_base_device::op_dec;
 					break;
 				case 0x000c:
 				case 0x000d:    // JMP k
-					m_op_funcs[op] = &avr8_device::op_jmp;
+					m_op_funcs[op] = &avr8_base_device::op_jmp;
 					m_op_cycles[op] = 3;
 					break;
 				case 0x000e:    // CALL k
 				case 0x000f:
-					m_op_funcs[op] = &avr8_device::op_call;
+					m_op_funcs[op] = &avr8_base_device::op_call;
 					m_op_cycles[op] = 4;
 					break;
 				default:
-					m_op_funcs[op] = &avr8_device::op_unimpl;
+					m_op_funcs[op] = &avr8_base_device::op_unimpl;
 					break;
 				}
 				break;
@@ -337,62 +336,62 @@ void avr8_device<NumTimers>::populate_ops()
 				switch (op & 0x000f)
 				{
 				case 0x0000:    // COM Rd
-					m_op_funcs[op] = &avr8_device::op_com;
+					m_op_funcs[op] = &avr8_base_device::op_com;
 					break;
 				case 0x0001:    // NEG Rd
-					m_op_funcs[op] = &avr8_device::op_neg;
+					m_op_funcs[op] = &avr8_base_device::op_neg;
 					break;
 				case 0x0002:    // SWAP Rd
-					m_op_funcs[op] = &avr8_device::op_swap;
+					m_op_funcs[op] = &avr8_base_device::op_swap;
 					break;
 				case 0x0003:    // INC Rd
-					m_op_funcs[op] = &avr8_device::op_inc;
+					m_op_funcs[op] = &avr8_base_device::op_inc;
 					break;
 				case 0x0005:    // ASR Rd
-					m_op_funcs[op] = &avr8_device::op_asr;
+					m_op_funcs[op] = &avr8_base_device::op_asr;
 					break;
 				case 0x0006:    // LSR Rd
-					m_op_funcs[op] = &avr8_device::op_lsr;
+					m_op_funcs[op] = &avr8_base_device::op_lsr;
 					break;
 				case 0x0007:    // ROR Rd
-					m_op_funcs[op] = &avr8_device::op_ror;
+					m_op_funcs[op] = &avr8_base_device::op_ror;
 					break;
 				case 0x0008:
 					switch (op & 0x00f0)
 					{
 					case 0x0000:    // RET
-						m_op_funcs[op] = &avr8_device::op_ret;
+						m_op_funcs[op] = &avr8_base_device::op_ret;
 						m_op_cycles[op] = 4;
 						break;
 					case 0x0010:    // RETI
-						m_op_funcs[op] = &avr8_device::op_reti;
+						m_op_funcs[op] = &avr8_base_device::op_reti;
 						m_op_cycles[op] = 4;
 						break;
 					case 0x0080:    // SLEEP
-						m_op_funcs[op] = &avr8_device::op_sleep;
+						m_op_funcs[op] = &avr8_base_device::op_sleep;
 						m_op_cycles[op] = 1;
 						break;
 					case 0x0090:    // BREAK
-						m_op_funcs[op] = &avr8_device::op_unimpl;
+						m_op_funcs[op] = &avr8_base_device::op_unimpl;
 						break;
 					case 0x00a0:    // WDR
-						m_op_funcs[op] = &avr8_device::op_wdr;
+						m_op_funcs[op] = &avr8_base_device::op_wdr;
 						break;
 					case 0x00c0:    // LPM
-						m_op_funcs[op] = &avr8_device::op_lpm;
+						m_op_funcs[op] = &avr8_base_device::op_lpm;
 						m_op_cycles[op] = 3;
 						break;
 					case 0x00d0:    // ELPM
-						m_op_funcs[op] = &avr8_device::op_elpm;
+						m_op_funcs[op] = &avr8_base_device::op_elpm;
 						break;
 					case 0x00e0:    // SPM
-						m_op_funcs[op] = &avr8_device::op_spm;
+						m_op_funcs[op] = &avr8_base_device::op_spm;
 						break;
 					case 0x00f0:    // SPM Z+
-						m_op_funcs[op] = &avr8_device::op_spmzi;
+						m_op_funcs[op] = &avr8_base_device::op_spmzi;
 						break;
 					default:
-						m_op_funcs[op] = &avr8_device::op_unimpl;
+						m_op_funcs[op] = &avr8_base_device::op_unimpl;
 						break;
 					}
 					break;
@@ -400,59 +399,59 @@ void avr8_device<NumTimers>::populate_ops()
 					switch (op & 0x00f0)
 					{
 					case 0x0000:    // ICALL
-						m_op_funcs[op] = &avr8_device::op_icall;
+						m_op_funcs[op] = &avr8_base_device::op_icall;
 						m_op_cycles[op] = 3;
 						break;
 					case 0x0010:    // EICALL
-						m_op_funcs[op] = &avr8_device::op_eicall;
+						m_op_funcs[op] = &avr8_base_device::op_eicall;
 						break;
 					default:
-						m_op_funcs[op] = &avr8_device::op_unimpl;
+						m_op_funcs[op] = &avr8_base_device::op_unimpl;
 						break;
 					}
 					break;
 				case 0x000a:    // DEC Rd
-					m_op_funcs[op] = &avr8_device::op_dec;
+					m_op_funcs[op] = &avr8_base_device::op_dec;
 					break;
 				case 0x000c:
 				case 0x000d:    // JMP k
-					m_op_funcs[op] = &avr8_device::op_jmp;
+					m_op_funcs[op] = &avr8_base_device::op_jmp;
 					m_op_cycles[op] = 3;
 					break;
 				case 0x000e:
 				case 0x000f:    // CALL k
-					m_op_funcs[op] = &avr8_device::op_call;
+					m_op_funcs[op] = &avr8_base_device::op_call;
 					m_op_cycles[op] = 4;
 					break;
 				}
 				break;
 			case 0x0600:    // ADIW Rd+1:Rd,K
-				m_op_funcs[op] = &avr8_device::op_adiw;
+				m_op_funcs[op] = &avr8_base_device::op_adiw;
 				m_op_cycles[op] = 2;
 				break;
 			case 0x0700:    // SBIW Rd+1:Rd,K
-				m_op_funcs[op] = &avr8_device::op_sbiw;
+				m_op_funcs[op] = &avr8_base_device::op_sbiw;
 				m_op_cycles[op] = 2;
 				break;
 			case 0x0800:    // CBI A,b
-				m_op_funcs[op] = &avr8_device::op_cbi;
+				m_op_funcs[op] = &avr8_base_device::op_cbi;
 				m_op_cycles[op] = 2;
 				break;
 			case 0x0900:    // SBIC A,b
-				m_op_funcs[op] = &avr8_device::op_sbic;
+				m_op_funcs[op] = &avr8_base_device::op_sbic;
 				break;
 			case 0x0a00:    // SBI A,b
-				m_op_funcs[op] = &avr8_device::op_sbi;
+				m_op_funcs[op] = &avr8_base_device::op_sbi;
 				m_op_cycles[op] = 2;
 				break;
 			case 0x0b00:    // SBIS A,b
-				m_op_funcs[op] = &avr8_device::op_sbis;
+				m_op_funcs[op] = &avr8_base_device::op_sbis;
 				break;
 			case 0x0c00:
 			case 0x0d00:
 			case 0x0e00:
 			case 0x0f00:    // MUL Rd,Rr
-				m_op_funcs[op] = &avr8_device::op_mul;
+				m_op_funcs[op] = &avr8_base_device::op_mul;
 				m_op_cycles[op] = 2;
 				break;
 			}
@@ -460,51 +459,51 @@ void avr8_device<NumTimers>::populate_ops()
 		case 0xb000:
 			if (op & 0x0800) // OUT A,Rr
 			{
-				m_op_funcs[op] = &avr8_device::op_out;
+				m_op_funcs[op] = &avr8_base_device::op_out;
 			}
 			else            // IN Rd,A
 			{
-				m_op_funcs[op] = &avr8_device::op_in;
+				m_op_funcs[op] = &avr8_base_device::op_in;
 			}
 			break;
 		case 0xc000:    // RJMP k
-			m_op_funcs[op] = &avr8_device::op_rjmp;
+			m_op_funcs[op] = &avr8_base_device::op_rjmp;
 			m_op_cycles[op] = 2;
 			break;
 		case 0xd000:    // RCALL k
-			m_op_funcs[op] = &avr8_device::op_rcall;
+			m_op_funcs[op] = &avr8_base_device::op_rcall;
 			m_op_cycles[op] = 3;
 			break;
 		case 0xe000:    // LDI Rd,K
-			m_op_funcs[op] = &avr8_device::op_ldi;
+			m_op_funcs[op] = &avr8_base_device::op_ldi;
 			break;
 		case 0xf000:
 			switch (op & 0x0c00)
 			{
 			case 0x0000: // BRLO through BRIE
-				m_op_funcs[op] = &avr8_device::op_brset;
+				m_op_funcs[op] = &avr8_base_device::op_brset;
 				break;
 			case 0x0400: // BRSH through BRID
-				m_op_funcs[op] = &avr8_device::op_brclr;
+				m_op_funcs[op] = &avr8_base_device::op_brclr;
 				break;
 			case 0x0800:
 				if (op & 0x0200) // BST Rd, b
 				{
-					m_op_funcs[op] = &avr8_device::op_bst;
+					m_op_funcs[op] = &avr8_base_device::op_bst;
 				}
 				else            // BLD Rd, b
 				{
-					m_op_funcs[op] = &avr8_device::op_bld;
+					m_op_funcs[op] = &avr8_base_device::op_bld;
 				}
 				break;
 			case 0x0c00:
 				if (op & 0x0200) // SBRS Rd, b
 				{
-					m_op_funcs[op] = &avr8_device::op_sbrs;
+					m_op_funcs[op] = &avr8_base_device::op_sbrs;
 				}
 				else             // SBRC Rd, b
 				{
-					m_op_funcs[op] = &avr8_device::op_sbrc;
+					m_op_funcs[op] = &avr8_base_device::op_sbrc;
 				}
 				break;
 			}
@@ -513,8 +512,7 @@ void avr8_device<NumTimers>::populate_ops()
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::populate_add_flag_cache()
+void avr8_base_device::populate_add_flag_cache()
 {
 	for (uint16_t rd = 0; rd < 0x100; rd++)
 	{
@@ -522,19 +520,18 @@ void avr8_device<NumTimers>::populate_add_flag_cache()
 		{
 			const uint8_t res = rd + rr;
 			uint8_t flags = 0;
-			flags |= (((rd & 8) && (rr & 8)) || ((rr & 8) && !(res & 8)) || (!(res & 8) && (rd & 8))) ? AVR8_SREG_MASK_H : 0;
-			flags |= (((rd & 0x80) && (rr & 0x80) && !(res & 0x80)) || (!(rd & 0x80) && !(rr & 0x80) && (res & 0x80))) ? AVR8_SREG_MASK_V : 0;
-			flags |= (res & 0x80) ? AVR8_SREG_MASK_N : 0;
-			flags |= (bool(flags & AVR8_SREG_MASK_N) != bool(flags & AVR8_SREG_MASK_V)) ? AVR8_SREG_MASK_S : 0;
-			flags |= (res == 0) ? AVR8_SREG_MASK_Z : 0;
-			flags |= (((rd & 0x80) && (rr & 0x80)) || ((rr & 0x80) && !(res & 0x80)) || (!(res & 0x80) && (rd & 0x80))) ? AVR8_SREG_MASK_C : 0;
+			flags |= (((rd & 8) && (rr & 8)) || ((rr & 8) && !(res & 8)) || (!(res & 8) && (rd & 8))) ? SREG_MASK_H : 0;
+			flags |= (((rd & 0x80) && (rr & 0x80) && !(res & 0x80)) || (!(rd & 0x80) && !(rr & 0x80) && (res & 0x80))) ? SREG_MASK_V : 0;
+			flags |= (res & 0x80) ? SREG_MASK_N : 0;
+			flags |= (bool(flags & SREG_MASK_N) != bool(flags & SREG_MASK_V)) ? SREG_MASK_S : 0;
+			flags |= (res == 0) ? SREG_MASK_Z : 0;
+			flags |= (((rd & 0x80) && (rr & 0x80)) || ((rr & 0x80) && !(res & 0x80)) || (!(res & 0x80) && (rd & 0x80))) ? SREG_MASK_C : 0;
 			m_add_flag_cache[(rd << 8) | rr] = flags;
 		}
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::populate_adc_flag_cache()
+void avr8_base_device::populate_adc_flag_cache()
 {
 	for (uint16_t rd = 0; rd < 0x100; rd++)
 	{
@@ -544,20 +541,19 @@ void avr8_device<NumTimers>::populate_adc_flag_cache()
 			{
 				const uint8_t res = rd + rr + c;
 				uint8_t flags = 0;
-				flags |= (((rd & 8) && (rr & 8)) || ((rr & 8) && !(res & 8)) || (!(res & 8) && (rd & 8))) ? AVR8_SREG_MASK_H : 0;
-				flags |= (((rd & 0x80) && (rr & 0x80) && !(res & 0x80)) || (!(rd & 0x80) && !(rr & 0x80) && (res & 0x80))) ? AVR8_SREG_MASK_V : 0;
-				flags |= (res & 0x80) ? AVR8_SREG_MASK_N : 0;
-				flags |= (bool(flags & AVR8_SREG_MASK_N) != bool(flags & AVR8_SREG_MASK_V)) ? AVR8_SREG_MASK_S : 0;
-				flags |= (res == 0) ? AVR8_SREG_MASK_Z : 0;
-				flags |= (((rd & 0x80) && (rr & 0x80)) || ((rr & 0x80) && !(res & 0x80)) || (!(res & 0x80) && (rd & 0x80))) ? AVR8_SREG_MASK_C : 0;
+				flags |= (((rd & 8) && (rr & 8)) || ((rr & 8) && !(res & 8)) || (!(res & 8) && (rd & 8))) ? SREG_MASK_H : 0;
+				flags |= (((rd & 0x80) && (rr & 0x80) && !(res & 0x80)) || (!(rd & 0x80) && !(rr & 0x80) && (res & 0x80))) ? SREG_MASK_V : 0;
+				flags |= (res & 0x80) ? SREG_MASK_N : 0;
+				flags |= (bool(flags & SREG_MASK_N) != bool(flags & SREG_MASK_V)) ? SREG_MASK_S : 0;
+				flags |= (res == 0) ? SREG_MASK_Z : 0;
+				flags |= (((rd & 0x80) && (rr & 0x80)) || ((rr & 0x80) && !(res & 0x80)) || (!(res & 0x80) && (rd & 0x80))) ? SREG_MASK_C : 0;
 				m_adc_flag_cache[(c << 16) | (rd << 8) | rr] = flags;
 			}
 		}
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::populate_sub_flag_cache()
+void avr8_base_device::populate_sub_flag_cache()
 {
 	for (uint16_t rd = 0; rd < 0x100; rd++)
 	{
@@ -565,19 +561,18 @@ void avr8_device<NumTimers>::populate_sub_flag_cache()
 		{
 			const uint8_t res = rd - rr;
 			uint8_t flags = 0;
-			flags |= ((!(rd & 8) && (rr & 8)) || ((rr & 8) && (res & 8)) || ((res & 8) && !(rd & 8))) ? AVR8_SREG_MASK_H : 0;
-			flags |= (((rd & 0x80) && !(rr & 0x80) && !(res & 0x80)) || (!(rd & 0x80) && (rr & 0x80) && (res & 0x80))) ? AVR8_SREG_MASK_V : 0;
-			flags |= (res & 0x80) ? AVR8_SREG_MASK_N : 0;
-			flags |= (bool(flags & AVR8_SREG_MASK_N) != bool(flags & AVR8_SREG_MASK_V)) ? AVR8_SREG_MASK_S : 0;
-			flags |= (res == 0) ? AVR8_SREG_MASK_Z : 0;
-			flags |= ((!(rd & 0x80) && (rr & 0x80)) || ((rr & 0x80) && (res & 0x80)) || ((res & 0x80) && !(rd & 0x80))) ? AVR8_SREG_MASK_C : 0;
+			flags |= ((!(rd & 8) && (rr & 8)) || ((rr & 8) && (res & 8)) || ((res & 8) && !(rd & 8))) ? SREG_MASK_H : 0;
+			flags |= (((rd & 0x80) && !(rr & 0x80) && !(res & 0x80)) || (!(rd & 0x80) && (rr & 0x80) && (res & 0x80))) ? SREG_MASK_V : 0;
+			flags |= (res & 0x80) ? SREG_MASK_N : 0;
+			flags |= (bool(flags & SREG_MASK_N) != bool(flags & SREG_MASK_V)) ? SREG_MASK_S : 0;
+			flags |= (res == 0) ? SREG_MASK_Z : 0;
+			flags |= ((!(rd & 0x80) && (rr & 0x80)) || ((rr & 0x80) && (res & 0x80)) || ((res & 0x80) && !(rd & 0x80))) ? SREG_MASK_C : 0;
 			m_sub_flag_cache[(rd << 8) | rr] = flags;
 		}
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::populate_sbc_flag_cache()
+void avr8_base_device::populate_sbc_flag_cache()
 {
 	for (uint16_t rd = 0; rd < 0x100; rd++)
 	{
@@ -589,12 +584,12 @@ void avr8_device<NumTimers>::populate_sbc_flag_cache()
 				{
 					const uint8_t res = rd - (rr + c);
 					uint8_t flags = 0;
-					flags |= ((!(rd & 8) && (rr & 8)) || ((rr & 8) && (res & 8)) || ((res & 8) && !(rd & 8))) ? AVR8_SREG_MASK_H : 0;
-					flags |= (((rd & 0x80) && !(rr & 0x80) && !(res & 0x80)) || (!(rd & 0x80) && (rr & 0x80) && (res & 0x80))) ? AVR8_SREG_MASK_V : 0;
-					flags |= (res & 0x80) ? AVR8_SREG_MASK_N : 0;
-					flags |= (bool(flags & AVR8_SREG_MASK_N) != bool(flags & AVR8_SREG_MASK_V)) ? AVR8_SREG_MASK_S : 0;
-					flags |= (res == 0) ? (z ? AVR8_SREG_MASK_Z : 0) : 0;
-					flags |= ((!(rd & 0x80) && (rr & 0x80)) || ((rr & 0x80) && (res & 0x80)) || ((res & 0x80) && !(rd & 0x80))) ? AVR8_SREG_MASK_C : 0;
+					flags |= ((!(rd & 8) && (rr & 8)) || ((rr & 8) && (res & 8)) || ((res & 8) && !(rd & 8))) ? SREG_MASK_H : 0;
+					flags |= (((rd & 0x80) && !(rr & 0x80) && !(res & 0x80)) || (!(rd & 0x80) && (rr & 0x80) && (res & 0x80))) ? SREG_MASK_V : 0;
+					flags |= (res & 0x80) ? SREG_MASK_N : 0;
+					flags |= (bool(flags & SREG_MASK_N) != bool(flags & SREG_MASK_V)) ? SREG_MASK_S : 0;
+					flags |= (res == 0) ? (z ? SREG_MASK_Z : 0) : 0;
+					flags |= ((!(rd & 0x80) && (rr & 0x80)) || ((rr & 0x80) && (res & 0x80)) || ((res & 0x80) && !(rd & 0x80))) ? SREG_MASK_C : 0;
 					m_sbc_flag_cache[(z << 17) | (c << 16) | (rd << 8) | rr] = flags;
 				}
 			}
@@ -602,136 +597,138 @@ void avr8_device<NumTimers>::populate_sbc_flag_cache()
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::populate_bool_flag_cache()
+void avr8_base_device::populate_bool_flag_cache()
 {
 	for (uint16_t res = 0; res < 0x100; res++)
 	{
 		uint8_t flags = 0;
-		flags |= (res & 0x80) ? AVR8_SREG_MASK_N : 0;
-		flags |= (bool(flags & AVR8_SREG_MASK_N) != bool(flags & AVR8_SREG_MASK_V)) ? AVR8_SREG_MASK_S : 0;
-		flags |= (res == 0) ? AVR8_SREG_MASK_Z : 0;
+		flags |= (res & 0x80) ? SREG_MASK_N : 0;
+		flags |= (bool(flags & SREG_MASK_N) != bool(flags & SREG_MASK_V)) ? SREG_MASK_S : 0;
+		flags |= (res == 0) ? SREG_MASK_Z : 0;
 		m_bool_flag_cache[res] = flags;
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::populate_shift_flag_cache()
+void avr8_base_device::populate_shift_flag_cache()
 {
 	for (uint16_t rd = 0; rd < 0x100; rd++)
 	{
 		for (uint16_t res = 0; res < 0x100; res++)
 		{
 			uint8_t flags = 0;
-			flags |= (rd & 1) ? AVR8_SREG_MASK_C : 0;
-			flags |= (res == 0) ? AVR8_SREG_MASK_Z : 0;
-			flags |= (rd & 0x80) ? AVR8_SREG_MASK_N : 0;
-			flags |= (bool(flags & AVR8_SREG_MASK_N) != bool(flags & AVR8_SREG_MASK_C)) ? AVR8_SREG_MASK_V : 0;
-			flags |= (bool(flags & AVR8_SREG_MASK_N) != bool(flags & AVR8_SREG_MASK_V)) ? AVR8_SREG_MASK_S : 0;
+			flags |= (rd & 1) ? SREG_MASK_C : 0;
+			flags |= (res == 0) ? SREG_MASK_Z : 0;
+			flags |= (rd & 0x80) ? SREG_MASK_N : 0;
+			flags |= (bool(flags & SREG_MASK_N) != bool(flags & SREG_MASK_C)) ? SREG_MASK_V : 0;
+			flags |= (bool(flags & SREG_MASK_N) != bool(flags & SREG_MASK_V)) ? SREG_MASK_S : 0;
 			m_shift_flag_cache[(rd << 8) | res] = flags;
 		}
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_nop(uint16_t op)
+void avr8_base_device::op_nop(uint16_t op)
 {
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_movw(uint16_t op)
+void avr8_base_device::op_movw(uint16_t op)
 {
 	m_r[(RD4(op) << 1) + 1] = m_r[(RR4(op) << 1) + 1];
 	m_r[RD4(op) << 1] = m_r[RR4(op) << 1];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_muls(uint16_t op)
+void avr8_base_device::op_muls(uint16_t op)
 {
 	const int16_t sd = (int8_t)m_r[16 + RD4(op)] * (int8_t)m_r[16 + RR4(op)];
 	m_r[1] = (sd >> 8) & 0x00ff;
 	m_r[0] = sd & 0x00ff;
-	SREG_W(AVR8_SREG_C, (sd & 0x8000) ? 1 : 0);
-	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
+	m_r[SREG] &= ~(SREG_MASK_C | SREG_MASK_Z);
+	if (BIT(sd, 15))
+		m_r[SREG] |= SREG_MASK_C;
+	else if (sd == 0)
+		m_r[SREG] |= SREG_MASK_Z;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_mulsu(uint16_t op)
+void avr8_base_device::op_mulsu(uint16_t op)
 {
 	const int16_t sd = (int8_t)m_r[16 + RD3(op)] * (uint8_t)m_r[16 + RR3(op)];
 	m_r[1] = (sd >> 8) & 0x00ff;
 	m_r[0] = sd & 0x00ff;
-	SREG_W(AVR8_SREG_C, (sd & 0x8000) ? 1 : 0);
-	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
+	m_r[SREG] &= ~(SREG_MASK_C | SREG_MASK_Z);
+	if (BIT(sd, 15))
+		m_r[SREG] |= SREG_MASK_C;
+	else if (sd == 0)
+		m_r[SREG] |= SREG_MASK_Z;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_fmul(uint16_t op)
+void avr8_base_device::op_fmul(uint16_t op)
 {
 	const int16_t sd = ((uint8_t)m_r[16 + RD3(op)] * (uint8_t)m_r[16 + RR3(op)]) << 1;
 	m_r[1] = (sd >> 8) & 0x00ff;
 	m_r[0] = sd & 0x00ff;
-	SREG_W(AVR8_SREG_C, (sd & 0x8000) ? 1 : 0);
-	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
+	m_r[SREG] &= ~(SREG_MASK_C | SREG_MASK_Z);
+	if (BIT(sd, 15))
+		m_r[SREG] |= SREG_MASK_C;
+	else if (sd == 0)
+		m_r[SREG] |= SREG_MASK_Z;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_fmuls(uint16_t op)
+void avr8_base_device::op_fmuls(uint16_t op)
 {
 	const int16_t sd = ((int8_t)m_r[16 + RD3(op)] * (int8_t)m_r[16 + RR3(op)]) << 1;
 	m_r[1] = (sd >> 8) & 0x00ff;
 	m_r[0] = sd & 0x00ff;
-	SREG_W(AVR8_SREG_C, (sd & 0x8000) ? 1 : 0);
-	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
+	m_r[SREG] &= ~(SREG_MASK_C | SREG_MASK_Z);
+	if (BIT(sd, 15))
+		m_r[SREG] |= SREG_MASK_C;
+	else if (sd == 0)
+		m_r[SREG] |= SREG_MASK_Z;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_fmulsu(uint16_t op)
+void avr8_base_device::op_fmulsu(uint16_t op)
 {
 	const int16_t sd = ((int8_t)m_r[16 + RD3(op)] * (uint8_t)m_r[16 + RR3(op)]) << 1;
 	m_r[1] = (sd >> 8) & 0x00ff;
 	m_r[0] = sd & 0x00ff;
-	SREG_W(AVR8_SREG_C, (sd & 0x8000) ? 1 : 0);
-	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
+	m_r[SREG] &= ~(SREG_MASK_C | SREG_MASK_Z);
+	if (BIT(sd, 15))
+		m_r[SREG] |= SREG_MASK_C;
+	else if (sd == 0)
+		m_r[SREG] |= SREG_MASK_Z;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_cpc(uint16_t op)
+void avr8_base_device::op_cpc(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
-	const uint8_t c = m_r[SREG] & AVR8_SREG_MASK_C;
-	const uint32_t z = (m_r[SREG] & AVR8_SREG_MASK_Z) ? (1 << 17) : 0;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	const uint8_t c = m_r[SREG] & SREG_MASK_C;
+	const uint32_t z = (m_r[SREG] & SREG_MASK_Z) ? (1 << 17) : 0;
+	m_r[SREG] &= ~(SREG_MASK_H | SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z | SREG_MASK_C);
 	m_r[SREG] |= m_sbc_flag_cache[z | (c << 16) | (rd << 8) | rr];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_sbc(uint16_t op)
+void avr8_base_device::op_sbc(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
-	const uint8_t c = m_r[SREG] & AVR8_SREG_MASK_C;
+	const uint8_t c = m_r[SREG] & SREG_MASK_C;
 	const uint8_t res = rd - (rr + c);
 	m_r[RD5(op)] = res;
-	const uint32_t z = (m_r[SREG] & AVR8_SREG_MASK_Z) ? (1 << 17) : 0;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	const uint32_t z = (m_r[SREG] & SREG_MASK_Z) ? (1 << 17) : 0;
+	m_r[SREG] &= ~(SREG_MASK_H | SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z | SREG_MASK_C);
 	m_r[SREG] |= m_sbc_flag_cache[z | (c << 16) | (rd << 8) | rr];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_add(uint16_t op)
+void avr8_base_device::op_add(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
 	const uint8_t res = rd + rr;
 	m_r[RD5(op)] = res;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] &= ~(SREG_MASK_H | SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z | SREG_MASK_C);
 	m_r[SREG] |= m_add_flag_cache[(rd << 8) | rr];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_cpse(uint16_t op)
+void avr8_base_device::op_cpse(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
@@ -743,156 +740,138 @@ void avr8_device<NumTimers>::op_cpse(uint16_t op)
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_cp(uint16_t op)
+void avr8_base_device::op_cp(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
-	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] &= ~(SREG_MASK_H | SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z | SREG_MASK_C);
 	m_r[SREG] |= m_sub_flag_cache[(rd << 8) | rr];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_sub(uint16_t op)
+void avr8_base_device::op_sub(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
 	const uint8_t res = rd - rr;
 	m_r[RD5(op)] = res;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] &= ~(SREG_MASK_H | SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z | SREG_MASK_C);
 	m_r[SREG] |= m_sub_flag_cache[(rd << 8) | rr];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_adc(uint16_t op)
+void avr8_base_device::op_adc(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t rr = m_r[RR5(op)];
-	const uint8_t c = m_r[SREG] & AVR8_SREG_MASK_C;
+	const uint8_t c = m_r[SREG] & SREG_MASK_C;
 	const uint8_t res = rd + rr + c;
 	m_r[RD5(op)] = res;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] &= ~(SREG_MASK_H | SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z | SREG_MASK_C);
 	m_r[SREG] |= m_adc_flag_cache[(c << 16) | (rd << 8) | rr];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_and(uint16_t op)
+void avr8_base_device::op_and(uint16_t op)
 {
 	const uint8_t res = m_r[RD5(op)] & m_r[RR5(op)];
 	m_r[RD5(op)] = res;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
+	m_r[SREG] &= ~(SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z);
 	m_r[SREG] |= m_bool_flag_cache[res];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_eor(uint16_t op)
+void avr8_base_device::op_eor(uint16_t op)
 {
 	const uint8_t res = m_r[RD5(op)] ^ m_r[RR5(op)];
 	m_r[RD5(op)] = res;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
+	m_r[SREG] &= ~(SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z);
 	m_r[SREG] |= m_bool_flag_cache[res];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_or(uint16_t op)
+void avr8_base_device::op_or(uint16_t op)
 {
 	const uint8_t res = m_r[RD5(op)] | m_r[RR5(op)];
 	m_r[RD5(op)] = res;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
+	m_r[SREG] &= ~(SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z);
 	m_r[SREG] |= m_bool_flag_cache[res];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_mov(uint16_t op)
+void avr8_base_device::op_mov(uint16_t op)
 {
 	m_r[RD5(op)] = m_r[RR5(op)];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_cpi(uint16_t op)
+void avr8_base_device::op_cpi(uint16_t op)
 {
 	const uint8_t rd = m_r[16 + RD4(op)];
 	const uint8_t rr = KCONST8(op);
-	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] &= ~(SREG_MASK_H | SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z | SREG_MASK_C);
 	m_r[SREG] |= m_sub_flag_cache[(rd << 8) | rr];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_sbci(uint16_t op)
+void avr8_base_device::op_sbci(uint16_t op)
 {
 	const uint8_t rd = m_r[16 + RD4(op)];
 	const uint8_t rr = KCONST8(op);
-	const uint8_t c = m_r[SREG] & AVR8_SREG_MASK_C;
+	const uint8_t c = m_r[SREG] & SREG_MASK_C;
 	const uint8_t res = rd - (rr + c);
 	m_r[16 + RD4(op)] = res;
-	const uint32_t z = (m_r[SREG] & AVR8_SREG_MASK_Z) ? (1 << 17) : 0;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	const uint32_t z = (m_r[SREG] & SREG_MASK_Z) ? (1 << 17) : 0;
+	m_r[SREG] &= ~(SREG_MASK_H | SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z | SREG_MASK_C);
 	m_r[SREG] |= m_sbc_flag_cache[z | (c << 16) | (rd << 8) | rr];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_subi(uint16_t op)
+void avr8_base_device::op_subi(uint16_t op)
 {
 	const uint8_t rd = m_r[16 + RD4(op)];
 	const uint8_t rr = KCONST8(op);
 	const uint8_t res = rd - rr;
 	m_r[16 + RD4(op)] = res;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_H | AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_C);
+	m_r[SREG] &= ~(SREG_MASK_H | SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z | SREG_MASK_C);
 	m_r[SREG] |= m_sub_flag_cache[(rd << 8) | rr];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ori(uint16_t op)
+void avr8_base_device::op_ori(uint16_t op)
 {
 	const uint8_t res = m_r[16 + RD4(op)] | KCONST8(op);
 	m_r[16 + RD4(op)] = res;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
+	m_r[SREG] &= ~(SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z);
 	m_r[SREG] |= m_bool_flag_cache[res];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_andi(uint16_t op)
+void avr8_base_device::op_andi(uint16_t op)
 {
 	const uint8_t res = m_r[16 + RD4(op)] & KCONST8(op);
 	m_r[16 + RD4(op)] = res;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_V | AVR8_SREG_MASK_N | AVR8_SREG_MASK_S | AVR8_SREG_MASK_Z);
+	m_r[SREG] &= ~(SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z);
 	m_r[SREG] |= m_bool_flag_cache[res];
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_lddz(uint16_t op)
+void avr8_base_device::op_lddz(uint16_t op)
 {
 	m_r[RD5(op)] = m_data->read_byte(ZREG + QCONST6(op));
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_lddy(uint16_t op)
+void avr8_base_device::op_lddy(uint16_t op)
 {
 	m_r[RD5(op)] = m_data->read_byte(YREG + QCONST6(op));
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_stdz(uint16_t op)
+void avr8_base_device::op_stdz(uint16_t op)
 {
 	m_data->write_byte(ZREG + QCONST6(op), m_r[RD5(op)]);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_stdy(uint16_t op)
+void avr8_base_device::op_stdy(uint16_t op)
 {
 	m_data->write_byte(YREG + QCONST6(op), m_r[RD5(op)]);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_lds(uint16_t op)
+void avr8_base_device::op_lds(uint16_t op)
 {
 	m_pc += 2;
 	const uint16_t addr = m_program->read_word(m_pc);
 	m_r[RD5(op)] = m_data->read_byte(addr);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ldzi(uint16_t op)
+void avr8_base_device::op_ldzi(uint16_t op)
 {
 	uint16_t pd = ZREG;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -901,8 +880,7 @@ void avr8_device<NumTimers>::op_ldzi(uint16_t op)
 	m_r[30] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ldzd(uint16_t op)
+void avr8_base_device::op_ldzd(uint16_t op)
 {
 	const uint16_t pd = ZREG - 1;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -910,14 +888,12 @@ void avr8_device<NumTimers>::op_ldzd(uint16_t op)
 	m_r[30] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_lpmz(uint16_t op)
+void avr8_base_device::op_lpmz(uint16_t op)
 {
 	m_r[RD5(op)] = m_program->read_byte(ZREG);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_lpmzi(uint16_t op)
+void avr8_base_device::op_lpmzi(uint16_t op)
 {
 	uint16_t pd = ZREG;
 	m_r[RD5(op)] = m_program->read_byte(pd);
@@ -926,14 +902,12 @@ void avr8_device<NumTimers>::op_lpmzi(uint16_t op)
 	m_r[30] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_elpmz(uint16_t op)
+void avr8_base_device::op_elpmz(uint16_t op)
 {
 	m_r[RD5(op)] = m_program->read_byte((m_r[RAMPZ] << 16) | ZREG);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_elpmzi(uint16_t op)
+void avr8_base_device::op_elpmzi(uint16_t op)
 {
 	uint32_t pd32 = (m_r[RAMPZ] << 16) | ZREG;
 	m_r[RD5(op)] = m_program->read_byte(pd32);
@@ -943,8 +917,7 @@ void avr8_device<NumTimers>::op_elpmzi(uint16_t op)
 	m_r[30] = pd32 & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ldyi(uint16_t op)
+void avr8_base_device::op_ldyi(uint16_t op)
 {
 	uint16_t pd = YREG;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -953,8 +926,7 @@ void avr8_device<NumTimers>::op_ldyi(uint16_t op)
 	m_r[28] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ldyd(uint16_t op)
+void avr8_base_device::op_ldyd(uint16_t op)
 {
 	const uint16_t pd = YREG - 1;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -962,14 +934,12 @@ void avr8_device<NumTimers>::op_ldyd(uint16_t op)
 	m_r[28] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ldx(uint16_t op)
+void avr8_base_device::op_ldx(uint16_t op)
 {
 	m_r[RD5(op)] = m_data->read_byte(XREG);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ldxi(uint16_t op)
+void avr8_base_device::op_ldxi(uint16_t op)
 {
 	uint16_t pd = XREG;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -978,8 +948,7 @@ void avr8_device<NumTimers>::op_ldxi(uint16_t op)
 	m_r[26] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ldxd(uint16_t op)
+void avr8_base_device::op_ldxd(uint16_t op)
 {
 	const uint16_t pd = XREG - 1;
 	m_r[RD5(op)] = m_data->read_byte(pd);
@@ -987,22 +956,19 @@ void avr8_device<NumTimers>::op_ldxd(uint16_t op)
 	m_r[26] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_pop(uint16_t op)
+void avr8_base_device::op_pop(uint16_t op)
 {
 	m_r[RD5(op)] = pop();
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_sts(uint16_t op)
+void avr8_base_device::op_sts(uint16_t op)
 {
 	m_pc += 2;
 	const uint16_t addr = m_program->read_word(m_pc);
 	m_data->write_byte(addr, m_r[RD5(op)]);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_stzi(uint16_t op)
+void avr8_base_device::op_stzi(uint16_t op)
 {
 	uint16_t pd = ZREG;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -1011,8 +977,7 @@ void avr8_device<NumTimers>::op_stzi(uint16_t op)
 	m_r[30] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_stzd(uint16_t op)
+void avr8_base_device::op_stzd(uint16_t op)
 {
 	const uint16_t pd = ZREG - 1;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -1020,8 +985,7 @@ void avr8_device<NumTimers>::op_stzd(uint16_t op)
 	m_r[30] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_styi(uint16_t op)
+void avr8_base_device::op_styi(uint16_t op)
 {
 	uint16_t pd = YREG;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -1030,8 +994,7 @@ void avr8_device<NumTimers>::op_styi(uint16_t op)
 	m_r[28] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_styd(uint16_t op)
+void avr8_base_device::op_styd(uint16_t op)
 {
 	const uint16_t pd = YREG - 1;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -1039,14 +1002,12 @@ void avr8_device<NumTimers>::op_styd(uint16_t op)
 	m_r[28] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_stx(uint16_t op)
+void avr8_base_device::op_stx(uint16_t op)
 {
 	m_data->write_byte(XREG, m_r[RD5(op)]);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_stxi(uint16_t op)
+void avr8_base_device::op_stxi(uint16_t op)
 {
 	uint16_t pd = XREG;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -1055,8 +1016,7 @@ void avr8_device<NumTimers>::op_stxi(uint16_t op)
 	m_r[26] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_stxd(uint16_t op)
+void avr8_base_device::op_stxd(uint16_t op)
 {
 	const uint16_t pd = XREG - 1;
 	m_data->write_byte(pd, m_r[RD5(op)]);
@@ -1064,125 +1024,127 @@ void avr8_device<NumTimers>::op_stxd(uint16_t op)
 	m_r[26] = pd & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_push(uint16_t op)
+void avr8_base_device::op_push(uint16_t op)
 {
 	push(m_r[RD5(op)]);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_com(uint16_t op)
+void avr8_base_device::op_com(uint16_t op)
 {
 	const uint8_t res = ~m_r[RD5(op)];
-	SREG_W(AVR8_SREG_C, 1);
-	SREG_W(AVR8_SREG_Z, (res == 0) ? 1 : 0);
-	SREG_W(AVR8_SREG_N, BIT(res,7));
-	SREG_W(AVR8_SREG_V, 0);
-	SREG_W(AVR8_SREG_S, SREG_R(AVR8_SREG_N) ^ SREG_R(AVR8_SREG_V));
+	m_r[SREG] &= ~(SREG_MASK_Z | SREG_MASK_N | SREG_MASK_V | SREG_MASK_S);
+	m_r[SREG] |= SREG_MASK_C;
+	if (BIT(res, 7))
+		m_r[SREG] |= SREG_MASK_N | SREG_MASK_S;
+	else if (res == 0)
+		m_r[SREG] |= SREG_MASK_Z;
 	m_r[RD5(op)] = res;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_neg(uint16_t op)
+void avr8_base_device::op_neg(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t res = 0 - rd;
-	SREG_W(AVR8_SREG_C, (res == 0) ? 0 : 1);
-	SREG_W(AVR8_SREG_Z, (res == 0) ? 1 : 0);
-	SREG_W(AVR8_SREG_N, BIT(res,7));
-	SREG_W(AVR8_SREG_V, (res == 0x80) ? 1 : 0);
-	SREG_W(AVR8_SREG_S, SREG_R(AVR8_SREG_N) ^ SREG_R(AVR8_SREG_V));
-	SREG_W(AVR8_SREG_H, BIT(res,3) | BIT(rd,3));
+	m_r[SREG] &= ~(SREG_MASK_C | SREG_MASK_Z | SREG_MASK_N | SREG_MASK_V | SREG_MASK_S | SREG_MASK_H);
+	if (res == 0)
+	{
+		m_r[SREG] |= SREG_MASK_Z;
+	}
+	else
+	{
+		m_r[SREG] |= SREG_MASK_C;
+		if (res == 0x80)
+			m_r[SREG] |= SREG_MASK_N | SREG_MASK_V;
+		else if (BIT(res, 7))
+			m_r[SREG] |= SREG_MASK_N | SREG_MASK_S;
+	}
+	if (BIT(rd, 3) || BIT(res, 3))
+		m_r[SREG] |= SREG_MASK_H;
 	m_r[RD5(op)] = res;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_swap(uint16_t op)
+void avr8_base_device::op_swap(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	m_r[RD5(op)] = (rd >> 4) | (rd << 4);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_inc(uint16_t op)
+void avr8_base_device::op_inc(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t res = rd + 1;
-	SREG_W(AVR8_SREG_V, (rd == 0x7f) ? 1 : 0);
-	SREG_W(AVR8_SREG_N, BIT(res,7));
-	SREG_W(AVR8_SREG_S, SREG_R(AVR8_SREG_N) ^ SREG_R(AVR8_SREG_V));
-	SREG_W(AVR8_SREG_Z, (res == 0) ? 1 : 0);
+	m_r[SREG] &= ~(SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z);
+	if (res == 0)
+		m_r[SREG] |= SREG_MASK_Z;
+	else if (res == 0x80)
+		m_r[SREG] |= SREG_MASK_N | SREG_MASK_V;
+	else if (BIT(res, 7))
+		m_r[SREG] |= SREG_MASK_N | SREG_MASK_S;
 	m_r[RD5(op)] = res;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_asr(uint16_t op)
+void avr8_base_device::op_asr(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t res = (rd & 0x80) | (rd >> 1);
-	m_r[SREG] &= ~(AVR8_SREG_MASK_C | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_N | AVR8_SREG_MASK_V | AVR8_SREG_MASK_S);
+	m_r[SREG] &= ~(SREG_MASK_C | SREG_MASK_Z | SREG_MASK_N | SREG_MASK_V | SREG_MASK_S);
 	m_r[SREG] |= m_shift_flag_cache[(rd << 8) | res];
 	m_r[RD5(op)] = res;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_lsr(uint16_t op)
+void avr8_base_device::op_lsr(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t res = rd >> 1;
-	m_r[SREG] &= ~(AVR8_SREG_MASK_C | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_N | AVR8_SREG_MASK_V | AVR8_SREG_MASK_S);
+	m_r[SREG] &= ~(SREG_MASK_C | SREG_MASK_Z | SREG_MASK_N | SREG_MASK_V | SREG_MASK_S);
 	m_r[SREG] |= m_shift_flag_cache[(rd << 8) | res];
 	m_r[RD5(op)] = res;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ror(uint16_t op)
+void avr8_base_device::op_ror(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
-	const uint8_t res = (rd >> 1) | (SREG_R(AVR8_SREG_C) << 7);
-	m_r[SREG] &= ~(AVR8_SREG_MASK_C | AVR8_SREG_MASK_Z | AVR8_SREG_MASK_N | AVR8_SREG_MASK_V | AVR8_SREG_MASK_S);
+	const uint8_t res = (rd >> 1) | (m_r[SREG] << 7);
+	m_r[SREG] &= ~(SREG_MASK_C | SREG_MASK_Z | SREG_MASK_N | SREG_MASK_V | SREG_MASK_S);
 	m_r[SREG] |= m_shift_flag_cache[(rd << 8) | res];
 	m_r[RD5(op)] = res;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_setf(uint16_t op)
+void avr8_base_device::op_setf(uint16_t op)
 {
-	SREG_W((op >> 4) & 0x07, 1);
+	m_r[SREG] |= 1 << ((op >> 4) & 0x07);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_clrf(uint16_t op)
+void avr8_base_device::op_clrf(uint16_t op)
 {
-	SREG_W((op >> 4) & 0x07, 0);
+	m_r[SREG] &= ~(1 << ((op >> 4) & 0x07));
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ijmp(uint16_t op)
+void avr8_base_device::op_ijmp(uint16_t op)
 {
 	m_pc = (ZREG - 1) << 1;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_eijmp(uint16_t op)
+void avr8_base_device::op_eijmp(uint16_t op)
 {
 	m_pc = ((m_r[EIND] << 16 | ZREG) << 1) - 2;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_dec(uint16_t op)
+void avr8_base_device::op_dec(uint16_t op)
 {
 	const uint8_t rd = m_r[RD5(op)];
 	const uint8_t res = rd - 1;
-	SREG_W(AVR8_SREG_V, (rd == 0x7f) ? 1 : 0);
-	SREG_W(AVR8_SREG_N, BIT(res,7));
-	SREG_W(AVR8_SREG_S, SREG_R(AVR8_SREG_N) ^ SREG_R(AVR8_SREG_V));
-	SREG_W(AVR8_SREG_Z, (res == 0) ? 1 : 0);
+	m_r[SREG] &= ~(SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z);
+	if (rd == 0x7f)
+		m_r[SREG] |= SREG_MASK_V | SREG_MASK_S;
+	else if (BIT(res, 7))
+		m_r[SREG] |= SREG_MASK_N | SREG_MASK_S;
+	else if (res == 0)
+		m_r[SREG] |= SREG_MASK_Z;
 	m_r[RD5(op)] = res;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_jmp(uint16_t op)
+void avr8_base_device::op_jmp(uint16_t op)
 {
 	uint32_t offs = KCONST22(op) << 16;
 	m_pc += 2;
@@ -1192,8 +1154,7 @@ void avr8_device<NumTimers>::op_jmp(uint16_t op)
 	m_pc -= 2;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_call(uint16_t op)
+void avr8_base_device::op_call(uint16_t op)
 {
 	push(((m_pc >> 1) + 2) & 0x00ff);
 	push((((m_pc >> 1) + 2) >> 8) & 0x00ff);
@@ -1204,118 +1165,117 @@ void avr8_device<NumTimers>::op_call(uint16_t op)
 	m_pc -= 2;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ret(uint16_t op)
+void avr8_base_device::op_ret(uint16_t op)
 {
 	m_pc = pop() << 8;
 	m_pc |= pop();
 	m_pc = (m_pc << 1) - 2;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_reti(uint16_t op)
+void avr8_base_device::op_reti(uint16_t op)
 {
 	m_pc = pop() << 8;
 	m_pc |= pop();
 	m_pc = (m_pc << 1) - 2;
-	SREG_W(AVR8_SREG_I, 1);
+	m_r[SREG] |= SREG_MASK_I;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_sleep(uint16_t op)
+void avr8_base_device::op_sleep(uint16_t op)
 {
-	m_pc = (m_pc << 1) - 2;
+	m_pc -= 2;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_break(uint16_t op)
+void avr8_base_device::op_break(uint16_t op)
 {
 	op_unimpl(op);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_wdr(uint16_t op)
+void avr8_base_device::op_wdr(uint16_t op)
 {
 	LOGMASKED(LOG_WDOG, "%s: Watchdog reset opcode\n", machine().describe_context());
 	//op_unimpl(op);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_lpm(uint16_t op)
+void avr8_base_device::op_lpm(uint16_t op)
 {
 	m_r[0] = m_program->read_byte(ZREG);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_elpm(uint16_t op)
+void avr8_base_device::op_elpm(uint16_t op)
 {
 	op_unimpl(op);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_spm(uint16_t op)
+void avr8_base_device::op_spm(uint16_t op)
 {
 	op_unimpl(op);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_spmzi(uint16_t op)
+void avr8_base_device::op_spmzi(uint16_t op)
 {
 	op_unimpl(op);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_icall(uint16_t op)
+void avr8_base_device::op_icall(uint16_t op)
 {
 	push(((m_pc >> 1) + 1) & 0x00ff);
 	push((((m_pc >> 1) + 1) >> 8) & 0x00ff);
 	m_pc = (ZREG << 1) - 2;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_eicall(uint16_t op)
+void avr8_base_device::op_eicall(uint16_t op)
 {
 	op_unimpl(op);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_adiw(uint16_t op)
+void avr8_base_device::op_adiw(uint16_t op)
 {
 	const uint8_t rd = m_r[24 + (DCONST(op) << 1)];
 	const uint8_t rr = m_r[25 + (DCONST(op) << 1)];
 	const uint16_t pd = ((rr << 8) | rd) + KCONST6(op);
-	SREG_W(AVR8_SREG_V, BIT(pd,15) & NOT(BIT(rr,7)));
-	SREG_W(AVR8_SREG_N, BIT(pd,15));
-	SREG_W(AVR8_SREG_S, SREG_R(AVR8_SREG_N) ^ SREG_R(AVR8_SREG_V));
-	SREG_W(AVR8_SREG_Z, (pd == 0) ? 1 : 0);
-	SREG_W(AVR8_SREG_C, NOT(BIT(pd,15)) & BIT(rr,7));
+	m_r[SREG] &= ~(SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z | SREG_MASK_C);
+	if (pd == 0)
+		m_r[SREG] |= SREG_MASK_Z;
+	else if (BIT(pd, 15))
+	{
+		m_r[SREG] |= SREG_MASK_N;
+		if (!BIT(rr, 7))
+			m_r[SREG] |= SREG_MASK_V;
+		else
+			m_r[SREG] |= SREG_MASK_S;
+	}
+	if (BIT(rr, 7) && !BIT(pd, 15))
+		m_r[SREG] |= SREG_MASK_C;
 	m_r[24 + (DCONST(op) << 1)] = pd & 0x00ff;
 	m_r[25 + (DCONST(op) << 1)] = (pd >> 8) & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_sbiw(uint16_t op)
+void avr8_base_device::op_sbiw(uint16_t op)
 {
 	const uint8_t rd = m_r[24 + (DCONST(op) << 1)];
 	const uint8_t rr = m_r[25 + (DCONST(op) << 1)];
 	const uint16_t pd = ((rr << 8) | rd) - KCONST6(op);
-	SREG_W(AVR8_SREG_V, NOT(BIT(pd,15)) & BIT(rr,7));
-	SREG_W(AVR8_SREG_N, BIT(pd,15));
-	SREG_W(AVR8_SREG_S, SREG_R(AVR8_SREG_N) ^ SREG_R(AVR8_SREG_V));
-	SREG_W(AVR8_SREG_Z, (pd == 0) ? 1 : 0);
-	SREG_W(AVR8_SREG_C, BIT(pd,15) & NOT(BIT(rr,7)));
+	m_r[SREG] &= ~(SREG_MASK_V | SREG_MASK_N | SREG_MASK_S | SREG_MASK_Z | SREG_MASK_C);
+	m_r[SREG] |= (pd == 0) ? SREG_MASK_Z : 0;
+	if (BIT(pd, 15))
+	{
+		if (BIT(rr, 7))
+			m_r[SREG] |= SREG_MASK_N | SREG_MASK_S | SREG_MASK_C;
+		else
+			m_r[SREG] |= SREG_MASK_N | SREG_MASK_S;
+	}
+	else if (BIT(rr, 7))
+		m_r[SREG] |= SREG_MASK_V | SREG_MASK_S;
 	m_r[24 + (DCONST(op) << 1)] = pd & 0x00ff;
 	m_r[25 + (DCONST(op) << 1)] = (pd >> 8) & 0x00ff;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_cbi(uint16_t op)
+void avr8_base_device::op_cbi(uint16_t op)
 {
 	m_data->write_byte(32 + ACONST5(op), m_data->read_byte(32 + ACONST5(op)) &~ (1 << RR3(op)));
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_sbic(uint16_t op)
+void avr8_base_device::op_sbic(uint16_t op)
 {
 	if (!BIT(m_data->read_byte(32 + ACONST5(op)), RR3(op)))
 	{
@@ -1325,14 +1285,12 @@ void avr8_device<NumTimers>::op_sbic(uint16_t op)
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_sbi(uint16_t op)
+void avr8_base_device::op_sbi(uint16_t op)
 {
 	m_data->write_byte(32 + ACONST5(op), m_data->read_byte(32 + ACONST5(op)) | (1 << RR3(op)));
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_sbis(uint16_t op)
+void avr8_base_device::op_sbis(uint16_t op)
 {
 	if (BIT(m_data->read_byte(32 + ACONST5(op)), RR3(op)))
 	{
@@ -1342,36 +1300,34 @@ void avr8_device<NumTimers>::op_sbis(uint16_t op)
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_mul(uint16_t op)
+void avr8_base_device::op_mul(uint16_t op)
 {
 	const int16_t sd = (uint8_t)m_r[RD5(op)] * (uint8_t)m_r[RR5(op)];
 	m_r[1] = (sd >> 8) & 0x00ff;
 	m_r[0] = sd & 0x00ff;
-	SREG_W(AVR8_SREG_C, (sd & 0x8000) ? 1 : 0);
-	SREG_W(AVR8_SREG_Z, (sd == 0) ? 1 : 0);
+	m_r[SREG] &= ~(SREG_MASK_C | SREG_MASK_Z);
+	if (sd == 0)
+		m_r[SREG] |= SREG_MASK_Z;
+	else if (BIT(sd, 15))
+		m_r[SREG] |= SREG_MASK_C;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_out(uint16_t op)
+void avr8_base_device::op_out(uint16_t op)
 {
 	m_data->write_byte(32 + ACONST6(op), m_r[RD5(op)]);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_in(uint16_t op)
+void avr8_base_device::op_in(uint16_t op)
 {
 	m_r[RD5(op)] = m_data->read_byte(0x20 + ACONST6(op));
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_rjmp(uint16_t op)
+void avr8_base_device::op_rjmp(uint16_t op)
 {
 	m_pc += (int32_t)((op & 0x0800) ? ((op & 0x0fff) | 0xfffff000) : (op & 0x0fff)) << 1;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_rcall(uint16_t op)
+void avr8_base_device::op_rcall(uint16_t op)
 {
 	const int32_t offs = (int32_t)((op & 0x0800) ? ((op & 0x0fff) | 0xfffff000) : (op & 0x0fff)) << 1;
 	push(((m_pc >> 1) + 1) & 0x00ff);
@@ -1379,53 +1335,46 @@ void avr8_device<NumTimers>::op_rcall(uint16_t op)
 	m_pc += offs;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_ldi(uint16_t op)
+void avr8_base_device::op_ldi(uint16_t op)
 {
 	m_r[16 + RD4(op)] = KCONST8(op);
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_brset(uint16_t op)
+void avr8_base_device::op_brset(uint16_t op)
 {
-	if (SREG_R(op & 0x0007))
+	if (BIT(m_r[SREG], op & 0x0007))
 	{
 		m_pc += util::sext(KCONST7(op), 7) << 1;
 		m_opcycles++;
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_brclr(uint16_t op)
+void avr8_base_device::op_brclr(uint16_t op)
 {
-	if (SREG_R(op & 0x0007) == 0)
+	if (!BIT(m_r[SREG], op & 0x0007))
 	{
 		m_pc += util::sext(KCONST7(op), 7) << 1;
 		m_opcycles++;
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_bst(uint16_t op)
+void avr8_base_device::op_bst(uint16_t op)
 {
-	SREG_W(AVR8_SREG_T, (BIT(m_r[RD5(op)], RR3(op))) ? 1 : 0);
-}
-
-template <int NumTimers>
-void avr8_device<NumTimers>::op_bld(uint16_t op)
-{
-	if (SREG_R(AVR8_SREG_T))
-	{
-		m_r[RD5(op)] |= (1 << RR3(op));
-	}
+	if (BIT(m_r[RD5(op)], RR3(op)))
+		m_r[SREG] |= SREG_MASK_T;
 	else
-	{
-		m_r[RD5(op)] &= ~(1 << RR3(op));
-	}
+		m_r[SREG] &= ~SREG_MASK_T;
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_sbrs(uint16_t op)
+void avr8_base_device::op_bld(uint16_t op)
+{
+	if (m_r[SREG] & SREG_MASK_T)
+		m_r[RD5(op)] |= (1 << RR3(op));
+	else
+		m_r[RD5(op)] &= ~(1 << RR3(op));
+}
+
+void avr8_base_device::op_sbrs(uint16_t op)
 {
 	if (BIT(m_r[RD5(op)], RR3(op)))
 	{
@@ -1435,8 +1384,7 @@ void avr8_device<NumTimers>::op_sbrs(uint16_t op)
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_sbrc(uint16_t op)
+void avr8_base_device::op_sbrc(uint16_t op)
 {
 	if (!BIT(m_r[RD5(op)], RR3(op)))
 	{
@@ -1446,8 +1394,7 @@ void avr8_device<NumTimers>::op_sbrc(uint16_t op)
 	}
 }
 
-template <int NumTimers>
-void avr8_device<NumTimers>::op_unimpl(uint16_t op)
+void avr8_base_device::op_unimpl(uint16_t op)
 {
 	unimplemented_opcode(op);
 }

--- a/src/mame/elektor/avrmax.cpp
+++ b/src/mame/elektor/avrmax.cpp
@@ -15,7 +15,7 @@ It was not manufactured by Elektor, only described as a homebrew project.
 FN 1 = new game, FN 2 = set level, FN 3 = principle variation.
 Moves are confirmed by pressing GO twice.
 
-The program is the same for all versions, only the display differs.
+The chess program is the same for all versions, only the display differs.
 
 Hardware notes:
 
@@ -52,8 +52,8 @@ TODO:
 #include "screen.h"
 
 // internal artwork
-#include "avrmax.lh" // clickable
-#include "atm18mcc.lh" // clickable
+#include "avrmax.lh"
+#include "atm18mcc.lh"
 
 
 namespace {

--- a/src/mame/elektor/avrmax.cpp
+++ b/src/mame/elektor/avrmax.cpp
@@ -15,7 +15,7 @@ It was not manufactured by Elektor, only described as a homebrew project.
 FN 1 = new game, FN 2 = set level, FN 3 = principle variation.
 Moves are confirmed by pressing GO twice.
 
-The chess program is the same for all versions, only the display differs.
+The program is the same for all versions, only the display differs.
 
 Hardware notes:
 
@@ -52,8 +52,8 @@ TODO:
 #include "screen.h"
 
 // internal artwork
-#include "avrmax.lh"
-#include "atm18mcc.lh"
+#include "avrmax.lh" // clickable
+#include "atm18mcc.lh" // clickable
 
 
 namespace {
@@ -78,7 +78,7 @@ protected:
 
 private:
 	// devices/pointers
-	required_device<avr8_device> m_maincpu;
+	required_device<atmega88_device> m_maincpu;
 	optional_device<pwm_display_device> m_digit_pwm;
 	optional_device<hd44780_device> m_lcd;
 	required_ioport_array<4> m_inputs;
@@ -254,8 +254,8 @@ void avrmax_state::base(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &avrmax_state::main_map);
 	m_maincpu->set_addrmap(AS_DATA, &avrmax_state::data_map);
 	m_maincpu->set_eeprom_tag("eeprom");
-	m_maincpu->gpio_in<AVR8_IO_PORTB>().set(FUNC(avrmax_state::input_r));
-	m_maincpu->gpio_out<AVR8_IO_PORTC>().set(FUNC(avrmax_state::input_w));
+	m_maincpu->gpio_in<atmega88_device::GPIOB>().set(FUNC(avrmax_state::input_r));
+	m_maincpu->gpio_out<atmega88_device::GPIOC>().set(FUNC(avrmax_state::input_w));
 }
 
 void avrmax_state::avrmax(machine_config &config)
@@ -264,8 +264,8 @@ void avrmax_state::avrmax(machine_config &config)
 
 	// basic machine hardware
 	m_maincpu->set_clock(8000000); // internal R/C clock
-	m_maincpu->gpio_out<AVR8_IO_PORTC>().set(FUNC(avrmax_state::digit_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTD>().set(FUNC(avrmax_state::segment_w));
+	m_maincpu->gpio_out<atmega88_device::GPIOC>().set(FUNC(avrmax_state::digit_w));
+	m_maincpu->gpio_out<atmega88_device::GPIOD>().set(FUNC(avrmax_state::segment_w));
 
 	// video hardware
 	PWM_DISPLAY(config, m_digit_pwm).set_size(4, 8);
@@ -278,7 +278,7 @@ void avrmax_state::atm18mcc(machine_config &config)
 	base(config);
 
 	// basic machine hardware
-	m_maincpu->gpio_out<AVR8_IO_PORTD>().set(FUNC(avrmax_state::lcd_w));
+	m_maincpu->gpio_out<atmega88_device::GPIOD>().set(FUNC(avrmax_state::lcd_w));
 
 	// video hardware
 	auto &screen(SCREEN(config, "screen", SCREEN_TYPE_LCD));

--- a/src/mame/handheld/pensebem.cpp
+++ b/src/mame/handheld/pensebem.cpp
@@ -144,7 +144,7 @@ private:
 	uint8_t m_port_d = 0;
 	uint8_t m_port_e = 0;
 
-	required_device<avr8_device> m_maincpu;
+	required_device<atmega168_device> m_maincpu;
 	required_device<dac_bit_interface> m_dac;
 	required_device<pwm_display_device> m_display;
 	required_ioport_array<4> m_keyb_rows;
@@ -281,11 +281,11 @@ void pensebem2017_state::pensebem2017(machine_config &config)
 	m_maincpu->set_high_fuses(0xdd);
 	m_maincpu->set_extended_fuses(0xf9);
 	m_maincpu->set_lock_bits(0x0f);
-	m_maincpu->gpio_in<AVR8_IO_PORTB>().set(FUNC(pensebem2017_state::port_b_r));
-	m_maincpu->gpio_out<AVR8_IO_PORTB>().set(FUNC(pensebem2017_state::port_b_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTC>().set(FUNC(pensebem2017_state::port_c_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTD>().set(FUNC(pensebem2017_state::port_d_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTE>().set(FUNC(pensebem2017_state::port_e_w));
+	m_maincpu->gpio_in<atmega88_device::GPIOB>().set(FUNC(pensebem2017_state::port_b_r));
+	m_maincpu->gpio_out<atmega88_device::GPIOB>().set(FUNC(pensebem2017_state::port_b_w));
+	m_maincpu->gpio_out<atmega88_device::GPIOC>().set(FUNC(pensebem2017_state::port_c_w));
+	m_maincpu->gpio_out<atmega88_device::GPIOD>().set(FUNC(pensebem2017_state::port_d_w));
+	m_maincpu->gpio_out<atmega88_device::GPIOE>().set(FUNC(pensebem2017_state::port_e_w));
 
 	/* video hardware */
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_SVG));

--- a/src/mame/handheld/pensebem.cpp
+++ b/src/mame/handheld/pensebem.cpp
@@ -281,11 +281,11 @@ void pensebem2017_state::pensebem2017(machine_config &config)
 	m_maincpu->set_high_fuses(0xdd);
 	m_maincpu->set_extended_fuses(0xf9);
 	m_maincpu->set_lock_bits(0x0f);
-	m_maincpu->gpio_in<atmega88_device::GPIOB>().set(FUNC(pensebem2017_state::port_b_r));
-	m_maincpu->gpio_out<atmega88_device::GPIOB>().set(FUNC(pensebem2017_state::port_b_w));
-	m_maincpu->gpio_out<atmega88_device::GPIOC>().set(FUNC(pensebem2017_state::port_c_w));
-	m_maincpu->gpio_out<atmega88_device::GPIOD>().set(FUNC(pensebem2017_state::port_d_w));
-	m_maincpu->gpio_out<atmega88_device::GPIOE>().set(FUNC(pensebem2017_state::port_e_w));
+	m_maincpu->gpio_in<atmega168_device::GPIOB>().set(FUNC(pensebem2017_state::port_b_r));
+	m_maincpu->gpio_out<atmega168_device::GPIOB>().set(FUNC(pensebem2017_state::port_b_w));
+	m_maincpu->gpio_out<atmega168_device::GPIOC>().set(FUNC(pensebem2017_state::port_c_w));
+	m_maincpu->gpio_out<atmega168_device::GPIOD>().set(FUNC(pensebem2017_state::port_d_w));
+	m_maincpu->gpio_out<atmega168_device::GPIOE>().set(FUNC(pensebem2017_state::port_e_w));
 
 	/* video hardware */
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_SVG));

--- a/src/mame/homebrew/lft_chiptune.cpp
+++ b/src/mame/homebrew/lft_chiptune.cpp
@@ -32,7 +32,7 @@ protected:
 	void prg_map(address_map &map);
 	void data_map(address_map &map);
 
-	required_device<avr8_device> m_maincpu;
+	required_device<atmega88_device> m_maincpu;
 	required_device<dac_byte_interface> m_dac;
 };
 
@@ -64,7 +64,7 @@ void lft_chiptune_state::chiptune(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &lft_chiptune_state::prg_map);
 	m_maincpu->set_addrmap(AS_DATA, &lft_chiptune_state::data_map);
 	m_maincpu->set_eeprom_tag("eeprom");
-	m_maincpu->gpio_out<AVR8_IO_PORTD>().set(m_dac, FUNC(dac_8bit_r2r_device::write));
+	m_maincpu->gpio_out<atmega88_device::GPIOD>().set(m_dac, FUNC(dac_8bit_r2r_device::write));
 
 	/* sound hardware */
 	SPEAKER(config, "avr8").front_center();

--- a/src/mame/homebrew/lft_craft.cpp
+++ b/src/mame/homebrew/lft_craft.cpp
@@ -13,7 +13,6 @@
 #include "emupal.h"
 #include "speaker.h"
 
-
 namespace {
 
 #define MASTER_CLOCK        20000000
@@ -56,7 +55,7 @@ protected:
 	void video_update();
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	required_device<avr8_device> m_maincpu;
+	required_device<atmega88_device> m_maincpu;
 	required_device<dac_byte_interface> m_dac;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
@@ -203,11 +202,11 @@ void lft_craft_state::craft(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &lft_craft_state::prg_map);
 	m_maincpu->set_addrmap(AS_DATA, &lft_craft_state::data_map);
 	m_maincpu->set_eeprom_tag("eeprom");
-	m_maincpu->gpio_in<AVR8_IO_PORTB>().set([this]() { return m_gpio_b; });
-	m_maincpu->gpio_in<AVR8_IO_PORTC>().set([this]() { return m_gpio_c; });
-	m_maincpu->gpio_out<AVR8_IO_PORTB>().set(FUNC(lft_craft_state::port_b_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTC>().set(FUNC(lft_craft_state::port_c_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTD>().set(FUNC(lft_craft_state::port_d_w));
+	m_maincpu->gpio_in<atmega88_device::GPIOB>().set([this]() { return m_gpio_b; });
+	m_maincpu->gpio_in<atmega88_device::GPIOC>().set([this]() { return m_gpio_c; });
+	m_maincpu->gpio_out<atmega88_device::GPIOB>().set(FUNC(lft_craft_state::port_b_w));
+	m_maincpu->gpio_out<atmega88_device::GPIOC>().set(FUNC(lft_craft_state::port_c_w));
+	m_maincpu->gpio_out<atmega88_device::GPIOD>().set(FUNC(lft_craft_state::port_d_w));
 
 	PALETTE(config, m_palette, FUNC(lft_craft_state::init_palette), 64);
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);

--- a/src/mame/homebrew/lft_phasor.cpp
+++ b/src/mame/homebrew/lft_phasor.cpp
@@ -48,7 +48,7 @@ protected:
 	void video_update();
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	required_device<avr8_device> m_maincpu;
+	required_device<atmega88_device> m_maincpu;
 	required_device<dac_byte_interface> m_dac;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
@@ -206,10 +206,10 @@ void lft_phasor_state::phasor(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &lft_phasor_state::prg_map);
 	m_maincpu->set_addrmap(AS_DATA, &lft_phasor_state::data_map);
 	m_maincpu->set_eeprom_tag("eeprom");
-	m_maincpu->gpio_in<AVR8_IO_PORTB>().set([this]() { return m_gpio_b; });
-	m_maincpu->gpio_out<AVR8_IO_PORTB>().set(FUNC(lft_phasor_state::port_b_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTC>().set([this](uint8_t data) { m_dac->write(data & 0x3f); });
-	m_maincpu->gpio_out<AVR8_IO_PORTD>().set([this](uint8_t data) { m_latched_sample = data; });
+	m_maincpu->gpio_in<atmega88_device::GPIOB>().set([this]() { return m_gpio_b; });
+	m_maincpu->gpio_out<atmega88_device::GPIOB>().set(FUNC(lft_phasor_state::port_b_w));
+	m_maincpu->gpio_out<atmega88_device::GPIOC>().set([this](uint8_t data) { m_dac->write(data & 0x3f); });
+	m_maincpu->gpio_out<atmega88_device::GPIOD>().set([this](uint8_t data) { m_latched_sample = data; });
 
 	PALETTE(config, m_palette, FUNC(lft_phasor_state::init_palette), 0x10);
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);

--- a/src/mame/homebrew/sbc6510.cpp
+++ b/src/mame/homebrew/sbc6510.cpp
@@ -94,7 +94,7 @@ private:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 	required_device<cpu_device> m_maincpu;
-	required_device<avr8_device> m_videocpu;
+	required_device<atmega88_device> m_videocpu;
 	required_device<generic_terminal_device> m_terminal;
 	required_ioport_array<9> m_keyboard;
 };

--- a/src/mame/homebrew/uzebox.cpp
+++ b/src/mame/homebrew/uzebox.cpp
@@ -49,7 +49,7 @@ public:
 	void uzebox(machine_config &config);
 
 private:
-	required_device<avr8_device> m_maincpu;
+	required_device<atmega644_device> m_maincpu;
 	required_device<screen_device> m_screen;
 	required_device<generic_slot_device> m_cart;
 	required_device<snes_control_port_device> m_ctrl1;
@@ -285,14 +285,14 @@ void uzebox_state::uzebox(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &uzebox_state::prg_map);
 	m_maincpu->set_addrmap(AS_DATA, &uzebox_state::data_map);
 	m_maincpu->set_eeprom_tag("eeprom");
-	m_maincpu->gpio_in<AVR8_IO_PORTA>().set(FUNC(uzebox_state::port_a_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTB>().set(FUNC(uzebox_state::port_b_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTC>().set(FUNC(uzebox_state::port_c_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTD>().set(FUNC(uzebox_state::port_d_r));
-	m_maincpu->gpio_out<AVR8_IO_PORTA>().set(FUNC(uzebox_state::port_a_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTB>().set(FUNC(uzebox_state::port_b_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTC>().set(FUNC(uzebox_state::port_c_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTD>().set(FUNC(uzebox_state::port_d_w));
+	m_maincpu->gpio_in<atmega644_device::GPIOA>().set(FUNC(uzebox_state::port_a_r));
+	m_maincpu->gpio_in<atmega644_device::GPIOB>().set(FUNC(uzebox_state::port_b_r));
+	m_maincpu->gpio_in<atmega644_device::GPIOC>().set(FUNC(uzebox_state::port_c_r));
+	m_maincpu->gpio_in<atmega644_device::GPIOD>().set(FUNC(uzebox_state::port_d_r));
+	m_maincpu->gpio_out<atmega644_device::GPIOA>().set(FUNC(uzebox_state::port_a_w));
+	m_maincpu->gpio_out<atmega644_device::GPIOB>().set(FUNC(uzebox_state::port_b_w));
+	m_maincpu->gpio_out<atmega644_device::GPIOC>().set(FUNC(uzebox_state::port_c_w));
+	m_maincpu->gpio_out<atmega644_device::GPIOD>().set(FUNC(uzebox_state::port_d_w));
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(59.99);

--- a/src/mame/makerbot/replicator.cpp
+++ b/src/mame/makerbot/replicator.cpp
@@ -229,7 +229,7 @@ private:
 
 	uint8_t m_shift_register_value;
 
-	required_device<avr8_device> m_maincpu;
+	required_device<atmega1280_device> m_maincpu;
 	required_device<hd44780_device> m_lcdc;
 	required_device<dac_bit_interface> m_dac;
 	required_ioport m_io_keypad;
@@ -696,29 +696,29 @@ void replicator_state::replicator(machine_config &config)
 	m_maincpu->set_extended_fuses(0xf4);
 	m_maincpu->set_lock_bits(0x0f);
 
-	m_maincpu->gpio_in<AVR8_IO_PORTA>().set(FUNC(replicator_state::port_a_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTB>().set(FUNC(replicator_state::port_b_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTC>().set(FUNC(replicator_state::port_c_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTD>().set(FUNC(replicator_state::port_d_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTE>().set(FUNC(replicator_state::port_e_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTF>().set(FUNC(replicator_state::port_f_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTG>().set(FUNC(replicator_state::port_g_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTH>().set(FUNC(replicator_state::port_h_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTJ>().set(FUNC(replicator_state::port_j_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTK>().set(FUNC(replicator_state::port_k_r));
-	m_maincpu->gpio_in<AVR8_IO_PORTL>().set(FUNC(replicator_state::port_l_r));
+	m_maincpu->gpio_in<atmega1280_device::GPIOA>().set(FUNC(replicator_state::port_a_r));
+	m_maincpu->gpio_in<atmega1280_device::GPIOB>().set(FUNC(replicator_state::port_b_r));
+	m_maincpu->gpio_in<atmega1280_device::GPIOC>().set(FUNC(replicator_state::port_c_r));
+	m_maincpu->gpio_in<atmega1280_device::GPIOD>().set(FUNC(replicator_state::port_d_r));
+	m_maincpu->gpio_in<atmega1280_device::GPIOE>().set(FUNC(replicator_state::port_e_r));
+	m_maincpu->gpio_in<atmega1280_device::GPIOF>().set(FUNC(replicator_state::port_f_r));
+	m_maincpu->gpio_in<atmega1280_device::GPIOG>().set(FUNC(replicator_state::port_g_r));
+	m_maincpu->gpio_in<atmega1280_device::GPIOH>().set(FUNC(replicator_state::port_h_r));
+	m_maincpu->gpio_in<atmega1280_device::GPIOJ>().set(FUNC(replicator_state::port_j_r));
+	m_maincpu->gpio_in<atmega1280_device::GPIOK>().set(FUNC(replicator_state::port_k_r));
+	m_maincpu->gpio_in<atmega1280_device::GPIOL>().set(FUNC(replicator_state::port_l_r));
 
-	m_maincpu->gpio_out<AVR8_IO_PORTA>().set(FUNC(replicator_state::port_a_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTB>().set(FUNC(replicator_state::port_b_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTC>().set(FUNC(replicator_state::port_c_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTD>().set(FUNC(replicator_state::port_d_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTE>().set(FUNC(replicator_state::port_e_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTF>().set(FUNC(replicator_state::port_f_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTG>().set(FUNC(replicator_state::port_g_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTH>().set(FUNC(replicator_state::port_h_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTJ>().set(FUNC(replicator_state::port_j_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTK>().set(FUNC(replicator_state::port_k_w));
-	m_maincpu->gpio_out<AVR8_IO_PORTL>().set(FUNC(replicator_state::port_l_w));
+	m_maincpu->gpio_out<atmega1280_device::GPIOA>().set(FUNC(replicator_state::port_a_w));
+	m_maincpu->gpio_out<atmega1280_device::GPIOB>().set(FUNC(replicator_state::port_b_w));
+	m_maincpu->gpio_out<atmega1280_device::GPIOC>().set(FUNC(replicator_state::port_c_w));
+	m_maincpu->gpio_out<atmega1280_device::GPIOD>().set(FUNC(replicator_state::port_d_w));
+	m_maincpu->gpio_out<atmega1280_device::GPIOE>().set(FUNC(replicator_state::port_e_w));
+	m_maincpu->gpio_out<atmega1280_device::GPIOF>().set(FUNC(replicator_state::port_f_w));
+	m_maincpu->gpio_out<atmega1280_device::GPIOG>().set(FUNC(replicator_state::port_g_w));
+	m_maincpu->gpio_out<atmega1280_device::GPIOH>().set(FUNC(replicator_state::port_h_w));
+	m_maincpu->gpio_out<atmega1280_device::GPIOJ>().set(FUNC(replicator_state::port_j_w));
+	m_maincpu->gpio_out<atmega1280_device::GPIOK>().set(FUNC(replicator_state::port_k_w));
+	m_maincpu->gpio_out<atmega1280_device::GPIOL>().set(FUNC(replicator_state::port_l_w));
 
 	/*TODO: Add an ATMEGA8U2 for USB-Serial communications */
 

--- a/src/mame/ultimachine/rambo.cpp
+++ b/src/mame/ultimachine/rambo.cpp
@@ -48,7 +48,7 @@ private:
 	void rambo_data_map(address_map &map);
 
 	uint8_t m_port_a = 0;
-	required_device<avr8_device> m_maincpu;
+	required_device<atmega2560_device> m_maincpu;
 };
 
 /****************************************************\
@@ -89,8 +89,8 @@ void rambo_state::rambo(machine_config &config)
 	m_maincpu->set_high_fuses(0xda);
 	m_maincpu->set_extended_fuses(0xf4);
 	m_maincpu->set_lock_bits(0x0f);
-	m_maincpu->gpio_in<AVR8_IO_PORTA>().set([this]() { return m_port_a; });
-	m_maincpu->gpio_out<AVR8_IO_PORTA>().set([this](uint8_t data) { m_port_a = data; });
+	m_maincpu->gpio_in<atmega2560_device::GPIOA>().set([this]() { return m_port_a; });
+	m_maincpu->gpio_out<atmega2560_device::GPIOA>().set([this](uint8_t data) { m_port_a = data; });
 
 	/*TODO: Add an ATMEGA32U2 for USB-Serial communications */
 	/*TODO: Emulate the AD5206 digipot */


### PR DESCRIPTION
AVR8:
- Optimized general-timer and SPI-timer handling.
- Templatized timer accessor functions in order to flatten branches and reduce runtime load.
- Approximately 1.5x speedup; `uzebox frogger` which ran at 82-83% unthrottled now runs at 146-147% unthrottled. Other AVR-based drivers show a similar speedup.