### PR TITLE
rm/rmnimbus.cpp: Change default mouse emulation mode to HLE

### DIFF
--- a/src/mame/rm/rmnimbus.cpp
+++ b/src/mame/rm/rmnimbus.cpp
@@ -69,7 +69,7 @@ void rmnimbus_state::nimbus_io(address_map &map)
 
 static INPUT_PORTS_START( nimbus )
 	PORT_START("config")
-	PORT_CONFNAME( 0x01, 0x00, "Mouse emulation mode" )
+	PORT_CONFNAME( 0x01, 0x01, "Mouse emulation mode" )
 	PORT_CONFSETTING( 0x00, "Real" )
 	PORT_CONFSETTING( 0x01, "HLE" )
 


### PR DESCRIPTION
As discussed in comments to my previous pull request (https://github.com/mamedev/mame/pull/11890) this PR changes the default mouse emulation mode to HLE.  I think this is a more useful default as it gives the best user experience now (especially for casual users that might not discover the config setting).