### PR TITLE
rm/rm380z.cpp: Use real character ROM for COS 4.0, correct screen resolution and add support for user defined characters

### DIFF
--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -136,7 +136,6 @@ Notes on COS 4.0 disassembly:
 
 TODO:
 
-- Properly implement "backwards" or "last 4 lines" scrolling
 - Properly implement dimming and graphic chars (>0x80)
 - Understand why any write to disk command fails with "bad sector"
 - Understand why ctrl-U (blinking cursor) in COS 4.0 stops keyboard input from working
@@ -248,8 +247,10 @@ void rm380z_state::rm380z(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
 	// according to videos and pictures of the real hardware, chars are spaced of at least 1 pixel
 	// and there is at least 1 pixel between each row of characters
-	screen.set_size((RM380Z_SCREENCOLS*(RM380Z_CHDIMX+1)), (RM380Z_SCREENROWS*(RM380Z_CHDIMY+1)));
-	screen.set_visarea(0, (RM380Z_SCREENCOLS*(RM380Z_CHDIMX+1))-1, 0, (RM380Z_SCREENROWS*(RM380Z_CHDIMY+1))-1);
+	//screen.set_size((RM380Z_SCREENCOLS*(RM380Z_CHDIMX+1)), (RM380Z_SCREENROWS*(RM380Z_CHDIMY+1)));
+	//screen.set_visarea(0, (RM380Z_SCREENCOLS*(RM380Z_CHDIMX+1))-1, 0, (RM380Z_SCREENROWS*(RM380Z_CHDIMY+1))-1);
+	screen.set_size(640, 240);
+	screen.set_visarea(0, 639, 0, 239);
 	screen.set_screen_update(FUNC(rm380z_state::screen_update_rm380z));
 	screen.set_palette("palette");
 
@@ -326,9 +327,8 @@ ROM_START( rm380z ) // COS 4.0B/M
 	ROM_LOAD( "cos40b-m.bin", 0x0000, 0x1000, BAD_DUMP CRC(1f0b3a5c) SHA1(0b29cb2a3b7eaa3770b34f08c4fd42844f42700f))
 	ROM_LOAD( "cos40b-m_f600-f9ff.bin", 0x1000, 0x400, BAD_DUMP CRC(e3397d9d) SHA1(490a0c834b0da392daf782edc7d51ca8f0668b1a))
 	ROM_LOAD( "cos40b-m_1c00-1dff.bin", 0x1400, 0x200, BAD_DUMP CRC(0f759f44) SHA1(9689c1c1faa62c56def999cbedbbb0c8d928dcff))
-	// chargen ROM is undumped, afaik
-	ROM_REGION( 0x1680, "chargen", 0 )
-	ROM_LOAD( "ch3.raw", 0x0000, 0x1680, BAD_DUMP CRC(c223622b) SHA1(185ef24896419d7ff46f71a760ac217de3811684))
+	ROM_REGION( 2048, "chargen", 0 )
+	ROM_LOAD( "c-gen-22.bin", 0x0000, 2048, CRC(1b67127f) SHA1(289a919871d30c5e832d22244bcac1dcfd544baa))
 ROM_END
 
 // RM480Z is quite different, might be better off in its own driver

--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -326,12 +326,12 @@ ROM_END
 
 ROM_START( rm380z ) // COS 4.0B/M
 	ROM_REGION( 0x10000, RM380Z_MAINCPU_TAG, 0 )
-	// I'm not sure of how those roms have been dumped. I don't know if those are good dumps or not.
-	ROM_LOAD( "cos40b-m.bin", 0x0000, 0x1000, BAD_DUMP CRC(1f0b3a5c) SHA1(0b29cb2a3b7eaa3770b34f08c4fd42844f42700f))
-	ROM_LOAD( "cos40b-m_f600-f9ff.bin", 0x1000, 0x400, BAD_DUMP CRC(e3397d9d) SHA1(490a0c834b0da392daf782edc7d51ca8f0668b1a))
-	ROM_LOAD( "cos40b-m_1c00-1dff.bin", 0x1400, 0x200, BAD_DUMP CRC(0f759f44) SHA1(9689c1c1faa62c56def999cbedbbb0c8d928dcff))
-	ROM_REGION( 2048, "chargen", 0 )
-	ROM_LOAD( "c-gen-22.bin", 0x0000, 2048, CRC(1b67127f) SHA1(289a919871d30c5e832d22244bcac1dcfd544baa))
+	// I'm not sure of how those ROMs have been dumped. I don't know if those are good dumps or not.
+	ROM_LOAD( "cos40b-m.bin",           0x0000, 0x1000, BAD_DUMP CRC(1f0b3a5c) SHA1(0b29cb2a3b7eaa3770b34f08c4fd42844f42700f) )
+	ROM_LOAD( "cos40b-m_f600-f9ff.bin", 0x1000, 0x0400, BAD_DUMP CRC(e3397d9d) SHA1(490a0c834b0da392daf782edc7d51ca8f0668b1a) )
+	ROM_LOAD( "cos40b-m_1c00-1dff.bin", 0x1400, 0x0200, BAD_DUMP CRC(0f759f44) SHA1(9689c1c1faa62c56def999cbedbbb0c8d928dcff) )
+	ROM_REGION( 0x0800, "chargen", 0 )
+	ROM_LOAD( "c-gen-22.bin",           0x0000, 0x0800, CRC(1b67127f) SHA1(289a919871d30c5e832d22244bcac1dcfd544baa) )
 ROM_END
 
 // RM480Z is quite different, might be better off in its own driver
@@ -340,7 +340,7 @@ ROM_START( rm480z )
 	ROM_LOAD( "fv2.0_0_12099_19.2.86.ic83", 0x0000, 0x4000, CRC(a0f02d8a) SHA1(1c063b842699dc0ad85a5a5f337f2864497f9c0f) )
 	ROM_LOAD( "fv2.0_1_12100_27.2.86.ic93", 0x4000, 0x4000, CRC(2a93ca6e) SHA1(7fdd772d4251dbf951a687d184ed787cfe21212b) )
 	ROM_REGION( 0x2000, "chargen", 0 )
-	ROM_LOAD( "cg06_12098_28.2.86.ic98", 0x0000, 0x2000, CRC(15d40f7e) SHA1(a7266357eb9be849f77a97ff3013b236c0af8289) )
+	ROM_LOAD( "cg06_12098_28.2.86.ic98",    0x0000, 0x2000, CRC(15d40f7e) SHA1(a7266357eb9be849f77a97ff3013b236c0af8289) )
 ROM_END
 
 ROM_START( rm480za )
@@ -353,7 +353,7 @@ ROM_START( rm480za )
 	ROM_LOAD( "idc3-1i.rom",   0x0000, 0x2000, CRC(39e2cdf0) SHA1(ba523af357b61bbe6192727139850f36597d79f1) )
 	ROM_LOAD( "idc5-1j.rom",   0x2000, 0x2000, CRC(d2ac27e2) SHA1(12d3966e0096c9bfb98135e15c3ddb37920cce15) )
 	ROM_REGION( 0x2000, "chargen", 0 )
-	ROM_LOAD( "cg06.lq", 0x0000, 0x2000, BAD_DUMP CRC(15d40f7e) SHA1(a7266357eb9be849f77a97ff3013b236c0af8289) ) // chip is marked CG05, might not be the same, so marked as bad
+	ROM_LOAD( "cg06.lq",       0x0000, 0x2000, BAD_DUMP CRC(15d40f7e) SHA1(a7266357eb9be849f77a97ff3013b236c0af8289) ) // chip is marked CG05, might not be the same, so marked as bad
 ROM_END
 
 
@@ -362,6 +362,5 @@ ROM_END
 COMP(1978, rm380z,    0,      0,      rm380z,  rm380z, rm380z_state, init_rm380z,    "Research Machines", "RM-380Z, COS 4.0B",    MACHINE_NO_SOUND_HW)
 COMP(1978, rm380z34d, rm380z, 0,      rm380z,  rm380z, rm380z_state, init_rm380z34d, "Research Machines", "RM-380Z, COS 3.4D",    MACHINE_NO_SOUND_HW)
 COMP(1978, rm380z34e, rm380z, 0,      rm380z,  rm380z, rm380z_state, init_rm380z34e, "Research Machines", "RM-380Z, COS 3.4E",    MACHINE_NO_SOUND_HW)
-COMP(1981, rm480z,    rm380z, 0,      rm480z,  rm380z, rm380z_state, init_rm480z, "Research Machines", "LINK RM-480Z (set 1)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
-COMP(1981, rm480za,   rm380z, 0,      rm480z,  rm380z, rm380z_state, init_rm480z, "Research Machines", "LINK RM-480Z (set 2)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
-
+COMP(1981, rm480z,    rm380z, 0,      rm480z,  rm380z, rm380z_state, init_rm480z,    "Research Machines", "LINK RM-480Z (set 1)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
+COMP(1981, rm480za,   rm380z, 0,      rm480z,  rm380z, rm380z_state, init_rm480z,    "Research Machines", "LINK RM-480Z (set 2)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND)

--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -230,7 +230,14 @@ static void rm380z_floppies(device_slot_interface &device)
 
 uint32_t rm380z_state::screen_update_rm380z(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	update_screen(bitmap);
+	if (screen.width() > 240)
+	{
+		update_screen_vdu80(bitmap);
+	}
+	else
+	{
+		update_screen_vdu40(bitmap);
+	}
 	return 0;
 }
 
@@ -242,17 +249,13 @@ void rm380z_state::rm380z(machine_config &config)
 	m_maincpu->set_addrmap(AS_IO, &rm380z_state::rm380z_io);
 
 	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(50);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	// according to videos and pictures of the real hardware, chars are spaced of at least 1 pixel
-	// and there is at least 1 pixel between each row of characters
-	//screen.set_size((RM380Z_SCREENCOLS*(RM380Z_CHDIMX+1)), (RM380Z_SCREENROWS*(RM380Z_CHDIMY+1)));
-	//screen.set_visarea(0, (RM380Z_SCREENCOLS*(RM380Z_CHDIMX+1))-1, 0, (RM380Z_SCREENROWS*(RM380Z_CHDIMY+1))-1);
-	screen.set_size(640, 240);
-	screen.set_visarea(0, 639, 0, 239);
-	screen.set_screen_update(FUNC(rm380z_state::screen_update_rm380z));
-	screen.set_palette("palette");
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(50);
+	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
+	m_screen->set_size(640, 240);
+	m_screen->set_visarea_full();
+	m_screen->set_screen_update(FUNC(rm380z_state::screen_update_rm380z));
+	m_screen->set_palette("palette");
 
 	PALETTE(config, "palette", palette_device::MONOCHROME);
 

--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -362,6 +362,6 @@ ROM_END
 COMP(1978, rm380z,    0,      0,      rm380z,  rm380z, rm380z_state, init_rm380z,    "Research Machines", "RM-380Z, COS 4.0B",    MACHINE_NO_SOUND_HW)
 COMP(1978, rm380z34d, rm380z, 0,      rm380z,  rm380z, rm380z_state, init_rm380z34d, "Research Machines", "RM-380Z, COS 3.4D",    MACHINE_NO_SOUND_HW)
 COMP(1978, rm380z34e, rm380z, 0,      rm380z,  rm380z, rm380z_state, init_rm380z34e, "Research Machines", "RM-380Z, COS 3.4E",    MACHINE_NO_SOUND_HW)
-COMP(1981, rm480z,    rm380z, 0,      rm480z,  rm380z, rm380z_state, init_rm380z34e, "Research Machines", "LINK RM-480Z (set 1)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
-COMP(1981, rm480za,   rm380z, 0,      rm480z,  rm380z, rm380z_state, init_rm380z34e, "Research Machines", "LINK RM-480Z (set 2)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
+COMP(1981, rm480z,    rm380z, 0,      rm480z,  rm380z, rm380z_state, init_rm480z, "Research Machines", "LINK RM-480Z (set 1)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
+COMP(1981, rm480za,   rm380z, 0,      rm480z,  rm380z, rm380z_state, init_rm480z, "Research Machines", "LINK RM-480Z (set 2)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
 

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -29,6 +29,31 @@ Research Machines RM 380Z
 //
 //
 
+template <int ROWS, int COLS>
+class rm380z_vram
+{
+public:
+	void set_char(int row, int col, uint8_t data) { m_chars[get_row(row)][col] = data; }
+	void set_attrib(int row, int col, uint8_t data) { m_attribs[get_row(row)][col] = data; }
+	void set_scroll_register(uint8_t value) { m_scroll_reg = value; }
+	void reset();
+
+	uint8_t get_char(int row, int col) const { return m_chars[get_row(row)][col]; }
+	uint8_t get_attrib(int row, int col) const { return m_attribs[get_row(row)][col]; }
+private:
+	int get_row(int row) const { return (row + m_scroll_reg) % ROWS; }
+
+	uint8_t m_chars[ROWS][COLS];
+	uint8_t m_attribs[ROWS][COLS];
+	uint8_t m_scroll_reg = 0;
+};
+
+template <int ROWS, int COLS>
+void rm380z_vram<ROWS, COLS>::reset()
+{
+	memset(m_attribs, 0, sizeof(m_attribs));
+	memset(m_chars, 0x80, sizeof(m_chars));
+}
 
 class rm380z_state : public driver_device
 {
@@ -68,9 +93,6 @@ private:
 	static inline constexpr int RM380Z_SCREENCOLS = 80;
 	static inline constexpr int RM380Z_SCREENROWS = 24;
 
-	static inline constexpr int RM380Z_VIDEORAM_SIZE = 0x600;
-	static inline constexpr int RM380Z_SCREENSIZE = 0x1200;
-
 	bool ports_enabled_high() const { return ( m_port0 & 0x80 ); }
 	bool ports_enabled_low() const { return !( m_port0 & 0x80 ); }
 
@@ -80,9 +102,7 @@ private:
 
 	void putChar(int charnum, int attribs, int x, int y, bitmap_ind16 &bitmap, int vmode);
 	void decode_videoram_char(int row, int col, uint8_t &chr, uint8_t &attrib);
-	void scroll_videoram();
 	void config_videomode();
-	void check_scroll_register();
 
 	void port_write(offs_t offset, uint8_t data);
 	uint8_t port_read(offs_t offset);
@@ -114,28 +134,25 @@ private:
 	void rm480z_io(address_map &map);
 	void rm480z_mem(address_map &map);
 
-	int writenum = 0;
-
 	uint8_t m_port0 = 0;
 	uint8_t m_port0_mask = 0;
 	uint8_t m_port0_kbd = 0;
 	uint8_t m_port1 = 0;
-	uint8_t m_fbfd = 0;
+	uint8_t m_fbfd_mask = 0;
 	uint8_t m_fbfe = 0;
 
-	uint8_t m_graphic_chars[0x80][(RM380Z_CHDIMX+1)*(RM380Z_CHDIMY+1)];
+	uint8_t m_character_row = 0;
+	uint8_t m_character = 0;
 
-	uint8_t   m_vramchars[RM380Z_SCREENROWS][RM380Z_SCREENCOLS];
-	uint8_t   m_vramattribs[RM380Z_SCREENROWS][RM380Z_SCREENCOLS];
+	uint8_t m_graphic_chars[0x80][(RM380Z_CHDIMX+1)*(RM380Z_CHDIMY+1)];
+	uint8_t m_user_defined_chars[2048];
+
+	rm380z_vram<RM380Z_SCREENROWS, RM380Z_SCREENCOLS> m_vram;
 
 	int m_rasterlineCtr = 0;
 	emu_timer* m_vblankTimer = nullptr;
 
-	uint8_t m_old_fbfd = 0;
-	uint8_t m_old_old_fbfd = 0;
-
 	int m_videomode = 0;
-	int m_old_videomode = 0;
 
 	emu_timer *m_static_vblank_timer = nullptr;
 

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -29,31 +29,6 @@ Research Machines RM 380Z
 //
 //
 
-template <int ROWS, int COLS>
-class rm380z_vram
-{
-public:
-	void set_char(int row, int col, uint8_t data) { m_chars[get_row(row)][col] = data; }
-	void set_attrib(int row, int col, uint8_t data) { m_attribs[get_row(row)][col] = data; }
-	void set_scroll_register(uint8_t value) { m_scroll_reg = value; }
-	void reset();
-
-	uint8_t get_char(int row, int col) const { return m_chars[get_row(row)][col]; }
-	uint8_t get_attrib(int row, int col) const { return m_attribs[get_row(row)][col]; }
-private:
-	int get_row(int row) const { return (row + m_scroll_reg) % ROWS; }
-
-	uint8_t m_chars[ROWS][COLS];
-	uint8_t m_attribs[ROWS][COLS];
-	uint8_t m_scroll_reg = 0;
-};
-
-template <int ROWS, int COLS>
-void rm380z_vram<ROWS, COLS>::reset()
-{
-	memset(m_attribs, 0, sizeof(m_attribs));
-	memset(m_chars, 0x80, sizeof(m_chars));
-}
 
 class rm380z_state : public driver_device
 {
@@ -84,6 +59,25 @@ protected:
 	virtual void machine_start() override;
 
 private:
+	template <int ROWS, int COLS>
+	class rm380z_vram
+	{
+	public:
+		void set_char(int row, int col, uint8_t data) { m_chars[get_row(row)][col] = data; }
+		void set_attrib(int row, int col, uint8_t data) { m_attribs[get_row(row)][col] = data; }
+		void set_scroll_register(uint8_t value) { m_scroll_reg = value; }
+		void reset() { memset(m_attribs, 0, sizeof(m_attribs)); memset(m_chars, 0x80, sizeof(m_chars)); }
+
+		uint8_t get_char(int row, int col) const { return m_chars[get_row(row)][col]; }
+		uint8_t get_attrib(int row, int col) const { return m_attribs[get_row(row)][col]; }
+	private:
+		int get_row(int row) const { return (row + m_scroll_reg) % ROWS; }
+
+		uint8_t m_chars[ROWS][COLS];
+		uint8_t m_attribs[ROWS][COLS];
+		uint8_t m_scroll_reg = 0;
+	};
+
 	static inline constexpr int RM380Z_VIDEOMODE_40COL = 0x01;
 	static inline constexpr int RM380Z_VIDEOMODE_80COL = 0x02;
 

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -161,7 +161,7 @@ private:
 
 	required_region_ptr<u8> m_chargen;
 	required_device<cpu_device> m_maincpu;
-	required_device<screen_device> m_screen;
+	optional_device<screen_device> m_screen;
 	optional_device<cassette_image_device> m_cassette;
 	optional_device<ram_device> m_messram;
 	optional_device<fd1771_device> m_fdc;

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -62,6 +62,7 @@ public:
 		driver_device(mconfig, type, tag),
 		m_chargen(*this, "chargen"),
 		m_maincpu(*this, RM380Z_MAINCPU_TAG),
+		m_screen(*this, "screen"),
 		m_cassette(*this, "cassette"),
 		m_messram(*this, RAM_TAG),
 		m_fdc(*this, "wd1771"),
@@ -100,7 +101,8 @@ private:
 	void put_point(int charnum, int x, int y, int col);
 	void init_graphic_chars();
 
-	void putChar(int charnum, int attribs, int x, int y, bitmap_ind16 &bitmap, int vmode);
+	void putChar_vdu80(int charnum, int attribs, int x, int y, bitmap_ind16 &bitmap);
+	void putChar_vdu40(int charnum, int x, int y, bitmap_ind16 &bitmap);
 	void decode_videoram_char(int row, int col, uint8_t &chr, uint8_t &attrib);
 	void config_videomode();
 
@@ -124,7 +126,8 @@ private:
 	DECLARE_MACHINE_RESET(rm480z);
 
 	void config_memory_map();
-	void update_screen(bitmap_ind16 &bitmap);
+	void update_screen_vdu80(bitmap_ind16 &bitmap);
+	void update_screen_vdu40(bitmap_ind16 &bitmap);
 	uint32_t screen_update_rm380z(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_rm480z(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	TIMER_CALLBACK_MEMBER(static_vblank_timer);
@@ -158,6 +161,7 @@ private:
 
 	required_region_ptr<u8> m_chargen;
 	required_device<cpu_device> m_maincpu;
+	required_device<screen_device> m_screen;
 	optional_device<cassette_image_device> m_cassette;
 	optional_device<ram_device> m_messram;
 	optional_device<fd1771_device> m_fdc;

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -70,6 +70,7 @@ private:
 
 		uint8_t get_char(int row, int col) const { return m_chars[get_row(row)][col]; }
 		uint8_t get_attrib(int row, int col) const { return m_attribs[get_row(row)][col]; }
+
 	private:
 		int get_row(int row) const { return (row + m_scroll_reg) % ROWS; }
 

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -276,12 +276,16 @@ void rm380z_state::init_rm380z34d()
 {
 	m_videomode = RM380Z_VIDEOMODE_40COL;
 	m_port0_mask = 0xdf;      // disable 80 column mode
+	m_screen->set_size(240, 240);
+	m_screen->set_visarea_full();
 }
 
 void rm380z_state::init_rm380z34e()
 {
 	m_videomode = RM380Z_VIDEOMODE_40COL;
 	m_port0_mask = 0xdf;      // disable 80 column mode
+	m_screen->set_size(240, 240);
+	m_screen->set_visarea_full();
 }
 
 

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -7,7 +7,8 @@ RM 380Z machine
 
 */
 
-
+//#include <iostream>
+//#include <bitset>
 #include "emu.h"
 #include "rm380z.h"
 
@@ -51,21 +52,40 @@ void rm380z_state::port_write(offs_t offset, uint8_t data)
 	case 0xfd:      // screen line counter (?)
 		//printf("%s FBFC [%2.2x] FBFDw[%2.2x] FBFE [%2.2x] writenum [%4.4x]\n",machine().describe_context().c_str(),m_port0,data,m_fbfe,writenum);
 
-		m_old_old_fbfd = m_old_fbfd;
-		m_old_fbfd = m_fbfd;
-		m_fbfd = data;
-
-		writenum++;
-
-		check_scroll_register();
+		if (m_port0 & 0x08)
+		{
+			// update user defined character data
+			//std::bitset<8> bits(data);
+			//std::cout << std::hex << (unsigned)m_character << ", " << (unsigned)m_character_row << ", " << bits << std::endl;
+			if (m_character >= 128)
+			{
+				m_user_defined_chars[(m_character % 128) * 16 + m_character_row] = data;
+			}
+		}
+		// ignore updates while bit 4 of port 0 is set
+		// (counter is not used to set the scroll register in this case, maybe used for smooth scrolling?)
+		else if (!(m_port0 & 0x10))
+		{
+			// set scroll register (used to verticaly scroll the screen and effect vram addressing)
+			m_vram.set_scroll_register(data & m_fbfd_mask);
+		}
 
 		break;
 
 	// port 1
 	case 0xfe:      // line on screen to write to divided by 2
 		//printf("%s FBFC [%2.2x] FBFD [%2.2x] FBFEw[%2.2x] writenum [%4.4x]\n",machine().describe_context().c_str(),m_port0,m_fbfd,data,writenum);
-		m_fbfe = data;
 
+		if (!(m_port0 & 0x04))
+		{
+			m_character_row = data;
+		}
+		else if (m_port0 & 0x08)
+		{
+			m_character = data;
+		}
+
+		m_fbfe = data;
 		break;
 
 	case 0xff:      // user I/O port
@@ -94,7 +114,22 @@ uint8_t rm380z_state::port_read(offs_t offset)
 
 	case 0xfd:      // "counter" (?)
 		//printf("%s: Read from counter FBFD\n", machine().describe_context().c_str());
-		data = 0x00;
+		if (m_port0 & 0x08)
+		{
+			// return character data for requested character and row
+			if (m_character >= 128)
+			{
+				data = m_user_defined_chars[(m_character % 128) * 16 + m_character_row];
+			}
+			else
+			{
+				data = m_chargen[m_character * 16 + m_character_row];
+			}
+		}
+		else
+		{
+			data = 0x00;
+		}
 		break;
 
 	case 0xfe:      // PORT1
@@ -233,21 +268,19 @@ void rm380z_state::machine_start()
 void rm380z_state::init_rm380z()
 {
 	m_videomode = RM380Z_VIDEOMODE_80COL;
-	m_old_videomode = m_videomode;
 	m_port0_mask = 0xff;
+	m_fbfd_mask = 0x1f;		// enable hw scrolling (uses lower 5 bits of counter)
 }
 
 void rm380z_state::init_rm380z34d()
 {
 	m_videomode = RM380Z_VIDEOMODE_40COL;
-	m_old_videomode = m_videomode;
 	m_port0_mask = 0xdf;      // disable 80 column mode
 }
 
 void rm380z_state::init_rm380z34e()
 {
 	m_videomode = RM380Z_VIDEOMODE_40COL;
-	m_old_videomode = m_videomode;
 	m_port0_mask = 0xdf;      // disable 80 column mode
 }
 
@@ -257,19 +290,12 @@ void rm380z_state::machine_reset()
 	m_port0 = 0x00;
 	m_port0_kbd = 0x00;
 	m_port1 = 0x00;
-	m_fbfd = 0x00;
 	m_fbfe = 0x00;
-	m_old_fbfd = 0x00;
-	m_old_old_fbfd = 0x00;
-	writenum = 0;
 
-//  m_videomode=RM380Z_VIDEOMODE_80COL;
-//  m_old_videomode = m_videomode;
 	m_rasterlineCtr = 0;
 
 	// note: from COS 4.0 videos, screen seems to show garbage at the beginning
-	memset(m_vramattribs, 0, sizeof(m_vramattribs));
-	memset(m_vramchars, 0, sizeof(m_vramchars));
+	m_vram.reset();
 
 	config_memory_map();
 	m_fdc->reset();

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -7,8 +7,7 @@ RM 380Z machine
 
 */
 
-//#include <iostream>
-//#include <bitset>
+
 #include "emu.h"
 #include "rm380z.h"
 
@@ -55,8 +54,6 @@ void rm380z_state::port_write(offs_t offset, uint8_t data)
 		if (m_port0 & 0x08)
 		{
 			// update user defined character data
-			//std::bitset<8> bits(data);
-			//std::cout << std::hex << (unsigned)m_character << ", " << (unsigned)m_character_row << ", " << bits << std::endl;
 			if (m_character >= 128)
 			{
 				m_user_defined_chars[(m_character % 128) * 16 + m_character_row] = data;

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -7,7 +7,6 @@ RM 380Z machine
 
 */
 
-
 #include "emu.h"
 #include "rm380z.h"
 
@@ -29,13 +28,13 @@ bit7: 1=map ROM at 0000-0fff/0=RAM
 
 void rm380z_state::port_write(offs_t offset, uint8_t data)
 {
-	switch ( offset )
+	switch (offset)
 	{
 	case 0xfc:      // PORT0
-		//printf("%s FBFCw[%2.2x] FBFD [%2.2x] FBFE [%2.2x] writenum [%4.4x]\n",machine().describe_context().c_str(),data,m_fbfd,m_fbfe,writenum);
+		//printf("%s FBFCw[%2.2x] FBFD [%2.2x] FBFE [%2.2x] writenum [%4.4x]\n", machine().describe_context().c_str(), data, m_fbfd, m_fbfe,writenum);
 		m_port0 = data;
 
-		m_cassette->output((m_port0 & 0xEF) ? +1.0 : -1.0); // set 2400hz, bit 4
+		m_cassette->output((m_port0 & 0xef) ? +1.0 : -1.0); // set 2400hz, bit 4
 
 		if (data & 0x01)
 		{
@@ -87,7 +86,7 @@ void rm380z_state::port_write(offs_t offset, uint8_t data)
 
 	case 0xff:      // user I/O port
 		//printf("write of [%x] to FBFF\n",data);
-		//logerror("%s: Write %02X to user I/O port\n", machine().describe_context(), data );
+		//logerror("%s: Write %02X to user I/O port\n", machine().describe_context(), data);
 		break;
 
 	default:
@@ -99,7 +98,7 @@ uint8_t rm380z_state::port_read(offs_t offset)
 {
 	uint8_t data = 0xff;
 
-	switch ( offset )
+	switch (offset)
 	{
 	case 0xfc:      // PORT0
 		//m_port0_kbd=getKeyboard();
@@ -131,7 +130,7 @@ uint8_t rm380z_state::port_read(offs_t offset)
 
 	case 0xfe:      // PORT1
 		if (m_cassette->input() < +0.0)
-			m_port1 &= 0xDF;    // bit 5 off
+			m_port1 &= 0xdf;    // bit 5 off
 		else
 			m_port1 |= 0x20;    // bit 5 on
 
@@ -314,16 +313,16 @@ void rm380z_state::config_memory_map()
 	uint8_t *rom = memregion(RM380Z_MAINCPU_TAG)->base();
 	uint8_t* m_ram_p = m_messram->pointer();
 
-	if ( ports_enabled_high() )
+	if (ports_enabled_high())
 	{
-		program.install_ram( 0x0000, 0xDFFF, m_ram_p );
+		program.install_ram(0x0000, 0xdfff, m_ram_p);
 	}
 	else
 	{
-		program.install_rom( 0x0000, 0x0FFF, rom );
-		program.install_readwrite_handler(0x1BFC, 0x1BFF, read8sm_delegate(*this, FUNC(rm380z_state::port_read_1b00)), write8sm_delegate(*this, FUNC(rm380z_state::port_write_1b00)));
-		program.install_rom( 0x1C00, 0x1DFF, rom + 0x1400 );
-		program.install_ram( 0x4000, 0xDFFF, m_ram_p );
+		program.install_rom(0x0000, 0x0fff, rom);
+		program.install_readwrite_handler(0x1bfc, 0x1bff, read8sm_delegate(*this, FUNC(rm380z_state::port_read_1b00)), write8sm_delegate(*this, FUNC(rm380z_state::port_write_1b00)));
+		program.install_rom(0x1c00, 0x1dff, rom + 0x1400);
+		program.install_ram(0x4000, 0xdfff, m_ram_p);
 	}
 }
 

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -288,6 +288,10 @@ void rm380z_state::init_rm380z34e()
 	m_screen->set_visarea_full();
 }
 
+void rm380z_state::init_rm480z()
+{
+	// machine not working so do nothing
+}
 
 void rm380z_state::machine_reset()
 {

--- a/src/mame/rm/rm380z_v.cpp
+++ b/src/mame/rm/rm380z_v.cpp
@@ -66,6 +66,8 @@ void rm380z_state::init_graphic_chars()
 
 void rm380z_state::config_videomode()
 {
+	int old_mode = m_videomode;
+
 	if (m_port0 & 0x20 & m_port0_mask)
 	{
 		// 80 cols
@@ -75,6 +77,19 @@ void rm380z_state::config_videomode()
 	{
 		// 40 cols
 		m_videomode = RM380Z_VIDEOMODE_40COL;
+	}
+
+	if (m_videomode != old_mode)
+	{
+		if (m_videomode == RM380Z_VIDEOMODE_80COL)
+		{
+			m_screen->set_size(640, 240);
+		}
+		else
+		{
+			m_screen->set_size(320, 240);
+		}
+		m_screen->set_visarea_full();
 	}
 }
 
@@ -106,15 +121,6 @@ void rm380z_state::decode_videoram_char(int row, int col, uint8_t& chr, uint8_t 
 		attrib = 8;
 		return;
 	}
-// 	else if (ch1 == 0)
-// 	{
-// 		// NUL character looked like 'O' when displayed and could be used instead of 'O'
-// 		// In fact the front panel writes 0x49, 0x00 to display "IO" with COS 4.0, and in
-// 		// earlier versions of COS displaying or typing 'O' actually writes 0x00 to vram
-// 		chr = 'O';
-// 		attrib = ch2;
-// 		return;
-// 	}
 	else if ((ch1 == 4) && (ch2 == 4))
 	{
 		// reversed cursor?
@@ -183,21 +189,15 @@ uint8_t rm380z_state::videoram_read(offs_t offset)
 	return 0; // return 0 if out of bounds (see VTIN description in firmware guide)
 }
 
-void rm380z_state::putChar(int charnum, int attribs, int x, int y, bitmap_ind16 &bitmap, int vmode)
+void rm380z_state::putChar_vdu80(int charnum, int attribs, int x, int y, bitmap_ind16 &bitmap)
 {
 	const bool attrUnder = attribs & 0x02;
 	const bool attrRev = attribs & 0x08;
 	
 	int data_pos = (charnum % 128) * 16;
-	int pixel_width = 1;
-	if (vmode == RM380Z_VIDEOMODE_40COL)
-	{
-		pixel_width = 2;
-	}
 
 	for (int r=0; r < 10; r++, data_pos++)
 	{
-		uint8_t mask = 0x80;
 		uint8_t data;
 
 		if (charnum < 128)
@@ -214,154 +214,49 @@ void rm380z_state::putChar(int charnum, int attribs, int x, int y, bitmap_ind16 
 			// rows 11 and 12 of char data replace rows 9 and 10 to underline
 			data_pos += 2;
 		}
-		for (int c=0; c < 8; c++, mask >>= 1)
+		for (int c=0; c < 8; c++, data <<= 1)
 		{
-			uint8_t pixel_value = (data & mask) ? 1 : 0;
+			uint8_t pixel_value = (data & 0x80) ? 1 : 0;
 			if (attrRev)
 			{
 				pixel_value = !pixel_value;
 			}
-			bitmap.pix(y * 10 + r, (x * 8 + c) * pixel_width) = pixel_value;
-			if (pixel_width == 2)
+			bitmap.pix(y * 10 + r, x * 8 + c) = pixel_value;
+		}
+	}
+}
+
+void rm380z_state::putChar_vdu40(int charnum, int x, int y, bitmap_ind16 &bitmap)
+{
+	if ((charnum > 0) && (charnum <= 0x7f))
+	{
+		// normal chars (base set)
+		int basex=RM380Z_CHDIMX*(charnum/RM380Z_NCY);
+		int basey=RM380Z_CHDIMY*(charnum%RM380Z_NCY);
+
+		for (int r=0;r<RM380Z_CHDIMY;r++)
+		{
+			for (int c=0;c<RM380Z_CHDIMX;c++)
 			{
-				bitmap.pix(y * 10 + r, (x * 8 + c) * pixel_width + 1) = pixel_value;
+				uint8_t chval = (m_chargen[((basey + r) * RM380Z_CHDIMX * RM380Z_NCX) + basex + c] == 0xff) ? 0 : 1;
+				bitmap.pix(y * (RM380Z_CHDIMY+1) + r, x * (RM380Z_CHDIMX+1) + c) = chval;
+			}
+		}
+	}
+	else
+	{
+		// graphic chars
+		for (int r=0;r<RM380Z_CHDIMY;r++)
+		{
+			for (int c=0;c<RM380Z_CHDIMX;c++)
+			{
+				bitmap.pix(y * (RM380Z_CHDIMY+1) + r, x * (RM380Z_CHDIMX+1) +c) = m_graphic_chars[charnum&0x3f][c + r * (RM380Z_CHDIMX+1)];
 			}
 		}
 	}
 }
 
-// void rm380z_state::putChar(int charnum, int attribs, int x, int y, bitmap_ind16 &bitmap, int vmode)
-// {
-// 	const bool attrUnder = attribs & 0x02;
-// 	//const bool attrDim = attribs & 0x04;
-// 	const bool attrRev = attribs & 0x08;
-// 
-// 	if ((charnum > 0) && (charnum <= 0x7f))
-// 	{
-// 		// normal chars (base set)
-// 
-// 		if (vmode==RM380Z_VIDEOMODE_80COL)
-// 		{
-// 			int basex=RM380Z_CHDIMX*(charnum/RM380Z_NCY);
-// 			int basey=RM380Z_CHDIMY*(charnum%RM380Z_NCY);
-// 
-// 			for (int r=0;r<RM380Z_CHDIMY;r++)
-// 			{
-// 				for (int c=0;c<RM380Z_CHDIMX;c++)
-// 				{
-// 					uint8_t chval = (m_chargen[((basey + r) * RM380Z_CHDIMX * RM380Z_NCX) + (basex + c)] == 0xff) ? 0 : 1;
-// 
-// 					if (attrRev)
-// 					{
-// 						if (chval==0) chval=1;
-// 						else chval=0;
-// 					}
-// 
-// 					if (attrUnder)
-// 					{
-// 						if (r==(RM380Z_CHDIMY-1))
-// 						{
-// 							if (attrRev) chval=0;
-// 							else chval=1;
-// 						}
-// 					}
-// 
-// 					bitmap.pix((y*(RM380Z_CHDIMY+1))+r,(x*(RM380Z_CHDIMX+1))+c) = chval;
-// 				}
-// 			}
-// 
-// 			// last pixel of underline
-// 			if (attrUnder&&(!attrRev))
-// 			{
-// 				bitmap.pix((y*(RM380Z_CHDIMY+1))+(RM380Z_CHDIMY-1),(x*(RM380Z_CHDIMX+1))+RM380Z_CHDIMX) = attrRev?0:1;
-// 			}
-// 
-// 			// if reversed, print another column of pixels on the right
-// 			if (attrRev)
-// 			{
-// 				for (int r=0;r<RM380Z_CHDIMY;r++)
-// 				{
-// 					bitmap.pix((y*(RM380Z_CHDIMY+1))+r,(x*(RM380Z_CHDIMX+1))+RM380Z_CHDIMX) = 1;
-// 				}
-// 			}
-// 		}
-// 		else if (vmode==RM380Z_VIDEOMODE_40COL)
-// 		{
-// 			int basex=RM380Z_CHDIMX*(charnum/RM380Z_NCY);
-// 			int basey=RM380Z_CHDIMY*(charnum%RM380Z_NCY);
-// 
-// 			for (int r=0;r<RM380Z_CHDIMY;r++)
-// 			{
-// 				for (int c=0;c<(RM380Z_CHDIMX*2);c+=2)
-// 				{
-// 					uint8_t chval = (m_chargen[((basey + r) * RM380Z_CHDIMX * RM380Z_NCX) + (basex + (c / 2))] == 0xff) ? 0 : 1;
-// 
-// 					if (attrRev)
-// 					{
-// 						if (chval==0) chval=1;
-// 						else chval=0;
-// 					}
-// 
-// 					if (attrUnder)
-// 					{
-// 						if (r==(RM380Z_CHDIMY-1))
-// 						{
-// 							if (attrRev) chval=0;
-// 							else chval=1;
-// 						}
-// 					}
-// 
-// 					bitmap.pix( (y*(RM380Z_CHDIMY+1))+r,((x*(RM380Z_CHDIMX+1))*2)+c) = chval;
-// 					bitmap.pix( (y*(RM380Z_CHDIMY+1))+r,((x*(RM380Z_CHDIMX+1))*2)+c+1) = chval;
-// 				}
-// 			}
-// 
-// 			// last 2 pixels of underline
-// 			if (attrUnder)
-// 			{
-// 				bitmap.pix( (y*(RM380Z_CHDIMY+1))+RM380Z_CHDIMY-1 , ((x*(RM380Z_CHDIMX+1))*2)+(RM380Z_CHDIMX*2)) = attrRev?0:1;
-// 				bitmap.pix( (y*(RM380Z_CHDIMY+1))+RM380Z_CHDIMY-1 , ((x*(RM380Z_CHDIMX+1))*2)+(RM380Z_CHDIMX*2)+1) = attrRev?0:1;
-// 			}
-// 
-// 			// if reversed, print another 2 columns of pixels on the right
-// 			if (attrRev)
-// 			{
-// 				for (int r=0;r<RM380Z_CHDIMY;r++)
-// 				{
-// 					bitmap.pix( (y*(RM380Z_CHDIMY+1))+r,((x*(RM380Z_CHDIMX+1))*2)+((RM380Z_CHDIMX)*2)) = 1;
-// 					bitmap.pix( (y*(RM380Z_CHDIMY+1))+r,((x*(RM380Z_CHDIMX+1))*2)+((RM380Z_CHDIMX)*2)+1) = 1;
-// 				}
-// 			}
-// 		}
-// 	}
-// 	else
-// 	{
-// 		// graphic chars: 0x80-0xbf is "dimmed", 0xc0-0xff is full bright
-// 		if (vmode==RM380Z_VIDEOMODE_80COL)
-// 		{
-// 			for (int r=0;r<(RM380Z_CHDIMY+1);r++)
-// 			{
-// 				for (int c=0;c<RM380Z_CHDIMX;c++)
-// 				{
-// 					bitmap.pix((y*(RM380Z_CHDIMY+1))+r,(x*(RM380Z_CHDIMX+1))+c) = m_graphic_chars[charnum&0x3f][c+(r*(RM380Z_CHDIMX+1))];
-// 				}
-// 			}
-// 		}
-// 		else
-// 		{
-// 			for (int r=0;r<RM380Z_CHDIMY;r++)
-// 			{
-// 				for (int c=0;c<(RM380Z_CHDIMX*2);c+=2)
-// 				{
-// 					bitmap.pix( (y*(RM380Z_CHDIMY+1))+r,((x*(RM380Z_CHDIMX+1))*2)+c) = m_graphic_chars[charnum&0x3f][(c/2)+(r*(RM380Z_CHDIMX+1))];
-// 					bitmap.pix( (y*(RM380Z_CHDIMY+1))+r,((x*(RM380Z_CHDIMX+1))*2)+c+1) = m_graphic_chars[charnum&0x3f][(c/2)+(r*(RM380Z_CHDIMX+1))];
-// 				}
-// 			}
-// 		}
-// 	}
-// }
-
-void rm380z_state::update_screen(bitmap_ind16 &bitmap)
+void rm380z_state::update_screen_vdu80(bitmap_ind16 &bitmap)
 {
 	const int ncols = (m_videomode == RM380Z_VIDEOMODE_40COL) ? 40 : 80;
 
@@ -374,8 +269,32 @@ void rm380z_state::update_screen(bitmap_ind16 &bitmap)
 		{
 			uint8_t curch,attribs;
 			decode_videoram_char(row, col, curch, attribs);
-			putChar(curch, attribs, col, row, bitmap, m_videomode);
-			//putChar(0x44, 0x00, 10, 10, bitmap, m_videomode);
+			putChar_vdu80(curch, attribs, col, row, bitmap);
+		}
+	}
+}
+
+void rm380z_state::update_screen_vdu40(bitmap_ind16 &bitmap)
+{
+	const int ncols = 40;
+
+	// blank screen
+	bitmap.fill(0);
+
+	for (int row = 0; row < RM380Z_SCREENROWS; row++)
+	{
+		for (int col = 0; col < ncols; col++)
+		{
+			uint8_t curch = m_vram.get_char(row, col);
+			if (curch == 0)
+			{
+				// NUL character looked like 'O' when displayed and could be used instead of 'O'
+				// In fact the front panel writes 0x49, 0x00 to display "IO", and in COS 3.4
+				// displaying or typing 'O' actually writes 0x00 to vram.
+				// This hack is only necessary because we don't have the real 74LS262 charset ROM
+				curch = 'O';
+			}
+			putChar_vdu40(curch, col, row, bitmap);
 		}
 	}
 }

--- a/src/mame/rm/rm380z_v.cpp
+++ b/src/mame/rm/rm380z_v.cpp
@@ -200,6 +200,12 @@ void rm380z_state::putChar_vdu80(int charnum, int attribs, int x, int y, bitmap_
 	{
 		uint8_t data;
 
+		if (attrUnder && (r == 8))
+		{
+			// rows 11 and 12 of char data replace rows 9 and 10 to underline
+			data_pos += 2;
+		}
+
 		if (charnum < 128)
 		{
 			data = m_chargen[data_pos];
@@ -209,11 +215,6 @@ void rm380z_state::putChar_vdu80(int charnum, int attribs, int x, int y, bitmap_
 			data = m_user_defined_chars[data_pos];
 		}
 
-		if (attrUnder && (r == 8))
-		{
-			// rows 11 and 12 of char data replace rows 9 and 10 to underline
-			data_pos += 2;
-		}
 		for (int c=0; c < 8; c++, data <<= 1)
 		{
 			uint8_t pixel_value = (data & 0x80) ? 1 : 0;


### PR DESCRIPTION
I've managed to obtain a dump of the real character ROM for COS 4.0 courtesy of the Research Machines user group, and this PR pulls this in and updates the display code to use it.

What is the correct process for updating a rom set?  This my working version that includes the new character rom:

[rm380z.zip](https://github.com/mamedev/mame/files/14268302/rm380z.zip)

The real characters are actually larger than the fake set we used before (8x10 rather then 5x9) and even include 2 extra rows to be used when the underline attribute is set.  This all makes the display handling much easier and improves the display greatly.

So with these characters 80 column mode has a display resolution of 640x240 and 40 column mode uses 320x240.

For COS 3.4 I've set the display resolution to 240x240 which I think is correct because COS 3.0 only supported the VDU40 adaptor which uses the TI 74LS262 character ROM.  These characters are 5x9, padded to 6x10 for display.  It's a shame we don't have the real ROM for this as well, but at the moment I'm concentrating on getting COS 4.0 to work properly anyway!

The new ROM only includes characters 0x00 to 0x79 because the additional teletext characters (0x80 to 0xFF) are actually generated by COS as user defined characters.  I've also added support for user defined characters so that these continue to work.

This PR includes all my changes for HW scrolling from the last PR which is still in review (https://github.com/mamedev/mame/pull/12014), but I don't want to close that until the review comment has been cleared.  I can do any further re-work under this PR.