### PR TITLE
imgtool/bml3: fix a crash when format doesn't implement get_sectors_p…

### DIFF
--- a/src/tools/imgtool/modules/bml3.cpp
+++ b/src/tools/imgtool/modules/bml3.cpp
@@ -517,7 +517,10 @@ static imgtoolerr_t bml3_diskimage_open(imgtool::image &image, imgtool::stream::
 	ferr = callbacks->get_sector_length(floppy, 0, 20, 1, &sector_length);
 	if (ferr)
 		return imgtool_floppy_error(ferr);
-	int sectors_per_track = callbacks->get_sectors_per_track(floppy, 0, 20);
+
+	int sectors_per_track = -1;
+	if (callbacks->get_sectors_per_track)
+		sectors_per_track = callbacks->get_sectors_per_track(floppy, 0, 20);
 
 	if (heads_per_disk == 2 && sector_length == 128 && sectors_per_track == 16) {
 		// single-sided, single-density


### PR DESCRIPTION
…er_track()

The crash:

  Starting program: ./imgtool identify ./altos586/SDX-586.IMD
  ...
  Program received signal SIGSEGV, Segmentation fault.
  0x0000000000000000 in ?? ()
  (gdb) bt
  #0  0x0000000000000000 in ?? ()
  #1  0x000000000025d426 in bml3_diskimage_open (image=..., dummy=...)
      at .../src/tools/imgtool/modules/bml3.cpp:520
  #2  0x000000000024807d in imgtool_floppy_open_internal (stream=..., image=...)
      at .../src/tools/imgtool/iflopimg.cpp:83
  #3  imgtool_floppy_open (image=..., stream=...)
      at .../src/tools/imgtool/iflopimg.cpp:101
  #4  0x000000000024bbdf in imgtool::image::internal_open
      (module=module@entry=0x302320, filename="./altos586/SDX-586.IMD",
      read_or_write=read_or_write@entry=0, createopts=createopts@entry=0x0,
      outimg=std::unique_ptr<imgtool::image> = {...})
      at .../src/tools/imgtool/imgtool.cpp:986
  #5  0x000000000024bd19 in imgtool::image::open (module=module@entry=0x302320,
      filename="./altos586/SDX-586.IMD", read_or_write=read_or_write@entry=0,
      outimg=std::unique_ptr<imgtool::image> = {...})
      at .../src/tools/imgtool/imgtool.cpp:1010
  #6  0x0000000000250413 in evaluate_module (fname=fname@entry=0x2fa610
      "./altos586/SDX-586.IMD", module=0x302320, result=@0x7fffffffd4dc: 0)
      at .../src/tools/imgtool/imgtool.cpp:271
  #7  0x000000000025075f in imgtool::image::identify_file (fname=0x2fa610
      "./altos586/SDX-586.IMD", modules=modules@entry=0x7fffffffd5d0, count=127,
      count@entry=128)
      at/usr/include/c++/13/bits/unique_ptr.h:199
  #8  0x000000000025382e in cmd_identify (c=0x229d50 <cmds+400>, argc=<optimized
      out>, argv=0x7fffffffda00)
      at .../src/tools/imgtool/main.cpp:578
  #9  0x0000000000253efc in main (argc=3, argv=0x7fffffffd9f0)
      at .../src/tools/imgtool/main.cpp:939
  (gdb) up
  #1  0x000000000025d426 in bml3_diskimage_open (image=..., dummy=...)
      at .../src/tools/imgtool/modules/bml3.cpp:520
  520             int sectors_per_track = callbacks->get_sectors_per_track(floppy, 0, 20);
  (gdb) print *callbacks
  $2 = {read_sector = 0x28de1c <imd_read_sector(...)>,
      write_sector = 0x0,
      read_indexed_sector = 0x28de03 <imd_read_indexed_sector(...)>,
      write_indexed_sector = 0x28de35 <imd_write_indexed_sector(...)>,
      read_track = 0x0,
      write_track = 0x0,
      format_track = 0x0,
      post_format = 0x0,
      get_heads_per_disk = 0x28dfef <imd_get_heads_per_disk(...)>,
      get_tracks_per_disk = 0x28dfff <imd_get_tracks_per_disk(...)>,
      get_sectors_per_track = 0x0,
      get_track_size = 0x0,
      get_sector_length = 0x28dd1c <imd_get_sector_length(...)>,
      get_indexed_sector_info = 0x28d95c <imd_get_indexed_sector_info(...)>,
      get_track_data_offset = 0x0}
  (gdb)

With patch applied:

  $ ./imgtool identify ./altos586/SDX-586.IMD

  imd_vzdos IMD floppy disk image (VZ-DOS format)
  imd_dgndos IMD floppy disk image (Dragon DOS format)