### PR TITLE
cidelsa.cpp: Add Cidelsa's "Altair II"

### DIFF
--- a/src/mame/efo/cidelsa.cpp
+++ b/src/mame/efo/cidelsa.cpp
@@ -3,7 +3,7 @@
 #include "emu.h"
 #include "cidelsa.h"
 
-/* CDP1802 Interface */
+// CDP1802 Interface
 
 int cidelsa_state::clear_r()
 {
@@ -15,7 +15,7 @@ void cidelsa_state::q_w(int state)
 	m_cdp1802_q = state;
 }
 
-/* Sound Interface */
+// Sound Interface
 
 void draco_state::sound_bankswitch_w(uint8_t data)
 {
@@ -79,7 +79,7 @@ void draco_state::psg_w(uint8_t data)
 	m_psg_latch = data;
 }
 
-/* Read/Write Handlers */
+// Read/Write Handlers
 
 void cidelsa_state::destryer_out1_w(uint8_t data)
 {
@@ -97,7 +97,7 @@ void cidelsa_state::destryer_out1_w(uint8_t data)
 	*/
 }
 
-/* CDP1852 Interfaces */
+// CDP1852 Interfaces
 
 void cidelsa_state::altair_out1_w(uint8_t data)
 {
@@ -137,7 +137,7 @@ void draco_state::out1_w(uint8_t data)
 	m_sound = (data & 0xe0) >> 5;
 }
 
-/* Memory Maps */
+// Memory Maps
 
 // Destroyer
 
@@ -205,7 +205,7 @@ void draco_state::draco_sound_map(address_map &map)
 	map(0x000, 0x3ff).bankr("bank1");
 }
 
-/* Input Ports */
+// Input Ports
 
 int cidelsa_state::cdp1869_pcb_r()
 {
@@ -225,10 +225,10 @@ static INPUT_PORTS_START( destryer )
 
 	PORT_START("IN1")
 	PORT_DIPNAME( 0x03, 0x02, DEF_STR( Difficulty ) )
-	PORT_DIPSETTING(    0x00, "Very Conserv" )
-	PORT_DIPSETTING(    0x01, "Conserv" )
-	PORT_DIPSETTING(    0x02, "Liberal" )
-	PORT_DIPSETTING(    0x03, "Very Liberal" )
+	PORT_DIPSETTING(    0x00, DEF_STR( Very_Hard ) )
+	PORT_DIPSETTING(    0x01, DEF_STR( Hard ) )
+	PORT_DIPSETTING(    0x02, DEF_STR( Easy ) )
+	PORT_DIPSETTING(    0x03, DEF_STR( Very_Easy ) )
 	PORT_DIPNAME( 0x0c, 0x04, DEF_STR( Bonus_Life ) )
 	PORT_DIPSETTING(    0x0c, "5000" )
 	PORT_DIPSETTING(    0x08, "7000" )
@@ -265,10 +265,10 @@ static INPUT_PORTS_START( altair )
 
 	PORT_START("IN1")
 	PORT_DIPNAME( 0x03, 0x02, DEF_STR( Difficulty ) )
-	PORT_DIPSETTING(    0x00, "Very Conserv" )
-	PORT_DIPSETTING(    0x01, "Conserv" )
-	PORT_DIPSETTING(    0x02, "Liberal" )
-	PORT_DIPSETTING(    0x03, "Very Liberal" )
+	PORT_DIPSETTING(    0x00, DEF_STR( Very_Hard ) )
+	PORT_DIPSETTING(    0x01, DEF_STR( Hard ) )
+	PORT_DIPSETTING(    0x02, DEF_STR( Easy ) )
+	PORT_DIPSETTING(    0x03, DEF_STR( Very_Easy ) )
 	PORT_DIPNAME( 0x0c, 0x04, DEF_STR( Bonus_Life ) )
 	PORT_DIPSETTING(    0x0c, "5000" )
 	PORT_DIPSETTING(    0x08, "7000" )
@@ -313,12 +313,13 @@ static INPUT_PORTS_START( draco )
 	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_UNKNOWN )
 	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER(DEVICE_SELF, cidelsa_state, cdp1869_pcb_r)
 
+	// According to the manual, there's only two difficulty (easy/hard) settings and the first DIP switch is not used
 	PORT_START("IN1")
 	PORT_DIPNAME( 0x03, 0x02, DEF_STR( Difficulty ) )
-	PORT_DIPSETTING(    0x00, "Very Conserv" )
-	PORT_DIPSETTING(    0x01, "Conserv" )
-	PORT_DIPSETTING(    0x02, "Liberal" )
-	PORT_DIPSETTING(    0x03, "Very Liberal" )
+	PORT_DIPSETTING(    0x00, DEF_STR( Very_Hard ) )
+	PORT_DIPSETTING(    0x01, DEF_STR( Hard ) )
+	PORT_DIPSETTING(    0x02, DEF_STR( Easy ) )
+	PORT_DIPSETTING(    0x03, DEF_STR( Very_Easy ) )
 	PORT_DIPNAME( 0x0c, 0x04, DEF_STR( Bonus_Life ) )
 	PORT_DIPSETTING(    0x0c, "5000" )
 	PORT_DIPSETTING(    0x08, "7000" )
@@ -354,7 +355,7 @@ static INPUT_PORTS_START( draco )
 	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_COIN1 ) PORT_WRITE_LINE_DEVICE_MEMBER(CDP1802_TAG, cosmac_device, ef4_w)
 INPUT_PORTS_END
 
-/* Machine Start */
+// Machine Start
 
 TIMER_CALLBACK_MEMBER(cidelsa_state::reset_done)
 {
@@ -365,7 +366,7 @@ void cidelsa_state::machine_start()
 {
 	m_leds.resolve();
 
-	/* register for state saving */
+	// register for state saving
 	save_item(NAME(m_reset));
 
 	m_reset_timer = timer_alloc(FUNC(cidelsa_state::reset_done), this);
@@ -375,29 +376,29 @@ void draco_state::machine_start()
 {
 	cidelsa_state::machine_start();
 
-	/* setup COP402 memory banking */
+	// setup COP402 memory banking
 	membank("bank1")->configure_entries(0, 2, memregion(COP402N_TAG)->base(), 0x400);
 	membank("bank1")->set_entry(0);
 
-	/* register for state saving */
+	// register for state saving
 	save_item(NAME(m_sound));
 	save_item(NAME(m_psg_latch));
 }
 
-/* Machine Reset */
+// Machine Reset
 
 void cidelsa_state::machine_reset()
 {
-	/* reset the CPU */
+	// reset the CPU
 	m_reset = 0;
 	m_reset_timer->adjust(attotime::from_msec(200));
 }
 
-/* Machine Drivers */
+// Machine Drivers
 
 void cidelsa_state::destryer(machine_config &config)
 {
-	/* basic system hardware */
+	// basic system hardware
 	cdp1802_device &cpu(CDP1802(config, CDP1802_TAG, DESTRYER_CHR1));
 	cpu.set_addrmap(AS_PROGRAM, &cidelsa_state::destryer_map);
 	cpu.set_addrmap(AS_IO, &cidelsa_state::destryer_io_map);
@@ -407,13 +408,13 @@ void cidelsa_state::destryer(machine_config &config)
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
-	/* sound and video hardware */
+	// sound and video hardware
 	destryer_video(config);
 }
 
 void cidelsa_state::destryera(machine_config &config)
 {
-	/* basic system hardware */
+	// basic system hardware
 	cdp1802_device &cpu(CDP1802(config, CDP1802_TAG, DESTRYER_CHR1));
 	cpu.set_addrmap(AS_PROGRAM, &cidelsa_state::destryera_map);
 	cpu.set_addrmap(AS_IO, &cidelsa_state::destryer_io_map);
@@ -423,13 +424,13 @@ void cidelsa_state::destryera(machine_config &config)
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
-	/* sound and video hardware */
+	// sound and video hardware
 	destryer_video(config);
 }
 
 void cidelsa_state::altair(machine_config &config)
 {
-	/* basic system hardware */
+	// basic system hardware
 	cdp1802_device &cpu(CDP1802(config, CDP1802_TAG, ALTAIR_CHR1));
 	cpu.set_addrmap(AS_PROGRAM, &cidelsa_state::altair_map);
 	cpu.set_addrmap(AS_IO, &cidelsa_state::altair_io_map);
@@ -440,7 +441,7 @@ void cidelsa_state::altair(machine_config &config)
 
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
-	/* input/output hardware */
+	// input/output hardware
 	cdp1852_device &ic23(CDP1852(config, "ic23")); // clock is really tied to CDP1869 CMSEL (pin 37)
 	ic23.mode_cb().set_constant(0);
 	ic23.di_cb().set_ioport("IN0");
@@ -457,13 +458,13 @@ void cidelsa_state::altair(machine_config &config)
 	ic26.mode_cb().set_constant(1);
 	ic26.do_cb().set(FUNC(cidelsa_state::altair_out1_w));
 
-	/* sound and video hardware */
+	// sound and video hardware
 	altair_video(config);
 }
 
 void draco_state::draco(machine_config &config)
 {
-	/* basic system hardware */
+	// basic system hardware
 	cdp1802_device &cpu(CDP1802(config, CDP1802_TAG, DRACO_CHR1));
 	cpu.set_addrmap(AS_PROGRAM, &draco_state::draco_map);
 	cpu.set_addrmap(AS_IO, &draco_state::draco_io_map);
@@ -483,7 +484,7 @@ void draco_state::draco(machine_config &config)
 	cop.write_l().set(FUNC(draco_state::psg_w));
 	cop.read_in().set(FUNC(draco_state::sound_in_r));
 
-	/* input/output hardware */
+	// input/output hardware
 	cdp1852_device &ic29(CDP1852(config, "ic29")); // clock is really tied to CDP1869 CMSEL (pin 37)
 	ic29.mode_cb().set_constant(0);
 	ic29.di_cb().set_ioport("IN0");
@@ -500,11 +501,11 @@ void draco_state::draco(machine_config &config)
 	ic32.mode_cb().set_constant(1);
 	ic32.do_cb().set(FUNC(draco_state::out1_w));
 
-	/* sound and video hardware */
+	// sound and video hardware
 	draco_video(config);
 }
 
-/* ROMs */
+// ROMs
 
 ROM_START( destryer )
 	ROM_REGION( 0x2000, CDP1802_TAG, 0 )
@@ -533,6 +534,16 @@ ROM_START( altair )
 	ROM_LOAD( "alt f 1.ic12", 0x2800, 0x0800, CRC(a06dd905) SHA1(c24ad9ff6d4e3b4e57fd75f946e8832fa00c2ea0) )
 ROM_END
 
+ROM_START( altair2 )
+	ROM_REGION( 0x3000, CDP1802_TAG, 0 )
+	ROM_LOAD( "alta2-2716.ic7",  0x0000, 0x0800, CRC(e82833ab) SHA1(dfc8a3eb9ab2e31bbbf84db39047d43501c027f9) )
+	ROM_LOAD( "altb2-2716.ic8",  0x0800, 0x0800, CRC(92df504a) SHA1(2e831c048a7ea332bccd369ded19159a0f8c8688) )
+	ROM_LOAD( "altc2-2716.ic9",  0x1000, 0x0800, CRC(a4e33775) SHA1(3f59b24fcdbfc7d9d393ea35dc4e0a499b0f2738) )
+	ROM_LOAD( "altd2-2716.ic10", 0x1800, 0x0800, CRC(79b56041) SHA1(02edab6ba799907f089db4026c4466ac8e9daae9) )
+	ROM_LOAD( "alte2-2716.ic11", 0x2000, 0x0800, CRC(be7fdb42) SHA1(b41bfa072911c3d4c532963f283a04dbf26d2d1b) )
+	ROM_LOAD( "altf2-2716.ic12", 0x2800, 0x0800, CRC(cf74b50f) SHA1(b7bdfd9bba6d838cac4af3fd031316e4b05f9758) )
+ROM_END
+
 ROM_START( draco )
 	ROM_REGION( 0x4000, CDP1802_TAG, 0 )
 	ROM_LOAD( "dra a 1.ic10", 0x0000, 0x0800, CRC(ca127984) SHA1(46721cf42b1c891f7c88bc063a2149dd3cefea74) )
@@ -548,9 +559,10 @@ ROM_START( draco )
 	ROM_LOAD( "dra s 1.ic4",  0x0000, 0x0800, CRC(292a57f8) SHA1(b34a189394746d77c3ee669db24109ee945c3be7) )
 ROM_END
 
-/* Game Drivers */
+// Game Drivers
 
 GAME( 1980, destryer,  0,        destryer,  destryer, cidelsa_state, empty_init, ROT90, "Cidelsa", "Destroyer (Cidelsa) (set 1)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 GAME( 1980, destryera, destryer, destryera, destryer, cidelsa_state, empty_init, ROT90, "Cidelsa", "Destroyer (Cidelsa) (set 2)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1981, altair,    0,        altair,    altair,   cidelsa_state, empty_init, ROT90, "Cidelsa", "Altair", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1981, draco,     0,        draco,     draco,    draco_state,   empty_init, ROT90, "Cidelsa", "Draco", MACHINE_IMPERFECT_COLORS | MACHINE_SUPPORTS_SAVE )
+GAME( 1981, altair,    0,        altair,    altair,   cidelsa_state, empty_init, ROT90, "Cidelsa", "Altair",                      MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 198?, altair2,   0,        altair,    altair,   cidelsa_state, empty_init, ROT90, "Cidelsa", "Altair II",                   MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1981, draco,     0,        draco,     draco,    draco_state,   empty_init, ROT90, "Cidelsa", "Draco",                       MACHINE_IMPERFECT_COLORS | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -17427,6 +17427,7 @@ mag_xain
 
 @source:efo/cidelsa.cpp
 altair                          // (c) 1981 Cidelsa
+altair2                         // (c) 198? Cidelsa
 destryer                        // (c) 1981 Cidelsa
 destryera                       // (c) 1981 Cidelsa
 draco                           // (c) 1981 Cidelsa


### PR DESCRIPTION
New working machine
-------------------------
Altair II [Basilio García, Recreativas.org]

Also renamed the difficulty levels on all driver's games from "Conservative" / "Liberal" to standard names. Cidelsa uses standard names, Spanish (fácil / difícil) or English (easy / difficult), on their documents, I have not found a single reference of "Conservative"/ "Liberal".