### PR TITLE
atari/shuuz.cpp: add missing sprite-to-playfield shadow effect 

### DIFF
--- a/src/mame/atari/shuuz.cpp
+++ b/src/mame/atari/shuuz.cpp
@@ -165,6 +165,7 @@ uint32_t shuuz_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap,
 			uint16_t const *const mo = &mobitmap.pix(y);
 			uint16_t *const pf = &bitmap.pix(y);
 			for (int x = rect->left(); x <= rect->right(); x++)
+			{
 				if (mo[x] != 0xffff)
 				{
 					/* verified from the GALs on the real PCB; equations follow
@@ -181,21 +182,24 @@ uint32_t shuuz_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap,
 					 *         +PFS7*(LBD7&LBD6)*!M3*!O13
 					 *
 					 */
-					int const o13 = ((pf[x] & 0xf0) == 0xf0);
 
-					// compute the MO/PF signal
-					int mopf = ((!(pf[x] & 0x80) && ((mo[x] & 0xc0) != 0xc0) && !o13) ||
-								 ((pf[x] & 0x80) && ((mo[x] & 0xc0) == 0xc0) && !o13));
+					// This is based on observations, and not verified against schematics and GAL equations.
+					// TODO:
+					// * Locate schematics for (or trace out) video mixing section.
+					// * Obtain equations for video mixing GALs.
+					bool const o13 = (pf[x] & 0xf0) == 0xf0;
+					bool const mopf = ((pf[x] & 0x80) ? ((mo[x] & 0xc0) == 0xc0) : ((mo[x] & 0xc0) != 0xc0)) && !o13;
 
-					// if MO/PF is 1, we draw the MO
+					// if MO/PF is asserted, we draw the MO
 					if (mopf)
 					{
-						if ((mo[x] & 0x0e) != 0x00)		// MO colors 2 to F are solid
+						if (mo[x] & 0x0e)       // solid colors
 							pf[x] = mo[x];
-						else if ((mo[x] & 0x0f) == 0x1) // MO color 1 causes a shadow on the PF 
-						    pf[x] |= 0x200;		        // Game sets palette 300:3FF to shadowed values of palette 100:1FF
+						else if (mo[x] & 0x01)  // shadows
+						    pf[x] |= 0x200;
 				    }
 				}
+			}
 		}
 	return 0;
 }

--- a/src/mame/atari/shuuz.cpp
+++ b/src/mame/atari/shuuz.cpp
@@ -184,14 +184,17 @@ uint32_t shuuz_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap,
 					int const o13 = ((pf[x] & 0xf0) == 0xf0);
 
 					// compute the MO/PF signal
-					int mopf = 0;
-					if ((!(pf[x] & 0x80) && ((mo[x] & 0xc0) != 0xc0) && ((mo[x] & 0x0e) != 0x00) && !o13) ||
-						((pf[x] & 0x80) && ((mo[x] & 0xc0) == 0xc0) && ((mo[x] & 0x0e) != 0x00) && !o13))
-						mopf = 1;
+					int mopf = ((!(pf[x] & 0x80) && ((mo[x] & 0xc0) != 0xc0) && !o13) ||
+								 ((pf[x] & 0x80) && ((mo[x] & 0xc0) == 0xc0) && !o13));
 
 					// if MO/PF is 1, we draw the MO
 					if (mopf)
-						pf[x] = mo[x];
+					{
+						if ((mo[x] & 0x0e) != 0x00)		// MO colors 2 to F are solid
+							pf[x] = mo[x];
+						else if ((mo[x] & 0x0f) == 0x1) // MO color 1 causes a shadow on the PF 
+						    pf[x] |= 0x200;		        // Game sets palette 300:3FF to shadowed values of palette 100:1FF
+				    }
 				}
 		}
 	return 0;


### PR DESCRIPTION
Shuuz has been missing its sprite-shadow effect.
MO color 1 causes a PF palette shift + 0x200, if the mo has priority over the pf.

These shadows are visible at the feet of the round-card woman and the standing on-screen players.

Reference: https://farm5.staticflickr.com/4767/38913008994_3e2d2f6449_b.jpg
![38913008994_3e2d2f6449_b](https://github.com/mamedev/mame/assets/36536480/ef8f6e58-ce37-4b35-bda7-1351d598d24e)
