### PR TITLE
emu/save.cpp: Make illegal save state registrations always fatal

### DIFF
--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -890,10 +890,6 @@ void running_machine::handle_saveload()
 				// handle the result
 				switch (saverr)
 				{
-				case STATERR_ILLEGAL_REGISTRATIONS:
-					popmessage("Error: Unable to %s state %s %s due to illegal registrations. See error.log for details.", opname, preposname, m_saveload_pending_file);
-					break;
-
 				case STATERR_INVALID_HEADER:
 					popmessage("Error: Unable to %s state %s %s due to an invalid header. Make sure the save state is correct for this system.", opname, preposname, m_saveload_pending_file);
 					break;

--- a/src/emu/save.h
+++ b/src/emu/save.h
@@ -34,7 +34,6 @@ enum save_error
 {
 	STATERR_NONE,
 	STATERR_NOT_FOUND,
-	STATERR_ILLEGAL_REGISTRATIONS,
 	STATERR_INVALID_HEADER,
 	STATERR_READ_ERROR,
 	STATERR_WRITE_ERROR,
@@ -334,7 +333,6 @@ private:
 	running_machine &         m_machine;              // reference to our machine
 	std::unique_ptr<rewinder> m_rewind;               // rewinder
 	bool                      m_reg_allowed;          // are registrations allowed?
-	s32                       m_illegal_regs;         // number of illegal registrations
 
 	std::vector<std::unique_ptr<state_entry>>    m_entry_list;       // list of registered entries
 	std::vector<std::unique_ptr<ram_state>>      m_ramstate_list;    // list of ram states


### PR DESCRIPTION
The only thing that causes non-fatal illegal save state registrations right now is registering an item for save states after start in a system not marked as supporting save states.

It’s high time anything doing that gets fixed.  Not supporting save states means save state support is incomplete, not that the driver has a license to do illegal things.

Opening this as a pull request to give fair warning, and so it can be merged after freeze.