### PR TITLE
bus/a2bus: Added Vista A800 8inch Disk Controller Card

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -2948,6 +2948,8 @@ if (BUSES["A2BUS"]~=null) then
 		MAME_DIR .. "src/devices/bus/a2bus/uniprint.h",
 		MAME_DIR .. "src/devices/bus/a2bus/uthernet.cpp",
 		MAME_DIR .. "src/devices/bus/a2bus/uthernet.h",
+		MAME_DIR .. "src/devices/bus/a2bus/vistaa800.cpp",
+		MAME_DIR .. "src/devices/bus/a2bus/vistaa800.h",
 	}
 end
 

--- a/src/devices/bus/a2bus/cards.cpp
+++ b/src/devices/bus/a2bus/cards.cpp
@@ -71,6 +71,7 @@
 #include "transwarp.h"
 #include "uniprint.h"
 #include "uthernet.h"
+#include "vistaa800.h"
 
 
 void apple2_slot0_cards(device_slot_interface &device)
@@ -149,6 +150,7 @@ void apple2_cards(device_slot_interface &device)
 	device.option_add("q68plus", A2BUS_Q68PLUS);               // Stellation Q68 Plus 68000 card
 	device.option_add("grafex", A2BUS_GRAFEX);                 // Grafex card (uPD7220 graphics)
 	device.option_add("excel9", A2BUS_EXCEL9);                 // Excel-9 (6809 coprocessor)
+	device.option_add("vistaa800", A2BUS_VISTAA800);           // Vista A800 8" Disk Controller Card
 }
 
 void apple2e_cards(device_slot_interface &device)
@@ -228,6 +230,7 @@ void apple2e_cards(device_slot_interface &device)
 	device.option_add("grafex", A2BUS_GRAFEX);                 // Grafex card (uPD7220 graphics)
 	device.option_add("pdromdrive", A2BUS_PRODOSROMDRIVE);     // ProDOS ROM Drive
 	device.option_add("superdrive", A2BUS_SUPERDRIVE);         // Apple II 3.5" Disk Controller
+	device.option_add("vistaa800", A2BUS_VISTAA800);           // Vista A800 8" Disk Controller Card
 }
 
 void apple2gs_cards(device_slot_interface &device)

--- a/src/devices/bus/a2bus/vistaa800.cpp
+++ b/src/devices/bus/a2bus/vistaa800.cpp
@@ -44,20 +44,55 @@
 *********************************************************************/
 
 #include "emu.h"
-#include "imagedev/floppy.h"
 #include "vistaa800.h"
 
-/***************************************************************************
-    PARAMETERS
-***************************************************************************/
+#include "machine/wd_fdc.h"
+#include "imagedev/floppy.h"
 
-//**************************************************************************
-//  GLOBAL VARIABLES
-//**************************************************************************
+namespace {
 
-DEFINE_DEVICE_TYPE(A2BUS_VISTAA800, a2bus_vistaa800_device, "vistaa800", "Vista A800 8inch disk Controller Card")
+class a2bus_vistaa800_device : public device_t, public device_a2bus_card_interface
+{
+public:
+	a2bus_vistaa800_device(machine_config const &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-#define VISTAA800_ROM_REGION  "vistaa800_rom"
+	// device_a2bus_card_interface implementation
+	virtual uint8_t read_c0nx(uint8_t offset) override;
+	virtual void write_c0nx(uint8_t offset, uint8_t data) override;
+	virtual uint8_t read_cnxx(uint8_t offset) override;
+	virtual uint8_t read_c800(uint16_t offset) override;
+
+protected:
+	virtual void device_start() override;
+	virtual void device_reset() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+	virtual const tiny_rom_entry *device_rom_region() const override;
+
+private:
+	static void floppy_formats(format_registration &fr);
+
+    // fdc handlers
+	void fdc_intrq_w(uint8_t state);
+	void fdc_drq_w(uint8_t state);
+	void fdc_sso_w(uint8_t state);
+
+	required_device<fd1797_device> m_fdc;
+	required_device<floppy_connector> m_floppy0;
+	required_device<floppy_connector> m_floppy1;
+	required_device<floppy_connector> m_floppy2;
+	required_device<floppy_connector> m_floppy3;
+	required_region_ptr<uint8_t> m_rom;
+
+	uint16_t m_dmaaddr;
+	bool m_dmaenable_read;
+	bool m_dmaenable_write;
+	uint8_t m_density;
+	uint8_t m_side;
+	uint8_t m_sso;
+
+};
+
+
 
 static void vistaa800_floppies(device_slot_interface &device)
 {
@@ -67,14 +102,32 @@ static void vistaa800_floppies(device_slot_interface &device)
 	device.option_add("8dsdd",  FLOPPY_8_DSDD);       // 77 trks ds dd 8"
 }
 
-ROM_START( vistaa800 )
-	ROM_REGION(0x0800, VISTAA800_ROM_REGION, 0)
+ROM_START(vistaa800)
+	ROM_REGION(0x0800, "vistaa800_rom", 0)
 	ROM_LOAD( "vista a800 boot 3.1.bin", 0x000000, 0x000800, CRC(22df90b8) SHA1(8e0b4f4c6c467e2280bd250ee54f471728640964) )
 ROM_END
 
-//-------------------------------------------------
-//  device_add_mconfig - add device configuration
-//-------------------------------------------------
+
+a2bus_vistaa800_device::a2bus_vistaa800_device(machine_config const &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, A2BUS_VISTAA800, tag, owner, clock),
+	device_a2bus_card_interface(mconfig, *this),
+	m_fdc(*this, "fdc"),
+	m_floppy0(*this, "fdc:0"),
+	m_floppy1(*this, "fdc:1"),
+	m_floppy2(*this, "fdc:2"),
+	m_floppy3(*this, "fdc:3"),
+	m_rom(*this, "vistaa800_rom")
+{
+}
+
+//----------------------------------------------
+//  device_t implementation
+//----------------------------------------------
+
+const tiny_rom_entry *a2bus_vistaa800_device::device_rom_region() const
+{
+	return ROM_NAME(vistaa800);
+}
 
 void a2bus_vistaa800_device::device_add_mconfig(machine_config &config)
 {
@@ -88,40 +141,6 @@ void a2bus_vistaa800_device::device_add_mconfig(machine_config &config)
 	m_fdc->drq_wr_callback().set(FUNC(a2bus_vistaa800_device::fdc_drq_w));
 	m_fdc->sso_wr_callback().set(FUNC(a2bus_vistaa800_device::fdc_sso_w));
 }
-
-//-------------------------------------------------
-//  rom_region - device-specific ROM region
-//-------------------------------------------------
-
-const tiny_rom_entry *a2bus_vistaa800_device::device_rom_region() const
-{
-	return ROM_NAME( vistaa800 );
-}
-
-//**************************************************************************
-//  LIVE DEVICE
-//**************************************************************************
-
-a2bus_vistaa800_device::a2bus_vistaa800_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
-	device_t(mconfig, type, tag, owner, clock),
-	device_a2bus_card_interface(mconfig, *this),
-	m_fdc(*this, "fdc"),
-	m_floppy0(*this, "fdc:0"),
-	m_floppy1(*this, "fdc:1"),
-	m_floppy2(*this, "fdc:2"),
-	m_floppy3(*this, "fdc:3"),
-	m_rom(*this, VISTAA800_ROM_REGION)
-{
-}
-
-a2bus_vistaa800_device::a2bus_vistaa800_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	a2bus_vistaa800_device(mconfig, A2BUS_VISTAA800, tag, owner, clock)
-{
-}
-
-//-------------------------------------------------
-//  device_start - device-specific startup
-//-------------------------------------------------
 
 void a2bus_vistaa800_device::device_start()
 {
@@ -143,9 +162,9 @@ void a2bus_vistaa800_device::device_reset()
 	m_sso = 0;
 }
 
-/*-------------------------------------------------
-    read_c0nx - called for reads from this card's c0nx space
--------------------------------------------------*/
+//----------------------------------------------
+//  device_a2bus_card_interface implementation
+//----------------------------------------------
 
 uint8_t a2bus_vistaa800_device::read_c0nx(uint8_t offset)
 {
@@ -194,11 +213,6 @@ uint8_t a2bus_vistaa800_device::read_c0nx(uint8_t offset)
 	return result;
 }
 
-
-/*-------------------------------------------------
-    write_c0nx - called for writes to this card's c0nx space
--------------------------------------------------*/
-
 void a2bus_vistaa800_device::write_c0nx(uint8_t offset, uint8_t data)
 {
 	floppy_image_device *floppy = nullptr;
@@ -218,28 +232,23 @@ void a2bus_vistaa800_device::write_c0nx(uint8_t offset, uint8_t data)
 			
 		case 8:
 			m_dmaaddr = (m_dmaaddr & 0xff00) + data;
-			//logerror("set dma low address: %04X\n", m_dmaaddr);
 			break;
 
 		case 9:
 			m_dmaaddr = (m_dmaaddr & 0x00ff) + (data << 8);
-			//logerror("set dma high address: %04X\n", m_dmaaddr);
 			break;
 
 		case 0xa:
 			m_dmaenable_read = true;
-			//logerror("dma enable read\n");
 			break;
 
 		case 0xb:
 			m_dmaenable_write = true;
-			//logerror("dma enable write\n");
 			break;
 
 		case 0xc:
 			m_dmaenable_read = false;
 			m_dmaenable_write = false;
-			//logerror("dma enable off\n");
 			break;
 
 		case 0xd:
@@ -267,10 +276,6 @@ void a2bus_vistaa800_device::write_c0nx(uint8_t offset, uint8_t data)
 	}
 }
 
-/*-------------------------------------------------
-    read_cnxx - called for reads from this card's cnxx space
--------------------------------------------------*/
-
 uint8_t a2bus_vistaa800_device::read_cnxx(uint8_t offset)
 {
 	return m_rom[offset];
@@ -281,15 +286,14 @@ uint8_t a2bus_vistaa800_device::read_c800(uint16_t offset)
 	return m_rom[offset];
 }
 
-/*-------------------------------------------------
-    fdc handlers
--------------------------------------------------*/
+//-------------------------------------------------
+//    fdc handlers
+//-------------------------------------------------
 
 void a2bus_vistaa800_device::fdc_intrq_w(uint8_t state)
 {
 	m_dmaenable_read = false;
 	m_dmaenable_write = false;
-	//logerror("dma finished - off\n");
 }
 
 void a2bus_vistaa800_device::fdc_drq_w(uint8_t state)
@@ -316,3 +320,8 @@ void a2bus_vistaa800_device::fdc_sso_w(uint8_t state)
 {
 	m_sso = state; // Todo: needs to be verified on real h/w. This is meant to be from the drive
 }
+
+} // anonymous namespace
+
+
+DEFINE_DEVICE_TYPE_PRIVATE(A2BUS_VISTAA800, device_a2bus_card_interface, a2bus_vistaa800_device, "vistaa800", "Vista A800 8inch disk Controller Card")

--- a/src/devices/bus/a2bus/vistaa800.cpp
+++ b/src/devices/bus/a2bus/vistaa800.cpp
@@ -1,0 +1,318 @@
+// license:BSD-3-Clause
+// copyright-holders:R. Justice
+/*********************************************************************
+
+	vistaa800.c
+
+	Implementation of the Vista A800 8" disk Controller Card for the Apple II
+	
+	This supported up to four double sided/double density 8inch drives.
+	With DMA support for the data transfers, and booting from the first 8inch drive.
+	
+	Manual available here:
+	http://mirrors.apple2.org.za/Apple%20II%20Documentation%20Project/Interface%20Cards/Disk%20Drive%20Controllers/Vista%20A800%20Disk%20Controller/Manuals/Vista%20A800%20Disk%20Controller%20Manual.pdf
+	
+	I/O address details:
+	Addr	Write						Read
+	----	-----						----
+	C0n0	1797 cmd reg				1797 status reg
+	C0n1	1797 track reg				1797 track reg
+	C0n2	1797 sector reg				1797 sector reg
+	C0n3	1797 data reg				1797 data reg
+	C0n4			--same as 0--
+	C0n5			--same as 1--
+	C0n6			--same as 2--
+	C0n7			--same as 3--
+	C0n8	low DMA address				not allowed
+	C0n9	high DMA address			not allowed
+	C0nA	DMA ON:Disk read			(same as write)
+	C0nB	DMA ON:Disk write			(same as write)
+	C0nC	DMA OFF						(same as write)
+
+			bit
+			7    6    5 4  3  2  1  0 
+	C0nD	sngl side x x fd fd fd fd	not allowed
+			dens sel  x x  3  2  1  0
+	C0nE			--spare--
+
+										bit
+										7   6    543210 
+	C0nF	not allowed					DMA one  xxxxxx
+										on  side
+
+
+*********************************************************************/
+
+#include "emu.h"
+#include "imagedev/floppy.h"
+#include "vistaa800.h"
+
+/***************************************************************************
+    PARAMETERS
+***************************************************************************/
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A2BUS_VISTAA800, a2bus_vistaa800_device, "vistaa800", "Vista A800 8inch disk Controller Card")
+
+#define VISTAA800_ROM_REGION  "vistaa800_rom"
+
+static void vistaa800_floppies(device_slot_interface &device)
+{
+	device.option_add("8sssd",  FLOPPY_8_SSSD);       // 77 trks ss sd 8"
+	device.option_add("8dssd",  FLOPPY_8_DSSD);       // 77 trks ds sd 8"
+	device.option_add("8ssdd",  FLOPPY_8_SSDD);       // 77 trks ss dd 8"
+	device.option_add("8dsdd",  FLOPPY_8_DSDD);       // 77 trks ds dd 8"
+}
+
+ROM_START( vistaa800 )
+	ROM_REGION(0x0800, VISTAA800_ROM_REGION, 0)
+	ROM_LOAD( "vista a800 boot 3.1.bin", 0x000000, 0x000800, CRC(22df90b8) SHA1(8e0b4f4c6c467e2280bd250ee54f471728640964) )
+ROM_END
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void a2bus_vistaa800_device::device_add_mconfig(machine_config &config)
+{
+	FD1797(config, m_fdc, 2000000);
+	FLOPPY_CONNECTOR(config, "fdc:0", vistaa800_floppies, "8dsdd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
+	FLOPPY_CONNECTOR(config, "fdc:1", vistaa800_floppies, "8dsdd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
+	FLOPPY_CONNECTOR(config, "fdc:2", vistaa800_floppies, "8dsdd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
+	FLOPPY_CONNECTOR(config, "fdc:3", vistaa800_floppies, "8dsdd", floppy_image_device::default_mfm_floppy_formats).enable_sound(true);
+
+	m_fdc->intrq_wr_callback().set(FUNC(a2bus_vistaa800_device::fdc_intrq_w));
+	m_fdc->drq_wr_callback().set(FUNC(a2bus_vistaa800_device::fdc_drq_w));
+	m_fdc->sso_wr_callback().set(FUNC(a2bus_vistaa800_device::fdc_sso_w));
+}
+
+//-------------------------------------------------
+//  rom_region - device-specific ROM region
+//-------------------------------------------------
+
+const tiny_rom_entry *a2bus_vistaa800_device::device_rom_region() const
+{
+	return ROM_NAME( vistaa800 );
+}
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+a2bus_vistaa800_device::a2bus_vistaa800_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_a2bus_card_interface(mconfig, *this),
+	m_fdc(*this, "fdc"),
+	m_floppy0(*this, "fdc:0"),
+	m_floppy1(*this, "fdc:1"),
+	m_floppy2(*this, "fdc:2"),
+	m_floppy3(*this, "fdc:3"),
+	m_rom(*this, VISTAA800_ROM_REGION)
+{
+}
+
+a2bus_vistaa800_device::a2bus_vistaa800_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	a2bus_vistaa800_device(mconfig, A2BUS_VISTAA800, tag, owner, clock)
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a2bus_vistaa800_device::device_start()
+{
+	save_item(NAME(m_dmaaddr));
+	save_item(NAME(m_dmaenable_read));
+	save_item(NAME(m_dmaenable_write));
+	save_item(NAME(m_density));
+	save_item(NAME(m_side));
+	save_item(NAME(m_sso));
+}
+
+void a2bus_vistaa800_device::device_reset()
+{
+	m_dmaaddr = 0;
+	m_dmaenable_read = false;
+	m_dmaenable_write = false;
+	m_density = 0;
+	m_side = 0;
+	m_sso = 0;
+}
+
+/*-------------------------------------------------
+    read_c0nx - called for reads from this card's c0nx space
+-------------------------------------------------*/
+
+uint8_t a2bus_vistaa800_device::read_c0nx(uint8_t offset)
+{
+	uint8_t result = 0;
+
+	switch (offset)
+	{
+		case 0:
+		case 1:
+		case 2:
+		case 3:
+		case 4:
+		case 5:
+		case 6:
+		case 7:
+			result = m_fdc->fd1797_device::read(offset & 0x03);
+			break;
+			
+		case 0xa:
+			m_dmaenable_read = true;
+			break;
+
+		case 0xb:
+			m_dmaenable_write = true;
+			break;
+
+		case 0xc:
+			m_dmaenable_read = false;
+			m_dmaenable_write = false;
+			break;
+
+		case 0xf:
+			if (m_dmaenable_read || m_dmaenable_write)
+			{
+				result = result | 0x80;
+			}
+
+			result = result | (m_side << 5); // Todo: check this
+			break;
+
+		default:
+			logerror("Read c0n%x (%s)\n", offset, machine().describe_context());
+			break;
+	}
+
+	return result;
+}
+
+
+/*-------------------------------------------------
+    write_c0nx - called for writes to this card's c0nx space
+-------------------------------------------------*/
+
+void a2bus_vistaa800_device::write_c0nx(uint8_t offset, uint8_t data)
+{
+	floppy_image_device *floppy = nullptr;
+
+	switch (offset)
+	{
+		case 0:
+		case 1:
+		case 2:
+		case 3:
+		case 4:
+		case 5:
+		case 6:
+		case 7:
+			m_fdc->fd1797_device::write(offset & 0x03, data);
+			break;
+			
+		case 8:
+			m_dmaaddr = (m_dmaaddr & 0xff00) + data;
+			//logerror("set dma low address: %04X\n", m_dmaaddr);
+			break;
+
+		case 9:
+			m_dmaaddr = (m_dmaaddr & 0x00ff) + (data << 8);
+			//logerror("set dma high address: %04X\n", m_dmaaddr);
+			break;
+
+		case 0xa:
+			m_dmaenable_read = true;
+			//logerror("dma enable read\n");
+			break;
+
+		case 0xb:
+			m_dmaenable_write = true;
+			//logerror("dma enable write\n");
+			break;
+
+		case 0xc:
+			m_dmaenable_read = false;
+			m_dmaenable_write = false;
+			//logerror("dma enable off\n");
+			break;
+
+		case 0xd:
+			m_density = BIT(data, 7);
+			m_fdc->dden_w(m_density);
+
+			m_side = BIT(data, 6);
+			
+			if (BIT(data, 0)) floppy = m_floppy0->get_device();
+			if (BIT(data, 1)) floppy = m_floppy1->get_device();
+			if (BIT(data, 2)) floppy = m_floppy2->get_device();
+			if (BIT(data, 3)) floppy = m_floppy3->get_device();
+			m_fdc->set_floppy(floppy);
+
+			if (floppy)
+			{
+				floppy->ss_w(m_side);
+				floppy->mon_w(0);
+			}
+			break;
+
+		default:
+			logerror("Write %02x to c0n%x (%s)\n", data, offset, machine().describe_context());
+			break;
+	}
+}
+
+/*-------------------------------------------------
+    read_cnxx - called for reads from this card's cnxx space
+-------------------------------------------------*/
+
+uint8_t a2bus_vistaa800_device::read_cnxx(uint8_t offset)
+{
+	return m_rom[offset];
+}
+
+uint8_t a2bus_vistaa800_device::read_c800(uint16_t offset)
+{
+	return m_rom[offset];
+}
+
+/*-------------------------------------------------
+    fdc handlers
+-------------------------------------------------*/
+
+void a2bus_vistaa800_device::fdc_intrq_w(uint8_t state)
+{
+	m_dmaenable_read = false;
+	m_dmaenable_write = false;
+	//logerror("dma finished - off\n");
+}
+
+void a2bus_vistaa800_device::fdc_drq_w(uint8_t state)
+{
+	if (state)
+	{
+		if (m_dmaenable_read) //Todo: verify if both can be turned on at the same time, and which has priority
+		{
+			uint8_t data = m_fdc->data_r();
+			slot_dma_write(m_dmaaddr, data);
+			m_dmaaddr++;
+		}
+
+		if (m_dmaenable_write)
+		{
+			uint8_t data = slot_dma_read(m_dmaaddr);
+			m_fdc->data_w(data);
+			m_dmaaddr++;
+		}
+	}
+}
+
+void a2bus_vistaa800_device::fdc_sso_w(uint8_t state)
+{
+	m_sso = state; // Todo: needs to be verified on real h/w. This is meant to be from the drive
+}

--- a/src/devices/bus/a2bus/vistaa800.h
+++ b/src/devices/bus/a2bus/vistaa800.h
@@ -1,0 +1,75 @@
+// license:BSD-3-Clause
+// copyright-holders:R. Justice
+/*********************************************************************
+
+    vistaa800.h
+
+    Vista A800 8" disk Controller Card
+
+*********************************************************************/
+
+#ifndef MAME_BUS_A2BUS_VISTAA800_H
+#define MAME_BUS_A2BUS_VISTAA800_H
+
+#pragma once
+
+#include "a2bus.h"
+
+#include "machine/wd_fdc.h"
+#include "imagedev/floppy.h"
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+
+class a2bus_vistaa800_device:
+	public device_t,
+	public device_a2bus_card_interface
+{
+public:
+	// construction/destruction
+	a2bus_vistaa800_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	a2bus_vistaa800_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void device_start() override;
+	virtual void device_reset() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+	virtual const tiny_rom_entry *device_rom_region() const override;
+
+	// overrides of standard a2bus slot functions
+	virtual uint8_t read_c0nx(uint8_t offset) override;
+	virtual void write_c0nx(uint8_t offset, uint8_t data) override;
+	virtual uint8_t read_cnxx(uint8_t offset) override;
+	virtual uint8_t read_c800(uint16_t offset) override;
+
+	required_device<fd1797_device> m_fdc;
+	required_device<floppy_connector> m_floppy0;
+	required_device<floppy_connector> m_floppy1;
+	required_device<floppy_connector> m_floppy2;
+	required_device<floppy_connector> m_floppy3;
+	required_region_ptr<u8> m_rom;
+
+private:
+	static void floppy_formats(format_registration &fr);
+
+	void fdc_intrq_w(uint8_t state);
+	void fdc_drq_w(uint8_t state);
+	void fdc_sso_w(uint8_t state);
+	
+	uint16_t m_dmaaddr;
+	bool m_dmaenable_read;
+	bool m_dmaenable_write;
+	uint8_t m_density;
+	uint8_t m_side;
+	uint8_t m_sso;
+
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(A2BUS_VISTAA800, a2bus_vistaa800_device)
+
+#endif  // MAME_BUS_A2BUS_VISTAA800_H

--- a/src/devices/bus/a2bus/vistaa800.h
+++ b/src/devices/bus/a2bus/vistaa800.h
@@ -15,61 +15,6 @@
 
 #include "a2bus.h"
 
-#include "machine/wd_fdc.h"
-#include "imagedev/floppy.h"
-
-
-//**************************************************************************
-//  TYPE DEFINITIONS
-//**************************************************************************
-
-
-class a2bus_vistaa800_device:
-	public device_t,
-	public device_a2bus_card_interface
-{
-public:
-	// construction/destruction
-	a2bus_vistaa800_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-protected:
-	a2bus_vistaa800_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
-
-	virtual void device_start() override;
-	virtual void device_reset() override;
-	virtual void device_add_mconfig(machine_config &config) override;
-	virtual const tiny_rom_entry *device_rom_region() const override;
-
-	// overrides of standard a2bus slot functions
-	virtual uint8_t read_c0nx(uint8_t offset) override;
-	virtual void write_c0nx(uint8_t offset, uint8_t data) override;
-	virtual uint8_t read_cnxx(uint8_t offset) override;
-	virtual uint8_t read_c800(uint16_t offset) override;
-
-	required_device<fd1797_device> m_fdc;
-	required_device<floppy_connector> m_floppy0;
-	required_device<floppy_connector> m_floppy1;
-	required_device<floppy_connector> m_floppy2;
-	required_device<floppy_connector> m_floppy3;
-	required_region_ptr<u8> m_rom;
-
-private:
-	static void floppy_formats(format_registration &fr);
-
-	void fdc_intrq_w(uint8_t state);
-	void fdc_drq_w(uint8_t state);
-	void fdc_sso_w(uint8_t state);
-	
-	uint16_t m_dmaaddr;
-	bool m_dmaenable_read;
-	bool m_dmaenable_write;
-	uint8_t m_density;
-	uint8_t m_side;
-	uint8_t m_sso;
-
-};
-
-// device type definition
-DECLARE_DEVICE_TYPE(A2BUS_VISTAA800, a2bus_vistaa800_device)
+DECLARE_DEVICE_TYPE(A2BUS_VISTAA800, device_a2bus_card_interface)
 
 #endif  // MAME_BUS_A2BUS_VISTAA800_H


### PR DESCRIPTION
Added support for the Vista A800 8" disk controller card. 

I picked up a non working one of these cards, so wanted to understand it better. I was able to use the Vista A800 disks and rom available on the Apple2 documentation project and then format and boot DOS 3.3 and CPM ok from the 8 inch disks.