### PR TITLE
asio: Fix variable reference in sockatmark()

### DIFF
--- a/3rdparty/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/3rdparty/asio/include/asio/detail/impl/socket_ops.ipp
@@ -641,7 +641,7 @@ bool sockatmark(socket_type s, asio::error_code& ec)
 # endif // defined(ENOTTY)
 #else // defined(SIOCATMARK)
   int value = ::sockatmark(s);
-  get_last_error(ec, result < 0);
+  get_last_error(ec, value < 0);
 #endif // defined(SIOCATMARK)
 
   return ec ? false : value != 0;


### PR DESCRIPTION
This fixes an incorrect variable reference in ASIO 1.20.0, replacing `result` with `value`. It was fixed in ASIO 1.22.1: https://github.com/chriskohlhoff/asio/commit/f79d3dc5c85675b01196d301595155ede085483d

I discovered this when porting MAME 0.259 to HaikuOS. (BTW, porting was successful, and the recipe is now in HaikuPorts.)