### PR TITLE
Fix calling of SEC data_w() and clk_w()

### DIFF
--- a/src/mame/barcrest/mpu5.cpp
+++ b/src/mame/barcrest/mpu5.cpp
@@ -274,9 +274,9 @@ void mpu5_state::asic_w8(offs_t offset, uint8_t data)
 
 		case 0x09:
 			//Assume SEC fitted for now
-			m_sec->data_w(~data&0x01);
-			m_sec->clk_w(~data&0x02);
-			m_sec->cs_w(~data&0x04);
+			m_sec->data_w(!BIT(data, 0));
+			m_sec->clk_w(!BIT(data, 1));
+			m_sec->cs_w(!BIT(data, 2));
 			[[fallthrough]];
 		case 0x0b:
 			m_statuslamp[0] = BIT(data, 4);

--- a/src/mame/bfm/bfm_sc4.cpp
+++ b/src/mame/bfm/bfm_sc4.cpp
@@ -554,7 +554,7 @@ void sc4_state::sc4_mem_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 						case 0x0330:
 							logerror("%08x meter write %04x\n",pc, data);
 							//m_meterstatus = (m_meterstatus&0xc0) | (data & 0x3f);
-							m_sec->clk_w(~data&0x20);
+							m_sec->clk_w(!BIT(data, 5));
 							break;
 
 						case 0x1248:
@@ -568,7 +568,8 @@ void sc4_state::sc4_mem_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 						case 0x1330:
 							bfm_sc4_reel4_w(data&0xf);
 							//m_meterstatus = (m_meterstatus&0x3f) | ((data & 0x30) << 2);
-							m_sec->data_w(~data&0x10);
+							m_sec->data_w(!BIT(data, 4));
+							m_sec->cs_w(!BIT(data, 5));
 							break;
 
 						default:

--- a/src/mame/shared/sec.cpp
+++ b/src/mame/shared/sec.cpp
@@ -84,8 +84,6 @@ int sec_device::data_r(void)
 
 void sec_device::clk_w(int state)
 {
-	state = state ? 1 : 0;
-
 	if (m_clk ^ state)
 	{
 		if (!state)


### PR DESCRIPTION
Above functions for the Starpoint Electronic Counter require 0 or 1 to be passed.  Fixed use by Barcrest MPU5 and BFM SC4.
Also added call to cs_w() (actually reset, not a chip select)  to BFM SC4.