### PR TITLE
ins8250.cpp: Remove scratchpad register access to 8250 class chips

### DIFF
--- a/src/devices/machine/ins8250.cpp
+++ b/src/devices/machine/ins8250.cpp
@@ -469,7 +469,10 @@ u8 ins8250_uart_device::ins8250_r(offs_t offset)
 			}
 			break;
 		case 7:
-			data = m_regs.scr;
+			if (m_device_type >= dev_type::NS16450)
+			{
+				data = m_regs.scr;
+			}
 			break;
 	}
 	return data;

--- a/src/devices/machine/ins8250.cpp
+++ b/src/devices/machine/ins8250.cpp
@@ -390,13 +390,16 @@ void ins8250_uart_device::ins8250_w(offs_t offset, u8 data)
 			 */
 			m_regs.msr = (m_regs.msr & 0xf0) | (data & 0x0f);
 
-			if ( m_regs.msr & 0x0f )
+			if (m_regs.msr & 0x0f)
 				trigger_int(COM_INT_PENDING_MODEM_STATUS_REGISTER);
 			else
 				clear_int(COM_INT_PENDING_MODEM_STATUS_REGISTER);
 			break;
 		case 7:
-			m_regs.scr = data;
+			if (m_device_type >= dev_type::INS8250A)
+			{
+				m_regs.scr = data;
+			}
 			break;
 	}
 }
@@ -469,7 +472,7 @@ u8 ins8250_uart_device::ins8250_r(offs_t offset)
 			}
 			break;
 		case 7:
-			if (m_device_type >= dev_type::NS16450)
+			if (m_device_type >= dev_type::INS8250A)
 			{
 				data = m_regs.scr;
 			}


### PR DESCRIPTION
The original 8250 class chips did not have a scratchpad register at offset 7. This was added in the 16450. 
8250 datasheets specify this, and can be found in some old manuals like the Heath H89 or H19 manual. 
Here is the chart in an H89 manual.

<img width="332" alt="Screenshot 2023-10-29 at 1 32 27 AM" src="https://github.com/mamedev/mame/assets/8291090/c0b13023-9e4a-49d2-952d-7bce4c7efeda">

It is also documented on this wiki, that the lack of the scratchpad was a way to determine it was an 8250 chip: https://en.wikibooks.org/wiki/Serial_Programming/8250_UART_Programming
