### PR TITLE
ins8250.cpp: Implement Break functionality

### DIFF
--- a/src/devices/machine/ins8250.cpp
+++ b/src/devices/machine/ins8250.cpp
@@ -179,7 +179,7 @@ static constexpr u8 INS8250_LCR_2STOP_BITS = 0x04;
 //static constexpr u8 INS8250_LCR_PEN = 0x08;
 //static constexpr u8 INS8250_LCR_EVEN_PAR = 0x10;
 //static constexpr u8 INS8250_LCR_PARITY = 0x20;
-//static constexpr u8 INS8250_LCR_BREAK = 0x40;
+static constexpr u8 INS8250_LCR_BREAK = 0x40;
 static constexpr u8 INS8250_LCR_DLAB = 0x80;
 
 /* ints will continue to be set for as long as there are ints pending */
@@ -568,6 +568,14 @@ void ins8250_uart_device::tra_complete()
 void ins8250_uart_device::tra_callback()
 {
 	m_txd = transmit_register_get_data_bit();
+
+	if (m_regs.lcr & INS8250_LCR_BREAK)
+	{
+		// if in break, set transmit bit to 0. Since the transmit_register_get_data_bit()
+		// has side effects(like transmit buffer empty), don't skip the call
+		m_txd = 0;
+	}
+
 	if (m_regs.mcr & INS8250_MCR_LOOPBACK)
 	{
 		device_serial_interface::rx_w(m_txd);

--- a/src/mame/heathkit/tlb.cpp
+++ b/src/mame/heathkit/tlb.cpp
@@ -15,8 +15,6 @@
     Input can also come from the serial port.
 
   TODO:
-    - INS8250 needs to implement "Set Break" (LCR, bit 6) before Break key
-      will function as expected.
     - 49/50 row mode does not work when DOT clocks are programmed as documented
       in the manual. It does work when DOT clock is fixed at the 20.282 MHz
       rate.


### PR DESCRIPTION
Compared behavior between a real H19 and the emulated H19, while holding down the break key. Both behaved identically, other keys pressed while the break key was pressed queued up and processed after the break key was released.