### PR TITLE
trs/mc10.cpp, agvision.cpp:  remove set_raw

### DIFF
--- a/src/mame/trs/agvision.cpp
+++ b/src/mame/trs/agvision.cpp
@@ -210,7 +210,7 @@ void agvision_state::agvision(machine_config &config)
 	m_pia_0->cb2_handler().set(FUNC(agvision_state::pia0_cb2_w));
 
 	// video hardware
-	SCREEN(config, m_screen, SCREEN_TYPE_RASTER).set_raw(3.579545_MHz_XTAL * 2, 456, 0, 320, 262, 0, 240);
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 
 	MC6847_NTSC(config, m_vdg, XTAL(14'318'181) / 4); // VClk output from MC6883
 	m_vdg->set_screen(m_screen);

--- a/src/mame/trs/mc10.cpp
+++ b/src/mame/trs/mc10.cpp
@@ -509,7 +509,7 @@ void mc10_state::mc10_video(machine_config &config)
 	RAM(config, m_ram).set_default_size("4K").set_extra_options("8K,20K,32K");
 
 	/* video hardware */
-	SCREEN(config, "screen", SCREEN_TYPE_RASTER).set_raw(3.579545_MHz_XTAL * 2, 456, 0, 320, 262, 0, 240);
+	SCREEN(config, "screen", SCREEN_TYPE_RASTER);
 
 	mc6847_ntsc_device &vdg(MC6847_NTSC(config, "mc6847", XTAL(3'579'545)));
 	vdg.set_screen("screen");


### PR DESCRIPTION
Remove set_raw from mc10 and agvision driver. No longer needed after VDG update.