### PR TITLE
machine/8042kbdc.cpp: make aux port to be alive with PS/2 interface

### DIFF
--- a/src/devices/machine/8042kbdc.cpp
+++ b/src/devices/machine/8042kbdc.cpp
@@ -387,7 +387,14 @@ void kbdc8042_device::data_w(offs_t offset, uint8_t data)
 					m_mouse.sample_rate = 100;
 					m_mouse.from_transmit = 0;
 					m_mouse.to_transmit = 0;
-					m_mouse.reporting = false;
+					if (m_keybtype == KBDC8042_PS2)
+					{
+						m_mouse.reporting = true;
+						m_mouse.on = true;
+					}
+					else
+						m_mouse.reporting = false;
+					
 					if (m_mouse.on)
 					{
 						mouse_enqueue(0xfa);


### PR DESCRIPTION
* Fix shutms11 recognizing mouse properly instead of indefinitely hang.