### PR TITLE
igs/goldstar.cpp: Added missing PROM and PLDs for 'hamhouse' [Taksangs]

### DIFF
--- a/src/mame/igs/goldstar.cpp
+++ b/src/mame/igs/goldstar.cpp
@@ -12938,6 +12938,7 @@ ROM_END
    -1 x Jfc 95101
    -3 banks of 8 DIP switches
    -12.000 MHz xtal
+  Video from the real PCB: https://youtu.be/qiSw044Twdc
 */
 ROM_START( hamhouse )
 	ROM_REGION( 0x10000, "maincpu", 0 )
@@ -12949,7 +12950,7 @@ ROM_START( hamhouse )
 	ROM_LOAD( "7_27c256.u43",       0x10000, 0x08000, CRC(31c419f0) SHA1(7c827af5c208bab0ca143558581a57b0b355a3ad) )
 
 	ROM_REGION( 0x08000, "gfx2", 0 )
-	ROM_LOAD( "3_hy27c64ad-15.u24", 0x00000, 0x02000, CRC(7f9c41db) SHA1(64c5fb779ecc05eae3264c7767c571eb76fb389f) )
+	ROM_LOAD( "3_hy27c64ad-15.u24", 0x00000, 0x02000, BAD_DUMP CRC(c13b3fa8) SHA1(8ae6d4bb468a4c1f98c3a059cda6531e3289333d) ) // Bitrotten
 	ROM_LOAD( "4_d27128a.u26",      0x02000, 0x02000, CRC(8cf3845e) SHA1(4f672d256548211c48e60ce89718c3c195f187d5) ) // 1ST AND 2ND HALF IDENTICAL
 	ROM_IGNORE( 0x2000 )
 	ROM_LOAD( "1_27c64-20.u10",     0x04000, 0x02000, CRC(c4efc953) SHA1(da24c802d33be377ad6d6a357ed32d5214ca7a3f) )
@@ -12958,16 +12959,16 @@ ROM_START( hamhouse )
 
 	ROM_REGION( 0x10000, "user1", ROMREGION_ERASE00 )
 
-	ROM_REGION( 0x8200, "proms_base", 0 )
+	ROM_REGION( 0x8400, "proms_base", 0 )
 	// EPROM on a small subboard wired to replace two bipolar PROMS
 	ROM_LOAD( "nm27c256.u55",       0x00000, 0x08000, CRC(f7c7c025) SHA1(f845dc960ed74f64bfff06e3766a1047a26e9de1) )
-	ROM_LOAD( "am27s33pc.u39",      0x08000, 0x00200, NO_DUMP ) // Separated from the other two PROM sockets on the PCB
+	ROM_LOAD( "am27s33pc.u39",      0x08000, 0x00400, CRC(6daaf529) SHA1(b8f81d4467b6b814ec6fc099fbb4f782f736c4f5) ) // Separated from the other two PROM sockets on the PCB
 
 	ROM_REGION( 0x200, "proms", ROMREGION_ERASE00 )
 
 	ROM_REGION( 0x400, "plds", 0 )
-	ROM_LOAD( "atf16v8b.u15",       0x00000, 0x00117, NO_DUMP )
-	ROM_LOAD( "atf16v8b.u35",       0x00200, 0x00117, NO_DUMP )
+	ROM_LOAD( "atf16v8b.u15",       0x00000, 0x00117, CRC(9a62f369) SHA1(c027a7e3dc12506ed45ed936b9f650549651be4f) )
+	ROM_LOAD( "atf16v8b.u35",       0x00200, 0x00117, CRC(a883a133) SHA1(d0b1ee535d60bffdc03a8ce94e6a0274ae6621d5) )
 ROM_END
 
 /*
@@ -20349,7 +20350,7 @@ GAME ( 199?, wcat3a,     wcat3,    chryangl, cmaster,  cmaster_state,  init_wcat
 GAMEL( 199?, ll3,        cmaster,  cm,       cmasterb, cmaster_state,  init_ll3,       ROT0, "bootleg",           "Lucky Line III",                              MACHINE_NOT_WORKING, layout_cmasterb )  // not looked at yet
 GAMEL( 199?, cmfb55,     cmaster,  cmfb55,   cmaster,  cmaster_state,  init_cmfb55,    ROT0, "bootleg",           "Cherry Master (bootleg, Game FB55 Ver.2)",    MACHINE_NOT_WORKING, layout_cmv4 ) // inputs not done
 GAMEL( 1991, srmagic,    cmv4,     cm,       cmv4,     cmaster_state,  empty_init,     ROT0, "bootleg",           "Super Real Magic (V6.3)",                     MACHINE_NOT_WORKING, layout_cmv4 ) // needs correct I/O
-GAMEL( 199?, hamhouse,   cmaster,  cm,       cmaster,  cmaster_state,  init_hamhouse,  ROT0, "bootleg",           "Hamburger House",                             MACHINE_NOT_WORKING, layout_cmaster ) // needs correct I/O
+GAMEL( 199?, hamhouse,   cmaster,  cm,       cmaster,  cmaster_state,  init_hamhouse,  ROT0, "bootleg",           "Hamburger House",                             MACHINE_NOT_WORKING | MACHINE_WRONG_COLORS, layout_cmaster ) // needs correct I/O
 
 GAMEL( 1991, tonypok,    0,        cm,       tonypok,  cmaster_state,  init_tonypok,   ROT0, "Corsica",           "Poker Master (Tony-Poker V3.A, hack?)",       0 ,                layout_tonypok )
 GAME(  1999, jkrmast,    0,        pkrmast,  pkrmast,  goldstar_state, init_jkrmast,   ROT0, "Pick-A-Party USA",  "Joker Master (V515)",                         MACHINE_NOT_WORKING ) // encryption broken, needs GFX and controls

--- a/src/mame/igs/goldstar.cpp
+++ b/src/mame/igs/goldstar.cpp
@@ -20350,7 +20350,7 @@ GAME ( 199?, wcat3a,     wcat3,    chryangl, cmaster,  cmaster_state,  init_wcat
 GAMEL( 199?, ll3,        cmaster,  cm,       cmasterb, cmaster_state,  init_ll3,       ROT0, "bootleg",           "Lucky Line III",                              MACHINE_NOT_WORKING, layout_cmasterb )  // not looked at yet
 GAMEL( 199?, cmfb55,     cmaster,  cmfb55,   cmaster,  cmaster_state,  init_cmfb55,    ROT0, "bootleg",           "Cherry Master (bootleg, Game FB55 Ver.2)",    MACHINE_NOT_WORKING, layout_cmv4 ) // inputs not done
 GAMEL( 1991, srmagic,    cmv4,     cm,       cmv4,     cmaster_state,  empty_init,     ROT0, "bootleg",           "Super Real Magic (V6.3)",                     MACHINE_NOT_WORKING, layout_cmv4 ) // needs correct I/O
-GAMEL( 199?, hamhouse,   cmaster,  cm,       cmaster,  cmaster_state,  init_hamhouse,  ROT0, "bootleg",           "Hamburger House",                             MACHINE_NOT_WORKING | MACHINE_WRONG_COLORS, layout_cmaster ) // needs correct I/O
+GAMEL( 199?, hamhouse,   cmaster,  cm,       cmaster,  cmaster_state,  init_hamhouse,  ROT0, "bootleg",           "Hamburger House",                             MACHINE_NOT_WORKING, layout_cmaster ) // needs correct I/O
 
 GAMEL( 1991, tonypok,    0,        cm,       tonypok,  cmaster_state,  init_tonypok,   ROT0, "Corsica",           "Poker Master (Tony-Poker V3.A, hack?)",       0 ,                layout_tonypok )
 GAME(  1999, jkrmast,    0,        pkrmast,  pkrmast,  goldstar_state, init_jkrmast,   ROT0, "Pick-A-Party USA",  "Joker Master (V515)",                         MACHINE_NOT_WORKING ) // encryption broken, needs GFX and controls


### PR DESCRIPTION
Redumped all the ROMs with a different programmer, and found out that U24 is bitrotten (replaced the current dump with the best one we got, marking it as BAD_DUMP).

Also recorded a video from the real PCB: https://youtu.be/qiSw044Twdc