### PR TITLE
nabupc: Update keyboard to use REVB ROM image

### DIFF
--- a/src/mame/misc/nabupc_kbd.cpp
+++ b/src/mame/misc/nabupc_kbd.cpp
@@ -57,7 +57,7 @@ namespace  {
 
 ROM_START(nabu_keyboard_rom)
 	ROM_REGION( 0x800, "mcu", 0 )
-	ROM_LOAD( "nabukeyboard-90020070-reva-2716.bin", 0x000, 0x800, CRC(eead3abc) SHA1(2f6ff63ca2f2ac90f3e03ef4f2b79883205e8a4e) )
+	ROM_LOAD( "nabukeyboard-90020070-revb-2716.bin", 0x000, 0x800, CRC(7d6ebc61) SHA1(5b0cb3da5b4afcae321c2a557e328c416b107dd7) )
 ROM_END
 
 //**************************************************************************


### PR DESCRIPTION
This updates the ROM used by the keyboard to use REVB. 

The REVB firmware fixes a bug in the keyboard's ROM that caused issues with using the second paddle on a controller port.