### PR TITLE
hd6309.cpp: Fix index addressing modes

### DIFF
--- a/src/devices/cpu/m6809/hd6309.lst
+++ b/src/devices/cpu/m6809/hd6309.lst
@@ -744,13 +744,13 @@ INDEXED:
 				eat((hd6309_native_mode() && !(m_opcode & 0x10)) ? 2 : 5);
 				break;
 
-			case 0x0F:
+			case 0x0F: case 0x10:
 				// 6309 specific mode
 				m_temp.w = m_q.r.w;
 				eat(1);
 				break;
 
-			case 0x2F:
+			case 0x2F: case 0x30:
 				// 6309 specific mode
 				@m_temp.b.h = read_opcode_arg();
 				@m_temp.b.l = read_opcode_arg();
@@ -758,14 +758,14 @@ INDEXED:
 				eat(hd6309_native_mode() ? 1 : 5);
 				break;
 
-			case 0x4F:
+			case 0x4F: case 0x50:
 				// 6309 specific mode
 				m_temp.w = m_q.r.w;
 				m_q.r.w += 2;
 				eat((hd6309_native_mode() && !(m_opcode & 0x10)) ? 2 : 4);
 				break;
 
-			case 0x6F:
+			case 0x6F: case 0x70:
 				// 6309 specific mode
 				m_q.r.w -= 2;
 				m_temp.w = m_q.r.w;
@@ -773,6 +773,7 @@ INDEXED:
 				break;
 
 			default:
+				pop_state();
 				goto ILLEGAL;
 		}
 

--- a/src/devices/cpu/m6809/hd6309.lst
+++ b/src/devices/cpu/m6809/hd6309.lst
@@ -744,13 +744,13 @@ INDEXED:
 				eat((hd6309_native_mode() && !(m_opcode & 0x10)) ? 2 : 5);
 				break;
 
-			case 0x0F: case 0x10:
+			case 0x0F:
 				// 6309 specific mode
 				m_temp.w = m_q.r.w;
 				eat(1);
 				break;
 
-			case 0x2F: case 0x30:
+			case 0x2F:
 				// 6309 specific mode
 				@m_temp.b.h = read_opcode_arg();
 				@m_temp.b.l = read_opcode_arg();
@@ -758,14 +758,14 @@ INDEXED:
 				eat(hd6309_native_mode() ? 1 : 5);
 				break;
 
-			case 0x4F: case 0x50:
+			case 0x4F:
 				// 6309 specific mode
 				m_temp.w = m_q.r.w;
 				m_q.r.w += 2;
 				eat((hd6309_native_mode() && !(m_opcode & 0x10)) ? 2 : 4);
 				break;
 
-			case 0x6F: case 0x70:
+			case 0x6F:
 				// 6309 specific mode
 				m_q.r.w -= 2;
 				m_temp.w = m_q.r.w;
@@ -773,7 +773,6 @@ INDEXED:
 				break;
 
 			default:
-				pop_state();
 				goto ILLEGAL;
 		}
 


### PR DESCRIPTION
Add case statements to enable indirect register W references. Problem discovered by Glenn Hewlett. Patch by Ciaran Anscomb.
When an illegal index addressing mode is executed, pop next CPU state off stack to ensure vector is correctly jumped to. Problem discovered by Glenn Hewlett.