### PR TITLE
mindset_flop.xml; adam_flop.xml; next_hdd.xml: Normalize software list description

### DIFF
--- a/hash/adam_flop.xml
+++ b/hash/adam_flop.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="adam_flop" description="Coleco ADAM diskettes">
+<softwarelist name="adam_flop" description="Coleco Adam diskettes">
 
 	<!--
 	Thanks to SacNews.net for their very comprehensive software database!

--- a/hash/mindset_flop.xml
+++ b/hash/mindset_flop.xml
@@ -4,7 +4,7 @@
 license:CC0-1.0
 -->
 
-<softwarelist name="mindset_flop" description="Mindset Corporation Mindset Floppy Discs">
+<softwarelist name="mindset_flop" description="Mindset Corporation Mindset floppy discs">
 	<software name="vyper" supported="partial">
 		<description>Vyper</description>
 		<year>1984</year>

--- a/hash/next_hdd.xml
+++ b/hash/next_hdd.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="next_hdd" description="Hard disk images for NeXT">
+<softwarelist name="next_hdd" description="NeXT hard disk images">
 
 	<!--
 	To boot from hard disk enter the ROM monitor (Command + `) and enter "p" to


### PR DESCRIPTION
mindset_flop.xml: Lower case on storage media's description (Mindset Corporation Mindset floppy discs).
adam_flop.xml: Keep upper case only on the first letter of the system's name (Coleco Adam diskettes).
next_hdd.xml: Put the manufacturer's name on first place (NeXT hard disk images).