### PR TITLE
Improve Magic Desk CRT compatability

### DIFF
--- a/src/devices/bus/c64/exp.cpp
+++ b/src/devices/bus/c64/exp.cpp
@@ -183,8 +183,9 @@ std::pair<std::error_condition, std::string> c64_expansion_slot_device::call_loa
 			}
 		}
 
-		if ((m_card->m_roml_size & (m_card->m_roml_size - 1)) || (m_card->m_romh_size & (m_card->m_romh_size - 1)))
-			return std::make_pair(image_error::INVALIDLENGTH, "ROM size must be power of 2");
+		//Commented out check, stops most MagicDesk CRTs which have a variable number of 8K banks
+		//if ((m_card->m_roml_size & (m_card->m_roml_size - 1)) || (m_card->m_romh_size & (m_card->m_romh_size - 1)))
+		//	return std::make_pair(image_error::INVALIDLENGTH, "ROM size must be power of 2");
 	}
 
 	return std::make_pair(std::error_condition(), std::string());


### PR DESCRIPTION
Commented out ^2 check, this stops a large number of MagicDesk CRTs from working. When this check is removed they work fine. The standard MagicDesk format consists of a variable number of 8 kB Bank, common sizes are 9-11 Banks.