### PR TITLE
New NMK214 device: added implementation for NMK214 descrambling GFX device and hook it up to nmk16 driver

### DIFF
--- a/src/mame/nmk/nmk16.cpp
+++ b/src/mame/nmk/nmk16.cpp
@@ -197,7 +197,6 @@ Reference of music tempo:
 #include "nmk16.h"
 
 #include "nmk004.h"
-#include "nmk214.h"
 
 #include "cpu/m68000/m68000.h"
 #include "cpu/pic16c5x/pic16c5x.h"
@@ -4918,7 +4917,7 @@ void tdragon_prot_state::mcu_port3_to_214_w(u8 data)
 		// bit 3 of the incoming value matches to the operation mode configured on each device:
 		m_nmk214[0]->set_init_config(m_init_data_nmk214);
 		m_nmk214[1]->set_init_config(m_init_data_nmk214);
-		
+
 		// Force decode gfx after setting both nmk214 init config, just for testing purposes. Real devices perform the decoding on the fly
 		// for each byte/word fetch from GFX ROMs
 		if (!m_gfx_decoded && m_nmk214[0]->is_device_initialized() && m_nmk214[1]->is_device_initialized())
@@ -4959,11 +4958,11 @@ void tdragon_prot_state::saboten_prot(machine_config &config)
 	// the 215 has these hooked up, going to the 214
 	m_protcpu->port_write<3>().set(FUNC(tdragon_prot_state::mcu_port3_to_214_w));
 	m_protcpu->port_write<7>().set(FUNC(tdragon_prot_state::mcu_port7_to_214_w));
-	
+
 	NMK214(config, m_nmk214[0], 0); // Descrambling device for sprite GFX data
 	m_nmk214[0]->set_mode(0);
 	m_nmk214[0]->set_input_address_bitswap(nmk214_sprites_address_bitswap);
-	
+
 	NMK214(config, m_nmk214[1], 0); // Descrambling device for BG GFX data
 	m_nmk214[1]->set_mode(1);
 	m_nmk214[1]->set_input_address_bitswap(nmk214_bg_address_bitswap);
@@ -5173,15 +5172,15 @@ void tdragon_prot_state::decode_sabotenb()
 		rom[A] = m_nmk214[1]->decode_byte(A, rom[A]);
 	}
 
-	// Sprites
+	// sprites
 	rom = memregion("sprites")->base();
 	len = memregion("sprites")->bytes();
-	for (int A = 0; A < len; A += 2)
+	for (int A = 0; A < (len - 1); A += 2)
 	{
-		// When the sprite ROM is loaded, it's also byte-swapped, so we keep the same order here to compound the word (A: second-byte, A+1: first-byte) (BE)
+		// sprite ROM is 16-bit big Endian
 		u16 word = get_u16be(&rom[A]);
 
-		// As Sprites ROM works in word mode, address value here is in terms of bytes and should be divided by 2 to get the proper base-16 address value:
+		// A is a byte address, divide by 2 to give word address for NMK214
 		put_u16be(&rom[A], m_nmk214[0]->decode_word(A/2, word));
 	}
 }

--- a/src/mame/nmk/nmk16.h
+++ b/src/mame/nmk/nmk16.h
@@ -241,28 +241,20 @@ class tdragon_prot_state : public nmk16_state
 public:
 	tdragon_prot_state(const machine_config &mconfig, device_type type, const char *tag) :
 		nmk16_state(mconfig, type, tag),
-		m_protcpu(*this, "protcpu"),
-		m_nmk214(*this, "nmk214_%u", 0U),
-		m_init_data_nmk214(0),
-		m_init_clock_nmk214(0),
-		m_gfx_decoded(false)
-	{}
+		m_protcpu(*this, "protcpu")
+	{
+	}
 
 	void tdragon_prot(machine_config &config);
 	void hachamf_prot(machine_config &config);
-	void saboten_prot(machine_config &config);
 
 protected:
-
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
 	optional_device<tlcs90_device> m_protcpu;
-	optional_device_array<nmk214_device, 2> m_nmk214;
 
 	void tdragon_prot_map(address_map &map);
-
-	void decode_sabotenb();
 
 	void mcu_side_shared_w(offs_t offset, u8 data);
 	u8 mcu_side_shared_r(offs_t offset);
@@ -271,15 +263,40 @@ protected:
 	u8 mcu_port6_r();
 	u8 mcu_port7_r(); // NMK-113 uses this
 
+	u8 m_bus_status;
+};
+
+class tdragon_prot_214_state : public tdragon_prot_state
+{
+public:
+	tdragon_prot_214_state(const machine_config &mconfig, device_type type, const char *tag) :
+		tdragon_prot_state(mconfig, type, tag),
+		m_nmk214(*this, "nmk214_%u", 0U),
+		m_init_data_nmk214(0),
+		m_init_clock_nmk214(0),
+		m_gfx_unscramble_enabled(false),
+		m_gfx_decoded(false)
+	{
+	}
+
+	void saboten_prot(machine_config &config);
+
+protected:
+	virtual void device_post_load() override;
+	virtual void machine_start() override;
+
+private:
+	void decode_nmk214();
+
 	void mcu_port3_to_214_w(u8 data);
 	void mcu_port7_to_214_w(u8 data);
 
-	u8 m_bus_status;
+	required_device_array<nmk214_device, 2> m_nmk214;
 
-private:
 	u8 m_init_data_nmk214;
 	u8 m_init_clock_nmk214;
-	bool m_gfx_decoded;
+	bool m_gfx_unscramble_enabled;
+	bool m_gfx_decoded; // excluded from save states
 };
 
 class afega_state : public nmk16_state

--- a/src/mame/nmk/nmk16.h
+++ b/src/mame/nmk/nmk16.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "nmk004.h"
+#include "nmk214.h"
 #include "nmk16spr.h"
 
 #include "seibusound.h"
@@ -240,7 +241,8 @@ class tdragon_prot_state : public nmk16_state
 public:
 	tdragon_prot_state(const machine_config &mconfig, device_type type, const char *tag) :
 		nmk16_state(mconfig, type, tag),
-		m_protcpu(*this, "protcpu")
+		m_protcpu(*this, "protcpu"),
+		m_nmk214(*this, "nmk214_%u", 0U)
 	{}
 
 	void tdragon_prot(machine_config &config);
@@ -253,8 +255,11 @@ protected:
 	virtual void machine_reset() override;
 
 	optional_device<tlcs90_device> m_protcpu;
+	optional_device_array<nmk214_device, 2> m_nmk214;
 
 	void tdragon_prot_map(address_map &map);
+
+	void decode_sabotenb();
 
 	void mcu_side_shared_w(offs_t offset, u8 data);
 	u8 mcu_side_shared_r(offs_t offset);
@@ -267,6 +272,11 @@ protected:
 	void mcu_port7_to_214_w(u8 data);
 
 	u8 m_bus_status;
+	
+private:
+
+    u8 m_init_data_nmk214;
+    u8 m_init_clock_nmk214;
 };
 
 class afega_state : public nmk16_state

--- a/src/mame/nmk/nmk16.h
+++ b/src/mame/nmk/nmk16.h
@@ -242,7 +242,10 @@ public:
 	tdragon_prot_state(const machine_config &mconfig, device_type type, const char *tag) :
 		nmk16_state(mconfig, type, tag),
 		m_protcpu(*this, "protcpu"),
-		m_nmk214(*this, "nmk214_%u", 0U)
+		m_nmk214(*this, "nmk214_%u", 0U),
+		m_init_data_nmk214(0),
+		m_init_clock_nmk214(0),
+		m_gfx_decoded(false)
 	{}
 
 	void tdragon_prot(machine_config &config);
@@ -277,6 +280,7 @@ private:
 
     u8 m_init_data_nmk214;
     u8 m_init_clock_nmk214;
+    bool m_gfx_decoded;
 };
 
 class afega_state : public nmk16_state

--- a/src/mame/nmk/nmk16.h
+++ b/src/mame/nmk/nmk16.h
@@ -275,12 +275,11 @@ protected:
 	void mcu_port7_to_214_w(u8 data);
 
 	u8 m_bus_status;
-	
-private:
 
-    u8 m_init_data_nmk214;
-    u8 m_init_clock_nmk214;
-    bool m_gfx_decoded;
+private:
+	u8 m_init_data_nmk214;
+	u8 m_init_clock_nmk214;
+	bool m_gfx_decoded;
 };
 
 class afega_state : public nmk16_state

--- a/src/mame/nmk/nmk214.cpp
+++ b/src/mame/nmk/nmk214.cpp
@@ -1,0 +1,192 @@
+// license:BSD-3-Clause
+// copyright-holders:Sergio Galiano
+/*
+    NMK214 GFX Descrambler emulation
+	
+	This device is used for descrambling the GFX data on some game pcbs from NMK (nmk16).
+	It works in tandem with NMK215, that is a Toshiba MCU which sends initialization data to NMK214 to perform the descrambling process.
+	Every game pcb using it has two units of NMK214, one for descrambling sprite data and another one for descrambling background tiles data.
+	It can work in two different modes: word and byte. For sprites it always works in word mode. On the order side, for backgrounds it always works in byte mode.
+	There are 8 different internal configs hardwired inside the device, and the data received from NMK215 selects one of those at startup. That init data is stored in the device when bit 3 matches with the operation mode wired directly on the pcb.
+	The descrambling process is essentially a dynamic bitswap of the incoming word/byte data, doing a different bitswap based on the address of the data to be descrambled.
+	The input address bus on the device is used to determine which bitswap do for each word/byte, and it's usually hooked up in different way for sprites and bg tiles, so an 'input_address_bitswap' is included in the implementation in order to get the effective address the device will use internally for each case.
+*/
+
+
+#include "emu.h"
+#include "nmk214.h"
+
+
+static const u8 default_input_address_bitswap[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+
+DEFINE_DEVICE_TYPE(NMK214, nmk214_device, "nmk214", "NMK214 GFX Descrambler")
+
+nmk214_device::nmk214_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, NMK214, tag, owner, clock)
+	, m_mode(0)
+	, m_init_config(0)
+	, m_device_initialized(false)
+	, m_input_address_bitswap(default_input_address_bitswap)
+{
+}
+
+// static byte values for each of the 8 different hardwired configs. One bit will be taken from each byte in the selected config (row), and those 3 bits will be used to select the output bitswap down below:
+static const u8 init_configs[8][3] = 
+{
+	{0xaa, 0xcc, 0xf0},  // Predefined config 0
+	{0x55, 0x39, 0x1e},  // Predefined config 1
+	{0xc5, 0x69, 0x5c},  // Predefined config 2
+	{0x35, 0x5c, 0xc5},  // Predefined config 3
+	{0x78, 0x1d, 0x2e},  // Predefined config 4
+	{0x55, 0x33, 0x0f},  // Predefined config 5
+	{0xa5, 0xb8, 0x36},  // Predefined config 6
+	{0x8b, 0x69, 0x2e}   // Predefined config 7
+};
+
+// 3 values for each config to determine which lines from input address bus are used to select one bit from hardwired config byte values above:
+static const u8 selection_address_bits[8][3] = 
+{
+	{0x8, 0x9, 0xa},  // A8, A9 and A10 for predefined config 0
+	{0x6, 0x8, 0xb},  // A6, A8 and A11 for predefined config 1
+	{0x3, 0x9, 0xc},  // A3, A9 and A12 for predefined config 2
+	{0x3, 0x7, 0xa},  // A3, A7 and A10 for predefined config 3
+	{0x2, 0x5, 0xb},  // A2, A5 and A11 for predefined config 4
+	{0x1, 0x4, 0xa},  // A1, A4 and A10 for predefined config 5
+	{0x2, 0x4, 0xa},  // A2, A4 and A10 for predefined config 6
+	{0x0, 0x4, 0xc}   // A0, A4 and A12 for predefined config 7
+};
+
+// output word data bitswaps hardwired inside the chip. Each value in the the same column represents which bit from input data word is used for current bit position in the output word.
+static const u8 output_word_bitswaps[8][16] =
+{
+//   D0   D1   D2   D3   D4   D5   D6   D7   D8   D9   D10  D11  D12  D13  D14  D15
+	{0x2, 0x3, 0x7, 0x8, 0xc, 0x4, 0xb, 0x9, 0x1, 0xf, 0xa, 0x5, 0xe, 0x6, 0xd, 0x0},  // word bitswap 0
+	{0x0, 0x3, 0x8, 0x7, 0xa, 0xc, 0x4, 0x1, 0xf, 0x9, 0x6, 0xd, 0xe, 0xb, 0x5, 0x2},  // word bitswap 1
+	{0x9, 0x8, 0x2, 0x3, 0x6, 0x5, 0xd, 0xf, 0x7, 0x0, 0xc, 0xb, 0xa, 0x4, 0xe, 0x1},  // word bitswap 2
+	{0x0, 0x3, 0x9, 0xf, 0xd, 0xc, 0xb, 0x1, 0x2, 0x7, 0xe, 0x6, 0x4, 0xa, 0x5, 0x8},  // word bitswap 3
+	{0x1, 0x3, 0xf, 0x7, 0xd, 0xa, 0xe, 0x9, 0x0, 0x8, 0xc, 0x4, 0x6, 0x5, 0xb, 0x2},  // word bitswap 4
+	{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf},  // word bitswap 5
+	{0x0, 0xf, 0x3, 0x2, 0xe, 0x4, 0x6, 0x7, 0x8, 0x9, 0x5, 0xd, 0xc, 0xb, 0xa, 0x1},  // word bitswap 6
+	{0xf, 0x2, 0x3, 0x1, 0xb, 0xe, 0xd, 0x8, 0x7, 0x0, 0x4, 0xc, 0x6, 0xa, 0x5, 0x9}   // word bitswap 7
+};
+
+// output byte data bitswaps hardwired inside the chip. Values on this table are calculated from the above word-bitswaps, based on the following input data lines correlation (that's how the data lines are hooked up in real hw):
+/* 
+   BYTE mode | WORD mode
+   ----------|----------
+   D0        | D13
+   D1        | D10
+   D2        | D4
+   D3        | D12
+   D4        | D6
+   D5        | D14
+   D6        | D11
+   D7        | D5
+*/
+static const u8 output_byte_bitswaps[8][8] =
+{
+//   D0   D1   D2   D3   D4   D5   D6   D7 
+	{0x4, 0x1, 0x3, 0x5, 0x6, 0x0, 0x7, 0x2},  // byte bitswap 0
+	{0x6, 0x4, 0x1, 0x5, 0x2, 0x7, 0x0, 0x3},  // byte bitswap 1
+	{0x2, 0x3, 0x4, 0x1, 0x0, 0x5, 0x6, 0x7},  // byte bitswap 2
+	{0x1, 0x5, 0x0, 0x2, 0x6, 0x7, 0x4, 0x3},  // byte bitswap 3
+	{0x7, 0x3, 0x0, 0x4, 0x5, 0x6, 0x2, 0x1},  // byte bitswap 4
+	{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7},  // byte bitswap 5
+	{0x6, 0x7, 0x5, 0x3, 0x4, 0x1, 0x0, 0x2},  // byte bitswap 6
+	{0x1, 0x2, 0x6, 0x4, 0x0, 0x7, 0x3, 0x5}   // byte bitswap 7
+};
+
+u8 nmk214_device::get_bitswap_select_value(u32 addr) 
+{	
+	// as the address lines could be hooked up in different order/positions on the game pcb, reorder it and get the effective address to use:
+	u32 effective_address = bitswap(addr,
+		m_input_address_bitswap[12],
+		m_input_address_bitswap[11],
+		m_input_address_bitswap[10],
+		m_input_address_bitswap[9],
+		m_input_address_bitswap[8],
+		m_input_address_bitswap[7],
+		m_input_address_bitswap[6],
+		m_input_address_bitswap[5],
+		m_input_address_bitswap[4],
+		m_input_address_bitswap[3],
+		m_input_address_bitswap[2],
+		m_input_address_bitswap[1],
+		m_input_address_bitswap[0]);
+
+	// get selection address using only 3 bits of the effective address, based on the initial config selected while device initialization:
+	u8 selection_address =
+		(BIT(effective_address, selection_address_bits[m_init_config][0]) << 0)
+		| (BIT(effective_address, selection_address_bits[m_init_config][1]) << 1)
+		| (BIT(effective_address, selection_address_bits[m_init_config][2]) << 2);
+	
+	// get the bitswap selection value, using the previously computed selection address and the selected internal config values:
+	return (BIT(init_configs[m_init_config][0], selection_address) << 0)
+		| (BIT(init_configs[m_init_config][1], selection_address) << 1)
+		| (BIT(init_configs[m_init_config][2], selection_address) << 2);
+}
+
+u16 nmk214_device::decode_word(u32 addr, u16 data)
+{
+	// compute the select value to choose which bitswap apply to the input word, based on the address where the data is located
+	u8 bitswap_select = get_bitswap_select_value(addr);
+
+	return bitswap(data,
+		output_word_bitswaps[bitswap_select][16],
+		output_word_bitswaps[bitswap_select][15],
+		output_word_bitswaps[bitswap_select][14],
+		output_word_bitswaps[bitswap_select][13],
+		output_word_bitswaps[bitswap_select][12],
+		output_word_bitswaps[bitswap_select][11],
+		output_word_bitswaps[bitswap_select][10],
+		output_word_bitswaps[bitswap_select][9],
+		output_word_bitswaps[bitswap_select][8],
+		output_word_bitswaps[bitswap_select][7],
+		output_word_bitswaps[bitswap_select][6],
+		output_word_bitswaps[bitswap_select][5],
+		output_word_bitswaps[bitswap_select][4],
+		output_word_bitswaps[bitswap_select][3],
+		output_word_bitswaps[bitswap_select][2],
+		output_word_bitswaps[bitswap_select][1],
+		output_word_bitswaps[bitswap_select][0]);
+}
+
+u8 nmk214_device::decode_byte(u32 addr, u8 data)
+{
+	// compute the select value to choose which bitswap apply to the input byte, based on the address where the data is located
+	u8 bitswap_select = get_bitswap_select_value(addr);
+
+	return bitswap(data,
+		output_byte_bitswaps[bitswap_select][7],
+		output_byte_bitswaps[bitswap_select][6],
+		output_byte_bitswaps[bitswap_select][5],
+		output_byte_bitswaps[bitswap_select][4],
+		output_byte_bitswaps[bitswap_select][3],
+		output_byte_bitswaps[bitswap_select][2],
+		output_byte_bitswaps[bitswap_select][1],
+		output_byte_bitswaps[bitswap_select][0]);
+}
+
+void nmk214_device::set_init_config(u8 init_config)
+{
+	// store config data only if Bit 3 matches with the operation mode of the device
+	if (BIT(init_config, 3) == m_mode)
+	{
+		m_init_config = init_config & 0x7;
+		m_device_initialized = true;
+	}
+}
+
+void nmk214_device::device_start()
+{	
+	save_item(NAME(m_mode));
+	save_item(NAME(m_init_config));
+	save_item(NAME(m_device_initialized));
+}
+
+void nmk214_device::device_reset()
+{
+	m_init_config = 0;
+	m_device_initialized = false;
+}

--- a/src/mame/nmk/nmk214.cpp
+++ b/src/mame/nmk/nmk214.cpp
@@ -2,19 +2,20 @@
 // copyright-holders:Sergio Galiano
 /*
     NMK214 GFX Descrambler emulation
-	
-	This device is used for descrambling the GFX data on some game pcbs from NMK (nmk16).
-	It works in tandem with NMK215, that's a Toshiba MCU which sends initialization data to NMK214 in order to do the descrambling process.
-	Every game pcb using it has two units of NMK214, one for sprite data and another one for background tiles data.
-	It can work in two different modes: word and byte:
-	For sprites it always works in word mode. On the order side, for backgrounds it always works in byte mode.
-	There are 8 different internal configs hardwired inside the device and the data received from NMK215 selects one of those them at startup.
-	That init data is stored in the device when bit 3 matches with the operation mode wired directly on the pcb.
-	The descrambling process is essentially a dynamic bitswap of the incoming word/byte data, doing a different bitswap
-	based on the address of the data to be descrambled.
-	The input address bus on the device is used to determine which bitswap do for each word/byte, and it's usually hooked up in different
-	way for sprites and bg tiles, so an 'input_address_bitswap' is included in the implementation in order to get the effective address
-	the device will use internally for each case.
+
+    This device is used for descrambling the GFX data on some game PCBs from NMK (nmk16).
+    It works in tandem with NMK215, that's a Toshiba MCU which sends initialization data to NMK214 in order to do the
+    descrambling process.
+    Every game PCB using it has two NMK214 chips, one for sprites and another for background tiles.
+    It can work in two different modes: word and byte:
+    For sprites it always works in word mode; for backgrounds it always works in byte mode.
+    There are 8 hard-wired internal configurations.  The data received from NMK215 selects one of those them at startup.
+    That init data is stored in the device when bit 3 matches with the operation mode wired directly on the PCB.
+    The descrambling process is essentially a dynamic bitswap of the incoming word/byte data, doing a different bitswap
+    based on the address of the data to be descrambled.
+    The input address bus on the device is used to determine which bitswap do for each word/byte, and it's usually
+    hooked differently for sprites and background tiles, so an 'input_address_bitswap' is included to get the effective
+    address the device will use.
 */
 
 
@@ -22,23 +23,14 @@
 #include "nmk214.h"
 
 
+namespace {
+
 const std::array<u8, 13> default_input_address_bitswap = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
-
-DEFINE_DEVICE_TYPE(NMK214, nmk214_device, "nmk214", "NMK214 GFX Descrambler")
-
-nmk214_device::nmk214_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: device_t(mconfig, NMK214, tag, owner, clock)
-	, m_mode(0)
-	, m_input_address_bitswap(default_input_address_bitswap)
-	, m_init_config(0)
-	, m_device_initialized(false)
-{
-}
-
-// Static byte values for each of the 8 different hardwired configs. One bit will be taken from each byte in the selected config (row),
-// and those 3 bits will be used to select the output bitswap down below:
-static const u8 init_configs[8][3] = 
+// Static byte values for each of the 8 different hardwired configurations.
+// One bit will be taken from each byte in the selected config (row), and those
+// 3 bits will be used to select the output bitswap down below:
+const u8 init_configs[8][3] =
 {
 	{0xaa, 0xcc, 0xf0},  // Predefined config 0
 	{0x55, 0x39, 0x1e},  // Predefined config 1
@@ -50,8 +42,9 @@ static const u8 init_configs[8][3] =
 	{0x8b, 0x69, 0x2e}   // Predefined config 7
 };
 
-// 3 values for each config to determine which lines from input address bus are used to select a bit from hardwired config byte values above:
-static const u8 selection_address_bits[8][3] = 
+// 3 values for each configuration to determine which lines from input address
+// bus are used to select a bit from hardwired config byte values above:
+const u8 selection_address_bits[8][3] =
 {
 	{0x8, 0x9, 0xa},  // A8, A9 and A10 for predefined config 0
 	{0x6, 0x8, 0xb},  // A6, A8 and A11 for predefined config 1
@@ -63,9 +56,10 @@ static const u8 selection_address_bits[8][3] =
 	{0x0, 0x4, 0xc}   // A0, A4 and A12 for predefined config 7
 };
 
-// Output word data bitswaps hardwired inside the chip. Each value in the the same column represents which bit from input data word is used
-// for current bit position in the output word.
-static const u8 output_word_bitswaps[8][16] =
+// Output word data bitswaps hardwired inside the chip.
+// Each value in the same column represents which bit from input data word is
+// used for current bit position in the output word.
+const u8 output_word_bitswaps[8][16] =
 {
 //   D0   D1   D2   D3   D4   D5   D6   D7   D8   D9   D10  D11  D12  D13  D14  D15
 	{0x2, 0x3, 0x7, 0x8, 0xc, 0x4, 0xb, 0x9, 0x1, 0xf, 0xa, 0x5, 0xe, 0x6, 0xd, 0x0},  // word bitswap 0
@@ -78,9 +72,11 @@ static const u8 output_word_bitswaps[8][16] =
 	{0xf, 0x2, 0x3, 0x1, 0xb, 0xe, 0xd, 0x8, 0x7, 0x0, 0x4, 0xc, 0x6, 0xa, 0x5, 0x9}   // word bitswap 7
 };
 
-// Output byte data bitswaps hardwired inside the chip. Values on the table are calculated from the above word-bitswaps based on the
-// following input data lines correlation (that's how the data lines are hooked up in real hw):
-/* 
+// Output byte data bitswaps hardwired inside the chip.
+// Values on the table are calculated from the above word-bitswaps based on the
+// following input data lines correlation (that's how the data lines are hooked
+// up in real hardware):
+/*
    BYTE mode | WORD mode
    ----------|----------
    D0        | D13
@@ -92,9 +88,9 @@ static const u8 output_word_bitswaps[8][16] =
    D6        | D11
    D7        | D5
 */
-static const u8 output_byte_bitswaps[8][8] =
+const u8 output_byte_bitswaps[8][8] =
 {
-//   D0   D1   D2   D3   D4   D5   D6   D7 
+//   D0   D1   D2   D3   D4   D5   D6   D7
 	{0x4, 0x1, 0x3, 0x5, 0x6, 0x0, 0x7, 0x2},  // byte bitswap 0
 	{0x6, 0x4, 0x1, 0x5, 0x2, 0x7, 0x0, 0x3},  // byte bitswap 1
 	{0x2, 0x3, 0x4, 0x1, 0x0, 0x5, 0x6, 0x7},  // byte bitswap 2
@@ -105,77 +101,96 @@ static const u8 output_byte_bitswaps[8][8] =
 	{0x1, 0x2, 0x6, 0x4, 0x0, 0x7, 0x3, 0x5}   // byte bitswap 7
 };
 
-u8 nmk214_device::get_bitswap_select_value(u32 addr) 
-{	
-	// as the address lines could be hooked up in different order/positions on the game pcb, reorder it and get the effective address to use:
-	u32 effective_address = bitswap(addr,
-		m_input_address_bitswap[12],
-		m_input_address_bitswap[11],
-		m_input_address_bitswap[10],
-		m_input_address_bitswap[9],
-		m_input_address_bitswap[8],
-		m_input_address_bitswap[7],
-		m_input_address_bitswap[6],
-		m_input_address_bitswap[5],
-		m_input_address_bitswap[4],
-		m_input_address_bitswap[3],
-		m_input_address_bitswap[2],
-		m_input_address_bitswap[1],
-		m_input_address_bitswap[0]);
+} // anonymous namespace
 
-	// get selection address using only 3 bits of the effective address, based on the initial config selected while device initialization:
-	u8 selection_address =
-		(BIT(effective_address, selection_address_bits[m_init_config][0]) << 0)
-		| (BIT(effective_address, selection_address_bits[m_init_config][1]) << 1)
-		| (BIT(effective_address, selection_address_bits[m_init_config][2]) << 2);
-	
-	// get the bitswap selection value, using the previously computed selection address and the selected internal config values:
+
+DEFINE_DEVICE_TYPE(NMK214, nmk214_device, "nmk214", "NMK214 Graphics Descrambler")
+
+nmk214_device::nmk214_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, NMK214, tag, owner, clock)
+	, m_mode(0)
+	, m_input_address_bitswap(default_input_address_bitswap)
+	, m_init_config(0)
+	, m_device_initialized(false)
+{
+}
+
+u8 nmk214_device::get_bitswap_select_value(u32 addr) const noexcept
+{
+	// as the address lines could be hooked up in different order/positions on
+	// the game PCB, reorder it and get the effective address to use:
+	const u32 effective_address = bitswap<13>(addr,
+			m_input_address_bitswap[12],
+			m_input_address_bitswap[11],
+			m_input_address_bitswap[10],
+			m_input_address_bitswap[9],
+			m_input_address_bitswap[8],
+			m_input_address_bitswap[7],
+			m_input_address_bitswap[6],
+			m_input_address_bitswap[5],
+			m_input_address_bitswap[4],
+			m_input_address_bitswap[3],
+			m_input_address_bitswap[2],
+			m_input_address_bitswap[1],
+			m_input_address_bitswap[0]);
+
+	// get selection address using only 3 bits of the effective address, based
+	// on the initial config selected while device initialization:
+	const u8 selection_address = bitswap<3>(effective_address,
+			selection_address_bits[m_init_config][2],
+			selection_address_bits[m_init_config][1],
+			selection_address_bits[m_init_config][0]);
+
+	// get the bitswap selection value, using the previously computed selection
+	// address and the selected internal config values:
 	return (BIT(init_configs[m_init_config][0], selection_address) << 0)
-		| (BIT(init_configs[m_init_config][1], selection_address) << 1)
-		| (BIT(init_configs[m_init_config][2], selection_address) << 2);
+			| (BIT(init_configs[m_init_config][1], selection_address) << 1)
+			| (BIT(init_configs[m_init_config][2], selection_address) << 2);
 }
 
-u16 nmk214_device::decode_word(u32 addr, u16 data)
+u16 nmk214_device::decode_word(u32 addr, u16 data) const noexcept
 {
-	// compute the select value to choose which bitswap apply to the input word, based on the address where the data is located
+	// compute the select value to choose which bitswap apply to the input word,
+	// based on the address where the data is located
+	const u8 bitswap_select = get_bitswap_select_value(addr);
+
+	return bitswap<16>(data,
+			output_word_bitswaps[bitswap_select][15],
+			output_word_bitswaps[bitswap_select][14],
+			output_word_bitswaps[bitswap_select][13],
+			output_word_bitswaps[bitswap_select][12],
+			output_word_bitswaps[bitswap_select][11],
+			output_word_bitswaps[bitswap_select][10],
+			output_word_bitswaps[bitswap_select][9],
+			output_word_bitswaps[bitswap_select][8],
+			output_word_bitswaps[bitswap_select][7],
+			output_word_bitswaps[bitswap_select][6],
+			output_word_bitswaps[bitswap_select][5],
+			output_word_bitswaps[bitswap_select][4],
+			output_word_bitswaps[bitswap_select][3],
+			output_word_bitswaps[bitswap_select][2],
+			output_word_bitswaps[bitswap_select][1],
+			output_word_bitswaps[bitswap_select][0]);
+}
+
+u8 nmk214_device::decode_byte(u32 addr, u8 data) const noexcept
+{
+	// compute the select value to choose which bitswap apply to the input byte,
+	// based on the address where the data is located
 	u8 bitswap_select = get_bitswap_select_value(addr);
 
-	return bitswap(data,
-		output_word_bitswaps[bitswap_select][15],
-		output_word_bitswaps[bitswap_select][14],
-		output_word_bitswaps[bitswap_select][13],
-		output_word_bitswaps[bitswap_select][12],
-		output_word_bitswaps[bitswap_select][11],
-		output_word_bitswaps[bitswap_select][10],
-		output_word_bitswaps[bitswap_select][9],
-		output_word_bitswaps[bitswap_select][8],
-		output_word_bitswaps[bitswap_select][7],
-		output_word_bitswaps[bitswap_select][6],
-		output_word_bitswaps[bitswap_select][5],
-		output_word_bitswaps[bitswap_select][4],
-		output_word_bitswaps[bitswap_select][3],
-		output_word_bitswaps[bitswap_select][2],
-		output_word_bitswaps[bitswap_select][1],
-		output_word_bitswaps[bitswap_select][0]);
+	return bitswap<8>(data,
+			output_byte_bitswaps[bitswap_select][7],
+			output_byte_bitswaps[bitswap_select][6],
+			output_byte_bitswaps[bitswap_select][5],
+			output_byte_bitswaps[bitswap_select][4],
+			output_byte_bitswaps[bitswap_select][3],
+			output_byte_bitswaps[bitswap_select][2],
+			output_byte_bitswaps[bitswap_select][1],
+			output_byte_bitswaps[bitswap_select][0]);
 }
 
-u8 nmk214_device::decode_byte(u32 addr, u8 data)
-{
-	// compute the select value to choose which bitswap apply to the input byte, based on the address where the data is located
-	u8 bitswap_select = get_bitswap_select_value(addr);
-
-	return bitswap(data,
-		output_byte_bitswaps[bitswap_select][7],
-		output_byte_bitswaps[bitswap_select][6],
-		output_byte_bitswaps[bitswap_select][5],
-		output_byte_bitswaps[bitswap_select][4],
-		output_byte_bitswaps[bitswap_select][3],
-		output_byte_bitswaps[bitswap_select][2],
-		output_byte_bitswaps[bitswap_select][1],
-		output_byte_bitswaps[bitswap_select][0]);
-}
-
-void nmk214_device::set_init_config(u8 init_config)
+void nmk214_device::set_init_config(u8 init_config) noexcept
 {
 	// store config data only if Bit 3 matches with the operation mode of the device
 	if (BIT(init_config, 3) == m_mode)
@@ -186,7 +201,7 @@ void nmk214_device::set_init_config(u8 init_config)
 }
 
 void nmk214_device::device_start()
-{	
+{
 	save_item(NAME(m_init_config));
 	save_item(NAME(m_device_initialized));
 }

--- a/src/mame/nmk/nmk214.cpp
+++ b/src/mame/nmk/nmk214.cpp
@@ -133,7 +133,6 @@ u16 nmk214_device::decode_word(u32 addr, u16 data)
 	u8 bitswap_select = get_bitswap_select_value(addr);
 
 	return bitswap(data,
-		output_word_bitswaps[bitswap_select][16],
 		output_word_bitswaps[bitswap_select][15],
 		output_word_bitswaps[bitswap_select][14],
 		output_word_bitswaps[bitswap_select][13],

--- a/src/mame/nmk/nmk214.h
+++ b/src/mame/nmk/nmk214.h
@@ -11,11 +11,12 @@ class nmk214_device : public device_t
 public:
 	nmk214_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	void set_mode(u8 mode) { m_mode = mode; }
+	void set_mode(const u8 mode) { m_mode = mode; }
+	void set_input_address_bitswap(const std::array<u8, 13> &input_address_bitswap) { m_input_address_bitswap = input_address_bitswap; }
+
 	void set_init_config(u8 init_config);
 	bool is_device_initialized() { return m_device_initialized; }
-	void set_input_address_bitswap(const u8 *input_address_bitswap) { m_input_address_bitswap = input_address_bitswap; }
-	
+
 	u16 decode_word(u32 addr, u16 data);
 	u8 decode_byte(u32 addr, u8 data);
 
@@ -24,13 +25,25 @@ protected:
 	virtual void device_reset() override;
 
 private:
-	u8 m_mode;                              // Operation mode. In practice, only LSB is used. Allowed values: 0 or 1. This value is hardwired for each NM214 out of 2 ones in the game board, each device having a different configuration than the other.
-	u8 m_init_config;                       // An init config out of 8 existing ones in NMK214 to be used while descrambling GFX. In practice, only lower 3 bits (From 0 to 2) are used, allowed values: 0 to 7. Bit 3 is used to match with operation mode and let the init config to be stored on the device or not
-	bool m_device_initialized;			    // Flag to mark the device already received the init configuration and it can perform descrambling from now on
+	// Operation mode. In practice, only LSB is used. Allowed values: 0 or 1. This value is hardwired for each NM214 out of 2 ones in the
+	// game board, each device having a different configuration than the other.
+	u8 m_mode;
 
-	const u8 *m_input_address_bitswap;      // Input address lines bitswap. These represents the way the 13 address lines on NMK214 (from A0 to A12) are hooked up externally related to the GFX ROMs address bus, that could be in different order/position
+	// Input address lines bitswap. These represents the way the 13 address lines on NMK214 (from A0 to A12) are hooked up externally
+	// related to the GFX ROMs address bus, that could be in different order/position
+	std::array<u8, 13> m_input_address_bitswap;
 
-	u8 get_bitswap_select_value(u32 addr);  // Gets the a value to select the output bitswap to apply to the input data, based on the address where the data is located
+	// An init config out of 8 existing ones in NMK214 to be used while descrambling GFX.
+	// In practice, only lower 3 bits (From 0 to 2) are used, allowed values: 0 to 7.
+	// Bit 3 is used to match with operation mode and let the init config to be stored on the device or not.
+	u8 m_init_config;
+
+	// Flag to mark the device already received the init configuration and it can perform descrambling from now on.
+	bool m_device_initialized;
+
+
+	// Gets the value to select the output bitswap to apply to input data based on the address where the data is located
+	u8 get_bitswap_select_value(u32 addr);  
 };
 
 DECLARE_DEVICE_TYPE(NMK214, nmk214_device)

--- a/src/mame/nmk/nmk214.h
+++ b/src/mame/nmk/nmk214.h
@@ -1,0 +1,38 @@
+// license:BSD-3-Clause
+// copyright-holders:Sergio Galiano
+#ifndef MAME_NMK_NMK214_H
+#define MAME_NMK_NMK214_H
+
+#pragma once
+
+
+class nmk214_device : public device_t
+{
+public:
+	nmk214_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	void set_mode(u8 mode) { m_mode = mode; }
+	void set_init_config(u8 init_config);
+	bool is_device_initialized() { return m_device_initialized; }
+	void set_input_address_bitswap(const u8 *input_address_bitswap) { m_input_address_bitswap = input_address_bitswap; }
+	
+	u16 decode_word(u32 addr, u16 data);
+	u8 decode_byte(u32 addr, u8 data);
+
+protected:
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+private:
+	u8 m_mode;                              // Operation mode. In practice, only LSB is used. Allowed values: 0 or 1. This value is hardwired for each NM214 out of 2 ones in the game board, each device having a different configuration than the other.
+	u8 m_init_config;                       // An init config out of 8 existing ones in NMK214 to be used while descrambling GFX. In practice, only lower 3 bits (From 0 to 2) are used, allowed values: 0 to 7. Bit 3 is used to match with operation mode and let the init config to be stored on the device or not
+	bool m_device_initialized;			    // Flag to mark the device already received the init configuration and it can perform descrambling from now on
+
+	const u8 *m_input_address_bitswap;      // Input address lines bitswap. These represents the way the 13 address lines on NMK214 (from A0 to A12) are hooked up externally related to the GFX ROMs address bus, that could be in different order/position
+
+	u8 get_bitswap_select_value(u32 addr);  // Gets the a value to select the output bitswap to apply to the input data, based on the address where the data is located
+};
+
+DECLARE_DEVICE_TYPE(NMK214, nmk214_device)
+
+#endif // MAME_NMK_NMK214_H

--- a/src/mame/nmk/nmk214.h
+++ b/src/mame/nmk/nmk214.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <array>
+
 
 class nmk214_device : public device_t
 {
@@ -14,36 +16,37 @@ public:
 	void set_mode(const u8 mode) { m_mode = mode; }
 	void set_input_address_bitswap(const std::array<u8, 13> &input_address_bitswap) { m_input_address_bitswap = input_address_bitswap; }
 
-	void set_init_config(u8 init_config);
-	bool is_device_initialized() { return m_device_initialized; }
+	void set_init_config(u8 init_config) noexcept;
+	bool is_device_initialized() const noexcept { return m_device_initialized; }
 
-	u16 decode_word(u32 addr, u16 data);
-	u8 decode_byte(u32 addr, u8 data);
+	u16 decode_word(u32 addr, u16 data) const noexcept;
+	u8 decode_byte(u32 addr, u8 data) const noexcept;
 
 protected:
 	virtual void device_start() override;
 	virtual void device_reset() override;
 
 private:
-	// Operation mode. In practice, only LSB is used. Allowed values: 0 or 1. This value is hardwired for each NM214 out of 2 ones in the
-	// game board, each device having a different configuration than the other.
+	// Operation mode - in practice, only LSB is used.
+	// Allowed values: 0 or 1.
+	// This is hard-wired on the PCB, with opposite values for the two devices.
 	u8 m_mode;
 
-	// Input address lines bitswap. These represents the way the 13 address lines on NMK214 (from A0 to A12) are hooked up externally
-	// related to the GFX ROMs address bus, that could be in different order/position
+	// Input address lines bitswap.
+	// Represents how the 13 NMK214 address lines are wired to the graphics ROM address bus.
 	std::array<u8, 13> m_input_address_bitswap;
 
-	// An init config out of 8 existing ones in NMK214 to be used while descrambling GFX.
-	// In practice, only lower 3 bits (From 0 to 2) are used, allowed values: 0 to 7.
-	// Bit 3 is used to match with operation mode and let the init config to be stored on the device or not.
+	// Selects between eight internal configurations.
+	// Bits 0 to 2 select the configuration.
+	// Bit 3 must be set to match the operation mode for the configuration to take effect.
 	u8 m_init_config;
 
-	// Flag to mark the device already received the init configuration and it can perform descrambling from now on.
+	// Indicates that the device has been configured and can perform descrambling.
 	bool m_device_initialized;
 
 
-	// Gets the value to select the output bitswap to apply to input data based on the address where the data is located
-	u8 get_bitswap_select_value(u32 addr);  
+	// Gets the bitswap index for a given data address.
+	u8 get_bitswap_select_value(u32 addr) const noexcept;
 };
 
 DECLARE_DEVICE_TYPE(NMK214, nmk214_device)


### PR DESCRIPTION
Added implementation for NMK214 as a new device. It's used for descrambling GFX data on some games in the nmk16 driver.

The implementation was made based on the reverse engineering work of the chip at silicon level: 
[https://github.com/sergiopolog/GateArray-RE/tree/master/NMK/nmk-214](https://github.com/sergiopolog/GateArray-RE/tree/master/NMK/nmk-214)

Results of the descrambling GFX process for both sprites and background tiles using this implementation match exactly with the ones from previous implementation made by @mamehaze (and Antiriad) back then.
In this case, all the internal configurations that could be selected to perform it are included, even if they are never used for any game, just for documentation purposes.

Real hardware performs the descrambling process on the fly for each word/byte fetch from GFX ROMs, but due how the drawgfx system is made on MAME, I couldn't find an option to integrate it and mimic the real hw behaviour.
I simply run the decoding of the entire GFX regions just when both devices are initialized at startup, (similar to what the previous implementation did on init handler).
If there is a way to do this on real GFX fetches from 'sprites' and 'bgtiles' regions, please, let me know.

By now, the descrambling process is only hooked up for sabotenb (and clones) set.
On a later PR, I plan to apply it to the rest of games using it on nmk16 driver and split the current "tdragon_prot_state" class into two different classes: One for NMK111 and NMK113 protection (tdragon and hachamf) and another one for NMK214-215 protection, as they are completely different processes, even if they use the same MCU model (TLCS-90)