### PR TITLE
breakout: change colors to match gel sheets

### DIFF
--- a/src/mame/layout/breakout.lay
+++ b/src/mame/layout/breakout.lay
@@ -4,32 +4,33 @@ license:CC0-1.0
 -->
 <mamelayout version="2">
 
-<!-- define elements -->
-
 	<element name="overlay">
+		<!-- score -->
 		<rect>
 			<bounds left="0" top="0" right="192" bottom="1440" />
 			<color red="1" green="1" blue="1" />
 		</rect>
+		<!-- color bars -->
 		<rect>
 			<bounds left="0" top="264" right="192" bottom="322" />
-			<color red="1" green="0.125" blue="0.125" />
+			<color red="0.941" green="0" blue="0.196" />
 		</rect>
 		<rect>
 			<bounds left="0" top="319" right="192" bottom="378" />
-			<color red="1" green="0.5" blue="0.0625" />
+			<color red="1" green="0.627" blue="0" />
 		</rect>
 		<rect>
 			<bounds left="0" top="375" right="192" bottom="434" />
-			<color red="0.25" green="1" blue="0.25" />
+			<color red="0.294" green="0.765" blue="0" />
 		</rect>
 		<rect>
 			<bounds left="0" top="431" right="192" bottom="487" />
-			<color red="1" green="1" blue="0.25" />
+			<color red="1" green="0.961" blue="0" />
 		</rect>
+		<!-- paddle -->
 		<rect>
 			<bounds left="0" top="1305" right="192" bottom="1338" />
-			<color red="0.125" green="0.125" blue="1" />
+			<color red="0" green="0.471" blue="0.784" />
 		</rect>
 	</element>
 
@@ -44,7 +45,7 @@ license:CC0-1.0
 
 	<element name="serve_led" defstate="0">
 		<disk state="0"><color red="0.1" green="0.01" blue="0.015" /></disk>
-		<disk state="1"><color red="1.0" green="0.1" blue="0.15" /></disk>
+		<disk state="1"><color red="1.0" green="0.12" blue="0" /></disk>
 	</element>
 
 	<element name="nothing" defstate="0">


### PR DESCRIPTION
the paddle is a little too dark blue if you look at videos of the machine in action
so i went to https://leefilters.com/lighting/gel-comparator/ and picked the colors they probably used

106 Primary Red
105 Orange
139 Primary Green
101 Yellow
119 Dark Blue

also calculated which color red LEDs at 640nm actually are
https://405nm.com/wavelength-to-color/

real machine:
![grafik](https://github.com/mamedev/mame/assets/10584181/a387b7ed-2702-4169-8fd1-9877468a1668)


before:
![grafik](https://github.com/mamedev/mame/assets/10584181/f1b10226-9f4d-42f1-9e83-560e1afe603b)
![grafik](https://github.com/mamedev/mame/assets/10584181/75c95193-cd65-4c4d-9212-396362b8021f)

after:
![grafik](https://github.com/mamedev/mame/assets/10584181/6d886112-b3c1-461d-b4c7-a658743731ec)
![grafik](https://github.com/mamedev/mame/assets/10584181/f11fb388-9ac6-48c0-9ea3-f6ebf5524bd4)
