### PR TITLE
heathkit/h89.cpp: Add software list for H88 cassette software

### DIFF
--- a/hash/h88_cass.xml
+++ b/hash/h88_cass.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+license:CC0-1.0
+-->
+<softwarelist name="h88_cass" description="Heath H88 cassettes">
+
+	<software name="bug8_02_05_00">
+		<description>BUG-8 02.05.00</description>
+		<year>1978</year>
+		<publisher>Heath Corp.</publisher>
+		<info name="alt_title" value="Heath/Wintek Terminal Debugger"/>
+		<info name="developer" value="Heath Corp./Wintek Corp."/>
+		<info name="distributor" value="Heath Corp."/>
+		<info name="release" value="197806xx"/>
+		<info name="version" value="02.05.00"/>
+
+		<part name="cass" interface="h88_cass_player">
+			<dataarea name="cass" size="7469604">
+				<rom name="bug8_02_05_00.wav" size="7469604" crc="daa26866" sha1="578d3689db9023999a12095f1d493c80d3486392"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bug8_02_06_00">
+		<description>BUG-8 02.06.00</description>
+		<year>1978</year>
+		<publisher>Heath Corp.</publisher>
+		<info name="alt_title" value="Heath/Wintek Terminal Debugger"/>
+		<info name="developer" value="Heath Corp./Wintek Corp."/>
+		<info name="distributor" value="Heath Corp."/>
+		<info name="release" value="197806xx"/>
+		<info name="version" value="02.06.00"/>
+
+		<part name="cass" interface="h88_cass_player">
+			<dataarea name="cass" size="7641284">
+				<rom name="bug8_02_06_00.wav" size="7641284" crc="56cfdab8" sha1="dd1d3a796d22129551279a4a10b79493c8d4fc9f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="exbasic_10_05_00">
+		<description>Extended Benton Harbor Basic 10.05.00</description>
+		<year>1978</year>
+		<publisher>Heath Corp.</publisher>
+		<info name="alt_title" value="Extended Benton Harbor Basic"/>
+		<info name="developer" value="Heath Corp./Wintek Corp."/>
+		<info name="distributor" value="Heath Corp."/>
+		<info name="release" value="197806xx"/>
+		<info name="version" value="10.05.00"/>
+
+		<part name="cass" interface="h88_cass_player">
+			<dataarea name="cass" size="17831084">
+				<rom name="exbasic_10_05_00.wav" size="17831084" crc="2ab64338" sha1="676dd011c11fe1ae2d60f6747beb8f3b10161b47"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="exbasic_10_05_01">
+		<description>Extended Benton Harbor Basic 10.05.01</description>
+		<year>1978</year>
+		<publisher>Heath Corp.</publisher>
+		<info name="alt_title" value="Extended Benton Harbor Basic"/>
+		<info name="developer" value="Heath Corp./Wintek Corp."/>
+		<info name="distributor" value="Heath Corp."/>
+		<info name="release" value="197806xx"/>
+		<info name="version" value="10.05.01"/>
+
+		<part name="cass" interface="h88_cass_player">
+			<dataarea name="cass" size="17832564">
+				<rom name="exbasic_10_05_01.wav" size="17832564" crc="8dad5b23" sha1="13db44e6df5a74ecaf1abd283822ddd3910161a8"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="exbasic_10_06_00">
+		<description>Extended Benton Harbor Basic 10.06.00</description>
+		<year>1979</year>
+		<publisher>Heath Corp.</publisher>
+		<info name="alt_title" value="Extended Benton Harbor Basic"/>
+		<info name="developer" value="Heath Corp./Wintek Corp."/>
+		<info name="distributor" value="Heath Corp."/>
+		<info name="release" value="197905xx"/>
+		<info name="version" value="10.06.00"/>
+
+		<part name="cass" interface="h88_cass_player">
+			<dataarea name="cass" size="18067884">
+				<rom name="exbasic_10_06_00.wav" size="18067884" crc="06d243e3" sha1="6f8483f7331aaf3d40621ab937fc5aeb9f0952fc"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hasl8_04_05_00">
+		<description>Heath H8 Assembler 04.05.00</description>
+		<year>1978</year>
+		<publisher>Heath Corp.</publisher>
+		<info name="alt_title" value="Heath HASL"/>
+		<info name="developer" value="Heath Corp."/>
+		<info name="distributor" value="Heath Corp."/>
+		<info name="release" value="197806xx"/>
+		<info name="version" value="04.05.00"/>
+
+		<part name="cass" interface="h88_cass_player">
+			<dataarea name="cass" size="11150364">
+				<rom name="hasl8_04_05_00.wav" size="11150364" crc="a3013409" sha1="5ba0f4ce8b5e2477df999e860e1dde630ccfe8f4"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hasl8_04_06_00">
+		<description>Heath H8 Assembler 04.06.00</description>
+		<year>1979</year>
+		<publisher>Heath Corp.</publisher>
+		<info name="alt_title" value="Heath HASL"/>
+		<info name="developer" value="Heath Corp."/>
+		<info name="distributor" value="Heath Corp."/>
+		<info name="release" value="197905xx"/>
+		<info name="version" value="04.05.00"/>
+
+		<part name="cass" interface="h88_cass_player">
+			<dataarea name="cass" size="11360524">
+				<rom name="hasl8_04_06_00.wav" size="11360524" crc="d2cc4af9" sha1="99228eea290531911d716230de5e485d7e570663"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ted8_03_05_00">
+		<description>Heath/Wintek H8 Editor 03.05.00</description>
+		<year>1979</year>
+		<publisher>Heath Corp.</publisher>
+		<info name="alt_title" value="TED-8"/>
+		<info name="developer" value="Heath Corp./Wintek Corp."/>
+		<info name="distributor" value="Heath Corp."/>
+		<info name="release" value="197803xx"/>
+		<info name="version" value="03.05.00"/>
+
+		<part name="cass" interface="h88_cass_player">
+			<dataarea name="cass" size="10352644">
+				<rom name="ted8_03_05_00.wav" size="10352644" crc="6dc65907" sha1="59a6a420adbd98834d9e4610578b4e7030091a4f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ted8_03_06_00">
+		<description>Heath/Wintek H8 Editor 03.06.00</description>
+		<year>1979</year>
+		<publisher>Heath Corp.</publisher>
+		<info name="alt_title" value="TED-8"/>
+		<info name="developer" value="Heath Corp./Wintek Corp."/>
+		<info name="distributor" value="Heath Corp."/>
+		<info name="release" value="197803xx"/>
+		<info name="version" value="03.05.00"/>
+
+		<part name="cass" interface="h88_cass_player">
+			<dataarea name="cass" size="10536164">
+				<rom name="ted8_03_06_00.wav" size="10536164" crc="e01091ab" sha1="caded9afe6fb0dd182289441a62ff15409e283cb"/>
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/h88_cass.xml
+++ b/hash/h88_cass.xml
@@ -5,7 +5,7 @@ license:CC0-1.0
 -->
 <softwarelist name="h88_cass" description="Heath H88 cassettes">
 
-	<software name="bug8_02_05_00">
+	<software name="bug8_02_05_00" cloneof="bug8">
 		<description>BUG-8 02.05.00</description>
 		<year>1978</year>
 		<publisher>Heath Corp.</publisher>
@@ -22,7 +22,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="bug8_02_06_00">
+	<software name="bug8">
 		<description>BUG-8 02.06.00</description>
 		<year>1978</year>
 		<publisher>Heath Corp.</publisher>
@@ -39,7 +39,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="exbasic_10_05_00">
+	<software name="exbasic_10_05_00" cloneof="exbasic">
 		<description>Extended Benton Harbor Basic 10.05.00</description>
 		<year>1978</year>
 		<publisher>Heath Corp.</publisher>
@@ -56,7 +56,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="exbasic_10_05_01">
+	<software name="exbasic_10_05_01" cloneof="exbasic">
 		<description>Extended Benton Harbor Basic 10.05.01</description>
 		<year>1978</year>
 		<publisher>Heath Corp.</publisher>
@@ -73,7 +73,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="exbasic_10_06_00">
+	<software name="exbasic">
 		<description>Extended Benton Harbor Basic 10.06.00</description>
 		<year>1979</year>
 		<publisher>Heath Corp.</publisher>
@@ -90,7 +90,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="hasl8_04_05_00">
+	<software name="hasl8_04_05_00" cloneof="hasl8">
 		<description>Heath H8 Assembler 04.05.00</description>
 		<year>1978</year>
 		<publisher>Heath Corp.</publisher>
@@ -107,7 +107,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="hasl8_04_06_00">
+	<software name="hasl8">
 		<description>Heath H8 Assembler 04.06.00</description>
 		<year>1979</year>
 		<publisher>Heath Corp.</publisher>
@@ -124,7 +124,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="ted8_03_05_00">
+	<software name="ted8_03_05_00" cloneof="ted8">
 		<description>Heath/Wintek H8 Editor 03.05.00</description>
 		<year>1979</year>
 		<publisher>Heath Corp.</publisher>
@@ -141,7 +141,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="ted8_03_06_00">
+	<software name="ted8">
 		<description>Heath/Wintek H8 Editor 03.06.00</description>
 		<year>1979</year>
 		<publisher>Heath Corp.</publisher>

--- a/hash/h88_cass.xml
+++ b/hash/h88_cass.xml
@@ -16,8 +16,8 @@ license:CC0-1.0
 		<info name="version" value="02.05.00"/>
 
 		<part name="cass" interface="h88_cass_player">
-			<dataarea name="cass" size="7469604">
-				<rom name="bug8_02_05_00.wav" size="7469604" crc="daa26866" sha1="578d3689db9023999a12095f1d493c80d3486392"/>
+			<dataarea name="cass" size="5027">
+				<rom name="bug8_02_05_00.h8t" size="5027" crc="6013dd00" sha1="805f89fee7ade4cf9d2401b111006634d9239d92"/>
 			</dataarea>
 		</part>
 	</software>
@@ -33,8 +33,8 @@ license:CC0-1.0
 		<info name="version" value="02.06.00"/>
 
 		<part name="cass" interface="h88_cass_player">
-			<dataarea name="cass" size="7641284">
-				<rom name="bug8_02_06_00.wav" size="7641284" crc="56cfdab8" sha1="dd1d3a796d22129551279a4a10b79493c8d4fc9f"/>
+			<dataarea name="cass" size="5143">
+				<rom name="bug8_02_06_00.h8t" size="5143" crc="63ab0c02" sha1="29c0b0242dca535eebc911288df40f34813cf08b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -50,8 +50,8 @@ license:CC0-1.0
 		<info name="version" value="10.05.00"/>
 
 		<part name="cass" interface="h88_cass_player">
-			<dataarea name="cass" size="17831084">
-				<rom name="exbasic_10_05_00.wav" size="17831084" crc="2ab64338" sha1="676dd011c11fe1ae2d60f6747beb8f3b10161b47"/>
+			<dataarea name="cass" size="12028">
+				<rom name="exbasic_10_05_00.h8t" size="12028" crc="f7ff8fcc" sha1="d1010ed4d3cb68a0fb4a3380bf3d5c31b72bf370"/>
 			</dataarea>
 		</part>
 	</software>
@@ -67,8 +67,8 @@ license:CC0-1.0
 		<info name="version" value="10.05.01"/>
 
 		<part name="cass" interface="h88_cass_player">
-			<dataarea name="cass" size="17832564">
-				<rom name="exbasic_10_05_01.wav" size="17832564" crc="8dad5b23" sha1="13db44e6df5a74ecaf1abd283822ddd3910161a8"/>
+			<dataarea name="cass" size="12029">
+				<rom name="exbasic_10_05_01.h8t" size="12029" crc="ac6f60f2" sha1="59cf1d2077548ba14cc5b600f065f3147b87a9e3"/>
 			</dataarea>
 		</part>
 	</software>
@@ -84,8 +84,8 @@ license:CC0-1.0
 		<info name="version" value="10.06.00"/>
 
 		<part name="cass" interface="h88_cass_player">
-			<dataarea name="cass" size="18067884">
-				<rom name="exbasic_10_06_00.wav" size="18067884" crc="06d243e3" sha1="6f8483f7331aaf3d40621ab937fc5aeb9f0952fc"/>
+			<dataarea name="cass" size="12188">
+				<rom name="exbasic_10_06_00.h8t" size="12188" crc="9fafdac1" sha1="f55bfab541640ac92e615e83eb2d705347d17510"/>
 			</dataarea>
 		</part>
 	</software>
@@ -101,8 +101,8 @@ license:CC0-1.0
 		<info name="version" value="04.05.00"/>
 
 		<part name="cass" interface="h88_cass_player">
-			<dataarea name="cass" size="11150364">
-				<rom name="hasl8_04_05_00.wav" size="11150364" crc="a3013409" sha1="5ba0f4ce8b5e2477df999e860e1dde630ccfe8f4"/>
+			<dataarea name="cass" size="7514">
+				<rom name="hasl8_04_05_00.h8t" size="7514" crc="2a67cc74" sha1="aa109a5cfc4e84d002c1f237e072524d7eb00cf9"/>
 			</dataarea>
 		</part>
 	</software>
@@ -118,8 +118,8 @@ license:CC0-1.0
 		<info name="version" value="04.05.00"/>
 
 		<part name="cass" interface="h88_cass_player">
-			<dataarea name="cass" size="11360524">
-				<rom name="hasl8_04_06_00.wav" size="11360524" crc="d2cc4af9" sha1="99228eea290531911d716230de5e485d7e570663"/>
+			<dataarea name="cass" size="7656">
+				<rom name="hasl8_04_06_00.h8t" size="7656" crc="803261b4" sha1="475d2c9edd7d3b1e4e91e18265055747909882ff"/>
 			</dataarea>
 		</part>
 	</software>
@@ -135,8 +135,8 @@ license:CC0-1.0
 		<info name="version" value="03.05.00"/>
 
 		<part name="cass" interface="h88_cass_player">
-			<dataarea name="cass" size="10352644">
-				<rom name="ted8_03_05_00.wav" size="10352644" crc="6dc65907" sha1="59a6a420adbd98834d9e4610578b4e7030091a4f"/>
+			<dataarea name="cass" size="6975">
+				<rom name="ted8_03_05_00.h8t" size="6975" crc="b2f174ef" sha1="719305f2a431d77c8f77e49cf4d0f40765b59f0d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -152,8 +152,8 @@ license:CC0-1.0
 		<info name="version" value="03.05.00"/>
 
 		<part name="cass" interface="h88_cass_player">
-			<dataarea name="cass" size="10536164">
-				<rom name="ted8_03_06_00.wav" size="10536164" crc="e01091ab" sha1="caded9afe6fb0dd182289441a62ff15409e283cb"/>
+			<dataarea name="cass" size="7099">
+				<rom name="ted8_03_06_00.h8t" size="7099" crc="0e2d2186" sha1="a3df79d1629fc11864060e5858d554aa9b5963d1"/>
 			</dataarea>
 		</part>
 	</software>

--- a/src/lib/formats/h8_cas.cpp
+++ b/src/lib/formats/h8_cas.cpp
@@ -7,16 +7,31 @@ Support for Heathkit H8 H8T cassette images
 
 Standard Kansas City format (300 baud)
 
+TODO - investigate 1200 buad support, H8 should support it, but H88 does not.
+
 We output a leader, followed by the contents of the H8T file.
 
 ********************************************************************/
 
 #include "h8_cas.h"
 
-#define WAVEENTRY_LOW  -32768
-#define WAVEENTRY_HIGH  32767
+#include <algorithm>
 
-#define H8_WAV_FREQUENCY   9600
+
+static const uint16_t WAVEENTRY_LOW         = -32768;
+static const uint16_t WAVEENTRY_HIGH        = 32767;
+static const uint16_t SILENCE               = 0;
+
+// using a multiple of 4800 will ensure an integer multiple of samples for each wave.
+static const uint16_t H8_WAV_FREQUENCY      = 9600;
+static const uint16_t TAPE_BAUD_RATE        = 300;
+static const uint16_t SAMPLES_PER_BIT       = H8_WAV_FREQUENCY / TAPE_BAUD_RATE;
+static const uint16_t SAMPLES_PER_HALF_WAVE = SAMPLES_PER_BIT / 2;
+
+static const uint16_t ONE_FREQ              = 1200;
+static const uint16_t ZERO_FREQ             = 2400;
+static const uint16_t ONE_CYCLES            = H8_WAV_FREQUENCY / ONE_FREQ;
+static const uint16_t ZERO_CYCLES           = H8_WAV_FREQUENCY / ZERO_FREQ;
 
 // image size
 static int h8_image_size; // FIXME: global variable prevents multiple instances
@@ -25,8 +40,7 @@ static int h8_put_samples(int16_t *buffer, int sample_pos, int count, int level)
 {
 	if (buffer)
 	{
-		for (int i=0; i<count; i++)
-			buffer[sample_pos + i] = level;
+		std::fill_n(&buffer[sample_pos], count, level);
 	}
 
 	return count;
@@ -36,57 +50,48 @@ static int h8_output_bit(int16_t *buffer, int sample_pos, bool bit)
 {
 	int samples = 0;
 
-	for (uint8_t i = 0; i < 4; i++)
+	int loops = bit ? ONE_CYCLES : ZERO_CYCLES;
+	int samplePerValue = SAMPLES_PER_HALF_WAVE / loops;
+
+	for (int i = 0; i < loops; i++)
 	{
-		if (bit)
-		{
-			samples += h8_put_samples(buffer, sample_pos + samples, 2, WAVEENTRY_LOW);
-			samples += h8_put_samples(buffer, sample_pos + samples, 2, WAVEENTRY_HIGH);
-			samples += h8_put_samples(buffer, sample_pos + samples, 2, WAVEENTRY_LOW);
-			samples += h8_put_samples(buffer, sample_pos + samples, 2, WAVEENTRY_HIGH);
-		}
-		else
-		{
-			samples += h8_put_samples(buffer, sample_pos + samples, 4, WAVEENTRY_LOW);
-			samples += h8_put_samples(buffer, sample_pos + samples, 4, WAVEENTRY_HIGH);
-		}
+		samples += h8_put_samples(buffer, sample_pos + samples, samplePerValue, WAVEENTRY_LOW);
+		samples += h8_put_samples(buffer, sample_pos + samples, samplePerValue, WAVEENTRY_HIGH);
 	}
 
 	return samples;
 }
 
-static int h8_output_byte(int16_t *buffer, int sample_pos, uint8_t byte)
+static int h8_output_byte(int16_t *buffer, int sample_pos, uint8_t data)
 {
 	int samples = 0;
-	uint8_t i;
 
 	// start bit
-	samples += h8_output_bit (buffer, sample_pos + samples, 0);
+	samples += h8_output_bit(buffer, sample_pos + samples, 0);
 
 	// data bits
-	for (i = 0; i<8; i++)
-		samples += h8_output_bit (buffer, sample_pos + samples, (byte >> i) & 1);
+	for (int i = 0; i < 8; i++)
+	{
+		samples += h8_output_bit(buffer, sample_pos + samples, data & 1);
+		data >>= 1;
+	}
 
-	// stop bits
-	for (i = 0; i<2; i++)
-		samples += h8_output_bit (buffer, sample_pos + samples, 1);
+	// stop bit
+	samples += h8_output_bit(buffer, sample_pos + samples, 1);
 
 	return samples;
 }
 
 static int h8_handle_cassette(int16_t *buffer, const uint8_t *bytes)
 {
-	uint32_t sample_count = 0;
-	uint32_t byte_count = 0;
-	uint32_t i;
+	int sample_count = 0;
 
-
-	// leader
-	for (i=0; i<2000; i++)
+	// leader - 1 second
+	for (int i = 0; i < TAPE_BAUD_RATE; i++)
 		sample_count += h8_output_bit(buffer, sample_count, 1);
 
 	// data
-	for (i=byte_count; i<h8_image_size; i++)
+	for (int i = 0; i < h8_image_size; i++)
 		sample_count += h8_output_byte(buffer, sample_count, bytes[i]);
 
 	return sample_count;

--- a/src/lib/formats/h8_cas.cpp
+++ b/src/lib/formats/h8_cas.cpp
@@ -18,20 +18,20 @@ We output a leader, followed by the contents of the H8T file.
 #include <algorithm>
 
 
-static const uint16_t WAVEENTRY_LOW         = -32768;
-static const uint16_t WAVEENTRY_HIGH        = 32767;
-static const uint16_t SILENCE               = 0;
+static constexpr uint16_t WAVEENTRY_LOW         = -32768;
+static constexpr uint16_t WAVEENTRY_HIGH        = 32767;
+static constexpr uint16_t SILENCE               = 0;
 
 // using a multiple of 4800 will ensure an integer multiple of samples for each wave.
-static const uint16_t H8_WAV_FREQUENCY      = 9600;
-static const uint16_t TAPE_BAUD_RATE        = 300;
-static const uint16_t SAMPLES_PER_BIT       = H8_WAV_FREQUENCY / TAPE_BAUD_RATE;
-static const uint16_t SAMPLES_PER_HALF_WAVE = SAMPLES_PER_BIT / 2;
+static constexpr uint16_t H8_WAV_FREQUENCY      = 9600;
+static constexpr uint16_t TAPE_BAUD_RATE        = 300;
+static constexpr uint16_t SAMPLES_PER_BIT       = H8_WAV_FREQUENCY / TAPE_BAUD_RATE;
+static constexpr uint16_t SAMPLES_PER_HALF_WAVE = SAMPLES_PER_BIT / 2;
 
-static const uint16_t ONE_FREQ              = 1200;
-static const uint16_t ZERO_FREQ             = 2400;
-static const uint16_t ONE_CYCLES            = H8_WAV_FREQUENCY / ONE_FREQ;
-static const uint16_t ZERO_CYCLES           = H8_WAV_FREQUENCY / ZERO_FREQ;
+static constexpr uint16_t ONE_FREQ              = 1200;
+static constexpr uint16_t ZERO_FREQ             = 2400;
+static constexpr uint16_t ONE_CYCLES            = H8_WAV_FREQUENCY / ONE_FREQ;
+static constexpr uint16_t ZERO_CYCLES           = H8_WAV_FREQUENCY / ZERO_FREQ;
 
 // image size
 static int h8_image_size; // FIXME: global variable prevents multiple instances
@@ -50,8 +50,8 @@ static int h8_output_bit(int16_t *buffer, int sample_pos, bool bit)
 {
 	int samples = 0;
 
-	int loops = bit ? ONE_CYCLES : ZERO_CYCLES;
-	int samplePerValue = SAMPLES_PER_HALF_WAVE / loops;
+	const int loops = bit ? ONE_CYCLES : ZERO_CYCLES;
+	const int samplePerValue = SAMPLES_PER_HALF_WAVE / loops;
 
 	for (int i = 0; i < loops; i++)
 	{

--- a/src/lib/formats/kc_cas.cpp
+++ b/src/lib/formats/kc_cas.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Sandro Ronco
+// copyright-holders:Sandro Ronco,Mark Garlanger
 /********************************************************************
 
     Support for KC85 cassette images
@@ -10,6 +10,7 @@
     - tp2: cassette image with ID and checksum (130 bytes block)
     - kcm: same as tp2 but without head
     - sss: BASIC data without head (miss the first 11 bytes)
+    - h8t: Heath H8/H88 format
 
 ********************************************************************/
 
@@ -34,7 +35,8 @@ enum
 	KC_IMAGE_KCC,
 	KC_IMAGE_TP2,
 	KC_IMAGE_TAP,
-	KC_IMAGE_KCM
+	KC_IMAGE_KCM,
+	KC_IMAGE_H8T
 };
 
 // image size
@@ -384,8 +386,97 @@ static const cassette_image::Format kc_sss_format =
 };
 
 
+static int kc_h8t_handle_cass(int16_t *buffer, const uint8_t *casdata, int type)
+{
+	int data_pos = 0;
+	int sample_count = 0;
+
+	// 0.25 sec of silence at start
+	sample_count += kc_cas_silence(buffer, sample_count, KC_WAV_FREQUENCY / 4);
+
+	// 100 cycles of BIT_1 for synchronization
+	for (int i=0; i < 100; i++)
+		sample_count += kc_cas_cycle( buffer, sample_count, FREQ_BIT_1);
+
+	// on the entire file
+	while( data_pos < kc_image_size )
+	{
+		uint8_t data = 0;
+
+		if (data_pos < kc_image_size)
+			data = casdata[data_pos++];
+
+		// write a byte
+		sample_count += kc_cas_byte( buffer, sample_count, data );
+	}
+
+	sample_count += kc_cas_cycle( buffer, sample_count, FREQ_SEPARATOR);
+
+	// 0.25 sec of silence
+	sample_count += kc_cas_silence(buffer, sample_count, KC_WAV_FREQUENCY / 4);
+
+	return sample_count;
+}
+
+static int kc_handle_h8t(int16_t *buffer, const uint8_t *casdata)
+{
+	return kc_h8t_handle_cass(buffer, casdata, KC_IMAGE_H8T);
+}
+
+/*******************************************************************
+   Generate samples for the tape image
+********************************************************************/
+static int kc_h8t_fill_wave(int16_t *buffer, int sample_count, uint8_t *bytes)
+{
+	return kc_handle_h8t(buffer, bytes);
+}
+
+
+/*******************************************************************
+   Calculate the number of samples needed for this tape image
+********************************************************************/
+static int kc_h8t_to_wav_size(const uint8_t *casdata, int caslen)
+{
+	kc_image_size = caslen ;
+
+	return kc_handle_h8t( nullptr, casdata );
+}
+
+
+static const cassette_image::LegacyWaveFiller kc_h8t_legacy_fill_wave =
+{
+	kc_h8t_fill_wave,                       /* fill_wave */
+	-1,                                     /* chunk_size */
+	0,                                      /* chunk_samples */
+	kc_h8t_to_wav_size,                     /* chunk_sample_calc */
+	KC_WAV_FREQUENCY,                       /* sample_frequency */
+	0,                                      /* header_samples */
+	0                                       /* trailer_samples */
+};
+
+static cassette_image::error kc_h8t_identify(cassette_image *cassette, cassette_image::Options *opts)
+{
+	return cassette->legacy_identify(opts, &kc_h8t_legacy_fill_wave);
+}
+
+
+static cassette_image::error kc_h8t_load(cassette_image *cassette)
+{
+	return cassette->legacy_construct(&kc_h8t_legacy_fill_wave);
+}
+
+static const cassette_image::Format kc_h8t_format =
+{
+	"h8t",
+	kc_h8t_identify,
+	kc_h8t_load,
+	nullptr
+};
+
+
 CASSETTE_FORMATLIST_START(kc_cassette_formats)
 	CASSETTE_FORMAT(kc_kcc_format)
 	CASSETTE_FORMAT(kc_tap_format)
 	CASSETTE_FORMAT(kc_sss_format)
+	CASSETTE_FORMAT(kc_h8t_format)
 CASSETTE_FORMATLIST_END

--- a/src/mame/heathkit/h89.cpp
+++ b/src/mame/heathkit/h89.cpp
@@ -53,6 +53,7 @@
 #include "machine/ram.h"
 #include "machine/timer.h"
 
+#include "softlist_dev.h"
 
 // Single Step
 #define LOG_SS    (1U << 1)
@@ -836,6 +837,8 @@ void h88_state::h88(machine_config &config)
 
 	m_intr_socket->set_default_option("original");
 	m_intr_socket->set_fixed(true);
+
+	SOFTWARE_LIST(config, "cass_list").set_original("h88_cass");
 
 	// H-88-5 Cassette interface board
 	HEATH_H88_CASS(config, m_cassette, H89_CLOCK);

--- a/src/mame/heathkit/h_88_cass.cpp
+++ b/src/mame/heathkit/h_88_cass.cpp
@@ -153,13 +153,13 @@ void heath_h_88_cass_device::device_add_mconfig(machine_config &config)
 	m_cass_player->set_formats(h8_cassette_formats);
 	m_cass_player->set_default_state(CASSETTE_STOPPED | CASSETTE_MOTOR_ENABLED | CASSETTE_SPEAKER_ENABLED);
 	m_cass_player->add_route(ALL_OUTPUTS, "mono", 0.15);
-	m_cass_player->set_interface("h89_cass_player");
+	m_cass_player->set_interface("h88_cass_player");
 
 	CASSETTE(config, m_cass_recorder);
 	m_cass_recorder->set_formats(h8_cassette_formats);
 	m_cass_recorder->set_default_state(CASSETTE_STOPPED | CASSETTE_MOTOR_ENABLED | CASSETTE_SPEAKER_ENABLED);
 	m_cass_recorder->add_route(ALL_OUTPUTS, "mono", 0.15);
-	m_cass_recorder->set_interface("h89_cass_recorder");
+	m_cass_recorder->set_interface("h88_cass_recorder");
 
 	TIMER(config, "kansas_w").configure_periodic(FUNC(heath_h_88_cass_device::kansas_w), attotime::from_hz(4800));
 	TIMER(config, "kansas_r").configure_periodic(FUNC(heath_h_88_cass_device::kansas_r), attotime::from_hz(40000));


### PR DESCRIPTION
Added official Heath software programs for the H88 cassette interface. These programs were originally written for the H8 and it's cassette interface, but needed updating to support the H89's 8250 UART for the console, instead of the original 8251 used in the H8.