### PR TITLE
Fix compilation against musl

### DIFF
--- a/src/lib/netlist/plib/pexception.cpp
+++ b/src/lib/netlist/plib/pexception.cpp
@@ -8,7 +8,7 @@
 #include <cfloat>
 #include <iostream>
 
-#if (defined(__x86_64__) || defined(__i386__)) && defined(__linux__)
+#if (defined(__x86_64__) || defined(__i386__)) && defined(__GLIBC__)
 #define HAS_FEENABLE_EXCEPT     (1)
 #else
 #define HAS_FEENABLE_EXCEPT     (0)

--- a/src/osd/modules/sound/pulse_sound.cpp
+++ b/src/osd/modules/sound/pulse_sound.cpp
@@ -120,7 +120,7 @@ char sound_pulse::get_main()
 {
 	pollfd pfds[1];
 	pfds[0].fd = m_pipe_to_main[0];
-	pfds[0].events = POLL_IN;
+	pfds[0].events = POLLIN;
 	pfds[0].revents = 0;
 	int err = poll(pfds, 1, -1);
 	if(err < 0)


### PR DESCRIPTION
- `__GLIBC__` is the correct macro to check for `feenableexcept`
- `POLLIN` is the correct macro for poll, `POLL_IN` is defined in `signal.h`

it still won't compile because bx [deliberately removed support](https://github.com/bkaradzic/bx/commit/d7ecac17060ab8cf765b21e55a762aa4855dfdb1), but at least removes the need to patch mame