### PR TITLE
cpu/z80/z80.cpp: More accurate emulation of WZ in I/O block instructions

### DIFF
--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -1299,6 +1299,7 @@ inline void z80_device::inir()
 	{
 		nomreq_addr(HL, 5);
 		PC -= 2;
+		WZ = PC + 1;
 		block_io_interrupted_flags(data);
 	}
 }
@@ -1313,6 +1314,7 @@ inline void z80_device::otir()
 	{
 		nomreq_addr(BC, 5);
 		PC -= 2;
+		WZ = PC + 1;
 		block_io_interrupted_flags(data);
 	}
 }
@@ -1359,6 +1361,7 @@ inline void z80_device::indr()
 	{
 		nomreq_addr(HL, 5);
 		PC -= 2;
+		WZ = PC + 1;
 		block_io_interrupted_flags(data);
 	}
 }
@@ -1373,6 +1376,7 @@ inline void z80_device::otdr()
 	{
 		nomreq_addr(BC, 5);
 		PC -= 2;
+		WZ = PC + 1;
 		block_io_interrupted_flags(data);
 	}
 }


### PR DESCRIPTION
### Credits

* Z80 CPU: Undocumented behavior of WZ - Manuel Sainz de Baranda y Goñi ([redcode](https://github.com/redcode))

### Description

This tiny PR adds emulation of a recently discovered undocumented behavior of the `inir/indr/otir/otdr` instructions:

As in `cpir/cpdr/ldir/lddr`, when the repeat condition is met, the Z80 CPU generates an extra M-cycle of 5 T-states to decrement PC. This M-cycle performs additional flag changes ([discovered](https://stardot.org.uk/forums/viewtopic.php?t=15464) and [cracked](https://github.com/hoglet67/Z80Decoder/wiki/Undocumented-Flags) by [David Banks](https://github.com/hoglet67)), but until now it was not known that the WZ register is also modified, being set, as in all other block instructions during this M-cycle, to PCi + 1 (PCi = value of PC at the start of the instruction, before it is incremented).

### Testing

As can be checked in the links provided below, this behavior has been verified on real hardware and in electronic simulations. It has been tested on 1 Zilog NMOS and 2 NEC NMOS processors. Also, the most important and so far only [test suite](https://github.com/raxoft/z80test) capable of partially detecting this behavior has been [updated](https://github.com/raxoft/z80test/releases/tag/v1.2a) accordingly.

### References

* https://github.com/raxoft/z80test/pull/3
* https://stardot.org.uk/forums/viewtopic.php?p=409774#p409774
* https://spectrumcomputing.co.uk/forums/viewtopic.php?t=10555