### PR TITLE
HD44780A00, KS0066_F00, SED1278_0B: fix errors in the ROM transcriptions from the datasheets. Add HD44780UA00 and HD44780UA02 variant devices. [Lord Nightmare]

### DIFF
--- a/src/devices/bus/bbc/userport/lcd.cpp
+++ b/src/devices/bus/bbc/userport/lcd.cpp
@@ -37,7 +37,12 @@ void bbc_lcd_device::device_add_mconfig(machine_config &config)
 
 	PALETTE(config, "palette", FUNC(bbc_lcd_device::lcd_palette), 3);
 
-	HD44780(config, m_lcdc, 250'000); // TODO: clock not measured, datasheet typical clock used
+	HD44780(config, m_lcdc, 122'427); // This uses a standard Hitachi LM044L
+	// LCD module, which uses an HD44780A00 clocked using its internal
+	// oscillator, using a "204" (200KOhm) Rf resistor. At 5V this should
+	// oscillate at around 1 / (2 * PI * resistance * 6.5pF) Hz.
+	// This is quite slow compared to the recommended datasheet clock speed,
+	// but is verified from pictures of an original Hitachi LM044L Module.
 	m_lcdc->set_lcd_size(4, 20);
 	m_lcdc->set_pixel_update_cb(FUNC(bbc_lcd_device::lcd_pixel_update));
 }

--- a/src/devices/video/hd44780.cpp
+++ b/src/devices/video/hd44780.cpp
@@ -22,10 +22,12 @@
 //  DEVICE DEFINITIONS
 //**************************************************************************
 
-DEFINE_DEVICE_TYPE(HD44780,    hd44780_device,    "hd44780_a00", "Hitachi HD44780 A00 LCD Controller")
-DEFINE_DEVICE_TYPE(SED1278_0B, sed1278_0b_device, "sed1278_0b",  "Epson SED1278-0B LCD Controller") // packaged as either SED1278F0B or SED1278D0B
-DEFINE_DEVICE_TYPE(KS0066_F00, ks0066_f00_device, "ks0066_f00",  "Samsung KS0066 F00 LCD Controller")
-DEFINE_DEVICE_TYPE(KS0066_F05, ks0066_f05_device, "ks0066_f05",  "Samsung KS0066 F05 LCD Controller")
+DEFINE_DEVICE_TYPE(HD44780,      hd44780_device,      "hd44780_a00",  "Hitachi HD44780A00 LCD Controller")
+DEFINE_DEVICE_TYPE(HD44780U_A00, hd44780u_a00_device, "hd44780u_a00", "Hitachi HD44780UA00 LCD Controller")
+//DEFINE_DEVICE_TYPE(HD44780U_A02, hd44780u_a02_device, "hd44780u_a02", "Hitachi HD44780UA02 LCD Controller")
+DEFINE_DEVICE_TYPE(SED1278_0B,   sed1278_0b_device,   "sed1278_0b",   "Epson SED1278-0B LCD Controller") // packaged as either SED1278F0B or SED1278D0B
+DEFINE_DEVICE_TYPE(KS0066_F00,   ks0066_f00_device,   "ks0066_f00",   "Samsung KS0066 F00 LCD Controller")
+DEFINE_DEVICE_TYPE(KS0066_F05,   ks0066_f05_device,   "ks0066_f05",   "Samsung KS0066 F05 LCD Controller")
 
 
 //-------------------------------------------------
@@ -34,23 +36,48 @@ DEFINE_DEVICE_TYPE(KS0066_F05, ks0066_f05_device, "ks0066_f05",  "Samsung KS0066
 
 ROM_START( hd44780_a00 )
 	ROM_REGION( 0x1000, "cgrom", 0 )
-	ROM_LOAD( "hd44780_a00.bin",    0x0000, 0x1000,  BAD_DUMP CRC(01d108e2) SHA1(bc0cdf0c9ba895f22e183c7bd35a3f655f2ca96f)) // from page 17 of the HD44780 datasheet
+	ROM_LOAD( "hd44780_a00.bin",    0x0000, 0x1000,  BAD_DUMP CRC(e459877c) SHA1(65cf075a988cdcbb316b9afdd0529b374a1a65ec)) // from page 97 of the 1985 HD44780 datasheet from crystalfontz
 ROM_END
+
+ROM_START( hd44780u_a00 )
+	ROM_REGION( 0x1000, "cgrom", 0 )
+	ROM_LOAD( "hd44780u_a00.bin",    0x0000, 0x1000,  BAD_DUMP CRC(8494cb6b) SHA1(2d4f9cf5ff81f20d2f4e4640f5b8a697a3781eef)) // from page 17 of the 1999 HD44780U datasheet
+	// this has 6 characters different from the HD44780A00
+	// this differs slightly (see the '7') from the HD44780UA00 font in the 1994 M24T026 Hitachi LCD Controller Driver LSI Data Book on bitsavers
+	// and needs confirmation from a real device as to which is correct; confirmation on the horizontal offset of the '[' would also be helpful
+ROM_END
+
+// Note the HD44780UA01 font does exist in the 1994 M24T026 Hitachi LCD Controller Driver LSI Data Book on bitsavers as well
+
+/*ROM_START( hd44780u_a02 )
+	ROM_REGION( 0x1000, "cgrom", 0 )
+	ROM_LOAD( "hd44780u_a02.bin",    0x0000, 0x1000,  BAD_DUMP CRC(6d522b42) SHA1(db8f59573c81933cfc9d3232d419406f0896e60b)) // from page 18 of the 1999 HD44780U datasheet
+	// this differs slightly (see the '7') from the HD44780UA02 font in the 1994 M24T026 Hitachi LCD Controller Driver LSI Data Book on bitsavers
+	// and needs confirmation from a real device as to which is correct
+ROM_END*/
+
+// TODO: SED1278_0A uses the exact same font as the hd44780a00
 
 ROM_START( sed1278_0b )
 	ROM_REGION( 0x1000, "cgrom", 0 )
 	ROM_LOAD( "sed1278_0b.bin",    0x0000, 0x1000,  BAD_DUMP CRC(eef342fa) SHA1(d6ac58a48e428e7cff26fb9c8ea9b4eeaa853038)) // from page 9-33 of the SED1278 datasheet
 ROM_END
 
+// TODO: many other SED1278 variants, documented in the datasheet
+
+// ks0066_f00 is 100% identical to hd44780a00, see page 61 of the KS0066 non-U datasheet
+// later ks0066 masks may be different, see page 48 of the other KS0066 datasheet
 ROM_START( ks0066_f00 )
 	ROM_REGION( 0x1000, "cgrom", 0 )
-	ROM_LOAD( "ks0066_f00.bin",    0x0000, 0x1000,  BAD_DUMP CRC(7a7d6027) SHA1(0cc77d8a028683b0e6c1b88f6f94b8801057601a)) // from page 48 of the KS0066 datasheet
+	ROM_LOAD( "ks0066_f00.bin",    0x0000, 0x1000,  BAD_DUMP CRC(e459877c) SHA1(65cf075a988cdcbb316b9afdd0529b374a1a65ec)) // from page 61 of the KS0066 non-U datasheet
 ROM_END
 
 ROM_START( ks0066_f05 )
 	ROM_REGION( 0x1000, "cgrom", 0 )
 	ROM_LOAD( "ks0066_f05.bin",    0x0000, 0x1000,  BAD_DUMP CRC(af9e7bd6) SHA1(0196e871584ee5d370856e7307c0f9d1466e3e51)) // from page 51 of the KS0066 datasheet
 ROM_END
+
+// TODO: many other KS0066 variants, documented in the datasheet
 
 //**************************************************************************
 //  live device
@@ -80,6 +107,18 @@ hd44780_device::hd44780_device(const machine_config &mconfig, device_type type, 
 {
 }
 
+hd44780u_a00_device::hd44780u_a00_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	hd44780_device(mconfig, HD44780U_A00, tag, owner, clock)
+{
+	set_charset_type(CHARSET_HD44780U_A00);
+}
+
+/*hd44780u_a02_device::hd44780u_a02_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	hd44780_device(mconfig, HD44780U_A02, tag, owner, clock)
+{
+	set_charset_type(CHARSET_HD44780U_A02);
+}*/
+
 sed1278_0b_device::sed1278_0b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	hd44780_device(mconfig, SED1278_0B, tag, owner, clock)
 {
@@ -108,6 +147,8 @@ const tiny_rom_entry *hd44780_device::device_rom_region() const
 	switch (m_charset_type)
 	{
 		case CHARSET_HD44780_A00:   return ROM_NAME( hd44780_a00 );
+		case CHARSET_HD44780U_A00:   return ROM_NAME( hd44780u_a00 );
+		//case CHARSET_HD44780U_A02:   return ROM_NAME( hd44780u_a02 );
 		case CHARSET_SED1278_0B:    return ROM_NAME( sed1278_0b );
 		case CHARSET_KS0066_F00:    return ROM_NAME( ks0066_f00 );
 		case CHARSET_KS0066_F05:    return ROM_NAME( ks0066_f05 );

--- a/src/devices/video/hd44780.cpp
+++ b/src/devices/video/hd44780.cpp
@@ -24,7 +24,7 @@
 
 DEFINE_DEVICE_TYPE(HD44780,      hd44780_device,      "hd44780_a00",  "Hitachi HD44780A00 LCD Controller")
 DEFINE_DEVICE_TYPE(HD44780U_A00, hd44780u_a00_device, "hd44780u_a00", "Hitachi HD44780UA00 LCD Controller")
-//DEFINE_DEVICE_TYPE(HD44780U_A02, hd44780u_a02_device, "hd44780u_a02", "Hitachi HD44780UA02 LCD Controller")
+DEFINE_DEVICE_TYPE(HD44780U_A02, hd44780u_a02_device, "hd44780u_a02", "Hitachi HD44780UA02 LCD Controller")
 DEFINE_DEVICE_TYPE(SED1278_0B,   sed1278_0b_device,   "sed1278_0b",   "Epson SED1278-0B LCD Controller") // packaged as either SED1278F0B or SED1278D0B
 DEFINE_DEVICE_TYPE(KS0066_F00,   ks0066_f00_device,   "ks0066_f00",   "Samsung KS0066 F00 LCD Controller")
 DEFINE_DEVICE_TYPE(KS0066_F05,   ks0066_f05_device,   "ks0066_f05",   "Samsung KS0066 F05 LCD Controller")
@@ -49,18 +49,18 @@ ROM_END
 
 // Note the HD44780UA01 font does exist in the 1994 M24T026 Hitachi LCD Controller Driver LSI Data Book on bitsavers as well
 
-/*ROM_START( hd44780u_a02 )
+ROM_START( hd44780u_a02 )
 	ROM_REGION( 0x1000, "cgrom", 0 )
 	ROM_LOAD( "hd44780u_a02.bin",    0x0000, 0x1000,  BAD_DUMP CRC(6d522b42) SHA1(db8f59573c81933cfc9d3232d419406f0896e60b)) // from page 18 of the 1999 HD44780U datasheet
 	// this differs slightly (see the '7') from the HD44780UA02 font in the 1994 M24T026 Hitachi LCD Controller Driver LSI Data Book on bitsavers
 	// and needs confirmation from a real device as to which is correct
-ROM_END*/
+ROM_END
 
-// TODO: SED1278_0A uses the exact same font as the hd44780a00
+// TODO: SED1278_0A is 100% identical to hd44780a00, see page 9-32 of the SED1278 datasheet
 
 ROM_START( sed1278_0b )
 	ROM_REGION( 0x1000, "cgrom", 0 )
-	ROM_LOAD( "sed1278_0b.bin",    0x0000, 0x1000,  BAD_DUMP CRC(eef342fa) SHA1(d6ac58a48e428e7cff26fb9c8ea9b4eeaa853038)) // from page 9-33 of the SED1278 datasheet
+	ROM_LOAD( "sed1278_0b.bin",    0x0000, 0x1000,  BAD_DUMP CRC(962498b7) SHA1(41866836ab4ed7bd4c3539bc8df492ba7d7ff42a)) // from page 9-33 of the SED1278 datasheet
 ROM_END
 
 // TODO: many other SED1278 variants, documented in the datasheet
@@ -113,11 +113,11 @@ hd44780u_a00_device::hd44780u_a00_device(const machine_config &mconfig, const ch
 	set_charset_type(CHARSET_HD44780U_A00);
 }
 
-/*hd44780u_a02_device::hd44780u_a02_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+hd44780u_a02_device::hd44780u_a02_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	hd44780_device(mconfig, HD44780U_A02, tag, owner, clock)
 {
 	set_charset_type(CHARSET_HD44780U_A02);
-}*/
+}
 
 sed1278_0b_device::sed1278_0b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	hd44780_device(mconfig, SED1278_0B, tag, owner, clock)
@@ -147,8 +147,8 @@ const tiny_rom_entry *hd44780_device::device_rom_region() const
 	switch (m_charset_type)
 	{
 		case CHARSET_HD44780_A00:   return ROM_NAME( hd44780_a00 );
-		case CHARSET_HD44780U_A00:   return ROM_NAME( hd44780u_a00 );
-		//case CHARSET_HD44780U_A02:   return ROM_NAME( hd44780u_a02 );
+		case CHARSET_HD44780U_A00:  return ROM_NAME( hd44780u_a00 );
+		case CHARSET_HD44780U_A02:  return ROM_NAME( hd44780u_a02 );
 		case CHARSET_SED1278_0B:    return ROM_NAME( sed1278_0b );
 		case CHARSET_KS0066_F00:    return ROM_NAME( ks0066_f00 );
 		case CHARSET_KS0066_F05:    return ROM_NAME( ks0066_f05 );

--- a/src/devices/video/hd44780.h
+++ b/src/devices/video/hd44780.h
@@ -71,7 +71,7 @@ protected:
 	{
 		CHARSET_HD44780_A00,
 		CHARSET_HD44780U_A00,
-		//CHARSET_HD44780U_A02,
+		CHARSET_HD44780U_A02,
 		CHARSET_SED1278_0B,
 		CHARSET_KS0066_F00,
 		CHARSET_KS0066_F05 /*,
@@ -154,12 +154,12 @@ public:
 
 // ======================> hd44780u_a02_device
 
-/*class hd44780u_a02_device :  public hd44780_device
+class hd44780u_a02_device :  public hd44780_device
 {
 public:
 	// construction/destruction
 	hd44780u_a02_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-};*/
+};
 
 // ======================> sed1278_0b_device
 
@@ -191,7 +191,7 @@ public:
 // device type definition
 DECLARE_DEVICE_TYPE(HD44780,      hd44780_device)
 DECLARE_DEVICE_TYPE(HD44780U_A00, hd44780u_a00_device)
-//DECLARE_DEVICE_TYPE(HD44780U_A02, hd44780u_a02_device)
+DECLARE_DEVICE_TYPE(HD44780U_A02, hd44780u_a02_device)
 DECLARE_DEVICE_TYPE(SED1278_0B,   sed1278_0b_device)
 DECLARE_DEVICE_TYPE(KS0066_F00,   ks0066_f00_device)
 DECLARE_DEVICE_TYPE(KS0066_F05,   ks0066_f05_device)

--- a/src/devices/video/hd44780.h
+++ b/src/devices/video/hd44780.h
@@ -70,11 +70,13 @@ protected:
 	enum
 	{
 		CHARSET_HD44780_A00,
+		CHARSET_HD44780U_A00,
+		//CHARSET_HD44780U_A02,
 		CHARSET_SED1278_0B,
 		CHARSET_KS0066_F00,
 		CHARSET_KS0066_F05 /*,
-		CHARSET_HD44780_A01,
-		CHARSET_HD44780_A02,
+		CHARSET_HD44780U_A01,
+		CHARSET_SED1278_0A,
 		CHARSET_KS0066_F03,
 		CHARSET_KS0066_F04,
 		CHARSET_KS0066_F06,
@@ -141,6 +143,24 @@ private:
 	enum        { DDRAM, CGRAM };
 };
 
+// ======================> hd44780u_a00_device
+
+class hd44780u_a00_device :  public hd44780_device
+{
+public:
+	// construction/destruction
+	hd44780u_a00_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+};
+
+// ======================> hd44780u_a02_device
+
+/*class hd44780u_a02_device :  public hd44780_device
+{
+public:
+	// construction/destruction
+	hd44780u_a02_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+};*/
+
 // ======================> sed1278_0b_device
 
 class sed1278_0b_device :  public hd44780_device
@@ -169,9 +189,11 @@ public:
 };
 
 // device type definition
-DECLARE_DEVICE_TYPE(HD44780,    hd44780_device)
-DECLARE_DEVICE_TYPE(SED1278_0B, sed1278_0b_device)
-DECLARE_DEVICE_TYPE(KS0066_F00, ks0066_f00_device)
-DECLARE_DEVICE_TYPE(KS0066_F05, ks0066_f05_device)
+DECLARE_DEVICE_TYPE(HD44780,      hd44780_device)
+DECLARE_DEVICE_TYPE(HD44780U_A00, hd44780u_a00_device)
+//DECLARE_DEVICE_TYPE(HD44780U_A02, hd44780u_a02_device)
+DECLARE_DEVICE_TYPE(SED1278_0B,   sed1278_0b_device)
+DECLARE_DEVICE_TYPE(KS0066_F00,   ks0066_f00_device)
+DECLARE_DEVICE_TYPE(KS0066_F05,   ks0066_f05_device)
 
 #endif // MAME_VIDEO_HD44780_H

--- a/src/mame/elektor/avrmax.cpp
+++ b/src/mame/elektor/avrmax.cpp
@@ -287,7 +287,7 @@ void avrmax_state::atm18mcc(machine_config &config)
 	screen.set_visarea_full();
 	screen.set_screen_update(FUNC(avrmax_state::screen_update));
 
-	HD44780(config, m_lcd, 270'000); // TODO: Wrong device type, should be HD44780U_A00; clock not measured, datasheet typical clock used
+	HD44780U_A00(config, m_lcd, 270'000); // TODO: clock not measured, datasheet typical clock used
 	config.set_default_layout(layout_atm18mcc);
 }
 

--- a/src/mame/elektor/avrmax.cpp
+++ b/src/mame/elektor/avrmax.cpp
@@ -287,7 +287,9 @@ void avrmax_state::atm18mcc(machine_config &config)
 	screen.set_visarea_full();
 	screen.set_screen_update(FUNC(avrmax_state::screen_update));
 
-	HD44780U_A00(config, m_lcd, 270'000); // TODO: clock not measured, datasheet typical clock used
+	// HD44780UA02 is required for certain international characters in cc2schach,
+	// the others can optionally use a more standard HD44780[U]A00 display
+	HD44780U_A02(config, m_lcd, 270'000); // TODO: clock not measured, datasheet typical clock used
 	config.set_default_layout(layout_atm18mcc);
 }
 

--- a/src/mame/omron/luna_88k.cpp
+++ b/src/mame/omron/luna_88k.cpp
@@ -492,7 +492,7 @@ void luna_88k_state_base::common_config(machine_config &config, XTAL clock)
 
 	BT458(config, m_ramdac, 108'992'000);
 
-	KS0066_F00(config, m_lcdc, 250'000);
+	KS0066_F00(config, m_lcdc, 270'000); // TODO: clock not measured, datasheet typical clock used
 	m_lcdc->set_function_set_at_any_time(true);
 	m_lcdc->set_lcd_size(2, 16);
 


### PR DESCRIPTION
HD44780A00: fix errors in the ROM transcription from the 1985 datasheet. [Lord Nightmare]
Added HD44780UA00 variant device with ROM transcribed from the 1999 datasheet. [Lord Nightmare]
KS0066_F00: fix errors in the ROM transcription from the datasheet, this ends up being identical to the HD44780A00 [Lord Nightmare]
Added HD44780UA02 variant device with ROM transcribed from the 1999 datasheet. [Lord Nightmare]
SED1278_0B: fix errors in the ROM transcription from the datasheet. [Lord Nightmare]