### PR TITLE
tms32025 neg instruction accidentally modifies ST0 instead of ST1

### DIFF
--- a/src/devices/cpu/tms32025/tms32025.cpp
+++ b/src/devices/cpu/tms32025/tms32025.cpp
@@ -1178,8 +1178,8 @@ void tms32025_device::neg()
 		if (OVM) m_ACC.d = 0x7fffffff;
 	}
 	else m_ACC.d = -m_ACC.d;
-	if (m_ACC.d) CLR0(C_FLAG);
-	else SET0(C_FLAG);
+	if (m_ACC.d) CLR1(C_FLAG);
+	else SET1(C_FLAG);
 }
 /*
 void tms32025_device::nop() { }   // NOP is a subset of the MAR instruction


### PR DESCRIPTION
The tms32025.cpp neg instruction, as coded, accidentally modifies ST0 instead of ST1.
The instruction should be modifying the C bit (in ST1) but the code calls SET0(C_FLAG) when it should call SET1(C_FLAG).
C_FLAG refers to a bit in ST1, not in ST0. 
Calling CLR0(C_FLAG) or SET0(C_FLAG) modifies ST0's INTM bit instead of ST1's C bit.

Reviewing the rest of the tms32025.cpp code, CLR1(C_FLAG) and SET1(C_FLAG) are used everywhere else.
