### PR TITLE
heathkit/tlb.cpp: Avoid clearing cliprect in MC6845_BEGIN_UPDATE for superset ROM. 

### DIFF
--- a/src/mame/heathkit/tlb.cpp
+++ b/src/mame/heathkit/tlb.cpp
@@ -1124,7 +1124,6 @@ void heath_superset_tlb_device::device_add_mconfig(machine_config &config)
 	// per line updates are needed for onscreen menu to display properly
 	m_screen->set_video_attributes(VIDEO_UPDATE_SCANLINE);
 
-	m_crtc->set_begin_update_callback(FUNC(heath_superset_tlb_device::crtc_begin_update));
 	m_crtc->set_update_row_callback(FUNC(heath_superset_tlb_device::crtc_update_row));
 
 	// link up the serial port outputs to font chip.
@@ -1187,11 +1186,6 @@ void heath_superset_tlb_device::crtc_reg_w(offs_t reg, uint8_t val)
 	heath_tlb_device::crtc_reg_w(reg, val);
 }
 
-MC6845_BEGIN_UPDATE(heath_superset_tlb_device::crtc_begin_update)
-{
-	bitmap.fill(rgb_t::black(), cliprect);
-}
-
 MC6845_UPDATE_ROW(heath_superset_tlb_device::crtc_update_row)
 {
 	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
@@ -1232,7 +1226,7 @@ MC6845_UPDATE_ROW(heath_superset_tlb_device::crtc_update_row)
 	}
 	else
 	{
-		std::fill_n(p, x_count * 8, palette[0]);
+		std::fill_n(p, bitmap.rowpixels(), palette[0]);
 	}
 }
 

--- a/src/mame/heathkit/tlb.h
+++ b/src/mame/heathkit/tlb.h
@@ -169,7 +169,6 @@ protected:
 	void mem_map(address_map &map);
 	void io_map(address_map &map);
 
-	MC6845_BEGIN_UPDATE(crtc_begin_update);
 	virtual MC6845_UPDATE_ROW(crtc_update_row) override;
 
 	void dtr_internal(int data);


### PR DESCRIPTION
When DE is not set, use the bitmap's `rowpixels()` instead of `count_x * 8` to clear the row. This allows the removal of the cliprect clearing occurring in the MC6845_BEGIN_UPDATE callback, which was need to properly handle the screen saver feature of the superset. 