### PR TITLE
netronics/exp85.cpp: implemented rom mirroring, fixed interrupt handling timing

### DIFF
--- a/src/mame/netronics/exp85.cpp
+++ b/src/mame/netronics/exp85.cpp
@@ -23,8 +23,8 @@
 	.XS nnnn-F87F mmmm-C000 <CR>
     .G <CR>
 
-	where nnnn is the previous value of the stack point, and mmmm is the previous
-	value of the stack pointer. 
+	where nnnn is the previous value of the stack pointer, and mmmm is the previous
+	value of the program counter. 
 
 	Basic will request the amount of RAM memory available, 8192 (bytes) must be entered.
 


### PR DESCRIPTION
The Netronics Explorer-85 has dedicated circuitry for mirroring the monitor ROM to  low memory (0x0000 -- 0x0800) after a system start/reset and during an interrupt. This logic was reproduced as accurately as possible, since the emulation of the intel 8085 does not have the pin outs needed for implementing the exact logic used in the original circuitry (IO/M, S0, S1 and ALE).
With the mirror switching working, it is possible to execute the MS BASIC ROM (it uses the low memory 8KB of RAM).

 <img src="https://github.com/mamedev/mame/assets/1981459/d230e832-81a4-46e1-ab5a-fb432c4e39d1" alt="Microsoft Basic" width="500"/>

Another non-working feature was the step by step execution capability of the monitor program. This tracer uses a timer to interrupt the executing program once per instruction. In a real system the 8155 timer chip has a delay of around ~70ns (measured). This is enough for the next instruction cycle to start and for the interrupt to be acknowledged one instruction later. This effect is fundamental for the ROM monitor stepping functionality. This is solved with a MAME timer, dealying the 8155 to signal. The stepping mechanism is now working:


 <img src="https://github.com/mamedev/mame/assets/1981459/e44e81d6-7da5-4b54-9cb5-aaeca0314be6" alt="Step by step execution" width="500"/>

