### PR TITLE
konami/k007121.cpp: Use device_gfx_interface for gfx decoding, Minor type value corrections

### DIFF
--- a/src/mame/konami/combatsc.cpp
+++ b/src/mame/konami/combatsc.cpp
@@ -563,17 +563,6 @@ INPUT_PORTS_END
  *
  *************************************/
 
-static const gfx_layout gfxlayout =
-{
-	8,8,
-	0x4000,
-	4,
-	{ 0,1,2,3 },
-	{ 0, 4, 8, 12, 16, 20, 24, 28},
-	{ 0*32, 1*32, 2*32, 3*32, 4*32, 5*32, 6*32, 7*32 },
-	32*8
-};
-
 static const gfx_layout tile_layout =
 {
 	8,8,
@@ -602,9 +591,12 @@ static const gfx_layout sprite_layout =
 	8*8*4
 };
 
-static GFXDECODE_START( gfx_combatsc )
-	GFXDECODE_ENTRY( "gfx1", 0x00000, gfxlayout, 0, 8*16 )
-	GFXDECODE_ENTRY( "gfx2", 0x00000, gfxlayout, 0, 8*16 )
+static GFXDECODE_START( gfx_combatsc_1 )
+	GFXDECODE_ENTRY( "gfx1", 0x00000, gfx_8x8x4_packed_msb, 0, 8*16 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_combatsc_2 )
+	GFXDECODE_ENTRY( "gfx2", 0x00000, gfx_8x8x4_packed_msb, 0, 8*16 )
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_combatscb )
@@ -702,15 +694,12 @@ void combatsc_state::combatsc(machine_config &config)
 	m_screen->set_screen_update(FUNC(combatsc_state::screen_update));
 	m_screen->set_palette(m_palette);
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_combatsc);
 	PALETTE(config, m_palette, FUNC(combatsc_state::palette));
 	m_palette->set_format(palette_device::xBGR_555, 8 * 16 * 16, 128);
 	m_palette->set_endianness(ENDIANNESS_LITTLE);
 
-	K007121(config, m_k007121[0], 0);
-	m_k007121[0]->set_palette_tag(m_palette);
-	K007121(config, m_k007121[1], 0);
-	m_k007121[1]->set_palette_tag(m_palette);
+	K007121(config, m_k007121[0], 0, m_palette, gfx_combatsc_1);
+	K007121(config, m_k007121[1], 0, m_palette, gfx_combatsc_2);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/konami/combatsc.h
+++ b/src/mame/konami/combatsc.h
@@ -28,7 +28,6 @@ public:
 		m_maincpu(*this, "maincpu"),
 		m_audiocpu(*this, "audiocpu"),
 		m_screen(*this, "screen"),
-		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
 		m_soundlatch(*this, "soundlatch"),
 		m_track_ports(*this, {"TRACK0_Y", "TRACK0_X", "TRACK1_Y", "TRACK1_X"}),
@@ -57,7 +56,6 @@ protected:
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_audiocpu;
 	required_device<screen_device> m_screen;
-	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
 	required_device<generic_latch_8_device> m_soundlatch;
 
@@ -131,6 +129,7 @@ class combatscb_state : public combatsc_base_state
 public:
 	combatscb_state(const machine_config &mconfig, device_type type, const char *tag) :
 		combatsc_base_state(mconfig, type, tag),
+		m_gfxdecode(*this, "gfxdecode"),
 		m_msm(*this, "msm"),
 		m_soundbank(*this, "soundbank"),
 		m_io_ram(*this, "io_ram", 0x4000, ENDIANNESS_BIG),
@@ -146,6 +145,7 @@ protected:
 	virtual void video_start() override;
 
 private:
+	optional_device<gfxdecode_device> m_gfxdecode;
 	required_device<msm5205_device> m_msm;
 	required_memory_bank m_soundbank;
 	memory_share_creator<uint8_t> m_io_ram;

--- a/src/mame/konami/combatsc_v.cpp
+++ b/src/mame/konami/combatsc_v.cpp
@@ -148,7 +148,7 @@ TILE_GET_INFO_MEMBER(combatsc_state::get_tile_info1)
 
 	number = m_videoram[1][tile_index + 0x400] + 256 * bank;
 
-	tileinfo.set(1,
+	tileinfo.set(0,
 			number,
 			color,
 			0);
@@ -250,9 +250,9 @@ TILE_GET_INFO_MEMBER(combatscb_state::get_text_info)
 
 void combatsc_state::video_start()
 {
-	m_bg_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(combatsc_state::get_tile_info0)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
-	m_bg_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(combatsc_state::get_tile_info1)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
-	m_textlayer =  &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(combatsc_state::get_text_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_bg_tilemap[0] = &machine().tilemap().create(*m_k007121[0], tilemap_get_info_delegate(*this, FUNC(combatsc_state::get_tile_info0)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_bg_tilemap[1] = &machine().tilemap().create(*m_k007121[1], tilemap_get_info_delegate(*this, FUNC(combatsc_state::get_tile_info1)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_textlayer =  &machine().tilemap().create(*m_k007121[0], tilemap_get_info_delegate(*this, FUNC(combatsc_state::get_text_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 
 	m_spriteram[0] = make_unique_clear<uint8_t[]>(0x800);
 	m_spriteram[1] = make_unique_clear<uint8_t[]>(0x800);
@@ -352,7 +352,7 @@ void combatsc_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprec
 	k007121_device *k007121 = circuit ? m_k007121[1] : m_k007121[0];
 	int base_color = (circuit * 4) * 16 + (k007121->ctrlram_r(6) & 0x10) * 2;
 
-	k007121->sprites_draw(bitmap, cliprect, m_gfxdecode->gfx(circuit), *m_palette, source, base_color, 0, 0, priority_bitmap, pri_mask);
+	k007121->sprites_draw(bitmap, cliprect, source, base_color, 0, 0, priority_bitmap, pri_mask);
 }
 
 

--- a/src/mame/konami/contra.cpp
+++ b/src/mame/konami/contra.cpp
@@ -171,7 +171,6 @@ public:
 		m_audiocpu(*this, "audiocpu"),
 		m_k007121(*this, "k007121_%u", 1U),
 		m_maincpu(*this, "maincpu"),
-		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette")
 	{ }
@@ -198,7 +197,6 @@ private:
 	required_device<cpu_device> m_audiocpu;
 	required_device_array<k007121_device, 2> m_k007121;
 	required_device<cpu_device> m_maincpu;
-	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 
@@ -289,7 +287,7 @@ TILE_GET_INFO_MEMBER(contra_state::get_tile_info)
 
 	bank = (bank & ~(mask << 1)) | ((ctrl_4 & mask) << 1);
 
-	tileinfo.set(Which,
+	tileinfo.set(0,
 			m_vram[Which][tile_index] + bank * 256,
 			((ctrl_6 & 0x30) * 2 + 16) + (attr & 7),
 			0);
@@ -326,9 +324,9 @@ TILE_GET_INFO_MEMBER(contra_state::get_tx_tile_info)
 
 void contra_state::video_start()
 {
-	m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(contra_state::get_tile_info<0>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
-	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(contra_state::get_tile_info<1>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
-	m_tilemap[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(contra_state::get_tx_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_tilemap[0] = &machine().tilemap().create(*m_k007121[0], tilemap_get_info_delegate(*this, FUNC(contra_state::get_tile_info<0>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_tilemap[1] = &machine().tilemap().create(*m_k007121[1], tilemap_get_info_delegate(*this, FUNC(contra_state::get_tile_info<1>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_tilemap[2] = &machine().tilemap().create(*m_k007121[0], tilemap_get_info_delegate(*this, FUNC(contra_state::get_tx_tile_info)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 
 	m_clip[1] = m_screen->visible_area();
 	m_clip[1].min_x += 40;
@@ -400,7 +398,7 @@ void contra_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect,
 {
 	int base_color = (m_k007121[Which]->ctrlram_r(6) & 0x30) * 2;
 
-	m_k007121[Which]->sprites_draw(bitmap, cliprect, m_gfxdecode->gfx(Which), *m_palette, m_buffered_spriteram[Which]->buffer(), base_color, 40, 0, priority_bitmap, (uint32_t)-1);
+	m_k007121[Which]->sprites_draw(bitmap, cliprect, m_buffered_spriteram[Which]->buffer(), base_color, 40, 0, priority_bitmap, (uint32_t)-1);
 }
 
 uint32_t contra_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
@@ -576,8 +574,11 @@ static INPUT_PORTS_START( gryzor )
 INPUT_PORTS_END
 
 
-static GFXDECODE_START( gfx_contra )
+static GFXDECODE_START( gfx_contra_1 )
 	GFXDECODE_ENTRY( "k007121_1", 0, gfx_8x8x4_packed_msb,       0, 8*16 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_contra_2 )
 	GFXDECODE_ENTRY( "k007121_2", 0, gfx_8x8x4_packed_msb, 8*16*16, 8*16 )
 GFXDECODE_END
 
@@ -620,17 +621,13 @@ void contra_state::contra(machine_config &config)
 	m_screen->set_screen_update(FUNC(contra_state::screen_update));
 	m_screen->set_palette(m_palette);
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_contra);
-
 	PALETTE(config, m_palette, FUNC(contra_state::palette));
 	m_palette->set_format(palette_device::xBGR_555, 2 * 8 * 16 * 16);
 	m_palette->set_indirect_entries(128);
 	m_palette->set_endianness(ENDIANNESS_LITTLE);
 
-	K007121(config, m_k007121[0], 0);
-	m_k007121[0]->set_palette_tag(m_palette);
-	K007121(config, m_k007121[1], 0);
-	m_k007121[1]->set_palette_tag(m_palette);
+	K007121(config, m_k007121[0], 0, m_palette, gfx_contra_1);
+	K007121(config, m_k007121[1], 0, m_palette, gfx_contra_2);
 
 	// sound hardware
 	SPEAKER(config, "lspeaker").front_left();

--- a/src/mame/konami/fastlane.cpp
+++ b/src/mame/konami/fastlane.cpp
@@ -42,7 +42,6 @@ public:
 		m_prgbank(*this, "prgbank"),
 		m_k007232(*this, "k007232_%u", 1U),
 		m_k007121(*this, "k007121"),
-		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette")
 	{ }
@@ -69,7 +68,6 @@ private:
 	// devices
 	required_device_array<k007232_device, 2> m_k007232;
 	required_device<k007121_device> m_k007121;
-	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 
@@ -146,8 +144,8 @@ TILE_GET_INFO_MEMBER(fastlane_state::get_tile_info)
 
 void fastlane_state::video_start()
 {
-	m_layer[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(fastlane_state::get_tile_info<0>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
-	m_layer[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(fastlane_state::get_tile_info<1>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_layer[0] = &machine().tilemap().create(*m_k007121, tilemap_get_info_delegate(*this, FUNC(fastlane_state::get_tile_info<0>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_layer[1] = &machine().tilemap().create(*m_k007121, tilemap_get_info_delegate(*this, FUNC(fastlane_state::get_tile_info<1>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 
 	m_layer[0]->set_scroll_rows(32);
 
@@ -194,7 +192,7 @@ uint32_t fastlane_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 	m_layer[0]->set_scrolly(0, m_k007121->ctrlram_r(2));
 
 	m_layer[0]->draw(screen, bitmap, finalclip0, 0, 0);
-	m_k007121->sprites_draw(bitmap, cliprect, m_gfxdecode->gfx(0), *m_palette, m_spriteram, 0, 40, 0, screen.priority(), (uint32_t)- 1);
+	m_k007121->sprites_draw(bitmap, cliprect, m_spriteram, 0, 40, 0, screen.priority(), (uint32_t)- 1);
 	m_layer[1]->draw(screen, bitmap, finalclip1, 0, 0);
 	return 0;
 }
@@ -332,19 +330,8 @@ static INPUT_PORTS_START( fastlane )
 	KONAMI8_B12_UNK(2)
 INPUT_PORTS_END
 
-static const gfx_layout gfxlayout =
-{
-	8,8,
-	0x80000/32,
-	4,
-	{ 0, 1, 2, 3 },
-	{ 2*4, 3*4, 0*4, 1*4, 6*4, 7*4, 4*4, 5*4 },
-	{ 0*32, 1*32, 2*32, 3*32, 4*32, 5*32, 6*32, 7*32 },
-	32*8
-};
-
 static GFXDECODE_START( gfx_fastlane )
-	GFXDECODE_ENTRY( "gfx", 0, gfxlayout, 0, 64*16 )
+	GFXDECODE_ENTRY( "gfx", 0, gfx_8x8x4_packed_msb, 0, 64*16 )
 GFXDECODE_END
 
 /***************************************************************************
@@ -385,11 +372,9 @@ void fastlane_state::fastlane(machine_config &config)
 	m_screen->set_screen_update(FUNC(fastlane_state::screen_update));
 	m_screen->set_palette(m_palette);
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_fastlane);
 	PALETTE(config, m_palette, FUNC(fastlane_state::palette)).set_format(palette_device::xBGR_555, 1024*16, 0x400);
 
-	K007121(config, m_k007121, 0);
-	m_k007121->set_palette_tag(m_palette);
+	K007121(config, m_k007121, 0, m_palette, gfx_fastlane);
 
 	K051733(config, "k051733", 0);
 
@@ -420,7 +405,7 @@ ROM_START( fastlane )
 	ROM_LOAD( "752_e01.10h", 0x08000, 0x10000, CRC(ff4d6029) SHA1(b5c5d8654ce728300d268628bd3dd878570ba7b8) )  // banked ROM
 
 	ROM_REGION( 0x80000, "gfx", 0 )
-	ROM_LOAD( "752e04.2i",   0x00000, 0x80000, CRC(a126e82d) SHA1(6663230c2c36dec563969bccad8c62e3d454d240) )  // tiles + sprites
+	ROM_LOAD16_WORD_SWAP( "752e04.2i",   0x00000, 0x80000, CRC(a126e82d) SHA1(6663230c2c36dec563969bccad8c62e3d454d240) )  // tiles + sprites
 
 	ROM_REGION( 0x0100, "proms", 0 )
 	ROM_LOAD( "752e03.6h",   0x0000, 0x0100, CRC(44300aeb) SHA1(580c6e88cbb3b6d8156ea0b9103834f199ec2747) )

--- a/src/mame/konami/flkatck.cpp
+++ b/src/mame/konami/flkatck.cpp
@@ -49,7 +49,6 @@ public:
 		m_k007121(*this, "k007121"),
 		m_k007232(*this, "k007232"),
 		m_watchdog(*this, "watchdog"),
-		m_gfxdecode(*this, "gfxdecode"),
 		m_soundlatch(*this, "soundlatch")
 	{ }
 
@@ -82,7 +81,6 @@ private:
 	required_device<k007121_device> m_k007121;
 	required_device<k007232_device> m_k007232;
 	required_device<watchdog_timer_device> m_watchdog;
-	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<generic_latch_8_device> m_soundlatch;
 
 	void bankswitch_w(uint8_t data);
@@ -161,8 +159,8 @@ TILE_GET_INFO_MEMBER(flkatck_state::get_tile_info_b)
 
 void flkatck_state::video_start()
 {
-	m_k007121_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(flkatck_state::get_tile_info_a)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
-	m_k007121_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(flkatck_state::get_tile_info_b)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_k007121_tilemap[0] = &machine().tilemap().create(*m_k007121, tilemap_get_info_delegate(*this, FUNC(flkatck_state::get_tile_info_a)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_k007121_tilemap[1] = &machine().tilemap().create(*m_k007121, tilemap_get_info_delegate(*this, FUNC(flkatck_state::get_tile_info_b)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 }
 
 
@@ -246,7 +244,7 @@ uint32_t flkatck_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 
 	// draw the graphics
 	m_k007121_tilemap[0]->draw(screen, bitmap, clip[0], 0, 0);
-	m_k007121->sprites_draw(bitmap, cliprect, m_gfxdecode->gfx(0), m_gfxdecode->palette(), &m_spriteram[sprite_buffer], 0, 40, 0, screen.priority(), (uint32_t)-1, true);
+	m_k007121->sprites_draw(bitmap, cliprect, &m_spriteram[sprite_buffer], 0, 40, 0, screen.priority(), (uint32_t)-1, true);
 	m_k007121_tilemap[1]->draw(screen, bitmap, clip[1], 0, 0);
 	return 0;
 }
@@ -383,19 +381,8 @@ static INPUT_PORTS_START( flkatck )
 	KONAMI8_B12_UNK(2)
 INPUT_PORTS_END
 
-static const gfx_layout gfxlayout =
-{
-	8,8,
-	0x80000/32,
-	4,
-	{ 0, 1, 2, 3 },
-	{ 2*4, 3*4, 0*4, 1*4, 6*4, 7*4, 4*4, 5*4 },
-	{ 0*32, 1*32, 2*32, 3*32, 4*32, 5*32, 6*32, 7*32 },
-	32*8
-};
-
 static GFXDECODE_START( gfx_flkatck )
-	GFXDECODE_ENTRY( "gfx", 0, gfxlayout, 0, 32 )
+	GFXDECODE_ENTRY( "gfx", 0, gfx_8x8x4_packed_msb, 0, 32 )
 GFXDECODE_END
 
 void flkatck_state::volume_callback(uint8_t data)
@@ -447,11 +434,9 @@ void flkatck_state::flkatck(machine_config &config)
 	screen.set_screen_update(FUNC(flkatck_state::screen_update));
 	screen.set_palette("palette");
 
-	GFXDECODE(config, m_gfxdecode, "palette", gfx_flkatck);
 	PALETTE(config, "palette").set_format(palette_device::xBGR_555, 512).set_endianness(ENDIANNESS_LITTLE);
 
-	K007121(config, m_k007121, 0);
-	m_k007121->set_palette_tag("palette");
+	K007121(config, m_k007121, 0, "palette", gfx_flkatck);
 
 	// sound hardware
 	SPEAKER(config, "lspeaker").front_left();
@@ -475,12 +460,11 @@ ROM_START( mx5000 )
 	ROM_REGION( 0x10000, "maincpu", 0 )  // 6309 code
 	ROM_LOAD( "669_r01.16c", 0x00000, 0x10000, CRC(79b226fc) SHA1(3bc4d93717230fecd54bd08a0c3eeedc1c8f571d) )
 
-
 	ROM_REGION( 0x8000, "audiocpu", 0 )
 	ROM_LOAD( "669_m02.16b", 0x0000, 0x8000, CRC(7e11e6b9) SHA1(7a7d65a458b15842a6345388007c8f682aec20a7) )
 
 	ROM_REGION( 0x80000, "gfx", 0 )  // tiles + sprites
-	ROM_LOAD( "gx669f03.5e", 0x00000, 0x80000, CRC(ff1d718b) SHA1(d44fe3ed5a3ba1b3036264e37f9cd3500b706635) ) // MASK4M
+	ROM_LOAD16_WORD_SWAP( "gx669f03.5e", 0x00000, 0x80000, CRC(ff1d718b) SHA1(d44fe3ed5a3ba1b3036264e37f9cd3500b706635) ) // MASK4M
 
 	ROM_REGION( 0x40000, "k007232", 0 )
 	ROM_LOAD( "gx669f04.11a", 0x00000, 0x40000, CRC(6d1ea61c) SHA1(9e6eb9ac61838df6e1f74e74bb72f3edf1274aed) ) // MASK2M
@@ -494,7 +478,7 @@ ROM_START( flkatck )
 	ROM_LOAD( "669_m02.16b", 0x0000, 0x8000, CRC(7e11e6b9) SHA1(7a7d65a458b15842a6345388007c8f682aec20a7) )
 
 	ROM_REGION( 0x80000, "gfx", 0 )  // tiles + sprites
-	ROM_LOAD( "gx669f03.5e", 0x00000, 0x80000, CRC(ff1d718b) SHA1(d44fe3ed5a3ba1b3036264e37f9cd3500b706635) ) // MASK4M
+	ROM_LOAD16_WORD_SWAP( "gx669f03.5e", 0x00000, 0x80000, CRC(ff1d718b) SHA1(d44fe3ed5a3ba1b3036264e37f9cd3500b706635) ) // MASK4M
 
 	ROM_REGION( 0x40000, "k007232", 0 )
 	ROM_LOAD( "gx669f04.11a", 0x00000, 0x40000, CRC(6d1ea61c) SHA1(9e6eb9ac61838df6e1f74e74bb72f3edf1274aed) ) // MASK2M
@@ -509,14 +493,14 @@ ROM_START( flkatcka )
 	ROM_LOAD( "669_m02.16b", 0x0000, 0x8000, CRC(7e11e6b9) SHA1(7a7d65a458b15842a6345388007c8f682aec20a7) )
 
 	ROM_REGION( 0x80000, "gfx", 0 )  // tiles + sprites, same data as above set, on PWB 450593 sub-board instead.
-	ROM_LOAD16_BYTE( "669_f03a.4b", 0x00001, 0x10000, CRC(f0ed4c1e) SHA1(58efe3cd81054d22de54a7d195aa3b865bde4a01) )
-	ROM_LOAD16_BYTE( "669_f03e.4d", 0x00000, 0x10000, CRC(95a57a26) SHA1(c8aa30c2c734c0740630b1b04ae43c69931cc7c1) )
-	ROM_LOAD16_BYTE( "669_f03b.5b", 0x20001, 0x10000, CRC(e2593f3c) SHA1(aa0f6d04015650eaef17c4a39f228eaccf9a2948) )
-	ROM_LOAD16_BYTE( "669_f03f.5d", 0x20000, 0x10000, CRC(c6c9903e) SHA1(432ad6d03992499cc533273226944a666b40fa58) )
-	ROM_LOAD16_BYTE( "669_f03c.6b", 0x40001, 0x10000, CRC(47be92dd) SHA1(9ccc62d7d42fccbd5ad60e35e3a0478a04405cf1) )
-	ROM_LOAD16_BYTE( "669_f03g.6d", 0x40000, 0x10000, CRC(70d35fbd) SHA1(21384f738684c5da4a7a84a1c9aa173fffddf47a) )
-	ROM_LOAD16_BYTE( "669_f03d.7b", 0x60001, 0x10000, CRC(18d48f9e) SHA1(b95e38aa813e0f3a0dc6bd45fdb4bf71f7e2066c) )
-	ROM_LOAD16_BYTE( "669_f03h.7d", 0x60000, 0x10000, CRC(abfe76e7) SHA1(f8661f189308e83056ec442fa6c936efff67ba0a) )
+	ROM_LOAD16_BYTE( "669_f03a.4b", 0x00000, 0x10000, CRC(f0ed4c1e) SHA1(58efe3cd81054d22de54a7d195aa3b865bde4a01) )
+	ROM_LOAD16_BYTE( "669_f03e.4d", 0x00001, 0x10000, CRC(95a57a26) SHA1(c8aa30c2c734c0740630b1b04ae43c69931cc7c1) )
+	ROM_LOAD16_BYTE( "669_f03b.5b", 0x20000, 0x10000, CRC(e2593f3c) SHA1(aa0f6d04015650eaef17c4a39f228eaccf9a2948) )
+	ROM_LOAD16_BYTE( "669_f03f.5d", 0x20001, 0x10000, CRC(c6c9903e) SHA1(432ad6d03992499cc533273226944a666b40fa58) )
+	ROM_LOAD16_BYTE( "669_f03c.6b", 0x40000, 0x10000, CRC(47be92dd) SHA1(9ccc62d7d42fccbd5ad60e35e3a0478a04405cf1) )
+	ROM_LOAD16_BYTE( "669_f03g.6d", 0x40001, 0x10000, CRC(70d35fbd) SHA1(21384f738684c5da4a7a84a1c9aa173fffddf47a) )
+	ROM_LOAD16_BYTE( "669_f03d.7b", 0x60000, 0x10000, CRC(18d48f9e) SHA1(b95e38aa813e0f3a0dc6bd45fdb4bf71f7e2066c) )
+	ROM_LOAD16_BYTE( "669_f03h.7d", 0x60001, 0x10000, CRC(abfe76e7) SHA1(f8661f189308e83056ec442fa6c936efff67ba0a) )
 
 	ROM_REGION( 0x40000, "k007232", 0 )
 	ROM_LOAD( "gx669f04.11a", 0x00000, 0x40000, CRC(6d1ea61c) SHA1(9e6eb9ac61838df6e1f74e74bb72f3edf1274aed) ) // MASK2M

--- a/src/mame/konami/hcastle.cpp
+++ b/src/mame/konami/hcastle.cpp
@@ -36,7 +36,6 @@ public:
 	hcastle_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
-		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
 		m_audiocpu(*this, "audiocpu"),
 		m_k007121(*this, "k007121_%u", 1U),
@@ -58,7 +57,6 @@ protected:
 private:
 	// devices
 	required_device<cpu_device> m_maincpu;
-	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
 	required_device<cpu_device> m_audiocpu;
 	required_device_array<k007121_device, 2> m_k007121;
@@ -154,7 +152,7 @@ TILE_GET_INFO_MEMBER(hcastle_state::get_tile_info)
 				((attr >> (bit2    )) & 0x08) |
 				((attr >> (bit3 - 1)) & 0x10);
 
-	tileinfo.set(Which,
+	tileinfo.set(0,
 			tile + bank * 0x100 + m_pf_bankbase[Which],
 			((ctrl_6 & 0x30) * 2 + 16) + color,
 			0);
@@ -171,8 +169,8 @@ TILE_GET_INFO_MEMBER(hcastle_state::get_tile_info)
 void hcastle_state::video_start()
 {
 	// 0 = FG, 1 = BG
-	m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(hcastle_state::get_tile_info<0>)), tilemap_mapper_delegate(*this, FUNC(hcastle_state::tilemap_scan)), 8, 8, 64, 32);
-	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(hcastle_state::get_tile_info<1>)), tilemap_mapper_delegate(*this, FUNC(hcastle_state::tilemap_scan)), 8, 8, 64, 32);
+	m_tilemap[0] = &machine().tilemap().create(*m_k007121[0], tilemap_get_info_delegate(*this, FUNC(hcastle_state::get_tile_info<0>)), tilemap_mapper_delegate(*this, FUNC(hcastle_state::tilemap_scan)), 8, 8, 64, 32);
+	m_tilemap[1] = &machine().tilemap().create(*m_k007121[1], tilemap_get_info_delegate(*this, FUNC(hcastle_state::get_tile_info<1>)), tilemap_mapper_delegate(*this, FUNC(hcastle_state::tilemap_scan)), 8, 8, 64, 32);
 
 	m_tilemap[0]->set_transparent_pen(0);
 }
@@ -227,7 +225,7 @@ void hcastle_state::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect
 	int base_color = (m_k007121[Which]->ctrlram_r(6) & 0x30) * 2;
 	int bank_base = (Which == 0) ? 0x4000 * (m_gfx_bank & 1) : 0;
 
-	m_k007121[Which]->sprites_draw(bitmap, cliprect, m_gfxdecode->gfx(Which), *m_palette, sbank, base_color, 0, bank_base, priority_bitmap, (uint32_t)-1);
+	m_k007121[Which]->sprites_draw(bitmap, cliprect, sbank, base_color, 0, bank_base, priority_bitmap, (uint32_t)-1);
 }
 
 /*****************************************************************************/
@@ -407,20 +405,12 @@ INPUT_PORTS_END
 
 /*****************************************************************************/
 
-static const gfx_layout charlayout =
-{
-	8,8,
-	32768,
-	4,
-	{ 0, 1, 2, 3 },
-	{ 2*4, 3*4, 0*4, 1*4, 6*4, 7*4, 4*4, 5*4 },
-	{ 0*32, 1*32, 2*32, 3*32, 4*32, 5*32, 6*32, 7*32 },
-	32*8
-};
+static GFXDECODE_START( gfx_hcastle_1 )
+	GFXDECODE_ENTRY( "k007121_1", 0, gfx_8x8x4_packed_msb,       0, 8*16 )
+GFXDECODE_END
 
-static GFXDECODE_START( gfx_hcastle )
-	GFXDECODE_ENTRY( "k007121_1", 0, charlayout,       0, 8*16 )
-	GFXDECODE_ENTRY( "k007121_2", 0, charlayout, 8*16*16, 8*16 )
+static GFXDECODE_START( gfx_hcastle_2 )
+	GFXDECODE_ENTRY( "k007121_2", 0, gfx_8x8x4_packed_msb, 8*16*16, 8*16 )
 GFXDECODE_END
 
 /*****************************************************************************/
@@ -476,13 +466,10 @@ void hcastle_state::hcastle(machine_config &config)
 	screen.set_screen_update(FUNC(hcastle_state::screen_update));
 	screen.set_palette(m_palette);
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_hcastle);
 	PALETTE(config, m_palette, FUNC(hcastle_state::palette)).set_format(palette_device::xBGR_555, 2*8*16*16, 128);
 
-	K007121(config, m_k007121[0], 0);
-	m_k007121[0]->set_palette_tag(m_palette);
-	K007121(config, m_k007121[1], 0);
-	m_k007121[1]->set_palette_tag(m_palette);
+	K007121(config, m_k007121[0], 0, m_palette, gfx_hcastle_1);
+	K007121(config, m_k007121[1], 0, m_palette, gfx_hcastle_2);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
@@ -512,12 +499,12 @@ ROM_START( hcastle )
 	ROM_LOAD( "768e01.e4",    0x00000, 0x08000, CRC(b9fff184) SHA1(c55f468c0da6afdaa2af65a111583c0c42868bd1) )
 
 	ROM_REGION( 0x100000, "k007121_1", 0 ) // chars and sprites
-	ROM_LOAD( "768c09.g21",   0x000000, 0x80000, CRC(e3be3fdd) SHA1(01a686af33a0a700066b1a5334d8552454ff186f) )
-	ROM_LOAD( "768c08.g19",   0x080000, 0x80000, CRC(9633db8b) SHA1(fe1b117c2566288b88f000106c649c2fa5648ddc) )
+	ROM_LOAD16_WORD_SWAP( "768c09.g21",   0x000000, 0x80000, CRC(e3be3fdd) SHA1(01a686af33a0a700066b1a5334d8552454ff186f) )
+	ROM_LOAD16_WORD_SWAP( "768c08.g19",   0x080000, 0x80000, CRC(9633db8b) SHA1(fe1b117c2566288b88f000106c649c2fa5648ddc) )
 
 	ROM_REGION( 0x100000, "k007121_2", 0 ) // chars and sprites
-	ROM_LOAD( "768c04.j5",    0x000000, 0x80000, CRC(2960680e) SHA1(72e1f025496c907de8516e3b5f1781e73d5b2c6c) )
-	ROM_LOAD( "768c05.j6",    0x080000, 0x80000, CRC(65a2f227) SHA1(43f368e533d6a164dc68d54130b81883e0d1bafe) )
+	ROM_LOAD16_WORD_SWAP( "768c04.j5",    0x000000, 0x80000, CRC(2960680e) SHA1(72e1f025496c907de8516e3b5f1781e73d5b2c6c) )
+	ROM_LOAD16_WORD_SWAP( "768c05.j6",    0x080000, 0x80000, CRC(65a2f227) SHA1(43f368e533d6a164dc68d54130b81883e0d1bafe) )
 
 	ROM_REGION( 0x0500, "proms", 0 )
 	ROM_LOAD( "768c13.j21",   0x0000, 0x0100, CRC(f5de80cb) SHA1(e8cc3e14a5d23b25fb7bf790e64786c6aa2df8b7) )    // 007121 #0 sprite lookup table
@@ -539,12 +526,12 @@ ROM_START( hcastlek )
 	ROM_LOAD( "768e01.e4",    0x00000, 0x08000, CRC(b9fff184) SHA1(c55f468c0da6afdaa2af65a111583c0c42868bd1) )
 
 	ROM_REGION( 0x100000, "k007121_1", 0 ) // chars and sprites
-	ROM_LOAD( "768c09.g21",   0x000000, 0x80000, CRC(e3be3fdd) SHA1(01a686af33a0a700066b1a5334d8552454ff186f) )
-	ROM_LOAD( "768c08.g19",   0x080000, 0x80000, CRC(9633db8b) SHA1(fe1b117c2566288b88f000106c649c2fa5648ddc) )
+	ROM_LOAD16_WORD_SWAP( "768c09.g21",   0x000000, 0x80000, CRC(e3be3fdd) SHA1(01a686af33a0a700066b1a5334d8552454ff186f) )
+	ROM_LOAD16_WORD_SWAP( "768c08.g19",   0x080000, 0x80000, CRC(9633db8b) SHA1(fe1b117c2566288b88f000106c649c2fa5648ddc) )
 
 	ROM_REGION( 0x100000, "k007121_2", 0 ) // chars and sprites
-	ROM_LOAD( "768c04.j5",    0x000000, 0x80000, CRC(2960680e) SHA1(72e1f025496c907de8516e3b5f1781e73d5b2c6c) )
-	ROM_LOAD( "768c05.j6",    0x080000, 0x80000, CRC(65a2f227) SHA1(43f368e533d6a164dc68d54130b81883e0d1bafe) )
+	ROM_LOAD16_WORD_SWAP( "768c04.j5",    0x000000, 0x80000, CRC(2960680e) SHA1(72e1f025496c907de8516e3b5f1781e73d5b2c6c) )
+	ROM_LOAD16_WORD_SWAP( "768c05.j6",    0x080000, 0x80000, CRC(65a2f227) SHA1(43f368e533d6a164dc68d54130b81883e0d1bafe) )
 
 	ROM_REGION( 0x0500, "proms", 0 )
 	ROM_LOAD( "768c13.j21",   0x0000, 0x0100, CRC(f5de80cb) SHA1(e8cc3e14a5d23b25fb7bf790e64786c6aa2df8b7) )    // 007121 #0 sprite lookup table
@@ -566,12 +553,12 @@ ROM_START( hcastlee )
 	ROM_LOAD( "768e01.e4",    0x00000, 0x08000, CRC(b9fff184) SHA1(c55f468c0da6afdaa2af65a111583c0c42868bd1) )
 
 	ROM_REGION( 0x100000, "k007121_1", 0 ) // chars and sprites
-	ROM_LOAD( "768c09.g21",   0x000000, 0x80000, CRC(e3be3fdd) SHA1(01a686af33a0a700066b1a5334d8552454ff186f) )
-	ROM_LOAD( "768c08.g19",   0x080000, 0x80000, CRC(9633db8b) SHA1(fe1b117c2566288b88f000106c649c2fa5648ddc) )
+	ROM_LOAD16_WORD_SWAP( "768c09.g21",   0x000000, 0x80000, CRC(e3be3fdd) SHA1(01a686af33a0a700066b1a5334d8552454ff186f) )
+	ROM_LOAD16_WORD_SWAP( "768c08.g19",   0x080000, 0x80000, CRC(9633db8b) SHA1(fe1b117c2566288b88f000106c649c2fa5648ddc) )
 
 	ROM_REGION( 0x100000, "k007121_2", 0 ) // chars and sprites
-	ROM_LOAD( "768c04.j5",    0x000000, 0x80000, CRC(2960680e) SHA1(72e1f025496c907de8516e3b5f1781e73d5b2c6c) )
-	ROM_LOAD( "768c05.j6",    0x080000, 0x80000, CRC(65a2f227) SHA1(43f368e533d6a164dc68d54130b81883e0d1bafe) )
+	ROM_LOAD16_WORD_SWAP( "768c04.j5",    0x000000, 0x80000, CRC(2960680e) SHA1(72e1f025496c907de8516e3b5f1781e73d5b2c6c) )
+	ROM_LOAD16_WORD_SWAP( "768c05.j6",    0x080000, 0x80000, CRC(65a2f227) SHA1(43f368e533d6a164dc68d54130b81883e0d1bafe) )
 
 	ROM_REGION( 0x0500, "proms", 0 )
 	ROM_LOAD( "768c13.j21",   0x0000, 0x0100, CRC(f5de80cb) SHA1(e8cc3e14a5d23b25fb7bf790e64786c6aa2df8b7) )    // 007121 #0 sprite lookup table
@@ -593,12 +580,12 @@ ROM_START( akumajou )
 	ROM_LOAD( "768e01.e4",    0x00000, 0x08000, CRC(b9fff184) SHA1(c55f468c0da6afdaa2af65a111583c0c42868bd1) )
 
 	ROM_REGION( 0x100000, "k007121_1", 0 ) // chars and sprites
-	ROM_LOAD( "768c09.g21",   0x000000, 0x80000, CRC(e3be3fdd) SHA1(01a686af33a0a700066b1a5334d8552454ff186f) )
-	ROM_LOAD( "768c08.g19",   0x080000, 0x80000, CRC(9633db8b) SHA1(fe1b117c2566288b88f000106c649c2fa5648ddc) )
+	ROM_LOAD16_WORD_SWAP( "768c09.g21",   0x000000, 0x80000, CRC(e3be3fdd) SHA1(01a686af33a0a700066b1a5334d8552454ff186f) )
+	ROM_LOAD16_WORD_SWAP( "768c08.g19",   0x080000, 0x80000, CRC(9633db8b) SHA1(fe1b117c2566288b88f000106c649c2fa5648ddc) )
 
 	ROM_REGION( 0x100000, "k007121_2", 0 ) // chars and sprites
-	ROM_LOAD( "768c04.j5",    0x000000, 0x80000, CRC(2960680e) SHA1(72e1f025496c907de8516e3b5f1781e73d5b2c6c) )
-	ROM_LOAD( "768c05.j6",    0x080000, 0x80000, CRC(65a2f227) SHA1(43f368e533d6a164dc68d54130b81883e0d1bafe) )
+	ROM_LOAD16_WORD_SWAP( "768c04.j5",    0x000000, 0x80000, CRC(2960680e) SHA1(72e1f025496c907de8516e3b5f1781e73d5b2c6c) )
+	ROM_LOAD16_WORD_SWAP( "768c05.j6",    0x080000, 0x80000, CRC(65a2f227) SHA1(43f368e533d6a164dc68d54130b81883e0d1bafe) )
 
 	ROM_REGION( 0x0500, "proms", 0 )
 	ROM_LOAD( "768c13.j21",   0x0000, 0x0100, CRC(f5de80cb) SHA1(e8cc3e14a5d23b25fb7bf790e64786c6aa2df8b7) )    // 007121 #0 sprite lookup table
@@ -620,12 +607,12 @@ ROM_START( akumajoun )
 	ROM_LOAD( "768e01.e4",    0x00000, 0x08000, CRC(b9fff184) SHA1(c55f468c0da6afdaa2af65a111583c0c42868bd1) )
 
 	ROM_REGION( 0x100000, "k007121_1", 0 ) // chars and sprites
-	ROM_LOAD( "768c09.g21",   0x000000, 0x80000, CRC(e3be3fdd) SHA1(01a686af33a0a700066b1a5334d8552454ff186f) )
-	ROM_LOAD( "768c08.g19",   0x080000, 0x80000, CRC(9633db8b) SHA1(fe1b117c2566288b88f000106c649c2fa5648ddc) )
+	ROM_LOAD16_WORD_SWAP( "768c09.g21",   0x000000, 0x80000, CRC(e3be3fdd) SHA1(01a686af33a0a700066b1a5334d8552454ff186f) )
+	ROM_LOAD16_WORD_SWAP( "768c08.g19",   0x080000, 0x80000, CRC(9633db8b) SHA1(fe1b117c2566288b88f000106c649c2fa5648ddc) )
 
 	ROM_REGION( 0x100000, "k007121_2", 0 ) // chars and sprites
-	ROM_LOAD( "768c04.j5",    0x000000, 0x80000, CRC(2960680e) SHA1(72e1f025496c907de8516e3b5f1781e73d5b2c6c) )
-	ROM_LOAD( "768c05.j6",    0x080000, 0x80000, CRC(65a2f227) SHA1(43f368e533d6a164dc68d54130b81883e0d1bafe) )
+	ROM_LOAD16_WORD_SWAP( "768c04.j5",    0x000000, 0x80000, CRC(2960680e) SHA1(72e1f025496c907de8516e3b5f1781e73d5b2c6c) )
+	ROM_LOAD16_WORD_SWAP( "768c05.j6",    0x080000, 0x80000, CRC(65a2f227) SHA1(43f368e533d6a164dc68d54130b81883e0d1bafe) )
 
 	ROM_REGION( 0x0500, "proms", 0 )
 	ROM_LOAD( "768c13.j21",   0x0000, 0x0100, CRC(f5de80cb) SHA1(e8cc3e14a5d23b25fb7bf790e64786c6aa2df8b7) )    // 007121 #0 sprite lookup table

--- a/src/mame/konami/k007121.cpp
+++ b/src/mame/konami/k007121.cpp
@@ -125,8 +125,8 @@ DEFINE_DEVICE_TYPE(K007121, k007121_device, "k007121", "K007121 Sprite/Tilemap C
 
 k007121_device::k007121_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, K007121, tag, owner, clock)
-	, m_flipscreen(0)
-	, m_palette(*this, finder_base::DUMMY_TAG)
+	, device_gfx_interface(mconfig, *this)
+	, m_flipscreen(false)
 {
 }
 
@@ -146,7 +146,7 @@ void k007121_device::device_start()
 
 void k007121_device::device_reset()
 {
-	m_flipscreen = 0;
+	m_flipscreen = false;
 
 	for (int i = 0; i < 8; i++)
 		m_ctrlram[i] = 0;
@@ -177,7 +177,7 @@ void k007121_device::ctrl_w(offs_t offset, uint8_t data)
 			machine().tilemap().mark_all_dirty();
 		break;
 	case 7:
-		m_flipscreen = data & 0x08;
+		m_flipscreen = BIT(data, 3);
 		break;
 	}
 
@@ -208,7 +208,7 @@ void k007121_device::ctrl_w(offs_t offset, uint8_t data)
  *
  */
 
-void k007121_device::sprites_draw( bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, device_palette_interface &palette,
+void k007121_device::sprites_draw( bitmap_ind16 &bitmap, const rectangle &cliprect,
 		const uint8_t *source, int base_color, int global_x_offset, int bank_base, bitmap_ind8 &priority_bitmap, uint32_t pri_mask, bool is_flakatck )
 {
 	// TODO: sprite limit is supposed to be per-line! (check MT #00185)
@@ -252,7 +252,7 @@ void k007121_device::sprites_draw( bitmap_ind16 &bitmap, const rectangle &clipre
 		if (is_flakatck)
 			transparent_mask = 1 << 0;
 		else
-			transparent_mask = palette.transpen_mask(*gfx, color, 0);
+			transparent_mask = palette().transpen_mask(*gfx(0), color, 0);
 
 		number += bank_base;
 
@@ -292,7 +292,7 @@ void k007121_device::sprites_draw( bitmap_ind16 &bitmap, const rectangle &clipre
 
 				if (pri_mask != (uint32_t)-1)
 				{
-					gfx->prio_transmask(bitmap,cliprect,
+					gfx(0)->prio_transmask(bitmap,cliprect,
 							number + x_offset[ex] + y_offset[ey],
 							color,
 							flipx,flipy,
@@ -302,7 +302,7 @@ void k007121_device::sprites_draw( bitmap_ind16 &bitmap, const rectangle &clipre
 				}
 				else
 				{
-					gfx->transmask(bitmap,cliprect,
+					gfx(0)->transmask(bitmap,cliprect,
 							number + x_offset[ex] + y_offset[ey],
 							color,
 							flipx,flipy,

--- a/src/mame/konami/k007121.h
+++ b/src/mame/konami/k007121.h
@@ -8,19 +8,23 @@
 #include "emupal.h"
 
 
-class k007121_device : public device_t
+class k007121_device : public device_t, public device_gfx_interface
 {
 public:
 	k007121_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	template <typename T> void set_palette_tag(T &&tag) { m_palette.set_tag(std::forward<T>(tag)); }
+	template<typename T> k007121_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&palette_tag, const gfx_decode_entry *gfxinfo)
+		: k007121_device(mconfig, tag, owner, clock)
+	{
+		set_info(gfxinfo);
+		set_palette(std::forward<T>(palette_tag));
+	}
 
 	uint8_t ctrlram_r(offs_t offset);
 	void ctrl_w(offs_t offset, uint8_t data);
 
 	/* shall we move source in the interface? */
 	/* also notice that now we directly pass *gfx[chip] instead of **gfx !! */
-	void sprites_draw( bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, device_palette_interface &palette, const uint8_t *source, int base_color, int global_x_offset, int bank_base, bitmap_ind8 &priority_bitmap, uint32_t pri_mask, bool is_flakatck = false );
+	void sprites_draw( bitmap_ind16 &bitmap, const rectangle &cliprect, const uint8_t *source, int base_color, int global_x_offset, int bank_base, bitmap_ind8 &priority_bitmap, uint32_t pri_mask, bool is_flakatck = false );
 
 protected:
 	// device-level overrides
@@ -30,8 +34,7 @@ protected:
 private:
 	// internal state
 	uint8_t  m_ctrlram[8];
-	int      m_flipscreen;
-	required_device<palette_device> m_palette;
+	bool     m_flipscreen;
 };
 
 DECLARE_DEVICE_TYPE(K007121, k007121_device)

--- a/src/mame/konami/labyrunr.cpp
+++ b/src/mame/konami/labyrunr.cpp
@@ -35,7 +35,6 @@ public:
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this,"maincpu"),
 		m_k007121(*this, "k007121"),
-		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
 		m_scrollram(*this, "scrollram"),
@@ -54,7 +53,6 @@ private:
 	// devices
 	required_device<cpu_device> m_maincpu;
 	required_device<k007121_device> m_k007121;
-	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 
@@ -153,8 +151,8 @@ TILE_GET_INFO_MEMBER(labyrunr_state::get_tile_info)
 
 void labyrunr_state::video_start()
 {
-	m_layer[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(labyrunr_state::get_tile_info<0>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
-	m_layer[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(labyrunr_state::get_tile_info<1>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_layer[0] = &machine().tilemap().create(*m_k007121, tilemap_get_info_delegate(*this, FUNC(labyrunr_state::get_tile_info<0>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
+	m_layer[1] = &machine().tilemap().create(*m_k007121, tilemap_get_info_delegate(*this, FUNC(labyrunr_state::get_tile_info<1>)), TILEMAP_SCAN_ROWS, 8, 8, 32, 32);
 
 	m_layer[0]->set_transparent_pen(0);
 	m_layer[1]->set_transparent_pen(0);
@@ -221,7 +219,7 @@ uint32_t labyrunr_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 		}
 
 		m_layer[0]->draw(screen, bitmap, finalclip0, TILEMAP_DRAW_OPAQUE | TILEMAP_DRAW_CATEGORY(0), 0);
-		m_k007121->sprites_draw(bitmap, cliprect, m_gfxdecode->gfx(0), *m_palette, m_spriteram, (m_k007121->ctrlram_r(6) & 0x30) * 2, 40, 0, screen.priority(), (m_k007121->ctrlram_r(3) & 0x40) >> 5);
+		m_k007121->sprites_draw(bitmap, cliprect, m_spriteram, (m_k007121->ctrlram_r(6) & 0x30) * 2, 40, 0, screen.priority(), (m_k007121->ctrlram_r(3) & 0x40) >> 5);
 		m_layer[0]->draw(screen, bitmap, finalclip0, TILEMAP_DRAW_OPAQUE | TILEMAP_DRAW_CATEGORY(1), 0);
 		// we ignore the transparency because layer1 is drawn only at the top of the screen also covering sprites
 		m_layer[1]->draw(screen, bitmap, finalclip1, TILEMAP_DRAW_OPAQUE, 0);
@@ -288,7 +286,7 @@ uint32_t labyrunr_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 		if (use_clip3[0])
 			m_layer[0]->draw(screen, bitmap, finalclip3, TILEMAP_DRAW_CATEGORY(0), 0);
 
-		m_k007121->sprites_draw(bitmap, cliprect, m_gfxdecode->gfx(0), *m_palette, m_spriteram, (m_k007121->ctrlram_r(6) & 0x30) * 2,40,0,screen.priority(),(m_k007121->ctrlram_r(3) & 0x40) >> 5);
+		m_k007121->sprites_draw(bitmap, cliprect, m_spriteram, (m_k007121->ctrlram_r(6) & 0x30) * 2,40,0,screen.priority(),(m_k007121->ctrlram_r(3) & 0x40) >> 5);
 
 		m_layer[0]->draw(screen, bitmap, finalclip0, TILEMAP_DRAW_CATEGORY(1), 0);
 		if (use_clip3[0])
@@ -420,19 +418,8 @@ INPUT_PORTS_END
 
 
 
-static const gfx_layout gfxlayout =
-{
-	8,8,
-	0x40000/32,
-	4,
-	{ 0, 1, 2, 3 },
-	{ 2*4, 3*4, 0*4, 1*4, 6*4, 7*4, 4*4, 5*4 },
-	{ 0*32, 1*32, 2*32, 3*32, 4*32, 5*32, 6*32, 7*32 },
-	32*8
-};
-
 static GFXDECODE_START( gfx_labyrunr )
-	GFXDECODE_ENTRY( "gfx", 0, gfxlayout, 0, 8*16 )
+	GFXDECODE_ENTRY( "gfx", 0, gfx_8x8x4_packed_msb, 0, 8*16 )
 GFXDECODE_END
 
 /***************************************************************************
@@ -467,12 +454,10 @@ void labyrunr_state::labyrunr(machine_config &config)
 	screen.set_palette(m_palette);
 	screen.screen_vblank().set(FUNC(labyrunr_state::vblank_irq));
 
-	GFXDECODE(config, m_gfxdecode, m_palette, gfx_labyrunr);
 	PALETTE(config, m_palette, FUNC(labyrunr_state::palette));
 	m_palette->set_format(palette_device::xBGR_555, 2*8*16*16, 128);
 
-	K007121(config, m_k007121, 0);
-	m_k007121->set_palette_tag(m_palette);
+	K007121(config, m_k007121, 0, m_palette, gfx_labyrunr);
 
 	K051733(config, "k051733", 0);
 
@@ -509,10 +494,10 @@ ROM_START( tricktrp )
 	ROM_LOAD( "771e03",     0x18000, 0x10000, CRC(d0d68036) SHA1(8589ee07e229259341a4cc22bc64de8f06536472) )
 
 	ROM_REGION( 0x40000, "gfx", 0 )
-	ROM_LOAD16_BYTE( "771e01a", 0x00000, 0x10000, CRC(103ffa0d) SHA1(1949c49ca3b243e4cfb5fb19ecd3a1e1492cfddd) )    // tiles + sprites
-	ROM_LOAD16_BYTE( "771e01c", 0x00001, 0x10000, CRC(cfec5be9) SHA1(2b6a32e2608a70c47d1ec9b4de38b5c3a0898cde) )
-	ROM_LOAD16_BYTE( "771d01b", 0x20000, 0x10000, CRC(07f2a71c) SHA1(63c79e75e71539e69d4d9d35e629a6021124f6d0) )
-	ROM_LOAD16_BYTE( "771d01d", 0x20001, 0x10000, CRC(f6810a49) SHA1(b40e9f0d0919188a05c1990347da8dc8ff12d65a) )
+	ROM_LOAD16_BYTE( "771e01a", 0x00001, 0x10000, CRC(103ffa0d) SHA1(1949c49ca3b243e4cfb5fb19ecd3a1e1492cfddd) )    // tiles + sprites
+	ROM_LOAD16_BYTE( "771e01c", 0x00000, 0x10000, CRC(cfec5be9) SHA1(2b6a32e2608a70c47d1ec9b4de38b5c3a0898cde) )
+	ROM_LOAD16_BYTE( "771d01b", 0x20001, 0x10000, CRC(07f2a71c) SHA1(63c79e75e71539e69d4d9d35e629a6021124f6d0) )
+	ROM_LOAD16_BYTE( "771d01d", 0x20000, 0x10000, CRC(f6810a49) SHA1(b40e9f0d0919188a05c1990347da8dc8ff12d65a) )
 
 	ROM_REGION( 0x0100, "proms", 0 )
 	ROM_LOAD( "771d02.08d", 0x0000, 0x0100, CRC(3d34bb5a) SHA1(3f3c845f1197457244e7c7e4f9b2a03c278613e4) )  // sprite lookup table
@@ -526,7 +511,7 @@ ROM_START( labyrunr )
 	ROM_LOAD( "771j03.08f", 0x18000, 0x10000, CRC(12b49044) SHA1(e9b22fb093cfb746a9767e94ef5deef98bed5b7a) )
 
 	ROM_REGION( 0x40000, "gfx", 0 )
-	ROM_LOAD( "771d01.14a", 0x00000, 0x40000, CRC(15c8f5f9) SHA1(e4235e1315d0331f3ce5047834a68764ed43aa4b) )    // tiles + sprites
+	ROM_LOAD16_WORD_SWAP( "771d01.14a", 0x00000, 0x40000, CRC(15c8f5f9) SHA1(e4235e1315d0331f3ce5047834a68764ed43aa4b) )    // tiles + sprites
 
 	ROM_REGION( 0x0100, "proms", 0 )
 	ROM_LOAD( "771d02.08d", 0x0000, 0x0100, CRC(3d34bb5a) SHA1(3f3c845f1197457244e7c7e4f9b2a03c278613e4) )  // sprite lookup table
@@ -540,10 +525,10 @@ ROM_START( labyrunrk )
 	ROM_LOAD( "771k03.8f",  0x18000, 0x10000, CRC(48d732ae) SHA1(8bc7917397f32cf5f995b3763ae921725e27de05) )
 
 	ROM_REGION( 0x40000, "gfx", 0 )
-	ROM_LOAD16_BYTE( "771d01a.13a", 0x00000, 0x10000, CRC(0cd1ed1a) SHA1(eac6c106de28acc54535ae1fb99f778c1ed4013e) )    // tiles + sprites
-	ROM_LOAD16_BYTE( "771d01c.13a", 0x00001, 0x10000, CRC(d75521fe) SHA1(72f0c4d9511bc70d77415f50be93293026305bd5) )
-	ROM_LOAD16_BYTE( "771d01b",     0x20000, 0x10000, CRC(07f2a71c) SHA1(63c79e75e71539e69d4d9d35e629a6021124f6d0) )
-	ROM_LOAD16_BYTE( "771d01d",     0x20001, 0x10000, CRC(f6810a49) SHA1(b40e9f0d0919188a05c1990347da8dc8ff12d65a) )
+	ROM_LOAD16_BYTE( "771d01a.13a", 0x00001, 0x10000, CRC(0cd1ed1a) SHA1(eac6c106de28acc54535ae1fb99f778c1ed4013e) )    // tiles + sprites
+	ROM_LOAD16_BYTE( "771d01c.13a", 0x00000, 0x10000, CRC(d75521fe) SHA1(72f0c4d9511bc70d77415f50be93293026305bd5) )
+	ROM_LOAD16_BYTE( "771d01b",     0x20001, 0x10000, CRC(07f2a71c) SHA1(63c79e75e71539e69d4d9d35e629a6021124f6d0) )
+	ROM_LOAD16_BYTE( "771d01d",     0x20000, 0x10000, CRC(f6810a49) SHA1(b40e9f0d0919188a05c1990347da8dc8ff12d65a) )
 
 	ROM_REGION( 0x0100, "proms", 0 )
 	ROM_LOAD( "771d02.08d", 0x0000, 0x0100, CRC(3d34bb5a) SHA1(3f3c845f1197457244e7c7e4f9b2a03c278613e4) )  // sprite lookup table


### PR DESCRIPTION
konami/combatsc.cpp, konami/contra.cpp, konami/fastlane.cpp, konami/flkatck.cpp, konami/hcastle.cpp, konami/labyrunr.cpp: Minor cleanup gfxdecode, Assign tilemap gfx per each K007121 chips