### PR TITLE
refactor chdman extractcd to allow split .bin/.cue output

### DIFF
--- a/docs/man/chdman.1
+++ b/docs/man/chdman.1
@@ -2,11 +2,11 @@
 .\"
 .\" chdman.1
 .\"
-.\" Man page created from source and usage information by 
+.\" Man page created from source and usage information by
 .\" Ashley T. Howes <debiandev@ashleyhowes.com>, February 2005
 .\" updated by Cesare Falco <c.falco@ubuntu.com>, February 2007
 .\"
-.TH CHDMAN 1 2016-07-21 0.176 "MAME Compressed Hunks of Data (CHD) manager"
+.TH CHDMAN 1 2023-11-12 0.261 "MAME Compressed Hunks of Data (CHD) manager"
 .\"
 .\" NAME chapter
 .SH NAME
@@ -84,6 +84,15 @@ Create a new compressed hard disk image from a raw file.
 [\fB\-np \fIprocessors\fR]
 Create a new compressed CD image from a raw file.
 .TP
+.B createdvd \
+\-o \fIfilename\fR \
+[\fB\-op \fIfilename\fR] \
+[\fB\-f\fR] \
+\fB\-i \fIfilename\fR \
+[\fB\-c none\fR|type1[,[...]]] \
+[\fB\-np \fIprocessors\fR]
+Create a new compressed DVD image from a raw file.
+.TP
 .B createld \
 \-o \fIfilename\fR \
 [\fB\-op \fIfilename\fR] \
@@ -121,10 +130,18 @@ Extract a hard disk block image from a CHD image.
 .B extractcd \
 \-o \fIfilename\fR \
 [\fB\-ob \fIfilename\fR] \
+[\fB\-os\fR] \
 [\fB\-f\fR] \
 \fB\-i \fIfilename\fR \
 [\fB\-ip \fIfilename\fR]
 Extract a CDRDAO .toc/.bin, CDRWIN .bin/.cue, or Sega Dreamcast .GDI file from a CHD\-CD image.
+.TP
+.B extractdvd \
+\-o \fIfilename\fR \
+[\fB\-f\fR] \
+\fB\-i \fIfilename\fR \
+[\fB\-ip \fIfilename\fR]
+Extract a DVD image from a CHD\-DVD image.
 .TP
 .B extractld \
 \-o \fIfilename\fR \
@@ -203,7 +220,7 @@ Effective length of the input in bytes.
 .TP
 .B \-\-inputframes, \-if \fIlength
 Effective length of the input in frames.
-.TP                              
+.TP
 .B \-\-inputhunks, \-ih \fIlength
 Effective length of the input in hunks.
 .TP
@@ -230,6 +247,11 @@ Output file name.
 .TP
 .B \-\-outputbin, \-ob \fIfilename
 Output binary file name for extractcd.
+.TP
+.B \-\-splitcue, \-os
+When using extractcd, write CDRWIN .bin/.cue format with individual data files for each track, using
+.B \-ob
+as a base name and extension if provided.
 .TP
 .B \-\-outputparent, \-op \fIfilename
 Parent CHD's output file name.


### PR DESCRIPTION
My partial solution to #5867 (only partial because it doesn't fix round-trip support fully, such as #10308).
Full list of things this does to `chdman`:
- Adds a `-os`/`--splitcue` option to `extractcd` to force output to `.cue` mode and output individual `.bin`s, naming them `basename (Track n).bin` if there is more than 1 track.
  - `n` will be 1 digit if there are less than 10 tracks in the CD, 2 digits otherwise.
  - `.bin` will be replaced by the file extension specified by `-ob`/`--outputbin` if applicable.
  - Its short name is `-os` in case the existing `-s`/`--size` option is used for `extractcd` in future.
- This new method also applies to `.gdi` output. Should I change this?
  - Output filenames will be different: no longer outputs audio files as `.raw`, format is as above instead of just appending the track number as 2 digits.
  - Deletes all bin files on error instead of just the last one before the error.
  - The percentage of completion no longer resets to 0 for each track, so it will actually say near 100% at completion.
- Checks output filename ends with `.cue` or `.gdi`, case insensitive, instead of just doing a case sensitive search for them anywhere in the filename.
- Removes unused `-ob`/`--outputbin` option from `extractdvd`.
- Updates its manpage, adding the missing `createdvd` and `extractdvd` documentation too.

Tell me if any changes should be made :)