### PR TITLE
imgtool: check for unrecognized options

### DIFF
--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -115,6 +115,9 @@ static int parse_options(int argc, char *argv[], int minunnamed, int maxunnamed,
 					goto error; /* Too few unnamed */
 
 				util::option_resolution::entry *entry = resolution->find(name);
+				if (entry == nullptr)
+					goto error; /* Unknown option */
+
 				if (entry->option_type() == util::option_guide::entry::option_type::ENUM_BEGIN)
 				{
 					const util::option_guide::entry *enum_value;


### PR DESCRIPTION
An invalid option to imgtool would cause it to crash:

  $ ./imgtool create mess_hd hdd.img --moo=666

  Segmentation fault (core dumped)

With a fix:

  $ ./imgtool create mess_hd hdd.img --moo=666

  --moo: Unrecognized option

Very lovely!