### PR TITLE
Make generation of has_foo.h files deterministic

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1530,7 +1530,7 @@ function generate_has_header(hashname, hash)
    file:write(string.format("#ifndef GENERATED_HAS_%s_H\n", hashname))
    file:write(string.format("#define GENERATED_HAS_%s_H\n", hashname))
    file:write("\n")
-   for k, v in pairs(hash) do
+   for k, v in ipairs(hash) do
 	  if v then
 		 file:write(string.format("#define HAS_%s_%s\n", hashname, k))
 	  end


### PR DESCRIPTION
Make generation of `has_*.h` files deterministic

Without this patch, order of entries in `generated/has_{buses,cpus,formats,machines,sounds,videos}.h` varied across builds.

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).