### PR TITLE
taito/cchance.cpp: Verify manufacturer and year of release

### DIFF
--- a/src/mame/taito/cchance.cpp
+++ b/src/mame/taito/cchance.cpp
@@ -327,4 +327,4 @@ ROM_END
 } // anonymous namespace
 
 
-GAME( 1987, cchance, 0, cchance, cchance, cchance_state, empty_init, ROT0, "Taito Corporation", "Cherry Chance", MACHINE_NOT_WORKING | MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // year/manufacturer assumed from GFX dump (not displayed)
+GAME( 1987, cchance, 0, cchance, cchance, cchance_state, empty_init, ROT0, "Taito Corporation", "Cherry Chance", MACHINE_NOT_WORKING | MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // year/manufacturer confirmed from Taito old page

--- a/src/mame/taito/cchance.cpp
+++ b/src/mame/taito/cchance.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:David Haywood, Angelo Salese
 /***************************************************************************************************************************
 
-Cherry Chance (c) 1987 Taito Corporation?
+Cherry Chance (c) 1987 Taito Corporation
 
 driver by David Haywood & Angelo Salese
 
@@ -327,4 +327,4 @@ ROM_END
 } // anonymous namespace
 
 
-GAME( 1987?, cchance, 0, cchance, cchance, cchance_state, empty_init, ROT0, "Taito Corporation?", "Cherry Chance", MACHINE_NOT_WORKING | MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // year/manufacturer assumed from GFX dump (not displayed)
+GAME( 1987, cchance, 0, cchance, cchance, cchance_state, empty_init, ROT0, "Taito Corporation", "Cherry Chance", MACHINE_NOT_WORKING | MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // year/manufacturer assumed from GFX dump (not displayed)


### PR DESCRIPTION
According to taito's past official web page ["Arcade Game History"](https://web.archive.org/web/19970624172849/http://www.taito.co.jp/AHIS80B.HTM), release year is 1987.
Cherry Chance (チェリーチャンス) can be found in the 1987 entry.