### PR TITLE
video/mc6845.cpp: Fix hang in ma7551t related to mc6845

### DIFF
--- a/src/devices/video/mc6845.cpp
+++ b/src/devices/video/mc6845.cpp
@@ -82,6 +82,7 @@ DEFINE_DEVICE_TYPE(AMS40489, ams40489_device, "ams40489", "AMS40489 ASIC (CRTC)"
 mc6845_device::mc6845_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, type, tag, owner, clock)
 	, device_video_interface(mconfig, *this, false)
+	, m_line_timer(nullptr)
 	, m_show_border_area(true)
 	, m_noninterlace_adjust(0)
 	, m_interlace_adjust(0)
@@ -531,7 +532,7 @@ void mc6845_device::recompute_parameters(bool postload)
 		m_hsync_off_pos = hsync_off_pos;
 		m_vsync_on_pos = vsync_on_pos;
 		m_vsync_off_pos = vsync_off_pos;
-		if (!m_line_timer->enabled() && m_has_valid_parameters)
+		if (m_line_timer && !m_line_timer->enabled() && m_has_valid_parameters)
 		{
 			m_line_timer->adjust(cclks_to_attotime(m_horiz_char_total + 1));
 		}

--- a/src/devices/video/mc6845.cpp
+++ b/src/devices/video/mc6845.cpp
@@ -531,6 +531,10 @@ void mc6845_device::recompute_parameters(bool postload)
 		m_hsync_off_pos = hsync_off_pos;
 		m_vsync_on_pos = vsync_on_pos;
 		m_vsync_off_pos = vsync_off_pos;
+		if (!m_line_timer->enabled() && m_has_valid_parameters)
+		{
+			m_line_timer->adjust(cclks_to_attotime(m_horiz_char_total + 1));
+		}
 		if ( (!m_reconfigure_cb.isnull()) && (!postload) )
 			m_line_counter = 0;
 	}
@@ -1301,8 +1305,10 @@ void mc6845_device::device_reset()
 
 	m_out_vsync_cb(false);
 
-	if (!m_line_timer->enabled())
+	if (!m_line_timer->enabled() && m_has_valid_parameters)
+	{
 		m_line_timer->adjust(cclks_to_attotime(m_horiz_char_total + 1));
+	}
 
 	m_light_pen_latched = false;
 


### PR DESCRIPTION
Changes in https://github.com/mamedev/mame/pull/11756 caused the ma7551t to hard lock up. With the updated code, the system seems to be overloaded with `handle_line_timer()` calls and initialization does not complete, even though the bool `m_has_valid_parameters` is false. This change, does not enable the line timer until `m_has_valid_parameters` becomes true, this allows the system to properly initialize. And for systems that has valid parameters, the enabling is done in `recompute_parameters()`.