### PR TITLE
add Casio WG-130 waveblaster device

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -5380,5 +5380,7 @@ if (BUSES["WAVEBLASTER"]~=null) then
 		MAME_DIR .. "src/devices/bus/waveblaster/db50xg.h",
 		MAME_DIR .. "src/devices/bus/waveblaster/db60xg.cpp",
 		MAME_DIR .. "src/devices/bus/waveblaster/db60xg.h",
+		MAME_DIR .. "src/devices/bus/waveblaster/wg130.cpp",
+		MAME_DIR .. "src/devices/bus/waveblaster/wg130.h",
 	}
 end

--- a/src/devices/bus/waveblaster/waveblaster.cpp
+++ b/src/devices/bus/waveblaster/waveblaster.cpp
@@ -7,6 +7,7 @@
 #include "omniwave.h"
 #include "db50xg.h"
 #include "db60xg.h"
+#include "wg130.h"
 
 
 DEFINE_DEVICE_TYPE(WAVEBLASTER_CONNECTOR, waveblaster_connector, "waveblaster_connector", "Waveblaster extension connector")
@@ -36,6 +37,7 @@ void waveblaster_intf(device_slot_interface &device)
 	device.option_add("omniwave", OMNIWAVE);
 	device.option_add("db50xg", DB50XG);
 	device.option_add("db60xg", DB60XG);
+	device.option_add("wg130", WG130);
 }
 
 device_waveblaster_interface::device_waveblaster_interface(const machine_config &mconfig, device_t &device) :

--- a/src/devices/bus/waveblaster/wg130.cpp
+++ b/src/devices/bus/waveblaster/wg130.cpp
@@ -1,0 +1,94 @@
+// license:BSD-3-Clause
+// copyright-holders: Devin Acker
+/*
+	Casio WG-130
+
+	This is the daughterboard version of the GZ-50M and GZ-70SP modules, using the same ROM.
+*/
+#include "emu.h"
+#include "wg130.h"
+
+DEFINE_DEVICE_TYPE(WG130, wg130_device, "wg130", "Casio WG-130")
+
+namespace {
+
+INPUT_PORTS_START(wg130)
+	PORT_START("gt913:kbd:FI0")
+	PORT_START("gt913:kbd:FI1")
+	PORT_START("gt913:kbd:FI2")
+	PORT_START("gt913:kbd:FI3")
+	PORT_START("gt913:kbd:FI4")
+	PORT_START("gt913:kbd:FI5")
+	PORT_START("gt913:kbd:FI6")
+	PORT_START("gt913:kbd:FI7")
+	PORT_START("gt913:kbd:FI8")
+	PORT_START("gt913:kbd:FI9")
+	PORT_START("gt913:kbd:FI10")
+	PORT_START("gt913:kbd:KI0")
+	PORT_START("gt913:kbd:KI1")
+	PORT_START("gt913:kbd:KI2")
+INPUT_PORTS_END
+
+} // anonymous namespace
+
+wg130_device::wg130_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, WG130, tag, owner, clock),
+	device_waveblaster_interface(mconfig, *this),
+	m_gt913(*this, "gt913")
+{
+}
+	
+wg130_device::~wg130_device()
+{
+}
+
+void wg130_device::midi_rx(int state)
+{
+	m_gt913->sci_rx_w<1>(state);
+}
+
+void wg130_device::map(address_map &map)
+{
+	map(0x000000, 0x1fffff).rom().region("gt913", 0);
+	map(0x300000, 0x301fff).ram().mirror(0x07e000);
+	map(0x380000, 0x380003).noprw(); // DSP is mapped here, but not actually present
+}
+
+void wg130_device::device_add_mconfig(machine_config &config)
+{
+	GT913(config, m_gt913, 30_MHz_XTAL / 2);
+	m_gt913->set_addrmap(AS_DATA, &wg130_device::map);
+	m_gt913->add_route(0, DEVICE_SELF_OWNER, 1.0, AUTO_ALLOC_INPUT, 0);
+	m_gt913->add_route(1, DEVICE_SELF_OWNER, 1.0, AUTO_ALLOC_INPUT, 1);
+	m_gt913->read_port1().set_constant(0xff);
+	m_gt913->write_port1().set_nop();
+	m_gt913->read_port2().set_constant(0xff);
+	m_gt913->write_port2().set_nop();
+	m_gt913->write_sci_tx<1>().set([this](int state) { m_connector->do_midi_tx(state); } );
+}
+
+ROM_START( wg130 )
+	ROM_REGION(0x200000, "gt913", 0)
+	ROM_LOAD("romsxgm.bin", 0x000000, 0x200000, CRC(c392cf89) SHA1(93ebe213ea7a085c67d88974ed39ac3e9bf8059b)) // from the SW-10 softsynth
+ROM_END
+
+void wg130_device::device_start()
+{
+	/*
+	the version of this ROM bundled with the SW-10 softsynth has little endian samples, so byteswap them
+	(and stop at the end of sample data, not the end of the whole ROM, otherwise the ROM test fails)
+	*/
+	uint16_t* rom = (uint16_t*)memregion("gt913")->base();
+	for (uint32_t addr = 0x2f000 >> 1; addr < 0x1fe8c2 >> 1; addr++)
+		rom[addr] = swapendian_int16(rom[addr]);
+}
+
+const tiny_rom_entry *wg130_device::device_rom_region() const
+{
+	return ROM_NAME(wg130);
+}
+
+ioport_constructor wg130_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME(wg130);
+}

--- a/src/devices/bus/waveblaster/wg130.cpp
+++ b/src/devices/bus/waveblaster/wg130.cpp
@@ -3,7 +3,7 @@
 /*
 	Casio WG-130
 
-	This is the daughterboard version of the GZ-50M and GZ-70SP modules, using the same ROM.
+	This is the daughterboard version of the GZ-30M and GZ-70SP modules, using the same ROM.
 */
 #include "emu.h"
 #include "wg130.h"
@@ -37,7 +37,7 @@ wg130_device::wg130_device(const machine_config &mconfig, const char *tag, devic
 	m_gt913(*this, "gt913")
 {
 }
-	
+
 wg130_device::~wg130_device()
 {
 }

--- a/src/devices/bus/waveblaster/wg130.h
+++ b/src/devices/bus/waveblaster/wg130.h
@@ -1,0 +1,33 @@
+#ifndef MAME_BUS_WAVEBLASTER_WG130_H
+#define MAME_BUS_WAVEBLASTER_WG130_H
+
+// Casio WG130
+
+#pragma once
+
+#include "waveblaster.h"
+#include "cpu/h8/gt913.h"
+
+DECLARE_DEVICE_TYPE(WG130, wg130_device)
+
+class wg130_device : public device_t, public device_waveblaster_interface
+{
+public:
+	wg130_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+	virtual ~wg130_device();
+
+	virtual void midi_rx(int state) override;
+
+protected:
+	virtual void device_start() override;
+	const tiny_rom_entry *device_rom_region() const override;
+	virtual ioport_constructor device_input_ports() const override;
+	virtual void device_add_mconfig(machine_config &config) override;
+
+private:
+	required_device<gt913_device> m_gt913;
+
+	void map(address_map &map);
+};
+
+#endif // MAME_BUS_WAVEBLASTER_WG130_H


### PR DESCRIPTION
Same ROM and everything else as the existing gz70sp driver, minus the test and demo inputs.