### PR TITLE
heathkit/tlb.cpp: Fix reset handling for slot device imaginator

### DIFF
--- a/src/mame/heathkit/tlb.cpp
+++ b/src/mame/heathkit/tlb.cpp
@@ -1520,6 +1520,8 @@ void heath_imaginator_tlb_device::device_start()
 
 void heath_imaginator_tlb_device::device_reset()
 {
+	heath_tlb_device::device_reset();
+
 	m_mem_map = 1;
 
 	m_mem_view.select(m_mem_map);


### PR DESCRIPTION
imaginator's `device_reset()` was missing a call to the base class device_reset.