### PR TITLE
seibu/dynduke.cpp: Use single-pass sprite rendering, Minor cleanups

### DIFF
--- a/src/mame/seibu/dynduke.cpp
+++ b/src/mame/seibu/dynduke.cpp
@@ -229,7 +229,7 @@ INPUT_PORTS_END
 static const gfx_layout charlayout =
 {
 	8,8,        /* 8*8 characters */
-	RGN_FRAC(1,2),
+	RGN_FRAC(1,1),
 	4,          /* 4 bits per pixel */
 	{ STEP4_INV(0, 4) },
 	{ STEP4(0, 1), STEP4(4*4, 1) },

--- a/src/mame/seibu/dynduke.h
+++ b/src/mame/seibu/dynduke.h
@@ -10,6 +10,7 @@
 #include "video/bufsprite.h"
 
 #include "emupal.h"
+#include "screen.h"
 #include "tilemap.h"
 
 
@@ -25,9 +26,9 @@ public:
 		m_palette(*this, "palette"),
 		m_spriteram(*this, "spriteram") ,
 		m_scroll_ram(*this, "scroll_ram"),
-		m_videoram(*this, "videoram"),
-		m_back_data(*this, "back_data"),
-		m_fore_data(*this, "fore_data")
+		m_text_ram(*this, "text_ram"),
+		m_bg_ram(*this, "bg_ram"),
+		m_fg_ram(*this, "fg_ram")
 	{ }
 
 	void dynduke(machine_config &config);
@@ -41,28 +42,28 @@ private:
 	required_device<palette_device> m_palette;
 	required_device<buffered_spriteram16_device> m_spriteram;
 
-	required_shared_ptr<uint16_t> m_scroll_ram;
-	required_shared_ptr<uint16_t> m_videoram;
-	required_shared_ptr<uint16_t> m_back_data;
-	required_shared_ptr<uint16_t> m_fore_data;
+	required_shared_ptr<u16> m_scroll_ram;
+	required_shared_ptr<u16> m_text_ram;
+	required_shared_ptr<u16> m_bg_ram;
+	required_shared_ptr<u16> m_fg_ram;
 
 	tilemap_t *m_bg_layer = nullptr;
 	tilemap_t *m_fg_layer = nullptr;
 	tilemap_t *m_tx_layer = nullptr;
-	int m_back_bankbase = 0;
-	int m_fore_bankbase = 0;
-	int m_back_enable = 0;
-	int m_fore_enable = 0;
-	int m_sprite_enable = 0;
-	int m_txt_enable = 0;
-	int m_old_back = 0;
-	int m_old_fore = 0;
+	u32 m_back_bankbase = 0;
+	u32 m_fore_bankbase = 0;
+	bool m_back_enable = false;
+	bool m_fore_enable = false;
+	bool m_sprite_enable = false;
+	bool m_txt_enable = false;
+	u32 m_old_back = 0;
+	u32 m_old_fore = 0;
 
-	void background_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void foreground_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void text_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void gfxbank_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void control_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void background_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void foreground_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void text_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void gfxbank_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void control_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
 	TILE_GET_INFO_MEMBER(get_bg_tile_info);
 	TILE_GET_INFO_MEMBER(get_fg_tile_info);
@@ -70,9 +71,9 @@ private:
 
 	virtual void video_start() override;
 
-	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	void draw_sprites(bitmap_ind16 &bitmap,const rectangle &cliprect,int pri);
-	void draw_background(bitmap_ind16 &bitmap, const rectangle &cliprect, int pri );
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	void draw_background(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int pri, u32 pri_mask);
 
 	void vblank_irq(int state);
 	void master_map(address_map &map);

--- a/src/mame/seibu/dynduke_v.cpp
+++ b/src/mame/seibu/dynduke_v.cpp
@@ -7,54 +7,54 @@
 
 /******************************************************************************/
 
-void dynduke_state::background_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void dynduke_state::background_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_back_data[offset]);
+	COMBINE_DATA(&m_bg_ram[offset]);
 	m_bg_layer->mark_tile_dirty(offset);
 }
 
-void dynduke_state::foreground_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void dynduke_state::foreground_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_fore_data[offset]);
+	COMBINE_DATA(&m_fg_ram[offset]);
 	m_fg_layer->mark_tile_dirty(offset);
 }
 
-void dynduke_state::text_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void dynduke_state::text_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_videoram[offset]);
+	COMBINE_DATA(&m_text_ram[offset]);
 	m_tx_layer->mark_tile_dirty(offset);
 }
 
 TILE_GET_INFO_MEMBER(dynduke_state::get_bg_tile_info)
 {
-	int tile=m_back_data[tile_index];
-	int color=tile >> 12;
+	u32 tile = m_bg_ram[tile_index];
+	const u32 color = BIT(tile, 12, 4);
 
-	tile=tile&0xfff;
+	tile = tile & 0xfff;
 
 	tileinfo.set(1,
-			tile+m_back_bankbase,
+			tile + m_back_bankbase,
 			color,
 			0);
 }
 
 TILE_GET_INFO_MEMBER(dynduke_state::get_fg_tile_info)
 {
-	int tile=m_fore_data[tile_index];
-	int color=tile >> 12;
+	u32 tile = m_fg_ram[tile_index];
+	const u32 color = BIT(tile, 12, 4);
 
-	tile=tile&0xfff;
+	tile = tile & 0xfff;
 
 	tileinfo.set(2,
-			tile+m_fore_bankbase,
+			tile + m_fore_bankbase,
 			color,
 			0);
 }
 
 TILE_GET_INFO_MEMBER(dynduke_state::get_tx_tile_info)
 {
-	int tile=m_videoram[tile_index];
-	int color=(tile >> 8) & 0x0f;
+	u32 tile = m_text_ram[tile_index];
+	const u32 color = BIT(tile, 8, 4);
 
 	tile = (tile & 0xff) | ((tile & 0xc000) >> 6);
 
@@ -83,25 +83,25 @@ void dynduke_state::video_start()
 	save_item(NAME(m_old_fore));
 }
 
-void dynduke_state::gfxbank_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void dynduke_state::gfxbank_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (ACCESSING_BITS_0_7)
 	{
-		if (data&0x01) m_back_bankbase=0x1000; else m_back_bankbase=0;
-		if (data&0x10) m_fore_bankbase=0x1000; else m_fore_bankbase=0;
+		m_back_bankbase = BIT(data, 0) ? 0x1000 : 0;
+		m_fore_bankbase = BIT(data, 4) ? 0x1000 : 0;
 
-		if (m_back_bankbase!=m_old_back)
+		if (m_back_bankbase != m_old_back)
 			m_bg_layer->mark_all_dirty();
-		if (m_fore_bankbase!=m_old_fore)
+		if (m_fore_bankbase != m_old_fore)
 			m_fg_layer->mark_all_dirty();
 
-		m_old_back=m_back_bankbase;
-		m_old_fore=m_fore_bankbase;
+		m_old_back = m_back_bankbase;
+		m_old_fore = m_fore_bankbase;
 	}
 }
 
 
-void dynduke_state::control_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void dynduke_state::control_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (ACCESSING_BITS_0_7)
 	{
@@ -114,53 +114,84 @@ void dynduke_state::control_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 		// bit 0x02 is used on the map screen (fore disable?)
 		// bit 0x01 set when inserting coin.. bg disable?
 
-		if (data&0x1) m_back_enable = 0; else m_back_enable = 1;
-		if (data&0x2) m_fore_enable=0; else m_fore_enable=1;
-		if (data&0x4) m_txt_enable = 0; else m_txt_enable = 1;
-		if (data&0x8) m_sprite_enable=0; else m_sprite_enable=1;
+		m_back_enable = BIT(~data, 0);
+		m_fore_enable = BIT(~data, 1);
+		m_txt_enable = BIT(~data, 2);
+		m_sprite_enable = BIT(~data, 3);
 
-		flip_screen_set(data & 0x40);
+		flip_screen_set(BIT(data, 6));
 	}
 }
 
-void dynduke_state::draw_sprites(bitmap_ind16 &bitmap,const rectangle &cliprect,int pri)
+/*
+
+    Sprite format (8 bytes per sprite)
+
+Offset  Bit                 Description
+        fedc ba98 7654 3210 
+00      x--- ---- ---- ---- Enable
+        -x-- ---- ---- ---- Flip Y
+        --x- ---- ---- ---- Flip X
+        ---x xxxx ---- ---- Palette select (16 colour each)
+        ---- ---- xxxx xxxx Y coordinate
+
+02      --xx xxxx xxxx xxxx Tile index
+
+04      -xx- ---- ---- ---- Priority select
+        ---- ---s xxxx xxxx X coordinate
+
+06      Unused?
+
+*/
+void dynduke_state::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t *buffered_spriteram16 = m_spriteram->buffer();
-	int offs,fx,fy,x,y,color,sprite;
+	u16 const *const spriteram = m_spriteram->buffer();
+
+	constexpr u32 pri_mask[4] = {
+		GFX_PMASK_8 | GFX_PMASK_4 | GFX_PMASK_2, // Untested: does anything use it? Could be behind background
+		GFX_PMASK_8 | GFX_PMASK_4 | GFX_PMASK_2,
+		GFX_PMASK_8 | GFX_PMASK_4,
+		GFX_PMASK_8,
+	};
 
 	if (!m_sprite_enable) return;
 
-	for (offs = 0x800-4;offs >= 0;offs -= 4)
+	for (int offs = 0; offs < 0x800; offs += 4)
 	{
 		/* Don't draw empty sprite table entries */
-		if ((buffered_spriteram16[offs+3] >> 8)!=0xf) continue;
-		if (((buffered_spriteram16[offs+2]>>13)&3)!=pri) continue;
+		if (!BIT(spriteram[offs + 0], 15))
+			continue;
 
-		fx= buffered_spriteram16[offs+0]&0x2000;
-		fy= buffered_spriteram16[offs+0]&0x4000;
-		y = buffered_spriteram16[offs+0] & 0xff;
-		x = buffered_spriteram16[offs+2] & 0xff;
+		const u8 pri = BIT(spriteram[offs + 2], 13, 2);
 
-		if (buffered_spriteram16[offs+2]&0x100) x=0-(0x100-x);
+		bool fx = BIT(spriteram[offs + 0], 13);
+		bool fy = BIT(spriteram[offs + 0], 14);
+		s32 y = BIT(spriteram[offs + 0], 0, 8);
+		s32 x = BIT(spriteram[offs + 2], 0, 9);
 
-		color = (buffered_spriteram16[offs+0]>>8)&0x1f;
-		sprite = buffered_spriteram16[offs+1];
-		sprite &= 0x3fff;
+		if (BIT(x, 8)) x |= ~0x1ff;
+
+		const u32 color = BIT(spriteram[offs + 0], 8, 5);
+		const u32 sprite = BIT(spriteram[offs + 1], 0, 14);
 
 		if (flip_screen()) {
-			x=240-x;
-			y=240-y;
-			if (fx) fx=0; else fx=1;
-			if (fy) fy=0; else fy=1;
+			x = 240 - x;
+			y = 240 - y;
+			fx = !fx;
+			fy = !fy;
 		}
 
-		m_gfxdecode->gfx(3)->transpen(bitmap,cliprect,
+		m_gfxdecode->gfx(3)->prio_transpen(
+				bitmap, cliprect,
 				sprite,
-				color,fx,fy,x,y,15);
+				color,
+				fx, fy,
+				x, y,
+				screen.priority(), pri_mask[pri], 15);
 	}
 }
 
-void dynduke_state::draw_background(bitmap_ind16 &bitmap, const rectangle &cliprect, int pri )
+void dynduke_state::draw_background(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int pri, u32 pri_mask)
 {
 	/* The transparency / palette handling on the background layer is very strange */
 	bitmap_ind16 &bm = m_bg_layer->pixmap();
@@ -171,8 +202,8 @@ void dynduke_state::draw_background(bitmap_ind16 &bitmap, const rectangle &clipr
 		return;
 	}
 
-	int scrolly = ((m_scroll_ram[0x01]&0x30)<<4)+((m_scroll_ram[0x02]&0x7f)<<1)+((m_scroll_ram[0x02]&0x80)>>7);
-	int scrollx = ((m_scroll_ram[0x09]&0x30)<<4)+((m_scroll_ram[0x0a]&0x7f)<<1)+((m_scroll_ram[0x0a]&0x80)>>7);
+	int scrolly = ((m_scroll_ram[0x01] & 0x30) << 4) + ((m_scroll_ram[0x02] & 0x7f) << 1)+((m_scroll_ram[0x02] & 0x80) >> 7);
+	int scrollx = ((m_scroll_ram[0x09] & 0x30) << 4) + ((m_scroll_ram[0x0a] & 0x7f) << 1)+((m_scroll_ram[0x0a] & 0x80) >> 7);
 
 	if (flip_screen())
 	{
@@ -180,17 +211,17 @@ void dynduke_state::draw_background(bitmap_ind16 &bitmap, const rectangle &clipr
 		scrollx = 256 - scrollx;
 	}
 
-	for (int y=0;y<256;y++)
+	for (int y = cliprect.top(); y <= cliprect.bottom(); y++)
 	{
-		int realy = (y + scrolly) & 0x1ff;
-		uint16_t const *const src = &bm.pix(realy);
-		uint16_t *const dst = &bitmap.pix(y);
+		const u16 realy = (y + scrolly) & 0x1ff;
+		u16 const *const src = &bm.pix(realy);
+		u16 *const dst = &bitmap.pix(y);
+		u8 *const pdst = &screen.priority().pix(y);
 
-
-		for (int x=0;x<256;x++)
+		for (int x = cliprect.left(); x <= cliprect.right(); x++)
 		{
-			int realx = (x + scrollx) & 0x1ff;
-			uint16_t srcdat = src[realx];
+			const u16 realx = (x + scrollx) & 0x1ff;
+			u16 srcdat = src[realx];
 
 			/* 0x01 - data bits
 			   0x02
@@ -208,31 +239,28 @@ void dynduke_state::draw_background(bitmap_ind16 &bitmap, const rectangle &clipr
 
 				srcdat = (srcdat & 0x000f) | ((srcdat & 0xffc0) >> 2);
 				dst[x] = srcdat;
+				pdst[x] |= pri_mask;
 			}
-
-
 		}
 	}
 }
 
-uint32_t dynduke_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+u32 dynduke_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
+	screen.priority().fill(0, cliprect);
+
 	/* Setup the tilemaps */
-	m_fg_layer->set_scrolly(0, ((m_scroll_ram[0x11]&0x30)<<4)+((m_scroll_ram[0x12]&0x7f)<<1)+((m_scroll_ram[0x12]&0x80)>>7) );
-	m_fg_layer->set_scrollx(0, ((m_scroll_ram[0x19]&0x30)<<4)+((m_scroll_ram[0x1a]&0x7f)<<1)+((m_scroll_ram[0x1a]&0x80)>>7) );
+	m_fg_layer->set_scrolly(0, ((m_scroll_ram[0x11] & 0x30) << 4) + ((m_scroll_ram[0x12] & 0x7f) << 1) + ((m_scroll_ram[0x12] & 0x80) >> 7));
+	m_fg_layer->set_scrollx(0, ((m_scroll_ram[0x19] & 0x30) << 4) + ((m_scroll_ram[0x1a] & 0x7f) << 1) + ((m_scroll_ram[0x1a] & 0x80) >> 7));
 	m_fg_layer->enable(m_fore_enable);
 	m_tx_layer->enable(m_txt_enable);
 
+	draw_background(screen, bitmap, cliprect, 0x00, 1);
+	draw_background(screen, bitmap, cliprect, 0x20, 2);
+	m_fg_layer->draw(screen, bitmap, cliprect, 0, 4);
+	m_tx_layer->draw(screen, bitmap, cliprect, 0, 8);
 
-	draw_background(bitmap, cliprect,0x00);
-	draw_sprites(bitmap,cliprect,0); // Untested: does anything use it? Could be behind background
-	draw_sprites(bitmap,cliprect,1);
-	draw_background(bitmap, cliprect,0x20);
-
-	draw_sprites(bitmap,cliprect,2);
-	m_fg_layer->draw(screen, bitmap, cliprect, 0,0);
-	draw_sprites(bitmap,cliprect,3);
-	m_tx_layer->draw(screen, bitmap, cliprect, 0,0);
+	draw_sprites(screen, bitmap, cliprect);
 
 	return 0;
 }


### PR DESCRIPTION
Rename tilemap related RAM and ROM regions
use BIT for bitfield
Use shorter/correct type values
Minor cleanup gfxdecode
Add notes
Fix spacing