### PR TITLE
cpu/pps4/pps4.cpp: Fix typo on opcode comment [Arcade Hacker]

### DIFF
--- a/src/devices/cpu/pps4/pps4.cpp
+++ b/src/devices/cpu/pps4/pps4.cpp
@@ -978,7 +978,7 @@ void pps4_device::iT()
  * @brief pps4_device::iTM Transfer and mark indirect
  * HEX   BINARY    CYCLES  MNEMONIC
  * ----------------------------------
- * 0xc0+ 11xx xxxx      2   TM x
+ * 0xd0+ 11x1 xxxx      2   TM x
  *       yyyy yyyy  from page 3
  *
  * Symbolic equation


### PR DESCRIPTION
The code was documenting:
  iLB -  Load B indirect (0xc*)
  iTM - Transfer and mark indirect (0xc0 en el driver)

Clearly one of them is wrong. It's iTM, but it was wrong only on the comment, the implementation is good.