### PR TITLE
machine/z80scc.cpp: Added support for RTxC transmit/receive clock source

### DIFF
--- a/src/devices/machine/z80scc.h
+++ b/src/devices/machine/z80scc.h
@@ -233,6 +233,7 @@ protected:
 	virtual void device_reset() override;
 
 	unsigned int get_brg_rate();
+	unsigned int get_rtxc_rate();
 	void update_baudtimer();
 
 	void scc_register_write(uint8_t reg, uint8_t data);


### PR DESCRIPTION
Fixes serial emulation at 115200bps.

This leaves some things unimplemented (like TRxC and DPLL clock sources), but makes programs communicating at 115.200bps function properly.

For context, toggling this chip to 115200bps or 230400bps is done by
1) setting the clock multiplier to 16 (230400bps) or 32 (115200bps), WR4 bits 6 or 7
2) setting the clock source for TX and RX to /RTxC instead of BRG, WR11
3) stopping the baud rate generator, WR14 bit 0

I hope this is a good first PR.
Thanks!