### PR TITLE
rm/rm380z.cpp: Fix vram access to allow reading of character data from screen

### DIFF
--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -73,11 +73,12 @@ protected:
 	virtual void machine_start() override;
 
 private:
+	bool get_rowcol_from_offset(int& row, int& col, offs_t offset) const;
 	void put_point(int charnum,int x,int y,int col);
 	void init_graphic_chars();
 
 	void putChar(int charnum,int attribs,int x,int y,bitmap_ind16 &bitmap,unsigned char* chsb,int vmode);
-	void decode_videoram_char(int pos,uint8_t& chr,uint8_t& attrib);
+	void decode_videoram_char(int row, int col, uint8_t& chr, uint8_t& attrib);
 	void scroll_videoram();
 	void config_videomode();
 	void check_scroll_register();
@@ -93,10 +94,8 @@ private:
 
 	uint8_t m_graphic_chars[0x80][(RM380Z_CHDIMX+1)*(RM380Z_CHDIMY+1)];
 
-	uint8_t   m_mainVideoram[RM380Z_VIDEORAM_SIZE];
-	uint8_t   m_vramchars[RM380Z_SCREENSIZE];
-	uint8_t   m_vramattribs[RM380Z_SCREENSIZE];
-	uint8_t   m_vram[RM380Z_SCREENSIZE];
+	uint8_t   m_vramchars[RM380Z_SCREENROWS][RM380Z_SCREENCOLS];
+	uint8_t   m_vramattribs[RM380Z_SCREENROWS][RM380Z_SCREENCOLS];
 
 	int m_rasterlineCtr = 0;
 	emu_timer* m_vblankTimer = nullptr;

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -268,11 +268,8 @@ void rm380z_state::machine_reset()
 	m_rasterlineCtr=0;
 
 	// note: from COS 4.0 videos, screen seems to show garbage at the beginning
-	memset(m_mainVideoram,0,RM380Z_VIDEORAM_SIZE);
-
-	memset(m_vramattribs,0,RM380Z_SCREENSIZE);
-	memset(m_vramchars,0,RM380Z_SCREENSIZE);
-	memset(m_vram,0,RM380Z_SCREENSIZE);
+	memset(m_vramattribs, 0, sizeof(m_vramattribs));
+	memset(m_vramchars, 0, sizeof(m_vramchars));
 
 	config_memory_map();
 	m_fdc->reset();


### PR DESCRIPTION
As noted in https://mametesters.org/view.php?id=6484 the first character of the "Disc not ready" error message went missing when trying to boot from the monitor without a disc.  The message was written correctly, but then corrupted because it was not possible for the firmware to read character data back from the screen.  rm380z_state::videoram_read() always returned the last byte written to a (row,col) which was usually the attributes of a character rather than the character itself :-)  This lead to some sort of bug in the firmware where it would overwrite the "D" character with zero.

I've updated rm380z_state::videoram_read()  so that it returns the requested data (either a character or it's attributes) and the error message now displays correctly.  While doing this I've also tidied up the vram storage so that it just uses two 2d arrays which seems to mirror the actual hardware from reading the documentation (it had separate banks of RAM for character data and attributes).  This is also more efficient and make the code easier to read.

Unfortunately, I don't have any software for the machine but I wrote a quick assembler program to help debug and test the issue:

```
VTOUT:  equ 0x37
VTIN:   equ 0x38
KBDW:   equ 0x21
WIDTH:  equ 0x34

emt: macro routine
rst 0x30
defb routine
endm

org 0x100

ld a, 0x00		; set 40 character mode (use 0x01 for 80 column mode)
emt WIDTH
ld a, 'A'		; Write 'A' with underline attribute to position (4,4)
ld hl, 0x0404	
ld e, 0x02
emt VTOUT
emt VTIN		; Read back character and attributes from position (4,4)
push af
emt KBDW		; wait for keypress
pop af
```

Before my change both the A and E registers contained 0x02 (the underline attribute) after running the program.  Now A contains the character ('A').

The program can be assembled on Linux using z80asm and then loaded using the MAME debugger.  To run start the 380Z front panel by pressing (Ctrl + F) and then enter j followed by 100.

It looks like there are other bugs in the driver so I will try to improve it further when time allows.  It would also be nice to get the 480z driver to work (it's currently completely broken).



