### PR TITLE
casio/cz1.cpp: fix RAM cartridge corruption, redump RC-20 ROM

### DIFF
--- a/hash/cz1_cart.xml
+++ b/hash/cz1_cart.xml
@@ -24,7 +24,7 @@ license:CC0-1.0
 		<info name="serial" value="RC-20" />
 		<part name="cart" interface="cz_cart">
 			<dataarea name="rom" size="0x4000"> <!-- restored from a sysex dump -->
-				<rom name="rc20.bin" size="0x4000" crc="c0ae5b20" sha1="38df0703d469a53f2f2af00eb94de018d7f95a73" status="baddump" />
+				<rom name="rc20.bin" size="0x4000" crc="237a2516" sha1="d1d697fbca0e16a07fa6d2710d2f7327cae81704" status="baddump" />
 			</dataarea>
 		</part>
 	</software>

--- a/src/mame/casio/cz1.cpp
+++ b/src/mame/casio/cz1.cpp
@@ -594,7 +594,7 @@ void cz1_state::main_pb_w(u8 data)
 	if (BIT(data ^ m_main_port[1], 2))
 		m_subcpu->set_input_line(UPD7810_INTF1, BIT(data, 2));
 
-	if (!BIT(data, 6) && BIT(m_main_port[1], 6) && !BIT(m_main_port[2], 2))
+	if (BIT(data, 4) && !BIT(m_main_port[1], 4) && BIT(m_main_port[1], 6))
 		m_cart->write(m_cart_addr, m_main_port[0]);
 
 	m_hd44780->e_w(BIT(~data, 7));


### PR DESCRIPTION
Sorry, one more. Apparently I had a brainfart at some point and took part of the cartridge hookup from the wrong schematic.