### PR TITLE
rainbow.xml; intv.xml; digilog320.xml; compclr2_flop.xml: Normalize software list description

### DIFF
--- a/hash/compclr2_flop.xml
+++ b/hash/compclr2_flop.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="compclr2_flop" description="Compucolor II Disk Images">
+<softwarelist name="compclr2_flop" description="Compucolor II disk images">
 
 	<software name="asndware">
 		<description>Action Soundware</description>
@@ -50,7 +50,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="alieninva" cloneof="alieninv">
-		<description>Alien Invasion (v1.4, Alt)</description>
+		<description>Alien Invasion (v1.4, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="flop1" interface="floppy_5_25">
@@ -192,7 +192,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="asteroida" cloneof="asteroid">
-		<description>Asteroids (Alt)</description>
+		<description>Asteroids (alt)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="flop1" interface="floppy_5_25">
@@ -284,7 +284,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="basiclesa" cloneof="basicles">
-		<description>BASIC Lessons (Alt)</description>
+		<description>BASIC Lessons (alt)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="flop1" interface="floppy_5_25">
@@ -317,7 +317,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="bshipa" cloneof="bship">
-		<description>Battleship (Alt)</description>
+		<description>Battleship (alt)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="flop1" interface="floppy_5_25">
@@ -361,7 +361,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="blanka" cloneof="blank">
-		<description>Blank (Alt)</description>
+		<description>Blank (alt)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="flop1" interface="floppy_5_25">
@@ -1279,7 +1279,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="draw2a" cloneof="draw2">
-		<description>Draw 2 (Alt)</description>
+		<description>Draw 2 (alt)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="flop1" interface="floppy_5_25">
@@ -1436,7 +1436,7 @@ license:CC0-1.0
 
 
 	<software name="fortstra" cloneof="fortstr">
-		<description>FORTRAN Strings Source (Alt)</description>
+		<description>FORTRAN Strings Source (alt)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="flop1" interface="floppy_5_25">
@@ -1469,7 +1469,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="galaxiana" cloneof="galaxian">
-		<description>Galaxian (Alt)</description>
+		<description>Galaxian (alt)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="flop1" interface="floppy_5_25">
@@ -1641,7 +1641,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="invadersa" cloneof="invaders">
-		<description>Invaders (Alt)</description>
+		<description>Invaders (alt)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="flop1" interface="floppy_5_25">
@@ -1746,7 +1746,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="lifea" cloneof="life">
-		<description>Life (Alt)</description>
+		<description>Life (alt)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="flop1" interface="floppy_5_25">
@@ -2418,7 +2418,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="strekgea" cloneof="strekge">
-		<description>Star Trek (Graham Epps, v30.8.80, Alt)</description>
+		<description>Star Trek (Graham Epps, v30.8.80, alt)</description>
 		<year>19??</year>
 		<publisher>Graham Epps</publisher>
 		<part name="flop1" interface="floppy_5_25">

--- a/hash/digilog320.xml
+++ b/hash/digilog320.xml
@@ -3,7 +3,7 @@
 
 <!-- license:CC0-1.0 -->
 
-<softwarelist name="digilog320" description="Digilog 320 Disks">
+<softwarelist name="digilog320" description="Digilog 320 disks">
 
 	<!--
 	Marked bad because it contains extra files not present on the original disk:

--- a/hash/intv.xml
+++ b/hash/intv.xml
@@ -11,7 +11,7 @@ license:CC0-1.0
 -->
 
 
-<softwarelist name="intv" description="Intellivision cartridges">
+<softwarelist name="intv" description="Mattel Intellivision cartridges">
 
 	<software name="backgamm">
 		<description>ABPA Backgammon</description>

--- a/hash/rainbow.xml
+++ b/hash/rainbow.xml
@@ -6,7 +6,7 @@ license:CC0-1.0
 Software from here: http://rainbow-100.com
 -->
 
-<softwarelist name="rainbow" description="DEC Rainbow 100 Disk Images">
+<softwarelist name="rainbow" description="DEC Rainbow 100 disk images">
 	<software name="concpm86">
 		<description>Concurrent CP/M-86</description>
 		<year>198?</year>


### PR DESCRIPTION
rainbow.xml: Lowercase on storage media description (DEC Rainbow 100 disk images).
digilog320.xml: Lowercase on storage media description (Digilog 320 disks).
intv.xml: Added manufacturer's name (Mattel Intellivision cartridges)
compclr2_flop.xml: Lowercase on storage media description (Compucolor II disk images) and lowercase on descriptive text on software's name