### PR TITLE
kaneko/kan_pand.cpp: Use device_gfx_interface for gfx decoding behavior, use correct type for variables

### DIFF
--- a/src/mame/kaneko/airbustr.cpp
+++ b/src/mame/kaneko/airbustr.cpp
@@ -436,7 +436,7 @@ void airbustr_state::screen_vblank(int state)
 
 void airbustr_state::calc1_w(offs_t offset, uint8_t data)
 {
-	offset += 0x1fe0;
+	offset += 0xfe0;
 	m_devram[offset] = data;
 
 	// CALC1 chip is 16-bit
@@ -684,6 +684,9 @@ INPUT_PORTS_END
 
 static GFXDECODE_START( gfx_airbustr )
 	GFXDECODE_ENTRY( "tiles",   0, gfx_8x8x4_row_2x2_group_packed_lsb,   0, 32 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_airbustr_spr )
 	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_row_2x2_group_packed_msb, 512, 16 )
 GFXDECODE_END
 
@@ -768,9 +771,7 @@ void airbustr_state::airbustrb(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_airbustr);
 	PALETTE(config, m_palette).set_format(palette_device::xGRB_555, 768);
 
-	KANEKO_PANDORA(config, m_pandora, 0);
-	m_pandora->set_gfx_region(1);
-	m_pandora->set_gfxdecode_tag(m_gfxdecode);
+	KANEKO_PANDORA(config, m_pandora, 0, m_palette, gfx_airbustr_spr);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/kaneko/djboy.cpp
+++ b/src/mame/kaneko/djboy.cpp
@@ -283,7 +283,7 @@ TILE_GET_INFO_MEMBER(djboy_state::get_bg_tile_info)
 	if (color & 8)
 		code |= 0x1000;
 
-	tileinfo.set(1, code, color, 0);    // no flip
+	tileinfo.set(0, code, color, 0);    // no flip
 }
 
 void djboy_state::videoram_w(offs_t offset, uint8_t data)
@@ -607,8 +607,11 @@ INPUT_PORTS_END
 
 
 static GFXDECODE_START( gfx_djboy )
-	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0x100, 16 )
 	GFXDECODE_ENTRY( "bgtiles", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0x000, 16 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_djboy_spr )
+	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0x100, 16 )
 GFXDECODE_END
 
 /******************************************************************************/
@@ -699,8 +702,7 @@ void djboy_state::djboy(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_djboy);
 	PALETTE(config, m_palette).set_entries(0x200);
 
-	KANEKO_PANDORA(config, m_pandora, 0);
-	m_pandora->set_gfxdecode_tag(m_gfxdecode);
+	KANEKO_PANDORA(config, m_pandora, 0, m_palette, gfx_djboy_spr);
 
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();

--- a/src/mame/kaneko/galpanic.cpp
+++ b/src/mame/kaneko/galpanic.cpp
@@ -89,7 +89,6 @@ public:
 	galpanic_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
-		, m_gfxdecode(*this, "gfxdecode")
 		, m_screen(*this, "screen")
 		, m_palette(*this, "palette")
 		, m_pandora(*this, "pandora")
@@ -107,7 +106,6 @@ protected:
 
 private:
 	required_device<cpu_device> m_maincpu;
-	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	required_device<kaneko_pandora_device> m_pandora;
@@ -326,7 +324,7 @@ static INPUT_PORTS_START( galpanica )
 INPUT_PORTS_END
 
 
-static GFXDECODE_START( gfx_galpanic )
+static GFXDECODE_START( gfx_galpanic_spr )
 	GFXDECODE_ENTRY( "sprites", 0, gfx_8x8x4_row_2x2_group_packed_msb, 256, 16 )
 GFXDECODE_END
 
@@ -350,13 +348,11 @@ void galpanic_state::galpanic(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(galpanic_state::screen_vblank));
 	m_screen->set_palette(m_palette);
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_galpanic);
 	// fg palette RAM, bit 0 seems to be a transparency flag for the front bitmap
 	PALETTE(config, m_palette, FUNC(galpanic_state::palette)).set_format(palette_device::GRBx_555, 1024 + 32768);
 
-	KANEKO_PANDORA(config, m_pandora, 0);
+	KANEKO_PANDORA(config, m_pandora, 0, m_palette, gfx_galpanic_spr);
 	m_pandora->set_offsets(0, -16);
-	m_pandora->set_gfxdecode_tag(m_gfxdecode);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/kaneko/hvyunit.cpp
+++ b/src/mame/kaneko/hvyunit.cpp
@@ -206,7 +206,7 @@ TILE_GET_INFO_MEMBER(hvyunit_state::get_bg_tile_info)
 	int code = m_videoram[tile_index] + ((attr & 0x0f) << 8);
 	int color = (attr >> 4);
 
-	tileinfo.set(1, code, color, 0);
+	tileinfo.set(0, code, color, 0);
 }
 
 void hvyunit_state::video_start()
@@ -578,8 +578,11 @@ INPUT_PORTS_END
  *************************************/
 
 static GFXDECODE_START( gfx_hvyunit )
-	GFXDECODE_ENTRY( "gfx1", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0x100, 16 ) /* sprite bank */
 	GFXDECODE_ENTRY( "gfx2", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0x000, 16 ) /* background tiles */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_hvyunit_spr )
+	GFXDECODE_ENTRY( "gfx1", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0x100, 16 ) /* sprite bank */
 GFXDECODE_END
 
 
@@ -652,8 +655,7 @@ void hvyunit_state::hvyunit(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_hvyunit);
 	PALETTE(config, m_palette).set_format(palette_device::xRGB_444, 0x800);
 
-	KANEKO_PANDORA(config, m_pandora, 0);
-	m_pandora->set_gfxdecode_tag(m_gfxdecode);
+	KANEKO_PANDORA(config, m_pandora, 0, m_palette, gfx_hvyunit_spr);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/kaneko/kan_pand.cpp
+++ b/src/mame/kaneko/kan_pand.cpp
@@ -59,8 +59,11 @@ kaneko_pandora_device::kaneko_pandora_device(const machine_config &mconfig, cons
 	: device_t(mconfig, KANEKO_PANDORA, tag, owner, clock)
 	, device_video_interface(mconfig, *this)
 	, device_gfx_interface(mconfig, *this)
+	, m_clear_bitmap(false)
+	, m_bg_pen(0)
 	, m_xoffset(0)
 	, m_yoffset(0)
+	, m_flip_screen(false)
 {
 }
 
@@ -100,14 +103,14 @@ void kaneko_pandora_device::device_reset()
     IMPLEMENTATION
 *****************************************************************************/
 
-void kaneko_pandora_device::set_bg_pen( uint16_t pen )
+void kaneko_pandora_device::set_bg_pen(uint16_t pen)
 {
 	m_bg_pen = pen;
 }
 
-void kaneko_pandora_device::set_clear_bitmap( bool clear )
+void kaneko_pandora_device::set_clear_bitmap(int clear)
 {
-	m_clear_bitmap = clear;
+	m_clear_bitmap = clear != 0;
 }
 
 void kaneko_pandora_device::update( bitmap_ind16 &bitmap, const rectangle &cliprect )

--- a/src/mame/kaneko/kan_pand.cpp
+++ b/src/mame/kaneko/kan_pand.cpp
@@ -58,10 +58,9 @@ DEFINE_DEVICE_TYPE(KANEKO_PANDORA, kaneko_pandora_device, "kaneko_pandora", "Kan
 kaneko_pandora_device::kaneko_pandora_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, KANEKO_PANDORA, tag, owner, clock)
 	, device_video_interface(mconfig, *this)
-	, m_gfx_region(0)
+	, device_gfx_interface(mconfig, *this)
 	, m_xoffset(0)
 	, m_yoffset(0)
-	, m_gfxdecode(*this, finder_base::DUMMY_TAG)
 {
 }
 
@@ -93,7 +92,7 @@ void kaneko_pandora_device::device_reset()
 {
 	memset(m_spriteram.get(), 0x00, 0x1000);
 
-	m_clear_bitmap = 1;
+	m_clear_bitmap = true;
 }
 
 
@@ -101,12 +100,12 @@ void kaneko_pandora_device::device_reset()
     IMPLEMENTATION
 *****************************************************************************/
 
-void kaneko_pandora_device::set_bg_pen( int pen )
+void kaneko_pandora_device::set_bg_pen( uint16_t pen )
 {
 	m_bg_pen = pen;
 }
 
-void kaneko_pandora_device::set_clear_bitmap( int clear )
+void kaneko_pandora_device::set_clear_bitmap( bool clear )
 {
 	m_clear_bitmap = clear;
 }
@@ -198,7 +197,7 @@ void kaneko_pandora_device::draw( bitmap_ind16 &bitmap, const rectangle &cliprec
 		if (sy & 0x100)
 			sy -= 0x200;
 
-		m_gfxdecode->gfx(m_gfx_region)->transpen(bitmap,cliprect,
+		gfx(0)->transpen(bitmap,cliprect,
 				tile,
 				(tilecolour & 0xf0) >> 4,
 				flipx, flipy,

--- a/src/mame/kaneko/kan_pand.h
+++ b/src/mame/kaneko/kan_pand.h
@@ -43,9 +43,9 @@ public:
 	void spriteram_LSB_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t spriteram_LSB_r(offs_t offset);
 	void update( bitmap_ind16 &bitmap, const rectangle &cliprect );
-	void set_clear_bitmap( bool clear );
+	void set_clear_bitmap(int clear);
 	void eof();
-	void set_bg_pen( uint16_t pen );
+	void set_bg_pen(uint16_t pen);
 	void flip_screen_set(bool flip) { m_flip_screen = flip; }
 
 protected:
@@ -57,13 +57,13 @@ protected:
 
 private:
 	// internal state
-	std::unique_ptr<uint8_t[]>        m_spriteram;
-	std::unique_ptr<bitmap_ind16> m_sprites_bitmap; /* bitmap to render sprites to, Pandora seems to be frame'buffered' */
-	bool            m_clear_bitmap = false;
-	uint16_t        m_bg_pen = 0; // might work some other way..
+	std::unique_ptr<uint8_t[]>    m_spriteram;
+	std::unique_ptr<bitmap_ind16> m_sprites_bitmap; // bitmap to render sprites to, Pandora seems to be frame'buffered'
+	bool            m_clear_bitmap;
+	uint16_t        m_bg_pen; // might work some other way..
 	int32_t         m_xoffset;
 	int32_t         m_yoffset;
-	bool            m_flip_screen = false;
+	bool            m_flip_screen;
 };
 
 DECLARE_DEVICE_TYPE(KANEKO_PANDORA, kaneko_pandora_device)

--- a/src/mame/kaneko/kan_pand.h
+++ b/src/mame/kaneko/kan_pand.h
@@ -17,15 +17,22 @@
 ***************************************************************************/
 
 class kaneko_pandora_device : public device_t,
-								public device_video_interface
+								public device_video_interface,
+								public device_gfx_interface
 {
 public:
+	// constructor/destructor
 	kaneko_pandora_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	template <typename T> kaneko_pandora_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&palette_tag, const gfx_decode_entry *gfxinfo)
+		: kaneko_pandora_device(mconfig, tag, owner, clock)
+	{
+		set_info(gfxinfo);
+		set_palette(std::forward<T>(palette_tag));
+	}
 
 	// configuration
-	template <typename T> void set_gfxdecode_tag(T &&tag) { m_gfxdecode.set_tag(std::forward<T>(tag)); }
-	void set_gfx_region(int gfxregion) { m_gfx_region = gfxregion; }
-	void set_offsets(int x_offset, int y_offset)
+	void set_gfxinfo(const gfx_decode_entry *gfxinfo) { set_info(gfxinfo); }
+	void set_offsets(int32_t x_offset, int32_t y_offset)
 	{
 		m_xoffset = x_offset;
 		m_yoffset = y_offset;
@@ -36,9 +43,9 @@ public:
 	void spriteram_LSB_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t spriteram_LSB_r(offs_t offset);
 	void update( bitmap_ind16 &bitmap, const rectangle &cliprect );
-	void set_clear_bitmap( int clear );
+	void set_clear_bitmap( bool clear );
 	void eof();
-	void set_bg_pen( int pen );
+	void set_bg_pen( uint16_t pen );
 	void flip_screen_set(bool flip) { m_flip_screen = flip; }
 
 protected:
@@ -52,13 +59,11 @@ private:
 	// internal state
 	std::unique_ptr<uint8_t[]>        m_spriteram;
 	std::unique_ptr<bitmap_ind16> m_sprites_bitmap; /* bitmap to render sprites to, Pandora seems to be frame'buffered' */
-	int             m_clear_bitmap = 0;
-	int             m_bg_pen = 0; // might work some other way..
-	uint8_t           m_gfx_region;
-	int             m_xoffset;
-	int             m_yoffset;
+	bool            m_clear_bitmap = false;
+	uint16_t        m_bg_pen = 0; // might work some other way..
+	int32_t         m_xoffset;
+	int32_t         m_yoffset;
 	bool            m_flip_screen = false;
-	required_device<gfxdecode_device> m_gfxdecode;
 };
 
 DECLARE_DEVICE_TYPE(KANEKO_PANDORA, kaneko_pandora_device)

--- a/src/mame/kaneko/sandscrp.cpp
+++ b/src/mame/kaneko/sandscrp.cpp
@@ -420,7 +420,7 @@ static INPUT_PORTS_START( sandscrp )
 INPUT_PORTS_END
 
 
-static GFXDECODE_START( gfx_sandscrp )
+static GFXDECODE_START( gfx_sandscrp_spr )
 	GFXDECODE_ENTRY( "gfx1", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0x000, 0x10 ) // [0] Sprites
 GFXDECODE_END
 
@@ -453,7 +453,6 @@ void sandscrp_state::sandscrp(machine_config &config)
 	screen.screen_vblank().set(FUNC(sandscrp_state::screen_vblank));
 	screen.set_palette("palette");
 
-	GFXDECODE(config, "gfxdecode", "palette", gfx_sandscrp);
 	PALETTE(config, "palette").set_format(palette_device::xGRB_555, 2048);
 
 	KANEKO_TMAP(config, m_view2);
@@ -463,8 +462,7 @@ void sandscrp_state::sandscrp(machine_config &config)
 
 	KANEKO_HIT(config, "calc1_mcu").set_type(0);
 
-	KANEKO_PANDORA(config, m_pandora, 0);
-	m_pandora->set_gfxdecode_tag("gfxdecode");
+	KANEKO_PANDORA(config, m_pandora, 0, "palette", gfx_sandscrp_spr);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/kaneko/snowbros.cpp
+++ b/src/mame/kaneko/snowbros.cpp
@@ -1661,7 +1661,7 @@ INPUT_PORTS_END
 
 /* SnowBros */
 
-static GFXDECODE_START( gfx_snowbros )
+static GFXDECODE_START( gfx_snowbros_spr )
 	GFXDECODE_ENTRY( "gfx1", 0, gfx_8x8x4_row_2x2_group_packed_msb, 0, 16 )
 GFXDECODE_END
 
@@ -1740,7 +1740,7 @@ static GFXDECODE_START( gfx_sb3 )
 	GFXDECODE_ENTRY( "gfx2", 0, sb3_tilebglayout,                   0,  2 )
 GFXDECODE_END
 
-static GFXDECODE_START( gfx_hyperpac )
+static GFXDECODE_START( gfx_hyperpac_spr )
 	GFXDECODE_ENTRY( "gfx1", 0, hyperpac_tilelayout, 0, 16 )
 GFXDECODE_END
 
@@ -1784,11 +1784,9 @@ void snowbros_state::snowbros(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(snowbros_state::screen_vblank_snowbros));
 	m_screen->set_palette(m_palette);
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_snowbros);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 256);
 
-	KANEKO_PANDORA(config, m_pandora, 0);
-	m_pandora->set_gfxdecode_tag(m_gfxdecode);
+	KANEKO_PANDORA(config, m_pandora, 0, m_palette, gfx_snowbros_spr);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -1814,7 +1812,7 @@ void snowbros_state::wintbob(machine_config &config)
 	config.device_remove("pandora");
 
 	/* video hardware */
-	m_gfxdecode->set_info(gfx_wb);
+	GFXDECODE(config, m_gfxdecode, m_palette, gfx_wb);
 
 	m_screen->set_screen_update(FUNC(snowbros_state::screen_update_wintbob));
 	m_screen->screen_vblank().set_nop();
@@ -1832,7 +1830,7 @@ void snowbros_state::semicom(machine_config &config)
 	m_soundcpu->set_addrmap(AS_PROGRAM, &snowbros_state::hyperpac_sound_map);
 	m_soundcpu->set_addrmap(AS_IO, address_map_constructor());
 
-	m_gfxdecode->set_info(gfx_hyperpac);
+	m_pandora->set_gfxinfo(gfx_hyperpac_spr);
 
 	m_soundlatch->data_pending_callback().set_nop();
 
@@ -1987,7 +1985,7 @@ void snowbros_state::_4in1(machine_config &config)
 	semicom(config);
 
 	/* basic machine hardware */
-	m_gfxdecode->set_info(gfx_snowbros);
+	m_pandora->set_gfxinfo(gfx_snowbros_spr);
 }
 
 void snowbros_state::snowbro3(machine_config &config) /* PCB has 16MHz & 12MHz OSCs */
@@ -2036,11 +2034,9 @@ void snowbros_state::yutnori(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(snowbros_state::screen_vblank_snowbros));
 	m_screen->set_palette(m_palette);
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_hyperpac);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 256);
 
-	KANEKO_PANDORA(config, m_pandora, 0);
-	m_pandora->set_gfxdecode_tag(m_gfxdecode);
+	KANEKO_PANDORA(config, m_pandora, 0, m_palette, gfx_hyperpac_spr);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/kaneko/snowbros.h
+++ b/src/mame/kaneko/snowbros.h
@@ -60,7 +60,7 @@ private:
 	required_device<cpu_device> m_maincpu;
 	optional_device<cpu_device> m_soundcpu;
 	optional_device<okim6295_device> m_oki;
-	required_device<gfxdecode_device> m_gfxdecode;
+	optional_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
 	required_device<screen_device> m_screen;
 	optional_device<generic_latch_8_device> m_soundlatch; // not snowbro3


### PR DESCRIPTION
kaneko/airbustr.cpp: Fix out of range issue