### PR TITLE
Use P1 and P3 Phosphor colors for monochrome monitors

### DIFF
--- a/src/lib/util/palette.h
+++ b/src/lib/util/palette.h
@@ -83,7 +83,7 @@ public:
     // CRT phosphors
 	static constexpr rgb_t white() { return rgb_t(255, 255, 255); }
 	static constexpr rgb_t green() { return rgb_t(74, 255, 0); }; }
-	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); }; }
+	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); };
 private:
 	uint32_t  m_data;
 };

--- a/src/lib/util/palette.h
+++ b/src/lib/util/palette.h
@@ -82,7 +82,7 @@ public:
     static constexpr rgb_t transparent() { return rgb_t(0, 0, 0, 0); }
     // CRT phosphors
 	static constexpr rgb_t white() { return rgb_t(255, 255, 255); }
-	static constexpr rgb_t green() { return rgb_t(74, 255, 0); }; }
+	static constexpr rgb_t green() { return rgb_t(74, 255, 0); }
 	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); }
 
 private:

--- a/src/lib/util/palette.h
+++ b/src/lib/util/palette.h
@@ -83,7 +83,8 @@ public:
     // CRT phosphors
 	static constexpr rgb_t white() { return rgb_t(255, 255, 255); }
 	static constexpr rgb_t green() { return rgb_t(74, 255, 0); }; }
-	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); };
+	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); }
+
 private:
 	uint32_t  m_data;
 };

--- a/src/lib/util/palette.h
+++ b/src/lib/util/palette.h
@@ -79,11 +79,12 @@ public:
 
 	// constant factories
 	static constexpr rgb_t black() { return rgb_t(0, 0, 0);
-    static constexpr rgb_t transparent() { return rgb_t(0, 0, 0, 0); };
+    static constexpr rgb_t transparent() { return rgb_t(0, 0, 0, 0);
     // CRT phosphors
 	static constexpr rgb_t white() { return rgb_t(255, 255, 255);
 	static constexpr rgb_t green() { return rgb_t(74, 255, 0); };
 	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); };
+	};
 private:
 	uint32_t  m_data;
 };

--- a/src/lib/util/palette.h
+++ b/src/lib/util/palette.h
@@ -80,8 +80,8 @@ public:
 	// constant factories
 	static constexpr rgb_t black() { return rgb_t(0, 0, 0); }
 	static constexpr rgb_t white() { return rgb_t(255, 255, 255); }
-	static constexpr rgb_t green() { return rgb_t(0, 255, 0); }
-	static constexpr rgb_t amber() { return rgb_t(247, 170, 0); }
+	static constexpr rgb_t green() { return rgb_t(74, 255, 0); }
+	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); }
 	static constexpr rgb_t transparent() { return rgb_t(0, 0, 0, 0); }
 
 private:

--- a/src/lib/util/palette.h
+++ b/src/lib/util/palette.h
@@ -78,12 +78,12 @@ public:
 	static constexpr uint8_t clamplo(int32_t value) { return (value < 0) ? 0 : value; }
 
 	// constant factories
-	static constexpr rgb_t black() { return rgb_t(0, 0, 0); }
-	static constexpr rgb_t white() { return rgb_t(255, 255, 255); }
+	static constexpr rgb_t black() { return rgb_t(0, 0, 0);
+    static constexpr rgb_t transparent() { return rgb_t(0, 0, 0, 0); }
+    // CRT phosphors
+	static constexpr rgb_t white() { return rgb_t(255, 255, 255);
 	static constexpr rgb_t green() { return rgb_t(74, 255, 0); }
 	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); }
-	static constexpr rgb_t transparent() { return rgb_t(0, 0, 0, 0); }
-
 private:
 	uint32_t  m_data;
 };

--- a/src/lib/util/palette.h
+++ b/src/lib/util/palette.h
@@ -79,11 +79,11 @@ public:
 
 	// constant factories
 	static constexpr rgb_t black() { return rgb_t(0, 0, 0);
-    static constexpr rgb_t transparent() { return rgb_t(0, 0, 0, 0); }
+    static constexpr rgb_t transparent() { return rgb_t(0, 0, 0, 0); };
     // CRT phosphors
 	static constexpr rgb_t white() { return rgb_t(255, 255, 255);
-	static constexpr rgb_t green() { return rgb_t(74, 255, 0); }
-	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); }
+	static constexpr rgb_t green() { return rgb_t(74, 255, 0); };
+	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); };
 private:
 	uint32_t  m_data;
 };

--- a/src/lib/util/palette.h
+++ b/src/lib/util/palette.h
@@ -78,13 +78,12 @@ public:
 	static constexpr uint8_t clamplo(int32_t value) { return (value < 0) ? 0 : value; }
 
 	// constant factories
-	static constexpr rgb_t black() { return rgb_t(0, 0, 0);
-    static constexpr rgb_t transparent() { return rgb_t(0, 0, 0, 0);
+	static constexpr rgb_t black() { return rgb_t(0, 0, 0); }
+    static constexpr rgb_t transparent() { return rgb_t(0, 0, 0, 0); }
     // CRT phosphors
-	static constexpr rgb_t white() { return rgb_t(255, 255, 255);
-	static constexpr rgb_t green() { return rgb_t(74, 255, 0); };
-	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); };
-	};
+	static constexpr rgb_t white() { return rgb_t(255, 255, 255); }
+	static constexpr rgb_t green() { return rgb_t(74, 255, 0); }; }
+	static constexpr rgb_t amber() { return rgb_t(255, 183, 0); }; }
 private:
 	uint32_t  m_data;
 };

--- a/src/mame/luxor/abc80x.cpp
+++ b/src/mame/luxor/abc80x.cpp
@@ -283,7 +283,7 @@ void abc800c_state::abc800c_palette(palette_device &palette) const
 {
 	palette.set_pen_color(0, rgb_t::black());
 	palette.set_pen_color(1, rgb_t(0xff, 0x00, 0x00)); // red
-	palette.set_pen_color(2, rgb_t::green());
+	palette.set_pen_color(2, rgb_t(0x00, 0xff, 0x00)); // green
 	palette.set_pen_color(3, rgb_t(0xff, 0xff, 0x00)); // yellow
 	palette.set_pen_color(4, rgb_t(0x00, 0x00, 0xff)); // blue
 	palette.set_pen_color(5, rgb_t(0xff, 0x00, 0xff)); // magenta
@@ -1127,7 +1127,7 @@ void abc806_state::abc806_palette(palette_device &palette) const
 {
 	palette.set_pen_color(0, rgb_t::black());
 	palette.set_pen_color(1, rgb_t(0xff, 0x00, 0x00)); // red
-	palette.set_pen_color(2, rgb_t::green());
+	palette.set_pen_color(2, rgb_t(0x00, 0xff, 0x00)); // green
 	palette.set_pen_color(3, rgb_t(0xff, 0xff, 0x00)); // yellow
 	palette.set_pen_color(4, rgb_t(0x00, 0x00, 0xff)); // blue
 	palette.set_pen_color(5, rgb_t(0xff, 0x00, 0xff)); // magenta


### PR DESCRIPTION
Resolves #5311 

Got the wavelengths from https://en.wikipedia.org/wiki/Phosphor and converted them using https://academo.org/demos/wavelength-to-colour-relationship/