### PR TITLE
emu/rendlay.cpp: keep the alpha channel intact when rendering text components

### DIFF
--- a/src/emu/rendlay.cpp
+++ b/src/emu/rendlay.cpp
@@ -3727,12 +3727,6 @@ void layout_element::component::draw_text(
 		int align,
 		const render_color &color)
 {
-	// compute premultiplied color
-	u32 const r(color.r * 255.0f);
-	u32 const g(color.g * 255.0f);
-	u32 const b(color.b * 255.0f);
-	u32 const a(color.a * 255.0f);
-
 	// get the width of the string
 	float aspect = 1.0f;
 	s32 width;
@@ -3797,12 +3791,7 @@ void layout_element::component::draw_text(
 						u32 spix = rgb_t(src[x]).a();
 						if (spix != 0)
 						{
-							rgb_t dpix = d[effx];
-							u32 ta = (a * (spix + 1)) >> 8;
-							u32 tr = (r * ta + dpix.r() * (0x100 - ta)) >> 8;
-							u32 tg = (g * ta + dpix.g() * (0x100 - ta)) >> 8;
-							u32 tb = (b * ta + dpix.b() * (0x100 - ta)) >> 8;
-							d[effx] = rgb_t(tr, tg, tb);
+							alpha_blend(d[effx], color, spix / 255.0);
 						}
 					}
 				}


### PR DESCRIPTION
This makes text on non-black backgrounds look better without the need to give text elements an explicit background color.

Before and after, using pss6 as an example:

![image](https://github.com/mamedev/mame/assets/4616298/25d90dda-75f8-4f0d-9bd3-26f9fb2f7668)
![image](https://github.com/mamedev/mame/assets/4616298/9573fb62-0217-49c6-bc7f-e6863abf4c5c)
