### PR TITLE
cpu/patinhofeio/patinho_feio.cpp: Fix missing space in printf string

### DIFF
--- a/src/devices/cpu/patinhofeio/patinho_feio.cpp
+++ b/src/devices/cpu/patinhofeio/patinho_feio.cpp
@@ -683,7 +683,7 @@ void patinho_feio_cpu_device::execute_instruction()
 							if (channel==0xE){
 								//TODO: Implement-me!
 							} else {
-								printf("Function 8 of the /FNC instruction can only be used with"\
+								printf("Function 8 of the /FNC instruction can only be used with "\
 										"the papertape reader device at channel /E.\n");
 							}
 							break;


### PR DESCRIPTION
Fixes the string concatenation "withthe" without a space between the words.