### PR TITLE
formats/imd_dsk: implement get_sectors_per_track()

### DIFF
--- a/src/lib/formats/imd_dsk.cpp
+++ b/src/lib/formats/imd_dsk.cpp
@@ -23,6 +23,7 @@ struct imddsk_tag
 {
 	int heads;
 	int tracks;
+	int track_sectors[84*2]; /* number of sectors for each track */
 	int sector_size;
 	uint64_t track_offsets[84*2]; /* offset within data for each track */
 };
@@ -58,6 +59,11 @@ static int imd_get_heads_per_disk(floppy_image_legacy *floppy)
 static int imd_get_tracks_per_disk(floppy_image_legacy *floppy)
 {
 	return get_tag(floppy)->tracks;
+}
+
+static int imd_get_sectors_per_track(floppy_image_legacy *floppy, int head, int track)
+{
+	return get_tag(floppy)->track_sectors[(track<<1) + head];
 }
 
 static uint64_t imd_get_track_offset(floppy_image_legacy *floppy, int head, int track)
@@ -334,9 +340,11 @@ FLOPPY_CONSTRUCT( imd_dsk_construct )
 	tag->heads = 1;
 	do {
 		floppy_image_read(floppy, header, pos, 5);
-		if ((header[2] & 1)==1) tag->heads = 2;
-		tag->track_offsets[(header[1]<<1) + (header[2] & 1)] = pos;
 		sector_num = header[3];
+		int track = (header[1]<<1) + (header[2] & 1);
+		if ((header[2] & 1)==1) tag->heads = 2;
+		tag->track_offsets[track] = pos;
+		tag->track_sectors[track] = sector_num;
 		pos += 5 + sector_num; // skip header and sector numbering map
 		if(header[2] & 0x80) pos += sector_num; // skip cylinder numbering map
 		if(header[2] & 0x40) pos += sector_num; // skip head numbering map
@@ -365,6 +373,7 @@ FLOPPY_CONSTRUCT( imd_dsk_construct )
 	callbacks->get_heads_per_disk = imd_get_heads_per_disk;
 	callbacks->get_tracks_per_disk = imd_get_tracks_per_disk;
 	callbacks->get_indexed_sector_info = imd_get_indexed_sector_info;
+	callbacks->get_sectors_per_track = imd_get_sectors_per_track;
 
 	return FLOPPY_ERROR_SUCCESS;
 }


### PR DESCRIPTION
Otherwise imgtool gets unhappy with IMD images:

  Starting program: ./imgtool identify ./altos586/SDX-586.IMD
  ...
  Program received signal SIGSEGV, Segmentation fault.
  0x0000000000000000 in ?? ()
  (gdb) bt
  #0  0x0000000000000000 in ?? ()
  #1  0x000000000025d426 in bml3_diskimage_open (image=..., dummy=...)
      at .../src/tools/imgtool/modules/bml3.cpp:520
  #2  0x000000000024807d in imgtool_floppy_open_internal (stream=..., image=...)
      at .../src/tools/imgtool/iflopimg.cpp:83
  #3  imgtool_floppy_open (image=..., stream=...)
      at .../src/tools/imgtool/iflopimg.cpp:101
  #4  0x000000000024bbdf in imgtool::image::internal_open
      (module=module@entry=0x302320, filename="./altos586/SDX-586.IMD",
      read_or_write=read_or_write@entry=0, createopts=createopts@entry=0x0,
      outimg=std::unique_ptr<imgtool::image> = {...})
      at .../src/tools/imgtool/imgtool.cpp:986
  #5  0x000000000024bd19 in imgtool::image::open (module=module@entry=0x302320,
      filename="./altos586/SDX-586.IMD", read_or_write=read_or_write@entry=0,
      outimg=std::unique_ptr<imgtool::image> = {...})
      at .../src/tools/imgtool/imgtool.cpp:1010
  #6  0x0000000000250413 in evaluate_module (fname=fname@entry=0x2fa610
      "./altos586/SDX-586.IMD", module=0x302320, result=@0x7fffffffd4dc: 0)
      at .../src/tools/imgtool/imgtool.cpp:271
  #7  0x000000000025075f in imgtool::image::identify_file (fname=0x2fa610
      "./altos586/SDX-586.IMD", modules=modules@entry=0x7fffffffd5d0, count=127,
      count@entry=128)
      at/usr/include/c++/13/bits/unique_ptr.h:199
  #8  0x000000000025382e in cmd_identify (c=0x229d50 <cmds+400>, argc=<optimized
      out>, argv=0x7fffffffda00)
      at .../src/tools/imgtool/main.cpp:578
  #9  0x0000000000253efc in main (argc=3, argv=0x7fffffffd9f0)
      at .../src/tools/imgtool/main.cpp:939
  (gdb) up
  #1  0x000000000025d426 in bml3_diskimage_open (image=..., dummy=...)
      at .../src/tools/imgtool/modules/bml3.cpp:520
  520             int sectors_per_track = callbacks->get_sectors_per_track(floppy, 0, 20);
  (gdb) print *callbacks
  $2 = {read_sector = 0x28de1c <imd_read_sector(...)>,
      write_sector = 0x0,
      read_indexed_sector = 0x28de03 <imd_read_indexed_sector(...)>,
      write_indexed_sector = 0x28de35 <imd_write_indexed_sector(...)>,
      read_track = 0x0,
      write_track = 0x0,
      format_track = 0x0,
      post_format = 0x0,
      get_heads_per_disk = 0x28dfef <imd_get_heads_per_disk(...)>,
      get_tracks_per_disk = 0x28dfff <imd_get_tracks_per_disk(...)>,
      get_sectors_per_track = 0x0,
      get_track_size = 0x0,
      get_sector_length = 0x28dd1c <imd_get_sector_length(...)>,
      get_indexed_sector_info = 0x28d95c <imd_get_indexed_sector_info(...)>,
      get_track_data_offset = 0x0}
  (gdb)

With patch applied:

  $ ./imgtool identify ./altos586/SDX-586.IMD

  imd_vzdos IMD floppy disk image (VZ-DOS format)
  imd_dgndos IMD floppy disk image (Dragon DOS format)