### PR TITLE
heathkit/h89.cpp: Add H-88-5 Cassette interface and the H88 clone of H89

### DIFF
--- a/src/mame/heathkit/h89.cpp
+++ b/src/mame/heathkit/h89.cpp
@@ -367,8 +367,11 @@ static INPUT_PORTS_START( h88 )
 
 	PORT_START("SW501")
 	// MTR-88  (444-40)
-	PORT_DIPNAME( 0x1f, 0x00, DEF_STR( Unused ) )               PORT_DIPLOCATION("SW501:1,2,3,4,5")
-	PORT_DIPSETTING( 0x00, "Undefined" )
+	PORT_DIPUNUSED_DIPLOC(0x01, 0x00, "SW501:1")
+	PORT_DIPUNUSED_DIPLOC(0x02, 0x00, "SW501:2")
+	PORT_DIPUNUSED_DIPLOC(0x04, 0x00, "SW501:3")
+	PORT_DIPUNUSED_DIPLOC(0x08, 0x00, "SW501:4")
+	PORT_DIPUNUSED_DIPLOC(0x10, 0x00, "SW501:5")
 	PORT_DIPNAME( 0x20, 0x20, "Perform memory test at start" )  PORT_DIPLOCATION("SW501:6")
 	PORT_DIPSETTING( 0x20, DEF_STR( No ) )
 	PORT_DIPSETTING( 0x00, DEF_STR( Yes ) )
@@ -811,8 +814,8 @@ void h88_state::h88(machine_config &config)
 	h89_base_state::h89_base(config);
 	m_maincpu->set_io_map(&h88_state::h88_io);
 
-	subdevice<heath_intr_socket>("intr_socket")->set_default_option("original");
-	subdevice<heath_intr_socket>("intr_socket")->set_fixed(true);
+	m_intr_socket->set_default_option("original");
+	m_intr_socket->set_fixed(true);
 
 	// H-88-5 Cassette interface board
 	HEATH_H88_CASS(config, m_cassette, H89_CLOCK);
@@ -823,8 +826,8 @@ void h89_state::h89(machine_config &config)
 	h89_base_state::h89_base(config);
 	m_maincpu->set_io_map(&h89_state::h89_io);
 
-	subdevice<heath_intr_socket>("intr_socket")->set_default_option("h37");
-	subdevice<heath_intr_socket>("intr_socket")->set_fixed(true);
+	m_intr_socket->set_default_option("h37");
+	m_intr_socket->set_fixed(true);
 
 	// Z-89-37 Soft-sectored controller
 	HEATH_Z37_FDC(config, m_h37);

--- a/src/mame/heathkit/h_88_cass.cpp
+++ b/src/mame/heathkit/h_88_cass.cpp
@@ -1,0 +1,166 @@
+// license:BSD-3-Clause
+// copyright-holders:Mark Garlanger
+/***************************************************************************
+
+  Heathkit H-17 Floppy controller
+
+    This was an option for both the Heathkit H8 and H89 computer systems.
+
+****************************************************************************/
+
+#include "emu.h"
+
+#include "h_88_cass.h"
+
+#include "machine/clock.h"
+
+#include "speaker.h"
+
+#define LOG_REG   (1U << 0)
+#define LOG_LINES (1U << 1)
+#define LOG_CASS  (1U << 2)
+#define LOG_FUNC  (1U << 3)
+//#define VERBOSE (0xff)
+
+#include "logmacro.h"
+
+#define LOGREG(...)        LOGMASKED(LOG_REG, __VA_ARGS__)
+#define LOGLINES(...)      LOGMASKED(LOG_LINES, __VA_ARGS__)
+#define LOGCASS(...)       LOGMASKED(LOG_CASS,    __VA_ARGS__)
+#define LOGFUNC(...)       LOGMASKED(LOG_FUNC, __VA_ARGS__)
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+DEFINE_DEVICE_TYPE(HEATH_H88_CASS, heath_h_88_cass_device, "heath_h_88_cass_device", "Heath H-88-5 Cassette Interface");
+
+heath_h_88_cass_device::heath_h_88_cass_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock):
+	device_t(mconfig, HEATH_H88_CASS, tag, owner, 0),
+	m_uart(*this, "uart"),
+	m_cass_player(*this, "cassette_player"),
+	m_cass_recorder(*this, "cassette_recorder")
+{
+}
+
+
+void heath_h_88_cass_device::write(offs_t reg, u8 val)
+{
+	LOGREG("%s: reg: %d val: 0x%02x\n", FUNCNAME, reg, val);
+
+	m_uart->write(reg, val);
+}
+
+u8 heath_h_88_cass_device::read(offs_t reg)
+{
+	u8 val = m_uart->read(reg);
+
+	LOGREG("%s: reg: %d val: 0x%02x\n", FUNCNAME, reg, val);
+
+	return val;
+}
+
+
+TIMER_DEVICE_CALLBACK_MEMBER(heath_h_88_cass_device::kansas_w)
+{
+	m_cass_data[3]++;
+
+	if (m_cassbit != m_cassold)
+	{
+		LOGCASS("kansas_w: m_cassbit changed : %d\n", m_cassbit);
+		m_cass_data[3] = 0;
+		m_cassold = m_cassbit;
+	}
+
+	LOGCASS("kansas_w: m_cassbit: %d\n", m_cassbit);
+	// 2400Hz -> 0
+	// 1200Hz -> 1
+	const int bit_pos = m_cassbit ? 0 : 1;
+
+	m_cass_recorder->output(BIT(m_cass_data[3], bit_pos) ? -1.0 : +1.0);
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(heath_h_88_cass_device::kansas_r)
+{
+	/* cassette - turn 1200/2400Hz to a bit */
+	m_cass_data[1]++;
+	u8 cass_ws = (m_cass_player->input() > +0.03) ? 1 : 0;
+
+	LOGCASS("kansas_r: cass_ws: %d\n", cass_ws);
+
+	if (cass_ws != m_cass_data[0])
+	{
+		LOGCASS("kansas_r: cass_ws has changed value\n");
+		m_cass_data[0] = cass_ws;
+		m_uart->write_rxd((m_cass_data[1] < 12) ? 1 : 0);
+		m_cass_data[1] = 0;
+	}
+}
+
+void heath_h_88_cass_device::uart_rts(u8 data)
+{
+	LOGLINES("%s: data: %d\n", FUNCNAME, data);
+
+	m_cass_player->change_state(bool(data) ? CASSETTE_STOPPED : CASSETTE_PLAY, CASSETTE_MASK_UISTATE);
+}
+
+void heath_h_88_cass_device::uart_tx_empty(u8 data)
+{
+	LOGLINES("%s: data: %d\n", FUNCNAME, data);
+
+	m_cass_recorder->change_state(bool(data) ? CASSETTE_STOPPED : CASSETTE_RECORD, CASSETTE_MASK_UISTATE);
+}
+
+void heath_h_88_cass_device::device_start()
+{
+	save_item(NAME(m_cass_data));
+	save_item(NAME(m_cassbit));
+	save_item(NAME(m_cassold));
+}
+
+void heath_h_88_cass_device::device_reset()
+{
+	LOGFUNC("%s\n", FUNCNAME);
+
+	// cassette
+	m_cassbit = 1;
+	m_cassold = 0;
+	m_cass_data[0] = 0;
+	m_cass_data[1] = 0;
+	m_cass_data[3] = 0;
+
+	m_uart->write_cts(0);
+	m_uart->write_dsr(0);
+	m_uart->write_rxd(0);
+}
+
+void heath_h_88_cass_device::device_add_mconfig(machine_config &config)
+{
+	I8251(config, m_uart, 0);
+	m_uart->txd_handler().set([this] (bool state) { m_cassbit = state; });
+	m_uart->rts_handler().set(FUNC(heath_h_88_cass_device::uart_rts));
+	m_uart->txempty_handler().set(FUNC(heath_h_88_cass_device::uart_tx_empty));
+
+	clock_device &cassette_clock(CLOCK(config, "cassette_clock", 4800));
+	cassette_clock.signal_handler().set(m_uart, FUNC(i8251_device::write_txc));
+	cassette_clock.signal_handler().append(m_uart, FUNC(i8251_device::write_rxc));
+
+	SPEAKER(config, "mono").front_right();
+
+	CASSETTE(config, m_cass_player);
+	m_cass_player->set_formats(h8_cassette_formats);
+	m_cass_player->set_default_state(CASSETTE_STOPPED | CASSETTE_MOTOR_ENABLED | CASSETTE_SPEAKER_ENABLED);
+	m_cass_player->add_route(ALL_OUTPUTS, "mono", 0.15);
+	m_cass_player->set_interface("h89_cass_player");
+
+	CASSETTE(config, m_cass_recorder);
+	m_cass_recorder->set_formats(h8_cassette_formats);
+	m_cass_recorder->set_default_state(CASSETTE_STOPPED | CASSETTE_MOTOR_ENABLED | CASSETTE_SPEAKER_ENABLED);
+	m_cass_recorder->add_route(ALL_OUTPUTS, "mono", 0.15);
+	m_cass_recorder->set_interface("h89_cass_recorder");
+
+	TIMER(config, "kansas_w").configure_periodic(FUNC(heath_h_88_cass_device::kansas_w), attotime::from_hz(4800));
+	TIMER(config, "kansas_r").configure_periodic(FUNC(heath_h_88_cass_device::kansas_r), attotime::from_hz(40000));
+}

--- a/src/mame/heathkit/h_88_cass.cpp
+++ b/src/mame/heathkit/h_88_cass.cpp
@@ -16,17 +16,17 @@
 
 #include "speaker.h"
 
-#define LOG_REG   (1U << 0)
-#define LOG_LINES (1U << 1)
-#define LOG_CASS  (1U << 2)
-#define LOG_FUNC  (1U << 3)
+#define LOG_REG   (1U << 1)
+#define LOG_LINES (1U << 2)
+#define LOG_CASS  (1U << 3)
+#define LOG_FUNC  (1U << 4)
 //#define VERBOSE (0xff)
 
 #include "logmacro.h"
 
 #define LOGREG(...)        LOGMASKED(LOG_REG, __VA_ARGS__)
 #define LOGLINES(...)      LOGMASKED(LOG_LINES, __VA_ARGS__)
-#define LOGCASS(...)       LOGMASKED(LOG_CASS,    __VA_ARGS__)
+#define LOGCASS(...)       LOGMASKED(LOG_CASS, __VA_ARGS__)
 #define LOGFUNC(...)       LOGMASKED(LOG_FUNC, __VA_ARGS__)
 
 #ifdef _MSC_VER
@@ -84,7 +84,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(heath_h_88_cass_device::kansas_w)
 
 TIMER_DEVICE_CALLBACK_MEMBER(heath_h_88_cass_device::kansas_r)
 {
-	/* cassette - turn 1200/2400Hz to a bit */
+	// cassette - turn 1200/2400Hz to a bit
 	m_cass_data[1]++;
 	u8 cass_ws = (m_cass_player->input() > +0.03) ? 1 : 0;
 
@@ -129,6 +129,7 @@ void heath_h_88_cass_device::device_reset()
 	m_cassold = 0;
 	m_cass_data[0] = 0;
 	m_cass_data[1] = 0;
+	m_cass_data[2] = 0;
 	m_cass_data[3] = 0;
 
 	m_uart->write_cts(0);

--- a/src/mame/heathkit/h_88_cass.cpp
+++ b/src/mame/heathkit/h_88_cass.cpp
@@ -2,9 +2,10 @@
 // copyright-holders:Mark Garlanger
 /***************************************************************************
 
-  Heathkit H-17 Floppy controller
+  Heathkit H-88-5 Cassette Interface Card
 
-    This was an option for both the Heathkit H8 and H89 computer systems.
+    Came standard on the H88 computer and was on option for other H89 class
+    systems.
 
 ****************************************************************************/
 
@@ -45,7 +46,6 @@ heath_h_88_cass_device::heath_h_88_cass_device(const machine_config &mconfig, co
 {
 }
 
-
 void heath_h_88_cass_device::write(offs_t reg, u8 val)
 {
 	LOGREG("%s: reg: %d val: 0x%02x\n", FUNCNAME, reg, val);
@@ -62,19 +62,18 @@ u8 heath_h_88_cass_device::read(offs_t reg)
 	return val;
 }
 
-
 TIMER_DEVICE_CALLBACK_MEMBER(heath_h_88_cass_device::kansas_w)
 {
 	m_cass_data[3]++;
 
 	if (m_cassbit != m_cassold)
 	{
-		LOGCASS("kansas_w: m_cassbit changed : %d\n", m_cassbit);
+		LOGCASS("%s: m_cassbit changed : %d\n", FUNCNAME, m_cassbit);
 		m_cass_data[3] = 0;
 		m_cassold = m_cassbit;
 	}
 
-	LOGCASS("kansas_w: m_cassbit: %d\n", m_cassbit);
+	LOGCASS("%s: m_cassbit: %d\n", FUNCNAME, m_cassbit);
 	// 2400Hz -> 0
 	// 1200Hz -> 1
 	const int bit_pos = m_cassbit ? 0 : 1;
@@ -88,11 +87,11 @@ TIMER_DEVICE_CALLBACK_MEMBER(heath_h_88_cass_device::kansas_r)
 	m_cass_data[1]++;
 	u8 cass_ws = (m_cass_player->input() > +0.03) ? 1 : 0;
 
-	LOGCASS("kansas_r: cass_ws: %d\n", cass_ws);
+	LOGCASS("%s: cass_ws: %d\n", FUNCNAME, cass_ws);
 
 	if (cass_ws != m_cass_data[0])
 	{
-		LOGCASS("kansas_r: cass_ws has changed value\n");
+		LOGCASS("%s: cass_ws has changed value\n", FUNCNAME);
 		m_cass_data[0] = cass_ws;
 		m_uart->write_rxd((m_cass_data[1] < 12) ? 1 : 0);
 		m_cass_data[1] = 0;

--- a/src/mame/heathkit/h_88_cass.h
+++ b/src/mame/heathkit/h_88_cass.h
@@ -1,0 +1,53 @@
+// license:BSD-3-Clause
+// copyright-holders:Mark Garlanger
+/***************************************************************************
+
+  Heathkit H-88-5 Cassette Interface card
+
+****************************************************************************/
+
+#ifndef MAME_HEATHKIT_H_88_CASS_H
+#define MAME_HEATHKIT_H_88_CASS_H
+
+#pragma once
+
+#include "machine/i8251.h"
+#include "machine/timer.h"
+#include "imagedev/cassette.h"
+
+#include "formats/h8_cas.h"
+
+
+class heath_h_88_cass_device : public device_t
+{
+public:
+	heath_h_88_cass_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
+
+	void write(offs_t reg, u8 val);
+	u8   read(offs_t reg);
+
+protected:
+
+	virtual void device_start() override;
+	virtual void device_reset() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	void uart_rts(u8 data);
+	void uart_tx_empty(u8 data);
+
+	TIMER_DEVICE_CALLBACK_MEMBER(kansas_r);
+	TIMER_DEVICE_CALLBACK_MEMBER(kansas_w);
+
+	required_device<i8251_device> m_uart;
+	required_device<cassette_image_device> m_cass_player;
+	required_device<cassette_image_device> m_cass_recorder;
+
+	u8 m_cass_data[4]{};
+	bool m_cassbit;
+	bool m_cassold;
+};
+
+DECLARE_DEVICE_TYPE(HEATH_H88_CASS, heath_h_88_cass_device)
+
+
+#endif // MAME_HEATHKIT_H_88_CASS_H

--- a/src/mame/heathkit/h_88_cass.h
+++ b/src/mame/heathkit/h_88_cass.h
@@ -11,9 +11,9 @@
 
 #pragma once
 
+#include "imagedev/cassette.h"
 #include "machine/i8251.h"
 #include "machine/timer.h"
-#include "imagedev/cassette.h"
 
 #include "formats/h8_cas.h"
 
@@ -42,7 +42,7 @@ protected:
 	required_device<cassette_image_device> m_cass_player;
 	required_device<cassette_image_device> m_cass_recorder;
 
-	u8 m_cass_data[4]{};
+	u8 m_cass_data[4];
 	bool m_cassbit;
 	bool m_cassold;
 };

--- a/src/mame/heathkit/h_88_cass.h
+++ b/src/mame/heathkit/h_88_cass.h
@@ -42,7 +42,7 @@ protected:
 	required_device<cassette_image_device> m_cass_player;
 	required_device<cassette_image_device> m_cass_recorder;
 
-	u8 m_cass_data[4];
+	u8   m_cass_data[4];
 	bool m_cassbit;
 	bool m_cassold;
 };

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -19225,7 +19225,8 @@ h8                              //
 h19                             // Heath H19 (Zenith Z-19)
 
 @source:heathkit/h89.cpp
-h89                             // Heath H89 (H88, Zenith Z-89, Z-90)
+h89                             // Heath H89 (WH89, Zenith Z-89, Z-90)
+h88                             // Heath H88 (with cassette tape)
 
 @source:hec2hrp/hec2hrp.cpp
 hec2hr                          //


### PR DESCRIPTION
Adds the H-88-5 cassette interface board and the H88 clone of the H89. 

Adding the H88 clone (which Heath Company sold with only the cassette interface board) is simpler and more historically accurate. 

MTR-88 BIOS was also change to only be valid with the H88 and the only bios supported by the H88. 

