### PR TITLE
nes.xml: Fixed board name

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -51764,9 +51764,9 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<publisher>CSG Imagesoft</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="sxrom" />
-			<feature name="pcb" value="NES-SLROM" />
+			<feature name="pcb" value="NES-SNEPROM" />
 			<dataarea name="prg" size="131072">
-				<rom name="super sushi pinball (usa) (beta).prg" size="131072" crc="24118960" sha1="4aef1331d11d6ce24c1d5809d1b4d2e5549b28c0" />
+				<rom name="0.prg" size="131072" crc="24118960" sha1="4aef1331d11d6ce24c1d5809d1b4d2e5549b28c0" />
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -51764,7 +51764,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<publisher>CSG Imagesoft</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="sxrom" />
-			<feature name="pcb" value="NES-SNEPROM" />
+			<feature name="pcb" value="NES-SNEPROM-01" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="24118960" sha1="4aef1331d11d6ce24c1d5809d1b4d2e5549b28c0" />
 			</dataarea>


### PR DESCRIPTION
Fixed the board type name of `sspinbal`, which is "NES-SNEPROM-01" as seen in the picture:
![image](https://github.com/mamedev/mame/assets/47050710/91ca6100-df95-4da0-8fd7-553a8ed29578)

Also renamed the dump to "0.prg", following the notes in the softlist:
> When no label was present on the cart pcb, we have arbitrarily chosen the names
>    0.prg and 0.chr (alternatively, 1.prg and 1.chr for later revisions of a game).