### PR TITLE
pinball/recel.cpp: Added the Recel System III BIOS [pps4.fr, Recreativas.org]

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -36775,8 +36775,7 @@ trailer                         //
 ufo_x                           //
 
 @source:pinball/recel.cpp
-recel13                         //
-recel14                         //
+recel                           //
 r_alaska                        //
 r_blackm4                       //
 r_blackmag                      //
@@ -36790,7 +36789,6 @@ r_mrevil                        //
 r_pokrplus                      //
 r_quijote                       //
 r_screech                       //
-r_screech4                      //
 r_swash                         //
 r_torneo                        //
 

--- a/src/mame/pinball/recel.cpp
+++ b/src/mame/pinball/recel.cpp
@@ -28,13 +28,12 @@ C6   10738     Bus Interface Circuit } These 2 interface the C5 eprom to the CPU
 
 
 ToDo:
-- Everything (the code below is mostly a carry-over from gts1 and is incomplete or guesswork)
-- Need dumps of bios roms from B1/B2
+- Everything (the code below is mostly a carry-over from gts1 and is incomplete or guesswork).
 - There's lots of manuals, with lots of info, but not what we need. For example, no proper schematics.
-- No info on the sound (all it says is 4 TTL chips controlled by 6 bits of the IO expander)
+- No info on the sound (all it says is 4 TTL chips controlled by 6 bits of the IO expander).
 - A plug-in printer is used to view and alter settings. We have no info about it.
-- Default layout
-- Outputs
+- Default layout.
+- Outputs.
 
 *****************************************************************************************************/
 
@@ -383,92 +382,80 @@ void recel_state::recel(machine_config & config)
 	genpin_audio(config);
 }
 
-/* There are two different BIOS sets:
+/* The BIOS is the same for all sets, but is labeled different depending on the ROM type:
     -13: For machines with personality PROM 1702.
     -14: For machines with 2716 EPROM.
+   On both cases, the second half of each chip is not used, having their A11 ping grounded
+   (these chips have A1 to A11, there's no A0).
 */
+#define RECEL_BIOS \
+	ROM_REGION( 0x800, "maincpu", ROMREGION_ERASEFF ) \
+	ROM_LOAD("a2361.b1", 0x0000, 0x0400, CRC(d0c4695d) SHA1(4846adb3f6c292626840ba5255ffc5e788a69301) ) \
+        ROM_IGNORE( 0x400 ) \
+	ROM_LOAD("a2362.b2", 0x0400, 0x0400, CRC(39a70611) SHA1(8545e168a5f256150bcff12d1e6d8efffd08c3cd) ) \
+        ROM_IGNORE( 0x400 )
 
-#define RECEL_BIOS_13 \
-	ROM_REGION( 0x0800, "maincpu", ROMREGION_ERASEFF ) \
-	ROM_LOAD("a2361_13.b1", 0x0000, 0x0400, NO_DUMP ) \
-	ROM_LOAD("a2362_13.b2", 0x0400, 0x0400, NO_DUMP )
-
-#define RECEL_BIOS_14 \
-	ROM_REGION( 0x0800, "maincpu", ROMREGION_ERASEFF ) \
-	ROM_LOAD("a2361_14.b1", 0x0000, 0x0400, NO_DUMP ) \
-	ROM_LOAD("a2362_14.b2", 0x0400, 0x0400, NO_DUMP )
-
-
-ROM_START( recel13 )
-	RECEL_BIOS_13
-
-	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
-ROM_END
-
-ROM_START( recel14 )
-	RECEL_BIOS_14
+ROM_START( recel )
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 ROM_END
 
 ROM_START(r_alaska)
-	RECEL_BIOS_13
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("al.c5",         0x0000, 0x0100, CRC(905ef624) SHA1(ab0bb2e7262650b670524ce9f88bd1f14ffd749a) )
 ROM_END
 
+/* There's no Hot & Cold version for 2716, but some collectors made fake ROMs just repeating the content until filling
+   0x800, so they can replace the original personality PROM 1702 with a more common 2716 EPROM. */
 ROM_START(r_hotcold)
-	RECEL_BIOS_13
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("hc.c5",         0x0000, 0x0100, CRC(f58d0c05) SHA1(54ecf9f67ce3a5264bfd9c063353705f9202d524) )
 ROM_END
 
+/* There's a fake set (CRC(ddf2beac) SHA1(2ce67e2679bf7d545434a90209c462ad53c50e01)) made by collectors
+   for replacing the original personality PROM 1702 with a more common 2716 EPROM. */
 ROM_START(r_screech)
-	RECEL_BIOS_13
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("sc_1_1702.bin", 0x0000, 0x0100, CRC(c9185ef3) SHA1(3ace6cccc96375c5eab3d43f86f52bf52124334e) )
 ROM_END
 
-ROM_START(r_screech4)
-	RECEL_BIOS_14
-
-	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
-	ROM_LOAD("sc.c5",         0x0000, 0x0800, CRC(ddf2beac) SHA1(2ce67e2679bf7d545434a90209c462ad53c50e01) )
-ROM_END
-
 ROM_START(r_mrevil)
-	RECEL_BIOS_13
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD( "me.c5",        0x0000, 0x0100, CRC(53ce24a0) SHA1(42d376e3e7a4e94a09db2f974af8d4869579d0f5) )
 ROM_END
 
 ROM_START(r_torneo)
-	RECEL_BIOS_13
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("to.c5",         0x0000, 0x0100, CRC(06518bca) SHA1(6e8d4dba3cc5713208794aafc40cad6aca558aa6) )
 ROM_END
 
 ROM_START(r_crzyrace)
-	RECEL_BIOS_14
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("cr.c5",         0x0000, 0x0800, CRC(60088804) SHA1(a73a7f8a0583a79588f9823a5e65ed28edad96a3) )
 ROM_END
 
 ROM_START(r_fairfght)
-	RECEL_BIOS_13
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("fa.c5",         0x0000, 0x0100, CRC(5d3694da) SHA1(4d0a8033acb6ef2e2af107f76540fd19b4a39b12) )
 ROM_END
 
 ROM_START(r_pokrplus)
-	RECEL_BIOS_13
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("po.c5",         0x0000, 0x0100, CRC(60a199a8) SHA1(045d61f56ea03a694722da810d465ab65d85cbfd) )
@@ -477,14 +464,14 @@ ROM_START(r_pokrplus)
 ROM_END
 
 ROM_START(r_mrdoom)
-	RECEL_BIOS_13
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("md.c5",         0x0000, 0x0100, CRC(ca679a69) SHA1(f08f0cfe646f08882473dcd5d23889fffe4a03c8) )
 ROM_END
 
 ROM_START(r_cavalier)
-	RECEL_BIOS_13
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("ca.c5",         0x0000, 0x0100, CRC(dc2e865f) SHA1(3f15f90dafa9d5e42381605044b6c9b529afd3af) )
@@ -493,14 +480,14 @@ ROM_START(r_cavalier)
 ROM_END
 
 ROM_START(r_swash)
-	RECEL_BIOS_13
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("sw.c5",         0x0000, 0x0100, CRC(69326f5f) SHA1(f0bb4251f579ccf97c1cabb63254ba466ccd141e) )
 ROM_END
 
 ROM_START(r_quijote)
-	RECEL_BIOS_13
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("qu.c5",         0x0000, 0x0100, CRC(1fd535d0) SHA1(a9c9a72881d195a0de751f10fa54fb181523a33f) )
@@ -509,21 +496,21 @@ ROM_START(r_quijote)
 ROM_END
 
 ROM_START(r_flipper)
-	RECEL_BIOS_14
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("fl.c5",         0x0000, 0x0800, CRC(76ee0370) SHA1(f2a835a0b76f7258d5e65390c239f5456e30e87a) )
 ROM_END
 
 ROM_START(r_blackmag)
-	RECEL_BIOS_14
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("bm_1065_1.bin", 0x0000, 0x0800, CRC(a917718c) SHA1(0b4fdf270560df902e95b34c25cca20e91f1071c) )
 ROM_END
 
 ROM_START(r_blackm4)
-	RECEL_BIOS_14
+	RECEL_BIOS
 
 	ROM_REGION( 0x0800, "module", ROMREGION_ERASEFF )
 	ROM_LOAD("b4.c5",         0x0000, 0x0800, CRC(cd383f5b) SHA1(c38acaae46e5fd2660efbd0e2d35e295892e60a5) )
@@ -531,22 +518,20 @@ ROM_END
 
 } // anonymous namespace
 
-GAME(1977,  recel13,    0,       recel, recel, recel_state, empty_init, ROT0, "Recel",     "Recel BIOS (for 1702)", MACHINE_IS_BIOS_ROOT | MACHINE_NOT_WORKING)
-GAME(1977,  recel14,    0,       recel, recel, recel_state, empty_init, ROT0, "Recel",     "Recel BIOS (for 2716)", MACHINE_IS_BIOS_ROOT | MACHINE_NOT_WORKING)
+GAME(1977,  recel,      0,     recel, recel, recel_state, empty_init, ROT0, "Recel",     "Recel BIOS",       MACHINE_IS_BIOS_ROOT | MACHINE_NOT_WORKING)
 
-GAME(1978,  r_alaska,   recel13, recel, recel, recel_state, empty_init, ROT0, "Interflip", "Alaska",                MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1978,  r_hotcold,  recel13, recel, recel, recel_state, empty_init, ROT0, "Inder",     "Hot & Cold",            MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1978,  r_screech,  recel13, recel, recel, recel_state, empty_init, ROT0, "Inder",     "Screech (1 player)",    MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1978,  r_screech4, recel14, recel, recel, recel_state, empty_init, ROT0, "Inder",     "Screech (4 players)",   MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1978,  r_mrevil,   recel13, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Mr. Evil",              MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1978,  r_torneo,   recel13, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Torneo",                MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1978,  r_crzyrace, recel14, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Crazy Race",            MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1978,  r_fairfght, recel13, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Fair Fight",            MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1978,  r_pokrplus, recel13, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Poker Plus",            MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1979,  r_mrdoom,   recel13, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Mr. Doom",              MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1979,  r_cavalier, recel13, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Cavalier",              MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1979,  r_swash,    recel13, recel, recel, recel_state, empty_init, ROT0, "Recel",     "SwashBuckler",          MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1979,  r_quijote,  recel13, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Don Quijote",           MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1980,  r_flipper,  recel14, recel, recel, recel_state, empty_init, ROT0, "Recel",     "The Flipper Game",      MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1980,  r_blackmag, recel14, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Black Magic",           MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
-GAME(1980,  r_blackm4,  recel14, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Black Magic 4",         MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1978,  r_alaska,   recel, recel, recel, recel_state, empty_init, ROT0, "Interflip", "Alaska",           MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1978,  r_hotcold,  recel, recel, recel, recel_state, empty_init, ROT0, "Inder",     "Hot & Cold",       MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1978,  r_screech,  recel, recel, recel, recel_state, empty_init, ROT0, "Inder",     "Screech",          MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1978,  r_mrevil,   recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Mr. Evil",         MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1978,  r_torneo,   recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Torneo",           MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1978,  r_crzyrace, recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Crazy Race",       MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1978,  r_fairfght, recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Fair Fight",       MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1978,  r_pokrplus, recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Poker Plus",       MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1979,  r_mrdoom,   recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Mr. Doom",         MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1979,  r_cavalier, recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Cavalier",         MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1979,  r_swash,    recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "SwashBuckler",     MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1979,  r_quijote,  recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Don Quijote",      MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1980,  r_flipper,  recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "The Flipper Game", MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1980,  r_blackmag, recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Black Magic",      MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )
+GAME(1980,  r_blackm4,  recel, recel, recel, recel_state, empty_init, ROT0, "Recel",     "Black Magic 4",    MACHINE_IS_SKELETON_MECHANICAL | MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
Verified that the BIOS is the same for 1702 (13) and 2716 (14) chips, and also verified the BIOS ROM size.

Removed 'r_screech' set, as we confirmed it's a fake set for replacing 2716 chips with more common 2716 EPROMs.