### PR TITLE
apple/apple2e.cpp: update LC memory map when LC state changes

### DIFF
--- a/src/mame/apple/apple2e.cpp
+++ b/src/mame/apple/apple2e.cpp
@@ -495,6 +495,7 @@ private:
 	void write_slot_rom(int slotbias, int offset, u8 data);
 	u8 read_int_rom(int slotbias, int offset);
 	void auxbank_update();
+	void lcrom_update();
 	void cec_lcrom_update();
 	void raise_irq(int irq);
 	void lower_irq(int irq);
@@ -1231,6 +1232,7 @@ void apple2e_state::machine_reset()
 	m_lcram2 = true;
 	m_lcprewrite = false;
 	m_lcwriteenable = true;
+	lcrom_update();
 
 	m_exp_bankhior = 0xf0;
 
@@ -1323,6 +1325,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(apple2e_state::apple2_interrupt)
 				m_lcram2 = true;
 				m_lcprewrite = false;
 				m_lcwriteenable = true;
+				lcrom_update();
 
 				// More Sather: all MMU switches off (80STORE, RAMRD, RAMWRT, INTCXROM, ALTZP, SLOTC3ROM, PAGE2, HIRES, INTC8ROM)
 				m_video->a80store_w(false);
@@ -1602,28 +1605,7 @@ void apple2e_state::lc_update(int offset, bool writing)
 
 	if (m_lcram != old_lcram)
 	{
-		if (m_iscec)
-		{
-			cec_lcrom_update();
-		}
-		else
-		{
-			if (m_lcram)
-			{
-				m_lcbank.select(1);
-			}
-			else
-			{
-				if (m_romswitch)
-				{
-					m_lcbank.select(2);
-				}
-				else
-				{
-					m_lcbank.select(0);
-				}
-			}
-		}
+		lcrom_update();
 	}
 
 	#if 0
@@ -1633,6 +1615,32 @@ void apple2e_state::lc_update(int offset, bool writing)
 			m_lcram2 ? 0x1000 : 0x0000,
 			m_altzp, m_maincpu->pc());
 	#endif
+}
+
+void apple2e_state::lcrom_update()
+{
+	if (m_iscec)
+	{
+		cec_lcrom_update();
+	}
+	else
+	{
+		if (m_lcram)
+		{
+			m_lcbank.select(1);
+		}
+		else
+		{
+			if (m_romswitch)
+			{
+				m_lcbank.select(2);
+			}
+			else
+			{
+				m_lcbank.select(0);
+			}
+		}
+	}
 }
 
 void apple2e_state::cec_lcrom_update()
@@ -1747,6 +1755,7 @@ void apple2e_state::do_io(int offset, bool is_iic)
 			{
 				m_romswitch = !m_romswitch;
 				update_slotrom_banks();
+				lcrom_update();
 
 				// MIG is reset when ROMSWITCH turns off
 				if ((m_isiicplus) && !(m_romswitch))
@@ -1754,19 +1763,6 @@ void apple2e_state::do_io(int offset, bool is_iic)
 					m_migpage = 0;
 					m_intdrive = false;
 					m_35sel = false;
-				}
-
-				// if LC is not enabled
-				if (!m_lcram)
-				{
-					if (m_romswitch)
-					{
-						m_lcbank.select(2);
-					}
-					else
-					{
-						m_lcbank.select(0);
-					}
 				}
 			}
 			break;


### PR DESCRIPTION
It appears that during a reset, the expected and executed language card state changes do not also update the system memory map. This can cause a reset vector to fail when the language card RAM has been banked over ROM. The following software hangs when reset is asserted:

Merlin running from [32 Meg Hard Drive Image](https://wiki.reactivemicro.com/32_Meg_Hard_Drive_Image)

BBC Basic running from [Applecorn](https://github.com/bobbimanners/Applecorn/releases/tag/v0.52-beta)

A reset hang can be demonstrated from a clean boot by entering the following code into the monitor. It banks in the LC over ROM and waits for the user to press reset. If the LC bank is uninitialized and reset is pressed, it will hang in a cascade of `BRK` instructions.

```
*300: 2C 80 C0 4C 03 03 N 300G
```

The Apple //c will hang a little differently since it copies an IRQ/BRK vector into the LC RAM area when it boots. The interrupt service routine will attempt to jump to a ROM location but it isn't banked in, a `BRK` will be hit, and the routine will be triggered again.

I must stress that I don't fully understand how memory mapping works. I copied the pattern seen in parts of the code, consolidated it into a function `lcrom_update()`, and inserted calls to it wherever the language card state changed. These changes resolve the reset vector problems but someone wiser than me should review what I've done carefully. The `ALTZP` softswitch affects the language card area but I gather changes to `m_altzp` followed by a call to `auxbank_update()` bank AUX memory into the LC RAM area automatically (though it is not explicitly stated).

A true slot 0 language card in an early model Apple II does not change its state when reset so this has been left alone. According to Jeff Mazur there is no hardware reset of `m_romswitch` and the extended ROM code supports that so that has not been changed. I don't know enough about the CEC computers to comment and have tried to leave its LC mapping undisturbed.
