### PR TITLE
rm/rm380z.cpp: Add support for 4-line and backwards hw scrolling

### DIFF
--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -136,7 +136,6 @@ Notes on COS 4.0 disassembly:
 
 TODO:
 
-- Properly implement "backwards" or "last 4 lines" scrolling
 - Properly implement dimming and graphic chars (>0x80)
 - Understand why any write to disk command fails with "bad sector"
 - Understand why ctrl-U (blinking cursor) in COS 4.0 stops keyboard input from working

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -67,9 +67,7 @@ private:
 	static inline constexpr int RM380Z_NCY = 16;
 	static inline constexpr int RM380Z_SCREENCOLS = 80;
 	static inline constexpr int RM380Z_SCREENROWS = 24;
-
-	static inline constexpr int RM380Z_VIDEORAM_SIZE = 0x600;
-	static inline constexpr int RM380Z_SCREENSIZE = 0x1200;
+	static inline constexpr int RM380Z_ROW_MAX = RM380Z_SCREENROWS - 1;
 
 	bool ports_enabled_high() const { return ( m_port0 & 0x80 ); }
 	bool ports_enabled_low() const { return !( m_port0 & 0x80 ); }
@@ -80,7 +78,8 @@ private:
 
 	void putChar(int charnum, int attribs, int x, int y, bitmap_ind16 &bitmap, int vmode);
 	void decode_videoram_char(int row, int col, uint8_t &chr, uint8_t &attrib);
-	void scroll_videoram();
+	void scroll_videoram_up(int n = RM380Z_ROW_MAX, bool clear = true);
+	void scroll_videoram_down(int n = RM380Z_ROW_MAX, bool clear = true);
 	void config_videomode();
 	void check_scroll_register();
 
@@ -121,6 +120,7 @@ private:
 	uint8_t m_port0_kbd = 0;
 	uint8_t m_port1 = 0;
 	uint8_t m_fbfd = 0;
+	uint8_t m_fbfd_mask = 0;
 	uint8_t m_fbfe = 0;
 
 	uint8_t m_graphic_chars[0x80][(RM380Z_CHDIMX+1)*(RM380Z_CHDIMY+1)];
@@ -135,7 +135,7 @@ private:
 	uint8_t m_old_old_fbfd = 0;
 
 	int m_videomode = 0;
-	int m_old_videomode = 0;
+	int m_rows_to_scroll = 0;
 
 	emu_timer *m_static_vblank_timer = nullptr;
 

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -35,10 +35,8 @@ class rm380z_vram
 public:
 	void set_char(int row, int col, uint8_t data) { m_chars[get_row(row)][col] = data; }
 	void set_attrib(int row, int col, uint8_t data) { m_attribs[get_row(row)][col] = data; }
+	void set_scroll_register(uint8_t value) { m_scroll_reg = value; }
 	void reset();
-
-	void scroll_up() { m_scroll_reg = (m_scroll_reg + 1) % ROWS; }
-	void scroll_down() { m_scroll_reg = (m_scroll_reg) ? m_scroll_reg - 1 : ROWS - 1; }
 
 	uint8_t get_char(int row, int col) const { return m_chars[get_row(row)][col]; }
 	uint8_t get_attrib(int row, int col) const { return m_attribs[get_row(row)][col]; }
@@ -47,7 +45,7 @@ private:
 
 	uint8_t m_chars[ROWS][COLS];
 	uint8_t m_attribs[ROWS][COLS];
-	int m_scroll_reg = 0;
+	uint8_t m_scroll_reg = 0;
 };
 
 template <int ROWS, int COLS>
@@ -94,7 +92,6 @@ private:
 	static inline constexpr int RM380Z_NCY = 16;
 	static inline constexpr int RM380Z_SCREENCOLS = 80;
 	static inline constexpr int RM380Z_SCREENROWS = 24;
-	static inline constexpr int RM380Z_ROW_MAX = RM380Z_SCREENROWS - 1;
 
 	bool ports_enabled_high() const { return ( m_port0 & 0x80 ); }
 	bool ports_enabled_low() const { return !( m_port0 & 0x80 ); }
@@ -106,7 +103,6 @@ private:
 	void putChar(int charnum, int attribs, int x, int y, bitmap_ind16 &bitmap, int vmode);
 	void decode_videoram_char(int row, int col, uint8_t &chr, uint8_t &attrib);
 	void config_videomode();
-	void check_scroll_register();
 
 	void port_write(offs_t offset, uint8_t data);
 	uint8_t port_read(offs_t offset);
@@ -138,13 +134,10 @@ private:
 	void rm480z_io(address_map &map);
 	void rm480z_mem(address_map &map);
 
-	int writenum = 0;
-
 	uint8_t m_port0 = 0;
 	uint8_t m_port0_mask = 0;
 	uint8_t m_port0_kbd = 0;
 	uint8_t m_port1 = 0;
-	uint8_t m_fbfd = 0;
 	uint8_t m_fbfd_mask = 0;
 	uint8_t m_fbfe = 0;
 
@@ -154,9 +147,6 @@ private:
 
 	int m_rasterlineCtr = 0;
 	emu_timer* m_vblankTimer = nullptr;
-
-	uint8_t m_old_fbfd = 0;
-	uint8_t m_old_old_fbfd = 0;
 
 	int m_videomode = 0;
 

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -39,8 +39,6 @@ public:
 
 	void scroll_up() { m_scroll_reg = (m_scroll_reg + 1) % ROWS; }
 	void scroll_down() { m_scroll_reg = (m_scroll_reg) ? m_scroll_reg - 1 : ROWS - 1; }
-	void scroll_4L_up();
-	void scroll_4L_down();
 
 	uint8_t get_char(int row, int col) const { return m_chars[get_row(row)][col]; }
 	uint8_t get_attrib(int row, int col) const { return m_attribs[get_row(row)][col]; }
@@ -57,29 +55,6 @@ void rm380z_vram<ROWS, COLS>::reset()
 {
 	memset(m_attribs, 0, sizeof(m_attribs));
 	memset(m_chars, 0x80, sizeof(m_chars));
-}
-
-template <int ROWS, int COLS>
-void rm380z_vram<ROWS, COLS>::scroll_4L_up()
-{
-	// annoyingly two rows need to be copied here because the firmware updates the other two after!
-	// i.e. it reads row 23, copies that to row 22 and then clears row 23
-	for (int row = (ROWS - 4); row <= (ROWS - 3); row++)
-	{
-		std::memcpy(m_chars[get_row(row)], m_chars[get_row(row+1)], COLS);
-		std::memcpy(m_attribs[get_row(row)], m_attribs[get_row(row+1)], COLS);
-	}
-}
-
-template <int ROWS, int COLS>
-void rm380z_vram<ROWS, COLS>::scroll_4L_down()
-{
-	// annoyingly two rows need to be copied here because the firmware updates the other two after!
-	for (int row = (ROWS - 1); row >= (ROWS - 2); row--)
-	{
-		std::memcpy(m_chars[get_row(row)], m_chars[get_row(row-1)], COLS);
-		std::memcpy(m_attribs[get_row(row)], m_attribs[get_row(row-1)], COLS);
-	}
 }
 
 class rm380z_state : public driver_device
@@ -184,7 +159,6 @@ private:
 	uint8_t m_old_old_fbfd = 0;
 
 	int m_videomode = 0;
-	int m_rows_to_scroll = 0;
 
 	emu_timer *m_static_vblank_timer = nullptr;
 

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -51,19 +51,16 @@ void rm380z_state::port_write(offs_t offset, uint8_t data)
 	case 0xfd:      // screen line counter (?)
 		//printf("%s FBFC [%2.2x] FBFDw[%2.2x] FBFE [%2.2x] writenum [%4.4x]\n",machine().describe_context().c_str(),m_port0,data,m_fbfe,writenum);
 
-		data &= m_fbfd_mask;
-
-		// ignore repeated values and updates while bit 4 of port 0 is set
-		// (counter goes crazy when bit 4 is set so must have a different purpose then)
-		if ((data != m_fbfd) && !(m_port0 & 0x10))
+		if (m_port0 & 0x08)
 		{
-			m_old_old_fbfd=m_old_fbfd;
-			m_old_fbfd=m_fbfd;
-			m_fbfd=data;
-
-			writenum++;
-
-			check_scroll_register();
+			// user defined character data (not yet implemented)
+		}
+		// ignore updates while bit 4 of port 0 is set
+		// (counter is not used to set the scroll register in this case, maybe used for smooth scrolling?)
+		else if (!(m_port0 & 0x10))
+		{
+			// set scroll register (used to verticaly scroll the screen and effect vram addressing)
+			m_vram.set_scroll_register(data & m_fbfd_mask);
 		}
 
 		break;
@@ -262,11 +259,7 @@ void rm380z_state::machine_reset()
 	m_port0 = 0x00;
 	m_port0_kbd = 0x00;
 	m_port1 = 0x00;
-	m_fbfd = 0x00;
 	m_fbfe = 0x00;
-	m_old_fbfd = 0x00;
-	m_old_old_fbfd = 0x00;
-	writenum = 0;
 
 	m_rasterlineCtr = 0;
 

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -239,21 +239,21 @@ void rm380z_state::machine_start()
 
 void rm380z_state::init_rm380z()
 {
-	m_videomode=RM380Z_VIDEOMODE_80COL;
-	m_port0_mask=0xff;
+	m_videomode = RM380Z_VIDEOMODE_80COL;
+	m_port0_mask = 0xff;
 	m_fbfd_mask = 0x1f;		// enable hw scrolling (uses lower 5 bits of counter)
 }
 
 void rm380z_state::init_rm380z34d()
 {
-	m_videomode=RM380Z_VIDEOMODE_40COL;
-	m_port0_mask=0xdf;      // disable 80 column mode
+	m_videomode = RM380Z_VIDEOMODE_40COL;
+	m_port0_mask = 0xdf;      // disable 80 column mode
 }
 
 void rm380z_state::init_rm380z34e()
 {
-	m_videomode=RM380Z_VIDEOMODE_40COL;
-	m_port0_mask=0xdf;      // disable 80 column mode
+	m_videomode = RM380Z_VIDEOMODE_40COL;
+	m_port0_mask = 0xdf;      // disable 80 column mode
 }
 
 
@@ -269,7 +269,7 @@ void rm380z_state::machine_reset()
 	writenum = 0;
 
 	m_rows_to_scroll = 0;
-	m_rasterlineCtr=0;
+	m_rasterlineCtr = 0;
 
 	// note: from COS 4.0 videos, screen seems to show garbage at the beginning
 	memset(m_vramattribs, 0, sizeof(m_vramattribs));

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -272,8 +272,7 @@ void rm380z_state::machine_reset()
 	m_rasterlineCtr = 0;
 
 	// note: from COS 4.0 videos, screen seems to show garbage at the beginning
-	memset(m_vramattribs, 0, sizeof(m_vramattribs));
-	memset(m_vramchars, 0x20, sizeof(m_vramchars));
+	m_vram.reset();
 
 	config_memory_map();
 	m_fdc->reset();

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -268,7 +268,6 @@ void rm380z_state::machine_reset()
 	m_old_old_fbfd = 0x00;
 	writenum = 0;
 
-	m_rows_to_scroll = 0;
 	m_rasterlineCtr = 0;
 
 	// note: from COS 4.0 videos, screen seems to show garbage at the beginning

--- a/src/mame/rm/rm380z_v.cpp
+++ b/src/mame/rm/rm380z_v.cpp
@@ -147,8 +147,8 @@ void rm380z_state::scroll_videoram_up(int n, bool clear)
 	if (clear)
 	{
 		// the last line is filled with spaces
-		std::memset(m_vramchars[RM380Z_SCREENROWS - 1], 0x20, RM380Z_SCREENCOLS);
-		std::memset(m_vramattribs[RM380Z_SCREENROWS - 1], 0x00, RM380Z_SCREENCOLS);
+		std::memset(m_vramchars[RM380Z_ROW_MAX], 0x20, RM380Z_SCREENCOLS);
+		std::memset(m_vramattribs[RM380Z_ROW_MAX], 0x00, RM380Z_SCREENCOLS);
 	}
 }
 
@@ -192,7 +192,6 @@ a 4-line scroll.
 Only COS 4.x suports hw scrolling and COS 3.x implemented the same calls in sw.
 
 */
-
 void rm380z_state::check_scroll_register()
 {
 	const uint8_t r[3] = { m_old_old_fbfd, m_old_fbfd, m_fbfd };
@@ -215,6 +214,7 @@ void rm380z_state::check_scroll_register()
 		address_space &space = m_maincpu->space(AS_PROGRAM);
 		uint8_t top_row = space.read_byte(0xff6a);
 		uint8_t rows_to_scroll = space.read_byte(0xff0e);
+		m_rows_to_scroll = 0;
 
 		if (((r[2] > r[1]) && (r[2] - r[1] != RM380Z_ROW_MAX)) || ((r[2] == 0) && (r[1] == RM380Z_ROW_MAX)))
 		{

--- a/src/mame/rm/rm380z_v.cpp
+++ b/src/mame/rm/rm380z_v.cpp
@@ -138,43 +138,6 @@ void rm380z_state::decode_videoram_char(int row, int col, uint8_t& chr, uint8_t 
 	}
 }
 
-/* hw scrolling notes -
-
-Scrolling can be switched between full screen and 4-line mode using the GRAFIX and SCROLL emt firmware calls.
-
-The lower 5-bits of port FBFD serve as a scroll counter, and in normal operation the counter increments
-when moving down the screen (to scroll text upwards).  It then decrements in the reverse direction, e.g.
-
-a sequence of 0, 1, 2, 3 might be seen when scrolling text upwards 3 times.
-and 3, 2, 1, 0 when scrolling text downwards 3 times.
-
-In 4-line mode only the bottom 4 rows scroll and this is used for command input in the front panel
-and also with HRG (not yet emulated) as high resolution graphics only plots over the first 20 rows. In
-this mode the counter sequence flips between two values instead, eg.
-
-a sequence of 0, 1, 0, 1, 0, 1, 0 might be seen when scrolling text upwards 3 times.
-and 1, 0, 1, 0, 1, 0, 1 when scrolling text downwards 3 times.
-
-4-line scrolling is mostly implemented in SW, but HW full screen scrolling is used to help with this which
-explains the flipped counter sequence.
-
-Only COS 4.x suports hw scrolling and COS 3.x implemented the same calls in sw.
-
-*/
-void rm380z_state::check_scroll_register()
-{
-	const uint8_t r[3] = { m_old_old_fbfd, m_old_fbfd, m_fbfd };
-
-	if (((r[2] > r[1]) && (r[2] - r[1] != RM380Z_ROW_MAX)) || ((r[2] == 0) && (r[1] == RM380Z_ROW_MAX)))
-	{
-		m_vram.scroll_up();
-	}
-	else
-	{
-		m_vram.scroll_down();
-	}
-}
-
 // after ctrl-L (clear screen?): routine at EBBD is executed
 // EB30??? next line?
 // memory at FF02 seems to hold the line counter (same as FBFD)


### PR DESCRIPTION
Previously only full screen scrolling was supported in one direction, and even this went a little haywire with CP/M paging, e.g. when listing the contents of a disk with more than 23 files.  This PR fixes that and adds 4-line scrolling (GRAFIX mode) and backwards scrolling.

4-line scrolling is needed for the Front Panel to work properly, otherwise rows from the bottom of the screen corrupt the display area above when scrolling!  This is why it looks so bad in this odd YouTube video:

https://www.youtube.com/watch?v=zzl37lfEymI

Notice how it gets corrupted at around 1:46 with a duplicate IO port line.  This has scrolled up from below :-)

Also notice that the 'O' in "IO" is missing.  This is a different issue that I have also fixed with this PR.  Basically 'O' can also be stored as ASCII nul, but as we don't have the real character ROM we need to manually cater for that.  Anyway, now the front panel seems to behave properly and a history of the commands you type is displayed at the bottom.

To test scrolling backwards I wrote the following bit of assembler:

```
OUTC:   equ 0x01
KBDW:   equ 0x21
WIDTH:  equ 0x34
GRAFIX: equ 0x0D

emt: macro routine
rst 0x30
defb routine
endm

org 0x100

ld a, 0x00          ; set 40 character mode (use 0x01 for 80 column mode)
emt WIDTH

emt GRAFIX          ; set 4-line scrolling mode

loop:   emt KBDW    ; read character from keyboard (ctrl+k/j to move cursor up/down)
        emt OUTC    ; and output to screen
        cp 'q'
        jr nz, loop ; repeat until 'q' pressed
```
When started from 0x100 it allows 4-line scrolling to be tested in both directions.  When started from 0x106 it does the same with full screen scrolling.  Control character are interpreted by OUTC so you can move the cursor around the screen etc.

I also tested page scrolling in CP/M and full screen scrolling at the monitor prompt etc.

I've tried to explain how hw scrolling works (to the best of my understanding at least) in the code comments.  I figured most of that out by setting watch points on the IO ports and experimenting.  Please ask if anything isn't clear.
