### PR TITLE
floppy.cpp: Update class variables to the current encouraged naming convention.

### DIFF
--- a/src/devices/bus/thomson/cd90_015.cpp
+++ b/src/devices/bus/thomson/cd90_015.cpp
@@ -61,13 +61,13 @@ ud90_070_device::ud90_070_device(const machine_config &mconfig, const char *tag,
 
 void ud90_070_device::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 40;
-	sides = 1;
-	has_trk00_sensor = false;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 40;
+	m_sides = 1;
+	m_has_trk00_sensor = false;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSSD);
 }
 
 void cd90_015_device::floppy_drives(device_slot_interface &device)

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -244,32 +244,32 @@ floppy_image_device *floppy_connector::get_device()
 floppy_image_device::floppy_image_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, type, tag, owner, clock),
 		device_image_interface(mconfig, *this),
-		input_format(nullptr),
-		output_format(nullptr),
-		image(),
-		index_timer(nullptr),
-		tracks(0),
-		sides(0),
-		form_factor(0),
-		motor_always_on(false),
-		dskchg_writable(false),
-		has_trk00_sensor(true),
-		dir(0), stp(0), wtg(0), mon(0), ss(0), ds(-1), idx(0), wpt(0), rdy(0), dskchg(0),
-		ready(false),
-		rpm(0),
-		angular_speed(0),
-		revolution_count(0),
-		cyl(0),
-		subcyl(0),
-		amplifier_freakout_time(attotime::from_usec(16)),
-		image_dirty(false),
-		track_dirty(false),
-		ready_counter(0),
+		m_input_format(nullptr),
+		m_output_format(nullptr),
+		m_image(),
+		m_index_timer(nullptr),
+		m_tracks(0),
+		m_sides(0),
+		m_form_factor(0),
+		m_motor_always_on(false),
+		m_dskchg_writable(false),
+		m_has_trk00_sensor(true),
+		m_dir(0), m_stp(0), m_wtg(0), m_mon(0), m_ss(0), m_ds(-1), m_idx(0), m_wpt(0), m_rdy(0), m_dskchg(0),
+		m_ready(false),
+		m_rpm(0),
+		m_angular_speed(0),
+		m_revolution_count(0),
+		m_cyl(0),
+		m_subcyl(0),
+		m_amplifier_freakout_time(attotime::from_usec(16)),
+		m_image_dirty(false),
+		m_track_dirty(false),
+		m_ready_counter(0),
 		m_make_sound(false),
 		m_sound_out(nullptr),
 		m_flux_screen(*this, "flux")
 {
-	extension_list[0] = '\0';
+	m_extension_list[0] = '\0';
 }
 
 //-------------------------------------------------
@@ -282,32 +282,32 @@ floppy_image_device::~floppy_image_device()
 
 void floppy_image_device::setup_load_cb(load_cb cb)
 {
-	cur_load_cb = cb;
+	m_cur_load_cb = cb;
 }
 
 void floppy_image_device::setup_unload_cb(unload_cb cb)
 {
-	cur_unload_cb = cb;
+	m_cur_unload_cb = cb;
 }
 
 void floppy_image_device::setup_index_pulse_cb(index_pulse_cb cb)
 {
-	cur_index_pulse_cb = cb;
+	m_cur_index_pulse_cb = cb;
 }
 
 void floppy_image_device::setup_ready_cb(ready_cb cb)
 {
-	cur_ready_cb = cb;
+	m_cur_ready_cb = cb;
 }
 
 void floppy_image_device::setup_wpt_cb(wpt_cb cb)
 {
-	cur_wpt_cb = cb;
+	m_cur_wpt_cb = cb;
 }
 
 void floppy_image_device::setup_led_cb(led_cb cb)
 {
-	cur_led_cb = cb;
+	m_cur_led_cb = cb;
 }
 
 struct floppy_image_device::fs_enum : public fs::manager_t::floppy_enumerator {
@@ -322,7 +322,7 @@ protected:
 };
 
 floppy_image_device::fs_enum::fs_enum(floppy_image_device *fid)
-	: fs::manager_t::floppy_enumerator(fid->form_factor, fid->variants)
+	: fs::manager_t::floppy_enumerator(fid->m_form_factor, fid->m_variants)
 	, m_fid(fid)
 {
 }
@@ -340,15 +340,15 @@ void floppy_image_device::fs_enum::add_raw(const char *name, u32 key, const char
 void floppy_image_device::register_formats()
 {
 	format_registration fr;
-	if(format_registration_cb)
-		format_registration_cb(fr);
+	if(m_format_registration_cb)
+		m_format_registration_cb(fr);
 
-	extension_list[0] = '\0';
-	fif_list = std::move(fr.m_formats);
-	for(const floppy_image_format_t *fif : fif_list)
+	m_extension_list[0] = '\0';
+	m_fif_list = std::move(fr.m_formats);
+	for(const floppy_image_format_t *fif : m_fif_list)
 	{
 		add_format(fif->name(), fif->description(), fif->extensions(), "");
-		image_specify_extension( extension_list, 256, fif->extensions() );
+		image_specify_extension( m_extension_list, 256, fif->extensions() );
 	}
 
 	fs_enum fse(this);
@@ -362,45 +362,45 @@ void floppy_image_device::register_formats()
 
 void floppy_image_device::set_formats(std::function<void (format_registration &fr)> formats)
 {
-	format_registration_cb = formats;
+	m_format_registration_cb = formats;
 }
 
 const std::vector<const floppy_image_format_t *> &floppy_image_device::get_formats() const
 {
-	return fif_list;
+	return m_fif_list;
 }
 
 const floppy_image_format_t *floppy_image_device::get_load_format() const
 {
-	return input_format;
+	return m_input_format;
 }
 
 void floppy_image_device::set_rpm(float _rpm)
 {
-	if(rpm == _rpm)
+	if(m_rpm == _rpm)
 		return;
 
-	rpm = _rpm;
-	rev_time = attotime::from_double(60/rpm);
-	angular_speed = rpm/60.0*2e8;
+	m_rpm = _rpm;
+	m_rev_time = attotime::from_double(60/m_rpm);
+	m_angular_speed = m_rpm/60.0*2e8;
 }
 
 void floppy_image_device::setup_write(const floppy_image_format_t *_output_format)
 {
-	output_format = _output_format;
-	if(image)
+	m_output_format = _output_format;
+	if(m_image)
 		commit_image();
 }
 
 void floppy_image_device::commit_image()
 {
-	if(FLUX_SCREEN && track_dirty) {
-		flux_image_compute_for_track(((cyl << 2) | subcyl) >> (2 - image->get_resolution()), ss);
-		track_dirty = false;
+	if(FLUX_SCREEN && m_track_dirty) {
+		flux_image_compute_for_track(((m_cyl << 2) | m_subcyl) >> (2 - m_image->get_resolution()), m_ss);
+		m_track_dirty = false;
 	}
 
-	image_dirty = false;
-	if(!output_format || !output_format->supports_save())
+	m_image_dirty = false;
+	if(!m_output_format || !m_output_format->supports_save())
 		return;
 
 	check_for_file();
@@ -414,15 +414,15 @@ void floppy_image_device::commit_image()
 	if (err)
 		popmessage("Error, unable to truncate image: %s", err.message());
 
-	output_format->save(*io, variants, *image);
+	m_output_format->save(*io, m_variants, *m_image);
 }
 
 void floppy_image_device::device_config_complete()
 {
-	rpm = 0;
-	motor_always_on = false;
-	dskchg_writable = false;
-	has_trk00_sensor = true;
+	m_rpm = 0;
+	m_motor_always_on = false;
+	m_dskchg_writable = false;
+	m_has_trk00_sensor = true;
 
 	setup_characteristics();
 	register_formats();
@@ -441,57 +441,57 @@ const software_list_loader &floppy_image_device::get_software_list_loader() cons
 void floppy_image_device::device_start()
 {
 	// better would be an extra parameter in the MCFG macro
-	drive_index = atoi(owner()->basetag());
+	m_drive_index = atoi(owner()->basetag());
 
-	idx = 0;
+	m_idx = 0;
 
 	/* motor off */
-	mon = 1;
+	m_mon = 1;
 
-	cyl = 0;
-	subcyl = 0;
-	ss  = 0;
-	actual_ss = 0;
-	ds = -1;
-	stp = 1;
-	wpt = 0;
-	dskchg = exists() ? 1 : 0;
-	index_timer = timer_alloc(FUNC(floppy_image_device::index_resync), this);
-	image_dirty = false;
-	ready = true;
-	ready_counter = 0;
-	phases = 0;
+	m_cyl = 0;
+	m_subcyl = 0;
+	m_ss  = 0;
+	m_actual_ss = 0;
+	m_ds = -1;
+	m_stp = 1;
+	m_wpt = 0;
+	m_dskchg = exists() ? 1 : 0;
+	m_index_timer = timer_alloc(FUNC(floppy_image_device::index_resync), this);
+	m_image_dirty = false;
+	m_ready = true;
+	m_ready_counter = 0;
+	m_phases = 0;
 
 
 	if (m_make_sound) m_sound_out = subdevice<floppy_sound_device>(FLOPSND_TAG);
 
-	save_item(NAME(dir));
-	save_item(NAME(stp));
-	save_item(NAME(wtg));
-	save_item(NAME(mon));
-	save_item(NAME(ss));
-	save_item(NAME(actual_ss));
-	save_item(NAME(ds));
-	save_item(NAME(idx));
-	save_item(NAME(wpt));
-	save_item(NAME(rdy));
-	save_item(NAME(dskchg));
-	save_item(NAME(ready));
-	save_item(NAME(rpm));
-	save_item(NAME(angular_speed));
-	save_item(NAME(revolution_start_time));
-	save_item(NAME(rev_time));
-	save_item(NAME(revolution_count));
-	save_item(NAME(cyl));
-	save_item(NAME(subcyl));
-	save_item(NAME(cache_start_time));
-	save_item(NAME(cache_end_time));
-	save_item(NAME(cache_index));
-	save_item(NAME(cache_entry));
-	save_item(NAME(cache_weak));
-	save_item(NAME(image_dirty));
-	save_item(NAME(ready_counter));
-	save_item(NAME(phases));
+	save_item(NAME(m_dir));
+	save_item(NAME(m_stp));
+	save_item(NAME(m_wtg));
+	save_item(NAME(m_mon));
+	save_item(NAME(m_ss));
+	save_item(NAME(m_actual_ss));
+	save_item(NAME(m_ds));
+	save_item(NAME(m_idx));
+	save_item(NAME(m_wpt));
+	save_item(NAME(m_rdy));
+	save_item(NAME(m_dskchg));
+	save_item(NAME(m_ready));
+	save_item(NAME(m_rpm));
+	save_item(NAME(m_angular_speed));
+	save_item(NAME(m_revolution_start_time));
+	save_item(NAME(m_rev_time));
+	save_item(NAME(m_revolution_count));
+	save_item(NAME(m_cyl));
+	save_item(NAME(m_subcyl));
+	save_item(NAME(m_cache_start_time));
+	save_item(NAME(m_cache_end_time));
+	save_item(NAME(m_cache_index));
+	save_item(NAME(m_cache_entry));
+	save_item(NAME(m_cache_weak));
+	save_item(NAME(m_image_dirty));
+	save_item(NAME(m_ready_counter));
+	save_item(NAME(m_phases));
 
 	if(FLUX_SCREEN) {
 		m_flux_per_pixel_infos.resize(flux_screen_sx*flux_screen_sy);
@@ -525,11 +525,11 @@ void floppy_image_device::device_reset()
 		m_make_sound = m_sound_out->samples_loaded();
 	}
 
-	revolution_start_time = attotime::never;
-	revolution_count = 0;
-	mon = 1;
+	m_revolution_start_time = attotime::never;
+	m_revolution_count = 0;
+	m_mon = 1;
 	set_ready(true);
-	if(motor_always_on && image)
+	if(m_motor_always_on && m_image)
 		mon_w(0);
 	cache_clear();
 }
@@ -548,8 +548,8 @@ std::pair<std::error_condition, const floppy_image_format_t *> floppy_image_devi
 
 	int best = 0;
 	const floppy_image_format_t *best_format = nullptr;
-	for(const floppy_image_format_t *format : fif_list) {
-		int score = format->identify(*io, form_factor, variants);
+	for(const floppy_image_format_t *format : m_fif_list) {
+		int score = format->identify(*io, m_form_factor, m_variants);
 		if(score > best) {
 			best = score;
 			best_format = format;
@@ -562,27 +562,27 @@ std::pair<std::error_condition, const floppy_image_format_t *> floppy_image_devi
 void floppy_image_device::init_floppy_load(bool write_supported)
 {
 	cache_clear();
-	revolution_start_time = mon ? attotime::never : machine().time();
-	revolution_count = 0;
+	m_revolution_start_time = m_mon ? attotime::never : machine().time();
+	m_revolution_count = 0;
 
 	index_resync(0);
 
-	wpt = 1; // disk sleeve is covering the sensor
-	if (!cur_wpt_cb.isnull())
-		cur_wpt_cb(this, wpt);
+	m_wpt = 1; // disk sleeve is covering the sensor
+	if (!m_cur_wpt_cb.isnull())
+		m_cur_wpt_cb(this, m_wpt);
 
-	wpt = is_readonly() || (!write_supported);
-	if (!cur_wpt_cb.isnull())
-		cur_wpt_cb(this, wpt);
+	m_wpt = is_readonly() || (!write_supported);
+	if (!m_cur_wpt_cb.isnull())
+		m_cur_wpt_cb(this, m_wpt);
 
-	if (motor_always_on) {
+	if (m_motor_always_on) {
 		// When disk is inserted, start motor
 		mon_w(0);
-	} else if(!mon)
-		ready_counter = 2;
+	} else if(!m_mon)
+		m_ready_counter = 2;
 
-	if (dskchg_writable)
-		dskchg = 1;
+	if (m_dskchg_writable)
+		m_dskchg = 1;
 }
 
 std::pair<std::error_condition, std::string> floppy_image_device::call_load()
@@ -594,8 +594,8 @@ std::pair<std::error_condition, std::string> floppy_image_device::call_load()
 
 	int best = 0;
 	const floppy_image_format_t *best_format = nullptr;
-	for (const floppy_image_format_t *format : fif_list) {
-		int score = format->identify(*io, form_factor, variants);
+	for (const floppy_image_format_t *format : m_fif_list) {
+		int score = format->identify(*io, m_form_factor, m_variants);
 		if(score && format->extension_matches(filename()))
 			score |= floppy_image_format_t::FIFID_EXT;
 		if(score > best) {
@@ -607,19 +607,19 @@ std::pair<std::error_condition, std::string> floppy_image_device::call_load()
 	if (!best_format)
 		return std::make_pair(image_error::INVALIDIMAGE, "Unable to identify image file format");
 
-	image = std::make_unique<floppy_image>(tracks, sides, form_factor);
-	if (!best_format->load(*io, form_factor, variants, *image)) {
-		image.reset();
+	m_image = std::make_unique<floppy_image>(m_tracks, m_sides, m_form_factor);
+	if (!best_format->load(*io, m_form_factor, m_variants, *m_image)) {
+		m_image.reset();
 		return std::make_pair(image_error::INVALIDIMAGE, "Incompatible image file format or corrupted data");
 	}
-	output_format = is_readonly() ? nullptr : best_format;
+	m_output_format = is_readonly() ? nullptr : best_format;
 
-	image_dirty = false;
+	m_image_dirty = false;
 
-	init_floppy_load(output_format != nullptr);
+	init_floppy_load(m_output_format != nullptr);
 
-	if (!cur_load_cb.isnull())
-		cur_load_cb(this);
+	if (!m_cur_load_cb.isnull())
+		m_cur_load_cb(this);
 
 	flux_image_prepare();
 
@@ -632,8 +632,8 @@ void floppy_image_device::flux_image_prepare()
 		return;
 
 	int tracks = 0, heads = 0, rez = 0;
-	image->get_maximal_geometry(tracks, heads);
-	rez = image->get_resolution();
+	m_image->get_maximal_geometry(tracks, heads);
+	rez = m_image->get_resolution();
 
 	int trackm = (tracks - 1) << rez;
 	int tmask = (1 << rez) - 1;
@@ -673,7 +673,7 @@ void floppy_image_device::flux_image_prepare()
 void floppy_image_device::flux_image_compute_for_track(int track, int head)
 {
 	auto *pcti = m_flux_per_combined_track_infos.data() + track;
-	const std::vector<uint32_t> &buffer = image->get_buffer(pcti->m_track, head, pcti->m_subtrack);
+	const std::vector<uint32_t> &buffer = m_image->get_buffer(pcti->m_track, head, pcti->m_subtrack);
 	int sz = buffer.size();
 	if(!sz) {
 		for(flux_per_pixel_info *p : m_flux_per_combined_track_infos[track].m_pixels[head])
@@ -725,9 +725,9 @@ void floppy_image_device::flux_image_compute_for_track(int track, int head)
 
 uint32_t floppy_image_device::flux_screen_update(screen_device &device, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	if(image.get()) {
-		int ctrack = ((cyl << 2) | subcyl) >> (2 - image->get_resolution());
-		if(mon)
+	if(m_image.get()) {
+		int ctrack = ((m_cyl << 2) | m_subcyl) >> (2 - m_image->get_resolution());
+		if(m_mon)
 			ctrack = -1;
 		for(int y = cliprect.min_y; y <= cliprect.max_y; y++) {
 			int head = y >= flux_screen_sy / 2;
@@ -738,7 +738,7 @@ uint32_t floppy_image_device::flux_screen_update(screen_device &device, bitmap_r
 					*p++ = 0;
 				else {
 					u32 color = 0x010101 * ppi->m_color;
-					if(ppi->m_combined_track == ctrack && head == ss)
+					if(ppi->m_combined_track == ctrack && head == m_ss)
 						color &= 0x0000ff;
 					*p++ = color;
 				}
@@ -765,26 +765,26 @@ uint32_t floppy_image_device::flux_screen_update(screen_device &device, bitmap_r
 void floppy_image_device::call_unload()
 {
 	cache_clear();
-	dskchg = 0;
+	m_dskchg = 0;
 
-	if (image) {
-		if(image_dirty)
+	if (m_image) {
+		if(m_image_dirty)
 			commit_image();
-		image.reset();
+		m_image.reset();
 	}
 
-	wpt = 1; // disk sleeve is covering the sensor
-	if (!cur_wpt_cb.isnull())
-		cur_wpt_cb(this, wpt);
+	m_wpt = 1; // disk sleeve is covering the sensor
+	if (!m_cur_wpt_cb.isnull())
+		m_cur_wpt_cb(this, m_wpt);
 
-	wpt = 0; // sensor is uncovered
-	if (!cur_wpt_cb.isnull())
-		cur_wpt_cb(this, wpt);
+	m_wpt = 0; // sensor is uncovered
+	if (!m_cur_wpt_cb.isnull())
+		m_cur_wpt_cb(this, m_wpt);
 
-	if (!cur_unload_cb.isnull())
-		cur_unload_cb(this);
+	if (!m_cur_unload_cb.isnull())
+		m_cur_unload_cb(this);
 
-	if (motor_always_on) {
+	if (m_motor_always_on) {
 		// When disk is removed, stop motor
 		mon_w(1);
 	}
@@ -794,11 +794,11 @@ void floppy_image_device::call_unload()
 
 std::pair<std::error_condition, std::string> floppy_image_device::call_create(int format_type, util::option_resolution *format_options)
 {
-	image = std::make_unique<floppy_image>(tracks, sides, form_factor);
-	output_format = nullptr;
+	m_image = std::make_unique<floppy_image>(m_tracks, m_sides, m_form_factor);
+	m_output_format = nullptr;
 
 	// search for a suitable format based on the extension
-	for(const floppy_image_format_t *i : fif_list)
+	for(const floppy_image_format_t *i : m_fif_list)
 	{
 		// only consider formats that actually support saving
 		if(!i->supports_save())
@@ -806,13 +806,13 @@ std::pair<std::error_condition, std::string> floppy_image_device::call_create(in
 
 		if (i->extension_matches(basename()))
 		{
-			output_format = i;
+			m_output_format = i;
 			break;
 		}
 
 		// Use MFI as a default.
 		if (!strcmp(i->name(), "mfi"))
-			output_format = i;
+			m_output_format = i;
 	}
 
 	init_floppy_load(true);
@@ -824,7 +824,7 @@ std::pair<std::error_condition, std::string> floppy_image_device::call_create(in
 
 void floppy_image_device::init_fs(const fs_info *fs, const fs::meta_data &meta)
 {
-	assert(image);
+	assert(m_image);
 	if (fs->m_type) {
 		std::vector<u8> img(fs->m_image_size);
 		fs::fsblk_vec_t blockdev(img);
@@ -832,54 +832,54 @@ void floppy_image_device::init_fs(const fs_info *fs, const fs::meta_data &meta)
 		cfs->format(meta);
 
 		auto io = util::ram_read(img.data(), img.size(), 0xff);
-		fs->m_type->load(*io, floppy_image::FF_UNKNOWN, variants, *image);
+		fs->m_type->load(*io, floppy_image::FF_UNKNOWN, m_variants, *m_image);
 	} else {
-		fs::unformatted_image::format(fs->m_key, image.get());
+		fs::unformatted_image::format(fs->m_key, m_image.get());
 	}
 
 	// intializing a file system makes the floppy dirty
-	image_dirty = true;
+	m_image_dirty = true;
 }
 
 /* write protect, active high
    phase 1 can force it to 1 for drive detection
-   on the rare drives that actually use phases.
+   on the rare drives that actually use m_phases.
  */
 bool floppy_image_device::wpt_r()
 {
-	return wpt || (phases & 2);
+	return m_wpt || (m_phases & 2);
 }
 
 /* motor on, active low */
 void floppy_image_device::mon_w(int state)
 {
-	if(mon == state)
+	if(m_mon == state)
 		return;
 
-	mon = state;
+	m_mon = state;
 
 	/* off -> on */
-	if (!mon && image)
+	if (!m_mon && m_image)
 	{
-		revolution_start_time = machine().time();
+		m_revolution_start_time = machine().time();
 		cache_clear();
-		if (motor_always_on) {
+		if (m_motor_always_on) {
 			// Drives with motor that is always spinning are immediately ready when a disk is loaded
 			// because there is no spin-up time
 			set_ready(false);
 		} else {
-			ready_counter = 2;
+			m_ready_counter = 2;
 		}
 		index_resync(0);
 	}
 
 	/* on -> off */
 	else {
-		if(image_dirty)
+		if(m_image_dirty)
 			commit_image();
 		cache_clear();
-		revolution_start_time = attotime::never;
-		index_timer->adjust(attotime::zero);
+		m_revolution_start_time = attotime::never;
+		m_index_timer->adjust(attotime::zero);
 		set_ready(true);
 	}
 
@@ -889,85 +889,85 @@ void floppy_image_device::mon_w(int state)
 
 attotime floppy_image_device::time_next_index()
 {
-	if(revolution_start_time.is_never())
+	if(m_revolution_start_time.is_never())
 		return attotime::never;
-	return revolution_start_time + rev_time;
+	return m_revolution_start_time + m_rev_time;
 }
 
-/* index pulses at rpm/60 Hz, and stays high for ~2ms at 300rpm */
+/* index pulses at m_rpm/60 Hz, and stays high for ~2ms at 300rpm */
 TIMER_CALLBACK_MEMBER(floppy_image_device::index_resync)
 {
-	if(revolution_start_time.is_never()) {
-		if(idx) {
-			idx = 0;
-			if (!cur_index_pulse_cb.isnull())
-				cur_index_pulse_cb(this, idx);
+	if(m_revolution_start_time.is_never()) {
+		if(m_idx) {
+			m_idx = 0;
+			if (!m_cur_index_pulse_cb.isnull())
+				m_cur_index_pulse_cb(this, m_idx);
 		}
 		return;
 	}
 
-	attotime delta = machine().time() - revolution_start_time;
-	while(delta >= rev_time) {
-		delta -= rev_time;
-		revolution_start_time += rev_time;
-		revolution_count++;
+	attotime delta = machine().time() - m_revolution_start_time;
+	while(delta >= m_rev_time) {
+		delta -= m_rev_time;
+		m_revolution_start_time += m_rev_time;
+		m_revolution_count++;
 	}
-	int position = int(delta.as_double()*angular_speed + 0.5);
+	int position = int(delta.as_double()*m_angular_speed + 0.5);
 
 	int new_idx = position < 2000000;
 
 	if(new_idx) {
-		attotime index_up_time = attotime::from_double(2000000/angular_speed);
-		index_timer->adjust(index_up_time - delta);
+		attotime index_up_time = attotime::from_double(2000000/m_angular_speed);
+		m_index_timer->adjust(index_up_time - delta);
 	} else
-		index_timer->adjust(rev_time - delta);
+		m_index_timer->adjust(m_rev_time - delta);
 
-	if(new_idx != idx) {
-		idx = new_idx;
-		if(idx && ready) {
-			ready_counter--;
-			if(!ready_counter) {
+	if(new_idx != m_idx) {
+		m_idx = new_idx;
+		if(m_idx && m_ready) {
+			m_ready_counter--;
+			if(!m_ready_counter) {
 				// logerror("Drive spun up\n");
 				set_ready(false);
 			}
 		}
-		if (!cur_index_pulse_cb.isnull())
-			cur_index_pulse_cb(this, idx);
+		if (!m_cur_index_pulse_cb.isnull())
+			m_cur_index_pulse_cb(this, m_idx);
 	}
 }
 
 bool floppy_image_device::ready_r()
 {
-	return ready;
+	return m_ready;
 }
 
 void floppy_image_device::set_ready(bool state)
 {
-	if (state != ready)
+	if (state != m_ready)
 	{
-		ready = state;
+		m_ready = state;
 		check_led();
-		if (!cur_ready_cb.isnull())
-			cur_ready_cb(this, ready);
+		if (!m_cur_ready_cb.isnull())
+			m_cur_ready_cb(this, m_ready);
 	}
 }
 
 void floppy_image_device::check_led()
 {
-	if(!cur_led_cb.isnull())
-		cur_led_cb(this, (ds == drive_index) && !ready ? 1 : 0);
+	if(!m_cur_led_cb.isnull())
+		m_cur_led_cb(this, (m_ds == m_drive_index) && !m_ready ? 1 : 0);
 }
 
 double floppy_image_device::get_pos()
 {
-	return index_timer->elapsed().as_double();
+	return m_index_timer->elapsed().as_double();
 }
 
 bool floppy_image_device::twosid_r()
 {
 	int tracks = 0, heads = 0;
 
-	if (image) image->get_actual_geometry(tracks, heads);
+	if (m_image) m_image->get_actual_geometry(tracks, heads);
 
 	return heads == 1;
 }
@@ -981,48 +981,48 @@ void floppy_image_device::stp_w(int state)
 	// Before spin-up is done, ignore step pulses
 	// TODO: There are reports about drives supporting step operation with
 	// stopped spindle. Need to check that on real drives.
-	// if (ready_counter > 0) return;
+	// if (m_ready_counter > 0) return;
 
-	if ( stp != state ) {
+	if ( m_stp != state ) {
 		cache_clear();
-		stp = state;
-		if ( stp == 0 ) {
-			if(FLUX_SCREEN && track_dirty) {
-				flux_image_compute_for_track(((cyl << 2) | subcyl) >> (2 - image->get_resolution()), ss);
-				track_dirty = false;
+		m_stp = state;
+		if ( m_stp == 0 ) {
+			if(FLUX_SCREEN && m_track_dirty) {
+				flux_image_compute_for_track(((m_cyl << 2) | m_subcyl) >> (2 - m_image->get_resolution()), m_ss);
+				m_track_dirty = false;
 			}
 
-			int ocyl = cyl;
-			if ( dir ) {
-				if ( cyl ) cyl--;
+			int ocyl = m_cyl;
+			if ( m_dir ) {
+				if ( m_cyl ) m_cyl--;
 			} else {
-				if ( cyl < tracks-1 ) cyl++;
+				if ( m_cyl < m_tracks-1 ) m_cyl++;
 			}
-			if(ocyl != cyl)
+			if(ocyl != m_cyl)
 			{
-				if (TRACE_STEP) logerror("track %d\n", cyl);
+				if (TRACE_STEP) logerror("track %d\n", m_cyl);
 				// Do we want a stepper sound?
 				// We plan for 5 zones with possibly specific sounds
-				if (m_make_sound) m_sound_out->step(cyl*5/tracks);
+				if (m_make_sound) m_sound_out->step(m_cyl*5/m_tracks);
 				track_changed();
 			}
 			/* Update disk detection if applicable */
-			if (exists() && !dskchg_writable)
+			if (exists() && !m_dskchg_writable)
 			{
-				if (dskchg==0) dskchg = 1;
+				if (m_dskchg==0) m_dskchg = 1;
 			}
 		}
-		subcyl = 0;
+		m_subcyl = 0;
 	}
 }
 
 void floppy_image_device::seek_phase_w(int _phases)
 {
-	phases = _phases;
+	m_phases = _phases;
 
-	int cur_pos = (cyl << 2) | subcyl;
+	int cur_pos = (m_cyl << 2) | m_subcyl;
 	int req_pos;
-	switch(phases) {
+	switch(m_phases) {
 	case 0x1: req_pos = 0; break;
 	case 0x3: req_pos = 1; break;
 	case 0x2: req_pos = 2; break;
@@ -1045,28 +1045,28 @@ void floppy_image_device::seek_phase_w(int _phases)
 		next_pos -= 8;
 	if(next_pos < 0)
 		next_pos = 0;
-	else if(next_pos > (tracks-1)*4)
-		next_pos = (tracks-1)*4;
+	else if(next_pos > (m_tracks-1)*4)
+		next_pos = (m_tracks-1)*4;
 
-	if(FLUX_SCREEN && track_dirty) {
-		flux_image_compute_for_track(((cyl << 2) | subcyl) >> (2 - image->get_resolution()), ss);
-		track_dirty = false;
+	if(FLUX_SCREEN && m_track_dirty) {
+		flux_image_compute_for_track(((m_cyl << 2) | m_subcyl) >> (2 - m_image->get_resolution()), m_ss);
+		m_track_dirty = false;
 	}
 
-	cyl = next_pos >> 2;
-	subcyl = next_pos & 3;
+	m_cyl = next_pos >> 2;
+	m_subcyl = next_pos & 3;
 
 	cache_clear();
 
 	if(next_pos != cur_pos) {
-		if (TRACE_STEP) logerror("track %d.%d\n", cyl, subcyl);
-		if (m_make_sound) m_sound_out->step(subcyl);
+		if (TRACE_STEP) logerror("track %d.%d\n", m_cyl, m_subcyl);
+		if (m_make_sound) m_sound_out->step(m_subcyl);
 	}
 
 	/* Update disk detection if applicable */
-	if (exists() && !dskchg_writable)
-		if (dskchg==0)
-			dskchg = 1;
+	if (exists() && !m_dskchg_writable)
+		if (m_dskchg==0)
+			m_dskchg = 1;
 }
 
 // From http://burtleburtle.net/bob/hash/integer.html
@@ -1102,67 +1102,67 @@ int floppy_image_device::find_index(uint32_t position, const std::vector<uint32_
 
 uint32_t floppy_image_device::find_position(attotime &base, const attotime &when)
 {
-	base = revolution_start_time;
+	base = m_revolution_start_time;
 	attotime delta = when - base;
 
-	while(delta >= rev_time) {
-		delta -= rev_time;
-		base += rev_time;
+	while(delta >= m_rev_time) {
+		delta -= m_rev_time;
+		base += m_rev_time;
 	}
 	while(delta < attotime::zero) {
-		delta += rev_time;
-		base -= rev_time;
+		delta += m_rev_time;
+		base -= m_rev_time;
 	}
 
-	uint32_t res = uint32_t(delta.as_double()*angular_speed+0.5);
+	uint32_t res = uint32_t(delta.as_double()*m_angular_speed+0.5);
 	if (res >= 200000000) {
 		// Due to rounding errors in the previous operation,
 		// 'res' sometimes overflows 2E+8
 		res -= 200000000;
-		base += rev_time;
+		base += m_rev_time;
 	}
 	return res;
 }
 
 attotime floppy_image_device::position_to_time(const attotime &base, int position) const
 {
-	return base + attotime::from_double(position/angular_speed);
+	return base + attotime::from_double(position/m_angular_speed);
 }
 
 void floppy_image_device::cache_fill_index(const std::vector<uint32_t> &buf, int &index, attotime &base)
 {
 	int cells = buf.size();
 
-	cache_index = index;
-	cache_start_time = position_to_time(base, buf[index] & floppy_image::TIME_MASK);
-	cache_entry = buf[cache_index];
+	m_cache_index = index;
+	m_cache_start_time = position_to_time(base, buf[index] & floppy_image::TIME_MASK);
+	m_cache_entry = buf[m_cache_index];
 
 	index ++;
 	if(index >= cells) {
 		index = 0;
-		base += rev_time;
+		base += m_rev_time;
 	}
 
-	cache_end_time = position_to_time(base, buf[index] & floppy_image::TIME_MASK);
+	m_cache_end_time = position_to_time(base, buf[index] & floppy_image::TIME_MASK);
 }
 
 void floppy_image_device::cache_clear()
 {
-	cache_start_time = cache_end_time = cache_weak_start = attotime::zero;
-	cache_index = 0;
-	cache_entry = 0;
-	cache_weak = false;
+	m_cache_start_time = m_cache_end_time = m_cache_weak_start = attotime::zero;
+	m_cache_index = 0;
+	m_cache_entry = 0;
+	m_cache_weak = false;
 }
 
 void floppy_image_device::cache_fill(const attotime &when)
 {
-	std::vector<uint32_t> &buf = image->get_buffer(cyl, ss, subcyl);
+	std::vector<uint32_t> &buf = m_image->get_buffer(m_cyl, m_ss, m_subcyl);
 	uint32_t cells = buf.size();
 	if(cells <= 1) {
-		cache_start_time = attotime::zero;
-		cache_end_time = attotime::never;
-		cache_index = 0;
-		cache_entry = cells == 1 ? buf[0] : floppy_image::MG_N;
+		m_cache_start_time = attotime::zero;
+		m_cache_end_time = attotime::never;
+		m_cache_index = 0;
+		m_cache_entry = cells == 1 ? buf[0] : floppy_image::MG_N;
 		cache_weakness_setup();
 		return;
 	}
@@ -1174,17 +1174,17 @@ void floppy_image_device::cache_fill(const attotime &when)
 
 	if(index == -1) {
 		// I suspect this should be an abort(), to check...
-		cache_start_time = attotime::zero;
-		cache_end_time = attotime::never;
-		cache_index = 0;
-		cache_entry = buf[0];
+		m_cache_start_time = attotime::zero;
+		m_cache_end_time = attotime::never;
+		m_cache_index = 0;
+		m_cache_entry = buf[0];
 		cache_weakness_setup();
 		return;
 	}
 
 	for(;;) {
 		cache_fill_index(buf, index, base);
-		if(cache_end_time > when) {
+		if(m_cache_end_time > when) {
 			cache_weakness_setup();
 			return;
 		}
@@ -1193,40 +1193,40 @@ void floppy_image_device::cache_fill(const attotime &when)
 
 void floppy_image_device::cache_weakness_setup()
 {
-	u32 type = cache_entry & floppy_image::MG_MASK;
+	u32 type = m_cache_entry & floppy_image::MG_MASK;
 	if(type == floppy_image::MG_N || type == floppy_image::MG_D) {
-		cache_weak = true;
-		cache_weak_start = cache_start_time;
+		m_cache_weak = true;
+		m_cache_weak_start = m_cache_start_time;
 		return;
 	}
 
-	cache_weak = cache_end_time.is_never() || (cache_end_time - cache_start_time >= amplifier_freakout_time);
-	if(!cache_weak) {
-		cache_weak_start = attotime::never;
+	m_cache_weak = m_cache_end_time.is_never() || (m_cache_end_time - m_cache_start_time >= m_amplifier_freakout_time);
+	if(!m_cache_weak) {
+		m_cache_weak_start = attotime::never;
 		return;
 	}
-	cache_weak_start = cache_start_time + attotime::from_usec(16);
+	m_cache_weak_start = m_cache_start_time + attotime::from_usec(16);
 }
 
 attotime floppy_image_device::get_next_transition(const attotime &from_when)
 {
-	if(!image || mon)
+	if(!m_image || m_mon)
 		return attotime::never;
 
-	if(from_when < cache_start_time || cache_start_time.is_zero() || (!cache_end_time.is_never() && from_when >= cache_end_time))
+	if(from_when < m_cache_start_time || m_cache_start_time.is_zero() || (!m_cache_end_time.is_never() && from_when >= m_cache_end_time))
 		cache_fill(from_when);
 
-	if(!cache_weak)
-		return cache_end_time;
+	if(!m_cache_weak)
+		return m_cache_end_time;
 
 	// Put a flux transition in the middle of a 4us interval with a 50% probability
-	uint64_t interval_index = (from_when < cache_weak_start) ? 0 : (from_when - cache_weak_start).as_ticks(250000);
-	attotime weak_time = cache_weak_start + attotime::from_ticks(interval_index*2+1, 500000);
+	uint64_t interval_index = (from_when < m_cache_weak_start) ? 0 : (from_when - m_cache_weak_start).as_ticks(250000);
+	attotime weak_time = m_cache_weak_start + attotime::from_ticks(interval_index*2+1, 500000);
 	for(;;) {
-		if(weak_time >= cache_end_time)
-			return cache_end_time;
+		if(weak_time >= m_cache_end_time)
+			return m_cache_end_time;
 		if(weak_time > from_when) {
-			u32 test = hash32(hash32(hash32(hash32(revolution_count) ^ 0x4242) + cache_index) + interval_index);
+			u32 test = hash32(hash32(hash32(hash32(m_revolution_count) ^ 0x4242) + m_cache_index) + interval_index);
 			if(test & 1)
 				return weak_time;
 		}
@@ -1239,19 +1239,19 @@ bool floppy_image_device::writing_disabled() const
 {
 	// Disable writing when write protect is on or when, in the diskii
 	// case, phase 1 is 1
-	return wpt || (phases & 2);
+	return m_wpt || (m_phases & 2);
 }
 
 void floppy_image_device::write_flux(const attotime &start, const attotime &end, int transition_count, const attotime *transitions)
 {
-	if(!image || mon)
+	if(!m_image || m_mon)
 		return;
 
 	if(writing_disabled())
 		return;
 
-	image_dirty = true;
-	track_dirty = true;
+	m_image_dirty = true;
+	m_track_dirty = true;
 	cache_clear();
 
 	std::vector<wspan> wspans(1);
@@ -1265,7 +1265,7 @@ void floppy_image_device::write_flux(const attotime &start, const attotime &end,
 
 	wspan_split_on_wrap(wspans);
 
-	std::vector<uint32_t> &buf = image->get_buffer(cyl, ss, subcyl);
+	std::vector<uint32_t> &buf = m_image->get_buffer(m_cyl, m_ss, m_subcyl);
 
 	if(buf.empty()) {
 		buf.push_back(floppy_image::MG_N);
@@ -1400,27 +1400,27 @@ void floppy_image_device::wspan_write(const std::vector<wspan> &wspans, std::vec
 
 void floppy_image_device::set_write_splice(const attotime &when)
 {
-	if(image && !mon) {
-		image_dirty = true;
+	if(m_image && !m_mon) {
+		m_image_dirty = true;
 		attotime base;
 		int splice_pos = find_position(base, when);
-		image->set_write_splice_position(cyl, ss, splice_pos, subcyl);
+		m_image->set_write_splice_position(m_cyl, m_ss, splice_pos, m_subcyl);
 	}
 }
 
 uint32_t floppy_image_device::get_form_factor() const
 {
-	return form_factor;
+	return m_form_factor;
 }
 
 uint32_t floppy_image_device::get_variant() const
 {
-	return image ? image->get_variant() : 0;
+	return m_image ? m_image->get_variant() : 0;
 }
 
 std::vector<uint32_t> &floppy_image_device::get_buffer()
 {
-	return image->get_buffer(cyl, ss, subcyl);
+	return m_image->get_buffer(m_cyl, m_ss, m_subcyl);
 }
 
 //===================================================================
@@ -1697,7 +1697,7 @@ void floppy_sound_device::sound_stream_update(sound_stream &stream, std::vector<
 
 	int16_t out;
 	auto &samplebuffer = outputs[0];
-	int idx = 0;
+	int m_idx = 0;
 	int sampleend = 0;
 
 	for (int sampindex = 0; sampindex < samplebuffer.samples(); sampindex++)
@@ -1707,9 +1707,9 @@ void floppy_sound_device::sound_stream_update(sound_stream &stream, std::vector<
 		// Motor sound
 		if (m_spin_playback_sample != QUIET)
 		{
-			idx = m_spin_playback_sample;
-			sampleend = m_sample[idx].data.size();
-			out = m_sample[idx].data[m_spin_samplepos++];
+			m_idx = m_spin_playback_sample;
+			sampleend = m_sample[m_idx].data.size();
+			out = m_sample[m_idx].data[m_spin_samplepos++];
 
 			if (m_spin_samplepos >= sampleend)
 			{
@@ -1762,10 +1762,10 @@ void floppy_sound_device::sound_stream_update(sound_stream &stream, std::vector<
 		{
 			m_seek_sound_timeout--;
 
-			idx = m_step_base + m_seek_playback_sample;
-			sampleend = m_sample[idx].data.size();
+			m_idx = m_step_base + m_seek_playback_sample;
+			sampleend = m_sample[m_idx].data.size();
 			// Mix it into the stream value
-			out += m_sample[idx].data[(int)m_seek_samplepos];
+			out += m_sample[m_idx].data[(int)m_seek_samplepos];
 			// By adding different values than 1, we can change the playback speed
 			// This will be used to adjust the seek sound
 			m_seek_samplepos += m_seek_pitch;
@@ -1779,11 +1779,11 @@ void floppy_sound_device::sound_stream_update(sound_stream &stream, std::vector<
 			// Stepper sound
 			if (m_step_playback_sample != QUIET)
 			{
-				idx = m_step_base + m_step_playback_sample;
-				sampleend = m_sample[idx].data.size();
+				m_idx = m_step_base + m_step_playback_sample;
+				sampleend = m_sample[m_idx].data.size();
 
 				// Mix it into the stream value
-				out += m_sample[idx].data[m_step_samplepos++];
+				out += m_sample[m_idx].data[m_step_samplepos++];
 				if (m_step_samplepos >= sampleend)
 				{
 					// Step sample done
@@ -1837,12 +1837,12 @@ floppy_3_ssdd::~floppy_3_ssdd()
 
 void floppy_3_ssdd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_3;
-	tracks = 42;
-	sides = 1;
+	m_form_factor = floppy_image::FF_3;
+	m_tracks = 42;
+	m_sides = 1;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSDD);
 }
 
 //-------------------------------------------------
@@ -1860,13 +1860,13 @@ floppy_3_dsdd::~floppy_3_dsdd()
 
 void floppy_3_dsdd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_3;
-	tracks = 42;
-	sides = 2;
+	m_form_factor = floppy_image::FF_3;
+	m_tracks = 42;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
 }
 
 //-------------------------------------------------
@@ -1884,13 +1884,13 @@ floppy_35_ssdd::~floppy_35_ssdd()
 
 void floppy_35_ssdd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 84;
-	sides = 1;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 84;
+	m_sides = 1;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
 }
 
 //-------------------------------------------------
@@ -1908,14 +1908,14 @@ floppy_35_dd::~floppy_35_dd()
 
 void floppy_35_dd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 84;
-	sides = 2;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 84;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
 }
 
 //-------------------------------------------------
@@ -1933,15 +1933,15 @@ floppy_35_hd::~floppy_35_hd()
 
 void floppy_35_hd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 84;
-	sides = 2;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 84;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
-	variants.push_back(floppy_image::DSHD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::DSHD);
 }
 
 //-------------------------------------------------
@@ -1959,16 +1959,16 @@ floppy_35_ed::~floppy_35_ed()
 
 void floppy_35_ed::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 84;
-	sides = 2;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 84;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
-	variants.push_back(floppy_image::DSHD);
-	variants.push_back(floppy_image::DSED);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::DSHD);
+	m_variants.push_back(floppy_image::DSED);
 }
 
 //-------------------------------------------------
@@ -1986,12 +1986,12 @@ floppy_525_sssd_35t::~floppy_525_sssd_35t()
 
 void floppy_525_sssd_35t::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 35;
-	sides = 1;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 35;
+	m_sides = 1;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSSD);
 }
 
 //-------------------------------------------------
@@ -2009,13 +2009,13 @@ floppy_525_sd_35t::~floppy_525_sd_35t()
 
 void floppy_525_sd_35t::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 35;
-	sides = 2;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 35;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::DSSD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::DSSD);
 }
 
 //-------------------------------------------------
@@ -2025,7 +2025,7 @@ void floppy_525_sd_35t::setup_characteristics()
 floppy_525_vtech::floppy_525_vtech(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	floppy_image_device(mconfig, FLOPPY_525_VTECH, tag, owner, clock)
 {
-	amplifier_freakout_time = attotime::from_usec(64);
+	m_amplifier_freakout_time = attotime::from_usec(64);
 }
 
 floppy_525_vtech::~floppy_525_vtech()
@@ -2034,12 +2034,12 @@ floppy_525_vtech::~floppy_525_vtech()
 
 void floppy_525_vtech::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 40;
-	sides = 1;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 40;
+	m_sides = 1;
 	set_rpm(85);
 
-	variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSSD);
 }
 
 //-------------------------------------------------
@@ -2057,12 +2057,12 @@ floppy_525_sssd::~floppy_525_sssd()
 
 void floppy_525_sssd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 42;
-	sides = 1;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 42;
+	m_sides = 1;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSSD);
 }
 
 //-------------------------------------------------
@@ -2080,12 +2080,12 @@ floppy_525_sd::~floppy_525_sd()
 
 void floppy_525_sd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 42;
-	sides = 2;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 42;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSSD);
 }
 
 //-------------------------------------------------
@@ -2103,13 +2103,13 @@ floppy_525_ssdd::~floppy_525_ssdd()
 
 void floppy_525_ssdd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 42;
-	sides = 1;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 42;
+	m_sides = 1;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
 }
 
 //-------------------------------------------------
@@ -2127,14 +2127,14 @@ floppy_525_dd::~floppy_525_dd()
 
 void floppy_525_dd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 42;
-	sides = 2;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 42;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
 }
 
 //-------------------------------------------------
@@ -2152,14 +2152,14 @@ floppy_525_ssqd::~floppy_525_ssqd()
 
 void floppy_525_ssqd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 84;
-	sides = 1;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 84;
+	m_sides = 1;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::SSQD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSQD);
 }
 
 //-------------------------------------------------
@@ -2177,17 +2177,17 @@ floppy_525_qd::~floppy_525_qd()
 
 void floppy_525_qd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 84;
-	sides = 2;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 84;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::SSQD);
-	variants.push_back(floppy_image::DSSD);
-	variants.push_back(floppy_image::DSDD);
-	variants.push_back(floppy_image::DSQD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSQD);
+	m_variants.push_back(floppy_image::DSSD);
+	m_variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::DSQD);
 }
 
 //-------------------------------------------------
@@ -2205,17 +2205,17 @@ floppy_525_hd::~floppy_525_hd()
 
 void floppy_525_hd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 84;
-	sides = 2;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 84;
+	m_sides = 2;
 	set_rpm(360);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::SSQD);
-	variants.push_back(floppy_image::DSDD);
-	variants.push_back(floppy_image::DSQD);
-	variants.push_back(floppy_image::DSHD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSQD);
+	m_variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::DSQD);
+	m_variants.push_back(floppy_image::DSHD);
 }
 
 //-------------------------------------------------
@@ -2233,13 +2233,13 @@ floppy_8_sssd::~floppy_8_sssd()
 
 void floppy_8_sssd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_8;
-	tracks = 77;
-	sides = 1;
-	motor_always_on = true;
+	m_form_factor = floppy_image::FF_8;
+	m_tracks = 77;
+	m_sides = 1;
+	m_motor_always_on = true;
 	set_rpm(360);
 
-	variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSSD);
 }
 
 //-------------------------------------------------
@@ -2257,14 +2257,14 @@ floppy_8_dssd::~floppy_8_dssd()
 
 void floppy_8_dssd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_8;
-	tracks = 77;
-	sides = 2;
-	motor_always_on = true;
+	m_form_factor = floppy_image::FF_8;
+	m_tracks = 77;
+	m_sides = 2;
+	m_motor_always_on = true;
 	set_rpm(360);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::DSSD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::DSSD);
 }
 
 //-------------------------------------------------
@@ -2282,14 +2282,14 @@ floppy_8_ssdd::~floppy_8_ssdd()
 
 void floppy_8_ssdd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_8;
-	tracks = 77;
-	sides = 1;
-	motor_always_on = true;
+	m_form_factor = floppy_image::FF_8;
+	m_tracks = 77;
+	m_sides = 1;
+	m_motor_always_on = true;
 	set_rpm(360);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
 }
 
 //-------------------------------------------------
@@ -2307,15 +2307,15 @@ floppy_8_dsdd::~floppy_8_dsdd()
 
 void floppy_8_dsdd::setup_characteristics()
 {
-	form_factor = floppy_image::FF_8;
-	tracks = 77;
-	sides = 2;
-	motor_always_on = true;
+	m_form_factor = floppy_image::FF_8;
+	m_tracks = 77;
+	m_sides = 2;
+	m_motor_always_on = true;
 	set_rpm(360);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
 }
 
 
@@ -2344,13 +2344,13 @@ epson_smd_165::~epson_smd_165()
 
 void epson_smd_165::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 40;
-	sides = 2;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 40;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::DSSD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::DSSD);
 }
 
 //-------------------------------------------------
@@ -2391,14 +2391,14 @@ epson_sd_320::~epson_sd_320()
 
 void epson_sd_320::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 40;
-	sides = 2;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 40;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
 }
 
 //-------------------------------------------------
@@ -2419,14 +2419,14 @@ epson_sd_321::~epson_sd_321()
 
 void epson_sd_321::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 40;
-	sides = 2;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 40;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
 }
 
 
@@ -2451,15 +2451,15 @@ pana_ju_363::~pana_ju_363()
 
 void pana_ju_363::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 84;
-	sides = 2;
-	dskchg_writable = true;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 84;
+	m_sides = 2;
+	m_dskchg_writable = true;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
 }
 
 //-------------------------------------------------
@@ -2483,14 +2483,14 @@ sony_oa_d31v::~sony_oa_d31v()
 
 void sony_oa_d31v::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 70;
-	sides = 1;
-	dskchg_writable = true;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 70;
+	m_sides = 1;
+	m_dskchg_writable = true;
 	set_rpm(600);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
 }
 
 //-------------------------------------------------
@@ -2515,15 +2515,15 @@ sony_oa_d32w::~sony_oa_d32w()
 
 void sony_oa_d32w::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 80;
-	sides = 2;
-	dskchg_writable = true;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 80;
+	m_sides = 2;
+	m_dskchg_writable = true;
 	set_rpm(600);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
 }
 
 //-------------------------------------------------
@@ -2548,14 +2548,14 @@ sony_oa_d32v::~sony_oa_d32v()
 
 void sony_oa_d32v::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 80;
-	sides = 1;
-	dskchg_writable = true;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 80;
+	m_sides = 1;
+	m_dskchg_writable = true;
 	set_rpm(600);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
 }
 
 //-------------------------------------------------
@@ -2579,12 +2579,12 @@ teac_fd_30a::~teac_fd_30a()
 
 void teac_fd_30a::setup_characteristics()
 {
-	form_factor = floppy_image::FF_3;
-	tracks = 40;
-	sides = 1;
+	m_form_factor = floppy_image::FF_3;
+	m_tracks = 40;
+	m_sides = 1;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSDD);
 }
 
 //-------------------------------------------------
@@ -2608,13 +2608,13 @@ teac_fd_55a::~teac_fd_55a()
 
 void teac_fd_55a::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 40;
-	sides = 1;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 40;
+	m_sides = 1;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
 }
 
 //-------------------------------------------------
@@ -2638,15 +2638,15 @@ teac_fd_55b::~teac_fd_55b()
 
 void teac_fd_55b::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 40;
-	sides = 2;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 40;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSSD);
-	variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSSD);
+	m_variants.push_back(floppy_image::DSDD);
 }
 
 //-------------------------------------------------
@@ -2670,14 +2670,14 @@ teac_fd_55e::~teac_fd_55e()
 
 void teac_fd_55e::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 80;
-	sides = 1;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 80;
+	m_sides = 1;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::SSQD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSQD);
 }
 
 //-------------------------------------------------
@@ -2701,17 +2701,17 @@ teac_fd_55f::~teac_fd_55f()
 
 void teac_fd_55f::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 80;
-	sides = 2;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 80;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::SSQD);
-	variants.push_back(floppy_image::DSSD);
-	variants.push_back(floppy_image::DSDD);
-	variants.push_back(floppy_image::DSQD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSQD);
+	m_variants.push_back(floppy_image::DSSD);
+	m_variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::DSQD);
 }
 
 //-------------------------------------------------
@@ -2735,17 +2735,17 @@ teac_fd_55g::~teac_fd_55g()
 
 void teac_fd_55g::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 77;
-	sides = 2;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 77;
+	m_sides = 2;
 	set_rpm(360);
 
-	variants.push_back(floppy_image::SSSD);
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::SSQD);
-	variants.push_back(floppy_image::DSDD);
-	variants.push_back(floppy_image::DSQD);
-	variants.push_back(floppy_image::DSHD);
+	m_variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSQD);
+	m_variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::DSQD);
+	m_variants.push_back(floppy_image::DSHD);
 }
 
 //-------------------------------------------------
@@ -2765,13 +2765,13 @@ alps_3255190x::~alps_3255190x()
 
 void alps_3255190x::setup_characteristics()
 {
-	form_factor = floppy_image::FF_525;
-	tracks = 84;
-	sides = 1;
+	m_form_factor = floppy_image::FF_525;
+	m_tracks = 84;
+	m_sides = 1;
 	set_rpm(300);
-	cyl = 34;
+	m_cyl = 34;
 
-	variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSSD);
 }
 
 //-------------------------------------------------
@@ -2789,14 +2789,14 @@ ibm_6360::~ibm_6360()
 
 void ibm_6360::setup_characteristics()
 {
-	form_factor = floppy_image::FF_8;
-	tracks = 77;
-	sides = 1;
-	motor_always_on = true;
-	has_trk00_sensor = false;
+	m_form_factor = floppy_image::FF_8;
+	m_tracks = 77;
+	m_sides = 1;
+	m_motor_always_on = true;
+	m_has_trk00_sensor = false;
 	set_rpm(360);
 
-	variants.push_back(floppy_image::SSSD);
+	m_variants.push_back(floppy_image::SSSD);
 }
 
 
@@ -2807,7 +2807,7 @@ void ibm_6360::setup_characteristics()
 mac_floppy_device::mac_floppy_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) : floppy_image_device(mconfig, type, tag, owner, clock)
 {
 	m_has_mfm = false;
-	dskchg_writable = true;
+	m_dskchg_writable = true;
 }
 
 void mac_floppy_device::device_start()
@@ -2835,7 +2835,7 @@ void mac_floppy_device::device_reset()
 
 bool mac_floppy_device::writing_disabled() const
 {
-	return wpt;
+	return m_wpt;
 }
 
 bool mac_floppy_device::wpt_r()
@@ -2847,50 +2847,50 @@ bool mac_floppy_device::wpt_r()
 		"RdData1", "MFMModeOn", "NoReady", "HD"
 	};
 
-	// actual_ss may have changed after the phases were set
-	m_reg = (m_reg & 7) | (actual_ss ? 8 : 0);
+	// m_actual_ss may have changed after the m_phases were set
+	m_reg = (m_reg & 7) | (m_actual_ss ? 8 : 0);
 
 	if(0 && (m_reg != 4 && m_reg != 12 && m_reg != 5 && m_reg != 13))
-		logerror("fdc disk sense reg %x %s %p\n", m_reg, regnames[m_reg], image.get());
+		logerror("fdc disk sense reg %x %s %p\n", m_reg, regnames[m_reg], m_image.get());
 
 	switch(m_reg) {
 	case 0x0: // Step direction
-		return dir;
+		return m_dir;
 
 	case 0x1: // Step signal
 		// We don't do the delay
 		return true;
 
 	case 0x2: // Is the motor on?
-		return mon;
+		return m_mon;
 
 	case 0x3: // Disk change signal
-		return !dskchg;
+		return !m_dskchg;
 
 	case 0x4:
 	case 0xc: // Index pulse, probably only in mfm mode and while writing though
-		return !m_has_mfm ? false : !image || mon ? true : !idx;
+		return !m_has_mfm ? false : !m_image || m_mon ? true : !m_idx;
 
 	case 0x5: // Is it a superdrive (supports 1.4M MFM) ?
 		return m_has_mfm;
 
 	case 0x6: // Is the drive double-sided?
-		return sides == 2;
+		return m_sides == 2;
 
 	case 0x7: // Does the drive exist?
 		return false;
 
 	case 0x8: // Is there a disk in the drive?
-		return image.get() == nullptr;
+		return m_image.get() == nullptr;
 
 	case 0x9: // Is the disk write-protected?
-		return !wpt;
+		return !m_wpt;
 
 	case 0xa: // Not on track 0?
-		return cyl != 0;
+		return m_cyl != 0;
 
 	case 0xb:{// Tachometer, 60 pulses/rotation
-		if(image.get() != nullptr && !mon) {
+		if(m_image.get() != nullptr && !m_mon) {
 			attotime base;
 			uint32_t pos = find_position(base, machine().time());
 			uint32_t subpos = pos % 3333334;
@@ -2903,7 +2903,7 @@ bool mac_floppy_device::wpt_r()
 		return m_mfm;
 
 	case 0xe: // Is the floppy ready?
-		return ready;
+		return m_ready;
 
 	case 0xf: // Does it implement the new interface *or* is the current disk is 1.4M MFM (superdrive only)
 		return is_2m();
@@ -2924,7 +2924,7 @@ void mac_floppy_device::seek_phase_w(int phases)
 
 	bool prev_strb = m_strb;
 
-	m_reg = (phases & 7) | (actual_ss ? 8 : 0);
+	m_reg = (phases & 7) | (m_actual_ss ? 8 : 0);
 	m_strb = (phases >> 3) & 1;
 
 	if(m_strb && !prev_strb) {
@@ -2973,9 +2973,9 @@ void mac_floppy_device::seek_phase_w(int phases)
 			}
 			break;
 
-		case 0xc: // Clear dskchg
-			logerror("cmd clear dskchg\n");
-			dskchg = 1;
+		case 0xc: // Clear m_dskchg
+			logerror("cmd clear m_dskchg\n");
+			m_dskchg = 1;
 			break;
 
 		case 0xd: // GCR mode on
@@ -2998,18 +2998,18 @@ void mac_floppy_device::track_changed()
 	float new_rpm;
 	if(m_mfm)
 		new_rpm = is_2m() ? 600 : 300;
-	else if(cyl <= 15)
+	else if(m_cyl <= 15)
 		new_rpm = 394;
-	else if(cyl <= 31)
+	else if(m_cyl <= 31)
 		new_rpm = 429;
-	else if(cyl <= 47)
+	else if(m_cyl <= 47)
 		new_rpm = 472;
-	else if(cyl <= 63)
+	else if(m_cyl <= 63)
 		new_rpm = 525;
 	else
 		new_rpm = 590;
 
-	if(rpm != new_rpm)
+	if(m_rpm != new_rpm)
 		set_rpm(new_rpm);
 }
 
@@ -3033,12 +3033,12 @@ oa_d34v_device::oa_d34v_device(const machine_config &mconfig, const char *tag, d
 
 void oa_d34v_device::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 80;
-	sides = 1;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 80;
+	m_sides = 1;
 	set_rpm(394);
 
-	variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::SSDD);
 }
 
 bool oa_d34v_device::is_2m() const
@@ -3048,8 +3048,8 @@ bool oa_d34v_device::is_2m() const
 
 void oa_d34v_device::track_changed()
 {
-	// Skip the rpm-setting mac generic version, the single-sided
-	// drive's rpm is externally controlled through a PWM signal.
+	// Skip the m_rpm-setting mac generic version, the single-sided
+	// drive's m_rpm is externally controlled through a PWM signal.
 
 	floppy_image_device::track_changed();
 }
@@ -3059,13 +3059,13 @@ mfd51w_device::mfd51w_device(const machine_config &mconfig, const char *tag, dev
 }
 void mfd51w_device::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 80;
-	sides = 2;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 80;
+	m_sides = 2;
 	set_rpm(394);
 
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
 }
 
 bool mfd51w_device::is_2m() const
@@ -3080,22 +3080,22 @@ mfd75w_device::mfd75w_device(const machine_config &mconfig, const char *tag, dev
 
 void mfd75w_device::setup_characteristics()
 {
-	form_factor = floppy_image::FF_35;
-	tracks = 80;
-	sides = 2;
+	m_form_factor = floppy_image::FF_35;
+	m_tracks = 80;
+	m_sides = 2;
 	set_rpm(300);
 
-	variants.push_back(floppy_image::SSDD);
-	variants.push_back(floppy_image::DSDD);
-	variants.push_back(floppy_image::DSHD);
+	m_variants.push_back(floppy_image::SSDD);
+	m_variants.push_back(floppy_image::DSDD);
+	m_variants.push_back(floppy_image::DSHD);
 }
 
 bool mfd75w_device::is_2m() const
 {
-	if(!image)
+	if(!m_image)
 		return false;
 
-	if(image->get_variant() == floppy_image::SSDD || image->get_variant() == floppy_image::DSDD)
+	if(m_image->get_variant() == floppy_image::SSDD || m_image->get_variant() == floppy_image::DSDD)
 		return true;
 
 	return false;

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -103,7 +103,7 @@ public:
 	virtual bool is_writeable() const noexcept override { return true; }
 	virtual bool is_creatable() const noexcept override { return true; }
 	virtual bool is_reset_on_load() const noexcept override { return false; }
-	virtual const char *file_extensions() const noexcept override { return extension_list; }
+	virtual const char *file_extensions() const noexcept override { return m_extension_list; }
 	virtual const char *image_type_name() const noexcept override { return "floppydisk"; }
 	virtual const char *image_brief_type_name() const noexcept override { return "flop"; }
 	void setup_write(const floppy_image_format_t *output_format);
@@ -116,8 +116,8 @@ public:
 	void setup_led_cb(led_cb cb);
 
 	std::vector<uint32_t> &get_buffer();
-	int get_cyl() const { return cyl; }
-	bool on_track() const { return !subcyl; }
+	int get_cyl() const { return m_cyl; }
+	bool on_track() const { return !m_subcyl; }
 
 	virtual void mon_w(int state);
 	bool ready_r();
@@ -126,28 +126,28 @@ public:
 	virtual void tfsel_w(int state) { }    // 35SEL line for Apple Sony drives
 
 	virtual bool wpt_r(); // Mac sony drives using this for various reporting
-	int dskchg_r() { return dskchg; }
-	bool trk00_r() { return (has_trk00_sensor ? (cyl != 0) : 1); }
-	int idx_r() { return idx; }
-	int mon_r() { return mon; }
-	bool ss_r() { return ss; }
+	int dskchg_r() { return m_dskchg; }
+	bool trk00_r() { return (m_has_trk00_sensor ? (m_cyl != 0) : 1); }
+	int idx_r() { return m_idx; }
+	int mon_r() { return m_mon; }
+	bool ss_r() { return m_ss; }
 	bool twosid_r();
 
 	virtual bool writing_disabled() const;
 
 	virtual void seek_phase_w(int phases);
 	void stp_w(int state);
-	void dir_w(int state) { dir = state; }
-	void ss_w(int state) { actual_ss = state; if (sides > 1) ss = state; }
+	void dir_w(int state) { m_dir = state; }
+	void ss_w(int state) { m_actual_ss = state; if (m_sides > 1) m_ss = state; }
 	void inuse_w(int state) { }
-	void dskchg_w(int state) { if (dskchg_writable) dskchg = state; }
-	void ds_w(int state) { ds = state; check_led(); }
+	void dskchg_w(int state) { if (m_dskchg_writable) m_dskchg = state; }
+	void ds_w(int state) { m_ds = state; check_led(); }
 
 	attotime time_next_index();
 	attotime get_next_transition(const attotime &from_when);
 	void write_flux(const attotime &start, const attotime &end, int transition_count, const attotime *transitions);
 	void set_write_splice(const attotime &when);
-	int get_sides() { return sides; }
+	int get_sides() { return m_sides; }
 	uint32_t get_form_factor() const;
 	uint32_t get_variant() const;
 
@@ -179,68 +179,68 @@ protected:
 
 	void init_floppy_load(bool write_supported);
 
-	std::function<void (format_registration &fr)> format_registration_cb;
-	const floppy_image_format_t *input_format;
-	const floppy_image_format_t *output_format;
-	std::vector<uint32_t> variants;
-	std::unique_ptr<floppy_image> image;
-	char                  extension_list[256];
-	std::vector<const floppy_image_format_t *> fif_list;
+	std::function<void (format_registration &fr)> m_format_registration_cb;
+	const floppy_image_format_t *m_input_format;
+	const floppy_image_format_t *m_output_format;
+	std::vector<uint32_t> m_variants;
+	std::unique_ptr<floppy_image> m_image;
+	char                  m_extension_list[256];
+	std::vector<const floppy_image_format_t *> m_fif_list;
 	std::vector<fs_info>  m_fs;
 	std::vector<const fs::manager_t *> m_fs_managers;
-	emu_timer             *index_timer;
+	emu_timer             *m_index_timer;
 
 	/* Physical characteristics, filled by setup_characteristics */
-	int tracks; /* addressable tracks */
-	int sides;  /* number of heads */
-	uint32_t form_factor; /* 3"5, 5"25, etc */
-	bool motor_always_on;
-	bool dskchg_writable;
-	bool has_trk00_sensor;
+	int m_tracks; /* addressable tracks */
+	int m_sides;  /* number of heads */
+	uint32_t m_form_factor; /* 3"5, 5"25, etc */
+	bool m_motor_always_on;
+	bool m_dskchg_writable;
+	bool m_has_trk00_sensor;
 
-	int drive_index;
+	int m_drive_index;
 
 	/* state of input lines */
-	int dir;  /* direction */
-	int stp;  /* step */
-	int wtg;  /* write gate */
-	int mon;  /* motor on */
-	int ss, actual_ss; /* side select (forced to 0 if single-sided drive / actual value) */
-	int ds; /* drive select */
+	int m_dir;  /* direction */
+	int m_stp;  /* step */
+	int m_wtg;  /* write gate */
+	int m_mon;  /* motor on */
+	int m_ss, m_actual_ss; /* side select (forced to 0 if single-sided drive / actual value) */
+	int m_ds; /* drive select */
 
-	int phases; /* phases lines, when they exist */
+	int m_phases; /* phases lines, when they exist */
 
 	/* state of output lines */
-	int idx;  /* index pulse */
-	int wpt;  /* write protect */
-	int rdy;  /* ready */
-	int dskchg;     /* disk changed */
-	bool ready;
+	int m_idx;  /* index pulse */
+	int m_wpt;  /* write protect */
+	int m_rdy;  /* ready */
+	int m_dskchg;     /* disk changed */
+	bool m_ready;
 
 	/* rotation per minute => gives index pulse frequency */
-	float rpm;
+	float m_rpm;
 	/* angular speed, where a full circle is 2e8 */
-	double angular_speed;
+	double m_angular_speed;
 
-	attotime revolution_start_time, rev_time;
-	uint32_t revolution_count;
-	int cyl, subcyl;
+	attotime m_revolution_start_time, m_rev_time;
+	uint32_t m_revolution_count;
+	int m_cyl, m_subcyl;
 	/* Current floppy zone cache */
-	attotime cache_start_time, cache_end_time, cache_weak_start;
-	attotime amplifier_freakout_time;
-	int cache_index;
-	u32 cache_entry;
-	bool cache_weak;
+	attotime m_cache_start_time, m_cache_end_time, m_cache_weak_start;
+	attotime m_amplifier_freakout_time;
+	int m_cache_index;
+	u32 m_cache_entry;
+	bool m_cache_weak;
 
-	bool image_dirty, track_dirty;
-	int ready_counter;
+	bool m_image_dirty, m_track_dirty;
+	int m_ready_counter;
 
-	load_cb cur_load_cb;
-	unload_cb cur_unload_cb;
-	index_pulse_cb cur_index_pulse_cb;
-	ready_cb cur_ready_cb;
-	wpt_cb cur_wpt_cb;
-	led_cb cur_led_cb;
+	load_cb m_cur_load_cb;
+	unload_cb m_cur_unload_cb;
+	index_pulse_cb m_cur_index_pulse_cb;
+	ready_cb m_cur_ready_cb;
+	wpt_cb m_cur_wpt_cb;
+	led_cb m_cur_led_cb;
 
 
 	// Temporary structure storing a write span


### PR DESCRIPTION
Updated all member variables to be prefixed with `m_`, the existing code had a few with the prefix but most without. This made it more difficult to follow the code.
