### PR TITLE
cpu/powerpc: Remove illegal instruction exception for lmw invalid form case (MT08791)

### DIFF
--- a/src/devices/cpu/powerpc/ppcfe.cpp
+++ b/src/devices/cpu/powerpc/ppcfe.cpp
@@ -290,19 +290,10 @@ bool ppc_device::frontend::describe(opcode_desc &desc, const opcode_desc *prev)
 		case 0x2e:  // LMW
 			GPR_USED_OR_ZERO(desc, G_RA(op));
 
-			if (G_RD(op) <= G_RA(op) && !(m_ppc.m_cap & PPCCAP_4XX) && !is_601_class())
+			for (regnum = G_RD(op); regnum < 32; regnum++)
 			{
-				// Undefined invalid form that has different behavior between CPUs
-				// See ppcdrc.cpp for a more detailed explanation
-				desc.flags |= OPFLAG_INVALID_OPCODE;
-			}
-			else
-			{
-				for (regnum = G_RD(op); regnum < 32; regnum++)
-				{
-					if (regnum != G_RA(op) || ((m_ppc.m_cap & PPCCAP_4XX) && regnum == 31))
-						GPR_MODIFIED(desc, regnum);
-				}
+				if (regnum != G_RA(op) || ((m_ppc.m_cap & PPCCAP_4XX) && regnum == 31))
+					GPR_MODIFIED(desc, regnum);
 			}
 			desc.flags |= OPFLAG_READS_MEMORY;
 			desc.cycles = 32 - G_RD(op);


### PR DESCRIPTION
Tested with tropchnc to make sure the original broken case is still working, as well as the landhigh and dendego3 games mentioned in the MAME testers report. landhigh gets to the title screen again and dendego3 boots to a question mark screen which is as far as it seems to go even without the invalid form checks I added in https://github.com/mamedev/mame/pull/11512.

After looking into it some more this week I saw in the 403 manuals it specifically states "The PPC403GCX executes all invalid instruction forms without causing an illegal instruction exception" (and similar for the other 403 variants). Couldn't find a direct mention of how to handle it in 60x manuals besides it just being undefined behavior, but it doesn't look like it should throw an illegal instruction exception there either based on the broken Taito PPC603-based games.