### PR TITLE
upd7220: Sync command should enable/disable the DE bit

### DIFF
--- a/src/devices/video/upd7220.cpp
+++ b/src/devices/video/upd7220.cpp
@@ -1173,6 +1173,11 @@ void upd7220_device::process_fifo()
 		break;
 
 	case COMMAND_SYNC: /* sync format specify */
+		if (flag == FIFO_COMMAND)
+		{
+			m_de = m_cr & 1;
+		}
+
 		if (m_param_ptr == 9)
 		{
 			m_mode = m_pr[1];


### PR DESCRIPTION
The SYNC command according to the upd7220 datasheet has a DE (Display Enable) on bit one of the command byte. This should be processed when receiving the command. 

This fixes LOGO professor on the Epson QX-10. That program during boot uses BCTRL to disable the display and then slightly later issues a SYNC command to re-enable the display. Without this fix the disable is never turned back on.