### PR TITLE
add support for 2nd RM Nimbus joystick

### DIFF
--- a/src/mame/rm/rmnimbus.cpp
+++ b/src/mame/rm/rmnimbus.cpp
@@ -54,7 +54,8 @@ void rmnimbus_state::nimbus_io(address_map &map)
 	map(0x0000, 0x0031).rw(FUNC(rmnimbus_state::nimbus_video_io_r), FUNC(rmnimbus_state::nimbus_video_io_w));
 	map(0x0080, 0x0080).rw(FUNC(rmnimbus_state::nimbus_mcu_r), FUNC(rmnimbus_state::nimbus_mcu_w));
 	map(0x0092, 0x0092).rw(FUNC(rmnimbus_state::nimbus_iou_r), FUNC(rmnimbus_state::nimbus_iou_w));
-	map(0x00a0, 0x00a0).r(FUNC(rmnimbus_state::nimbus_joystick_r));
+	map(0x00a0, 0x00a0).rw(FUNC(rmnimbus_state::nimbus_joystick_r), FUNC(rmnimbus_state::nimbus_select_joystick0));
+	map(0x00a2, 0x00a2).w(FUNC(rmnimbus_state::nimbus_select_joystick1));
 	map(0x00a4, 0x00a4).rw(FUNC(rmnimbus_state::nimbus_mouse_js_r), FUNC(rmnimbus_state::nimbus_mouse_js_w));
 	map(0x00c0, 0x00cf).rw(FUNC(rmnimbus_state::nimbus_pc8031_r), FUNC(rmnimbus_state::nimbus_pc8031_w)).umask16(0x00ff);
 	map(0x00e0, 0x00ef).rw(AY8910_TAG, FUNC(ay8910_device::data_r), FUNC(ay8910_device::address_data_w)).umask16(0x00ff);
@@ -72,8 +73,14 @@ static INPUT_PORTS_START( nimbus )
 	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(1) PORT_8WAY
 	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN )  PORT_PLAYER(1) PORT_8WAY
 	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP )    PORT_PLAYER(1) PORT_8WAY
-	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_PLAYER(1)
 	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(1)
+
+	PORT_START(JOYSTICK1_TAG)
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT )  PORT_PLAYER(2) PORT_8WAY
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_PLAYER(2) PORT_8WAY
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN )  PORT_PLAYER(2) PORT_8WAY
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP )    PORT_PLAYER(2) PORT_8WAY
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_PLAYER(2)
 
 	PORT_START(MOUSE_BUTTON_TAG)  /* Mouse buttons */
 	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_BUTTON2) PORT_NAME("Mouse Button 2") PORT_CODE(MOUSECODE_BUTTON2)

--- a/src/mame/rm/rmnimbus.cpp
+++ b/src/mame/rm/rmnimbus.cpp
@@ -54,8 +54,8 @@ void rmnimbus_state::nimbus_io(address_map &map)
 	map(0x0000, 0x0031).rw(FUNC(rmnimbus_state::nimbus_video_io_r), FUNC(rmnimbus_state::nimbus_video_io_w));
 	map(0x0080, 0x0080).rw(FUNC(rmnimbus_state::nimbus_mcu_r), FUNC(rmnimbus_state::nimbus_mcu_w));
 	map(0x0092, 0x0092).rw(FUNC(rmnimbus_state::nimbus_iou_r), FUNC(rmnimbus_state::nimbus_iou_w));
-	map(0x00a0, 0x00a0).rw(FUNC(rmnimbus_state::nimbus_joystick_r), FUNC(rmnimbus_state::nimbus_select_joystick0));
-	map(0x00a2, 0x00a2).w(FUNC(rmnimbus_state::nimbus_select_joystick1));
+	map(0x00a0, 0x00a0).r(FUNC(rmnimbus_state::nimbus_joystick_r));
+	map(0x00a0, 0x00a3).w(FUNC(rmnimbus_state::nimbus_joystick_select));
 	map(0x00a4, 0x00a4).rw(FUNC(rmnimbus_state::nimbus_mouse_js_r), FUNC(rmnimbus_state::nimbus_mouse_js_w));
 	map(0x00c0, 0x00cf).rw(FUNC(rmnimbus_state::nimbus_pc8031_r), FUNC(rmnimbus_state::nimbus_pc8031_w)).umask16(0x00ff);
 	map(0x00e0, 0x00ef).rw(AY8910_TAG, FUNC(ay8910_device::data_r), FUNC(ay8910_device::address_data_w)).umask16(0x00ff);

--- a/src/mame/rm/rmnimbus.h
+++ b/src/mame/rm/rmnimbus.h
@@ -41,6 +41,7 @@
 /* Mouse / Joystick */
 
 #define JOYSTICK0_TAG           "joystick0"
+#define JOYSTICK1_TAG           "joystick1"
 #define MOUSE_BUTTON_TAG        "mousebtn"
 #define MOUSEX_TAG              "mousex"
 #define MOUSEY_TAG              "mousey"
@@ -76,6 +77,7 @@ public:
 		m_z80sio(*this, Z80SIO_TAG),
 		m_screen(*this, "screen"),
 		m_io_joystick0(*this, JOYSTICK0_TAG),
+		m_io_joystick1(*this, JOYSTICK1_TAG),
 		m_io_mouse_button(*this, MOUSE_BUTTON_TAG),
 		m_io_mousex(*this, MOUSEX_TAG),
 		m_io_mousey(*this, MOUSEY_TAG)
@@ -103,9 +105,11 @@ private:
 	required_device<z80sio_device> m_z80sio;
 	required_device<screen_device> m_screen;
 	required_ioport m_io_joystick0;
+	required_ioport m_io_joystick1;
 	required_ioport m_io_mouse_button;
 	required_ioport m_io_mousex;
 	required_ioport m_io_mousey;
+	ioport_port* m_io_selected_js;
 
 	bitmap_ind16 m_video_mem;
 
@@ -149,6 +153,8 @@ private:
 	void nimbus_sound_ay8910_porta_w(uint8_t data);
 	void nimbus_sound_ay8910_portb_w(uint8_t data);
 	uint8_t nimbus_joystick_r();
+	void nimbus_select_joystick0(uint8_t data);
+	void nimbus_select_joystick1(uint8_t data);
 	uint8_t nimbus_mouse_js_r();
 	void nimbus_mouse_js_w(uint8_t data);
 	uint16_t nimbus_video_io_r(offs_t offset, uint16_t mem_mask = ~0);

--- a/src/mame/rm/rmnimbus.h
+++ b/src/mame/rm/rmnimbus.h
@@ -151,8 +151,7 @@ private:
 	void nimbus_sound_ay8910_porta_w(uint8_t data);
 	void nimbus_sound_ay8910_portb_w(uint8_t data);
 	uint8_t nimbus_joystick_r();
-	void nimbus_select_joystick0(uint8_t data);
-	void nimbus_select_joystick1(uint8_t data);
+	void nimbus_joystick_select(offs_t offset, uint16_t data);
 	uint8_t nimbus_mouse_js_r();
 	void nimbus_mouse_js_w(uint8_t data);
 	uint16_t nimbus_video_io_r(offs_t offset, uint16_t mem_mask = ~0);

--- a/src/mame/rm/rmnimbus.h
+++ b/src/mame/rm/rmnimbus.h
@@ -151,7 +151,7 @@ private:
 	void nimbus_sound_ay8910_porta_w(uint8_t data);
 	void nimbus_sound_ay8910_portb_w(uint8_t data);
 	uint8_t nimbus_joystick_r();
-	void nimbus_joystick_select(offs_t offset, uint16_t data);
+	void nimbus_joystick_select(offs_t offset, uint8_t data);
 	uint8_t nimbus_mouse_js_r();
 	void nimbus_mouse_js_w(uint8_t data);
 	uint16_t nimbus_video_io_r(offs_t offset, uint16_t mem_mask = ~0);

--- a/src/mame/rm/rmnimbus.h
+++ b/src/mame/rm/rmnimbus.h
@@ -40,8 +40,9 @@
 
 /* Mouse / Joystick */
 
-#define JOYSTICK0_TAG           "joystick0"
-#define JOYSTICK1_TAG           "joystick1"
+#define JOYSTICK_TAG_BASE       "joystick"
+#define JOYSTICK0_TAG           JOYSTICK_TAG_BASE "0"
+#define JOYSTICK1_TAG           JOYSTICK_TAG_BASE "1"
 #define MOUSE_BUTTON_TAG        "mousebtn"
 #define MOUSEX_TAG              "mousex"
 #define MOUSEY_TAG              "mousey"
@@ -76,8 +77,7 @@ public:
 		m_fdc(*this, FDC_TAG),
 		m_z80sio(*this, Z80SIO_TAG),
 		m_screen(*this, "screen"),
-		m_io_joystick0(*this, JOYSTICK0_TAG),
-		m_io_joystick1(*this, JOYSTICK1_TAG),
+		m_io_joysticks(*this, JOYSTICK_TAG_BASE "%u", 0),
 		m_io_mouse_button(*this, MOUSE_BUTTON_TAG),
 		m_io_mousex(*this, MOUSEX_TAG),
 		m_io_mousey(*this, MOUSEY_TAG)
@@ -104,12 +104,10 @@ private:
 	required_device<wd2793_device> m_fdc;
 	required_device<z80sio_device> m_z80sio;
 	required_device<screen_device> m_screen;
-	required_ioport m_io_joystick0;
-	required_ioport m_io_joystick1;
+	required_ioport_array<2> m_io_joysticks;
 	required_ioport m_io_mouse_button;
 	required_ioport m_io_mousex;
 	required_ioport m_io_mousey;
-	ioport_port* m_io_selected_js;
 
 	bitmap_ind16 m_video_mem;
 
@@ -227,7 +225,7 @@ private:
 		uint8_t status_out = 0;
 	} m_ipc_interface;
 
-	/* Mouse/Joystick */
+	/* Mouse */
 	struct
 	{
 		uint8_t m_mouse_x = 0;
@@ -243,6 +241,8 @@ private:
 
 		emu_timer *m_mouse_timer = nullptr;
 	} m_nimbus_mouse;
+
+	uint8_t m_selected_js_idx = 0;
 
 	bool m_voice_enabled = false;
 

--- a/src/mame/rm/rmnimbus_m.cpp
+++ b/src/mame/rm/rmnimbus_m.cpp
@@ -1071,15 +1071,15 @@ void rmnimbus_state::mouse_js_reset()
 	// Setup timer to poll the mouse
 	m_nimbus_mouse.m_mouse_timer->adjust(attotime::zero, 0, attotime::from_hz(MOUSE_POLL_FREQUENCY));
 
-	m_io_selected_js = m_io_joystick0.target();
+	m_selected_js_idx = 0;
 }
 
 uint8_t rmnimbus_state::nimbus_joystick_r()
 {
 	/* Only the joystick drection data is read from this port
-	   (which corresponds to the the low nibble of m_io_selected_js).
+	   (which corresponds to the the low nibble of the selected joystick port).
 	   The joystick buttons are read from the mouse data port instead. */
-	uint8_t result = m_io_selected_js->read() & 0x0f;
+	uint8_t result = m_io_joysticks[m_selected_js_idx]->read() & 0x0f;
 
 	if (result & CONTROLLER_RIGHT)
 	{
@@ -1098,12 +1098,12 @@ uint8_t rmnimbus_state::nimbus_joystick_r()
 
 void rmnimbus_state::nimbus_select_joystick0(uint8_t data)
 {
-	m_io_selected_js = m_io_joystick0.target();
+	m_selected_js_idx = 0;
 }
 
 void rmnimbus_state::nimbus_select_joystick1(uint8_t data)
 {
-	m_io_selected_js = m_io_joystick1.target();
+	m_selected_js_idx = 1;
 }
 
 uint8_t rmnimbus_state::nimbus_mouse_js_r()
@@ -1127,8 +1127,8 @@ uint8_t rmnimbus_state::nimbus_mouse_js_r()
 	// set button bits if either mouse or joystick buttons are pressed
 	result |= m_io_mouse_button->read();
 	// NB only the button bits of the joystick(s) are read from this port
-	result |= m_io_joystick0->read() & 0x20;
-	result |= m_io_joystick1->read() & 0x10;
+	result |= m_io_joysticks[0]->read() & 0x20;
+	result |= m_io_joysticks[1]->read() & 0x10;
 
 	return result;
 }

--- a/src/mame/rm/rmnimbus_m.cpp
+++ b/src/mame/rm/rmnimbus_m.cpp
@@ -1070,14 +1070,16 @@ void rmnimbus_state::mouse_js_reset()
 
 	// Setup timer to poll the mouse
 	m_nimbus_mouse.m_mouse_timer->adjust(attotime::zero, 0, attotime::from_hz(MOUSE_POLL_FREQUENCY));
+
+	m_io_selected_js = m_io_joystick0.target();
 }
 
 uint8_t rmnimbus_state::nimbus_joystick_r()
 {
 	/* Only the joystick drection data is read from this port
-	   (which corresponds to the the low nibble of m_io_joystick0).
+	   (which corresponds to the the low nibble of m_io_selected_js).
 	   The joystick buttons are read from the mouse data port instead. */
-	uint8_t result = m_io_joystick0->read() & 0x0f;
+	uint8_t result = m_io_selected_js->read() & 0x0f;
 
 	if (result & CONTROLLER_RIGHT)
 	{
@@ -1094,18 +1096,28 @@ uint8_t rmnimbus_state::nimbus_joystick_r()
 	return result;
 }
 
+void rmnimbus_state::nimbus_select_joystick0(uint8_t data)
+{
+	m_io_selected_js = m_io_joystick0.target();
+}
+
+void rmnimbus_state::nimbus_select_joystick1(uint8_t data)
+{
+	m_io_selected_js = m_io_joystick1.target();
+}
+
 uint8_t rmnimbus_state::nimbus_mouse_js_r()
 {
 	/*
 
 	    bit     description
 
-	    0       JOY 0-Up    or mouse XB
-	    1       JOY 0-Down  or mouse XA
-	    2       JOY 0-Left  or mouse YA
-	    3       JOY 0-Right or mouse YB
-	    4       JOY 0-b0    or mouse rbutton
-	    5       JOY 0-b1    or mouse lbutton
+	    0       mouse XB
+	    1       mouse XA
+	    2       mouse YA
+	    3       mouse YB
+	    4       JOY 1-button or mouse rbutton
+	    5       JOY 0-button or mouse lbutton
 	    6       ?? always reads 1
 	    7       ?? always reads 1
 
@@ -1114,8 +1126,9 @@ uint8_t rmnimbus_state::nimbus_mouse_js_r()
 	
 	// set button bits if either mouse or joystick buttons are pressed
 	result |= m_io_mouse_button->read();
-	// NB only the two button bits of the joystick are read from this port
-	result |= m_io_joystick0->read() & 0x30;
+	// NB only the button bits of the joystick(s) are read from this port
+	result |= m_io_joystick0->read() & 0x20;
+	result |= m_io_joystick1->read() & 0x10;
 
 	return result;
 }

--- a/src/mame/rm/rmnimbus_m.cpp
+++ b/src/mame/rm/rmnimbus_m.cpp
@@ -1096,14 +1096,11 @@ uint8_t rmnimbus_state::nimbus_joystick_r()
 	return result;
 }
 
-void rmnimbus_state::nimbus_select_joystick0(uint8_t data)
+void rmnimbus_state::nimbus_joystick_select(offs_t offset, uint16_t data)
 {
-	m_selected_js_idx = 0;
-}
-
-void rmnimbus_state::nimbus_select_joystick1(uint8_t data)
-{
-	m_selected_js_idx = 1;
+	/* NB joystick 0 is selected by writing to address 0xa0, and
+	   joystick 1 is selected by writing to address 0xa2 */
+	m_selected_js_idx = offset;
 }
 
 uint8_t rmnimbus_state::nimbus_mouse_js_r()

--- a/src/mame/rm/rmnimbus_m.cpp
+++ b/src/mame/rm/rmnimbus_m.cpp
@@ -1096,11 +1096,14 @@ uint8_t rmnimbus_state::nimbus_joystick_r()
 	return result;
 }
 
-void rmnimbus_state::nimbus_joystick_select(offs_t offset, uint16_t data)
+void rmnimbus_state::nimbus_joystick_select(offs_t offset, uint8_t data)
 {
 	/* NB joystick 0 is selected by writing to address 0xa0, and
 	   joystick 1 is selected by writing to address 0xa2 */
-	m_selected_js_idx = offset;
+	if (offset % 2 == 0)
+	{
+		m_selected_js_idx = offset >> 1;
+	}
 }
 
 uint8_t rmnimbus_state::nimbus_mouse_js_r()


### PR DESCRIPTION
This PR adds support for a second joystick on the RM Nimbus.  I decided to do this after discovering the RM Basic demo program that covers joystick support.  It's basically a two player paint program with two brushes (each controlled by a different joystick).  To run the demo start RM Basic and type

```
load "mousedem"
run
```

(then wait until it asks about having a joystick before pressing a key to begin).

Interestingly this demo makes it obvious that each joystick should actually only have one button!  This fits with the description of using an Atari style joystick, given in the service manual, as those joysticks only had one button.  Hence the button data returned via the mouse data port actually relates to the button status of both joysticks.

Questions and comments welcome.

