### PR TITLE
atari/mediagx: Adds Preliminary Input Handling, gets machine working for a51site4

### DIFF
--- a/src/mame/atari/mediagx.cpp
+++ b/src/mame/atari/mediagx.cpp
@@ -594,13 +594,13 @@ uint16_t mk_parport_outval(uint8_t v) {
 	return v2 << 8;
 }
 
-int parPointerOutVal = 0x5;
+int par_pointer_out_val = 0x5;
 
 uint8_t previous_parport_state = 0;
 
-// used to control whether 2-bits for P2 lightgun X should be read
+// used to control whether 2-bits for P2 jgun X should be read
 // same value usually triggers system menu, so tracking when this is okay to read to avoid the overlap
-bool shouldReadP2X_HighBits = false;
+bool should_read_p2x_highbits = false;
 
 // Reads from the parallel port
 // 'offset' seems to be nearly constant in this case
@@ -612,7 +612,7 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 	if (ACCESSING_BITS_8_15)
 	{
 		uint32_t mp0 = 0;
-		uint8_t upperReg = m_parport_control_reg >> 4;
+		uint8_t upper_reg = m_parport_control_reg >> 4;
 
 		if(m_parport_control_reg == 0x10) {
 			r = mk_parport_outval(0);
@@ -630,7 +630,7 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					// allow opening the System Menu (TEST)
 					r = mk_parport_outval(2);
 
-				} else if (p2x > 512 && shouldReadP2X_HighBits) {
+				} else if (p2x > 512 && should_read_p2x_highbits) {
 					// P2 X 3/3, only when we're allowed to read this (always a bit after a 0x5 has been seen)
 					r = mk_parport_outval(2);
 
@@ -644,41 +644,41 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 				}
 
 				// clear this flag
-				shouldReadP2X_HighBits = false;
+				should_read_p2x_highbits = false;
 
 			} else {
 				r = mk_parport_outval(0);
 			}
 
-		} else if(upperReg == 0x2) {
+		} else if(upper_reg == 0x2) {
 			// Tilt, Test, unused, Bill... 3rd option is unused, Bill is inverted by the way
 			uint8_t mp2 = m_ports[2].read_safe(0);
 			r = mk_parport_outval(mp2);
 
-		} else if(upperReg == 0x3) {
+		} else if(upper_reg == 0x3) {
 			// Coins
 			mp0 = m_ports[0].read_safe(0);
 			// @montymxb This toggles the appropriate coin switches 1-4, but does not actually cause a credit to show up.
 			// Instead we rely on 0x6 to actually put coins in, and this to toggle the switch correctly...not sure why yet
 			r = mk_parport_outval((mp0 & 0xf0) >> 4 ^ 0xe);
 
-		} else if(upperReg == 0x4) {
+		} else if(upper_reg == 0x4) {
 			// SVC (service credits 1 + 2), and Audio controls
 			uint32_t mp1 = m_ports[1].read_safe(0);
 			// Service Credits 1 + 2, along with Volume controls.
 			// Bit 4 has to be inverted (0x8), active low, done in inputs already
 			r = mk_parport_outval(mp1);
 
-		} else if(upperReg == 0x5) {
+		} else if(upper_reg == 0x5) {
 			// Start buttons
 			// P1 - P4 start buttons
-			// All start buttons lead to lightgun movements being registered, but in a different fashion?
+			// All start buttons lead to jgun movements being registered, but in a different fashion?
 			mp0 = m_ports[0].read_safe(0);
 			r = mk_parport_outval(mp0 >> 0x8);
 
 			// set flag that next time control reg is 0x18,
 			// we should read P2 X high bits
-			shouldReadP2X_HighBits = true;
+			should_read_p2x_highbits = true;
 
 		} else if(m_parport_control_reg == 0x60) {
 			// Reset watchdogs?
@@ -692,7 +692,7 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 				r = mk_parport_outval(0x1);
 			}
 
-		} else if(upperReg == 0xF) {
+		} else if(upper_reg == 0xF) {
 			// TODO Internal pointer advance?
 			mp0 = m_ports[0].read_safe(0);
 
@@ -703,13 +703,13 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 			int16_t p2y;
 			int16_t p2x;
 
-			uint8_t mpGen;
+			uint8_t mp_gen;
 
 			// JGun Analog Controls
 			switch (m_parallel_pointer) {
 				case 10:
 					// Related to enabling P2 Start, P1 start, and allows some basic controls as such
-					r = mk_parport_outval(parPointerOutVal);
+					r = mk_parport_outval(par_pointer_out_val);
 					break;
 				case 11:
 					// TRIGGERS (1 & 2)
@@ -717,8 +717,8 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					// 0x2 = P2 Trigger
 					// TODO @montymxb Oct. 30th, 2022: Muzzle 'flash' shows up sporadically when shooting, random values of even 0/1 will trigger it as well.
 					// Seems to be connected to some other state machine? Unsure.
-					mpGen = m_ports[7].read_safe(0);
-					r = mk_parport_outval(mpGen);
+					mp_gen = m_ports[7].read_safe(0);
+					r = mk_parport_outval(mp_gen);
 					break;
 				case 12:
 					// P1 control select (but P2 as well?)
@@ -847,7 +847,7 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 			}
 
 
-		} else if(upperReg == 0x0) {
+		} else if(upper_reg == 0x0) {
 			// TODO some empty data written on start
 
 		}

--- a/src/mame/atari/mediagx.cpp
+++ b/src/mame/atari/mediagx.cpp
@@ -3,7 +3,6 @@
 /*  Atari MediaGX
 
     Driver by Ville Linde
-		Updates by Ben Wilson
 */
 
 /*
@@ -32,7 +31,7 @@
     15 PIN VGA CONNECTOR (DSUB15, plugged into custom Atari board)
     25 PIN PARALLEL CONNECTOR (DSUB25, plugged into custom Atari board)
 			Data Signal bus with the Custom Atari board
-			* Only 17 pins used in manual, but definitely a 25-pin connector
+			* Only 17 pins used in manual, but appears to be a 25-pin connector
 
     ICS9120 (SOIC8)
     AD706 (SOIC8)
@@ -76,64 +75,6 @@
     74F244 (x2, SOIC20)
     ST ULN2064B (DIP16)
 
-		https://wiki.mamedev.org/index.php/MNW#mediagx
-			> Mainly just need the inputs hooked up, which are mapped to the parallel port via a JAMMA interface.
-*/
-
-
-/*
-NOT CORRECT, BUT HELPFUL FOR DESIGNIGNING THIS BOARD LAYOUT AS WELL
-
-NOT RIGHT!!!
-
-PCB Layout
-----------
-
-No.6899-B
-|--------------------------------------------------------|
-|UPC1241H          YM3014  YM2151    14.31818MHz         |
-|     VOL       358                  89C51        B1     |
-|          M6295                                         |
-|                  S1      PAL                           |
-|                                             A1         |
-|                                                        |
-|J                                           6116        |
-|A                 P1                        6116        |
-|M   DSW3                                                |
-|M   DSW2                                                |
-|A   DSW1   DSW4                                         |
-|                               |-------|    6116        |
-|                               |LATTICE|    6116  PAL   |
-|               62256    62256  |1032E  |                |
-|                               |       |    T1          |
-|                    68000      |-------|                |
-| 3.6V_BATT     |-------------|                          |
-|               |        93C46|                          |
-|               |             |                          |
-|               |  *          |              6116        |
-|               |             |  22MHz       6116        |
-|---------------|PLASTIC COVER|--------------------------|
-Notes:
-      68000 clock - 11.000MHz [22/2]
-      VSync       - 58Hz
-      Hsync       - none (dead board, no signal)
-      M6295 clock - 1.100MHz [22/20], sample rate = 1100000 / 165, chip is printed 'AD-65'
-      YM2151 clock- 2.750MHz [22/8], chip is printed 'K-666'. YM3014 chip is printed 'K-664'
-                * - Unpopulated position for PIC16F84
-        3.6V_BATT - Purpose of battery unknown, does not appear to be used for backup of suicide RAM,
-                    and there's no RTC on the board.
-            93C46 - 128 x8 EEPROM. This chip was covered by a plastic cover. There's nothing else under
-                    the cover, but there was an unpopulated position for a PIC16F84
-            89C51 - Atmel 89C51 Microcontroller (protected)
-
-      ROMs -
-            P1 - Hitachi HN27C4096  (Main PRG)
-            T1 - Macronix MX27C4000 (GFX)
-            A1 - Atmel AT27C080     (GFX)
-            B1 - Macronix MX261000  (GFX?? or PRG/data for 89C51?)
-            S1 - Macronix MX27C2000 (OKI samples)
-
-Keep pressed 9 and press reset to enter service mode.
 */
 
 #include "emu.h"
@@ -154,7 +95,6 @@ Keep pressed 9 and press reset to enter service mode.
 
 namespace {
 
-// no speed hacks, @montymxb...
 #define SPEEDUP_HACKS 1
 
 class mediagx_state : public pcat_base_state
@@ -172,8 +112,6 @@ public:
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
-		// This describes mapping the External ports as INPUTs w/ various arrays into our device
-		// I.e. the inputs we're providing need to be mapped FROM m_ports into this machine
 		m_ports(*this, "IN%u", 0U)
 	{ }
 
@@ -223,9 +161,6 @@ private:
 	void mediagx_map(address_map &map);
 	void ramdac_map(address_map &map);
 
-	// TODO remove once done with debugging...
-	void update_debug_controls();
-
 	uint32_t cx5510_pci_r(int function, int reg, uint32_t mem_mask)
 	{
 		//osd_printf_debug("CX5510: PCI read %d, %02X, %08X\n", function, reg, mem_mask);
@@ -255,7 +190,7 @@ private:
 	required_device<palette_device> m_palette;
 	uint8_t m_pal[768];
 
-	optional_ioport_array<11> m_ports;   // but parallel_pointer takes values 0 -> 23
+	optional_ioport_array<11> m_ports; // but parallel_pointer takes values 0 -> 23
 
 	uint32_t m_disp_ctrl_reg[256/4]{};
 	int m_frame_width = 0;
@@ -275,7 +210,7 @@ private:
 	uint8_t m_parallel_pointer = 0;
 	// This latches the value retrieved from m_ports[m_parallel_pointer], allowing us to read it later
 	uint8_t m_parallel_latched = 0;
-	// The parallel port itself, data is written here, and data is read from here
+	// The parallel port itself, data is read/written from here
 	uint32_t m_parport = 0;
 	// simple control register for the parallel port
 	// updates on writes, changing the state, and reflected in the subsequent reads
@@ -284,7 +219,7 @@ private:
 	//int m_control_num2;
 	//int m_control_read;
 
-	uint32_t m_cx5510_regs[256/4]{};
+	uint32_t m_cx5510_regs[256/4];
 
 	std::unique_ptr<int16_t[]> m_dacl;
 	std::unique_ptr<int16_t[]> m_dacr;
@@ -534,28 +469,23 @@ void mediagx_state::disp_ctrl_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 }
 
 
-// Read from memory
-// Generally done at start/setup
+// Read from memory, generally done at start/setup
 uint32_t mediagx_state::memory_ctrl_r(offs_t offset)
 {
-	//printf("* Reading from the memory control section?\n");
 	return m_memory_ctrl_reg[offset];
 }
 
 
-// Write to memory
-// Generally done at start/setup
+// Write to memory, generally done at start/setup
 void mediagx_state::memory_ctrl_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-  //printf("memory_ctrl_w %08X, %08X, %08X\n", data, offset*4, mem_mask);
+	// printf("memory_ctrl_w %08X, %08X, %08X\n", data, offset*4, mem_mask);
 	if (offset == 0x20/4)
 	{
 		if((m_disp_ctrl_reg[DC_GENERAL_CFG] & 0x00e00000) == 0x00400000)
 		{
-			// TODO no clue but this seems important?
 			// guess: crtc params?
 			// ...
-			//printf("----> Checking to write CRTC params?\n");
 		}
 		else if((m_disp_ctrl_reg[DC_GENERAL_CFG] & 0x00f00000) == 0x00000000)
 		{
@@ -604,7 +534,6 @@ void mediagx_state::biu_ctrl_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 
 void mediagx_state::bios_ram_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	//printf("bios_ram_w %08X, %08X, %08X\n", data, offset, mem_mask);
 }
 
 /**
@@ -627,7 +556,7 @@ uint8_t mediagx_state::io20_r(offs_t offset)
  * I/O locations 0x22 and 0x23 are used for MediaGX processor configuration register access.
  * A write to 0x22 sets the index of the configuration register.
  * A subsequent read on 0x23 should use this index
- * EACH operation o 0x23 should be proceeded by a valid index set on 0x22
+ * Each operation on 0x23 should be proceeded by a valid index set on 0x22
  */
 void mediagx_state::io20_w(offs_t offset, uint8_t data)
 {
@@ -665,147 +594,33 @@ uint16_t mk_parport_outval(uint8_t v) {
 	return v2 << 8;
 }
 
-// #define READ_0x1_TEST 1
-// #define READ_0x18_TEST 1
-// #define READ_0x2_TEST 1
-// #define READ_0x3_TEST 1
-// #define READ_0x4_TEST 1
-// #define READ_0x5_TEST 1  // gone...
-// #define READ_0x6_TEST 1
-//#define READ_0xFF_TEST 1
-
-// for the very end, as if all were switched on, overrides all values as well
-//#define READ_BLANKET_TEST 1
-
-// used for controlling 0xFF stuff
-bool lock = false;
-int parallelPointMark = 10;
 int parPointerOutVal = 0x5;
-
-// used for controlling other read stuff
-bool lock2 = false;
-int readSectionPointer = 0;
-uint32_t readSectionNames[7] = {0x10,0x18,0x20,0x30,0x40,0x50,0x60};
-uint32_t readSectionValues[7] = {0,0,0,0,0,0,0};
-
-void mediagx_state::update_debug_controls() {
-	// Have to move thse controls to something else, since the current setup is kinda odd.
-	// MODIFYING LOGIC START
-	uint32_t mp3 = m_ports[3].read_safe(0);
-	if(mp3 == 0x1 && !lock) {
-		// bump 'down' & lock
-		parallelPointMark--;
-		printf("Mark down to %d\n", parallelPointMark);
-		lock = true;
-
-	} else if(mp3 == 0x2 && !lock) {
-		// bump 'up' & lock
-		parallelPointMark++;
-		printf("Mark up to %d\n", parallelPointMark);
-		lock = true;
-
-	} else if(mp3 == 0x4 && !lock) {
-		// bump par pointer out val up
-		parPointerOutVal++;
-		printf("ParPointer outval up to %08x\n", parPointerOutVal);
-		lock = true;
-
-	} else if(mp3 == 0x8 && !lock) {
-		// bump par pointer out val DOWN
-		parPointerOutVal--;
-		printf("ParPointer outval down to %08x\n", parPointerOutVal);
-		lock = true;
-
-	} else if(mp3 == 0) {
-		// unlock
-		lock = false;
-
-	}
-
-	// allow controlling other things with the 'joystick controls'
-	uint32_t mp4 = m_ports[4].read_safe(0);
-	if(mp4 == 0x1 && !lock2) {
-		readSectionPointer = readSectionPointer == 6 ? 6 : readSectionPointer+1;
-		printf("Read Section Pointer UP to %08x\n", readSectionNames[readSectionPointer]);
-		lock2 = true;
-
-	} else if(mp4 == 0x2 && !lock2) {
-		readSectionPointer = readSectionPointer == 0 ? 0 : readSectionPointer-1;
-		printf("Read Section Pointer DOWN to %08x\n", readSectionNames[readSectionPointer]);
-		lock2 = true;
-
-	} else if(mp4 == 0x4 && !lock2) {
-		readSectionValues[readSectionPointer]--;
-		printf("Read Section Value at %08x DOWN to %08x\n", readSectionNames[readSectionPointer], readSectionValues[readSectionPointer]);
-		lock2 = true;
-
-	} else if(mp4 == 0x8 && !lock2) {
-		readSectionValues[readSectionPointer]++;
-		printf("Read Section Value at %08x UP to %08x\n", readSectionNames[readSectionPointer], readSectionValues[readSectionPointer]);
-		lock2 = true;
-
-	} else if(mp4 == 0) {
-		lock2 = false;
-
-	}
-
-	// MODIFYING LOGIC STOP
-}
 
 uint8_t previous_parport_state = 0;
 
-// used to control whether 2-bits for P2 X should be read
-// same value usually triggers system menu, so have to track 'when' this is okay to read due to overlap
+// used to control whether 2-bits for P2 lightgun X should be read
+// same value usually triggers system menu, so tracking when this is okay to read to avoid the overlap
 bool shouldReadP2X_HighBits = false;
 
-// Reads from the parallel port, seems to hit what we're looking for?
+// Reads from the parallel port
 // 'offset' seems to be nearly constant in this case
 // the 'mem_mask' changes between (L) 0000FF00 and (H) 00FF0000
 uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 {
 	uint32_t r = 0;
 
-	// TODO, updates debug controls that override how later controls works
-	update_debug_controls();
-
-	// ACCESSING_BITS_8_15 is a synonym for the following
-	// ((mem_mask & 0x0000ff00U) != 0)
 	if (ACCESSING_BITS_8_15)
 	{
-		// Reading STATUS
-		// This is important for token reads to work
-		// Pass along the latched information we had from before, flipping bit 7 as well for hardware negation
-		// also correctly staggers the last 3 bits, 2 across the high nibble & 1 at the top of the low nibble
-		//uint8_t nibble = m_parallel_latched;
-		//r |= ((~nibble & 0x08) << 12) | ((nibble & 0x07) << 11);
-
-		//logerror("%08X:parallel_port_r()\n", m_maincpu->pc());
-
 		uint32_t mp0 = 0;
 		uint8_t upperReg = m_parport_control_reg >> 4;
 
 		if(m_parport_control_reg == 0x10) {
-			// TODO something here?
-			// not really, was just testing here too
-			#ifdef READ_0x1_TEST
-			mp0 = m_ports[0].read_safe(0);
-			r = mk_parport_outval(mp0 >> 8);
-			#else
 			r = mk_parport_outval(0);
-			#endif
-
-			// TODO Try section value
-			if(readSectionValues[0] != 0) { r = mk_parport_outval(readSectionValues[0]); }
 
 		} else if(m_parport_control_reg == 0x18) {
 			// Check for F2 to open the system menu
 			// TEST MODE switch, only works here on 0x18
 			mp0 = m_ports[0].read_safe(0);
-
-			#ifdef READ_0x18_TEST
-			r = mk_parport_outval(mp0 >> 0x8);
-
-			#else
 
 			// high 2-bits of P2X (controls thirds of X access)
 			int16_t p2x = m_ports[9].read_safe(0) * 3;
@@ -816,11 +631,11 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					r = mk_parport_outval(2);
 
 				} else if (p2x > 512 && shouldReadP2X_HighBits) {
-					// P2X 3/3, only when we're allowed to read this (always a bit after a 0x5 has been seen)
+					// P2 X 3/3, only when we're allowed to read this (always a bit after a 0x5 has been seen)
 					r = mk_parport_outval(2);
 
 				} else if (p2x > 256) {
-					// P2X 2/3
+					// P2 X 2/3
 					r = mk_parport_outval(1);
 
 				} else {
@@ -835,69 +650,31 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 				r = mk_parport_outval(0);
 			}
 
-			#endif
-
-			// TODO Try section value
-			if(readSectionValues[1] != 0) { r = mk_parport_outval(readSectionValues[1]); }
-
 		} else if(upperReg == 0x2) {
-			// Obs: this value fluctuates on the low-bit, not sure what it does yet...
-			#ifdef READ_0x2_TEST
-			mp0 = m_ports[0].read_safe(0);
-			r |= mk_parport_outval(mp0 >> 0x8);
-			#else
-			// July 17th, 2022. BILL control is 'on' when this is on...may also be TEST and TILT
-			// TILT, TEST, X, BILL... 3rd option is unused, and BILL is inverted by the way
+			// Tilt, Test, unused, Bill... 3rd option is unused, Bill is inverted by the way
 			uint8_t mp2 = m_ports[2].read_safe(0);
 			r = mk_parport_outval(mp2);
-			#endif
-
-			// TODO Try section value
-			if(readSectionValues[2] != 0) { r = mk_parport_outval(readSectionValues[2]); }
 
 		} else if(upperReg == 0x3) {
-			// COINS
-			// Obs: this value flucuates on the low-bit, not sure what it does yet...
-
+			// Coins
 			mp0 = m_ports[0].read_safe(0);
-
-			#ifdef READ_0x3_TEST
-			r = mk_parport_outval(mp0 >> 0x8);
-			#else
-			// Appears to be coins, which are a nibble up, and negated inversely
-			// This toggles the appropriate coin switches 1-4, but does not actually cause a credit to show up starngely.
-			// Instead we rely on 0x6 to actually put coins in, and this to toggle the switch correctly...strange stuff
+			// @montymxb This toggles the appropriate coin switches 1-4, but does not actually cause a credit to show up.
+			// Instead we rely on 0x6 to actually put coins in, and this to toggle the switch correctly...not sure why yet
 			r = mk_parport_outval((mp0 & 0xf0) >> 4 ^ 0xe);
-			#endif
-
-			// TODO Try section value
-			if(readSectionValues[3] != 0) { r = mk_parport_outval(readSectionValues[3]); }
 
 		} else if(upperReg == 0x4) {
 			// SVC (service credits 1 + 2), and Audio controls
 			uint32_t mp1 = m_ports[1].read_safe(0);
-
-			#ifdef READ_0x4_TEST
-			r = mk_parport_outval(mp1 >> 0x8);
-			#else
 			// Service Credits 1 + 2, along with Volume controls.
 			// Bit 4 has to be inverted (0x8), active low, done in inputs already
 			r = mk_parport_outval(mp1);
-			#endif
-
-			// TODO Try section value
-			if(readSectionValues[4] != 0) { r = mk_parport_outval(readSectionValues[4]); }
 
 		} else if(upperReg == 0x5) {
-			// > START BUTTONS!
-			// TODO Can control watchdogged outputs here I think, kickers,
+			// Start buttons
 			// P1 - P4 start buttons
-			// All start buttons lead to guncon movements being registered, but in a different fashion?
+			// All start buttons lead to lightgun movements being registered, but in a different fashion?
 			mp0 = m_ports[0].read_safe(0);
 			r = mk_parport_outval(mp0 >> 0x8);
-
-			// TODO Try section value
-			if(readSectionValues[5] != 0) { r = mk_parport_outval(readSectionValues[5]); }
 
 			// set flag that next time control reg is 0x18,
 			// we should read P2 X high bits
@@ -905,132 +682,47 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 
 		} else if(m_parport_control_reg == 0x60) {
 			// Reset watchdogs?
-
-			// r |= ((~nibble & 0x08) << 12) | ((nibble & 0x07) << 11);
-			// this code here is not important, or at least that seems to be the case
-
 			// coins & coin tracker only tripped together under 0x60
 			mp0 = m_ports[0].read_safe(0);
 
-			#ifdef READ_0x6_TEST
-			r = mk_parport_outval(mp0 >> 0x8);
-			#else
 			// keeping 0xf0 as the bitmask pushes the coin insertion to keys 5-8, which is desirable
 			if(mp0 & 0xf0) {
 				// this changes coin insertion to show up on 1-5, but it doesn't block the mode interestingly enough
-				// drop a coin in
-				// This actually inserts a coin, but does not toggle the 'coin' switch
+				// drops a coin in, but does not toggle the 'coin' switch itself
 				r = mk_parport_outval(0x1);
 			}
-
-			#endif
-
-			// TODO Try section value
-			if(readSectionValues[6] != 0) { r = mk_parport_outval(readSectionValues[6]); }
 
 		} else if(upperReg == 0xF) {
 			// TODO Internal pointer advance?
 			mp0 = m_ports[0].read_safe(0);
 
-			#ifdef READ_0xFF_TEST
-			// test value regardless of the par pointer state
-			//r = mk_parport_outval(mp0 >> 0x8);
-			r = mk_parport_outval(0x5);
-
-			#else
-			// 0b1011 1000 is our bitmask, but now I have a handy function to abstract that away from me!
-			// not below 6, but above for screen & movement?
-			// but unsure about upper bound for < 12, no movement then?
-			// 10 - 12 gets colors & moving down a bit
-			// 10 alone does 'blue & arrows'
-			// 11 does nothing
-			// here's what we got so far
-			// Combination of keys [1] and [3] held will lead this to do 'something', but only for the following range of 10-12, 9 too?
-
-			// only need the one 'f' since we're just getting a nibble back I believe...not a lot of info, but yeah that's kinda how it works.
-
-			// Oct. 30th, 2022, Old code here, can remove as needed
-			// July 30th, Note, m_parallel_pointer ranges from 0x1 -> 0x17 (1 - 23)
-			// Oct. 13th, 2022: Removed this from IF below:: mp0 & 0xf00 &&
-			// TODO this mp0 & 0xf00 removal makes coin insertion a double tap?
-			// TODO also removes 'debug' menu feature
-			// (mp0 & 0xf00) &&
-			// if (m_parallel_pointer == parallelPointMark) {
-			// 	// ....
-			// } else {
-			// }
-
-
-			// @montymxb Using this fixes most of the 'extra' switches being closed unnecessarily, which is great!
-			// July 17th, 2022, no longer causes problems with coins showing up. Might disregard the point below then VVV.
 			r = mk_parport_outval(0);
 
 			int16_t mp5;
-			int8_t mp6; // TODO needs to be converted to 16-bit
+			int8_t mp6; // TODO should be converted to 16-bit
 			int16_t p2y;
 			int16_t p2x;
 
 			uint8_t mpGen;
 
-			//bool triggerPulled = m_ports[7].read_safe(0) & 0x1;
-
 			// JGun Analog Controls
 			switch (m_parallel_pointer) {
-				case 2:
-					// EXTRA CASE FOR MENU NAVIGATION
-					// TODO @montymxb Oct. 3rd, 2022, see below..
-					// TODO hack, using volume controls to drive P1UP / P1DN to make navigation easier
-					// Though the above was controlling analog gun controls, appears to be not the case
-					mpGen = m_ports[1].read_safe(0);
-					r = mk_parport_outval((mpGen >> 2) ^ 0x2);
-					break;
 				case 10:
-					// July 30th, Note, m_parallel_pointer ranges from 0x1 -> 0x17 (1 - 23)
-					// Oct. 13th, 2022: Removed this from IF below:: mp0 & 0xf00 &&
-					// TODO this mp0 & 0xf00 removal makes coin insertion a double tap?
-					// TODO also removes 'debug' menu feature
-					// (mp0 & 0xf00) &&
-					// Oct. 30th, 2022: NO LONGER REMOVES DEBUG FEATURE?
-
-					// Range of 10 is very important, w/out it, and w/out the below, a number of components (like volume menu access & start button pressing) don't work
-					// there's a lot at play here
-					/*
-					- Allows volume menu select
-					- Allows P1 Start Button to be pressed (likely P2 start as well)
-					Upper controls are co-dependent on this here as well...interesting
-					*/
-					// TODO disabled for just a moment...
-					//r |= mk_parport_outval(mp0 >> 0x8); // was 0x5
-
-					// ENABLES P2 Start as well as P1 start and allows some basic controls as such
-					// TODO, was 0x5, but fixing this is NOT correct...trying other things here
-					// if (mp0 & 0xf00) {
-						r = mk_parport_outval(parPointerOutVal);
-					// }
-
-					// P2 START is TRIGGERED here when 0x5 is set, in fact so is P1 (when (mp0 & 0xf00 && m_parallel_pointer == 10) == true)
-					/*
-					r |= mk_parport_outval(0x5);
-					...
-					1 + 3 = P1 start
-					2 + 3 = P2 start
-					...
-					during the game
-					1 + 3 = Fire special weapon, weird...seems to be cycling still
-					*/
+					// Related to enabling P2 Start, P1 start, and allows some basic controls as such
+					r = mk_parport_outval(parPointerOutVal);
 					break;
 				case 11:
 					// TRIGGERS (1 & 2)
 					// 0x1 = P1 Trigger
 					// 0x2 = P2 Trigger
 					// TODO @montymxb Oct. 30th, 2022: Muzzle 'flash' shows up sporadically when shooting, random values of even 0/1 will trigger it as well.
-					// Seems to be connected to some other state machine? Unsure how.
+					// Seems to be connected to some other state machine? Unsure.
 					mpGen = m_ports[7].read_safe(0);
 					r = mk_parport_outval(mpGen);
 					break;
 				case 12:
 					// P1 control select (but P2 as well?)
-					// 0x1 allows P1 gun (but P2 already works...hmmm)
+					// 0x1 allows P1 gun (but P2 already works?)
 					// 0x2, nothing?
 					// 0x4, nothing?
 					// 0x8, nothing?
@@ -1154,27 +846,14 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					break;
 			}
 
-			#endif
-
 
 		} else if(upperReg == 0x0) {
 			// TODO some empty data written on start
 
-		} else {
-			// unrecognized parport state, report this for debugging
-			printf("UNRECOGNIZED PARPORT_STATE = %08X\n", m_parport_control_reg);
-
 		}
 
-		#ifdef READ_BLANKET_TEST
-		// blanket cover!
-		mp0 = m_ports[0].read_safe(0);
-		r = mk_parport_outval(mp0 >> 8);
-
-		#endif
-
 		// record prior control register state for parport
-		// (used to help with distinguishing Sys Menu cmd from P2X high 2-bit inputs)
+		// (used to help with distinguishing Sys Menu cmd from P2 X high 2-bit inputs)
 		previous_parport_state = m_parport_control_reg;
 
 	}
@@ -1185,8 +864,6 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 		// 0x02 causes a slight shift in the overall access? (unsure what this really pertains to)
 		// negate bits 0,1, and 3, all are hardware inverted
 
-		// TODO trying some random bouncing on controls too
-		//r |= ((rand() % 0x100)) ^ 0x0b0000;
 		// standard ctrl read, return what was set before
 		r = (m_parport & 0xff0000) ^ 0x0b0000;
 
@@ -1200,11 +877,9 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 	return r;
 }
 
-//
 // Writes to m_parport and m_parallel_latched
 // Updates the m_parallel_pointer to the next port, but used only internally here
 // Uses a mask of 0x00FF0000 and 0x000000FF only, alternating
-//
 void mediagx_state::parallel_port_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	// update parport registers together, DATA, STATUS, and CONTROL
@@ -1232,27 +907,14 @@ void mediagx_state::parallel_port_w(offs_t offset, uint32_t data, uint32_t mem_m
 
 		//logerror("%08X:", m_maincpu->pc());
 
-		// Using the parallel pointer, we read in some data, probably w/ no offset.
-		// THEN, we take that same data, and shift if right by 4 * (the remainder of 3 on the parallel pointer)
-		// Why? And then also only the low 4-bits, weird
-		// Ah, so this reads the given input for the given 'pointer', and normalizes it so it can be used below
-		// TODO can remove parallel latched if it keeps being useless
-		//m_parallel_latched = (m_ports[m_parallel_pointer / 3].read_safe(0) >> (4 * (m_parallel_pointer % 3)));
-
-		// TODO try latching random stuff, what can we do?
-		//m_parallel_latched = rand() % 0x100;
-
-		//printf("LATCHED: %08x, ptr: %08x\n", m_parallel_latched, m_parallel_pointer);
-
 		//parallel_pointer++;
 		//logerror("[%02X] Advance pointer to %d\n", data, parallel_pointer);
 
-		// update the control register
+		// update the control register by masking off the low bit
 		// this controls our parallel reads
-		// cuts off bit 1, serves 0b11111110
 		m_parport_control_reg = data & 0xfc;
 
-		switch (m_parport_control_reg) // data & 0xfc
+		switch (m_parport_control_reg)
 		{
 			case 0x18:
 			//case 0x19: dropped anyways by 0xfc...
@@ -1292,7 +954,6 @@ void mediagx_state::parallel_port_w(offs_t offset, uint32_t data, uint32_t mem_m
 			case 0x54:
 			case 0x58:
 			case 0x5c:
-				//printf("[%02X] Kickers = %d%d\n", data, (data >> 1) & 1, data & 1);
 				//logerror("[%02X] Kickers = %d%d\n", data, (data >> 1) & 1, data & 1);
 				break;
 
@@ -1300,7 +961,6 @@ void mediagx_state::parallel_port_w(offs_t offset, uint32_t data, uint32_t mem_m
 			case 0x64:
 			case 0x68:
 			case 0x6c:
-				//printf("[%02X] Watchdog reset\n", data);
 				//logerror("[%02X] Watchdog reset\n", data);
 				break;
 
@@ -1308,12 +968,10 @@ void mediagx_state::parallel_port_w(offs_t offset, uint32_t data, uint32_t mem_m
 				if (data >= 0x70)
 				{
 					m_parallel_pointer++;
-					//printf("[%02X] Advance pointer to %d\n", data, m_parallel_pointer);
 					//logerror("[%02X] Advance pointer to %d\n", data, m_parallel_pointer);
 				}
 				else
 				{
-					//printf("[%02X] Unknown write\n", data);
 					//logerror("[%02X] Unknown write\n", data);
 				}
 				break;
@@ -1336,7 +994,6 @@ void mediagx_state::parallel_port_w(offs_t offset, uint32_t data, uint32_t mem_m
 TIMER_DEVICE_CALLBACK_MEMBER(mediagx_state::sound_timer_callback)
 {
 	m_ad1847_sample_counter = 0;
-	// 10 ms before was the default
 	timer.adjust(attotime::from_msec(AD1847_SAMPLE_DELAY));
 
 	m_dmadac[0]->transfer(1, 0, 1, m_dacl_ptr, m_dacl.get());
@@ -1432,19 +1089,8 @@ void mediagx_state::mediagx_map(address_map &map)
 	map(0x000a0000, 0x000affff).ram();
 	// CGA ram follows
 	map(0x000b0000, 0x000b7fff).ram().share(m_cga_ram);
-	// bios RAM follows after this, we likely won't touch that
+	// bios RAM follows after
 	map(0x000c0000, 0x000fffff).ram().share(m_bios_ram);
-	// pad
-
-	/*
-	EXAMPLE from redclash.cpp driver
-	Note that IO ports are mapped out directly here from before
-	Should I do the same?
-	map(0x4800, 0x4800).portr("IN0");    // IN0
-	map(0x4801, 0x4801).portr("IN1");    // IN1
-	map(0x4802, 0x4802).portr("DSW1");   // DSW0
-	map(0x4803, 0x4803).portr("DSW2");   // DSW1
-	*/
 
 	map(0x00100000, 0x00ffffff).ram();
 	// 256-bit region for BIU Control
@@ -1473,13 +1119,10 @@ void mediagx_state::mediagx_io(address_map &map)
 	// 2-bits
 	map(0x0022, 0x0023).rw(FUNC(mediagx_state::io20_r), FUNC(mediagx_state::io20_w));
 
-	// 0x40 -> 0x41 does something special but I cannot figure out what ???
+	// 0x40 -> 0x41 does something special but not sure?
 	// seems related to interrupts, fetching the result of something that was pressed perhaps?
 	// 0x40 programmable interrupt timer?
 	// See: https://wiki.osdev.org/PIT#I.2F0_Ports
-
-	// 0x60-0x61, Keyboard controller, reads presses for PS2 devices and such
-	//map(0x0060, 0x0061).rw(FUNC(mediagx_state::p60_r), FUNC(mediagx_state::p60_w));
 
 	// 4-bits for the I/O delay port
 	map(0x00e8, 0x00eb).noprw();
@@ -1492,7 +1135,7 @@ void mediagx_state::mediagx_io(address_map &map)
 	// 4-bytes
 	// Maps parallel port R/W to an address range in this system, https://en.wikipedia.org/wiki/Parallel_port
 	// Was at 0x037b, but think it should go to 37f for full range?
-	// but keeping at 0x37b so it's the same as it was before, but really doesn't matter so much I think...
+	// but keeping at 0x37b so it's the same as it was before, not sure how much it matters here
 	map(0x0378, 0x037b).rw(FUNC(mediagx_state::parallel_port_r), FUNC(mediagx_state::parallel_port_w));
 
 	// More Integrated Drive Electronics (IDE) controller stuff, for interfacing w/ external storage
@@ -1504,7 +1147,6 @@ void mediagx_state::mediagx_io(address_map &map)
 	// 256-bits
 	map(0x0400, 0x04ff).rw(FUNC(mediagx_state::ad1847_r), FUNC(mediagx_state::ad1847_w));
 
-	// Not sure what the PCIbus will be doing?
 	// PCI Configuration Space, https://en.wikipedia.org/wiki/PCI_configuration_space
 	// specifically for the Intel Pentium motherboard ("Neptune" chipset)
 	// 8-bits
@@ -1516,7 +1158,6 @@ void mediagx_state::mediagx_io(address_map &map)
 static const gfx_layout CGA_charlayout =
 {
 	8,8,                    /* 8 x 16 characters .... but says 8 intead? */
-	// TODO 8x16 above or 8x8? Written as 8x8 but says 8x16, okay...
 	256,                    /* 256 characters */
 	1,                      /* 1 bits per pixel */
 	{ 0 },                  /* no bitplanes; 1 bit per pixel */
@@ -1540,10 +1181,6 @@ static INPUT_PORTS_START(mediagx)
 	PORT_START("IN0")
 	// activates the debug service menu
 	PORT_SERVICE_NO_TOGGLE( 0x1, IP_ACTIVE_HIGH )
-	// removed the following, to put all 4 on a separate port
-	// PORT_BIT( 0x002, IP_ACTIVE_HIGH, IPT_SERVICE1 )
-	// PORT_BIT( 0x004, IP_ACTIVE_HIGH, IPT_SERVICE2 )
-	// PORT_BIT( 0x008, IP_ACTIVE_HIGH, IPT_VOLUME_DOWN )
 
 	// Coins
 	PORT_BIT( 0x010, IP_ACTIVE_HIGH, IPT_COIN1 )
@@ -1632,17 +1269,6 @@ void mediagx_state::machine_start()
 {
 	m_dacl = std::make_unique<int16_t[]>(65536);
 	m_dacr = std::make_unique<int16_t[]>(65536);
-
-	// TODO: from tmnt.cpp (for ssriders)
-	// Allows saving!
-	// save_item(NAME(m_toggle));
-	// save_item(NAME(m_last));
-	// save_item(NAME(m_tmnt_soundlatch));
-	// save_item(NAME(m_sprite_colorbase));
-	// save_item(NAME(m_layer_colorbase));
-	// save_item(NAME(m_layerpri));
-	// save_item(NAME(m_sorted_layer));
-	// save_item(NAME(m_irq5_mask));
 }
 
 void mediagx_state::machine_reset()
@@ -1663,36 +1289,9 @@ void mediagx_state::ramdac_map(address_map &map)
 	map(0x000, 0x3ff).rw(m_ramdac, FUNC(ramdac_device::ramdac_pal_r), FUNC(ramdac_device::ramdac_rgb666_w));
 }
 
-// TODO, Esc key still doesn't work for closing down the emulator, that should always exit out
-
 void mediagx_state::mediagx(machine_config &config)
 {
-	/* basic machine hardware */
-	//MEDIAGX(config, m_maincpu, 244000000);
-	// MEDIAGX(config, m_maincpu, 222000000);
-	// Speeds up the CPU execution speed...not necessarily what I want here, but could be nice
-	// tried 222000000, sped it up a lot,, but sound is borked :?
-
-	// uint lvl = (166000000 - 38456666) / 2;
-	// MEDIAGX(config, m_maincpu, 166000000);
-	// tried this speed to match the DAC, which means that the inverse is likely true as well? Audio needs to be greatly changed?
-	// audio worked great, but the game was too fast
-	// 38456556 ~~~ good
-	// 38456666.6666667 ~~~ also good
-	MEDIAGX(config, m_maincpu, 38456666);
-
-	/*
-	...Some other notes here
-	Type raster, resolution 640×240@60 Hz, CRT 15kHz, gameplay box  (0,0)÷(640,240), display box  640×480, pixel clock @18.432 MHz
-Orientation:
-Horizontal
-Scrolling:
-Unknown
-Colors:
--
-CPU:
-maincpu Cyrix MediaGX @166 MHz, dma8237_1 AM9517A @4.772727 MHz, dma8237_2 AM9517A @4.772727 MHz
-	*/
+	MEDIAGX(config, m_maincpu, 166000000);
 
 	// Program mapping
 	m_maincpu->set_addrmap(AS_PROGRAM, &mediagx_state::mediagx_map);
@@ -1715,73 +1314,13 @@ maincpu Cyrix MediaGX @166 MHz, dma8237_1 AM9517A @4.772727 MHz, dma8237_2 AM951
 
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	// sometimes 72 is fun to try as well
-	// 13.9 seems to do OK, but still lags out once the game starts, tends to desync a bit
-	// TODO: Not perfect, may need to be further resolved still
-	// m_screen->set_refresh_hz(13.9); // 60
-	// somewhere between 13.9 and 13.9375 (maybe 14) is the sweet spot
-	// seems like something around 13.91 or 13.92 could be really on point.
-	// m_screen->set_refresh_hz(13.9); // 60
-	// m_screen->set_refresh_hz(73.9);
 	m_screen->set_refresh_hz(61);
-	// 120 hits a good spot for the main (with -afs)
-	// 120 does flash, which is quite cool actually
-	// 61 or 30 is good for minigames
-	// still 13.9 w/ full 166MHz
 
-	// fiddling with raw values, kinda working
-	// ~~~~ increasing pxl clock slowly here...fixing the rest
-	// m_screen->set_raw(17992, 3, 0, 360, 480, 240, 0);
-
-	// hbend should be 0
-	// hbstart should be 640
-	// vbend should also be 0
-	// vbstart should be 240
-	// TODO Use this
-	// m_screen->set_raw(18432000, 640, 0, 640, 480, 0, 240);
-	// 3 - 4 ?
-	// m_screen->set_raw(3100000, 640, 0, 640, 480, 0, 240);
-	// TODO VERY CLOSE! NEED BETTER TIMINGS ON THE SOUND TIMER DELAY TO PROCEED
-	// Nov. 18th, 2022: This was one of the closer times, rest is OK
-	// m_screen->set_raw(3611500, 640, 0, 640, 480, 0, 240);
-	// m_screen->set_raw(18432000/4.7, 640, 0, 360, 480, 0, 240);
-
-
-	// TODO leads to a flash with 166MHZ cpu as well!
-	// m_screen->set_raw(18432000 * 4, 640, 0, 640, 480, 0, 240);
-
-
-
-	// m_screen->set_raw(38456666, 3800, 0, 360, 480, 240, 0);
-	// m_screen->set_raw(18432000/2, 456, 42, 402, 262, 17, 257);
-	// slow but smooth
-	// m_screen->set_raw(18432000, 3800, 0, 360, 480, 0, 240);
-	// with flash!
-	// m_screen->set_raw(18432000, 500, 360, 0, 248, 248, 0);
-
-	// todo, just trying some little things here
-	// m_screen->set_video_attributes(VIDEO_UPDATE_AFTER_VBLANK);
-	// m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(5500)); // not accurate
-
-	// TODO blocked off this part, as it should be set in the 'set_raw' function instead
-	// m_screen->set_size(640, 480);
-	// m_screen->set_visarea(0, 639, 0, 239);
+	// TODO should probably set this via set_raw instead
+	m_screen->set_size(640, 480);
+	m_screen->set_visarea(0, 639, 0, 239);
 
 	m_screen->set_screen_update(FUNC(mediagx_state::screen_update));
-
-	/* From SS riders
-	>>> idea, try some of these attributes here, does it improve performance? Especially if we use 60Hz again?
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_video_attributes(VIDEO_UPDATE_AFTER_VBLANK);
-	screen.set_refresh_hz(60);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); // not accurate
-	screen.set_size(64*8, 32*8);
-	screen.set_visarea(14*8, (64-14)*8-1, 2*8, 30*8-1);
-	screen.set_screen_update(FUNC(tmnt_state::screen_update_thndrx2));
-	screen.set_palette(m_palette);
-
-	WATCHDOG_TIMER(config, "watchdog");
-	*/
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_cga);
 
@@ -1919,5 +1458,5 @@ ROM_END
 
 /*****************************************************************************/
 
-GAME( 1998, a51site4, 0       , mediagx, mediagx, mediagx_state, init_a51site4,  ROT0,   "Atari Games",  "Area 51: Site 4 (HD Rev 2.01, September 7, 1998)", 0 ) // better flags here...
+GAME( 1998, a51site4, 0       , mediagx, mediagx, mediagx_state, init_a51site4,  ROT0,   "Atari Games",  "Area 51: Site 4 (HD Rev 2.01, September 7, 1998)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_CONTROLS | MACHINE_IMPERFECT_TIMING )
 GAME( 1998, a51site4a,a51site4, mediagx, mediagx, mediagx_state, init_a51site4,  ROT0,   "Atari Games",  "Area 51: Site 4 (HD Rev 2.0, September 11, 1998)", MACHINE_NOT_WORKING )

--- a/src/mame/atari/mediagx.cpp
+++ b/src/mame/atari/mediagx.cpp
@@ -155,7 +155,7 @@ Keep pressed 9 and press reset to enter service mode.
 namespace {
 
 // no speed hacks, @montymxb...
-#define SPEEDUP_HACKS	1
+#define SPEEDUP_HACKS 1
 
 class mediagx_state : public pcat_base_state
 {
@@ -476,15 +476,17 @@ void mediagx_state::draw_cga(bitmap_rgb32 &bitmap, const rectangle &cliprect)
 
 	for (int j=0; j < 25; j++)
 	{
+		int j8 = j*8;
 		for (int i=0; i < 80; i+=2)
 		{
+			int i8 = i*8;
 			int const att0 = (cga[index] >> 8) & 0xff;
 			int const ch0 = (cga[index] >> 0) & 0xff;
 			int const att1 = (cga[index] >> 24) & 0xff;
 			int const ch1 = (cga[index] >> 16) & 0xff;
 
-			draw_char(bitmap, cliprect, gfx, ch0, att0, i*8, j*8);
-			draw_char(bitmap, cliprect, gfx, ch1, att1, (i*8)+8, j*8);
+			draw_char(bitmap, cliprect, gfx, ch0, att0, i8, j8);
+			draw_char(bitmap, cliprect, gfx, ch1, att1, i8+8, j8);
 			index++;
 		}
 	}
@@ -695,7 +697,7 @@ void mediagx_state::update_debug_controls() {
 		parallelPointMark--;
 		printf("Mark down to %d\n", parallelPointMark);
 		lock = true;
-		
+
 	} else if(mp3 == 0x2 && !lock) {
 		// bump 'up' & lock
 		parallelPointMark++;
@@ -931,7 +933,7 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 			mp0 = m_ports[0].read_safe(0);
 
 			#ifdef READ_0xFF_TEST
-			// test value regardless of the par pointer state 
+			// test value regardless of the par pointer state
 			//r = mk_parport_outval(mp0 >> 0x8);
 			r = mk_parport_outval(0x5);
 
@@ -944,15 +946,15 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 			// 11 does nothing
 			// here's what we got so far
 			// Combination of keys [1] and [3] held will lead this to do 'something', but only for the following range of 10-12, 9 too?
-			
+
 			// only need the one 'f' since we're just getting a nibble back I believe...not a lot of info, but yeah that's kinda how it works.
 
 			// Oct. 30th, 2022, Old code here, can remove as needed
 			// July 30th, Note, m_parallel_pointer ranges from 0x1 -> 0x17 (1 - 23)
-			// Oct. 13th, 2022: Removed this from IF below:: mp0 & 0xf00 && 
+			// Oct. 13th, 2022: Removed this from IF below:: mp0 & 0xf00 &&
 			// TODO this mp0 & 0xf00 removal makes coin insertion a double tap?
 			// TODO also removes 'debug' menu feature
-			// (mp0 & 0xf00) && 
+			// (mp0 & 0xf00) &&
 			// if (m_parallel_pointer == parallelPointMark) {
 			// 	// ....
 			// } else {
@@ -984,10 +986,10 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					break;
 				case 10:
 					// July 30th, Note, m_parallel_pointer ranges from 0x1 -> 0x17 (1 - 23)
-					// Oct. 13th, 2022: Removed this from IF below:: mp0 & 0xf00 && 
+					// Oct. 13th, 2022: Removed this from IF below:: mp0 & 0xf00 &&
 					// TODO this mp0 & 0xf00 removal makes coin insertion a double tap?
 					// TODO also removes 'debug' menu feature
-					// (mp0 & 0xf00) && 
+					// (mp0 & 0xf00) &&
 					// Oct. 30th, 2022: NO LONGER REMOVES DEBUG FEATURE?
 
 					// Range of 10 is very important, w/out it, and w/out the below, a number of components (like volume menu access & start button pressing) don't work
@@ -1002,9 +1004,9 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 
 					// ENABLES P2 Start as well as P1 start and allows some basic controls as such
 					// TODO, was 0x5, but fixing this is NOT correct...trying other things here
-					if (mp0 & 0xf00) {
+					// if (mp0 & 0xf00) {
 						r = mk_parport_outval(parPointerOutVal);
-					}
+					// }
 
 					// P2 START is TRIGGERED here when 0x5 is set, in fact so is P1 (when (mp0 & 0xf00 && m_parallel_pointer == 10) == true)
 					/*
@@ -1036,13 +1038,13 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					break;
 				case 13:
 					// P1, Y (LOW)
-					// 0x1 = 1 
+					// 0x1 = 1
 					// 0x2 = 2
 					// 0x4 = 4
 					// 0x8 = 8
 					// convert mouse Y
-					mp6 = int(float(m_ports[6].read_safe(0)) / 255.0 * 248.0);
-					mp6 = 124 - mp6;
+					mp6 = m_ports[6].read_safe(0);
+					mp6 = 128 - mp6;
 					r = mk_parport_outval(mp6 & 0xf);
 					break;
 				case 14:
@@ -1051,13 +1053,13 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					// 0x2 = 32
 					// 0x4 = -64 (using this inverted approach, needs to be fixed?)
 					// 0x8 = +128
-					mp6 = int(float(m_ports[6].read_safe(0)) / 255.0 * 248.0);
-					mp6 = 124 - mp6;
+					mp6 = m_ports[6].read_safe(0);
+					mp6 = 128 - mp6;
 					if (mp6 >= 0 && mp6 < 64) {
 						// 2/4
 						r = mk_parport_outval(((mp6 >> 4) & 0x3));
 
-					} else if (mp6 <= -64) {
+					} else if (mp6 < -64) {
 						// 4/4
 						r = mk_parport_outval(((mp6 >> 4) & 0x3) | 0x8);
 
@@ -1077,9 +1079,9 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					// 0x2 = ???
 					// 0x4 = ???
 					// 0x8 = ???
-					mp6 = int(float(m_ports[6].read_safe(0)) / 255.0 * 248.0);
+					mp6 = m_ports[6].read_safe(0);
 					// mp6 = 124 - mp6;
-					if (mp6 >= 0 || mp6 <= -64) {
+					if (mp6 >= 0 || mp6 < -64) {
 						r = mk_parport_outval(0x1);
 					}
 					break;
@@ -1089,23 +1091,8 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					// 0x2 == 1
 					// 0x4 == 2
 					// 0x8 == 4
-					//r = mk_parport_outval(0x1);
-					// mp5 = m_ports[5].read_safe(0);
-					// r = mk_parport_outval(((mp5 & 0x7) << 1) | 0x1);
-
-					mp5 = int(float(m_ports[5].read_safe(0)) / 255.0 * 768.0) % 256;
+					mp5 = int(float(m_ports[5].read_safe(0)) * 3) % 256;
 					r = mk_parport_outval(mp5 & 0xf);
-
-
-					// // r = mk_parport_outval(((mp5 & 0x7) >> 1) & 1);
-					// if (mp5 < 64) {
-					// 	r = mk_parport_outval((mp5 & 0x3) << 2);
-					// } else if (mp5 < 296) {
-					// 	r = mk_parport_outval(0x1 | (mp5 & 0x7) << 1);
-					// } else {
-					// 	r = mk_parport_outval((mp5 & 0x3) << 2);
-					// }
-					// r = mk_parport_outval(rand() % 16);
 					break;
 				case 17:
 					// P1 X (Low + High)
@@ -1113,21 +1100,8 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					// 0x2 == 16
 					// 0x4 == 32
 					// 0x8 == 63 ** (not 64 for some reason?)
-
-					// mp5 = int(float(m_ports[5].read_safe(0)) / 255.0 * 720.0) % 120;
-					// if (mp5 < 64) {
-					// 	r = mk_parport_outval((mp5 & 0b111100) >> 2);
-					// } else if (mp5 < 296) {
-					// 	r = mk_parport_outval((mp5 & 0b11110) >> 1);
-					// } else {
-					// 	r = mk_parport_outval((mp5 & 0b111100) >> 2);
-					// }
-					// r = mk_parport_outval(((mp5 & 0x78) >> 3));
-
-					mp5 = int(float(m_ports[5].read_safe(0)) / 255.0 * 768.0) % 256;
+					mp5 = int(float(m_ports[5].read_safe(0)) * 3) % 256;
 					r = mk_parport_outval((mp5 >> 4) & 0xf);
-
-					// r = mk_parport_outval(rand() % 16);
 					break;
 				case 18:
 					// P1, X (HH)
@@ -1135,11 +1109,10 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					// 0x2 = last 3rd
 					// 0x4 nothing..
 					// 0x8 nothing..
-
-					mp5 = int(float(m_ports[5].read_safe(0)) / 255.0 * 384.0);
-					if (mp5 > 256) {
+					mp5 = int(float(m_ports[5].read_safe(0)) * 3);
+					if (mp5 > 512) {
 						r = mk_parport_outval(0x2);
-					} else if (mp5 > 128) {
+					} else if (mp5 > 256) {
 						r = mk_parport_outval(0x1);
 					}
 					break;
@@ -1181,7 +1154,7 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 					break;
 			}
 
-			#endif 
+			#endif
 
 
 		} else if(upperReg == 0x0) {
@@ -1199,8 +1172,8 @@ uint32_t mediagx_state::parallel_port_r(offs_t offset, uint32_t mem_mask)
 		r = mk_parport_outval(mp0 >> 8);
 
 		#endif
-		
-		// record prior control register state for parport 
+
+		// record prior control register state for parport
 		// (used to help with distinguishing Sys Menu cmd from P2X high 2-bit inputs)
 		previous_parport_state = m_parport_control_reg;
 
@@ -1572,104 +1545,6 @@ static INPUT_PORTS_START(mediagx)
 	// PORT_BIT( 0x004, IP_ACTIVE_HIGH, IPT_SERVICE2 )
 	// PORT_BIT( 0x008, IP_ACTIVE_HIGH, IPT_VOLUME_DOWN )
 
-	/*
-	- CREDIT
-	- VOL +
-	- VOL -
-	- TEST SWITCH
-
-	- START 1
-	- START 2
-
-	- COIN 1
-	- COIN 2
-
-	- JGUN 1 ?
-	- JGUN 2 ?
-	*/
-
-	/*
-	July 30th, recommended layout in the future
-
-	INPUT 0:
-	- Coin 1
-	- Coin 2
-	- Coin 3
-	- Coin 4
-
-	INPUT 1:
-	- Tilt
-	- Test (not sure if I've ever hit this before actually?)
-	- XXXX
-	- Bill
-
-	INPUT 2:
-	- SVC 	(service credit 1)
-	- SVC2  (service credit 2)
-	- VOL -
-	- VOL +
-
-	INPUT 3:
-	- P1ST
-	- P2ST
-	- P3ST
-	- P4ST
-
-	INPUT 4:
-	- P1UP
-	- P1DN
-	- P1LT
-	- P1RT
-
-	INPUT 5:
-	- P1A1
-	- P1A2
-	- P1A3
-	- P1A4
-
-	INPUT 6:
-	- P2UP
-	- P2DN
-	- P2LT
-	- P2RT
-
-	INPUT 7:
-	- P2A1
-	- P2A2
-	- P2A3
-	- P2A4
-
-	INPUT 8:
-	- P3UP
-	- P3DN
-	- P3LT
-	- P3RT
-
-	INPUT 9:
-	- P3A1
-	- P3A2
-	- P3A3
-	- P3A4
-
-	INPUT 10:
-	- P4UP
-	- P4DN
-	- P4LT
-	- P4RT
-
-	INPUT 11:
-	- P4A1
-	- P4A2
-	- P4A3
-	- P4A4
-
-	INPUT 12:
-	- P1 TRIG
-	- P2 TRIG
-	- XXXX
-	- XXXX
-	*/
-
 	// Coins
 	PORT_BIT( 0x010, IP_ACTIVE_HIGH, IPT_COIN1 )
 	PORT_BIT( 0x020, IP_ACTIVE_HIGH, IPT_COIN2 )
@@ -1682,49 +1557,20 @@ static INPUT_PORTS_START(mediagx)
 	PORT_BIT( 0x400, IP_ACTIVE_HIGH, IPT_START3 )
 	PORT_BIT( 0x800, IP_ACTIVE_HIGH, IPT_START4 )
 
-	// 'Light' Gun X & Y idea pulled from Carnevil's implementation using the Seattle Driver
-	PORT_START("JGUN0_X") //fake analog X
+	// 'Light' Gun X & Y, idea pulled from Carnevil's implementation using the Seattle Driver
+	PORT_START("JGUN0_X") // fake analog X
 	PORT_BIT( 0xff, 0x80, IPT_LIGHTGUN_X ) PORT_CROSSHAIR(X, 1.0, 0.0, 0) PORT_SENSITIVITY(50) PORT_KEYDELTA(10)
-	PORT_START("JGUN0_Y") //fake analog Y
+	PORT_START("JGUN0_Y") // fake analog Y
 	PORT_BIT( 0xff, 0x80, IPT_LIGHTGUN_Y ) PORT_CROSSHAIR(Y, 1.0, 0.0, 0) PORT_SENSITIVITY(70) PORT_KEYDELTA(10)
 
-	PORT_START("JGUN1_X") //fake analog X
+	PORT_START("JGUN1_X") // fake analog X
 	PORT_BIT( 0xff, 0x80, IPT_LIGHTGUN_X ) PORT_CROSSHAIR(X, 1.0, 0.0, 0) PORT_SENSITIVITY(50) PORT_KEYDELTA(10) PORT_PLAYER(2)
-	PORT_START("JGUN1_Y") //fake analog Y
+	PORT_START("JGUN1_Y") // fake analog Y
 	PORT_BIT( 0xff, 0x80, IPT_LIGHTGUN_Y ) PORT_CROSSHAIR(Y, 1.0, 0.0, 0) PORT_SENSITIVITY(70) PORT_KEYDELTA(10) PORT_PLAYER(2)
 
 	PORT_START("JGUN") // fake switches
 	PORT_BIT( 0x1, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(1) PORT_NAME("P1 Trigger")
 	PORT_BIT( 0x2, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(2) PORT_NAME("P2 Trigger")
-
-	/*
-	TODO remove these DIP examples, unless I plan to use them
-	EXAMPLE from redclash.cpp driver for DIPs,
-	...since I found a couple of them floating around in mem that I can map
-	PORT_START("DSW1")
-	PORT_DIPNAME( 0x03, 0x03, "Difficulty?" )
-	PORT_DIPSETTING(    0x03, "Easy?" )
-	PORT_DIPSETTING(    0x02, "Medium?" )
-	PORT_DIPSETTING(    0x01, "Hard?" )
-	PORT_DIPSETTING(    0x00, "Hardest?" )
-	PORT_DIPNAME( 0x04, 0x04, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(    0x04, DEF_STR( Off ) )
-	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
-	PORT_DIPNAME( 0x08, 0x00, DEF_STR( Cabinet ) )
-	PORT_DIPSETTING(    0x00, DEF_STR( Upright ) )
-	PORT_DIPSETTING(    0x08, DEF_STR( Cocktail ) )
-	PORT_DIPNAME( 0x10, 0x10, "High Score" )
-	PORT_DIPSETTING(    0x00, "0" )
-	PORT_DIPSETTING(    0x10, "10000" )
-	PORT_DIPNAME( 0x20, 0x20, DEF_STR( Unknown ) )
-	PORT_DIPSETTING(    0x20, DEF_STR( Off ) )
-	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
-	PORT_DIPNAME( 0xc0, 0xc0, DEF_STR( Lives ) )
-	PORT_DIPSETTING(    0x00, "1" )
-	PORT_DIPSETTING(    0xc0, "3" )
-	PORT_DIPSETTING(    0x80, "5" )
-	PORT_DIPSETTING(    0x40, "7" )
-	*/
 
 	// Service 1 + 2 & Volume controls
 	PORT_START("IN1")
@@ -1761,13 +1607,12 @@ static INPUT_PORTS_START(mediagx)
 	// JGun0 Y
 	PORT_START("IN6")
 	PORT_BIT( 0xff, 0x80, IPT_LIGHTGUN_Y ) PORT_CROSSHAIR(Y, 1.0, 0.0, 0) PORT_SENSITIVITY(30) PORT_KEYDELTA(10)
-	
+
 	// JGun Triggers
 	PORT_START("IN7")
 	PORT_BIT( 0x1, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(1) PORT_NAME("P1 Trigger")
 	PORT_BIT( 0x2, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(2) PORT_NAME("P2 Trigger")
 
-	// TODO, as needed we can extend a couple more ports for JGun1 x & y
 	PORT_START("IN8")
 	PORT_BIT( 0x00f, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP ) PORT_PLAYER(3)
 	PORT_BIT( 0x0f0, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN ) PORT_PLAYER(3)
@@ -1807,7 +1652,7 @@ void mediagx_state::machine_reset()
 	m_maincpu->reset();
 
 	timer_device *sound_timer = subdevice<timer_device>("sound_timer");
-	sound_timer->adjust(attotime::from_msec(10));
+	sound_timer->adjust(attotime::from_msec(AD1847_SAMPLE_DELAY));
 
 	m_dmadac[0]->enable(1);
 	m_dmadac[1]->enable(1);
@@ -1818,15 +1663,38 @@ void mediagx_state::ramdac_map(address_map &map)
 	map(0x000, 0x3ff).rw(m_ramdac, FUNC(ramdac_device::ramdac_pal_r), FUNC(ramdac_device::ramdac_rgb666_w));
 }
 
+// TODO, Esc key still doesn't work for closing down the emulator, that should always exit out
+
 void mediagx_state::mediagx(machine_config &config)
 {
 	/* basic machine hardware */
 	//MEDIAGX(config, m_maincpu, 244000000);
-	//MEDIAGX(config, m_maincpu, 222000000);
+	// MEDIAGX(config, m_maincpu, 222000000);
 	// Speeds up the CPU execution speed...not necessarily what I want here, but could be nice
 	// tried 222000000, sped it up a lot,, but sound is borked :?
-	MEDIAGX(config, m_maincpu, 166000000);
-	// Program mapping?
+
+	// uint lvl = (166000000 - 38456666) / 2;
+	// MEDIAGX(config, m_maincpu, 166000000);
+	// tried this speed to match the DAC, which means that the inverse is likely true as well? Audio needs to be greatly changed?
+	// audio worked great, but the game was too fast
+	// 38456556 ~~~ good
+	// 38456666.6666667 ~~~ also good
+	MEDIAGX(config, m_maincpu, 38456666);
+
+	/*
+	...Some other notes here
+	Type raster, resolution 640×240@60 Hz, CRT 15kHz, gameplay box  (0,0)÷(640,240), display box  640×480, pixel clock @18.432 MHz
+Orientation:
+Horizontal
+Scrolling:
+Unknown
+Colors:
+-
+CPU:
+maincpu Cyrix MediaGX @166 MHz, dma8237_1 AM9517A @4.772727 MHz, dma8237_2 AM9517A @4.772727 MHz
+	*/
+
+	// Program mapping
 	m_maincpu->set_addrmap(AS_PROGRAM, &mediagx_state::mediagx_map);
 	// Map address regions to I/O
 	m_maincpu->set_addrmap(AS_IO, &mediagx_state::mediagx_io);
@@ -1853,14 +1721,51 @@ void mediagx_state::mediagx(machine_config &config)
 	// m_screen->set_refresh_hz(13.9); // 60
 	// somewhere between 13.9 and 13.9375 (maybe 14) is the sweet spot
 	// seems like something around 13.91 or 13.92 could be really on point.
-	m_screen->set_refresh_hz(13.9); // 60
+	// m_screen->set_refresh_hz(13.9); // 60
+	// m_screen->set_refresh_hz(73.9);
+	m_screen->set_refresh_hz(61);
+	// 120 hits a good spot for the main (with -afs)
+	// 120 does flash, which is quite cool actually
+	// 61 or 30 is good for minigames
+	// still 13.9 w/ full 166MHz
+
+	// fiddling with raw values, kinda working
+	// ~~~~ increasing pxl clock slowly here...fixing the rest
+	// m_screen->set_raw(17992, 3, 0, 360, 480, 240, 0);
+
+	// hbend should be 0
+	// hbstart should be 640
+	// vbend should also be 0
+	// vbstart should be 240
+	// TODO Use this
+	// m_screen->set_raw(18432000, 640, 0, 640, 480, 0, 240);
+	// 3 - 4 ?
+	// m_screen->set_raw(3100000, 640, 0, 640, 480, 0, 240);
+	// TODO VERY CLOSE! NEED BETTER TIMINGS ON THE SOUND TIMER DELAY TO PROCEED
+	// Nov. 18th, 2022: This was one of the closer times, rest is OK
+	// m_screen->set_raw(3611500, 640, 0, 640, 480, 0, 240);
+	// m_screen->set_raw(18432000/4.7, 640, 0, 360, 480, 0, 240);
+
+
+	// TODO leads to a flash with 166MHZ cpu as well!
+	// m_screen->set_raw(18432000 * 4, 640, 0, 640, 480, 0, 240);
+
+
+
+	// m_screen->set_raw(38456666, 3800, 0, 360, 480, 240, 0);
+	// m_screen->set_raw(18432000/2, 456, 42, 402, 262, 17, 257);
+	// slow but smooth
+	// m_screen->set_raw(18432000, 3800, 0, 360, 480, 0, 240);
+	// with flash!
+	// m_screen->set_raw(18432000, 500, 360, 0, 248, 248, 0);
 
 	// todo, just trying some little things here
-	//m_screen->set_video_attributes(VIDEO_UPDATE_AFTER_VBLANK);
-	//m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(5500)); // not accurate
+	// m_screen->set_video_attributes(VIDEO_UPDATE_AFTER_VBLANK);
+	// m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(5500)); // not accurate
 
-	m_screen->set_size(640, 480);
-	m_screen->set_visarea(0, 639, 0, 239);
+	// TODO blocked off this part, as it should be set in the 'set_raw' function instead
+	// m_screen->set_size(640, 480);
+	// m_screen->set_visarea(0, 639, 0, 239);
 
 	m_screen->set_screen_update(FUNC(mediagx_state::screen_update));
 

--- a/src/mame/atari/mediagx.cpp
+++ b/src/mame/atari/mediagx.cpp
@@ -7,7 +7,7 @@
 
 /*
     Main Board number: P5GX-LG REV:1.1
-		A-22540 CPU Board Assembly
+        A-22540 CPU Board Assembly
 
     Components list on MAIN board, clockwise from top left.
     ----------------------------
@@ -30,8 +30,8 @@
     AD 706 (SOIC8)
     15 PIN VGA CONNECTOR (DSUB15, plugged into custom Atari board)
     25 PIN PARALLEL CONNECTOR (DSUB25, plugged into custom Atari board)
-			Data Signal bus with the Custom Atari board
-			* Only 17 pins used in manual, but appears to be a 25-pin connector
+            Data Signal bus with the Custom Atari board
+            * Only 17 pins used in manual, but appears to be a 25-pin connector
 
     ICS9120 (SOIC8)
     AD706 (SOIC8)
@@ -46,7 +46,7 @@
 
 
     Custom Atari board number: ATARI GAMES INC. 5772-15642-02 JAMMIT
-		04-11238 JAMMIT PCB Assembly
+        04-11238 JAMMIT PCB Assembly
 
     Components list on custom Atari board, clockwise from top left.
     -------------------------------------
@@ -56,8 +56,8 @@
     4 PIN POWER CONNECTOR for IDE Hard Drive
     15 PIN VGA CONNECTOR (DSUB15, plugged into MAIN board)
     25 PIN PARALLEL CONNECTOR (DSUB25, plugged into MAIN board)
-			Data Signal bus with the CPU (Main) Board Assembly
-			* Only 17 pins used in manual
+            Data Signal bus with the CPU (Main) Board Assembly
+            * Only 17 pins used in manual
 
     AD 813AR (x2, SOIC14)
     ST 084C P1S735 (x2, SOIC14)
@@ -67,10 +67,10 @@
     3 PIN JUMPER for SYNC (Set to -, alternative setting is +)
     OSC 14.31818MHz
     ACTEL A42MX09 (PLCC84, labelled 'JAMMINT U6 A-22505 (C)1996 ATARI')
-			Designation: 	U6
-			Part #: 			A-22505
-			Function: 		Gun control and security
-			Description: 	FPGA Assembly
+            Designation:    U6
+            Part #:             A-22505
+            Function:       Gun control and security
+            Description:    FPGA Assembly
     LS14 (SOIC14)
     74F244 (x2, SOIC20)
     ST ULN2064B (DIP16)
@@ -884,7 +884,7 @@ void mediagx_state::parallel_port_w(offs_t offset, uint32_t data, uint32_t mem_m
 {
 	// update parport registers together, DATA, STATUS, and CONTROL
 	// Can be seen like so: 0xCC SS DD
-	// 		where C = Control nibble, S = Status nibble, D = Data nibble
+	//      where C = Control nibble, S = Status nibble, D = Data nibble
 	COMBINE_DATA( &m_parport );
 
 	if (ACCESSING_BITS_0_7)
@@ -1108,9 +1108,9 @@ void mediagx_state::mediagx_map(address_map &map)
 
 // Maps address ranges to I/O Functions
 // These IO functions are defined for the MediaGX device specifically
-// Larger IO port list:				https://bochs.sourceforge.io/techspec/PORTS.LST
-// Programmaable Interrupt Timer:	https://wiki.osdev.org/PIT#I.2F0_Ports
-// Typical port usages: 			https://wiki.osdev.org/I/O_Ports
+// Larger IO port list:             https://bochs.sourceforge.io/techspec/PORTS.LST
+// Programmaable Interrupt Timer:   https://wiki.osdev.org/PIT#I.2F0_Ports
+// Typical port usages:             https://wiki.osdev.org/I/O_Ports
 void mediagx_state::mediagx_io(address_map &map)
 {
 	pcat32_io_common(map);


### PR DESCRIPTION
First time committer. I was working on this driver for a good portion of last year, and never got around to putting a PR up. The driver still needs to be 'modernized', and uses some older approaches that need to be phased out -- to my understanding. Still, I figured it's helpful to share this and see if it's possible to add it in, or at least iterate from this point forward.
...

This PR adds input handling support for the atari/mediagx driver. Previously the machine was flagged as not working, and was capable of starting up with no real functionality. This PR implements a functional (but still incomplete) mapping for handling inputs properly. In practice this allows starting up & running a51site4  (albeit with performance limitations).

The changes include:
- P1/P2 start buttons work
- P1/P2 coin insertions work
- P1/P2 JGun X/Y tracking & triggers work (but JGuns may need to be calibrated in test menu first)
- Test/Diagnostic menu can be accessed as expected

As a result, a51site4 can be run and played (provided you have the hardware to mitigate performance issues).

Limitations:
- Emulation speed is inconsistent at times, sometimes slowing down or speeding up depending on the computational complexity at hand. Not the worst issue, but something to keep in mind.
- Performance varies based on your hardware, same as before essentially, but overall not very performant. Testing this on some newer hardware (an M1) produced buttery smooth results, but an older machine struggled to even do seconds per frame at times.
- Audio is really bad. It's playing in short fragments, very clippy, not so great. I did play around with the CPU clock rate in an attempt to see if the audio would come out clean (dropping it to some absurdly low values), and it did come out perfectly clean; however that's not really a fix and was just an experiment. I think the sound timer for the AD1847 can be adjusted to rectify this properly, but that's as far I got there.
- Emulator has to be manually stopped (ESC is not bound correctly yet). This is more of a limitation on my understanding on how to do this properly.
- Coin insertion doesn't work without a double tap most of the time, but beyond that works fine.
- Coin tracking is not quite right, i.e. statistics are logged mostly under slot 1, likely needs further refinement.
- Muzzle flash is absent (almost had it at one point with the state logic, but got a bit hairy to keep other things working as expected).
- Saving is still not supported.
