### PR TITLE
higemaru: Add tile x/y flip, fixes hi-score screen

### DIFF
--- a/src/mame/capcom/higemaru.cpp
+++ b/src/mame/capcom/higemaru.cpp
@@ -168,10 +168,10 @@ void higemaru_state::c800_w(uint8_t data)
 
 TILE_GET_INFO_MEMBER(higemaru_state::get_bg_tile_info)
 {
-	int const code = m_videoram[tile_index] + ((m_colorram[tile_index] & 0x80) << 1);
-	int const color = m_colorram[tile_index];
+	int const attr = m_colorram[tile_index];
+	int const code = m_videoram[tile_index] | ((attr & 0x80) << 1);
 
-	tileinfo.set(0, code, color&0x1f, TILE_FLIPYX((color & 0x60) >> 5));
+	tileinfo.set(0, code, attr & 0x1f, TILE_FLIPYX((attr & 0x60) >> 5));
 }
 
 void higemaru_state::video_start()

--- a/src/mame/capcom/higemaru.cpp
+++ b/src/mame/capcom/higemaru.cpp
@@ -169,9 +169,9 @@ void higemaru_state::c800_w(uint8_t data)
 TILE_GET_INFO_MEMBER(higemaru_state::get_bg_tile_info)
 {
 	int const code = m_videoram[tile_index] + ((m_colorram[tile_index] & 0x80) << 1);
-	int const color = m_colorram[tile_index] & 0x1f;
+	int const color = m_colorram[tile_index];
 
-	tileinfo.set(0, code, color, 0);
+	tileinfo.set(0, code, color&0x1f, TILE_FLIPYX((color & 0x60) >> 5));
 }
 
 void higemaru_state::video_start()


### PR DESCRIPTION
Before

![0004](https://github.com/mamedev/mame/assets/1863036/beecd003-daeb-44a5-9a8b-2dcac14db119)

After

![0008](https://github.com/mamedev/mame/assets/1863036/b307b62e-86f1-4c73-bc3c-a554afd0c540)

Notice the four small red dots.