### PR TITLE
luaengine.cpp: Add output manager item_table function

### DIFF
--- a/src/emu/output.h
+++ b/src/emu/output.h
@@ -194,6 +194,9 @@ public:
 	// map a unique ID back to a name
 	const char *id_to_name(u32 id);
 
+	// return the item table
+	const std::unordered_map<std::string, output_item> &itemtable() const noexcept { return m_itemtable; }
+
 private:
 	output_item *find_item(std::string_view string);
 	output_item &create_new_item(std::string_view outname, s32 value);

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -2134,7 +2134,13 @@ void lua_engine::initialize()
 		};
 	output_type["name_to_id"] = &output_manager::name_to_id;
 	output_type["id_to_name"] = &output_manager::id_to_name;
-
+	output_type["item_table"] = sol::property([this] (output_manager &o)
+		{
+			sol::table table = sol().create_table();
+			for (const auto& [key, value] : o.itemtable())
+				table[key] = value.id();
+			return table;
+		});
 
 	auto mame_manager_type = sol().registry().new_usertype<mame_machine_manager>("manager", sol::no_constructor);
 	mame_manager_type["machine"] = sol::property(&mame_machine_manager::machine);


### PR DESCRIPTION
output.h: Add itemtable accessor

This will allow you to see the output manager item table in lua.  It can be useful to check the names and see what outputs there are.

usage:  

function printt(t) for i,j in pairs(t) do print(i,j) end end 
printt(manager.machine.output.item_table)