### PR TITLE
Nimbus joystick fix

### DIFF
--- a/src/mame/rm/rmnimbus.cpp
+++ b/src/mame/rm/rmnimbus.cpp
@@ -54,6 +54,7 @@ void rmnimbus_state::nimbus_io(address_map &map)
 	map(0x0000, 0x0031).rw(FUNC(rmnimbus_state::nimbus_video_io_r), FUNC(rmnimbus_state::nimbus_video_io_w));
 	map(0x0080, 0x0080).rw(FUNC(rmnimbus_state::nimbus_mcu_r), FUNC(rmnimbus_state::nimbus_mcu_w));
 	map(0x0092, 0x0092).rw(FUNC(rmnimbus_state::nimbus_iou_r), FUNC(rmnimbus_state::nimbus_iou_w));
+	map(0x00a0, 0x00a0).r(FUNC(rmnimbus_state::nimbus_joystick_r));
 	map(0x00a4, 0x00a4).rw(FUNC(rmnimbus_state::nimbus_mouse_js_r), FUNC(rmnimbus_state::nimbus_mouse_js_w));
 	map(0x00c0, 0x00cf).rw(FUNC(rmnimbus_state::nimbus_pc8031_r), FUNC(rmnimbus_state::nimbus_pc8031_w)).umask16(0x00ff);
 	map(0x00e0, 0x00ef).rw(AY8910_TAG, FUNC(ay8910_device::data_r), FUNC(ay8910_device::address_data_w)).umask16(0x00ff);
@@ -66,18 +67,13 @@ void rmnimbus_state::nimbus_io(address_map &map)
 
 
 static INPUT_PORTS_START( nimbus )
-	PORT_START("config")
-	PORT_CONFNAME( 0x01, 0x00, "Input Port 0 Device")
-	PORT_CONFSETTING( 0x00, "Mouse" )
-	PORT_CONFSETTING( 0x01, DEF_STR( Joystick ) )
-
 	PORT_START(JOYSTICK0_TAG)
-	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_JOYSTICK_UP )    PORT_PLAYER(1) PORT_8WAY // XB
-	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN )  PORT_PLAYER(1) PORT_8WAY // XA
-	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT )  PORT_PLAYER(1) PORT_8WAY // YA
-	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(1) PORT_8WAY // YB
-	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(1)
-	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1)
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT )  PORT_PLAYER(1) PORT_8WAY
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(1) PORT_8WAY
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN )  PORT_PLAYER(1) PORT_8WAY
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP )    PORT_PLAYER(1) PORT_8WAY
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER(1)
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(1)
 
 	PORT_START(MOUSE_BUTTON_TAG)  /* Mouse buttons */
 	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_BUTTON2) PORT_NAME("Mouse Button 2") PORT_CODE(MOUSECODE_BUTTON2)

--- a/src/mame/rm/rmnimbus.h
+++ b/src/mame/rm/rmnimbus.h
@@ -75,7 +75,6 @@ public:
 		m_fdc(*this, FDC_TAG),
 		m_z80sio(*this, Z80SIO_TAG),
 		m_screen(*this, "screen"),
-		m_io_config(*this, "config"),
 		m_io_joystick0(*this, JOYSTICK0_TAG),
 		m_io_mouse_button(*this, MOUSE_BUTTON_TAG),
 		m_io_mousex(*this, MOUSEX_TAG),
@@ -103,7 +102,6 @@ private:
 	required_device<wd2793_device> m_fdc;
 	required_device<z80sio_device> m_z80sio;
 	required_device<screen_device> m_screen;
-	required_ioport m_io_config;
 	required_ioport m_io_joystick0;
 	required_ioport m_io_mouse_button;
 	required_ioport m_io_mousex;
@@ -150,6 +148,7 @@ private:
 	void nimbus_rompack_w(offs_t offset, uint8_t data);
 	void nimbus_sound_ay8910_porta_w(uint8_t data);
 	void nimbus_sound_ay8910_portb_w(uint8_t data);
+	uint8_t nimbus_joystick_r();
 	uint8_t nimbus_mouse_js_r();
 	void nimbus_mouse_js_w(uint8_t data);
 	uint16_t nimbus_video_io_r(offs_t offset, uint16_t mem_mask = ~0);


### PR DESCRIPTION
This pull request fixes RM Nimbus joystick emulation by using the correct port address for directional data and setting the correct bits when that address is read.  Currently the mouse data port (0xa4) is used for all joystick data, but only the buttons are actually read from this port.  The joystick port (0xa0) is used for the directional data as described in chapter 2 of of the service manual (https://www.thenimbus.co.uk/upgrades-and-maintenance/service-manual).

This can be demonstrated/tested by running the following RM Basic program which does not work without my change:

```
10 SET MODE 40
20 SET JOYSTICK
30 REPEAT
40   ASK JOYSTICK X%, Y%, Button%
50   POINTS X%, Y%
60 UNTIL Button% = 1
```

I have also removed the "Input Port 0 Device" config port as this is no longer necessary and prevented the mouse buttons from working properly when set to the wrong value (the original code read joystick data when this was to "mouse", and mouse data when it was set to "joystick").  The mouse and joystick can now co-exist quite happily with joystick buttons doubling as mouse buttons and vice versa.

The wrong bits were also being set for each direction and I have of course corrected these to match those given in the service manual.  The above RM Basic program proves that theses are now correct.

The original machine also allowed switching between two joysticks by writing to ports 0xa0 (to select joystick 0) and 0xa2 (to select joystick 1), but I have not implemented this as it seems unnecessary - I have not found any software that makes use of it and I don't think it's possible to test using RM Basic. 

Please let me know if you have any questions! 

