### PR TITLE
netlist/build/makefile: Remove duplicate $(OBJ)/devices directory

### DIFF
--- a/src/lib/netlist/build/makefile
+++ b/src/lib/netlist/build/makefile
@@ -146,7 +146,6 @@ OBJDIRS = $(OBJ) \
 			$(OBJ)/solver \
 			$(OBJ)/devices \
 			$(OBJ)/plib \
-			$(OBJ)/devices \
 			$(OBJ)/macro \
 			$(OBJ)/macro/modules \
 			$(OBJ)/tests \


### PR DESCRIPTION
Removes the duplicate $(OBJ)/devices directory from the list of object directories.