### PR TITLE
deckarn.cpp, decmxc06.cpp: Use device_gfx_interface for gfx decoding

### DIFF
--- a/src/mame/dataeast/actfancr.cpp
+++ b/src/mame/dataeast/actfancr.cpp
@@ -113,7 +113,7 @@ uint32_t actfancr_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 	m_spritegen->set_flip_screen(flip);
 
 	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(1), m_spriteram16.target(), 0x800/2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_spriteram16.target(), 0x800/2);
 	m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
 
 	return 0;
@@ -329,14 +329,20 @@ static const gfx_layout layout_16x16x4 =
 
 static GFXDECODE_START( gfx_actfan )
 	GFXDECODE_ENTRY( "chars",   0, layout_8x8x4,     0, 16 )
-	GFXDECODE_ENTRY( "sprites", 0, layout_16x16x4, 512, 16 )
 	GFXDECODE_ENTRY( "tiles",   0, layout_16x16x4, 256, 16 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_actfan_spr )
+	GFXDECODE_ENTRY( "sprites", 0, layout_16x16x4, 512, 16 )
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_triothep )
 	GFXDECODE_ENTRY( "chars",   0, layout_8x8x4,     0, 16 )
-	GFXDECODE_ENTRY( "sprites", 0, layout_16x16x4, 256, 16 )
 	GFXDECODE_ENTRY( "tiles",   0, layout_16x16x4, 512, 16 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_triothep_spr )
+	GFXDECODE_ENTRY( "sprites", 0, layout_16x16x4, 256, 16 )
 GFXDECODE_END
 
 /******************************************************************************/
@@ -377,14 +383,14 @@ void actfancr_state::actfancr(machine_config &config)
 	PALETTE(config, "palette").set_format(palette_device::xBGR_444, 768);
 
 	DECO_BAC06(config, m_tilegen[0], 0);
-	m_tilegen[0]->set_gfx_region_wide(2, 2, 2);
+	m_tilegen[0]->set_gfx_region_wide(1, 1, 2);
 	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_BAC06(config, m_tilegen[1], 0);
 	m_tilegen[1]->set_gfx_region_wide(0, 0, 0);
 	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_MXC06(config, m_spritegen, 0);
+	DECO_MXC06(config, m_spritegen, 0, "palette", gfx_actfan_spr);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
@@ -419,8 +425,9 @@ void triothep_state::triothep(machine_config &config)
 
 	// video hardware
 	m_gfxdecode->set_info(gfx_triothep);
+	m_spritegen->set_info(gfx_triothep_spr);
 
-	m_tilegen[0]->set_gfx_region_wide(2, 2, 0);
+	m_tilegen[0]->set_gfx_region_wide(1, 1, 0);
 
 	// sound hardware
 	subdevice<ym2203_device>("ym1")->set_clock(XTAL(12'000'000) / 8); // verified on PCB

--- a/src/mame/dataeast/dec0.cpp
+++ b/src/mame/dataeast/dec0.cpp
@@ -1736,31 +1736,39 @@ static const gfx_layout automat_tilelayout2 =
 
 
 static GFXDECODE_START( gfx_dec0 )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,   0, 16 )   /* Characters 8x8 */
-	GFXDECODE_ENTRY( "gfx2", 0, tilelayout, 512, 16 )   /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx3", 0, tilelayout, 768, 16 )   /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx4", 0, tilelayout, 256, 16 )   /* Sprites 16x16 */
+	GFXDECODE_ENTRY( "char",    0, charlayout,   0, 16 )   /* Characters 8x8 */
+	GFXDECODE_ENTRY( "tiles1",  0, tilelayout, 512, 16 )   /* Tiles 16x16 */
+	GFXDECODE_ENTRY( "tiles2",  0, tilelayout, 768, 16 )   /* Tiles 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_dec0_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tilelayout, 256, 16 )   /* Sprites 16x16 */
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_midres )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout, 256, 16 )   /* Characters 8x8 */
-	GFXDECODE_ENTRY( "gfx2", 0, tilelayout, 512, 16 )   /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx3", 0, tilelayout, 768, 16 )   /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx4", 0, tilelayout,   0, 16 )   /* Sprites 16x16 */
+	GFXDECODE_ENTRY( "char",    0, charlayout, 256, 16 )   /* Characters 8x8 */
+	GFXDECODE_ENTRY( "tiles1",  0, tilelayout, 512, 16 )   /* Tiles 16x16 */
+	GFXDECODE_ENTRY( "tiles2",  0, tilelayout, 768, 16 )   /* Tiles 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_midres_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tilelayout,   0, 16 )   /* Sprites 16x16 */
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_automat )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,   0, 16 )   /* Characters 8x8 */
-	GFXDECODE_ENTRY( "gfx2", 0, automat_tilelayout3, 512, 16 )  /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx3", 0, automat_tilelayout2, 768, 16 )  /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx4", 0, automat_spritelayout, 256, 16 ) /* Sprites 16x16 */
+	GFXDECODE_ENTRY( "char",    0, charlayout,             0, 16 )   /* Characters 8x8 */
+	GFXDECODE_ENTRY( "tiles1",  0, automat_tilelayout3,  512, 16 )   /* Tiles 16x16 */
+	GFXDECODE_ENTRY( "tiles2",  0, automat_tilelayout2,  768, 16 )   /* Tiles 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_automat_spr )
+	GFXDECODE_ENTRY( "sprites", 0, automat_spritelayout, 256, 16 )   /* Sprites 16x16 */
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_secretab )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,     0x000, 0x10 )
-	GFXDECODE_ENTRY( "gfx2", 0, automat_tilelayout2,     0x200, 0x10 )
-	GFXDECODE_ENTRY( "gfx3", 0, automat_tilelayout2,     0x300, 0x10 )
-	GFXDECODE_ENTRY( "gfx4", 0, automat_spritelayout,    0x100, 0x10 )
+	GFXDECODE_ENTRY( "char",    0, charlayout,           0x000, 0x10 )
+	GFXDECODE_ENTRY( "tiles1",  0, automat_tilelayout2,  0x200, 0x10 )
+	GFXDECODE_ENTRY( "tiles2",  0, automat_tilelayout2,  0x300, 0x10 )
 GFXDECODE_END
 
 /******************************************************************************/
@@ -1802,7 +1810,7 @@ void dec0_state::dec0_base(machine_config &config)
 	m_tilegen[2]->set_gfx_region_wide(0, 2, 0);
 	m_tilegen[2]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_MXC06(config, m_spritegen, 0);
+	DECO_MXC06(config, m_spritegen, 0, m_palette, gfx_dec0_spr);
 
 	GENERIC_LATCH_8(config, m_soundlatch);
 	m_soundlatch->data_pending_callback().set_inputline(m_audiocpu, INPUT_LINE_NMI);
@@ -1935,7 +1943,7 @@ void dec0_automat_state::automat(machine_config &config)
 	m_tilegen[2]->set_gfx_region_wide(0, 2, 0);
 	m_tilegen[2]->set_gfxdecode_tag("gfxdecode");
 
-	DECO_MXC06(config, m_spritegen, 0);
+	DECO_MXC06(config, m_spritegen, 0, m_palette, gfx_automat_spr);
 	m_spritegen->set_colpri_callback(FUNC(dec0_automat_state::robocop_colpri_cb));
 
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_444, 1024);
@@ -2012,7 +2020,7 @@ void dec0_automat_state::secretab(machine_config &config) // all clocks verified
 	m_tilegen[2]->set_gfx_region_wide(0, 2, 0);
 	m_tilegen[2]->set_gfxdecode_tag("gfxdecode");
 
-	DECO_MXC06(config, m_spritegen, 0);
+	DECO_MXC06(config, m_spritegen, 0, m_palette, gfx_automat_spr);
 
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_444, 1024);
 
@@ -2266,6 +2274,7 @@ void dec0_state::midres(machine_config &config)
 	m_spritegen->set_colpri_callback(FUNC(dec0_state::midres_colpri_cb));
 
 	m_gfxdecode->set_info(gfx_midres);
+	m_spritegen->set_info(gfx_midres_spr);
 
 	subdevice<okim6295_device>("oki")->set_clock(XTAL(1'056'000));
 }
@@ -2317,11 +2326,11 @@ ROM_START( hbarrel ) /* DE-0289-2 main board, DE-0293-1 sub/rom board */
 	ROM_REGION( 0x1000, "mcu", 0 )  /* i8751 microcontroller */
 	ROM_LOAD( "ec31-e.9a", 0x0000, 0x1000, CRC(bf93a2ec) SHA1(e62687c9ae280485835b3bc56c161618f47c56a1) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ec25.15h", 0x00000, 0x10000, CRC(2e5732a2) SHA1(b730ce11db1876b81d2b7cde0f129bd6fbfeb771) )
 	ROM_LOAD( "ec26.16h", 0x10000, 0x10000, CRC(161a2c4d) SHA1(fbfa97ecc8b4d540d38f811ebb6272b348ed37e5) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ec18.14d", 0x00000, 0x10000, CRC(ef664373) SHA1(d66a8c685c44cc8583527297d7ea7778f0d9c8db) )
 	ROM_LOAD( "ec17.12d", 0x10000, 0x10000, CRC(a4f186ac) SHA1(ee422f8479c1f21bb62d040567a9748b646e6f9f) )
 	ROM_LOAD( "ec20.17d", 0x20000, 0x10000, CRC(2fc13be0) SHA1(cce46b91104c0ac4038e98131fe957e0ed2f1a88) )
@@ -2331,13 +2340,13 @@ ROM_START( hbarrel ) /* DE-0289-2 main board, DE-0293-1 sub/rom board */
 	ROM_LOAD( "ec24.17f", 0x60000, 0x10000, CRC(ae377361) SHA1(a9aa520044f5b5037a495402ef128d3d8522b20f) )
 	ROM_LOAD( "ec23.15f", 0x70000, 0x10000, CRC(bbdaf771) SHA1(7b29d6d606319337562b0431b6290df15cde17e2) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ec29.8h", 0x00000, 0x10000, CRC(5514b296) SHA1(d258134a95bb223db139780b8e7377cccbe01af0) )
 	ROM_LOAD( "ec30.9h", 0x10000, 0x10000, CRC(5855e8ef) SHA1(0f09143fed7c354231a4f343d0371424d8436877) )
 	ROM_LOAD( "ec27.8f", 0x20000, 0x10000, CRC(99db7b9c) SHA1(2faeb287d685c8ea72c21658777f62ff9e194a69) )
 	ROM_LOAD( "ec28.9f", 0x30000, 0x10000, CRC(33ce2b1a) SHA1(ef150dd5bc22368857ba27da18a17c161bb807a4) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ec15.16c", 0x00000, 0x10000, CRC(21816707) SHA1(859a70dfc7d8c01124a035dcd5ea554af5f4e871) )
 	ROM_LOAD( "ec16.17c", 0x10000, 0x10000, CRC(a5684574) SHA1(2dfe429cd6e110645ab976dd3a2b27d54ad91e89) )
 	ROM_LOAD( "ec11.16a", 0x20000, 0x10000, CRC(5c768315) SHA1(00905e59dec90bf51f1d8e2482f54ede0895d142) )
@@ -2375,11 +2384,11 @@ ROM_START( hbarrelu ) /* DE-0297-1 main board, DE-0299-0 sub/rom board */
 	ROM_REGION( 0x1000, "mcu", 0 )  /* i8751 microcontroller */
 	ROM_LOAD( "heavy_barrel_31.9a", 0x0000, 0x1000, CRC(239d726f) SHA1(969f38ae981ffde6053ece93cc51614d492edbbb) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "heavy_barrel_25.15h", 0x00000, 0x10000, CRC(8649762c) SHA1(84d3d82d4d011c54271ef7a0dc5857a34b61cf8a) )
 	ROM_LOAD( "heavy_barrel_26.16h", 0x10000, 0x10000, CRC(f8189bbd) SHA1(b4445f50e8771af6ba4fcbc34018f6ecd379779a) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "heavy_barrel_18.14d", 0x00000, 0x10000, CRC(ef664373) SHA1(d66a8c685c44cc8583527297d7ea7778f0d9c8db) )
 	ROM_LOAD( "heavy_barrel_17.12d", 0x10000, 0x10000, CRC(a4f186ac) SHA1(ee422f8479c1f21bb62d040567a9748b646e6f9f) )
 	ROM_LOAD( "heavy_barrel_20.17d", 0x20000, 0x10000, CRC(2fc13be0) SHA1(cce46b91104c0ac4038e98131fe957e0ed2f1a88) )
@@ -2389,13 +2398,13 @@ ROM_START( hbarrelu ) /* DE-0297-1 main board, DE-0299-0 sub/rom board */
 	ROM_LOAD( "heavy_barrel_24.17f", 0x60000, 0x10000, CRC(ae377361) SHA1(a9aa520044f5b5037a495402ef128d3d8522b20f) )
 	ROM_LOAD( "heavy_barrel_23.15f", 0x70000, 0x10000, CRC(bbdaf771) SHA1(7b29d6d606319337562b0431b6290df15cde17e2) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "heavy_barrel_29.8h", 0x00000, 0x10000, CRC(5514b296) SHA1(d258134a95bb223db139780b8e7377cccbe01af0) )
 	ROM_LOAD( "heavy_barrel_30.9h", 0x10000, 0x10000, CRC(5855e8ef) SHA1(0f09143fed7c354231a4f343d0371424d8436877) )
 	ROM_LOAD( "heavy_barrel_27.8f", 0x20000, 0x10000, CRC(99db7b9c) SHA1(2faeb287d685c8ea72c21658777f62ff9e194a69) )
 	ROM_LOAD( "heavy_barrel_28.9f", 0x30000, 0x10000, CRC(33ce2b1a) SHA1(ef150dd5bc22368857ba27da18a17c161bb807a4) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "heavy_barrel_15.16c", 0x00000, 0x10000, CRC(21816707) SHA1(859a70dfc7d8c01124a035dcd5ea554af5f4e871) )
 	ROM_LOAD( "heavy_barrel_16.17c", 0x10000, 0x10000, CRC(a5684574) SHA1(2dfe429cd6e110645ab976dd3a2b27d54ad91e89) )
 	ROM_LOAD( "heavy_barrel_11.16a", 0x20000, 0x10000, CRC(5c768315) SHA1(00905e59dec90bf51f1d8e2482f54ede0895d142) )
@@ -2427,23 +2436,23 @@ ROM_START( baddudes ) /* DE-0297-1 main board, DE-0299-1 sub/rom board */
 	ROM_REGION( 0x1000, "mcu", 0 )  /* i8751 microcontroller */
 	ROM_LOAD( "ei31.9a",   0x0000, 0x1000, CRC(2a8745d2) SHA1(f15ab17b1e7836d603135f5c66ca2e3d72f6e4a2) )
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x10000, "char", 0 ) /* chars */
 	ROM_LOAD( "ei25.15h",  0x00000, 0x08000, CRC(bcf59a69) SHA1(486727e19c12ea55b47e2ef773d0d0471cf50083) )
 	ROM_LOAD( "ei26.16h",  0x08000, 0x08000, CRC(9aff67b8) SHA1(18c3972a9f17a48897463f48be0d723ea0cf5aba) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ei18.14d",  0x00000, 0x10000, CRC(05cfc3e5) SHA1(a0163921c77dc9706463a402c3dd45ec4341cd21) )
 	ROM_LOAD( "ei20.17d",  0x10000, 0x10000, CRC(e11e988f) SHA1(0c59f0d8d1abe414c7e1ebd49d454179fed2cd00) )
 	ROM_LOAD( "ei22.14f",  0x20000, 0x10000, CRC(b893d880) SHA1(99e228174677f2e3e96154f77bfa9bf0f1c0a6a5) )
 	ROM_LOAD( "ei24.17f",  0x30000, 0x10000, CRC(6f226dda) SHA1(65ebb16a292c57d49c135fce7ed7537146226eb5) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ei30.9h",   0x08000, 0x08000, CRC(982da0d1) SHA1(d819a587905624d793988f2ea726783da527d9f2) )
 	ROM_CONTINUE(          0x00000, 0x08000 )   /* the two halves are swapped */
 	ROM_LOAD( "ei28.9f",   0x18000, 0x08000, CRC(f01ebb3b) SHA1(1686690cb0c87d9e687b2abb4896cf285ab8378f) )
 	ROM_CONTINUE(          0x10000, 0x08000 )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ei15.16c",  0x00000, 0x10000, CRC(a38a7d30) SHA1(5cb1fb97605829fc733c79a7e169fa52adc6863b) )
 	ROM_LOAD( "ei16.17c",  0x10000, 0x08000, CRC(17e42633) SHA1(405f5296a741901677cca978a1b287d894eb1e54) )
 	ROM_LOAD( "ei11.16a",  0x20000, 0x10000, CRC(3a77326c) SHA1(4de81752329cde6210a9c250a9f8ebe3dad9fe92) )
@@ -2475,23 +2484,23 @@ ROM_START( drgninja ) /* DE-0297-0 main board, DE-0299-0 sub/rom board */
 	ROM_LOAD( "eg31.9a",   0x0000, 0x1000, CRC(657aab2d) SHA1(c3b3837d1208596509e09ddd8e3e58845a4e07b2) )
 	/* various graphic and sound roms also differ when compared to baddudes */
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x10000, "char", 0 ) /* chars */
 	ROM_LOAD( "eg25.15h",  0x00000, 0x08000, CRC(6791bc20) SHA1(7240b2688cda04ee9ea331472a84fbffc85b8e90) ) // different to baddudes
 	ROM_LOAD( "eg26.16h",  0x08000, 0x08000, CRC(5d75fc8f) SHA1(92947dd78bfe8067fb5f645fa1ef212e48b69c70) ) // different to baddudes
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "eg18.14d",  0x00000, 0x10000, CRC(05cfc3e5) SHA1(a0163921c77dc9706463a402c3dd45ec4341cd21) )
 	ROM_LOAD( "eg20.17d",  0x10000, 0x10000, CRC(e11e988f) SHA1(0c59f0d8d1abe414c7e1ebd49d454179fed2cd00) )
 	ROM_LOAD( "eg22.14f",  0x20000, 0x10000, CRC(b893d880) SHA1(99e228174677f2e3e96154f77bfa9bf0f1c0a6a5) )
 	ROM_LOAD( "eg24.17f",  0x30000, 0x10000, CRC(6f226dda) SHA1(65ebb16a292c57d49c135fce7ed7537146226eb5) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "eg30.9h",   0x08000, 0x08000, CRC(2438e67e) SHA1(5f143aeb83606a2c64d0b31bfee38156d231dcc9) )
 	ROM_CONTINUE(          0x00000, 0x08000 )   /* the two halves are swapped */
 	ROM_LOAD( "eg28.9f",   0x18000, 0x08000, CRC(5c692ab3) SHA1(4c58ff50833f869575f1a15c776fbf1429944fab) )
 	ROM_CONTINUE(          0x10000, 0x08000 )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "eg15.16c",  0x00000, 0x10000, CRC(5617d67f) SHA1(8f684de27ae79c4d35720706cdd2733af0e0a9cc) ) // different to baddudes
 	ROM_LOAD( "eg16.17c",  0x10000, 0x08000, CRC(17e42633) SHA1(405f5296a741901677cca978a1b287d894eb1e54) )
 	ROM_LOAD( "eg11.16a",  0x20000, 0x10000, CRC(ba83e8d8) SHA1(63092a5d0da0c9228a72a83b43a67a47b1388724) ) // different to baddudes
@@ -2524,7 +2533,7 @@ ROM_START( drgninjab )
 
 	/* various graphic and sound roms also differ when compared to baddudes */
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x10000, "char", 0 ) /* chars */
 	// ROM_LOAD( "eg25.15h",  0x00000, 0x08000, CRC(6791bc20) SHA1(7240b2688cda04ee9ea331472a84fbffc85b8e90) ) has been verified
 	//  correct for the above drgninja set and dumped from an original DECO PCB with the original label intact.
 	// ROM_LOAD( "eg25.bin",  0x00000, 0x08000, CRC(dd557b19) SHA1(ce1e76aeb7e147f373bb48dbc1becc1601953499) ) has the unused
@@ -2532,19 +2541,19 @@ ROM_START( drgninjab )
 	ROM_LOAD( "eg25.bin",  0x00000, 0x08000, CRC(dd557b19) SHA1(ce1e76aeb7e147f373bb48dbc1becc1601953499) ) // 99.996948%
 	ROM_LOAD( "eg26.16h",  0x08000, 0x08000, CRC(5d75fc8f) SHA1(92947dd78bfe8067fb5f645fa1ef212e48b69c70) ) // different to baddudes
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "eg18.14d",  0x00000, 0x10000, CRC(05cfc3e5) SHA1(a0163921c77dc9706463a402c3dd45ec4341cd21) )
 	ROM_LOAD( "eg20.17d",  0x10000, 0x10000, CRC(e11e988f) SHA1(0c59f0d8d1abe414c7e1ebd49d454179fed2cd00) )
 	ROM_LOAD( "eg22.14f",  0x20000, 0x10000, CRC(b893d880) SHA1(99e228174677f2e3e96154f77bfa9bf0f1c0a6a5) )
 	ROM_LOAD( "eg24.17f",  0x30000, 0x10000, CRC(6f226dda) SHA1(65ebb16a292c57d49c135fce7ed7537146226eb5) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "eg30.9h",   0x08000, 0x08000, CRC(2438e67e) SHA1(5f143aeb83606a2c64d0b31bfee38156d231dcc9) )
 	ROM_CONTINUE(          0x00000, 0x08000 )   /* the two halves are swapped */
 	ROM_LOAD( "eg28.9f",   0x18000, 0x08000, CRC(5c692ab3) SHA1(4c58ff50833f869575f1a15c776fbf1429944fab) )
 	ROM_CONTINUE(          0x10000, 0x08000 )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "eg15.16c",  0x00000, 0x10000, CRC(5617d67f) SHA1(8f684de27ae79c4d35720706cdd2733af0e0a9cc) ) // different to baddudes
 	ROM_LOAD( "eg16.17c",  0x10000, 0x08000, CRC(17e42633) SHA1(405f5296a741901677cca978a1b287d894eb1e54) )
 	ROM_LOAD( "eg11.16a",  0x20000, 0x10000, CRC(ba83e8d8) SHA1(63092a5d0da0c9228a72a83b43a67a47b1388724) ) // different to baddudes
@@ -2614,23 +2623,23 @@ ROM_START( drgninjab2 )
 	ROM_REGION( 0x1000, "mcu", 0 )  /* 68705 microcontroller */
 	ROM_LOAD( "68705r3.0m",     0x0000, 0x1000, CRC(34bc5e7f) SHA1(7231dd7eb9b5152a287e1bcceb3c3a0b35f441af) )
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x10000, "char", 0 ) /* chars */
 	ROM_LOAD( "a22.9m",  0x00000, 0x08000, CRC(6791bc20) SHA1(7240b2688cda04ee9ea331472a84fbffc85b8e90) )
 	ROM_LOAD( "a23.9n",  0x08000, 0x08000, CRC(5d75fc8f) SHA1(92947dd78bfe8067fb5f645fa1ef212e48b69c70) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* tiles */ // identical but split into 4 roms
+	ROM_REGION( 0x40000, "tiles1", 0 ) /* tiles */ // identical but split into 4 roms
 	ROM_LOAD( "a25.10f",  0x00000, 0x10000, CRC(05cfc3e5) SHA1(a0163921c77dc9706463a402c3dd45ec4341cd21) )
 	ROM_LOAD( "a27.10h",  0x10000, 0x10000, CRC(e11e988f) SHA1(0c59f0d8d1abe414c7e1ebd49d454179fed2cd00) )
 	ROM_LOAD( "a24.10e",  0x20000, 0x10000, CRC(b893d880) SHA1(99e228174677f2e3e96154f77bfa9bf0f1c0a6a5) )
 	ROM_LOAD( "a26.10g",  0x30000, 0x10000, CRC(6f226dda) SHA1(65ebb16a292c57d49c135fce7ed7537146226eb5) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "a29.10k",   0x00000, 0x08000, CRC(4bf80966) SHA1(de4d83bac16f161a43678c2b2ae71f8fcac7212d) )
 	ROM_LOAD( "a21.9k",    0x08000, 0x08000, CRC(b2e989fc) SHA1(492c1f3b18a4059c87254e0cba01ad9848e8b553) )
 	ROM_LOAD( "a28.10j",   0x10000, 0x08000, CRC(2d38032d) SHA1(833ebff370825e5c8b8fc59fbe663b8998884353) )
 	ROM_LOAD( "a20.9j",    0x18000, 0x08000, CRC(e71c0793) SHA1(e42a8192c772da1d6c93f9f9e89c553d712e18f7) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "a6.4g",   0x00000, 0x10000, CRC(5617d67f) SHA1(8f684de27ae79c4d35720706cdd2733af0e0a9cc) )
 	ROM_LOAD( "a2.4c",   0x10000, 0x08000, CRC(17e42633) SHA1(405f5296a741901677cca978a1b287d894eb1e54) )
 	ROM_LOAD( "a8.5g",   0x20000, 0x10000, CRC(ba83e8d8) SHA1(63092a5d0da0c9228a72a83b43a67a47b1388724) )
@@ -2667,11 +2676,11 @@ ROM_START( birdtry ) // DE-0311-0 main board, DE-0299-2 sub/rom board
 	ROM_REGION( 0x1000, "mcu", 0 ) // i8751 microcontroller
 	ROM_LOAD( "ek-31-1.9a", 0x0000, 0x1000, CRC(3bf41abb) SHA1(d1833f5b59547c17f2683f4f2dced7ead3608d49) ) // revised code / game data
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) // chars
+	ROM_REGION( 0x10000, "char", 0 ) // chars
 	ROM_LOAD( "ek-25.15h", 0x00000, 0x08000, CRC(4df134ad) SHA1(f2cfa7e3fc4a2ac40897c2600c901ff75237e081) )
 	ROM_LOAD( "ek-26.16h", 0x08000, 0x08000, CRC(a00d3e8e) SHA1(3ac8511d55a684a5b2bc05d8d520169447a66840) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) // tiles
+	ROM_REGION( 0x80000, "tiles1", 0 ) // tiles
 	ROM_LOAD( "ek-18.14d", 0x00000, 0x10000, CRC(9886fb70) SHA1(d36c41bfe217affab7f9deec64ff3f12e3efa28c) )
 	ROM_LOAD( "ek-17.12d", 0x10000, 0x10000, CRC(bed91bf7) SHA1(f0ffc557a4c216a5a2e180b4c2366e7b49630064) )
 	ROM_LOAD( "ek-20.17d", 0x20000, 0x10000, CRC(45d53965) SHA1(d54d33cc82e099bcb511de8ee26cdcc64a0b8f1d) )
@@ -2681,10 +2690,10 @@ ROM_START( birdtry ) // DE-0311-0 main board, DE-0299-2 sub/rom board
 	ROM_LOAD( "ek-24.17f", 0x60000, 0x10000, CRC(2244cc75) SHA1(67c9868927319abe80a932203e8ac6595ae455b3) )
 	ROM_LOAD( "ek-23.15f", 0x70000, 0x10000, CRC(d0ed0116) SHA1(a35e64ecac57585b83e830a1bf90a402c931f071) )
 
-	ROM_REGION( 0x10000, "gfx3", ROMREGION_ERASEFF ) // tiles
+	ROM_REGION( 0x10000, "tiles2", ROMREGION_ERASEFF ) // tiles
 	/* This game doesn't have the extra playfield chip, so no roms */
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) // sprites
+	ROM_REGION( 0x80000, "sprites", 0 ) // sprites
 	ROM_LOAD( "ek-15.16c", 0x00000, 0x10000, CRC(a6a041a3) SHA1(3b8d18d5821e6d354ed97a4f547f1b2bee8674f5) )
 	ROM_LOAD( "ek-16.17c", 0x10000, 0x08000, CRC(784f62b0) SHA1(b68b234a5f469149d481645290a3251667bdab27) )
 	ROM_LOAD( "ek-11.16a", 0x20000, 0x10000, CRC(9224a6b9) SHA1(547c22db1728a85035a682eb54ce654a98a4ba3d) )
@@ -2717,11 +2726,11 @@ ROM_START( birdtrya ) // DE-0311-0 main board, DE-0299-2 sub/rom board
 	ROM_REGION( 0x1000, "mcu", 0 )  // i8751 microcontroller
 	ROM_LOAD( "ek-31.9a", 0x0000, 0x1000, CRC(68831ae9) SHA1(0c8ef4903adbff68dccec04d8385c36904923a3c) )
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) // chars
+	ROM_REGION( 0x10000, "char", 0 ) // chars
 	ROM_LOAD( "ek-25.15h", 0x00000, 0x08000, CRC(4df134ad) SHA1(f2cfa7e3fc4a2ac40897c2600c901ff75237e081) )
 	ROM_LOAD( "ek-26.16h", 0x08000, 0x08000, CRC(a00d3e8e) SHA1(3ac8511d55a684a5b2bc05d8d520169447a66840) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) // tiles
+	ROM_REGION( 0x80000, "tiles1", 0 ) // tiles
 	ROM_LOAD( "ek-18.14d", 0x00000, 0x10000, CRC(9886fb70) SHA1(d36c41bfe217affab7f9deec64ff3f12e3efa28c) )
 	ROM_LOAD( "ek-17.12d", 0x10000, 0x10000, CRC(bed91bf7) SHA1(f0ffc557a4c216a5a2e180b4c2366e7b49630064) )
 	ROM_LOAD( "ek-20.17d", 0x20000, 0x10000, CRC(45d53965) SHA1(d54d33cc82e099bcb511de8ee26cdcc64a0b8f1d) )
@@ -2731,10 +2740,10 @@ ROM_START( birdtrya ) // DE-0311-0 main board, DE-0299-2 sub/rom board
 	ROM_LOAD( "ek-24.17f", 0x60000, 0x10000, CRC(2244cc75) SHA1(67c9868927319abe80a932203e8ac6595ae455b3) )
 	ROM_LOAD( "ek-23.15f", 0x70000, 0x10000, CRC(d0ed0116) SHA1(a35e64ecac57585b83e830a1bf90a402c931f071) )
 
-	ROM_REGION( 0x10000, "gfx3", ROMREGION_ERASEFF ) // tiles
+	ROM_REGION( 0x10000, "tiles2", ROMREGION_ERASEFF ) // tiles
 	/* This game doesn't have the extra playfield chip, so no roms */
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) // sprites
+	ROM_REGION( 0x80000, "sprites", 0 ) // sprites
 	ROM_LOAD( "ek-15.16c", 0x00000, 0x10000, CRC(a6a041a3) SHA1(3b8d18d5821e6d354ed97a4f547f1b2bee8674f5) )
 	ROM_LOAD( "ek-16.17c", 0x10000, 0x08000, CRC(784f62b0) SHA1(b68b234a5f469149d481645290a3251667bdab27) )
 	ROM_LOAD( "ek-11.16a", 0x20000, 0x10000, CRC(9224a6b9) SHA1(547c22db1728a85035a682eb54ce654a98a4ba3d) )
@@ -2767,11 +2776,11 @@ ROM_START( birdtryb ) // DE-0311-0 main board, DE-0299-2 sub/rom board - All ROM
 	ROM_REGION( 0x1000, "mcu", 0 )  // i8751 microcontroller
 	ROM_LOAD( "ek-31-s.9a", 0x0000, 0x1000, CRC(68831ae9) SHA1(0c8ef4903adbff68dccec04d8385c36904923a3c) ) // == ek-31.9a (verified)
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) // chars
+	ROM_REGION( 0x10000, "char", 0 ) // chars
 	ROM_LOAD( "ek-25-s.15h", 0x00000, 0x08000, CRC(4df134ad) SHA1(f2cfa7e3fc4a2ac40897c2600c901ff75237e081) )
 	ROM_LOAD( "ek-26-s.16h", 0x08000, 0x08000, CRC(a00d3e8e) SHA1(3ac8511d55a684a5b2bc05d8d520169447a66840) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) // tiles
+	ROM_REGION( 0x80000, "tiles1", 0 ) // tiles
 	ROM_LOAD( "ek-18-s.14d", 0x00000, 0x10000, CRC(9886fb70) SHA1(d36c41bfe217affab7f9deec64ff3f12e3efa28c) )
 	ROM_LOAD( "ek-17-s.12d", 0x10000, 0x10000, CRC(bed91bf7) SHA1(f0ffc557a4c216a5a2e180b4c2366e7b49630064) )
 	ROM_LOAD( "ek-20-s.17d", 0x20000, 0x10000, CRC(45d53965) SHA1(d54d33cc82e099bcb511de8ee26cdcc64a0b8f1d) )
@@ -2781,10 +2790,10 @@ ROM_START( birdtryb ) // DE-0311-0 main board, DE-0299-2 sub/rom board - All ROM
 	ROM_LOAD( "ek-24-s.17f", 0x60000, 0x10000, CRC(2244cc75) SHA1(67c9868927319abe80a932203e8ac6595ae455b3) )
 	ROM_LOAD( "ek-23-s.15f", 0x70000, 0x10000, CRC(d0ed0116) SHA1(a35e64ecac57585b83e830a1bf90a402c931f071) )
 
-	ROM_REGION( 0x10000, "gfx3", ROMREGION_ERASEFF ) // tiles
+	ROM_REGION( 0x10000, "tiles2", ROMREGION_ERASEFF ) // tiles
 	/* This game doesn't have the extra playfield chip, so no roms */
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) // sprites
+	ROM_REGION( 0x80000, "sprites", 0 ) // sprites
 	ROM_LOAD( "ek-15-s.16c", 0x00000, 0x10000, CRC(a6a041a3) SHA1(3b8d18d5821e6d354ed97a4f547f1b2bee8674f5) )
 	ROM_LOAD( "ek-16-s.17c", 0x10000, 0x08000, CRC(784f62b0) SHA1(b68b234a5f469149d481645290a3251667bdab27) )
 	ROM_LOAD( "ek-11-s.16a", 0x20000, 0x10000, CRC(9224a6b9) SHA1(547c22db1728a85035a682eb54ce654a98a4ba3d) )
@@ -2816,23 +2825,23 @@ ROM_START( robocop ) /* DE-0297-3 main board, DE-0316-3 sub/rom board */
 	ROM_REGION( 0x200000, "sub", 0 )    /* HuC6280 CPU */
 	ROM_LOAD( "en_24_mb7124e.a2", 0x01e00, 0x0200, CRC(b8e2ca98) SHA1(bd1e193c544dc17a665aa6c4d3b844775ed08b43) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ep23", 0x00000, 0x10000, CRC(a77e4ab1) SHA1(d06cc847192b6c7f642e4ff7128e298d0aa034b2) )
 	ROM_LOAD( "ep22", 0x10000, 0x10000, CRC(9fbd6903) SHA1(9ac6ac8a18c23e915e8ae3782867d10c0bd65778) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ep20", 0x00000, 0x10000, CRC(1d8d38b8) SHA1(9add6349f8a578fb86b678cef921d6ec0cfccdad) )
 	ROM_LOAD( "ep21", 0x10000, 0x10000, CRC(187929b2) SHA1(deca1f0a52584769caee1d2302617aa957c56a71) )
 	ROM_LOAD( "ep18", 0x20000, 0x10000, CRC(b6580b5e) SHA1(ee216d8db89b8cb7a51a4e19bf6f17788547156b) )
 	ROM_LOAD( "ep19", 0x30000, 0x10000, CRC(9bad01c7) SHA1(947c7f9d0facaea13a924274adde0e996be7b999) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ep14", 0x00000, 0x08000, CRC(ca56ceda) SHA1(edbaa29fc166cddf071ff5e59cfcfb7eeb127d68) )
 	ROM_LOAD( "ep15", 0x08000, 0x08000, CRC(a945269c) SHA1(de0b387e8699298f7682d6d7ca803a209888f7a1) )
 	ROM_LOAD( "ep16", 0x10000, 0x08000, CRC(e7fa4d58) SHA1(32e3f649b4f112a4e6be00068473b82c627bc8d1) )
 	ROM_LOAD( "ep17", 0x18000, 0x08000, CRC(84aae89d) SHA1(037520bd0f291f862c2211a6f35b2a8a54f10b2a) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ep07", 0x00000, 0x10000, CRC(495d75cf) SHA1(0ffe677d53b7675073902e9bd40e4150f2cdfb1a) )
 	ROM_LOAD( "ep06", 0x10000, 0x08000, CRC(a2ae32e2) SHA1(4e8182205563da9d50a831c65951645e278b03e6) )
 	ROM_LOAD( "ep11", 0x20000, 0x10000, CRC(62fa425a) SHA1(be88c1a6436df8a456c405822e28c472e3e79a69) )
@@ -2874,23 +2883,23 @@ ROM_START( robocopw ) /* DE-0297-3 main board, DE-0316-3 sub/rom board */
 	ROM_REGION( 0x200000, "sub", 0 )    /* HuC6280 CPU */
 	ROM_LOAD( "en_24.a2", 0x01e00, 0x0200, CRC(b8e2ca98) SHA1(bd1e193c544dc17a665aa6c4d3b844775ed08b43) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ep23", 0x00000, 0x10000, CRC(a77e4ab1) SHA1(d06cc847192b6c7f642e4ff7128e298d0aa034b2) )
 	ROM_LOAD( "ep22", 0x10000, 0x10000, CRC(9fbd6903) SHA1(9ac6ac8a18c23e915e8ae3782867d10c0bd65778) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ep20", 0x00000, 0x10000, CRC(1d8d38b8) SHA1(9add6349f8a578fb86b678cef921d6ec0cfccdad) )
 	ROM_LOAD( "ep21", 0x10000, 0x10000, CRC(187929b2) SHA1(deca1f0a52584769caee1d2302617aa957c56a71) )
 	ROM_LOAD( "ep18", 0x20000, 0x10000, CRC(b6580b5e) SHA1(ee216d8db89b8cb7a51a4e19bf6f17788547156b) )
 	ROM_LOAD( "ep19", 0x30000, 0x10000, CRC(9bad01c7) SHA1(947c7f9d0facaea13a924274adde0e996be7b999) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ep14", 0x00000, 0x08000, CRC(ca56ceda) SHA1(edbaa29fc166cddf071ff5e59cfcfb7eeb127d68) )
 	ROM_LOAD( "ep15", 0x08000, 0x08000, CRC(a945269c) SHA1(de0b387e8699298f7682d6d7ca803a209888f7a1) )
 	ROM_LOAD( "ep16", 0x10000, 0x08000, CRC(e7fa4d58) SHA1(32e3f649b4f112a4e6be00068473b82c627bc8d1) )
 	ROM_LOAD( "ep17", 0x18000, 0x08000, CRC(84aae89d) SHA1(037520bd0f291f862c2211a6f35b2a8a54f10b2a) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ep07", 0x00000, 0x10000, CRC(495d75cf) SHA1(0ffe677d53b7675073902e9bd40e4150f2cdfb1a) )
 	ROM_LOAD( "ep06", 0x10000, 0x08000, CRC(a2ae32e2) SHA1(4e8182205563da9d50a831c65951645e278b03e6) )
 	ROM_LOAD( "ep11", 0x20000, 0x10000, CRC(62fa425a) SHA1(be88c1a6436df8a456c405822e28c472e3e79a69) )
@@ -2921,23 +2930,23 @@ ROM_START( robocopj ) /* DE-0297-3 main board, DE-0316-3 sub/rom board */
 	ROM_REGION( 0x200000, "sub", 0 )    /* HuC6280 CPU */
 	ROM_LOAD( "en_24.a2", 0x01e00, 0x0200, CRC(b8e2ca98) SHA1(bd1e193c544dc17a665aa6c4d3b844775ed08b43) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ep23", 0x00000, 0x10000, CRC(a77e4ab1) SHA1(d06cc847192b6c7f642e4ff7128e298d0aa034b2) )
 	ROM_LOAD( "ep22", 0x10000, 0x10000, CRC(9fbd6903) SHA1(9ac6ac8a18c23e915e8ae3782867d10c0bd65778) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ep20", 0x00000, 0x10000, CRC(1d8d38b8) SHA1(9add6349f8a578fb86b678cef921d6ec0cfccdad) )
 	ROM_LOAD( "ep21", 0x10000, 0x10000, CRC(187929b2) SHA1(deca1f0a52584769caee1d2302617aa957c56a71) )
 	ROM_LOAD( "ep18", 0x20000, 0x10000, CRC(b6580b5e) SHA1(ee216d8db89b8cb7a51a4e19bf6f17788547156b) )
 	ROM_LOAD( "ep19", 0x30000, 0x10000, CRC(9bad01c7) SHA1(947c7f9d0facaea13a924274adde0e996be7b999) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ep14", 0x00000, 0x08000, CRC(ca56ceda) SHA1(edbaa29fc166cddf071ff5e59cfcfb7eeb127d68) )
 	ROM_LOAD( "ep15", 0x08000, 0x08000, CRC(a945269c) SHA1(de0b387e8699298f7682d6d7ca803a209888f7a1) )
 	ROM_LOAD( "ep16", 0x10000, 0x08000, CRC(e7fa4d58) SHA1(32e3f649b4f112a4e6be00068473b82c627bc8d1) )
 	ROM_LOAD( "ep17", 0x18000, 0x08000, CRC(84aae89d) SHA1(037520bd0f291f862c2211a6f35b2a8a54f10b2a) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ep07", 0x00000, 0x10000, CRC(495d75cf) SHA1(0ffe677d53b7675073902e9bd40e4150f2cdfb1a) )
 	ROM_LOAD( "ep06", 0x10000, 0x08000, CRC(a2ae32e2) SHA1(4e8182205563da9d50a831c65951645e278b03e6) )
 	ROM_LOAD( "ep11", 0x20000, 0x10000, CRC(62fa425a) SHA1(be88c1a6436df8a456c405822e28c472e3e79a69) )
@@ -2968,23 +2977,23 @@ ROM_START( robocopu ) /* DE-0297-3 main board, DE-0316-3 sub/rom board */
 	ROM_REGION( 0x200000, "sub", 0 )    /* HuC6280 CPU */
 	ROM_LOAD( "en_24.a2", 0x01e00, 0x0200, CRC(b8e2ca98) SHA1(bd1e193c544dc17a665aa6c4d3b844775ed08b43) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ep23", 0x00000, 0x10000, CRC(a77e4ab1) SHA1(d06cc847192b6c7f642e4ff7128e298d0aa034b2) )
 	ROM_LOAD( "ep22", 0x10000, 0x10000, CRC(9fbd6903) SHA1(9ac6ac8a18c23e915e8ae3782867d10c0bd65778) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ep20", 0x00000, 0x10000, CRC(1d8d38b8) SHA1(9add6349f8a578fb86b678cef921d6ec0cfccdad) )
 	ROM_LOAD( "ep21", 0x10000, 0x10000, CRC(187929b2) SHA1(deca1f0a52584769caee1d2302617aa957c56a71) )
 	ROM_LOAD( "ep18", 0x20000, 0x10000, CRC(b6580b5e) SHA1(ee216d8db89b8cb7a51a4e19bf6f17788547156b) )
 	ROM_LOAD( "ep19", 0x30000, 0x10000, CRC(9bad01c7) SHA1(947c7f9d0facaea13a924274adde0e996be7b999) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ep14", 0x00000, 0x08000, CRC(ca56ceda) SHA1(edbaa29fc166cddf071ff5e59cfcfb7eeb127d68) )
 	ROM_LOAD( "ep15", 0x08000, 0x08000, CRC(a945269c) SHA1(de0b387e8699298f7682d6d7ca803a209888f7a1) )
 	ROM_LOAD( "ep16", 0x10000, 0x08000, CRC(e7fa4d58) SHA1(32e3f649b4f112a4e6be00068473b82c627bc8d1) )
 	ROM_LOAD( "ep17", 0x18000, 0x08000, CRC(84aae89d) SHA1(037520bd0f291f862c2211a6f35b2a8a54f10b2a) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ep07", 0x00000, 0x10000, CRC(495d75cf) SHA1(0ffe677d53b7675073902e9bd40e4150f2cdfb1a) )
 	ROM_LOAD( "ep06", 0x10000, 0x08000, CRC(a2ae32e2) SHA1(4e8182205563da9d50a831c65951645e278b03e6) )
 	ROM_LOAD( "ep11", 0x20000, 0x10000, CRC(62fa425a) SHA1(be88c1a6436df8a456c405822e28c472e3e79a69) )
@@ -3015,23 +3024,23 @@ ROM_START( robocopu0 ) /* DE-0297-3 main board, DE-0316-3 sub/rom board */
 	ROM_REGION( 0x200000, "sub", 0 )    /* HuC6280 CPU */
 	ROM_LOAD( "en_24.a2", 0x01e00, 0x0200, CRC(b8e2ca98) SHA1(bd1e193c544dc17a665aa6c4d3b844775ed08b43) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ep23", 0x00000, 0x10000, CRC(a77e4ab1) SHA1(d06cc847192b6c7f642e4ff7128e298d0aa034b2) )
 	ROM_LOAD( "ep22", 0x10000, 0x10000, CRC(9fbd6903) SHA1(9ac6ac8a18c23e915e8ae3782867d10c0bd65778) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ep20", 0x00000, 0x10000, CRC(1d8d38b8) SHA1(9add6349f8a578fb86b678cef921d6ec0cfccdad) )
 	ROM_LOAD( "ep21", 0x10000, 0x10000, CRC(187929b2) SHA1(deca1f0a52584769caee1d2302617aa957c56a71) )
 	ROM_LOAD( "ep18", 0x20000, 0x10000, CRC(b6580b5e) SHA1(ee216d8db89b8cb7a51a4e19bf6f17788547156b) )
 	ROM_LOAD( "ep19", 0x30000, 0x10000, CRC(9bad01c7) SHA1(947c7f9d0facaea13a924274adde0e996be7b999) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ep14", 0x00000, 0x08000, CRC(ca56ceda) SHA1(edbaa29fc166cddf071ff5e59cfcfb7eeb127d68) )
 	ROM_LOAD( "ep15", 0x08000, 0x08000, CRC(a945269c) SHA1(de0b387e8699298f7682d6d7ca803a209888f7a1) )
 	ROM_LOAD( "ep16", 0x10000, 0x08000, CRC(e7fa4d58) SHA1(32e3f649b4f112a4e6be00068473b82c627bc8d1) )
 	ROM_LOAD( "ep17", 0x18000, 0x08000, CRC(84aae89d) SHA1(037520bd0f291f862c2211a6f35b2a8a54f10b2a) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ep07", 0x00000, 0x10000, CRC(495d75cf) SHA1(0ffe677d53b7675073902e9bd40e4150f2cdfb1a) )
 	ROM_LOAD( "ep06", 0x10000, 0x08000, CRC(a2ae32e2) SHA1(4e8182205563da9d50a831c65951645e278b03e6) )
 	ROM_LOAD( "ep11", 0x20000, 0x10000, CRC(62fa425a) SHA1(be88c1a6436df8a456c405822e28c472e3e79a69) )
@@ -3059,23 +3068,23 @@ ROM_START( robocopb )
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* 6502 Sound */
 	ROM_LOAD( "ep03-3", 0x08000, 0x08000, CRC(5b164b24) SHA1(b217a2ac8b26aebd208631a13030487ed27d232e) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ep23", 0x00000, 0x10000, CRC(a77e4ab1) SHA1(d06cc847192b6c7f642e4ff7128e298d0aa034b2) )
 	ROM_LOAD( "ep22", 0x10000, 0x10000, CRC(9fbd6903) SHA1(9ac6ac8a18c23e915e8ae3782867d10c0bd65778) )
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ep20", 0x00000, 0x10000, CRC(1d8d38b8) SHA1(9add6349f8a578fb86b678cef921d6ec0cfccdad) )
 	ROM_LOAD( "ep21", 0x10000, 0x10000, CRC(187929b2) SHA1(deca1f0a52584769caee1d2302617aa957c56a71) )
 	ROM_LOAD( "ep18", 0x20000, 0x10000, CRC(b6580b5e) SHA1(ee216d8db89b8cb7a51a4e19bf6f17788547156b) )
 	ROM_LOAD( "ep19", 0x30000, 0x10000, CRC(9bad01c7) SHA1(947c7f9d0facaea13a924274adde0e996be7b999) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ep14", 0x00000, 0x08000, CRC(ca56ceda) SHA1(edbaa29fc166cddf071ff5e59cfcfb7eeb127d68) )
 	ROM_LOAD( "ep15", 0x08000, 0x08000, CRC(a945269c) SHA1(de0b387e8699298f7682d6d7ca803a209888f7a1) )
 	ROM_LOAD( "ep16", 0x10000, 0x08000, CRC(e7fa4d58) SHA1(32e3f649b4f112a4e6be00068473b82c627bc8d1) )
 	ROM_LOAD( "ep17", 0x18000, 0x08000, CRC(84aae89d) SHA1(037520bd0f291f862c2211a6f35b2a8a54f10b2a) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ep07", 0x00000, 0x10000, CRC(495d75cf) SHA1(0ffe677d53b7675073902e9bd40e4150f2cdfb1a) )
 	ROM_LOAD( "ep06", 0x10000, 0x08000, CRC(a2ae32e2) SHA1(4e8182205563da9d50a831c65951645e278b03e6) )
 	ROM_LOAD( "ep11", 0x20000, 0x10000, CRC(62fa425a) SHA1(be88c1a6436df8a456c405822e28c472e3e79a69) )
@@ -3145,20 +3154,20 @@ ROM_START( automat )
 	ROM_LOAD( "12.bin", 0x30000, 0x10000, CRC(00cd0990) SHA1(3fc498fcee2110001e376f5ee38d7dd361bd3ee3) ) // y
 
 	/* copy out the chars */
-	ROM_REGION( 0x20000, "gfx1", ROMREGION_INVERT ) /* chars */
+	ROM_REGION( 0x20000, "char", ROMREGION_INVERT ) /* chars */
 	ROM_COPY( "gfxload1", 0x00000, 0x00000, 0x8000 )
 	ROM_COPY( "gfxload1", 0x10000, 0x08000, 0x8000 )
 	ROM_COPY( "gfxload1", 0x20000, 0x10000, 0x8000 )
 	ROM_COPY( "gfxload1", 0x30000, 0x18000, 0x8000 )
 
-	ROM_REGION( 0x20000, "gfx3", ROMREGION_INVERT ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", ROMREGION_INVERT ) /* tiles */
 	ROM_COPY( "gfxload1", 0x08000, 0x00000, 0x8000 )
 	ROM_COPY( "gfxload1", 0x18000, 0x08000, 0x8000 )
 	ROM_COPY( "gfxload1", 0x28000, 0x10000, 0x8000 )
 	ROM_COPY( "gfxload1", 0x38000, 0x18000, 0x8000 )
 
 	// we have to rearrange this with ROM_CONTINUE due to the way gfxdecode works */
-	ROM_REGION( 0x40000, "gfx2", ROMREGION_INVERT ) /* tiles */
+	ROM_REGION( 0x40000, "tiles1", ROMREGION_INVERT ) /* tiles */
 	ROM_LOAD( "9.bin",  0x00000, 0x2000, CRC(ccf91ce0) SHA1(c976eddcea48da6e7fbd28a4d5c48706d61cabfb) )
 	ROM_CONTINUE(       0x04000, 0x2000 )
 	ROM_CONTINUE(       0x08000, 0x2000 )
@@ -3194,7 +3203,7 @@ ROM_START( automat )
 
 	// the sprite data is the same as robocop, but with the bits in each byte reversed
 	// 21.bin was repaired with this knowledge as the chip was faulty
-	ROM_REGION( 0x80000, "gfx4", 0) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0) /* sprites */
 	ROM_LOAD( "16.bin", 0x00000, 0x10000, CRC(e42e8675) SHA1(5b964477de8278ea330ffc2366e5fc7e10122ef8) )
 	ROM_LOAD( "17.bin", 0x10000, 0x08000, CRC(9a414c56) SHA1(017eb5a238e24cd6de50afd029c239993fc61a21) )
 	ROM_LOAD( "20.bin", 0x20000, 0x10000, CRC(7c62a2a1) SHA1(43a40355cdcbb17506f9634e8f12673287e79bd7) )
@@ -3221,23 +3230,23 @@ ROM_START( bandit )  /* DE-0289-2 main board, DE-0293-1 sub/rom board */
 	ROM_REGION( 0x1000, "mcu", 0 )  /* i8751 microcontroller */
 	ROM_LOAD( "hb31.9a",      0x0000, 0x1000, CRC(239d726f) SHA1(969f38ae981ffde6053ece93cc51614d492edbbb) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "25.25",     0x00000, 0x10000, CRC(4047ff81) SHA1(56a82c7694e6dbbdb9b42ed134120a76f848f7a5) )
 	ROM_LOAD( "26.26",     0x10000, 0x10000, CRC(3a0a2f1e) SHA1(f06b44e4a8c29ee2c0a6e8f786fbee144138ba72) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "18.18",     0x00000, 0x10000, CRC(ac38e585) SHA1(c1a6fb083c096d119351883dea121ee6358d9298) )
 	ROM_LOAD( "20.20",     0x20000, 0x10000, CRC(2194f737) SHA1(fbe2f7d0d6b80bf62fb9c38f9f2a001a728f3b7c) )
 	ROM_LOAD( "22.22",     0x40000, 0x10000, CRC(fcc6cb4d) SHA1(548bd8688b255cdd1eef82e4fbec3d88e1d0ab53) )
 	ROM_LOAD( "24.24",     0x60000, 0x10000, CRC(aa3c33b6) SHA1(f7770daedb5c1d5dd5099f1378c5c292c68a6a12) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "29.29",     0x00000, 0x10000, CRC(32218c8a) SHA1(33e922ffd7000a03a8fa8bbe61483cd8e916ebd6) )
 	ROM_LOAD( "30.30",     0x10000, 0x10000, CRC(6a5fe9a9) SHA1(a750373e9fb1a0ad81d63a19bbac7a6079d3372f) )
 	ROM_LOAD( "27.27",     0x20000, 0x10000, CRC(62970304) SHA1(57606bedfd83429629593bbea50fb25db1f2d874) )
 	ROM_LOAD( "28.28",     0x30000, 0x10000, CRC(e018459f) SHA1(136ce96523988173425fa791742dab62ecaef5c9) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "15.15",     0x00000, 0x10000, CRC(84c03235) SHA1(3b5a8e24dd0aba1d1530d37685aaa46a35b0249a) )
 	ROM_LOAD( "16.16",     0x10000, 0x10000, CRC(eaa35477) SHA1(08763d7937a6fa76f6029974d5b909ba05c69d81) )
 	ROM_LOAD( "11.11",     0x20000, 0x10000, CRC(c9e6b57f) SHA1(9c12e0e7e25d48c7679ea65c3dfeaca9fdfdcbb3) )
@@ -3270,23 +3279,23 @@ ROM_START( hippodrm )
 	ROM_REGION( 0x10000, "sub", 0 ) /* HuC6280 CPU */
 	ROM_LOAD( "ew08",         0x00000, 0x10000, CRC(53010534) SHA1(8b996e48414bacd009e05ff49848884ecf15d967) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ew14",         0x00000, 0x10000, CRC(71ca593d) SHA1(05ab9403c4010a21dcaa169f4c59d19c4169d9cd) )
 	ROM_LOAD( "ew13",         0x10000, 0x10000, CRC(86be5fa7) SHA1(71c31ca2e92fb39a5486e80150919e13d5617855) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ew19",         0x00000, 0x08000, CRC(6b80d7a3) SHA1(323162e7e0ce16f6244d8d98fdb2396ffef87e82) )
 	ROM_LOAD( "ew18",         0x08000, 0x08000, CRC(78d3d764) SHA1(e8f77a23bd4f4d268bec7c0153fb957acd07cdee) )
 	ROM_LOAD( "ew20",         0x10000, 0x08000, CRC(ce9f5de3) SHA1(b8af33f52ca3579a45b41395751697a58931f9d6) )
 	ROM_LOAD( "ew21",         0x18000, 0x08000, CRC(487a7ba2) SHA1(7d52cc1517def8426355e8281440ec5e617d1121) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ew24",         0x00000, 0x08000, CRC(4e1bc2a4) SHA1(d7d4c42fd932722436f1847929088e46d03184bd) )
 	ROM_LOAD( "ew25",         0x08000, 0x08000, CRC(9eb47dfb) SHA1(bb1e8a3a47f447f3a983ea51943d3081d56ad9a4) )
 	ROM_LOAD( "ew23",         0x10000, 0x08000, CRC(9ecf479e) SHA1(a8d4c1490f12e1b15d53a2a97147920dcb638378) )
 	ROM_LOAD( "ew22",         0x18000, 0x08000, CRC(e55669aa) SHA1(2a9b0e85bb81ff87a108e08b28e19b7b469463e4) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ew15",         0x00000, 0x10000, CRC(95423914) SHA1(e9e7a6bdf5aa717dc04a751709632f31762886fb) )
 	ROM_LOAD( "ew16",         0x10000, 0x10000, CRC(96233177) SHA1(929a1b7fb65ab33277719b84517ff57da563f875) )
 	ROM_LOAD( "ew10",         0x20000, 0x10000, CRC(4c25dfe8) SHA1(e4334de96698cd0112a8926dea131e748b6a84fc) )
@@ -3317,23 +3326,23 @@ ROM_START( ffantasyj )
 	ROM_REGION( 0x10000, "sub", 0 ) /* HuC6280 CPU */
 	ROM_LOAD( "ew08",         0x00000, 0x10000, CRC(53010534) SHA1(8b996e48414bacd009e05ff49848884ecf15d967) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ev14",         0x00000, 0x10000, CRC(686f72c1) SHA1(41d4fc1208d779f3428990a96586f6a555c28562) )
 	ROM_LOAD( "ev13",         0x10000, 0x10000, CRC(b787dcc9) SHA1(7fce9d2040bcb2483419ea1cafed538bb8aba4f9) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ew19",         0x00000, 0x08000, CRC(6b80d7a3) SHA1(323162e7e0ce16f6244d8d98fdb2396ffef87e82) )
 	ROM_LOAD( "ew18",         0x08000, 0x08000, CRC(78d3d764) SHA1(e8f77a23bd4f4d268bec7c0153fb957acd07cdee) )
 	ROM_LOAD( "ew20",         0x10000, 0x08000, CRC(ce9f5de3) SHA1(b8af33f52ca3579a45b41395751697a58931f9d6) )
 	ROM_LOAD( "ew21",         0x18000, 0x08000, CRC(487a7ba2) SHA1(7d52cc1517def8426355e8281440ec5e617d1121) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ew24",         0x00000, 0x08000, CRC(4e1bc2a4) SHA1(d7d4c42fd932722436f1847929088e46d03184bd) )
 	ROM_LOAD( "ew25",         0x08000, 0x08000, CRC(9eb47dfb) SHA1(bb1e8a3a47f447f3a983ea51943d3081d56ad9a4) )
 	ROM_LOAD( "ew23",         0x10000, 0x08000, CRC(9ecf479e) SHA1(a8d4c1490f12e1b15d53a2a97147920dcb638378) )
 	ROM_LOAD( "ew22",         0x18000, 0x08000, CRC(e55669aa) SHA1(2a9b0e85bb81ff87a108e08b28e19b7b469463e4) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ev15",         0x00000, 0x10000, CRC(1d80f797) SHA1(1b6878155367350ff826593ea73bda5b893c1823) )
 	ROM_LOAD( "ew16",         0x10000, 0x10000, CRC(96233177) SHA1(929a1b7fb65ab33277719b84517ff57da563f875) )
 	ROM_LOAD( "ev10",         0x20000, 0x10000, CRC(c4e7116b) SHA1(1e665ba150e08ceb1c0d5f7b7e777f3d60997811) )
@@ -3367,23 +3376,23 @@ ROM_START( ffantasy )
 	ROM_REGION( 0x10000, "sub", 0 ) /* HuC6280 CPU */
 	ROM_LOAD( "ew08",         0x00000, 0x10000, CRC(53010534) SHA1(8b996e48414bacd009e05ff49848884ecf15d967) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ev14",         0x00000, 0x10000, CRC(686f72c1) SHA1(41d4fc1208d779f3428990a96586f6a555c28562) )
 	ROM_LOAD( "ev13",         0x10000, 0x10000, CRC(b787dcc9) SHA1(7fce9d2040bcb2483419ea1cafed538bb8aba4f9) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ew19",         0x00000, 0x08000, CRC(6b80d7a3) SHA1(323162e7e0ce16f6244d8d98fdb2396ffef87e82) )
 	ROM_LOAD( "ew18",         0x08000, 0x08000, CRC(78d3d764) SHA1(e8f77a23bd4f4d268bec7c0153fb957acd07cdee) )
 	ROM_LOAD( "ew20",         0x10000, 0x08000, CRC(ce9f5de3) SHA1(b8af33f52ca3579a45b41395751697a58931f9d6) )
 	ROM_LOAD( "ew21",         0x18000, 0x08000, CRC(487a7ba2) SHA1(7d52cc1517def8426355e8281440ec5e617d1121) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ew24",         0x00000, 0x08000, CRC(4e1bc2a4) SHA1(d7d4c42fd932722436f1847929088e46d03184bd) )
 	ROM_LOAD( "ew25",         0x08000, 0x08000, CRC(9eb47dfb) SHA1(bb1e8a3a47f447f3a983ea51943d3081d56ad9a4) )
 	ROM_LOAD( "ew23",         0x10000, 0x08000, CRC(9ecf479e) SHA1(a8d4c1490f12e1b15d53a2a97147920dcb638378) )
 	ROM_LOAD( "ew22",         0x18000, 0x08000, CRC(e55669aa) SHA1(2a9b0e85bb81ff87a108e08b28e19b7b469463e4) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ev15",         0x00000, 0x10000, CRC(1d80f797) SHA1(1b6878155367350ff826593ea73bda5b893c1823) )
 	ROM_LOAD( "ew16",         0x10000, 0x10000, CRC(96233177) SHA1(929a1b7fb65ab33277719b84517ff57da563f875) )
 	ROM_LOAD( "ev10",         0x20000, 0x10000, CRC(c4e7116b) SHA1(1e665ba150e08ceb1c0d5f7b7e777f3d60997811) )
@@ -3414,23 +3423,23 @@ ROM_START( ffantasya )
 	ROM_REGION( 0x10000, "sub", 0 ) /* HuC6280 CPU */
 	ROM_LOAD( "ew08",         0x00000, 0x10000, CRC(53010534) SHA1(8b996e48414bacd009e05ff49848884ecf15d967) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ev14",         0x00000, 0x10000, CRC(686f72c1) SHA1(41d4fc1208d779f3428990a96586f6a555c28562) )
 	ROM_LOAD( "ev13",         0x10000, 0x10000, CRC(b787dcc9) SHA1(7fce9d2040bcb2483419ea1cafed538bb8aba4f9) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ew19",         0x00000, 0x08000, CRC(6b80d7a3) SHA1(323162e7e0ce16f6244d8d98fdb2396ffef87e82) )
 	ROM_LOAD( "ew18",         0x08000, 0x08000, CRC(78d3d764) SHA1(e8f77a23bd4f4d268bec7c0153fb957acd07cdee) )
 	ROM_LOAD( "ew20",         0x10000, 0x08000, CRC(ce9f5de3) SHA1(b8af33f52ca3579a45b41395751697a58931f9d6) )
 	ROM_LOAD( "ew21",         0x18000, 0x08000, CRC(487a7ba2) SHA1(7d52cc1517def8426355e8281440ec5e617d1121) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ew24",         0x00000, 0x08000, CRC(4e1bc2a4) SHA1(d7d4c42fd932722436f1847929088e46d03184bd) )
 	ROM_LOAD( "ew25",         0x08000, 0x08000, CRC(9eb47dfb) SHA1(bb1e8a3a47f447f3a983ea51943d3081d56ad9a4) )
 	ROM_LOAD( "ew23",         0x10000, 0x08000, CRC(9ecf479e) SHA1(a8d4c1490f12e1b15d53a2a97147920dcb638378) )
 	ROM_LOAD( "ew22",         0x18000, 0x08000, CRC(e55669aa) SHA1(2a9b0e85bb81ff87a108e08b28e19b7b469463e4) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ev15",         0x00000, 0x10000, CRC(1d80f797) SHA1(1b6878155367350ff826593ea73bda5b893c1823) )
 	ROM_LOAD( "ew16",         0x10000, 0x10000, CRC(96233177) SHA1(929a1b7fb65ab33277719b84517ff57da563f875) )
 	ROM_LOAD( "ev10",         0x20000, 0x10000, CRC(c4e7116b) SHA1(1e665ba150e08ceb1c0d5f7b7e777f3d60997811) )
@@ -3461,23 +3470,23 @@ ROM_START( ffantasyb )  // DE-0297-3 PCB. All EX labels.
 	ROM_REGION( 0x10000, "sub", 0 ) /* HuC6280 CPU */
 	ROM_LOAD( "ex08",         0x00000, 0x10000, CRC(53010534) SHA1(8b996e48414bacd009e05ff49848884ecf15d967) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "ex14",         0x00000, 0x10000, CRC(686f72c1) SHA1(41d4fc1208d779f3428990a96586f6a555c28562) )
 	ROM_LOAD( "ex13",         0x10000, 0x10000, CRC(b787dcc9) SHA1(7fce9d2040bcb2483419ea1cafed538bb8aba4f9) )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "ex19",         0x00000, 0x08000, CRC(6b80d7a3) SHA1(323162e7e0ce16f6244d8d98fdb2396ffef87e82) )
 	ROM_LOAD( "ex18",         0x08000, 0x08000, CRC(78d3d764) SHA1(e8f77a23bd4f4d268bec7c0153fb957acd07cdee) )
 	ROM_LOAD( "ex20",         0x10000, 0x08000, CRC(ce9f5de3) SHA1(b8af33f52ca3579a45b41395751697a58931f9d6) )
 	ROM_LOAD( "ex21",         0x18000, 0x08000, CRC(487a7ba2) SHA1(7d52cc1517def8426355e8281440ec5e617d1121) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "ex24",         0x00000, 0x08000, CRC(4e1bc2a4) SHA1(d7d4c42fd932722436f1847929088e46d03184bd) )
 	ROM_LOAD( "ex25",         0x08000, 0x08000, CRC(9eb47dfb) SHA1(bb1e8a3a47f447f3a983ea51943d3081d56ad9a4) )
 	ROM_LOAD( "ex23",         0x10000, 0x08000, CRC(9ecf479e) SHA1(a8d4c1490f12e1b15d53a2a97147920dcb638378) )
 	ROM_LOAD( "ex22",         0x18000, 0x08000, CRC(e55669aa) SHA1(2a9b0e85bb81ff87a108e08b28e19b7b469463e4) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "ex15",         0x00000, 0x10000, CRC(95423914) SHA1(e9e7a6bdf5aa717dc04a751709632f31762886fb) )
 	ROM_LOAD( "ex16",         0x10000, 0x10000, CRC(96233177) SHA1(929a1b7fb65ab33277719b84517ff57da563f875) )
 	ROM_LOAD( "ex10",         0x20000, 0x10000, CRC(4c25dfe8) SHA1(e4334de96698cd0112a8926dea131e748b6a84fc) )
@@ -3509,17 +3518,17 @@ ROM_START( ffantasybl )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* 68705 MCU */ // (labeled on PCB as Z80, but it isn't!)
 	ROM_LOAD( "68705u3.bin",              0x00000, 0x1000, NO_DUMP ) // nor dumped, maybe it's the same as the midresb one?
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "22.bin",         0x00000, 0x10000, CRC(686f72c1) SHA1(41d4fc1208d779f3428990a96586f6a555c28562) )
 	ROM_LOAD( "23.bin",         0x10000, 0x10000, CRC(28e69371) SHA1(32d57aabf948388825757ab0cfe87b6550a07a9d) ) // 94.793701% ev13
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "25.bin",         0x00000, 0x08000, CRC(6b80d7a3) SHA1(323162e7e0ce16f6244d8d98fdb2396ffef87e82) )
 	ROM_LOAD( "27.bin",         0x08000, 0x08000, CRC(78d3d764) SHA1(e8f77a23bd4f4d268bec7c0153fb957acd07cdee) )
 	ROM_LOAD( "24.bin",         0x10000, 0x08000, CRC(ce9f5de3) SHA1(b8af33f52ca3579a45b41395751697a58931f9d6) )
 	ROM_LOAD( "26.bin",         0x18000, 0x08000, CRC(487a7ba2) SHA1(7d52cc1517def8426355e8281440ec5e617d1121) )
 
-	ROM_REGION( 0x20000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "29.bin",         0x00000, 0x08000, CRC(4e1bc2a4) SHA1(d7d4c42fd932722436f1847929088e46d03184bd) )
 	ROM_LOAD( "21.bin",         0x08000, 0x08000, CRC(28b37d27) SHA1(c70718f8ce23f75a728dc0a7556fd7d259048b88) )
 	ROM_IGNORE(0x8000) // same content, double size as original, ignore 2nd half
@@ -3527,7 +3536,7 @@ ROM_START( ffantasybl )
 	ROM_LOAD( "20.bin",         0x18000, 0x08000, CRC(b5ca8ed9) SHA1(3f44ebf7fec76154a843ee4398d4ac8690e70342) )
 	ROM_IGNORE(0x8000) // same content, double size as original, ignore 2nd half
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "6.bin",         0x00000, 0x10000, CRC(95423914) SHA1(e9e7a6bdf5aa717dc04a751709632f31762886fb) )
 	ROM_LOAD( "3.bin",         0x10000, 0x10000, CRC(96233177) SHA1(929a1b7fb65ab33277719b84517ff57da563f875) )
 	ROM_LOAD( "8.bin",         0x20000, 0x10000, CRC(4c25dfe8) SHA1(e4334de96698cd0112a8926dea131e748b6a84fc) )
@@ -3552,21 +3561,21 @@ ROM_START( secretag ) /* DE-0322-2 PCB */
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
 	ROM_LOAD( "fb10.5h", 0x00000, 0x10000, CRC(dfd2ff25) SHA1(3dcd6d50b92b49daae4b51581abe9c95f764e848) )
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x10000, "char", 0 ) /* chars */
 	ROM_LOAD( "fb05.11a", 0x04000, 0x04000, CRC(09802924) SHA1(d9bc5fe7f053afa15cd39400aae993866d1b0226) )
 	ROM_CONTINUE(         0x00000, 0x04000 )    /* the two halves are swapped */
 	ROM_LOAD( "fb04.9a",  0x0c000, 0x04000, CRC(ec25b895) SHA1(8c1d2b9a2487fd7114d37fe9dc271183c4cc1613) )
 	ROM_CONTINUE(         0x08000, 0x04000 )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "fb07.17a", 0x00000, 0x10000, CRC(e932268b) SHA1(ee8ed29affa951e725cf19a5f56d3beac24420c9) )
 	ROM_LOAD( "fb06.15a", 0x10000, 0x10000, CRC(c4dd38c0) SHA1(267dbbdd5df6b13662cd307c5c95fdf643d64f45) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "fb09.22a", 0x00000, 0x20000, CRC(1395e9be) SHA1(60693ac6236ffe1e0933d81771cfad32e14514c3) )
 	ROM_LOAD( "fb08.21a", 0x20000, 0x20000, CRC(4d7464db) SHA1(82e2a3c3d78447985968220d52c7c1f1ff625d83) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "fb01.4a", 0x00000, 0x20000, CRC(99b0cd92) SHA1(2729e874730391b5fa93e9a28142c02c00eb5068) )
 	ROM_LOAD( "fb03.7a", 0x20000, 0x20000, CRC(0e7ea74d) SHA1(22078a2856933af2d31750a4a506b993fe309e9a) )
 	ROM_LOAD( "fb00.2a", 0x40000, 0x20000, CRC(f7df3fd7) SHA1(ed9e4649e0b1fcca61cf4d159b3f8a35f06102ce) )
@@ -3595,21 +3604,21 @@ ROM_START( secretagj ) /* DE-0322-2 PCB */
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
 	ROM_LOAD( "fc10.5h", 0x00000, 0x10000, CRC(dfd2ff25) SHA1(3dcd6d50b92b49daae4b51581abe9c95f764e848) ) // == FB counterpart from World set
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x10000, "char", 0 ) /* chars */
 	ROM_LOAD( "fc05.11a", 0x04000, 0x04000, CRC(09802924) SHA1(d9bc5fe7f053afa15cd39400aae993866d1b0226) ) // == FB counterpart from World set
 	ROM_CONTINUE(         0x00000, 0x04000 )    /* the two halves are swapped */
 	ROM_LOAD( "fc04.9a",  0x0c000, 0x04000, CRC(ec25b895) SHA1(8c1d2b9a2487fd7114d37fe9dc271183c4cc1613) ) // == FB counterpart from World set
 	ROM_CONTINUE(         0x08000, 0x04000 )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "fc07.17a", 0x00000, 0x10000, CRC(e932268b) SHA1(ee8ed29affa951e725cf19a5f56d3beac24420c9) ) // == FB counterpart from World set
 	ROM_LOAD( "fc06.15a", 0x10000, 0x10000, CRC(c4dd38c0) SHA1(267dbbdd5df6b13662cd307c5c95fdf643d64f45) ) // == FB counterpart from World set
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "fc09.22a", 0x00000, 0x20000, CRC(1395e9be) SHA1(60693ac6236ffe1e0933d81771cfad32e14514c3) ) // == FB counterpart from World set
 	ROM_LOAD( "fc08.21a", 0x20000, 0x20000, CRC(4d7464db) SHA1(82e2a3c3d78447985968220d52c7c1f1ff625d83) ) // == FB counterpart from World set
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "fc01.4a", 0x00000, 0x20000, CRC(99b0cd92) SHA1(2729e874730391b5fa93e9a28142c02c00eb5068) ) // == FB counterpart from World set
 	ROM_LOAD( "fc03.7a", 0x20000, 0x20000, CRC(0e7ea74d) SHA1(22078a2856933af2d31750a4a506b993fe309e9a) ) // == FB counterpart from World set
 	ROM_LOAD( "fc00.2a", 0x40000, 0x20000, CRC(f7df3fd7) SHA1(ed9e4649e0b1fcca61cf4d159b3f8a35f06102ce) ) // == FB counterpart from World set
@@ -3638,21 +3647,21 @@ ROM_START( slyspy ) /* DE-0322-3 PCB */
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
 	ROM_LOAD( "fa10.5h", 0x00000, 0x10000, CRC(dfd2ff25) SHA1(3dcd6d50b92b49daae4b51581abe9c95f764e848) ) // == FB counterpart from World set
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x10000, "char", 0 ) /* chars */
 	ROM_LOAD( "fa05.11a", 0x04000, 0x04000, CRC(09802924) SHA1(d9bc5fe7f053afa15cd39400aae993866d1b0226) ) // == FB counterpart from World set
 	ROM_CONTINUE(         0x00000, 0x04000 )    /* the two halves are swapped */
 	ROM_LOAD( "fa04.9a",  0x0c000, 0x04000, CRC(ec25b895) SHA1(8c1d2b9a2487fd7114d37fe9dc271183c4cc1613) ) // == FB counterpart from World set
 	ROM_CONTINUE(         0x08000, 0x04000 )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "fa07.17a", 0x00000, 0x10000, CRC(e932268b) SHA1(ee8ed29affa951e725cf19a5f56d3beac24420c9) ) // == FB counterpart from World set
 	ROM_LOAD( "fa06.15a", 0x10000, 0x10000, CRC(c4dd38c0) SHA1(267dbbdd5df6b13662cd307c5c95fdf643d64f45) ) // == FB counterpart from World set
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "fa09.22a", 0x00000, 0x20000, CRC(1395e9be) SHA1(60693ac6236ffe1e0933d81771cfad32e14514c3) ) // == FB counterpart from World set
 	ROM_LOAD( "fa08.21a", 0x20000, 0x20000, CRC(4d7464db) SHA1(82e2a3c3d78447985968220d52c7c1f1ff625d83) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "fa01.4a", 0x00000, 0x20000, CRC(99b0cd92) SHA1(2729e874730391b5fa93e9a28142c02c00eb5068) ) // == FB counterpart from World set
 	ROM_LOAD( "fa03.7a", 0x20000, 0x20000, CRC(0e7ea74d) SHA1(22078a2856933af2d31750a4a506b993fe309e9a) ) // == FB counterpart from World set
 	ROM_LOAD( "fa00.2a", 0x40000, 0x20000, CRC(f7df3fd7) SHA1(ed9e4649e0b1fcca61cf4d159b3f8a35f06102ce) ) // == FB counterpart from World set
@@ -3681,21 +3690,21 @@ ROM_START( slyspy3 ) /* DE-0322-3 PCB */
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
 	ROM_LOAD( "fa10.5h", 0x00000, 0x10000, CRC(dfd2ff25) SHA1(3dcd6d50b92b49daae4b51581abe9c95f764e848) ) // == FB counterpart from World set
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x10000, "char", 0 ) /* chars */
 	ROM_LOAD( "fa05.11a", 0x04000, 0x04000, CRC(09802924) SHA1(d9bc5fe7f053afa15cd39400aae993866d1b0226) ) // == FB counterpart from World set
 	ROM_CONTINUE(         0x00000, 0x04000 )    /* the two halves are swapped */
 	ROM_LOAD( "fa04.9a",  0x0c000, 0x04000, CRC(ec25b895) SHA1(8c1d2b9a2487fd7114d37fe9dc271183c4cc1613) ) // == FB counterpart from World set
 	ROM_CONTINUE(         0x08000, 0x04000 )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "fa07.17a", 0x00000, 0x10000, CRC(e932268b) SHA1(ee8ed29affa951e725cf19a5f56d3beac24420c9) ) // == FB counterpart from World set
 	ROM_LOAD( "fa06.15a", 0x10000, 0x10000, CRC(c4dd38c0) SHA1(267dbbdd5df6b13662cd307c5c95fdf643d64f45) ) // == FB counterpart from World set
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "fa09.22a", 0x00000, 0x20000, CRC(1395e9be) SHA1(60693ac6236ffe1e0933d81771cfad32e14514c3) ) // == FB counterpart from World set
 	ROM_LOAD( "fa08.21a", 0x20000, 0x20000, CRC(4d7464db) SHA1(82e2a3c3d78447985968220d52c7c1f1ff625d83) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "fa01.4a", 0x00000, 0x20000, CRC(99b0cd92) SHA1(2729e874730391b5fa93e9a28142c02c00eb5068) ) // == FB counterpart from World set
 	ROM_LOAD( "fa03.7a", 0x20000, 0x20000, CRC(0e7ea74d) SHA1(22078a2856933af2d31750a4a506b993fe309e9a) ) // == FB counterpart from World set
 	ROM_LOAD( "fa00.2a", 0x40000, 0x20000, CRC(f7df3fd7) SHA1(ed9e4649e0b1fcca61cf4d159b3f8a35f06102ce) ) // == FB counterpart from World set
@@ -3724,21 +3733,21 @@ ROM_START( slyspy2 ) /* DE-0322-3 PCB */
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
 	ROM_LOAD( "fa10.5h", 0x00000, 0x10000, CRC(dfd2ff25) SHA1(3dcd6d50b92b49daae4b51581abe9c95f764e848) ) // == FB counterpart from World set
 
-	ROM_REGION( 0x10000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x10000, "char", 0 ) /* chars */
 	ROM_LOAD( "fa05.11a", 0x04000, 0x04000, CRC(09802924) SHA1(d9bc5fe7f053afa15cd39400aae993866d1b0226) ) // == FB counterpart from World set
 	ROM_CONTINUE(         0x00000, 0x04000 )    /* the two halves are swapped */
 	ROM_LOAD( "fa04.9a",  0x0c000, 0x04000, CRC(ec25b895) SHA1(8c1d2b9a2487fd7114d37fe9dc271183c4cc1613) ) // == FB counterpart from World set
 	ROM_CONTINUE(         0x08000, 0x04000 )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "fa07.17a", 0x00000, 0x10000, CRC(e932268b) SHA1(ee8ed29affa951e725cf19a5f56d3beac24420c9) ) // == FB counterpart from World set
 	ROM_LOAD( "fa06.15a", 0x10000, 0x10000, CRC(c4dd38c0) SHA1(267dbbdd5df6b13662cd307c5c95fdf643d64f45) ) // == FB counterpart from World set
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "fa09.22a", 0x00000, 0x20000, CRC(1395e9be) SHA1(60693ac6236ffe1e0933d81771cfad32e14514c3) ) // == FB counterpart from World set
 	ROM_LOAD( "fa08.21a", 0x20000, 0x20000, CRC(4d7464db) SHA1(82e2a3c3d78447985968220d52c7c1f1ff625d83) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "fa01.4a", 0x00000, 0x20000, CRC(99b0cd92) SHA1(2729e874730391b5fa93e9a28142c02c00eb5068) ) // == FB counterpart from World set
 	ROM_LOAD( "fa03.7a", 0x20000, 0x20000, CRC(0e7ea74d) SHA1(22078a2856933af2d31750a4a506b993fe309e9a) ) // == FB counterpart from World set
 	ROM_LOAD( "fa00.2a", 0x40000, 0x20000, CRC(f7df3fd7) SHA1(ed9e4649e0b1fcca61cf4d159b3f8a35f06102ce) ) // == FB counterpart from World set
@@ -3796,25 +3805,25 @@ ROM_START( secretab )
 	ROM_LOAD( "sa_10.ic138", 0x20000, 0x10000, CRC(843c4679) SHA1(871f3e77aa7e628e924a40d06ddec700487e23fb) )
 	ROM_LOAD( "sa_14.ic188", 0x30000, 0x10000, CRC(3dac9128) SHA1(f3a2068e90973c1f04f1bbaa209111e3f9669ee0) )
 
-	ROM_REGION( 0x20000, "gfx1", ROMREGION_INVERT ) /* chars */
+	ROM_REGION( 0x20000, "char", ROMREGION_INVERT ) /* chars */
 	ROM_COPY( "charset", 0x00000, 0x00000, 0x8000 )
 	ROM_COPY( "charset", 0x10000, 0x08000, 0x8000 )
 	ROM_COPY( "charset", 0x20000, 0x10000, 0x8000 )
 	ROM_COPY( "charset", 0x30000, 0x18000, 0x8000 )
 
-	ROM_REGION( 0x20000, "gfx2", ROMREGION_INVERT ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", ROMREGION_INVERT ) /* tiles */
 	ROM_COPY( "charset", 0x08000, 0x00000, 0x8000 )
 	ROM_COPY( "charset", 0x18000, 0x08000, 0x8000 )
 	ROM_COPY( "charset", 0x28000, 0x10000, 0x8000 )
 	ROM_COPY( "charset", 0x38000, 0x18000, 0x8000 )
 
-	ROM_REGION( 0x40000, "gfx3", ROMREGION_INVERT ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", ROMREGION_INVERT ) /* tiles */
 	ROM_LOAD( "sa_09.ic139",     0x00000, 0x10000, CRC(9e412267) SHA1(482cd6e772fa21f15db66c27acf85e8f97f7c5a5) )
 	ROM_LOAD( "sa_11.ic157",     0x10000, 0x10000, CRC(e87650db) SHA1(381352428b12fd4a8cd13270009ff7602aa41a0b) )
 	ROM_LOAD( "sa_07.ic106",     0x20000, 0x10000, CRC(6ad2e575) SHA1(b6b159cb36e222fe62fc10271602226f027440e4) )
 	ROM_LOAD( "sa_13.ic189",     0x30000, 0x10000, CRC(e8601057) SHA1(fd73a36fb84049154248d250ffea68b1ee39a43f) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "sa_20.ic176",     0x00000, 0x10000, CRC(447e4f0b) SHA1(97db103e505a6e11eb9bdb3622e4aa3b796a9714) )
 	ROM_LOAD( "sa_19.ic177",     0x10000, 0x10000, CRC(d29bc22e) SHA1(ce0935d09f7e94fa32247c86e14a74b73514b29e) )
 	ROM_LOAD( "sa_16.ic180",     0x20000, 0x10000, CRC(ff72b838) SHA1(fdc48ecdd2225fc69472313f34973f6add8fb558) )
@@ -3843,25 +3852,25 @@ ROM_START( mastbond ) // same as secretab, but for the charset ROMs. Just a hack
 	ROM_LOAD( "10.ic138", 0x20000, 0x10000, CRC(16df8be2) SHA1(3d5e63933dc151caca56536dce67407a8bacb761) )
 	ROM_LOAD( "14.ic188", 0x30000, 0x10000, CRC(f1803c03) SHA1(d6504db6d98d838025b6ba68d5b5b5e3999b1c13) )
 
-	ROM_REGION( 0x20000, "gfx1", ROMREGION_INVERT ) // chars
+	ROM_REGION( 0x20000, "char", ROMREGION_INVERT ) // chars
 	ROM_COPY( "charset", 0x00000, 0x00000, 0x8000 )
 	ROM_COPY( "charset", 0x10000, 0x08000, 0x8000 )
 	ROM_COPY( "charset", 0x20000, 0x10000, 0x8000 )
 	ROM_COPY( "charset", 0x30000, 0x18000, 0x8000 )
 
-	ROM_REGION( 0x20000, "gfx2", ROMREGION_INVERT ) // tiles
+	ROM_REGION( 0x20000, "tiles1", ROMREGION_INVERT ) // tiles
 	ROM_COPY( "charset", 0x08000, 0x00000, 0x8000 )
 	ROM_COPY( "charset", 0x18000, 0x08000, 0x8000 )
 	ROM_COPY( "charset", 0x28000, 0x10000, 0x8000 )
 	ROM_COPY( "charset", 0x38000, 0x18000, 0x8000 )
 
-	ROM_REGION( 0x40000, "gfx3", ROMREGION_INVERT ) // tiles
+	ROM_REGION( 0x40000, "tiles2", ROMREGION_INVERT ) // tiles
 	ROM_LOAD( "9.ic139",     0x00000, 0x10000, CRC(9e412267) SHA1(482cd6e772fa21f15db66c27acf85e8f97f7c5a5) )
 	ROM_LOAD( "11.ic157",    0x10000, 0x10000, CRC(e87650db) SHA1(381352428b12fd4a8cd13270009ff7602aa41a0b) )
 	ROM_LOAD( "7.ic106",     0x20000, 0x10000, CRC(6ad2e575) SHA1(b6b159cb36e222fe62fc10271602226f027440e4) )
 	ROM_LOAD( "13.ic189",    0x30000, 0x10000, CRC(e8601057) SHA1(fd73a36fb84049154248d250ffea68b1ee39a43f) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) // sprites
+	ROM_REGION( 0x80000, "sprites", 0 ) // sprites
 	ROM_LOAD( "20.ic176",     0x00000, 0x10000, CRC(447e4f0b) SHA1(97db103e505a6e11eb9bdb3622e4aa3b796a9714) )
 	ROM_LOAD( "19.ic177",     0x10000, 0x10000, CRC(d29bc22e) SHA1(ce0935d09f7e94fa32247c86e14a74b73514b29e) )
 	ROM_LOAD( "16.ic180",     0x20000, 0x10000, CRC(ff72b838) SHA1(fdc48ecdd2225fc69472313f34973f6add8fb558) )
@@ -3888,23 +3897,23 @@ ROM_START( midres )
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
 	ROM_LOAD( "fl16.5f",           0x00000, 0x10000, CRC(66360bdf) SHA1(76ecaeb396118bb2fe6c0151bb0705a3a878f7a5) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "fk05.11a",          0x08000, 0x08000, CRC(3cdb7453) SHA1(d4b7fbf4726a375b4478922db6d936274bfa963c) )
 	ROM_CONTINUE(                  0x00000, 0x08000 )   /* the two halves are swapped */
 	ROM_LOAD( "fk04.10a",          0x18000, 0x08000, CRC(325ba20c) SHA1(fecd6254cf8c3b18496039fe18ded13c2ae47ff4) )
 	ROM_CONTINUE(                  0x10000, 0x08000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "fl-09.18a",         0x00000, 0x20000, CRC(907d5910) SHA1(6f4963724987bf44007988d117a1f7276cf270d8) )
 	ROM_LOAD( "fl-08.16a",         0x20000, 0x20000, CRC(a936c03c) SHA1(293e69874ce9b2dfb1d605c9f988fa736b12bbcf) )
 	ROM_LOAD( "fl-07.15a",         0x40000, 0x20000, CRC(2068c45c) SHA1(943ed767a462ee39a42cd15f02d06c8a2e4556b3) )
 	ROM_LOAD( "fl-06.13a",         0x60000, 0x20000, CRC(b7241ab9) SHA1(3e83f9285ff4c476f1287bf73b514eace482dccc) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "fl-11.21a",         0x00000, 0x20000, CRC(b86b73b4) SHA1(dd0e61d60574e537aa1b7f35ffdfd08434ec8208) )
 	ROM_LOAD( "fl-10.20a",         0x20000, 0x20000, CRC(92245b29) SHA1(3289842bbd4bd7858846b234f08ea5737c11536d) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "fl-01.4a",          0x00000, 0x20000, CRC(2c8b35a7) SHA1(9ab1c2f014a24837ee99c4db000291f7e55aeb12) )
 	ROM_LOAD( "fl-03.8a",          0x20000, 0x20000, CRC(1eefed3c) SHA1(be0ce3db211587086ae3ee8df85b7c56f831c623) )
 	ROM_LOAD( "fl-00.2a",          0x40000, 0x20000, CRC(756fb801) SHA1(35510c4ddf9258d87fdee0d3a64a8de0ebd1967d) )
@@ -3935,23 +3944,23 @@ ROM_START( midres2 ) // DE-0323-4 PCB, only the first 2 main CPU ROMs differ, RO
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "fl16.5f",           0x00000, 0x10000, CRC(66360bdf) SHA1(76ecaeb396118bb2fe6c0151bb0705a3a878f7a5) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) // chars
+	ROM_REGION( 0x20000, "char", 0 ) // chars
 	ROM_LOAD( "fl05.11a",          0x08000, 0x08000, CRC(d75aba06) SHA1(cb3b969db3dd8e0c5c3729482f7461cde3a961f3) )
 	ROM_CONTINUE(                  0x00000, 0x08000 )   // the two halves are swapped
 	ROM_LOAD( "fl04.10a",          0x18000, 0x08000, CRC(8f5bbb79) SHA1(cb10f68787606111ba5e9967bf0b0cd21269a902) )
 	ROM_CONTINUE(                  0x10000, 0x08000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) // tiles
+	ROM_REGION( 0x80000, "tiles1", 0 ) // tiles
 	ROM_LOAD( "fl-09.18a",         0x00000, 0x20000, CRC(907d5910) SHA1(6f4963724987bf44007988d117a1f7276cf270d8) )
 	ROM_LOAD( "fl-08.16a",         0x20000, 0x20000, CRC(a936c03c) SHA1(293e69874ce9b2dfb1d605c9f988fa736b12bbcf) )
 	ROM_LOAD( "fl-07.15a",         0x40000, 0x20000, CRC(2068c45c) SHA1(943ed767a462ee39a42cd15f02d06c8a2e4556b3) )
 	ROM_LOAD( "fl-06.13a",         0x60000, 0x20000, CRC(b7241ab9) SHA1(3e83f9285ff4c476f1287bf73b514eace482dccc) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) // tiles
+	ROM_REGION( 0x40000, "tiles2", 0 ) // tiles
 	ROM_LOAD( "fl-11.21a",         0x00000, 0x20000, CRC(b86b73b4) SHA1(dd0e61d60574e537aa1b7f35ffdfd08434ec8208) )
 	ROM_LOAD( "fl-10.20a",         0x20000, 0x20000, CRC(92245b29) SHA1(3289842bbd4bd7858846b234f08ea5737c11536d) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) // sprites
+	ROM_REGION( 0x80000, "sprites", 0 ) // sprites
 	ROM_LOAD( "fl-01.4a",          0x00000, 0x20000, CRC(2c8b35a7) SHA1(9ab1c2f014a24837ee99c4db000291f7e55aeb12) )
 	ROM_LOAD( "fl-03.8a",          0x20000, 0x20000, CRC(1eefed3c) SHA1(be0ce3db211587086ae3ee8df85b7c56f831c623) )
 	ROM_LOAD( "fl-00.2a",          0x40000, 0x20000, CRC(756fb801) SHA1(35510c4ddf9258d87fdee0d3a64a8de0ebd1967d) )
@@ -3982,23 +3991,23 @@ ROM_START( midresu )
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
 	ROM_LOAD( "fl16.5f",           0x00000, 0x10000, CRC(66360bdf) SHA1(76ecaeb396118bb2fe6c0151bb0705a3a878f7a5) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "fl05.11a",          0x08000, 0x08000, CRC(d75aba06) SHA1(cb3b969db3dd8e0c5c3729482f7461cde3a961f3) )
 	ROM_CONTINUE(                  0x00000, 0x08000 )   /* the two halves are swapped */
 	ROM_LOAD( "fl04.10a",          0x18000, 0x08000, CRC(8f5bbb79) SHA1(cb10f68787606111ba5e9967bf0b0cd21269a902) )
 	ROM_CONTINUE(                  0x10000, 0x08000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "fl-09.18a",         0x00000, 0x20000, CRC(907d5910) SHA1(6f4963724987bf44007988d117a1f7276cf270d8) )
 	ROM_LOAD( "fl-08.16a",         0x20000, 0x20000, CRC(a936c03c) SHA1(293e69874ce9b2dfb1d605c9f988fa736b12bbcf) )
 	ROM_LOAD( "fl-07.15a",         0x40000, 0x20000, CRC(2068c45c) SHA1(943ed767a462ee39a42cd15f02d06c8a2e4556b3) )
 	ROM_LOAD( "fl-06.13a",         0x60000, 0x20000, CRC(b7241ab9) SHA1(3e83f9285ff4c476f1287bf73b514eace482dccc) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "fl-11.21a",         0x00000, 0x20000, CRC(b86b73b4) SHA1(dd0e61d60574e537aa1b7f35ffdfd08434ec8208) )
 	ROM_LOAD( "fl-10.20a",         0x20000, 0x20000, CRC(92245b29) SHA1(3289842bbd4bd7858846b234f08ea5737c11536d) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "fl-01.4a",          0x00000, 0x20000, CRC(2c8b35a7) SHA1(9ab1c2f014a24837ee99c4db000291f7e55aeb12) )
 	ROM_LOAD( "fl-03.8a",          0x20000, 0x20000, CRC(1eefed3c) SHA1(be0ce3db211587086ae3ee8df85b7c56f831c623) )
 	ROM_LOAD( "fl-00.2a",          0x40000, 0x20000, CRC(756fb801) SHA1(35510c4ddf9258d87fdee0d3a64a8de0ebd1967d) )
@@ -4028,23 +4037,23 @@ ROM_START( midresj )
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
 	ROM_LOAD( "fh16.5f",           0x00000, 0x10000, CRC(00736f32) SHA1(292f98b5579314c866247dd0ea1346c6e160b304) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "fl05.11a",          0x08000, 0x08000, CRC(d75aba06) SHA1(cb3b969db3dd8e0c5c3729482f7461cde3a961f3) ) // ROM label FH-05, content matches FL05
 	ROM_CONTINUE(                  0x00000, 0x08000 )   /* the two halves are swapped */
 	ROM_LOAD( "fl04.10a",          0x18000, 0x08000, CRC(8f5bbb79) SHA1(cb10f68787606111ba5e9967bf0b0cd21269a902) ) // ROM label FH-04, content matches FL04
 	ROM_CONTINUE(                  0x10000, 0x08000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "fl-09.18a",         0x00000, 0x20000, CRC(907d5910) SHA1(6f4963724987bf44007988d117a1f7276cf270d8) )
 	ROM_LOAD( "fl-08.16a",         0x20000, 0x20000, CRC(a936c03c) SHA1(293e69874ce9b2dfb1d605c9f988fa736b12bbcf) )
 	ROM_LOAD( "fl-07.15a",         0x40000, 0x20000, CRC(2068c45c) SHA1(943ed767a462ee39a42cd15f02d06c8a2e4556b3) )
 	ROM_LOAD( "fl-06.13a",         0x60000, 0x20000, CRC(b7241ab9) SHA1(3e83f9285ff4c476f1287bf73b514eace482dccc) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "fl-11.21a",         0x00000, 0x20000, CRC(b86b73b4) SHA1(dd0e61d60574e537aa1b7f35ffdfd08434ec8208) )
 	ROM_LOAD( "fl-10.20a",         0x20000, 0x20000, CRC(92245b29) SHA1(3289842bbd4bd7858846b234f08ea5737c11536d) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "fl-01.4a",          0x00000, 0x20000, CRC(2c8b35a7) SHA1(9ab1c2f014a24837ee99c4db000291f7e55aeb12) )
 	ROM_LOAD( "fl-03.8a",          0x20000, 0x20000, CRC(1eefed3c) SHA1(be0ce3db211587086ae3ee8df85b7c56f831c623) )
 	ROM_LOAD( "fl-00.2a",          0x40000, 0x20000, CRC(756fb801) SHA1(35510c4ddf9258d87fdee0d3a64a8de0ebd1967d) )
@@ -4101,13 +4110,13 @@ ROM_START( midresb )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* 68705 MCU */
 	ROM_LOAD( "68705r3.bin",              0x00000, 0x1000, CRC(ad5b1c13) SHA1(3616dc5969323a54e3e171d169f76250ae4e711a) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "23.bin",             0x08000, 0x08000, CRC(d75aba06) SHA1(cb3b969db3dd8e0c5c3729482f7461cde3a961f3) )
 	ROM_CONTINUE(                   0x00000, 0x08000 )  /* the two halves are swapped */
 	ROM_LOAD( "24.bin",             0x18000, 0x08000, CRC(8f5bbb79) SHA1(cb10f68787606111ba5e9967bf0b0cd21269a902) )
 	ROM_CONTINUE(                   0x10000, 0x08000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "28.bin",             0x00000, 0x10000, CRC(4490ed48) SHA1(e825c6290c65b9e3fa38f961a2174836ec2324d9) )
 	ROM_LOAD( "19.bin",             0x10000, 0x10000, CRC(0f94f5c1) SHA1(235f1d8a09c0bfc51454a16c41489eb45ea29e0b) )
 	ROM_LOAD( "26.bin",             0x20000, 0x10000, CRC(d4994050) SHA1(1d78ad702325013c3fd0889622b969af76d749ee) )
@@ -4117,13 +4126,13 @@ ROM_START( midresb )
 	ROM_LOAD( "25.bin",             0x60000, 0x10000, CRC(323cce90) SHA1(8f5c5d0cc2bc2ded75bb4d0683f2611585b5affc) )
 	ROM_LOAD( "17.bin",             0x70000, 0x10000, CRC(7c94e1b4) SHA1(5b2d036f13c9ec85b46d601d8d925cfa14d204c3) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "22.bin",             0x00000, 0x10000, CRC(68d50336) SHA1(89a1b2398796ec2392f003e1c77ba914ea90c8c2) )
 	ROM_LOAD( "30.bin",             0x10000, 0x10000, CRC(efe22953) SHA1(2f4b6090c2fcd45381746ccc14c8ad8948aa096b) )
 	ROM_LOAD( "21.bin",             0x20000, 0x10000, CRC(3311d7b0) SHA1(d9812cd9d8b5bd38a78c4c3a92aa2a90d78525a3) )
 	ROM_LOAD( "29.bin",             0x30000, 0x10000, CRC(9210b713) SHA1(1db2775359d946221b99047fb648114a908690a9) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "8.bin",             0x00000, 0x10000, CRC(3f499acb) SHA1(1a22cfeed0497ddc2d571114d9f246b3ae18ede9) )
 	ROM_LOAD( "4.bin",             0x10000, 0x10000, CRC(5e7a6800) SHA1(8dd5c9005b6804a30627644053f14e4477fe0074) )
 	ROM_LOAD( "6.bin",             0x20000, 0x10000, CRC(897ba6e4) SHA1(70fd9cba3922751cb317770d6effdc2fb94c1324) )
@@ -4152,25 +4161,25 @@ ROM_START( midresbj )
 	ROM_REGION( 0x1000, "mcu", ROMREGION_ERASE00 )    /* 68705 MCU */
 	//ROM_LOAD( "68705r3.bin",              0x00000, 0x1000, CRC(ad5b1c13) SHA1(3616dc5969323a54e3e171d169f76250ae4e711a) ) // unpopulated socket
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "23",             0x08000, 0x08000, CRC(d75aba06) SHA1(cb3b969db3dd8e0c5c3729482f7461cde3a961f3) )
 	ROM_CONTINUE(                   0x00000, 0x08000 )  /* the two halves are swapped */
 	ROM_LOAD( "24",             0x18000, 0x08000, CRC(8f5bbb79) SHA1(cb10f68787606111ba5e9967bf0b0cd21269a902) )
 	ROM_CONTINUE(                   0x10000, 0x08000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "19",             0x00000, 0x20000, CRC(fd9ba1bd) SHA1(a105a4335eeed19662c89ab0f90485f1029cf03f) )
 	ROM_LOAD( "18",             0x20000, 0x20000, CRC(a936c03c) SHA1(293e69874ce9b2dfb1d605c9f988fa736b12bbcf) )
 	ROM_LOAD( "20",             0x40000, 0x20000, CRC(4d8e3cf1) SHA1(db804a608f6ba9ce4cedfec2581bcbb00de3f2ba) )
 	ROM_LOAD( "17",             0x60000, 0x20000, CRC(b7241ab9) SHA1(3e83f9285ff4c476f1287bf73b514eace482dccc) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "22",             0x10000, 0x10000, CRC(35a54bb4) SHA1(1869eb77a060e9df42b761b02e7fa5ecb7c414d1) )
 	ROM_CONTINUE(0x00000,0x10000)
 	ROM_LOAD( "21",             0x30000, 0x10000, CRC(4b9227b3) SHA1(7059f2d07fffa0468a45a42b87bf561da5e9c5a4) )
 	ROM_CONTINUE(0x20000,0x10000)
 
-	ROM_REGION( 0x80000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "4",             0x00000, 0x10000, CRC(3f499acb) SHA1(1a22cfeed0497ddc2d571114d9f246b3ae18ede9) )
 	ROM_LOAD( "8",             0x10000, 0x10000, CRC(5e7a6800) SHA1(8dd5c9005b6804a30627644053f14e4477fe0074) )
 	ROM_LOAD( "2",             0x20000, 0x10000, CRC(897ba6e4) SHA1(70fd9cba3922751cb317770d6effdc2fb94c1324) )
@@ -4197,21 +4206,21 @@ ROM_START( bouldash )
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
 	ROM_LOAD( "fn-10",      0x00000, 0x10000, CRC(c74106e7) SHA1(72213454c0ec78aa7d6843bd81d14b388ef7a48f) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "fn-04",        0x08000, 0x08000, CRC(40f5a760) SHA1(0d08b816714c08d0848dd25882a09d0a57fcc71b) )
 	ROM_CONTINUE(             0x00000, 0x08000 )    /* the two halves are swapped */
 	ROM_LOAD( "fn-05",        0x18000, 0x08000, CRC(824f2168) SHA1(32272a35e5faeebe41ece91fb902251707c9114b) )
 	ROM_CONTINUE(             0x10000, 0x08000 )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "fn-07",        0x00000, 0x10000, CRC(eac6a3b3) SHA1(359df7335d11134ae149675080169cb53cafc19c) )
 	ROM_LOAD( "fn-06",        0x10000, 0x10000, CRC(3feee292) SHA1(d0dc75afffff268e0b3b817fbc060d52418a2ca7) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "fn-09",        0x00000, 0x20000, CRC(c2b27bd2) SHA1(8452d4442af476a35d3dfc4bd4df0a7d84a3dd7c) )
 	ROM_LOAD( "fn-08",        0x20000, 0x20000, CRC(5ac97178) SHA1(7d246cb17986033ae2c219f7409e3b91be0dd259) )
 
-	ROM_REGION( 0x40000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x40000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "fn-01",        0x00000, 0x10000, CRC(9333121b) SHA1(826ed261b1af41dd5468b2244767593d48577618) )
 	ROM_LOAD( "fn-03",        0x10000, 0x10000, CRC(254ba60f) SHA1(71ab5cd48ee34da1d2dd951bb243a26d7a1171ae) )
 	ROM_LOAD( "fn-00",        0x20000, 0x10000, CRC(ec18d098) SHA1(3cd1a27de295a177e81c14b9e9bbfcf5793aade2) )
@@ -4236,21 +4245,21 @@ ROM_START( bouldashj )
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
 	ROM_LOAD( "fn-10",      0x00000, 0x10000, CRC(c74106e7) SHA1(72213454c0ec78aa7d6843bd81d14b388ef7a48f) )
 
-	ROM_REGION( 0x20000, "gfx1", 0 ) /* chars */
+	ROM_REGION( 0x20000, "char", 0 ) /* chars */
 	ROM_LOAD( "fn-04",        0x08000, 0x08000, CRC(40f5a760) SHA1(0d08b816714c08d0848dd25882a09d0a57fcc71b) )
 	ROM_CONTINUE(             0x00000, 0x08000 )    /* the two halves are swapped */
 	ROM_LOAD( "fn-05",        0x18000, 0x08000, CRC(824f2168) SHA1(32272a35e5faeebe41ece91fb902251707c9114b) )
 	ROM_CONTINUE(             0x10000, 0x08000 )
 
-	ROM_REGION( 0x20000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x20000, "tiles1", 0 ) /* tiles */
 	ROM_LOAD( "fn-07",        0x00000, 0x10000, CRC(eac6a3b3) SHA1(359df7335d11134ae149675080169cb53cafc19c) )
 	ROM_LOAD( "fn-06",        0x10000, 0x10000, CRC(3feee292) SHA1(d0dc75afffff268e0b3b817fbc060d52418a2ca7) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x40000, "tiles2", 0 ) /* tiles */
 	ROM_LOAD( "fn-09",        0x00000, 0x20000, CRC(c2b27bd2) SHA1(8452d4442af476a35d3dfc4bd4df0a7d84a3dd7c) )
 	ROM_LOAD( "fn-08",        0x20000, 0x20000, CRC(5ac97178) SHA1(7d246cb17986033ae2c219f7409e3b91be0dd259) )
 
-	ROM_REGION( 0x40000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x40000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "fn-01",        0x00000, 0x10000, CRC(9333121b) SHA1(826ed261b1af41dd5468b2244767593d48577618) )
 	ROM_LOAD( "fn-03",        0x10000, 0x10000, CRC(254ba60f) SHA1(71ab5cd48ee34da1d2dd951bb243a26d7a1171ae) )
 	ROM_LOAD( "fn-00",        0x20000, 0x10000, CRC(ec18d098) SHA1(3cd1a27de295a177e81c14b9e9bbfcf5793aade2) )

--- a/src/mame/dataeast/dec0_v.cpp
+++ b/src/mame/dataeast/dec0_v.cpp
@@ -45,7 +45,7 @@ uint32_t dec0_state::screen_update_hbarrel(screen_device &screen, bitmap_ind16 &
 	m_tilegen[2]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 1);
 	m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 2);
 	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 4);
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(3), m_buffered_spriteram, 0x800/2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
 	return 0;
 }
 
@@ -73,7 +73,7 @@ uint32_t dec0_state::screen_update_baddudes(screen_device &screen, bitmap_ind16 
 	if (m_pri & 2)
 		m_tilegen[bg]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles /* Foreground pens only */
 
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(3), m_buffered_spriteram, 0x800/2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
 
 	if (m_pri & 4)
 		m_tilegen[fg]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles /* Foreground pens only */
@@ -124,7 +124,7 @@ uint32_t dec0_state::screen_update_robocop(screen_device &screen, bitmap_ind16 &
 	const u8 bg = (m_pri & 0x01) ? 1 : 2;
 	m_tilegen[bg]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 1);
 	m_tilegen[fg]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 2);
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(3), m_buffered_spriteram, 0x800/2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
 	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 0);
 	return 0;
 }
@@ -172,7 +172,7 @@ uint32_t dec0_automat_state::screen_update_automat(screen_device &screen, bitmap
 	const u8 bg = (m_pri & 0x01) ? 1 : 2;
 	m_tilegen[bg]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 1);
 	m_tilegen[fg]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 2);
-	m_spritegen->draw_sprites_bootleg(screen, bitmap, cliprect, m_gfxdecode->gfx(3), m_buffered_spriteram, 0x800/2); // TODO : RAM size
+	m_spritegen->draw_sprites_bootleg(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2); // TODO : RAM size
 	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 0);
 	return 0;
 }
@@ -190,7 +190,7 @@ uint32_t dec0_state::screen_update_birdtry(screen_device &screen, bitmap_ind16 &
 	the palette does show through. */
 	bitmap.fill(m_palette->pen(768), cliprect);
 	m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 0);
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(3), m_buffered_spriteram, 0x800/2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
 	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 0);
 	return 0;
 }
@@ -208,7 +208,7 @@ uint32_t slyspy_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap
 	m_tilegen[2]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 0);
 	m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
 
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(3), m_buffered_spriteram, 0x800/2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
 
 	/* Redraw top 8 pens of top 8 palettes over sprites */
 	if (m_pri & 0x80)
@@ -257,7 +257,7 @@ uint32_t dec0_automat_state::screen_update_secretab(screen_device &screen, bitma
 	m_tilegen[2]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 0);
 	m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
 
-	m_spritegen->draw_sprites_bootleg(screen, bitmap, cliprect, m_gfxdecode->gfx(3), m_buffered_spriteram, 0x800/2); // TODO : RAM size
+	m_spritegen->draw_sprites_bootleg(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2); // TODO : RAM size
 
 	/* Redraw top 8 pens of top 8 palettes over sprites */
 	if (m_pri & 0x80)

--- a/src/mame/dataeast/dec8.cpp
+++ b/src/mame/dataeast/dec8.cpp
@@ -1714,43 +1714,54 @@ static const gfx_layout tiles_r =
 };
 
 static GFXDECODE_START( gfx_cobracom )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout_32k, 0, 8 )
-	GFXDECODE_ENTRY( "gfx2", 0, tiles,       64, 4 )
-	GFXDECODE_ENTRY( "gfx4", 0, tiles,      128, 4 )
-	GFXDECODE_ENTRY( "gfx3", 0, tiles,      192, 4 )
+	GFXDECODE_ENTRY( "char",    0, charlayout_32k, 0, 8 )
+	GFXDECODE_ENTRY( "tiles2",  0, tiles,        128, 4 )
+	GFXDECODE_ENTRY( "tiles1",  0, tiles,        192, 4 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_cobracom_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tiles, 64, 4 )
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_ghostb )
-	GFXDECODE_ENTRY( "gfx1", 0, chars_3bpp, 0,  4 )
-	GFXDECODE_ENTRY( "gfx2", 0, tiles,   256, 16 )
-	GFXDECODE_ENTRY( "gfx3", 0, tiles_r,   512, 16 )
+	GFXDECODE_ENTRY( "char",    0, chars_3bpp, 0,  4 )
+	GFXDECODE_ENTRY( "tiles1",  0, tiles_r,  512, 16 )
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_srdarwin )
-	GFXDECODE_ENTRY( "gfx1", 0x00000, charlayout_16k,128, 4 ) /* Only 1 used so far :/ */
-	GFXDECODE_ENTRY( "gfx2", 0x00000, sr_sprites,    64, 8 )
-	GFXDECODE_ENTRY( "gfx3", 0x00000, srdarwin_tiles,  0, 8 )
-	GFXDECODE_ENTRY( "gfx3", 0x10000, srdarwin_tiles,  0, 8 )
-	GFXDECODE_ENTRY( "gfx3", 0x20000, srdarwin_tiles,  0, 8 )
-	GFXDECODE_ENTRY( "gfx3", 0x30000, srdarwin_tiles,  0, 8 )
+	GFXDECODE_ENTRY( "char",    0x00000, charlayout_16k, 128, 4 ) /* Only 1 used so far :/ */
+	GFXDECODE_ENTRY( "sprites", 0x00000, sr_sprites,      64, 8 )
+	GFXDECODE_ENTRY( "tiles1",  0x00000, srdarwin_tiles,   0, 8 )
+	GFXDECODE_ENTRY( "tiles1",  0x10000, srdarwin_tiles,   0, 8 )
+	GFXDECODE_ENTRY( "tiles1",  0x20000, srdarwin_tiles,   0, 8 )
+	GFXDECODE_ENTRY( "tiles1",  0x30000, srdarwin_tiles,   0, 8 )
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_gondo )
-	GFXDECODE_ENTRY( "gfx1", 0, chars_3bpp,  0, 16 ) /* Chars */
-	GFXDECODE_ENTRY( "gfx2", 0, tiles,   256, 32 ) /* Sprites */
-	GFXDECODE_ENTRY( "gfx3", 0, tiles,   768, 16 ) /* Tiles */
+	GFXDECODE_ENTRY( "char",    0, chars_3bpp, 0, 16 ) /* Chars */
+	GFXDECODE_ENTRY( "tiles1",  0, tiles,    768, 16 ) /* Tiles */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_gondo_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tiles, 256, 32 ) /* Sprites */
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_oscar )
-	GFXDECODE_ENTRY( "gfx1", 0, oscar_charlayout, 256,  8 ) /* Chars */
-	GFXDECODE_ENTRY( "gfx2", 0, tiles,            0, 16 ) /* Sprites */
-	GFXDECODE_ENTRY( "gfx3", 0, tiles,          384,  8 ) /* Tiles */
+	GFXDECODE_ENTRY( "char",    0, oscar_charlayout, 256,  8 ) /* Chars */
+	GFXDECODE_ENTRY( "tiles1",  0, tiles,            384,  8 ) /* Tiles */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_oscar_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tiles, 0, 16 ) /* Sprites */
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_shackled )
-	GFXDECODE_ENTRY( "gfx1", 0, chars_3bpp,   0,  4 )
-	GFXDECODE_ENTRY( "gfx2", 0, tiles,    256, 16 )
-	GFXDECODE_ENTRY( "gfx3", 0, tiles,    768, 16 )
+	GFXDECODE_ENTRY( "char",    0, chars_3bpp, 0,  4 )
+	GFXDECODE_ENTRY( "tiles1",  0, tiles,    768, 16 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_shackled_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tiles, 256, 16 )
 GFXDECODE_END
 
 /******************************************************************************/
@@ -1890,7 +1901,7 @@ void lastmisn_state::lastmisn(machine_config &config)
 	/* video hardware */
 	BUFFERED_SPRITERAM8(config, m_spriteram);
 
-	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0);
+	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0, m_palette, gfx_shackled_spr);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 //  m_screen->set_refresh_hz(58);
@@ -1950,7 +1961,7 @@ void lastmisn_state::shackled(machine_config &config)
 	/* video hardware */
 	BUFFERED_SPRITERAM8(config, m_spriteram);
 
-	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0);
+	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0, m_palette, gfx_shackled_spr);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 //  m_screen->set_refresh_hz(58);
@@ -2002,7 +2013,7 @@ void gondo_state::gondo(machine_config &config)
 	/* video hardware */
 	BUFFERED_SPRITERAM8(config, m_spriteram);
 
-	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0);
+	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0, m_palette, gfx_gondo_spr);
 	m_spritegen_krn->set_colpri_callback(FUNC(gondo_state::gondo_colpri_cb));
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
@@ -2057,7 +2068,7 @@ void lastmisn_state::garyoret(machine_config &config)
 	/* video hardware */
 	BUFFERED_SPRITERAM8(config, m_spriteram);
 
-	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0);
+	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0, m_palette, gfx_gondo_spr);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 //  m_screen->set_refresh_hz(58);
@@ -2114,10 +2125,10 @@ void lastmisn_state::ghostb(machine_config &config)
 	BUFFERED_SPRITERAM8(config, m_spriteram);
 
 	DECO_BAC06(config, m_tilegen[0], 0);
-	m_tilegen[0]->set_gfx_region_wide(2, 2, 0);
+	m_tilegen[0]->set_gfx_region_wide(1, 1, 0);
 	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0);
+	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0, m_palette, gfx_shackled_spr);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 //  m_screen->set_refresh_hz(58);
@@ -2187,7 +2198,7 @@ void csilver_state::csilver(machine_config &config)
 	/* video hardware */
 	BUFFERED_SPRITERAM8(config, m_spriteram);
 
-	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0);
+	DECO_KARNOVSPRITES(config, m_spritegen_krn, 0, m_palette, gfx_shackled_spr);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 //  m_screen->set_refresh_hz(58);
@@ -2245,11 +2256,11 @@ void oscar_state::oscar(machine_config &config)
 	BUFFERED_SPRITERAM8(config, m_spriteram);
 
 	DECO_BAC06(config, m_tilegen[0], 0);
-	m_tilegen[0]->set_gfx_region_wide(2, 2, 0);
+	m_tilegen[0]->set_gfx_region_wide(1, 1, 0);
 	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 	m_tilegen[0]->set_tile_callback(FUNC(oscar_state::oscar_tile_cb));
 
-	DECO_MXC06(config, m_spritegen_mxc, 0);
+	DECO_MXC06(config, m_spritegen_mxc, 0, m_palette, gfx_oscar_spr);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 //  m_screen->set_refresh_hz(58);
@@ -2353,14 +2364,14 @@ void oscar_state::cobracom(machine_config &config)
 	BUFFERED_SPRITERAM8(config, m_spriteram);
 
 	DECO_BAC06(config, m_tilegen[0], 0);
-	m_tilegen[0]->set_gfx_region_wide(2, 2, 0);
+	m_tilegen[0]->set_gfx_region_wide(1, 1, 0);
 	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_BAC06(config, m_tilegen[1], 0);
-	m_tilegen[1]->set_gfx_region_wide(3, 3, 0);
+	m_tilegen[1]->set_gfx_region_wide(2, 2, 0);
 	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_MXC06(config, m_spritegen_mxc, 0);
+	DECO_MXC06(config, m_spritegen_mxc, 0, m_palette, gfx_cobracom_spr);
 	m_spritegen_mxc->set_colpri_callback(FUNC(oscar_state::cobracom_colpri_cb));
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
@@ -2410,19 +2421,19 @@ ROM_START( lastmisn )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "last_mission_dl00-e.18a", 0x0000, 0x1000, CRC(e97481c6) SHA1(5c6b0e3585712c03b1b657c814c502c396ffa333) BAD_DUMP ) /* not verified to be the same data as the "A" MCU dump */
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "last_mission_dl01-.2a",    0x00000, 0x2000, CRC(f3787a5d) SHA1(3701df42cb2aca951963703e72c6c7b272eed82b) )
 	ROM_CONTINUE(                         0x06000, 0x2000 )
 	ROM_CONTINUE(                         0x04000, 0x2000 )
 	ROM_CONTINUE(                         0x02000, 0x2000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "last_mission_dl11-.13f",   0x00000, 0x08000, CRC(36579d3b) SHA1(8edf952dafcd5bc66e08074687f0bec809fd4c2f) )
 	ROM_LOAD( "last_mission_dl12-.9f",    0x20000, 0x08000, CRC(2ba6737e) SHA1(c5e4c27726bf14e9cd60d62e2f17ea5be8093c37) )
 	ROM_LOAD( "last_mission_dl13-.8f",    0x40000, 0x08000, CRC(39a7dc93) SHA1(3b7968fd06ac0379525c1d3e73f8bbe18ea36439) )
 	ROM_LOAD( "last_mission_dl10-.16f",   0x60000, 0x08000, CRC(fe275ea8) SHA1(2f089f96583235f1f5226ef2a64b430d84efbeee) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "last_mission_dl09-.12k",   0x00000, 0x10000, CRC(6a5a0c5d) SHA1(0106cf693c284be5faf96e56b651fab92a410915) )
 	ROM_LOAD( "last_mission_dl08-.14k",   0x20000, 0x10000, CRC(3b38cfce) SHA1(d6829bed6916fb301c08031bd466ee4dcc05b275) )
 	ROM_LOAD( "last_mission_dl07-.15k",   0x40000, 0x10000, CRC(1b60604d) SHA1(1ee15cfdac87f7eeb92050766293b894cfad1466) )
@@ -2446,19 +2457,19 @@ ROM_START( lastmisnu6 )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "last_mission_dl00-a.18a", 0x0000, 0x1000, CRC(e97481c6) SHA1(5c6b0e3585712c03b1b657c814c502c396ffa333) ) /* Hand written "A", some MCUs are known to be labeled DL00-7, it's not verified to be the same data */
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "last_mission_dl01-.2a",    0x00000, 0x2000, CRC(f3787a5d) SHA1(3701df42cb2aca951963703e72c6c7b272eed82b) )
 	ROM_CONTINUE(                         0x06000, 0x2000 )
 	ROM_CONTINUE(                         0x04000, 0x2000 )
 	ROM_CONTINUE(                         0x02000, 0x2000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "last_mission_dl11-.13f",   0x00000, 0x08000, CRC(36579d3b) SHA1(8edf952dafcd5bc66e08074687f0bec809fd4c2f) )
 	ROM_LOAD( "last_mission_dl12-.9f",    0x20000, 0x08000, CRC(2ba6737e) SHA1(c5e4c27726bf14e9cd60d62e2f17ea5be8093c37) )
 	ROM_LOAD( "last_mission_dl13-.8f",    0x40000, 0x08000, CRC(39a7dc93) SHA1(3b7968fd06ac0379525c1d3e73f8bbe18ea36439) )
 	ROM_LOAD( "last_mission_dl10-.16f",   0x60000, 0x08000, CRC(fe275ea8) SHA1(2f089f96583235f1f5226ef2a64b430d84efbeee) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "last_mission_dl09-.12k",   0x00000, 0x10000, CRC(6a5a0c5d) SHA1(0106cf693c284be5faf96e56b651fab92a410915) )
 	ROM_LOAD( "last_mission_dl08-.14k",   0x20000, 0x10000, CRC(3b38cfce) SHA1(d6829bed6916fb301c08031bd466ee4dcc05b275) )
 	ROM_LOAD( "last_mission_dl07-.15k",   0x40000, 0x10000, CRC(1b60604d) SHA1(1ee15cfdac87f7eeb92050766293b894cfad1466) )
@@ -2482,19 +2493,19 @@ ROM_START( lastmisnu5 )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "last_mission_dl00-a.18a", 0x0000, 0x1000, CRC(e97481c6) SHA1(5c6b0e3585712c03b1b657c814c502c396ffa333) ) /* Hand written "A", some MCUs are known to be labeled DL00-7, it's not verified to be the same data */
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "last_mission_dl01-.2a",    0x00000, 0x2000, CRC(f3787a5d) SHA1(3701df42cb2aca951963703e72c6c7b272eed82b) )
 	ROM_CONTINUE(                         0x06000, 0x2000 )
 	ROM_CONTINUE(                         0x04000, 0x2000 )
 	ROM_CONTINUE(                         0x02000, 0x2000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "last_mission_dl11-.13f",   0x00000, 0x08000, CRC(36579d3b) SHA1(8edf952dafcd5bc66e08074687f0bec809fd4c2f) )
 	ROM_LOAD( "last_mission_dl12-.9f",    0x20000, 0x08000, CRC(2ba6737e) SHA1(c5e4c27726bf14e9cd60d62e2f17ea5be8093c37) )
 	ROM_LOAD( "last_mission_dl13-.8f",    0x40000, 0x08000, CRC(39a7dc93) SHA1(3b7968fd06ac0379525c1d3e73f8bbe18ea36439) )
 	ROM_LOAD( "last_mission_dl10-.16f",   0x60000, 0x08000, CRC(fe275ea8) SHA1(2f089f96583235f1f5226ef2a64b430d84efbeee) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "last_mission_dl09-.12k",   0x00000, 0x10000, CRC(6a5a0c5d) SHA1(0106cf693c284be5faf96e56b651fab92a410915) )
 	ROM_LOAD( "last_mission_dl08-.14k",   0x20000, 0x10000, CRC(3b38cfce) SHA1(d6829bed6916fb301c08031bd466ee4dcc05b275) )
 	ROM_LOAD( "last_mission_dl07-.15k",   0x40000, 0x10000, CRC(1b60604d) SHA1(1ee15cfdac87f7eeb92050766293b894cfad1466) )
@@ -2518,19 +2529,19 @@ ROM_START( lastmisnj )
 	ROM_REGION( 0x1000, "mcu", 0 )    // created from dump of the US version
 	ROM_LOAD( "last_mission_japan.18a", 0x0000, 0x1000, BAD_DUMP CRC(0d58c3a1) SHA1(184e75324b7ab2de8e6441f0c954046db80b2640) ) /* correct ROM label when real MCU is dumped */
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "last_mission_dl01-.2a",    0x00000, 0x2000, CRC(f3787a5d) SHA1(3701df42cb2aca951963703e72c6c7b272eed82b) )
 	ROM_CONTINUE(                         0x06000, 0x2000 )
 	ROM_CONTINUE(                         0x04000, 0x2000 )
 	ROM_CONTINUE(                         0x02000, 0x2000 )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "last_mission_dl11-.13f",   0x00000, 0x08000, CRC(36579d3b) SHA1(8edf952dafcd5bc66e08074687f0bec809fd4c2f) )
 	ROM_LOAD( "last_mission_dl12-.9f",    0x20000, 0x08000, CRC(2ba6737e) SHA1(c5e4c27726bf14e9cd60d62e2f17ea5be8093c37) )
 	ROM_LOAD( "last_mission_dl13-.8f",    0x40000, 0x08000, CRC(39a7dc93) SHA1(3b7968fd06ac0379525c1d3e73f8bbe18ea36439) )
 	ROM_LOAD( "last_mission_dl10-.16f",   0x60000, 0x08000, CRC(fe275ea8) SHA1(2f089f96583235f1f5226ef2a64b430d84efbeee) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "last_mission_dl09-.12k",   0x00000, 0x10000, CRC(6a5a0c5d) SHA1(0106cf693c284be5faf96e56b651fab92a410915) )
 	ROM_LOAD( "last_mission_dl08-.14k",   0x20000, 0x10000, CRC(3b38cfce) SHA1(d6829bed6916fb301c08031bd466ee4dcc05b275) )
 	ROM_LOAD( "last_mission_dl07-.15k",   0x40000, 0x10000, CRC(1b60604d) SHA1(1ee15cfdac87f7eeb92050766293b894cfad1466) )
@@ -2558,10 +2569,10 @@ ROM_START( shackled )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* ID8751H (fake) MCU (based on 'breywood' with ID byte changed from 00 to 01) */
 	ROM_LOAD( "dk-e.18a", 0x0000, 0x1000, CRC(1af06149) SHA1(b9cb2a4986dbcfc78b0cbea2c1e2bdac1db479cd) BAD_DUMP ) /* Hand written "E" */
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dk-00.2a", 0x00000, 0x08000, CRC(69b975aa) SHA1(38cb96768c79ff1aa1b4b190e08ec9155baf698a) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dk-12.15k", 0x00000, 0x10000, CRC(615c2371) SHA1(30b25dc27d34646d886a465c77622eaa894d83c3) )
 	ROM_LOAD( "dk-13.14k", 0x10000, 0x10000, CRC(479aa503) SHA1(1167f0d15439c95a1094f81855203e863ce0488d) )
 	ROM_LOAD( "dk-14.13k", 0x20000, 0x10000, CRC(cdc24246) SHA1(1a4189bc2b1fa99740dd7921608159936ba3bd07) )
@@ -2571,7 +2582,7 @@ ROM_START( shackled )
 	ROM_LOAD( "dk-18.8k",  0x60000, 0x10000, CRC(4d466757) SHA1(701d79bebbba4f266e19080d16ff2f93ffa94287) )
 	ROM_LOAD( "dk-19.6k",  0x70000, 0x10000, CRC(1911e83e) SHA1(174e9db3f2211ecbbb93c6bda8f6185dbfdbc818) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dk-11.12k", 0x00000, 0x10000, CRC(5cf5719f) SHA1(8c7582ac19010421ec748391a193aa18e51b981f) )
 	ROM_LOAD( "dk-10.14k", 0x20000, 0x10000, CRC(408e6d08) SHA1(28cb76792e5f84bd101a91cb82597a5939804f84) )
 	ROM_LOAD( "dk-09.15k", 0x40000, 0x10000, CRC(c1557fac) SHA1(7d39ec793113a48baf45c2ea07abb07e2e48985a) )
@@ -2599,10 +2610,10 @@ ROM_START( breywood )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "dj.18a", 0x0000, 0x1000, CRC(4cb20332) SHA1(e0bbba7be22e7bcff82fb0ae441410e559ec4566) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dj-00.2a",  0x00000, 0x08000, CRC(815a891a) SHA1(e557d6a35821a8589d9e3df0f42131b58b08c8ca) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dj12.15k", 0x00000, 0x10000, CRC(2b7634f2) SHA1(56d963d4960d9b3e888c8107340763e176adfa9b) )
 	ROM_LOAD( "dj13.14k", 0x10000, 0x10000, CRC(4530a952) SHA1(99251a21347815cba465669e18df31262bcdaba1) )
 	ROM_LOAD( "dj14.13k", 0x20000, 0x10000, CRC(87c28833) SHA1(3f1a294065326389d304e540bc880844c6c7cb06) )
@@ -2612,7 +2623,7 @@ ROM_START( breywood )
 	ROM_LOAD( "dj18.8k",  0x60000, 0x10000, CRC(12afe533) SHA1(6df3471c16a714d118717da549a7523aa388ddd3) )
 	ROM_LOAD( "dj19.6k",  0x70000, 0x10000, CRC(03373755) SHA1(d2541dd957803168f246d96b7cd74eae7fd43188) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dj11.12k", 0x00000, 0x10000, CRC(067e2a43) SHA1(f1da7455aab21f94ed25a93b0ebfde69baa475d1) )
 	ROM_LOAD( "dj10.14k", 0x20000, 0x10000, CRC(c19733aa) SHA1(3dfcfd33c5c4f792bb941ac933301c03ddd72b03) )
 	ROM_LOAD( "dj09.15k", 0x40000, 0x10000, CRC(e37d5dbe) SHA1(ff79b4f6d8b0a3061e78d15480df0155650f347f) )
@@ -2635,10 +2646,10 @@ ROM_START( gondo )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "dt-e.b1", 0x0000, 0x1000, BAD_DUMP CRC(0d0532ec) SHA1(30894f69ff24c1be4b684e07729bbb3e0f353086) ) // hand-crafted from the US version
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dt14-e.b18", 0x00000, 0x08000, CRC(00cbe9c8) SHA1(de7b640de8fd54ee79194945c96d5768d09f483b) ) // identical to Japanese version
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dt19.f13",   0x00000, 0x10000, CRC(da2abe4b) SHA1(d53e4769671f3fd437edcff7e7ea05156bbcb45d) ) // All sprite data matches the Japanese set
 	ROM_LOAD( "dt20-e.f15", 0x10000, 0x08000, CRC(0eef7f56) SHA1(05c23aa6a598478cd4822634cff96055c585e9d2) ) // Verified only DT17-E, DT18-E, DT20-E & DT22-E have the "-E" extention
 	ROM_LOAD( "dt16.f9",    0x20000, 0x10000, CRC(e9955d8f) SHA1(aeef5e18f9d36c1bab3000e95205ce1b18cfbf0b) ) // DT15, DT16, DT19 & DT21 do NOT have the "-E" extention
@@ -2648,7 +2659,7 @@ ROM_START( gondo )
 	ROM_LOAD( "dt21.f16",   0x60000, 0x10000, CRC(1c5f682d) SHA1(4b7022cce930a9e9a0087c91e8344269fe7ed889) )
 	ROM_LOAD( "dt22-e.f18", 0x70000, 0x08000, CRC(c8ffb148) SHA1(ae1a8b3cd1f5e423dc1a3c7d05f9fe7c689432e3) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dt08.h10", 0x00000, 0x08000, CRC(aec483f5) SHA1(1d6de823ab0eeb9c89e9c227428ff278663627f3) ) // Tiles data is the same for all 3 regions
 	ROM_CONTINUE(         0x10000, 0x08000 )
 	ROM_LOAD( "dt09.h12", 0x08000, 0x08000, CRC(446f0ce0) SHA1(072b88d6de5aa0ed6b1d60c266bcf170dea927d5) )
@@ -2679,10 +2690,10 @@ ROM_START( gondou )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "dt-a.b1", 0x0000, 0x1000, CRC(03abceeb) SHA1(a16b779d7cea1c1437f85fa6b6e08894a46a5674) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dt14.b18", 0x00000, 0x08000, CRC(4bef16e1) SHA1(b8157a7a1b8f36cea1fd353267a4e03d920cb4aa) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dt19.f13", 0x00000, 0x10000, CRC(da2abe4b) SHA1(d53e4769671f3fd437edcff7e7ea05156bbcb45d) )
 	ROM_LOAD( "dt20.f15", 0x10000, 0x08000, CRC(42d01002) SHA1(5a289ffdc83c05f21908a5d0b6247da5b51c1ddd) ) // Unique data to the US set
 	ROM_LOAD( "dt16.f9",  0x20000, 0x10000, CRC(e9955d8f) SHA1(aeef5e18f9d36c1bab3000e95205ce1b18cfbf0b) )
@@ -2692,7 +2703,7 @@ ROM_START( gondou )
 	ROM_LOAD( "dt21.f16", 0x60000, 0x10000, CRC(1c5f682d) SHA1(4b7022cce930a9e9a0087c91e8344269fe7ed889) )
 	ROM_LOAD( "dt22.f18", 0x70000, 0x08000, CRC(c1876a5f) SHA1(66122ce765723765e20036bd4d461a210c8b94d3) ) // Unique data to the US set
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dt08.h10", 0x00000, 0x08000, CRC(aec483f5) SHA1(1d6de823ab0eeb9c89e9c227428ff278663627f3) ) // Tiles data is the same for all 3 regions
 	ROM_CONTINUE(         0x10000, 0x08000 )
 	ROM_LOAD( "dt09.h12", 0x08000, 0x08000, CRC(446f0ce0) SHA1(072b88d6de5aa0ed6b1d60c266bcf170dea927d5) )
@@ -2723,10 +2734,10 @@ ROM_START( makyosen )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "ds.b1",  0x0000, 0x1000, CRC(08f36e35) SHA1(e8913da71704a89fad41d5bfba45682119166681) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "ds14.b18", 0x00000, 0x08000, CRC(00cbe9c8) SHA1(de7b640de8fd54ee79194945c96d5768d09f483b) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "ds19.f13", 0x00000, 0x10000, CRC(da2abe4b) SHA1(d53e4769671f3fd437edcff7e7ea05156bbcb45d) ) // == dt19.f13
 	ROM_LOAD( "ds20.f15", 0x10000, 0x08000, CRC(0eef7f56) SHA1(05c23aa6a598478cd4822634cff96055c585e9d2) ) // == dt20-e.f15
 	ROM_LOAD( "ds16.f9",  0x20000, 0x10000, CRC(e9955d8f) SHA1(aeef5e18f9d36c1bab3000e95205ce1b18cfbf0b) ) // == dt16.f9
@@ -2736,7 +2747,7 @@ ROM_START( makyosen )
 	ROM_LOAD( "ds21.f16", 0x60000, 0x10000, CRC(1c5f682d) SHA1(4b7022cce930a9e9a0087c91e8344269fe7ed889) ) // == dt21.f16
 	ROM_LOAD( "ds22.f18", 0x70000, 0x08000, CRC(c8ffb148) SHA1(ae1a8b3cd1f5e423dc1a3c7d05f9fe7c689432e3) ) // == dt22-e.f18
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "ds08.h10", 0x00000, 0x08000, CRC(aec483f5) SHA1(1d6de823ab0eeb9c89e9c227428ff278663627f3) ) // Tiles data is the same for all 3 regions
 	ROM_CONTINUE(         0x10000, 0x08000 )
 	ROM_LOAD( "ds09.h12", 0x08000, 0x08000, CRC(446f0ce0) SHA1(072b88d6de5aa0ed6b1d60c266bcf170dea927d5) )
@@ -2773,10 +2784,10 @@ ROM_START( garyoret )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* ID8751H (fake) MCU based on 'gondo' one */
 	ROM_LOAD( "dv__.mcu", 0x0000, 0x1000, BAD_DUMP CRC(37cacec6) SHA1(d81fe36939ccac784a83a69dfc6898b22a4515ec) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dv14", 0x00000, 0x08000, CRC(fb2bc581) SHA1(d597976c5ae586166c49051cc3de8cf0c2e5a5e1) )    /* Characters */
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dv22", 0x00000, 0x10000, CRC(cef0367e) SHA1(8beb3a6b91ec0a6ec052243c8f626a581d349f65) )
 	ROM_LOAD( "dv21", 0x10000, 0x08000, CRC(90042fb7) SHA1(f19bbf158c92030e8fddb5087b5b69b71956baf8) )
 	ROM_LOAD( "dv20", 0x20000, 0x10000, CRC(451a2d8c) SHA1(f4eea444b797d394edeb514ddc1c494fd7ccc2f2) )
@@ -2786,7 +2797,7 @@ ROM_START( garyoret )
 	ROM_LOAD( "dv16", 0x60000, 0x10000, CRC(37e4971e) SHA1(9442c315b7cdbcc046d9e6838cb793c1857174ed) )
 	ROM_LOAD( "dv15", 0x70000, 0x08000, CRC(ca41b6ac) SHA1(d7a9ef6c89741c1e8e17a668a9d39ea089f5c73f) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dv08", 0x00000, 0x08000, CRC(89c13e15) SHA1(6507e60de5cd78a5b46090e4825a44c2a23631d7) )
 	ROM_CONTINUE(     0x10000, 0x08000 )
 	ROM_LOAD( "dv09", 0x08000, 0x08000, CRC(6a345a23) SHA1(b86f81b9fe25acd833ca3e2cff6cfa853c02280a) )
@@ -2822,10 +2833,10 @@ ROM_START( ghostb )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "dz-1.1b", 0x0000, 0x1000, CRC(9f5f3cb5) SHA1(5ef2b8a5411dde28277d9364db014763019ecf15) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dz00.16b", 0x00000, 0x08000, CRC(992b4f31) SHA1(a9f255286193ccc261a9b6983aabf3c76ebe5ce5) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dz15.14f", 0x00000, 0x10000, CRC(a01a5fd9) SHA1(c15e11fbc0ede9e4a232abe37e6d221d5789ce8e) )
 	ROM_LOAD( "dz16.15f", 0x10000, 0x10000, CRC(5a9a344a) SHA1(f4e8c2bae023ce996e99383873eba23ab6f972a8) )
 	ROM_LOAD( "dz12.9f",  0x20000, 0x10000, CRC(817fae99) SHA1(4179501aedbdf5bb0824bf1c13e033685e57a207) )
@@ -2835,7 +2846,7 @@ ROM_START( ghostb )
 	ROM_LOAD( "dz17.17f", 0x60000, 0x10000, CRC(40361b8b) SHA1(6ee59129e236ead3d9b828fb9726311b7a4f2ff6) )
 	ROM_LOAD( "dz18.18f", 0x70000, 0x10000, CRC(8d219489) SHA1(0490ad84085d1a60ece1b8ab45f0c551d2ac219d) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dz07.12f", 0x00000, 0x10000, CRC(e7455167) SHA1(a4582ced57862563ef626a25ced4072bc2c95750) )
 	ROM_LOAD( "dz08.14f", 0x10000, 0x10000, CRC(32f9ddfe) SHA1(2b8c228b0ca938ab7495d53e1a39275a8b872828) )
 	ROM_LOAD( "dz09.15f", 0x20000, 0x10000, CRC(bb6efc02) SHA1(ec501cd4a624d9c36a545dd100bc4f2f8b1e5cc0) )
@@ -2860,10 +2871,10 @@ ROM_START( ghostb2a )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "dz-1.1b", 0x0000, 0x1000, CRC(9f5f3cb5) SHA1(5ef2b8a5411dde28277d9364db014763019ecf15) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dz00.16b", 0x00000, 0x08000, CRC(992b4f31) SHA1(a9f255286193ccc261a9b6983aabf3c76ebe5ce5) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dz15.14f", 0x00000, 0x10000, CRC(a01a5fd9) SHA1(c15e11fbc0ede9e4a232abe37e6d221d5789ce8e) )
 	ROM_LOAD( "dz16.15f", 0x10000, 0x10000, CRC(5a9a344a) SHA1(f4e8c2bae023ce996e99383873eba23ab6f972a8) )
 	ROM_LOAD( "dz12.9f",  0x20000, 0x10000, CRC(817fae99) SHA1(4179501aedbdf5bb0824bf1c13e033685e57a207) )
@@ -2873,7 +2884,7 @@ ROM_START( ghostb2a )
 	ROM_LOAD( "dz17.17f", 0x60000, 0x10000, CRC(40361b8b) SHA1(6ee59129e236ead3d9b828fb9726311b7a4f2ff6) )
 	ROM_LOAD( "dz18.18f", 0x70000, 0x10000, CRC(8d219489) SHA1(0490ad84085d1a60ece1b8ab45f0c551d2ac219d) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dz07.12f", 0x00000, 0x10000, CRC(e7455167) SHA1(a4582ced57862563ef626a25ced4072bc2c95750) )
 	ROM_LOAD( "dz08.14f", 0x10000, 0x10000, CRC(32f9ddfe) SHA1(2b8c228b0ca938ab7495d53e1a39275a8b872828) )
 	ROM_LOAD( "dz09.15f", 0x20000, 0x10000, CRC(bb6efc02) SHA1(ec501cd4a624d9c36a545dd100bc4f2f8b1e5cc0) )
@@ -2898,10 +2909,10 @@ ROM_START( ghostb3 )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "dz-1.1b", 0x0000, 0x1000, CRC(9f5f3cb5) SHA1(5ef2b8a5411dde28277d9364db014763019ecf15) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dz00.16b", 0x00000, 0x08000, CRC(992b4f31) SHA1(a9f255286193ccc261a9b6983aabf3c76ebe5ce5) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dz15.14f", 0x00000, 0x10000, CRC(a01a5fd9) SHA1(c15e11fbc0ede9e4a232abe37e6d221d5789ce8e) )
 	ROM_LOAD( "dz16.15f", 0x10000, 0x10000, CRC(5a9a344a) SHA1(f4e8c2bae023ce996e99383873eba23ab6f972a8) )
 	ROM_LOAD( "dz12.9f",  0x20000, 0x10000, CRC(817fae99) SHA1(4179501aedbdf5bb0824bf1c13e033685e57a207) )
@@ -2911,7 +2922,7 @@ ROM_START( ghostb3 )
 	ROM_LOAD( "dz17.17f", 0x60000, 0x10000, CRC(40361b8b) SHA1(6ee59129e236ead3d9b828fb9726311b7a4f2ff6) )
 	ROM_LOAD( "dz18.18f", 0x70000, 0x10000, CRC(8d219489) SHA1(0490ad84085d1a60ece1b8ab45f0c551d2ac219d) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dz07.12f", 0x00000, 0x10000, CRC(e7455167) SHA1(a4582ced57862563ef626a25ced4072bc2c95750) )
 	ROM_LOAD( "dz08.14f", 0x10000, 0x10000, CRC(32f9ddfe) SHA1(2b8c228b0ca938ab7495d53e1a39275a8b872828) )
 	ROM_LOAD( "dz09.15f", 0x20000, 0x10000, CRC(bb6efc02) SHA1(ec501cd4a624d9c36a545dd100bc4f2f8b1e5cc0) )
@@ -2938,10 +2949,10 @@ ROM_START( ghostb3a )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "dz-1.1b", 0x0000, 0x1000, CRC(9f5f3cb5) SHA1(5ef2b8a5411dde28277d9364db014763019ecf15) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dz00.16b", 0x00000, 0x08000, CRC(992b4f31) SHA1(a9f255286193ccc261a9b6983aabf3c76ebe5ce5) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dz15.14f", 0x00000, 0x10000, CRC(a01a5fd9) SHA1(c15e11fbc0ede9e4a232abe37e6d221d5789ce8e) )
 	ROM_LOAD( "dz16.15f", 0x10000, 0x10000, CRC(5a9a344a) SHA1(f4e8c2bae023ce996e99383873eba23ab6f972a8) )
 	ROM_LOAD( "dz12.9f",  0x20000, 0x10000, CRC(817fae99) SHA1(4179501aedbdf5bb0824bf1c13e033685e57a207) )
@@ -2951,7 +2962,7 @@ ROM_START( ghostb3a )
 	ROM_LOAD( "dz17.17f", 0x60000, 0x10000, CRC(40361b8b) SHA1(6ee59129e236ead3d9b828fb9726311b7a4f2ff6) )
 	ROM_LOAD( "dz18.18f", 0x70000, 0x10000, CRC(8d219489) SHA1(0490ad84085d1a60ece1b8ab45f0c551d2ac219d) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dz07.12f", 0x00000, 0x10000, CRC(e7455167) SHA1(a4582ced57862563ef626a25ced4072bc2c95750) )
 	ROM_LOAD( "dz08.14f", 0x10000, 0x10000, CRC(32f9ddfe) SHA1(2b8c228b0ca938ab7495d53e1a39275a8b872828) )
 	ROM_LOAD( "dz09.15f", 0x20000, 0x10000, CRC(bb6efc02) SHA1(ec501cd4a624d9c36a545dd100bc4f2f8b1e5cc0) )
@@ -3060,10 +3071,10 @@ ROM_START( meikyuh )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "dw.1b", 0x0000, 0x1000, CRC(28e9ced9) SHA1(a3d6dfa1e44fa93c0f30fa0a88b6dd3d6e5c4dda) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dw00.16b", 0x00000, 0x8000, CRC(3d25f15c) SHA1(590518460d069bc235b5efebec81731d7a2375de) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dw14.14f", 0x00000, 0x10000, CRC(9b0dbfa9) SHA1(c9db6e70b217a34fbc2bf17da3f5ec6f0130514a) )
 	ROM_LOAD( "dw15.15f", 0x10000, 0x10000, CRC(95683fda) SHA1(aa91ad1cd685790e29e16d64bd75a5b4367cf87b) )
 	ROM_LOAD( "dw11.9f",  0x20000, 0x10000, CRC(1b1fcca7) SHA1(17e510c1b3efa0f6da49461c286b89295db6b9a6) )
@@ -3073,7 +3084,7 @@ ROM_START( meikyuh )
 	ROM_LOAD( "dw16.17f", 0x60000, 0x10000, CRC(e5bcf927) SHA1(b96bd4c124c9745fae1c1f35bdbbdec9f97ab4a5) )
 	ROM_LOAD( "dw17.18f", 0x70000, 0x10000, CRC(9e10f723) SHA1(159c5e3d821a10b64cd6d538d19063d0f5b057c0) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dw06.12f", 0x00000, 0x10000, CRC(b65e029d) SHA1(f8791d57f688f16e0f076361603510e7133f4e36) )
 	ROM_LOAD( "dw07.14f", 0x10000, 0x10000, CRC(668d995d) SHA1(dc6221de6103168c8e19f2c6eb159b8989ca2208) )
 	ROM_LOAD( "dw08.15f", 0x20000, 0x10000, CRC(bb2cf4a0) SHA1(78806adb6a9ad9fc0707ead567a3220eb2bdb32f) )
@@ -3152,10 +3163,10 @@ ROM_START( meikyuhbl )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "dw.1b", 0x0000, 0x1000, CRC(28e9ced9) SHA1(a3d6dfa1e44fa93c0f30fa0a88b6dd3d6e5c4dda) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "27256.16b", 0x00000, 0x8000, CRC(3d25f15c) SHA1(590518460d069bc235b5efebec81731d7a2375de) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "92.6m", 0x00000, 0x10000, CRC(9b0dbfa9) SHA1(c9db6e70b217a34fbc2bf17da3f5ec6f0130514a) )
 	ROM_LOAD( "93.6o", 0x10000, 0x10000, CRC(95683fda) SHA1(aa91ad1cd685790e29e16d64bd75a5b4367cf87b) )
 	ROM_LOAD( "89.6i", 0x20000, 0x10000, CRC(1b1fcca7) SHA1(17e510c1b3efa0f6da49461c286b89295db6b9a6) )
@@ -3165,7 +3176,7 @@ ROM_START( meikyuhbl )
 	ROM_LOAD( "94.6p", 0x60000, 0x10000, CRC(e5bcf927) SHA1(b96bd4c124c9745fae1c1f35bdbbdec9f97ab4a5) )
 	ROM_LOAD( "95.6r", 0x70000, 0x10000, CRC(9e10f723) SHA1(159c5e3d821a10b64cd6d538d19063d0f5b057c0) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "27512.12f", 0x00000, 0x10000, CRC(b65e029d) SHA1(f8791d57f688f16e0f076361603510e7133f4e36) )
 	ROM_LOAD( "27512.14f", 0x10000, 0x10000, CRC(668d995d) SHA1(dc6221de6103168c8e19f2c6eb159b8989ca2208) )
 	ROM_LOAD( "27512.15f", 0x20000, 0x10000, CRC(bb2cf4a0) SHA1(78806adb6a9ad9fc0707ead567a3220eb2bdb32f) )
@@ -3246,10 +3257,10 @@ ROM_START( csilver )
 	// 017F: B4 4C 0D : cjne  a,#$4C,$018F   (ID code 0x4c = World version)
 	ROM_LOAD( "dx-8.19a", 0x0000, 0x1000, CRC(c0266263) SHA1(27ac6fa4af7195f04249c04dec168ab82158704e) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dx00.3d",  0x00000, 0x08000, CRC(f01ef985) SHA1(d5b823bd7c0efcf3137f8643c5d99a260bed5675) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites (3bpp) */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites (3bpp) */
 	ROM_LOAD( "dx14.15k",  0x00000, 0x10000, CRC(80f07915) SHA1(ea100f12ef3a68110af911fa9beeb73b388f069d) )
 	/* 0x10000-0x1ffff empty */
 	ROM_LOAD( "dx13.13k",  0x20000, 0x10000, CRC(d32c02e7) SHA1(d0518ec31e9e3f7b4e76fba5d7c05c33c61a9c72) )
@@ -3258,7 +3269,7 @@ ROM_START( csilver )
 	/* 0x50000-0x5ffff empty */
 	/* 0x60000-0x7ffff empty (no 4th plane) */
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles (3bpp) */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles (3bpp) */
 	ROM_LOAD( "dx06.5f",  0x00000, 0x10000, CRC(b6fb208c) SHA1(027d33f0b5feb6f0433134213cfcef96790eaace) )
 	ROM_LOAD( "dx07.7f",  0x10000, 0x10000, CRC(ee3e1817) SHA1(013496976a9ffacf1587b3a6fc0f548becb1ab0e) )
 	ROM_LOAD( "dx08.8f",  0x20000, 0x10000, CRC(705900fe) SHA1(53b9d09f9780a3bf3545bc27a2855ebee3884124) )
@@ -3287,10 +3298,10 @@ ROM_START( csilverj )
 	// hand modified version of csilver ROM
 	ROM_LOAD( "id8751h_japan.mcu", 0x0000, 0x1000, BAD_DUMP CRC(6e801217) SHA1(2d8f7ae533dd8146acf8461d61ddd839544adf55) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dx00.3d",  0x00000, 0x08000, CRC(f01ef985) SHA1(d5b823bd7c0efcf3137f8643c5d99a260bed5675) ) // dx00.a1
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites (3bpp) */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites (3bpp) */
 	ROM_LOAD( "dx14.15k",  0x00000, 0x10000, CRC(80f07915) SHA1(ea100f12ef3a68110af911fa9beeb73b388f069d) ) // dx14.b5
 	/* 0x10000-0x1ffff empty */
 	ROM_LOAD( "dx13.13k",  0x20000, 0x10000, CRC(d32c02e7) SHA1(d0518ec31e9e3f7b4e76fba5d7c05c33c61a9c72) ) // dx13.b4
@@ -3299,7 +3310,7 @@ ROM_START( csilverj )
 	/* 0x50000-0x5ffff empty */
 	/* 0x60000-0x7ffff empty (no 4th plane) */
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles (3bpp) */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles (3bpp) */
 	ROM_LOAD( "dx06.5f",  0x00000, 0x10000, CRC(b6fb208c) SHA1(027d33f0b5feb6f0433134213cfcef96790eaace) ) // dx06.a7
 	ROM_LOAD( "dx07.7f",  0x10000, 0x10000, CRC(ee3e1817) SHA1(013496976a9ffacf1587b3a6fc0f548becb1ab0e) ) // dx07.a8
 	ROM_LOAD( "dx08.8f",  0x20000, 0x10000, CRC(705900fe) SHA1(53b9d09f9780a3bf3545bc27a2855ebee3884124) ) // dx08.a9
@@ -3327,10 +3338,10 @@ ROM_START( csilverja ) // DE-0250-3 + DE-0251-2
 	// hand modified version of csilver ROM
 	ROM_LOAD( "id8751h_japan.mcu", 0x0000, 0x1000, BAD_DUMP CRC(6e801217) SHA1(2d8f7ae533dd8146acf8461d61ddd839544adf55) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dx00.3d",  0x00000, 0x08000, CRC(f01ef985) SHA1(d5b823bd7c0efcf3137f8643c5d99a260bed5675) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites (3bpp) */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites (3bpp) */
 	ROM_LOAD( "dx14.15k",  0x00000, 0x10000, CRC(80f07915) SHA1(ea100f12ef3a68110af911fa9beeb73b388f069d) )
 	/* 0x10000-0x1ffff empty */
 	ROM_LOAD( "dx13.13k",  0x20000, 0x10000, CRC(d32c02e7) SHA1(d0518ec31e9e3f7b4e76fba5d7c05c33c61a9c72) )
@@ -3339,7 +3350,7 @@ ROM_START( csilverja ) // DE-0250-3 + DE-0251-2
 	/* 0x50000-0x5ffff empty */
 	/* 0x60000-0x7ffff empty (no 4th plane) */
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles (3bpp) */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles (3bpp) */
 	ROM_LOAD( "dx06.5f",  0x00000, 0x10000, CRC(b6fb208c) SHA1(027d33f0b5feb6f0433134213cfcef96790eaace) )
 	ROM_LOAD( "dx07.7f",  0x10000, 0x10000, CRC(ee3e1817) SHA1(013496976a9ffacf1587b3a6fc0f548becb1ab0e) )
 	ROM_LOAD( "dx08.8f",  0x20000, 0x10000, CRC(705900fe) SHA1(53b9d09f9780a3bf3545bc27a2855ebee3884124) )
@@ -3362,16 +3373,16 @@ ROM_START( oscar )
 	ROM_REGION( 2*0x10000, "audiocpu", 0 )    /* 64K for sound CPU + 64k for decrypted opcodes */
 	ROM_LOAD( "ed12", 0x8000, 0x8000, CRC(432031c5) SHA1(af2deea48b98eb0f9e85a4fb1486021f999f9abd) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "ed08", 0x00000, 0x04000, CRC(308ac264) SHA1(fd1c4ec4e4f99c33e93cd15e178c4714251a9b7e) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "ed04", 0x00000, 0x10000, CRC(416a791b) SHA1(e6541b713225289a43962363029eb0e22a1ecb4a) )
 	ROM_LOAD( "ed05", 0x20000, 0x10000, CRC(fcdba431) SHA1(0be2194519c36ddf136610f60890506eda1faf0b) )
 	ROM_LOAD( "ed06", 0x40000, 0x10000, CRC(7d50bebc) SHA1(06375f3273c48c7c7d81f1c15cbc5d3f3e05b8ed) )
 	ROM_LOAD( "ed07", 0x60000, 0x10000, CRC(8fdf0fa5) SHA1(2b4d1ca1436864e89b13b3fa151a4a3708592e0a) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "ed01", 0x00000, 0x10000, CRC(d3a58e9e) SHA1(35eda2aa630fc2c11a1aff2b00bcfabe2f3d4249) )
 	ROM_LOAD( "ed03", 0x20000, 0x10000, CRC(4fc4fb0f) SHA1(0906762a3adbffe765e072255262fedaa78bdb2a) )
 	ROM_LOAD( "ed00", 0x40000, 0x10000, CRC(ac201f2d) SHA1(77f13eb6a1a44444ca9b25363031451b0d68c988) )
@@ -3389,16 +3400,16 @@ ROM_START( oscarbl )  // very similar to the original, main difference it's it u
 	ROM_REGION( 2*0x10000, "audiocpu", 0 )
 	ROM_LOAD( "at27c512.1", 0x08000, 0x10000, CRC(302ff92c) SHA1(222cc1e4673a5439da1cdd07cc65dc23f522da1c) ) // data in the first half, opcodes in the second
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "ed08", 0x00000, 0x04000, BAD_DUMP CRC(308ac264) SHA1(fd1c4ec4e4f99c33e93cd15e178c4714251a9b7e) ) // not included in this set, probably same
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "at27c512.6", 0x00000, 0x10000, CRC(967315b5) SHA1(b7a081241477ab8e62fe3df1b7025b50ceaba180) )
 	ROM_LOAD( "at27c512.7", 0x20000, 0x10000, CRC(fcdba431) SHA1(0be2194519c36ddf136610f60890506eda1faf0b) )
 	ROM_LOAD( "at27c512.8", 0x40000, 0x10000, CRC(7d50bebc) SHA1(06375f3273c48c7c7d81f1c15cbc5d3f3e05b8ed) )
 	ROM_LOAD( "at27c512.9", 0x60000, 0x10000, CRC(8fdf0fa5) SHA1(2b4d1ca1436864e89b13b3fa151a4a3708592e0a) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "at27c512.10", 0x00000, 0x10000, CRC(98cb4ffc) SHA1(75465a1e7c113db766e14d22b31bf999c520a8bf) )
 	ROM_LOAD( "at27c512.11", 0x20000, 0x10000, CRC(bff7fddc) SHA1(129e99fa99920e647a53b9af64c9c288c1e8ad57) )
 	ROM_LOAD( "at27c512.12", 0x40000, 0x10000, CRC(eff3b56c) SHA1(427d3aa053fa81ef004019eb8bb0aa97787f283e) )
@@ -3416,16 +3427,16 @@ ROM_START( oscaru )
 	ROM_REGION( 2*0x10000, "audiocpu", 0 )    /* 64K for sound CPU + 64k for decrypted opcodes */
 	ROM_LOAD( "ed12", 0x8000, 0x8000,  CRC(432031c5) SHA1(af2deea48b98eb0f9e85a4fb1486021f999f9abd) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "ed08", 0x00000, 0x04000, CRC(308ac264) SHA1(fd1c4ec4e4f99c33e93cd15e178c4714251a9b7e) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "ed04", 0x00000, 0x10000, CRC(416a791b) SHA1(e6541b713225289a43962363029eb0e22a1ecb4a) )
 	ROM_LOAD( "ed05", 0x20000, 0x10000, CRC(fcdba431) SHA1(0be2194519c36ddf136610f60890506eda1faf0b) )
 	ROM_LOAD( "ed06", 0x40000, 0x10000, CRC(7d50bebc) SHA1(06375f3273c48c7c7d81f1c15cbc5d3f3e05b8ed) )
 	ROM_LOAD( "ed07", 0x60000, 0x10000, CRC(8fdf0fa5) SHA1(2b4d1ca1436864e89b13b3fa151a4a3708592e0a) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "ed01", 0x00000, 0x10000, CRC(d3a58e9e) SHA1(35eda2aa630fc2c11a1aff2b00bcfabe2f3d4249) )
 	ROM_LOAD( "ed03", 0x20000, 0x10000, CRC(4fc4fb0f) SHA1(0906762a3adbffe765e072255262fedaa78bdb2a) )
 	ROM_LOAD( "ed00", 0x40000, 0x10000, CRC(ac201f2d) SHA1(77f13eb6a1a44444ca9b25363031451b0d68c988) )
@@ -3446,16 +3457,16 @@ ROM_START( oscarj1 )
 	ROM_REGION( 2*0x10000, "audiocpu", 0 )    /* 64K for sound CPU + 64k for decrypted opcodes */
 	ROM_LOAD( "ed12", 0x8000, 0x8000, CRC(432031c5) SHA1(af2deea48b98eb0f9e85a4fb1486021f999f9abd) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "ed08", 0x00000, 0x04000, CRC(308ac264) SHA1(fd1c4ec4e4f99c33e93cd15e178c4714251a9b7e) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "ed04", 0x00000, 0x10000, CRC(416a791b) SHA1(e6541b713225289a43962363029eb0e22a1ecb4a) )
 	ROM_LOAD( "ed05", 0x20000, 0x10000, CRC(fcdba431) SHA1(0be2194519c36ddf136610f60890506eda1faf0b) )
 	ROM_LOAD( "ed06", 0x40000, 0x10000, CRC(7d50bebc) SHA1(06375f3273c48c7c7d81f1c15cbc5d3f3e05b8ed) )
 	ROM_LOAD( "ed07", 0x60000, 0x10000, CRC(8fdf0fa5) SHA1(2b4d1ca1436864e89b13b3fa151a4a3708592e0a) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "ed01", 0x00000, 0x10000, CRC(d3a58e9e) SHA1(35eda2aa630fc2c11a1aff2b00bcfabe2f3d4249) )
 	ROM_LOAD( "ed03", 0x20000, 0x10000, CRC(4fc4fb0f) SHA1(0906762a3adbffe765e072255262fedaa78bdb2a) )
 	ROM_LOAD( "ed00", 0x40000, 0x10000, CRC(ac201f2d) SHA1(77f13eb6a1a44444ca9b25363031451b0d68c988) )
@@ -3553,16 +3564,16 @@ ROM_START( oscarj2 )
 	ROM_REGION( 2*0x10000, "audiocpu", 0 )    /* 64K for sound CPU + 64k for decrypted opcodes */
 	ROM_LOAD( "du12.k5", 0x8000, 0x8000, CRC(432031c5) SHA1(af2deea48b98eb0f9e85a4fb1486021f999f9abd) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "du08.e5", 0x00000, 0x04000, CRC(308ac264) SHA1(fd1c4ec4e4f99c33e93cd15e178c4714251a9b7e) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "du04.a11", 0x00000, 0x10000, CRC(416a791b) SHA1(e6541b713225289a43962363029eb0e22a1ecb4a) )
 	ROM_LOAD( "du05.a14", 0x20000, 0x10000, CRC(fcdba431) SHA1(0be2194519c36ddf136610f60890506eda1faf0b) )
 	ROM_LOAD( "du06.a16", 0x40000, 0x10000, CRC(7d50bebc) SHA1(06375f3273c48c7c7d81f1c15cbc5d3f3e05b8ed) )
 	ROM_LOAD( "du07.a20", 0x60000, 0x10000, CRC(8fdf0fa5) SHA1(2b4d1ca1436864e89b13b3fa151a4a3708592e0a) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "du01.a3", 0x00000, 0x10000, CRC(d3a58e9e) SHA1(35eda2aa630fc2c11a1aff2b00bcfabe2f3d4249) )
 	ROM_LOAD( "du03.a6", 0x20000, 0x10000, CRC(4fc4fb0f) SHA1(0906762a3adbffe765e072255262fedaa78bdb2a) )
 	ROM_LOAD( "du00.a1", 0x40000, 0x10000, CRC(ac201f2d) SHA1(77f13eb6a1a44444ca9b25363031451b0d68c988) )
@@ -3585,10 +3596,10 @@ ROM_START( srdarwin )
 	// 0160: B4 6B 0D : cjne  a,#$6B,$0170   (ID code 0x6b = World version)
 	ROM_LOAD( "dy-e.d11", 0x0000, 0x1000, CRC(11cd6ca4) SHA1(ec70f84228e37f9fc1bda85fa52a009f61c500b2) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dy_05.b6", 0x00000, 0x4000, CRC(8780e8a3) SHA1(03ea91fdc5aba8e139201604fb3bf9b69f71f056) )
 
-	ROM_REGION( 0x30000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x30000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dy_07.h16", 0x00000, 0x8000, CRC(97eaba60) SHA1(e3252b67bad7babcf4ece39f46ae4aeb950eb92b) )
 	ROM_LOAD( "dy_06.h14", 0x08000, 0x8000, CRC(c279541b) SHA1(eb3737413499d07b6c2af99a95b27b2590e670c5) )
 	ROM_LOAD( "dy_09.k13", 0x10000, 0x8000, CRC(d30d1745) SHA1(647b6121ab6fa812368da45e1295cc41f73be89d) )
@@ -3596,7 +3607,7 @@ ROM_START( srdarwin )
 	ROM_LOAD( "dy_11.k16", 0x20000, 0x8000, CRC(fd9ccc5b) SHA1(b38c44c01acdc455d4192e4c8be1d68d9eb0c7b6) )
 	ROM_LOAD( "dy_10.k14", 0x28000, 0x8000, CRC(88770ab8) SHA1(0a4a807a8d3b0653864bd984872d5567836f8cf8) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dy_03.b4",  0x00000, 0x4000, CRC(44f2a4f9) SHA1(97368dd112451cd630f2fa5ba54679e84e7d4d97) )
 	ROM_CONTINUE(          0x10000, 0x4000 )
 	ROM_CONTINUE(          0x20000, 0x4000 )
@@ -3622,10 +3633,10 @@ ROM_START( srdarwinj )
 	ROM_REGION( 0x1000, "mcu", 0 )    /* i8751 microcontroller */
 	ROM_LOAD( "dy.d11", 0x0000, 0x1000, BAD_DUMP CRC(4ac2ca9d) SHA1(6e07788df9fcf4248a9d3e87b8c5f54776bd269e) ) // hand-modified copy of world version to correct region + coinage
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "dy_05.b6", 0x00000, 0x4000, CRC(8780e8a3) SHA1(03ea91fdc5aba8e139201604fb3bf9b69f71f056) )
 
-	ROM_REGION( 0x30000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x30000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "dy_07.h16", 0x00000, 0x8000, CRC(97eaba60) SHA1(e3252b67bad7babcf4ece39f46ae4aeb950eb92b) )
 	ROM_LOAD( "dy_06.h14", 0x08000, 0x8000, CRC(c279541b) SHA1(eb3737413499d07b6c2af99a95b27b2590e670c5) )
 	ROM_LOAD( "dy_09.k13", 0x10000, 0x8000, CRC(d30d1745) SHA1(647b6121ab6fa812368da45e1295cc41f73be89d) )
@@ -3633,7 +3644,7 @@ ROM_START( srdarwinj )
 	ROM_LOAD( "dy_11.k16", 0x20000, 0x8000, CRC(fd9ccc5b) SHA1(b38c44c01acdc455d4192e4c8be1d68d9eb0c7b6) )
 	ROM_LOAD( "dy_10.k14", 0x28000, 0x8000, CRC(88770ab8) SHA1(0a4a807a8d3b0653864bd984872d5567836f8cf8) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )    /* tiles */
+	ROM_REGION( 0x40000, "tiles1", 0 )    /* tiles */
 	ROM_LOAD( "dy_03.b4",  0x00000, 0x4000, CRC(44f2a4f9) SHA1(97368dd112451cd630f2fa5ba54679e84e7d4d97) )
 	ROM_CONTINUE(          0x10000, 0x4000 )
 	ROM_CONTINUE(          0x20000, 0x4000 )
@@ -3656,22 +3667,22 @@ ROM_START( cobracom )
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "el10-4.1f", 0x8000, 0x8000, CRC(edfad118) SHA1(10de8805472346fead62460a3fdc09ae26a4e0d5) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "el14.14j", 0x00000, 0x08000, CRC(47246177) SHA1(51b025740dc03b04009ac97d8d110ab521894386) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "el00-4.2a", 0x00000, 0x10000, CRC(122da2a8) SHA1(ce72f16abf7e5449c7d044d4b827e8735c3be0ff) )
 	ROM_LOAD( "el01-4.3a", 0x20000, 0x10000, CRC(27bf705b) SHA1(196c35aaf3816d3eef4c2af6d146a90a48365d33) )
 	ROM_LOAD( "el02-4.5a", 0x40000, 0x10000, CRC(c86fede6) SHA1(97584fa19591651fcfb39d1b2b6306165e93554c) )
 	ROM_LOAD( "el03-4.6a", 0x60000, 0x10000, CRC(1d8a855b) SHA1(429261c200dddc62a330be8aea150b2037133188) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles 1 */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles 1 */
 	ROM_LOAD( "el05.15a", 0x00000, 0x10000, CRC(1c4f6033) SHA1(4a7dece911166d1ff5f41df6ec5140596206d8d4) )
 	ROM_LOAD( "el06.16a", 0x20000, 0x10000, CRC(d24ba794) SHA1(b34b7bbaab4ebdd81c87d363f087cc92e27e8d1c) )
 	ROM_LOAD( "el04.13a", 0x40000, 0x10000, CRC(d80a49ce) SHA1(1a92413b5ab53f80e44a954433e69ec5fe2c0aa6) )
 	ROM_LOAD( "el07.18a", 0x60000, 0x10000, CRC(6d771fc3) SHA1(f29979f3aa07bdb544fb0c1d773c5558b4533390) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 )    /* tiles 2 */
+	ROM_REGION( 0x80000, "tiles2", 0 )    /* tiles 2 */
 	ROM_LOAD( "el08.7d", 0x00000, 0x08000, CRC(cb0dcf4c) SHA1(e14853f83ee9ba5cbf2eb1e085fee4e65af3cc25) )
 	ROM_CONTINUE(        0x40000, 0x08000 )
 	ROM_LOAD( "el09.9d", 0x20000, 0x08000, CRC(1fae5be7) SHA1(be6e090b0b82648b385d9b6d11775f3ff40f0af3) )
@@ -3693,22 +3704,22 @@ ROM_START( cobracoma )
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "el10-4.1f", 0x8000, 0x8000, CRC(edfad118) SHA1(10de8805472346fead62460a3fdc09ae26a4e0d5) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "el14.14j", 0x00000, 0x08000, CRC(47246177) SHA1(51b025740dc03b04009ac97d8d110ab521894386) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "el00-4.2a", 0x00000, 0x10000, CRC(122da2a8) SHA1(ce72f16abf7e5449c7d044d4b827e8735c3be0ff) )
 	ROM_LOAD( "el01-4.3a", 0x20000, 0x10000, CRC(27bf705b) SHA1(196c35aaf3816d3eef4c2af6d146a90a48365d33) )
 	ROM_LOAD( "el02-4.5a", 0x40000, 0x10000, CRC(c86fede6) SHA1(97584fa19591651fcfb39d1b2b6306165e93554c) )
 	ROM_LOAD( "el03-4.6a", 0x60000, 0x10000, CRC(1d8a855b) SHA1(429261c200dddc62a330be8aea150b2037133188) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles 1 */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles 1 */
 	ROM_LOAD( "el05.15a", 0x00000, 0x10000, CRC(1c4f6033) SHA1(4a7dece911166d1ff5f41df6ec5140596206d8d4) )
 	ROM_LOAD( "el06.16a", 0x20000, 0x10000, CRC(d24ba794) SHA1(b34b7bbaab4ebdd81c87d363f087cc92e27e8d1c) )
 	ROM_LOAD( "el04.13a", 0x40000, 0x10000, CRC(d80a49ce) SHA1(1a92413b5ab53f80e44a954433e69ec5fe2c0aa6) )
 	ROM_LOAD( "el07.18a", 0x60000, 0x10000, CRC(6d771fc3) SHA1(f29979f3aa07bdb544fb0c1d773c5558b4533390) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 )    /* tiles 2 */
+	ROM_REGION( 0x80000, "tiles2", 0 )    /* tiles 2 */
 	ROM_LOAD( "el08.7d", 0x00000, 0x08000, CRC(cb0dcf4c) SHA1(e14853f83ee9ba5cbf2eb1e085fee4e65af3cc25) )
 	ROM_CONTINUE(        0x40000, 0x08000 )
 	ROM_LOAD( "el09.9d", 0x20000, 0x08000, CRC(1fae5be7) SHA1(be6e090b0b82648b385d9b6d11775f3ff40f0af3) )
@@ -3730,22 +3741,22 @@ ROM_START( cobracomb )
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "el10.1f", 0x8000, 0x8000, CRC(62ca5e89) SHA1(b04acaccc58846e0d277868a873a440b7f8071b0) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "el14.14j", 0x00000, 0x08000, CRC(47246177) SHA1(51b025740dc03b04009ac97d8d110ab521894386) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "el00.2a", 0x00000, 0x10000, CRC(d96b6797) SHA1(01c4a9f2bebb13cba14636690cd5356db73f045e) )
 	ROM_LOAD( "el01.3a", 0x20000, 0x10000, CRC(3fef9c02) SHA1(e4b731faf6a2f4e5fed8ba9bd07e0f203981ffec) )
 	ROM_LOAD( "el02.5a", 0x40000, 0x10000, CRC(bfae6c34) SHA1(9503a120e11e9466cd9a2931fd44a631d72ca5f0) )
 	ROM_LOAD( "el03.6a", 0x60000, 0x10000, CRC(d56790f8) SHA1(1cc7cb9f7102158de14a737e9317a54f01790ba8) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles 1 */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles 1 */
 	ROM_LOAD( "el05.15a", 0x00000, 0x10000, CRC(1c4f6033) SHA1(4a7dece911166d1ff5f41df6ec5140596206d8d4) )
 	ROM_LOAD( "el06.16a", 0x20000, 0x10000, CRC(d24ba794) SHA1(b34b7bbaab4ebdd81c87d363f087cc92e27e8d1c) )
 	ROM_LOAD( "el04.13a", 0x40000, 0x10000, CRC(d80a49ce) SHA1(1a92413b5ab53f80e44a954433e69ec5fe2c0aa6) )
 	ROM_LOAD( "el07.18a", 0x60000, 0x10000, CRC(6d771fc3) SHA1(f29979f3aa07bdb544fb0c1d773c5558b4533390) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 )    /* tiles 2 */
+	ROM_REGION( 0x80000, "tiles2", 0 )    /* tiles 2 */
 	ROM_LOAD( "el08.7d", 0x00000, 0x08000, CRC(cb0dcf4c) SHA1(e14853f83ee9ba5cbf2eb1e085fee4e65af3cc25) )
 	ROM_CONTINUE(        0x40000, 0x08000 )
 	ROM_LOAD( "el09.9d", 0x20000, 0x08000, CRC(1fae5be7) SHA1(be6e090b0b82648b385d9b6d11775f3ff40f0af3) )
@@ -3767,22 +3778,22 @@ ROM_START( cobracomj )
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "eh10.1f", 0x8000, 0x8000, CRC(62ca5e89) SHA1(b04acaccc58846e0d277868a873a440b7f8071b0) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    /* characters */
+	ROM_REGION( 0x08000, "char", 0 )    /* characters */
 	ROM_LOAD( "eh14.14j", 0x00000, 0x08000, CRC(47246177) SHA1(51b025740dc03b04009ac97d8d110ab521894386) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    /* sprites */
+	ROM_REGION( 0x80000, "sprites", 0 )    /* sprites */
 	ROM_LOAD( "eh00.2a", 0x00000, 0x10000, CRC(d96b6797) SHA1(01c4a9f2bebb13cba14636690cd5356db73f045e) )
 	ROM_LOAD( "eh01.3a", 0x20000, 0x10000, CRC(3fef9c02) SHA1(e4b731faf6a2f4e5fed8ba9bd07e0f203981ffec) )
 	ROM_LOAD( "eh02.5a", 0x40000, 0x10000, CRC(bfae6c34) SHA1(9503a120e11e9466cd9a2931fd44a631d72ca5f0) )
 	ROM_LOAD( "eh03.6a", 0x60000, 0x10000, CRC(d56790f8) SHA1(1cc7cb9f7102158de14a737e9317a54f01790ba8) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    /* tiles 1 */
+	ROM_REGION( 0x80000, "tiles1", 0 )    /* tiles 1 */
 	ROM_LOAD( "eh05.15a", 0x00000, 0x10000, CRC(1c4f6033) SHA1(4a7dece911166d1ff5f41df6ec5140596206d8d4) )
 	ROM_LOAD( "eh06.16a", 0x20000, 0x10000, CRC(d24ba794) SHA1(b34b7bbaab4ebdd81c87d363f087cc92e27e8d1c) )
 	ROM_LOAD( "eh04.13a", 0x40000, 0x10000, CRC(d80a49ce) SHA1(1a92413b5ab53f80e44a954433e69ec5fe2c0aa6) )
 	ROM_LOAD( "eh07.18a", 0x60000, 0x10000, CRC(6d771fc3) SHA1(f29979f3aa07bdb544fb0c1d773c5558b4533390) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 )    /* tiles 2 */
+	ROM_REGION( 0x80000, "tiles2", 0 )    /* tiles 2 */
 	ROM_LOAD( "eh08.7d", 0x00000, 0x08000, CRC(cb0dcf4c) SHA1(e14853f83ee9ba5cbf2eb1e085fee4e65af3cc25) )
 	ROM_CONTINUE(        0x40000, 0x08000 )
 	ROM_LOAD( "eh09.9d", 0x20000, 0x08000, CRC(1fae5be7) SHA1(be6e090b0b82648b385d9b6d11775f3ff40f0af3) )
@@ -3807,22 +3818,22 @@ ROM_START( cobracomjb )
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "cobra5.bin", 0x8000, 0x8000, CRC(62ca5e89) SHA1(b04acaccc58846e0d277868a873a440b7f8071b0) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )    // characters
+	ROM_REGION( 0x08000, "char", 0 )    // characters
 	ROM_LOAD( "cobra1.bin", 0x00000, 0x08000, CRC(47246177) SHA1(51b025740dc03b04009ac97d8d110ab521894386) )
 
-	ROM_REGION( 0x80000, "gfx2", 0 )    // sprites
+	ROM_REGION( 0x80000, "sprites", 0 )    // sprites
 	ROM_LOAD( "cob17.bin", 0x00000, 0x10000, CRC(d96b6797) SHA1(01c4a9f2bebb13cba14636690cd5356db73f045e) )
 	ROM_LOAD( "cob16.bin", 0x20000, 0x10000, CRC(3fef9c02) SHA1(e4b731faf6a2f4e5fed8ba9bd07e0f203981ffec) )
 	ROM_LOAD( "cob15.bin", 0x40000, 0x10000, CRC(bfae6c34) SHA1(9503a120e11e9466cd9a2931fd44a631d72ca5f0) )
 	ROM_LOAD( "cob14.bin", 0x60000, 0x10000, CRC(d56790f8) SHA1(1cc7cb9f7102158de14a737e9317a54f01790ba8) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )    // tiles 1
+	ROM_REGION( 0x80000, "tiles1", 0 )    // tiles 1
 	ROM_LOAD( "cob13.bin", 0x00000, 0x10000, CRC(1c4f6033) SHA1(4a7dece911166d1ff5f41df6ec5140596206d8d4) )
 	ROM_LOAD( "cob12.bin", 0x20000, 0x10000, CRC(d24ba794) SHA1(b34b7bbaab4ebdd81c87d363f087cc92e27e8d1c) )
 	ROM_LOAD( "cob11.bin", 0x40000, 0x10000, CRC(d80a49ce) SHA1(1a92413b5ab53f80e44a954433e69ec5fe2c0aa6) )
 	ROM_LOAD( "cob10.bin", 0x60000, 0x10000, CRC(6d771fc3) SHA1(f29979f3aa07bdb544fb0c1d773c5558b4533390) )
 
-	ROM_REGION( 0x80000, "gfx4", 0 )    // tiles 2
+	ROM_REGION( 0x80000, "tiles2", 0 )    // tiles 2
 	ROM_LOAD( "cobra6.bin", 0x00000, 0x08000, CRC(c991298f) SHA1(3f79773a8def6b79b77c2ca6b8e8dbde5bdcd127) )
 	ROM_LOAD( "cobra8.bin", 0x20000, 0x08000, CRC(6bcc5982) SHA1(5bafa9a7a115d2b67f4fd582dc79f7e2848e5010) )
 	ROM_LOAD( "cobra7.bin", 0x40000, 0x08000, CRC(f5e267e5) SHA1(4abda964b8ebceeaba7717d4df23a85862934490) )

--- a/src/mame/dataeast/dec8_v.cpp
+++ b/src/mame/dataeast/dec8_v.cpp
@@ -226,7 +226,7 @@ uint32_t oscar_state::screen_update_cobracom(screen_device &screen, bitmap_ind16
 
 	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 1);
 	m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 2);
-	m_spritegen_mxc->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(1), m_buffered_spriteram16.get(), 0x800/2);
+	m_spritegen_mxc->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram16.get(), 0x800/2);
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
@@ -261,7 +261,7 @@ VIDEO_START_MEMBER(oscar_state,cobracom)
 uint32_t lastmisn_state::screen_update_ghostb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 0);
-	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(1), m_buffered_spriteram16.get(), 0x400);
+	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram16.get(), 0x400);
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
@@ -307,7 +307,7 @@ uint32_t oscar_state::screen_update_oscar(screen_device &screen, bitmap_ind16 &b
 	m_fix_tilemap->set_flip(flip ? (TILEMAP_FLIPY | TILEMAP_FLIPX) : 0);
 
 	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER1, 0);
-	m_spritegen_mxc->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(1), m_buffered_spriteram16.get(), 0x800/2);
+	m_spritegen_mxc->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram16.get(), 0x800/2);
 	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0, 0);
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
@@ -345,7 +345,7 @@ uint32_t lastmisn_state::screen_update_lastmisn(screen_device &screen, bitmap_in
 	m_bg_tilemap->set_scrolly(0, ((m_scroll[2] << 8)+ m_scroll[3]));
 
 	m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
-	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(1), m_buffered_spriteram16.get(), 0x400);
+	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram16.get(), 0x400);
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
@@ -358,7 +358,7 @@ uint32_t lastmisn_state::screen_update_shackled(screen_device &screen, bitmap_in
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 0, 0);
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 1, 0);
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 0, 0);
-	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(1), m_buffered_spriteram16.get(), 0x400);
+	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram16.get(), 0x400);
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 1, 0);
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
@@ -381,7 +381,7 @@ TILE_GET_INFO_MEMBER(lastmisn_state::get_lastmisn_tile_info)
 	else
 		tileinfo.category = 0;
 
-	tileinfo.set(2,
+	tileinfo.set(1,
 			tile & 0xfff,
 			color,
 			0);
@@ -492,7 +492,7 @@ uint32_t gondo_state::screen_update_gondo(screen_device &screen, bitmap_ind16 &b
 
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1, 1);
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 2);
-	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(1), m_buffered_spriteram16.get(), 0x400);
+	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram16.get(), 0x400);
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
@@ -503,7 +503,7 @@ uint32_t lastmisn_state::screen_update_garyoret(screen_device &screen, bitmap_in
 	m_bg_tilemap->set_scrolly(0, ((m_scroll[2] << 8) + m_scroll[3]));
 
 	m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
-	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(1), m_buffered_spriteram16.get(), 0x400);
+	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram16.get(), 0x400);
 	m_bg_tilemap->draw(screen, bitmap, cliprect, 1, 0);
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
@@ -532,7 +532,7 @@ TILE_GET_INFO_MEMBER(lastmisn_state::get_gondo_tile_info)
 	else
 		tileinfo.category = 0;
 
-	tileinfo.set(2,
+	tileinfo.set(1,
 			tile&0xfff,
 			color,
 			0);

--- a/src/mame/dataeast/deckarn.cpp
+++ b/src/mame/dataeast/deckarn.cpp
@@ -12,6 +12,7 @@ deco_karnovsprites_device::deco_karnovsprites_device(const machine_config &mconf
 	: device_t(mconfig, DECO_KARNOVSPRITES, tag, owner, clock)
 	, device_gfx_interface(mconfig, *this)
 	, m_colpri_cb(*this)
+	, m_flip_screen(false)
 {
 }
 
@@ -27,18 +28,15 @@ void deco_karnovsprites_device::device_reset()
 {
 }
 
-void deco_karnovsprites_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, int size)
+void deco_karnovsprites_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, const u16 *spriteram, int size)
 {
 	const bool priority = !m_colpri_cb.isnull();
-	int start, end, inc;
-	if (priority)             { start = size - 4; end =   -4; inc = -4; }
-	else                      { start =        0; end = size; inc = +4; }
+	const int start = priority ? (size - 4) : 0;
+	const int end = priority ? -4 : size;
+	const int inc = priority ? -4 : 4;
 
 	for (int offs = start; offs != end; offs += inc)
 	{
-		int sprite2;
-		u32 pri_mask = 0;
-
 		const u16 data0 = spriteram[offs];
 		if (!(data0 & 0x8000))
 			continue;
@@ -46,6 +44,7 @@ void deco_karnovsprites_device::draw_sprites(screen_device &screen, bitmap_ind16
 		int y = data0 & 0x1ff;
 		const u16 data3 = spriteram[offs + 3];
 		u32 colour = data3 >> 12;
+		u32 pri_mask = 0;
 		if (priority)
 			m_colpri_cb(colour, pri_mask);
 
@@ -54,9 +53,9 @@ void deco_karnovsprites_device::draw_sprites(screen_device &screen, bitmap_ind16
 
 		const u16 data1 = spriteram[offs + 1];
 
-		/* the 8-bit implementation had this.
-		           illustrated by enemy projectile explosions in Shackled being left on screen. */
-		if ((data1 & 0x1) == 0) continue;
+		/* the 8-bit implementation had this.  illustrated by enemy projectile explosions in Shackled being left on screen. */
+		if ((data1 & 0x1) == 0)
+			continue;
 
 		const bool extra = (data1 & 0x10) ? 1 : 0;
 		int fy = data1 & 0x2;
@@ -83,6 +82,7 @@ void deco_karnovsprites_device::draw_sprites(screen_device &screen, bitmap_ind16
 		}
 
 		/* Y Flip determines order of multi-sprite */
+		int sprite2;
 		if (extra && fy)
 		{
 			sprite2 = sprite;

--- a/src/mame/dataeast/deckarn.cpp
+++ b/src/mame/dataeast/deckarn.cpp
@@ -10,6 +10,7 @@ DEFINE_DEVICE_TYPE(DECO_KARNOVSPRITES, deco_karnovsprites_device, "deco_karnovsp
 
 deco_karnovsprites_device::deco_karnovsprites_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, DECO_KARNOVSPRITES, tag, owner, clock)
+	, device_gfx_interface(mconfig, *this)
 	, m_colpri_cb(*this)
 {
 }
@@ -26,7 +27,7 @@ void deco_karnovsprites_device::device_reset()
 {
 }
 
-void deco_karnovsprites_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size)
+void deco_karnovsprites_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, int size)
 {
 	const bool priority = !m_colpri_cb.isnull();
 	int start, end, inc;
@@ -92,25 +93,25 @@ void deco_karnovsprites_device::draw_sprites(screen_device &screen, bitmap_ind16
 
 		if (priority)
 		{
-			gfx->prio_transpen(bitmap,cliprect,
+			gfx(0)->prio_transpen(bitmap,cliprect,
 					sprite,
 					colour,fx,fy,x,y,screen.priority(),pri_mask,0);
 
 			/* 1 more sprite drawn underneath */
 			if (extra)
-				gfx->prio_transpen(bitmap,cliprect,
+				gfx(0)->prio_transpen(bitmap,cliprect,
 					sprite2,
 					colour,fx,fy,x,y+16,screen.priority(),pri_mask,0);
 		}
 		else
 		{
-			gfx->transpen(bitmap,cliprect,
+			gfx(0)->transpen(bitmap,cliprect,
 					sprite,
 					colour,fx,fy,x,y,0);
 
 			/* 1 more sprite drawn underneath */
 			if (extra)
-				gfx->transpen(bitmap,cliprect,
+				gfx(0)->transpen(bitmap,cliprect,
 					sprite2,
 					colour,fx,fy,x,y+16,0);
 		}

--- a/src/mame/dataeast/deckarn.h
+++ b/src/mame/dataeast/deckarn.h
@@ -7,13 +7,20 @@
 
 #include "screen.h"
 
-class deco_karnovsprites_device : public device_t
+class deco_karnovsprites_device : public device_t, public device_gfx_interface
 {
 public:
 	typedef device_delegate<void (u32 &colour, u32 &pri_mask)> colpri_cb_delegate;
 
 	deco_karnovsprites_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
-	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size);
+	template <typename T> deco_karnovsprites_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&palette_tag, const gfx_decode_entry *gfxinfo)
+		: deco_karnovsprites_device(mconfig, tag, owner, clock)
+	{
+		set_info(gfxinfo);
+		set_palette(std::forward<T>(palette_tag));
+	}
+
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, int size);
 	void set_flip_screen(bool flip) { m_flip_screen = flip; }
 
 	template <typename... T> void set_colpri_callback(T &&... args) { m_colpri_cb.set(std::forward<T>(args)...); }

--- a/src/mame/dataeast/deckarn.h
+++ b/src/mame/dataeast/deckarn.h
@@ -20,10 +20,10 @@ public:
 		set_palette(std::forward<T>(palette_tag));
 	}
 
-	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, int size);
-	void set_flip_screen(bool flip) { m_flip_screen = flip; }
-
 	template <typename... T> void set_colpri_callback(T &&... args) { m_colpri_cb.set(std::forward<T>(args)...); }
+
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, const u16 *spriteram, int size);
+	void set_flip_screen(bool flip) { m_flip_screen = flip; }
 
 protected:
 	virtual void device_start() override;
@@ -31,7 +31,7 @@ protected:
 
 private:
 	colpri_cb_delegate m_colpri_cb;
-	bool m_flip_screen = false;
+	bool m_flip_screen;
 };
 
 DECLARE_DEVICE_TYPE(DECO_KARNOVSPRITES, deco_karnovsprites_device)

--- a/src/mame/dataeast/decmxc06.cpp
+++ b/src/mame/dataeast/decmxc06.cpp
@@ -48,12 +48,13 @@ DEFINE_DEVICE_TYPE(DECO_MXC06, deco_mxc06_device, "deco_mxc06", "DECO MXC06 Spri
 deco_mxc06_device::deco_mxc06_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, DECO_MXC06, tag, owner, clock)
 	, device_video_interface(mconfig, *this)
+	, device_gfx_interface(mconfig, *this)
 	, m_colpri_cb(*this)
 {
 }
 
 /* this implementation was originally from Mad Motor */
-void deco_mxc06_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size)
+void deco_mxc06_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, int size)
 {
 	const bool priority = !m_colpri_cb.isnull();
 	struct sprite_t *sprite_ptr = m_spritelist.get();
@@ -143,7 +144,7 @@ void deco_mxc06_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap
 							sprite_ptr->code[y] = code - y * incy;
 							sprite_ptr->x[y] = sx + (mult * x);
 							sprite_ptr->y[y] = sy + (mult * y);
-							gfx->transpen(bitmap, cliprect,
+							gfx(0)->transpen(bitmap, cliprect,
 								sprite_ptr->code[y],
 								sprite_ptr->colour,
 								sprite_ptr->flipx, sprite_ptr->flipy,
@@ -164,7 +165,7 @@ void deco_mxc06_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap
 
 			for (int y = 0; y < sprite_ptr->height; y++)
 			{
-				gfx->prio_transpen(bitmap, cliprect,
+				gfx(0)->prio_transpen(bitmap, cliprect,
 						sprite_ptr->code[y],
 						sprite_ptr->colour,
 						sprite_ptr->flipx, sprite_ptr->flipy,
@@ -176,7 +177,7 @@ void deco_mxc06_device::draw_sprites(screen_device &screen, bitmap_ind16 &bitmap
 
 /* this is used by the automat bootleg, it seems to have greatly simplified sprites compared to the real chip */
 /* spriteram is twice the size tho! */
-void deco_mxc06_device::draw_sprites_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size)
+void deco_mxc06_device::draw_sprites_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, int size)
 {
 	const bool priority = !m_colpri_cb.isnull();
 	struct sprite_t *sprite_ptr = m_spritelist.get();
@@ -213,7 +214,7 @@ void deco_mxc06_device::draw_sprites_bootleg(screen_device &screen, bitmap_ind16
 		}
 		else
 		{
-			gfx->transpen(bitmap,cliprect,
+			gfx(0)->transpen(bitmap,cliprect,
 				sprite_ptr->code[0],
 				sprite_ptr->colour,
 				sprite_ptr->flipx,sprite_ptr->flipy,
@@ -227,7 +228,7 @@ void deco_mxc06_device::draw_sprites_bootleg(screen_device &screen, bitmap_ind16
 		{
 			sprite_ptr--;
 
-			gfx->prio_transpen(bitmap, cliprect,
+			gfx(0)->prio_transpen(bitmap, cliprect,
 					sprite_ptr->code[0],
 					sprite_ptr->colour,
 					sprite_ptr->flipx, sprite_ptr->flipy,

--- a/src/mame/dataeast/decmxc06.h
+++ b/src/mame/dataeast/decmxc06.h
@@ -7,18 +7,24 @@
 
 #include "screen.h"
 
-class deco_mxc06_device : public device_t, public device_video_interface
+class deco_mxc06_device : public device_t, public device_video_interface, public device_gfx_interface
 {
 public:
 	typedef device_delegate<void (u32 &colour, u32 &pri_mask)> colpri_cb_delegate;
 
 	deco_mxc06_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	template <typename T> deco_mxc06_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&palette_tag, const gfx_decode_entry *gfxinfo)
+		: deco_mxc06_device(mconfig, tag, owner, clock)
+	{
+		set_info(gfxinfo);
+		set_palette(std::forward<T>(palette_tag));
+	}
 
 	// configuration
 	template <typename... T> void set_colpri_callback(T &&... args) { m_colpri_cb.set(std::forward<T>(args)...); }
 
-	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size);
-	void draw_sprites_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, gfx_element *gfx, u16* spriteram, int size);
+	void draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, int size);
+	void draw_sprites_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, int size);
 	void set_flip_screen(bool flip) { m_flip_screen = flip; }
 
 protected:

--- a/src/mame/dataeast/karnov.cpp
+++ b/src/mame/dataeast/karnov.cpp
@@ -606,7 +606,7 @@ uint32_t karnov_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap
 	m_bg_tilemap->set_scrollx(m_scroll[0]);
 	m_bg_tilemap->set_scrolly(m_scroll[1]);
 	m_bg_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(2), m_spriteram->buffer(), 0x800);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_spriteram->buffer(), 0x800);
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 
 	return 0;
@@ -700,9 +700,12 @@ static const gfx_layout tiles =
 };
 
 static GFXDECODE_START( gfx_karnov )
-	GFXDECODE_ENTRY( "gfx1", 0, chars,   0,  4 )  /* colors 0-31 */
-	GFXDECODE_ENTRY( "gfx2", 0, tiles, 512, 16 )  /* colors 512-767 */
-	GFXDECODE_ENTRY( "gfx3", 0, tiles, 256, 16 )  /* colors 256-511 */
+	GFXDECODE_ENTRY( "char",    0, chars,   0,  4 )  /* colors 0-31 */
+	GFXDECODE_ENTRY( "tiles",   0, tiles, 512, 16 )  /* colors 512-767 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_karnov_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tiles, 256, 16 )  /* colors 256-511 */
 GFXDECODE_END
 
 
@@ -771,7 +774,7 @@ void karnov_state::karnov(machine_config &config)
 	m_palette->set_prom_region("proms");
 	m_palette->set_init("palette", FUNC(deco_rmc3_device::palette_init_proms));
 
-	DECO_KARNOVSPRITES(config, m_spritegen, 0);
+	DECO_KARNOVSPRITES(config, m_spritegen, 0, m_palette, gfx_karnov_spr);
 
 	MCFG_VIDEO_START_OVERRIDE(karnov_state,karnov)
 
@@ -854,16 +857,16 @@ ROM_START( karnov ) /* DE-0248-3 main board, DE-259-0 sub/rom board */
 	ROM_REGION( 0x1000, "mcu", 0 )  // i8751 MCU (Note: Dump taken from a Rev 5 board)
 	ROM_LOAD( "dn-5.k14", 0x0000, 0x1000, CRC(d056de4e) SHA1(621587ed949ff46e5ccb0d0603612655a38b69a3) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )
+	ROM_REGION( 0x08000, "char", 0 )
 	ROM_LOAD( "dn00-.c5", 0x00000, 0x08000, CRC(0ed77c6d) SHA1(4ec86ac56c01c158a580dc13dea3e5cbdf90d0e9) )  /* Characters */
 
-	ROM_REGION( 0x40000, "gfx2", 0 )
+	ROM_REGION( 0x40000, "tiles", 0 )
 	ROM_LOAD( "dn04-.d18", 0x00000, 0x10000, CRC(a9121653) SHA1(04a67ba6fcf551719734ba2b86ee49c37ee1b842) )  /* Backgrounds */
 	ROM_LOAD( "dn01-.c15", 0x10000, 0x10000, CRC(18697c9e) SHA1(b454af7922c4b1a651d303a3d8d89e5cc102f9ca) )
 	ROM_LOAD( "dn03-.d15", 0x20000, 0x10000, CRC(90d9dd9c) SHA1(00a3bed276927f099d57e90f28fd77bd41a3c360) )
 	ROM_LOAD( "dn02-.c18", 0x30000, 0x10000, CRC(1e04d7b9) SHA1(a2c6fde42569a52cc6d9a86715dea4a8bea80092) )
 
-	ROM_REGION( 0x60000, "gfx3", 0 )
+	ROM_REGION( 0x60000, "sprites", 0 )
 	ROM_LOAD( "dn12-.f8",   0x00000, 0x10000, CRC(9806772c) SHA1(01f17fa033262a3e64e0675cc4e20b3c3f4b254d) )  /* Sprites - 2 sets of 4, interleaved here */
 	ROM_LOAD( "dn14-5.f11", 0x10000, 0x08000, CRC(ac9e6732) SHA1(6f61344eb8a13349471145dee252a01aadb8cdf0) )
 	ROM_LOAD( "dn13-.f9",   0x18000, 0x10000, CRC(a03308f9) SHA1(1d450725a5c488332c83d8f64a73a750ce7fe4c7) )
@@ -893,16 +896,16 @@ ROM_START( karnova ) /* DE-0248-3 main board, DE-259-0 sub/rom board */
 	ROM_REGION( 0x1000, "mcu", 0 )  // i8751 MCU
 	ROM_LOAD( "dn-5.k14", 0x0000, 0x1000, CRC(d056de4e) SHA1(621587ed949ff46e5ccb0d0603612655a38b69a3) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )
+	ROM_REGION( 0x08000, "char", 0 )
 	ROM_LOAD( "dn00-.c5", 0x00000, 0x08000, CRC(0ed77c6d) SHA1(4ec86ac56c01c158a580dc13dea3e5cbdf90d0e9) )  /* Characters */
 
-	ROM_REGION( 0x40000, "gfx2", 0 )
+	ROM_REGION( 0x40000, "tiles", 0 )
 	ROM_LOAD( "dn04-.d18", 0x00000, 0x10000, CRC(a9121653) SHA1(04a67ba6fcf551719734ba2b86ee49c37ee1b842) )  /* Backgrounds */
 	ROM_LOAD( "dn01-.c15", 0x10000, 0x10000, CRC(18697c9e) SHA1(b454af7922c4b1a651d303a3d8d89e5cc102f9ca) )
 	ROM_LOAD( "dn03-.d15", 0x20000, 0x10000, CRC(90d9dd9c) SHA1(00a3bed276927f099d57e90f28fd77bd41a3c360) )
 	ROM_LOAD( "dn02-.c18", 0x30000, 0x10000, CRC(1e04d7b9) SHA1(a2c6fde42569a52cc6d9a86715dea4a8bea80092) )
 
-	ROM_REGION( 0x60000, "gfx3", 0 )
+	ROM_REGION( 0x60000, "sprites", 0 )
 	ROM_LOAD( "dn12-.f8",   0x00000, 0x10000, CRC(9806772c) SHA1(01f17fa033262a3e64e0675cc4e20b3c3f4b254d) )  /* Sprites - 2 sets of 4, interleaved here */
 	ROM_LOAD( "dn14-5.f11", 0x10000, 0x08000, CRC(ac9e6732) SHA1(6f61344eb8a13349471145dee252a01aadb8cdf0) )
 	ROM_LOAD( "dn13-.f9",   0x18000, 0x10000, CRC(a03308f9) SHA1(1d450725a5c488332c83d8f64a73a750ce7fe4c7) )
@@ -932,16 +935,16 @@ ROM_START( karnovj ) /* DE-0248-3 main board, DE-259-0 sub/rom board */
 	ROM_REGION( 0x1000, "mcu", 0 )  // i8751 MCU (BAD_DUMP because it was created from the US version)
 	ROM_LOAD( "karnovj_i8751.k14", 0x0000, 0x1000, BAD_DUMP CRC(5a8c4d28) SHA1(58cc912d91e569503d5a20fa3180fbdca595e39f) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )
+	ROM_REGION( 0x08000, "char", 0 )
 	ROM_LOAD( "dn00-.c5",        0x00000, 0x08000, CRC(0ed77c6d) SHA1(4ec86ac56c01c158a580dc13dea3e5cbdf90d0e9) )  /* Characters */
 
-	ROM_REGION( 0x40000, "gfx2", 0 )
+	ROM_REGION( 0x40000, "tiles", 0 )
 	ROM_LOAD( "dn04-.d18", 0x00000, 0x10000, CRC(a9121653) SHA1(04a67ba6fcf551719734ba2b86ee49c37ee1b842) )  /* Backgrounds */
 	ROM_LOAD( "dn01-.c15", 0x10000, 0x10000, CRC(18697c9e) SHA1(b454af7922c4b1a651d303a3d8d89e5cc102f9ca) )
 	ROM_LOAD( "dn03-.d15", 0x20000, 0x10000, CRC(90d9dd9c) SHA1(00a3bed276927f099d57e90f28fd77bd41a3c360) )
 	ROM_LOAD( "dn02-.c18", 0x30000, 0x10000, CRC(1e04d7b9) SHA1(a2c6fde42569a52cc6d9a86715dea4a8bea80092) )
 
-	ROM_REGION( 0x60000, "gfx3", 0 )
+	ROM_REGION( 0x60000, "sprites", 0 )
 	ROM_LOAD( "dn12-.f8",  0x00000, 0x10000, CRC(9806772c) SHA1(01f17fa033262a3e64e0675cc4e20b3c3f4b254d) )  /* Sprites - 2 sets of 4, interleaved here */
 	ROM_LOAD( "kar14.f11", 0x10000, 0x08000, CRC(c6b39595) SHA1(3bc2d0a613cc1b5d255cccc3b26e21ea1c23e75b) )
 	ROM_LOAD( "dn13-.f9",  0x18000, 0x10000, CRC(a03308f9) SHA1(1d450725a5c488332c83d8f64a73a750ce7fe4c7) )
@@ -973,10 +976,10 @@ ROM_START( karnovjbl )
 	ROM_REGION( 0x1000, "mcu", 0 )  /* NEC D8748HD MCU */
 	ROM_LOAD( "mcu.bin", 0x0000, 0x1000, NO_DUMP ) // labeled 19 on PCB (yes, they labeled two chips as 19)
 
-	ROM_REGION( 0x08000, "gfx1", 0 )
+	ROM_REGION( 0x08000, "char", 0 )
 	ROM_LOAD( "8.bin",       0x00000, 0x08000, CRC(0ed77c6d) SHA1(4ec86ac56c01c158a580dc13dea3e5cbdf90d0e9) )  /* Characters */
 
-	ROM_REGION( 0x40000, "gfx2", 0 )
+	ROM_REGION( 0x40000, "tiles", 0 )
 	ROM_LOAD( "11.bin",       0x00000, 0x08000, CRC(fd18a75c) SHA1(21f753bd7062c00afde48a1585c9aeba247b68b8) )  /* Backgrounds */
 	ROM_LOAD( "12.bin",       0x08000, 0x08000, CRC(a47791d7) SHA1(c242afc80bb885b5d612cc4e7780a8a0ed1f0879) )
 	ROM_LOAD( "13.bin",       0x10000, 0x08000, CRC(e8baf220) SHA1(34ad6453757f87defde5d2f1946fda920a10b1f6) )
@@ -986,7 +989,7 @@ ROM_START( karnovjbl )
 	ROM_LOAD( "15.bin",       0x30000, 0x08000, CRC(04551cc8) SHA1(d0b89b55b8e139e11b79efd26edeffd8022ee385) )
 	ROM_LOAD( "16.bin",       0x38000, 0x08000, CRC(12bc9e09) SHA1(d2f527138d475fc7d798aaf48e08b133be090543) )
 
-	ROM_REGION( 0x60000, "gfx3", 0 )
+	ROM_REGION( 0x60000, "sprites", 0 )
 	ROM_LOAD( "17.bin",       0x00000, 0x10000, CRC(9806772c) SHA1(01f17fa033262a3e64e0675cc4e20b3c3f4b254d) )  /* Sprites - 2 sets of 4, interleaved here */
 	ROM_LOAD( "19.bin",       0x10000, 0x08000, CRC(c6b39595) SHA1(3bc2d0a613cc1b5d255cccc3b26e21ea1c23e75b) )
 	ROM_LOAD( "18.bin",       0x18000, 0x10000, CRC(a03308f9) SHA1(1d450725a5c488332c83d8f64a73a750ce7fe4c7) )
@@ -1016,16 +1019,16 @@ ROM_START( wndrplnt )
 	ROM_REGION( 0x1000, "mcu", 0 )  /* i8751 microcontroller */
 	ROM_LOAD( "ea.k14", 0x0000, 0x1000, CRC(b481f6a9) SHA1(e2c4376662fc7b209cd6a2f4e9a85807c8af2548) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )
+	ROM_REGION( 0x08000, "char", 0 )
 	ROM_LOAD( "ea00.c5",    0x00000, 0x08000, CRC(9f3cac4c) SHA1(af8a275ff531029dbada3c820c9f660fef383100) )   /* Characters */
 
-	ROM_REGION( 0x40000, "gfx2", 0 )
+	ROM_REGION( 0x40000, "tiles", 0 )
 	ROM_LOAD( "ea04.d18",    0x00000, 0x10000, CRC(7d701344) SHA1(4efaa73a4b2534078ee25111a2f5143c7c7e846f) )   /* Backgrounds */
 	ROM_LOAD( "ea01.c18",    0x10000, 0x10000, CRC(18df55fb) SHA1(406ea47365ff8372bb2588c97c438ea02aa17538) )
 	ROM_LOAD( "ea03.d15",    0x20000, 0x10000, CRC(922ef050) SHA1(e33aea6df2e1a14bd371ed0a2b172f58edcc0e8e) )
 	ROM_LOAD( "ea02.c18",    0x30000, 0x10000, CRC(700fde70) SHA1(9b5b59aaffac091622329dc6ebedb24806b69964) )
 
-	ROM_REGION( 0x80000, "gfx3", 0 )
+	ROM_REGION( 0x80000, "sprites", 0 )
 	ROM_LOAD( "ea12.f8",     0x00000, 0x10000, CRC(a6d4e99d) SHA1(a85dbb23d05d1e386d8a66f505fa9dfcc554327b) )   /* Sprites - 2 sets of 4, interleaved here */
 	ROM_LOAD( "ea14.f9",     0x10000, 0x10000, CRC(915ffdc9) SHA1(b65cdc8ee953494f2b69e06cd6c97ee142d83c3e) )
 	ROM_LOAD( "ea13.f13",    0x20000, 0x10000, CRC(cd839f3a) SHA1(7eae3a1e080b7db22968d556e80b620cb07976b0) )
@@ -1055,16 +1058,16 @@ ROM_START( chelnov ) /* DE-0248-1 main board, DE-259-0 sub/rom board */
 	ROM_REGION( 0x1000, "mcu", 0 )  /* i8751 microcontroller */
 	ROM_LOAD( "ee-e.k14", 0x0000, 0x1000, CRC(b7045395) SHA1(a873de0978cbd169b481ee4c4512e47e7745df77) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )
+	ROM_REGION( 0x08000, "char", 0 )
 	ROM_LOAD( "ee00-e.c5",    0x00000, 0x08000, CRC(e06e5c6b) SHA1(70166257da5be428cb8404d8e1063c59c7722365) )  /* Characters */
 
-	ROM_REGION( 0x40000, "gfx2", 0 )
+	ROM_REGION( 0x40000, "tiles", 0 )
 	ROM_LOAD( "ee04-.d18",    0x00000, 0x10000, CRC(96884f95) SHA1(9d88d203028288cb26e111880d090bf40ef9385b) )  /* Backgrounds */
 	ROM_LOAD( "ee01-.c15",    0x10000, 0x10000, CRC(f4b54057) SHA1(72cd0b098a465232c2148fe6b4224c42dd42e6bc) )
 	ROM_LOAD( "ee03-.d15",    0x20000, 0x10000, CRC(7178e182) SHA1(e8f03bda417e8f2f0508df40057d39ce6ee74f16) )
 	ROM_LOAD( "ee02-.c18",    0x30000, 0x10000, CRC(9d7c45ae) SHA1(014dfafa6898e5fd0d124391e698b4f76d38fa94) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )
+	ROM_REGION( 0x40000, "sprites", 0 )
 	ROM_LOAD( "ee12-.f8",     0x00000, 0x10000, CRC(9b1c53a5) SHA1(b0fdc89dc7fd0931fa4bca3bbc20fc88f637ec74) )  /* Sprites */
 	ROM_LOAD( "ee13-.f9",     0x10000, 0x10000, CRC(72b8ae3e) SHA1(535dfd70e6d13296342d96917a57d46bdb28a59e) )
 	ROM_LOAD( "ee14-.f13",    0x20000, 0x10000, CRC(d8f4bbde) SHA1(1f2d336dd97c9cc39e124c18cae634afb0ef3316) )
@@ -1090,16 +1093,16 @@ ROM_START( chelnovu ) /* DE-0248-1 main board, DE-259-0 sub/rom board */
 	ROM_REGION( 0x1000, "mcu", 0 )  /* i8751 microcontroller */
 	ROM_LOAD( "ee-a.k14", 0x0000, 0x1000, CRC(95ea1e7b) SHA1(6d9e3107a2b90734c826c6915c1a3443a7eddfdb) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )
+	ROM_REGION( 0x08000, "char", 0 )
 	ROM_LOAD( "ee00-e.c5",    0x00000, 0x08000, CRC(e06e5c6b) SHA1(70166257da5be428cb8404d8e1063c59c7722365) )  /* Characters */
 
-	ROM_REGION( 0x40000, "gfx2", 0 )
+	ROM_REGION( 0x40000, "tiles", 0 )
 	ROM_LOAD( "ee04-.d18",    0x00000, 0x10000, CRC(96884f95) SHA1(9d88d203028288cb26e111880d090bf40ef9385b) )  /* Backgrounds */
 	ROM_LOAD( "ee01-.c15",    0x10000, 0x10000, CRC(f4b54057) SHA1(72cd0b098a465232c2148fe6b4224c42dd42e6bc) )
 	ROM_LOAD( "ee03-.d15",    0x20000, 0x10000, CRC(7178e182) SHA1(e8f03bda417e8f2f0508df40057d39ce6ee74f16) )
 	ROM_LOAD( "ee02-.c18",    0x30000, 0x10000, CRC(9d7c45ae) SHA1(014dfafa6898e5fd0d124391e698b4f76d38fa94) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )
+	ROM_REGION( 0x40000, "sprites", 0 )
 	ROM_LOAD( "ee12-.f8",     0x00000, 0x10000, CRC(9b1c53a5) SHA1(b0fdc89dc7fd0931fa4bca3bbc20fc88f637ec74) )  /* Sprites */
 	ROM_LOAD( "ee13-.f9",     0x10000, 0x10000, CRC(72b8ae3e) SHA1(535dfd70e6d13296342d96917a57d46bdb28a59e) )
 	ROM_LOAD( "ee14-.f13",    0x20000, 0x10000, CRC(d8f4bbde) SHA1(1f2d336dd97c9cc39e124c18cae634afb0ef3316) )
@@ -1125,16 +1128,16 @@ ROM_START( chelnovj ) /* DE-0248-1 main board, DE-259-0 sub/rom board */
 	ROM_REGION( 0x1000, "mcu", 0 )  /* i8751 microcontroller */
 	ROM_LOAD( "ee.k14", 0x0000, 0x1000, CRC(b3dc380c) SHA1(81cc4ded918da9f232481f4e67cf71de814efc48) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )
+	ROM_REGION( 0x08000, "char", 0 )
 	ROM_LOAD( "ee00.c5",     0x00000, 0x08000, CRC(1abf2c6d) SHA1(86d625ae94cd9ea69e4e613895410640efb175b3) )  /* Characters */
 
-	ROM_REGION( 0x40000, "gfx2", 0 )
+	ROM_REGION( 0x40000, "tiles", 0 )
 	ROM_LOAD( "ee04-.d18",    0x00000, 0x10000, CRC(96884f95) SHA1(9d88d203028288cb26e111880d090bf40ef9385b) )  /* Backgrounds */
 	ROM_LOAD( "ee01-.c15",    0x10000, 0x10000, CRC(f4b54057) SHA1(72cd0b098a465232c2148fe6b4224c42dd42e6bc) )
 	ROM_LOAD( "ee03-.d15",    0x20000, 0x10000, CRC(7178e182) SHA1(e8f03bda417e8f2f0508df40057d39ce6ee74f16) )
 	ROM_LOAD( "ee02-.c18",    0x30000, 0x10000, CRC(9d7c45ae) SHA1(014dfafa6898e5fd0d124391e698b4f76d38fa94) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )
+	ROM_REGION( 0x40000, "sprites", 0 )
 	ROM_LOAD( "ee12-.f8",     0x00000, 0x10000, CRC(9b1c53a5) SHA1(b0fdc89dc7fd0931fa4bca3bbc20fc88f637ec74) )  /* Sprites */
 	ROM_LOAD( "ee13-.f9",     0x10000, 0x10000, CRC(72b8ae3e) SHA1(535dfd70e6d13296342d96917a57d46bdb28a59e) )
 	ROM_LOAD( "ee14-.f13",    0x20000, 0x10000, CRC(d8f4bbde) SHA1(1f2d336dd97c9cc39e124c18cae634afb0ef3316) )
@@ -1162,10 +1165,10 @@ ROM_START( chelnovjbl ) // code is the same as the regular chelnovj set
 	ROM_REGION( 0x2000, "mcu", 0 )    /* SCM8031HCCN40  */ // unique to the bootlegs (rewritten or adjusted to be 8031 compatible)
 	ROM_LOAD( "17o.bin", 0x0000, 0x2000, CRC(9af64150) SHA1(0f478d9f79baebd2ad90615c98c6bc2d73c0056a) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )
+	ROM_REGION( 0x08000, "char", 0 )
 	ROM_LOAD( "a-c5.bin",     0x00000, 0x08000, CRC(1abf2c6d) SHA1(86d625ae94cd9ea69e4e613895410640efb175b3) )  /* Characters */
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* Backgrounds */ // same content split into more roms
+	ROM_REGION( 0x40000, "tiles", 0 ) /* Backgrounds */ // same content split into more roms
 	ROM_LOAD( "8.bin",    0x00000, 0x08000, CRC(a78b174a) SHA1(e0d82b600a154b81d7e1a787f0e20eb1a341894f) )
 	ROM_LOAD( "9.bin",    0x08000, 0x08000, CRC(97d2c146) SHA1(075bb9afc4f0623cd413883ec2bca574d7ff88d4) )
 	ROM_LOAD( "2.bin",    0x10000, 0x08000, CRC(8c45e7de) SHA1(d843b7dcc64ed3a5b8717af172a1f22c4c599480) )
@@ -1175,7 +1178,7 @@ ROM_START( chelnovjbl ) // code is the same as the regular chelnovj set
 	ROM_LOAD( "4.bin",    0x30000, 0x08000, CRC(276a46de) SHA1(5b8932dec0e10be128f5ed41798a8928c0aa506b) )
 	ROM_LOAD( "5.bin",    0x38000, 0x08000, CRC(99cee6cd) SHA1(b2cd0a1aef04fd63ad27ac8a61d17a6bb4c8b600) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 ) /* Sprites */
+	ROM_REGION( 0x40000, "sprites", 0 ) /* Sprites */
 //  ROM_LOAD( "17.bin",       0x00000, 0x10000, CRC(47c857f8) SHA1(59f50365cee266c0e4075c989dc7fde50e43667a) ) // probably bad, 1 byte difference: byte 0x55CC == 0x30 vs 0xF0 in ee12-.f8
 	ROM_LOAD( "ee12-.f8",     0x00000, 0x10000, CRC(9b1c53a5) SHA1(b0fdc89dc7fd0931fa4bca3bbc20fc88f637ec74) )
 	ROM_LOAD( "ee13-.f9",     0x10000, 0x10000, CRC(72b8ae3e) SHA1(535dfd70e6d13296342d96917a57d46bdb28a59e) )
@@ -1214,10 +1217,10 @@ ROM_START( chelnovjbla )
 	ROM_REGION( 0x2000, "mcu", 0 )    /* MAB8031AH */ // unique to the bootlegs (rewritten or adjusted to be 8031 compatible)
 	ROM_LOAD( "17o.bin", 0x0000, 0x2000, CRC(9af64150) SHA1(0f478d9f79baebd2ad90615c98c6bc2d73c0056a) )
 
-	ROM_REGION( 0x08000, "gfx1", 0 )
+	ROM_REGION( 0x08000, "char", 0 )
 	ROM_LOAD( "a-c5.bin",     0x00000, 0x08000, CRC(1abf2c6d) SHA1(86d625ae94cd9ea69e4e613895410640efb175b3) )  /* Characters */
 
-	ROM_REGION( 0x40000, "gfx2", 0 ) /* Backgrounds */ // same content split into more roms
+	ROM_REGION( 0x40000, "tiles", 0 ) /* Backgrounds */ // same content split into more roms
 	ROM_LOAD( "8.bin",    0x00000, 0x08000, CRC(a78b174a) SHA1(e0d82b600a154b81d7e1a787f0e20eb1a341894f) )
 	ROM_LOAD( "9.bin",    0x08000, 0x08000, CRC(97d2c146) SHA1(075bb9afc4f0623cd413883ec2bca574d7ff88d4) )
 	ROM_LOAD( "2.bin",    0x10000, 0x08000, CRC(8c45e7de) SHA1(d843b7dcc64ed3a5b8717af172a1f22c4c599480) )
@@ -1227,7 +1230,7 @@ ROM_START( chelnovjbla )
 	ROM_LOAD( "4.bin",    0x30000, 0x08000, CRC(276a46de) SHA1(5b8932dec0e10be128f5ed41798a8928c0aa506b) )
 	ROM_LOAD( "5.bin",    0x38000, 0x08000, CRC(99cee6cd) SHA1(b2cd0a1aef04fd63ad27ac8a61d17a6bb4c8b600) )
 
-	ROM_REGION( 0x40000, "gfx3", 0 )
+	ROM_REGION( 0x40000, "sprites", 0 )
 	ROM_LOAD( "ee12-.f8",     0x00000, 0x10000, CRC(9b1c53a5) SHA1(b0fdc89dc7fd0931fa4bca3bbc20fc88f637ec74) )  /* Sprites */
 	ROM_LOAD( "ee13-.f9",     0x10000, 0x10000, CRC(72b8ae3e) SHA1(535dfd70e6d13296342d96917a57d46bdb28a59e) )
 	ROM_LOAD( "ee14-.f13",    0x20000, 0x10000, CRC(d8f4bbde) SHA1(1f2d336dd97c9cc39e124c18cae634afb0ef3316) )

--- a/src/mame/dataeast/madmotor.cpp
+++ b/src/mame/dataeast/madmotor.cpp
@@ -215,10 +215,13 @@ static const gfx_layout tilelayout =
 };
 
 static GFXDECODE_START( gfx_madmotor )
-	GFXDECODE_ENTRY( "gfx1", 0, charlayout,   0, 16 ) /* Characters 8x8 */
-	GFXDECODE_ENTRY( "gfx2", 0, tilelayout, 512, 16 ) /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx3", 0, tilelayout, 768, 16 ) /* Tiles 16x16 */
-	GFXDECODE_ENTRY( "gfx4", 0, tilelayout, 256, 16 ) /* Sprites 16x16 */
+	GFXDECODE_ENTRY( "char",    0, charlayout,   0, 16 ) /* Characters 8x8 */
+	GFXDECODE_ENTRY( "tiles1",  0, tilelayout, 512, 16 ) /* Tiles 16x16 */
+	GFXDECODE_ENTRY( "tiles2",  0, tilelayout, 768, 16 ) /* Tiles 16x16 */
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_madmotor_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tilelayout, 256, 16 ) /* Sprites 16x16 */
 GFXDECODE_END
 
 /******************************************************************************/
@@ -233,7 +236,7 @@ uint32_t madmotor_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 
 	m_tilegen[2]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 0);
 	m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 0);
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(3), m_spriteram, 0x800/2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_spriteram, 0x800/2);
 	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 0);
 	return 0;
 }
@@ -276,7 +279,7 @@ void madmotor_state::madmotor(machine_config &config)
 	m_tilegen[2]->set_gfx_region_wide(0, 2, 1);
 	m_tilegen[2]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_MXC06(config, m_spritegen, 0);
+	DECO_MXC06(config, m_spritegen, 0, "palette", gfx_madmotor_spr);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -308,21 +311,21 @@ ROM_START( madmotor )
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
 	ROM_LOAD( "14.l7",    0x00000, 0x10000, CRC(1c28a7e5) SHA1(ed30d0a5a8a079677bd34b6d98ab1b15b934b30f) )
 
-	ROM_REGION( 0x020000, "gfx1", 0 )
+	ROM_REGION( 0x020000, "char", 0 )
 	ROM_LOAD16_BYTE( "04.a9",     0x000000, 0x10000, CRC(833ca3ab) SHA1(7a3e7ebecc1596d2e487595369ad9ba54ced5bfb) )    /* chars */
 	ROM_LOAD16_BYTE( "05.a11",    0x000001, 0x10000, CRC(a691fbfe) SHA1(c726a4c15d599feb6883d9b643453e7028fa16d6) )
 
-	ROM_REGION( 0x040000, "gfx2", 0 )
+	ROM_REGION( 0x040000, "tiles1", 0 )
 	ROM_LOAD16_BYTE( "10.a19",    0x000000, 0x20000, CRC(9dbf482b) SHA1(086e9170d577e502604c180f174fbce53a1e20e5) )    /* tiles */
 	ROM_LOAD16_BYTE( "11.a21",    0x000001, 0x20000, CRC(593c48a9) SHA1(1158888f6b836253b8ae9db9b8e352f289b2e815) )
 
-	ROM_REGION( 0x080000, "gfx3", 0 )
+	ROM_REGION( 0x080000, "tiles2", 0 )
 	ROM_LOAD16_BYTE( "06.a13",    0x000000, 0x20000, CRC(448850e5) SHA1(6a44a42738cf6a55b4bec807e0a3939a42b36793) )    /* tiles */
 	ROM_LOAD16_BYTE( "07.a14",    0x040000, 0x20000, CRC(ede4d141) SHA1(7b847372bac043aa397aa5c274f90b9193de9176) )
 	ROM_LOAD16_BYTE( "08.a16",    0x000001, 0x20000, CRC(c380e5e5) SHA1(ec87a94e7948b84c96b1577f5a8caebc56e38a94) )
 	ROM_LOAD16_BYTE( "09.a18",    0x040001, 0x20000, CRC(1ee3326a) SHA1(bd03e5c4a2e7689260e6cc67288e71ef13f05a4b) )
 
-	ROM_REGION( 0x100000, "gfx4", 0 )
+	ROM_REGION( 0x100000, "sprites", 0 )
 	ROM_LOAD16_BYTE( "15.h11",    0x000000, 0x20000, CRC(90ae9f74) SHA1(806f96fd08fca1beeeaefe3c0fac1991410aa9c4) )    /* sprites */
 	ROM_LOAD16_BYTE( "16.h13",    0x040000, 0x20000, CRC(e96ac815) SHA1(a2b22a29ad0a4f144bb09299c454dc7a842a5318) )
 	ROM_LOAD16_BYTE( "17.h14",    0x000001, 0x20000, CRC(abad9a1b) SHA1(3cec6b4ef925205efe4a8fb28e08eb58e3ba4019) )

--- a/src/mame/dataeast/stadhero.cpp
+++ b/src/mame/dataeast/stadhero.cpp
@@ -172,7 +172,7 @@ uint32_t stadhero_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 	m_pf1_tilemap->set_flip(flip ? (TILEMAP_FLIPY | TILEMAP_FLIPX) : 0);
 
 	m_tilegen->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(2), m_spriteram, 0x800 / 2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_spriteram, 0x800 / 2);
 	m_pf1_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
@@ -360,6 +360,9 @@ static const gfx_layout spritelayout =
 static GFXDECODE_START( gfx_stadhero )
 	GFXDECODE_ENTRY( "chars",   0, charlayout,     0, 16 ) // 8x8
 	GFXDECODE_ENTRY( "tiles",   0, tile_3bpp,    512, 16 ) // 16x16
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_stadhero_spr )
 	GFXDECODE_ENTRY( "sprites", 0, spritelayout, 256, 16 ) // 16x16
 GFXDECODE_END
 
@@ -391,7 +394,7 @@ void stadhero_state::stadhero(machine_config &config)
 	m_tilegen->set_gfx_region_wide(1, 1, 2);
 	m_tilegen->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_MXC06(config, m_spritegen, 0);
+	DECO_MXC06(config, m_spritegen, 0, "palette", gfx_stadhero_spr);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/dataeast/thedeep.cpp
+++ b/src/mame/dataeast/thedeep.cpp
@@ -158,7 +158,7 @@ TILE_GET_INFO_MEMBER(thedeep_state::get_tile_info)
 {
 	uint8_t code  =   m_textram[ tile_index * 2 + 0 ];
 	uint8_t color =   m_textram[ tile_index * 2 + 1 ];
-	tileinfo.set(2,
+	tileinfo.set(1,
 			code + (color << 8),
 			(color & 0xf0) >> 4,
 			0);
@@ -208,7 +208,7 @@ uint32_t thedeep_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 	bitmap.fill(m_palette->black_pen(), cliprect);
 
 	m_tilegen->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(0), reinterpret_cast<uint16_t *>(m_spriteram.target()), 0x400 / 2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, reinterpret_cast<uint16_t *>(m_spriteram.target()), 0x400 / 2);
 	m_text_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
@@ -478,9 +478,12 @@ static const gfx_layout layout_16x16x4 =
 };
 
 static GFXDECODE_START( gfx_thedeep )
-	GFXDECODE_ENTRY( "sprites", 0, layout_16x16x4,  0x080,  8 )
 	GFXDECODE_ENTRY( "bg_gfx", 0, layout_16x16x4,   0x100, 16 )
 	GFXDECODE_ENTRY( "text", 0, layout_8x8x2,   0x000, 16 )
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_thedeep_spr )
+	GFXDECODE_ENTRY( "sprites", 0, layout_16x16x4,  0x080,  8 )
 GFXDECODE_END
 
 
@@ -539,10 +542,10 @@ void thedeep_state::thedeep(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_thedeep);
 	PALETTE(config, m_palette, FUNC(thedeep_state::palette), 512);
 
-	DECO_MXC06(config, m_spritegen, 0);
+	DECO_MXC06(config, m_spritegen, 0, m_palette, gfx_thedeep_spr);
 
 	DECO_BAC06(config, m_tilegen, 0);
-	m_tilegen->set_gfx_region_wide(1, 1, 0);
+	m_tilegen->set_gfx_region_wide(0, 0, 0);
 	m_tilegen->set_gfxdecode_tag(m_gfxdecode);
 	m_tilegen->set_thedeep_kludge();  // TODO: this game wants TILE_FLIPX always set. Investigate why.
 

--- a/src/mame/dataeast/vaportra.cpp
+++ b/src/mame/dataeast/vaportra.cpp
@@ -187,7 +187,7 @@ uint32_t vaportra_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 	}
 
-	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_gfxdecode->gfx(4), m_spriteram->buffer(), 0x800 / 2);
+	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_spriteram->buffer(), 0x800 / 2);
 	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
@@ -350,11 +350,14 @@ static const gfx_layout tilelayout =
 };
 
 static GFXDECODE_START( gfx_vaportra )
-	GFXDECODE_ENTRY( "tiles1",  0x000000, charlayout,    0x000, 0x500 )    // Characters 8x8
-	GFXDECODE_ENTRY( "tiles1",  0x000000, tilelayout,    0x000, 0x500 )    // Tiles 16x16
-	GFXDECODE_ENTRY( "tiles2",  0x000000, charlayout,    0x000, 0x500 )    // Characters 8x8
-	GFXDECODE_ENTRY( "tiles2",  0x000000, tilelayout,    0x000, 0x500 )    // Tiles 16x16 // ok
-	GFXDECODE_ENTRY( "sprites", 0x000000, tilelayout,    0x100, 16 )       // 16x16
+	GFXDECODE_ENTRY( "tiles1",  0, charlayout, 0x000, 0x500 )    // Characters 8x8
+	GFXDECODE_ENTRY( "tiles1",  0, tilelayout, 0x000, 0x500 )    // Tiles 16x16
+	GFXDECODE_ENTRY( "tiles2",  0, charlayout, 0x000, 0x500 )    // Characters 8x8
+	GFXDECODE_ENTRY( "tiles2",  0, tilelayout, 0x000, 0x500 )    // Tiles 16x16 // ok
+GFXDECODE_END
+
+static GFXDECODE_START( gfx_vaportra_spr )
+	GFXDECODE_ENTRY( "sprites", 0, tilelayout, 0x100, 16 )       // 16x16
 GFXDECODE_END
 
 /******************************************************************************/
@@ -427,7 +430,7 @@ void vaportra_state::vaportra(machine_config &config)
 	m_deco_tilegen[1]->set_pf12_16x16_bank(3);
 	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO_MXC06(config, m_spritegen, 0);
+	DECO_MXC06(config, m_spritegen, 0, m_palette, gfx_vaportra_spr);
 	m_spritegen->set_colpri_callback(FUNC(vaportra_state::colpri_cb));
 
 	// sound hardware


### PR DESCRIPTION
dataeast/dec0.cpp, dataeast/dec8.cpp, dataeast/karnov.cpp, dataeast/madmotor.cpp: Rename GFX ROM regions for consistency