### PR TITLE
ekara: add 9 cartridges [David Haywood, Team Europe]

### DIFF
--- a/hash/ekara_japan.xml
+++ b/hash/ekara_japan.xml
@@ -1143,6 +1143,7 @@ license:CC0-1.0
 		<description>Kids' Song Best 40 (Japan) (EC0084-KSB)</description>
 		<year>2003</year>
 		<publisher>Takara</publisher>
+		<info name="alt_title" value="キッズソングベスト40" />
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x200000">
 				<rom name="ec0084-ksb.u1" size="0x200000" crc="dab58ce4" sha1="e427df85cc1a06a055fcb4e1aa28cc083b558e69"/>

--- a/hash/ekara_japan.xml
+++ b/hash/ekara_japan.xml
@@ -176,10 +176,17 @@ license:CC0-1.0
 	 Everything below might not work with a standard e-kara, requires different hardware even if cart form is the same
 	************************************************************************************************************************************************************
 
-	Japanese cart listing (by KE code)
+	Japanese e-Kara Kids devices (by KH/KE code)
 
-	These are only compatible with some special 'Kids' unit and shaped as lyric books
-	They're not e-Kara compatible and the cartridges appear to contain an MCU rather than ROM
+	These are audio-only devices, not XaviX based and do not connect to a TV.  They are still e-Kara branded but have
+	nothing in common hardware-wise.  This information has been left here for reference only.
+	
+	The base units are as follows, they appear to contain an MCU rather than a ROM
+
+	KH-01  Standard
+	KH-02  Mini-Moni
+
+	The cartridges are as follows, as with the base unit they appear to contain an MCU rather than ROM
 
 	KE-01  Dōyō 1 (どうよう 1)
 	KE-02  Television 1 (テレビ 1)

--- a/hash/ekara_japan.xml
+++ b/hash/ekara_japan.xml
@@ -32,6 +32,7 @@ license:CC0-1.0
 	JPM = J-Pop Mix
 	KID = Kids' Song
 	KIR = Kirarin Revolution
+	KSB = Kids' Song Best
 	KSM = Kids' Song Mini
 	KTY = Hello Kitty
 	MIN = mini-moni

--- a/hash/ekara_japan.xml
+++ b/hash/ekara_japan.xml
@@ -172,18 +172,6 @@ license:CC0-1.0
 
 	(more? what's the highest regular number?)
 
-	***********************************************************************************
-
-	Japanese cart listing (by KD code)
-
-	Cartridges containing 20 children's songs each
-	These look like normal e-kara carts
-
-	KD-1  Kids' Song 20
-	KD-2  Kids' Song 20
-	KD-3  Kids' Song 20
-	KD-4  Kids' Song 20
-
 	************************************************************************************************************************************************************
 	 Everything below might not work with a standard e-kara, requires different hardware even if cart form is the same
 	************************************************************************************************************************************************************
@@ -191,12 +179,14 @@ license:CC0-1.0
 	Japanese cart listing (by KE code)
 
 	These are only compatible with some special 'Kids' unit and shaped as lyric books
-	(not e-kara compatible?)
+	They're not e-Kara compatible and the cartridges appear to contain an MCU rather than ROM
 
 	KE-01  Dōyō 1 (どうよう 1)
 	KE-02  Television 1 (テレビ 1)
-
-	(more?)
+	KE-03 - ??
+	KE-04 - ??
+	KE-05 - Ultraman
+	KE-06 - This is a mini-piano keyboard that plugs into where the cartridge would usually plug
 
 	***********************************************************************************
 

--- a/hash/ekara_japan.xml
+++ b/hash/ekara_japan.xml
@@ -167,7 +167,7 @@ license:CC0-1.0
 	81   EC0081-JPM  J-Pop Mix Volume 42
 	82  *EC0082-MBH  Matthew's Best Hit Selection
 	83   EC0083-JPM  J-Pop Mix Volume 43
-	84   EC0084-     Kids' Song Best 40
+	84  *EC0084-     Kids' Song Best 40
 	85   EC0085-ETZ  Enka Taizen Volume 3 (custom presentation etc.)
 
 	(more? what's the highest regular number?)
@@ -1142,7 +1142,16 @@ license:CC0-1.0
 
 	<!-- EC0083-JPM  J-Pop Mix Volume 43 -->
 
-	<!-- EC0084-     Kids' Song Best 40 -->
+	<software name="ec0084"> <!-- custom presentation -->
+		<description>Kids' Song Best 40 (Japan) (EC0084-KSB)</description>
+		<year>2003</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x200000">
+				<rom name="ec0084-ksb.u1" size="0x200000" crc="dab58ce4" sha1="e427df85cc1a06a055fcb4e1aa28cc083b558e69"/>
+			</dataarea>
+		</part>
+	</software>
 
 	<!-- EC0085-ETZ  Enka Taizen Volume 3 -->
 

--- a/hash/ekara_japan.xml
+++ b/hash/ekara_japan.xml
@@ -167,7 +167,7 @@ license:CC0-1.0
 	81   EC0081-JPM  J-Pop Mix Volume 42
 	82  *EC0082-MBH  Matthew's Best Hit Selection
 	83   EC0083-JPM  J-Pop Mix Volume 43
-	84  *EC0084-     Kids' Song Best 40
+	84  *EC0084-KSB  Kids' Song Best 40
 	85   EC0085-ETZ  Enka Taizen Volume 3 (custom presentation etc.)
 
 	(more? what's the highest regular number?)

--- a/hash/ekara_japan_ac.xml
+++ b/hash/ekara_japan_ac.xml
@@ -21,6 +21,16 @@ license:CC0-1.0
 	*KR-1  Kirarin Revolution (comes in kira kara Starter Set bundled with Kirarin Revolution microphone) (inside cart is marked AC0009-KIR)
 	*PR-06 Misora Hibari (inside cart is marked AC0009)
 
+	The following cartridges with 'PR code' have also been seen, they appear to be single song cartridges
+	and it is unknown how they were distributed (maybe pack-ins, but no pack-in box has been identified)
+	These are bright pink in colour with blue/white paper labels
+
+	PR-01 MNG  (c)2002
+	PR-02 AYY  (c)2003
+
+	maybe PR03 to PR05 also exist?
+
+
 	(more?)
 
 	-->

--- a/hash/ekara_japan_ac.xml
+++ b/hash/ekara_japan_ac.xml
@@ -21,7 +21,7 @@ license:CC0-1.0
 	*KR-1  Kirarin Revolution (comes in kira kara Starter Set bundled with Kirarin Revolution microphone) (inside cart is marked AC0009-KIR)
 	*PR-06 Misora Hibari (inside cart is marked AC0009)
 
-	The following cartridges with 'PR code' have also been seen, they appear to be single song cartridges
+	The following cartridges with 'PR' codes have also been seen, they appear to be single song cartridges
 	and it is unknown how they were distributed (maybe pack-ins, but no pack-in box has been identified)
 	These are bright pink in colour with blue/white paper labels
 

--- a/hash/ekara_japan_ac.xml
+++ b/hash/ekara_japan_ac.xml
@@ -63,7 +63,7 @@ license:CC0-1.0
 
 	<!-- CS019-004A on a sticker inside the cartridge -->
 	<software name="bx01"> <!-- custom presentation -->
-		<description>BX01-MOR (Japan) (BX01-MOR)</description>
+		<description>Morning Musume Special (Japan) (BX01-MOR)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">

--- a/hash/ekara_japan_ac.xml
+++ b/hash/ekara_japan_ac.xml
@@ -49,4 +49,18 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<!-- these are also pack-in cartridges, but don't fit elsewhere -->
+
+	<!-- CS019-004A on a sticker inside the cartridge -->
+	<software name="bx01"> <!-- custom presentation -->
+		<description>BX01-MOR (Japan) (BX01-MOR)</description>
+		<year>2001</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x100000">
+				<rom name="bx01-mor.u1" size="0x100000" crc="51a55097" sha1="44345f5ead30288cde83f023f7aabbecb2a53d63"/>
+			</dataarea>
+		</part>
+	</software>
+	
 </softwarelist>

--- a/hash/ekara_japan_en.xml
+++ b/hash/ekara_japan_en.xml
@@ -14,14 +14,36 @@ license:CC0-1.0
 
 	(check what units these are for)
 
-	 EN-1  Enka Collection - Volume 1
-	 EN-2  Enka Collection - Volume 2
+	*EN-1  Enka Collection - Volume 1
+	*EN-2  Enka Collection - Volume 2
 	*EN-3  Enka Collection - Volume 3
 	*EN-4  Enka Collection - Volume 4
 
 	(more? what's the EN highest number?)
 
 	-->
+
+	<software name="en1">
+		<description>Enka-shū Dai Volume 1 (Japan) (EN-1)</description> <!-- TODO: correct translation -->
+		<year>2004</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x100000">
+				<rom name="en-1.u1" size="0x100000" crc="7f9f61f3" sha1="f6efdcc7d00c181864009662a0e8671296c174b8"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="en2">
+		<description>Enka-shū Dai Volume 2 (Japan) (EN-2)</description> <!-- TODO: correct translation -->
+		<year>2004</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x100000">
+				<rom name="en-2.u1" size="0x100000" crc="be342a04" sha1="db355d3b9372fbfc0831133482d96110aa377915"/>
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="en3">
 		<description>Enka-shū Dai San-hen (Japan) (EN-3)</description>

--- a/hash/ekara_japan_en.xml
+++ b/hash/ekara_japan_en.xml
@@ -24,9 +24,10 @@ license:CC0-1.0
 	-->
 
 	<software name="en1">
-		<description>Enka-shū Dai Volume 1 (Japan) (EN-1)</description> <!-- TODO: correct translation -->
+		<description>Enka-shū Dai Ichi-hen (Japan) (EN-1)</description> <!-- TODO: correct translation -->
 		<year>2004</year>
 		<publisher>Takara</publisher>
+		<info name="alt_title" value="演歌集 第一篇" />
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
 				<rom name="en-1.u1" size="0x100000" crc="7f9f61f3" sha1="f6efdcc7d00c181864009662a0e8671296c174b8"/>
@@ -35,9 +36,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="en2">
-		<description>Enka-shū Dai Volume 2 (Japan) (EN-2)</description> <!-- TODO: correct translation -->
+		<description>Enka-shū Dai Ni-hen (Japan) (EN-2)</description> <!-- TODO: correct translation -->
 		<year>2004</year>
 		<publisher>Takara</publisher>
+		<info name="alt_title" value="演歌集 第二篇" />
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
 				<rom name="en-2.u1" size="0x100000" crc="be342a04" sha1="db355d3b9372fbfc0831133482d96110aa377915"/>

--- a/hash/ekara_japan_kd.xml
+++ b/hash/ekara_japan_kd.xml
@@ -18,9 +18,10 @@ license:CC0-1.0
 	-->
 
 	<software name="kd1"> <!-- KD0001 sticker inside cart -->
-		<description>Kids' Song 20 (Japan) (KD-1)</description> <!-- TODO: correct translation -->
+		<description>Kids' Song 20 (Japan) (KD-1)</description>
 		<year>2004</year>
 		<publisher>Takara</publisher>
+		<info name="alt_title" value="キッズソング20" />
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
 				<rom name="kd-1.u1" size="0x100000" crc="f351f615" sha1="791ecb6d951669e7c41f1a08a20173fa5c51f901"/>

--- a/hash/ekara_japan_kd.xml
+++ b/hash/ekara_japan_kd.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+license:CC0-1.0
+-->
+<softwarelist name="ekara_japan_en" description="Takara e-kara (Japan) KD-xx series cartridges">
+	<!-- cartridges contain the ROM only, the XaviX CPU and BIOS are in the base unit -->
+	<!--
+	Kids 20 series
+	Japanese cart listing (by KD code)  * = dumped
+	 * = dumped
+
+	*KD-1  Kids 20 - Volume 1
+	 KD-2  Kids 20 - Volume 2
+	 KD-3  Kids 20 - Volume 3
+	 KD-4  Kids 20 - Volume 4
+
+	-->
+
+	<software name="kd1"> <!-- KD0001 sticker inside cart -->
+		<description>Kids' 20 (Japan) (KD-1)</description> <!-- TODO: correct translation -->
+		<year>2004</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x100000">
+				<rom name="kd-1.u1" size="0x100000" crc="f351f615" sha1="791ecb6d951669e7c41f1a08a20173fa5c51f901"/>
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/hash/ekara_japan_kd.xml
+++ b/hash/ekara_japan_kd.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="ekara_japan_en" description="Takara e-kara (Japan) KD-xx series cartridges">
+<softwarelist name="ekara_japan_kd" description="Takara e-kara (Japan) KD-xx series cartridges">
 	<!-- cartridges contain the ROM only, the XaviX CPU and BIOS are in the base unit -->
 	<!--
 	Kids 20 series

--- a/hash/ekara_japan_kd.xml
+++ b/hash/ekara_japan_kd.xml
@@ -6,7 +6,7 @@ license:CC0-1.0
 <softwarelist name="ekara_japan_kd" description="Takara e-kara (Japan) KD-xx series cartridges">
 	<!-- cartridges contain the ROM only, the XaviX CPU and BIOS are in the base unit -->
 	<!--
-	Kids 20 series
+	Kids' Song 20 series
 	Japanese cart listing (by KD code)  * = dumped
 	 * = dumped
 
@@ -18,7 +18,7 @@ license:CC0-1.0
 	-->
 
 	<software name="kd1"> <!-- KD0001 sticker inside cart -->
-		<description>Kids' 20 (Japan) (KD-1)</description> <!-- TODO: correct translation -->
+		<description>Kids' Song 20 (Japan) (KD-1)</description> <!-- TODO: correct translation -->
 		<year>2004</year>
 		<publisher>Takara</publisher>
 		<part name="cart" interface="ekara_cart">

--- a/hash/ekara_japan_m.xml
+++ b/hash/ekara_japan_m.xml
@@ -125,6 +125,7 @@ license:CC0-1.0
 		<description>J-Pop Mix Mini Volume 1 (Japan) (MC0009-JPM)</description>
 		<year>2003</year>
 		<publisher>Takara</publisher>
+		<info name="alt_title" value="J-POP MIXミニ mini vol.1"/>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x080000">
 				<rom name="mc0009-jpm.u1" size="0x080000" crc="794a82ae" sha1="f97cdf42bd62731363eee02dec6235b5c8a798d2"/>
@@ -196,6 +197,7 @@ license:CC0-1.0
 		<description>Artist Mini Volume 9 (Yamaguchi Momoe) (Japan) (MC0016-ATM)</description>
 		<year>2003</year>
 		<publisher>Takara</publisher>
+		<info name="alt_title" value="アーティストミニ mini vol.9 (山口百恵)"/>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x080000">
 				<rom name="mc0016-atm.u1" size="0x080000" crc="937c07dd" sha1="6c3570394e781dec96e98d95db3a3c564abe35a4"/>

--- a/hash/ekara_japan_m.xml
+++ b/hash/ekara_japan_m.xml
@@ -17,14 +17,14 @@ license:CC0-1.0
 	M-6  *MC0006-KSM  Kids Song Mini Volume 2 (TV Hero)
 	M-7  *MC0007-ATM  Artist Mini Volume 5 (SMAP, KinKi Kids, ARASHI, TOKIO)
 	M-8  *MC0008-KSM  Kids Song Mini Volume 3
-	M-9   MC0009-     JPop Mix Mini Volume 1
+	M-9  *MC0009-JPM  J-Pop Mix Mini Volume 1
 	M-10 *MC0010-ATM  Artist Mini Volume 6 (Utada Hikaru)
 	M-11  MC0011-     Kids Song Mini Volume 4 (Fantastic)
 	M-12 *MC0012-ATM  Artist Mini Volume 7 (Ayumi Hamasaki)
 	M-13 *MC0013-KSM  Kids Song Mini Volume 5
 	M-14 *MC0014-ATM  Artist Mini Volume 8 (BoA)
 	M-15 *MC0015-TPM  TV Pop Mini Volume 1
-	M-16  MC0016-ATM  Artist Mini Volume 9  (Yamaguchi Momoe)
+	M-16 *MC0016-ATM  Artist Mini Volume 9  (Yamaguchi Momoe)
 	M-17  MC0017-     TV Pop Mini Volume 2?
 
 	unsure of KSM / TMP naming,  MC0005/0006/0008/0011/0013/0015/0017 all seem to be the same series
@@ -121,6 +121,17 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="mc0009">
+		<description>J-Pop Mix Mini Volume 1 (Japan) (MC0009-JPM)</description>
+		<year>2003</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x080000">
+				<rom name="mc0009-jpm.u1" size="0x080000" crc="794a82ae" sha1="f97cdf42bd62731363eee02dec6235b5c8a798d2"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="mc0010">
 		<description>Artist Mini Volume 6 (Utada Hikaru) (Japan) (MC0010-ATM)</description>
 		<year>2003</year>
@@ -180,5 +191,16 @@ license:CC0-1.0
 			</dataarea>
 		</part>
 	</software>
+	
+	<software name="mc0016">
+		<description>Artist Mini Volume 9 (Yamaguchi Momoe) (Japan) (MC0016-ATM)</description>
+		<year>2003</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x080000">
+				<rom name="mc0016-atm.u1" size="0x080000" crc="937c07dd" sha1="6c3570394e781dec96e98d95db3a3c564abe35a4"/>
+			</dataarea>
+		</part>
+	</software>	
 
 </softwarelist>

--- a/hash/ekara_japan_packin.xml
+++ b/hash/ekara_japan_packin.xml
@@ -3,33 +3,30 @@
 <!--
 license:CC0-1.0
 -->
-<softwarelist name="ekara_japan_ac" description="Takara e-kara (Japan) ACxxxx series cartridges">
+<softwarelist name="ekara_japan_packin" description="Takara e-kara (Japan) Pack-in cartridges">
 	<!-- cartridges contain the ROM only, the XaviX CPU and BIOS are in the base unit -->
 
 	<!--
-	These are bundled/pack-in cartridges that don't appear to be part of any other series
+	These are bundled/pack-in cartridges that don't appear to be part of any other series.
+	Some pack-in carts were just part of the regular line-ups instead, eg S-1 with the
+	Hello Kitty units, those are in their respective lists.
 
-	Japanese cart listing (by AC code)  * = dumped
-	 * = dumped
+	The numbering for the ones here is a little unusual
 
-	this numbering is a little unusual, maybe the 'A' series Pichi Pichi Pitch
-	are actually 1-8 here, just lacking the actual AC markings.
-	see ekara_japan_a.xml
+	Both KR-1 and PR-06 cart have 'AC0009' on the PCB (along with a PR0006 sticker)
 
-	the PR-06 cart also has 'AC0009' on the PCB (along with a PR0006 sticker) so this doesn't appear to a unique numbering
-
-	*KR-1  Kirarin Revolution (comes in kira kara Starter Set bundled with Kirarin Revolution microphone) (inside cart is marked AC0009-KIR)
-	*PR-06 Misora Hibari (inside cart is marked AC0009)
-
+	*KR-1      Kirarin Revolution (comes in kira kara Starter Set bundled with Kirarin Revolution microphone) (inside cart is marked AC0009-KIR)
+	*PR-06     Misora Hibari (inside cart is marked AC0009)
+	*BX01-MOR  Morning Musume Special (sticker inside cart is marked CS019-004A)
+	
 	The following cartridges with 'PR' codes have also been seen, they appear to be single song cartridges
 	and it is unknown how they were distributed (maybe pack-ins, but no pack-in box has been identified)
 	These are bright pink in colour with blue/white paper labels
 
-	PR-01 MNG  (c)2002
-	PR-02 AYY  (c)2003
+	PR-01 MNG  (c)2002   Morning Musume - I'm Here!
+	PR-02 AYY  (c)2003   Aya Matsuura - Prairies Man
 
 	maybe PR03 to PR05 also exist?
-
 
 	(more?)
 
@@ -62,7 +59,7 @@ license:CC0-1.0
 	<!-- these are also pack-in cartridges, but don't fit elsewhere -->
 
 	<!-- CS019-004A on a sticker inside the cartridge -->
-	<software name="bx01"> <!-- custom presentation -->
+	<software name="bx01">
 		<description>Morning Musume Special (Japan) (BX01-MOR)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>

--- a/hash/ekara_japan_packin.xml
+++ b/hash/ekara_japan_packin.xml
@@ -60,9 +60,10 @@ license:CC0-1.0
 
 	<!-- CS019-004A on a sticker inside the cartridge -->
 	<software name="bx01">
-		<description>Morning Musume Special (Japan) (BX01-MOR)</description>
+		<description>Saiten Cartridge: Morning Musume Special (Japan) (BX01-MOR)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>
+		<info name="alt_title" value="採点カートリッジ モーニング娘。スペシャル" />
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
 				<rom name="bx01-mor.u1" size="0x100000" crc="51a55097" sha1="44345f5ead30288cde83f023f7aabbecb2a53d63"/>

--- a/hash/ekara_japan_s.xml
+++ b/hash/ekara_japan_s.xml
@@ -24,12 +24,12 @@ license:CC0-1.0
 	S-8  *SC0008-SAI  Saiten Cartridge Challenge Idol vol.2
 	S-9  *SC0009-SAI  Saiten Cartridge Nesshō vol. 3
 	S-10 *SC0010-HKW  Hikawa Kiyoshi no Karaoke Dōjō
-	S-11  SC0011-     PostPet
+	S-11 *SC0011-PST  PostPet
 	S-12 *SC0012-SAI  Saiten Cartridge Challenge Idol vol.3
 	S-13  SC0013-SAI  Saiten Cartridge Nesshō vol. 4
 	S-14 *SC0014-SAI  Saiten Cartridge Challenge Idol vol.4
 	S-15 *SC0015-DCS  Saiten Cartridge Detective Conan Vol.2
-	S-16  SC0016-SAI  Saiten Cartridge Nesshō vol. 5
+	S-16 *SC0016-SAI  Saiten Cartridge Nesshō vol. 5
 	S-17  SC0017-SAI  Kids' Challenge Vol.2
 	S-18 *SC0018-SAI  Saiten Cartridge Challenge Artist Vol.1 (Morning Musume, Tanpopo, Petit Moni, Gotō Maki)
 	S-19 *SC0019-SAI  Saiten Cartridge Nesshō vol. 6
@@ -165,6 +165,17 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="sc0011">
+		<description>PostPet (Japan) (SC0011-PST)</description>
+		<year>2001</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x100000">
+				<rom name="sc0011-pst.u1" size="0x100000" crc="6cc02f14" sha1="497702bd93bdf5fbdec6921e3dddf781bc23189c"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="sc0012">
 		<description>Saiten Cartridge: Challenge Idol vol.3 (Japan) (SC0012-SAI)</description>
 		<year>2001</year>
@@ -201,6 +212,16 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="sc0016">
+		<description>Saiten Cartridge: Nesshō vol. 5 (Japan) (SC0016-SAI)</description>
+		<year>2002</year>
+		<publisher>Takara</publisher>
+		<part name="cart" interface="ekara_cart">
+			<dataarea name="rom" size="0x100000">
+				<rom name="sc0016-sai.u1" size="0x100000" crc="20f06e17" sha1="0f8c4ae3c175364a84ac32ae5dea6b27cac17319"/>
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="sc0018">
 		<description>Saiten Cartridge: Challenge Artist Vol.1 (Morning Musume, Tanpopo, Petit Moni, Gotō Maki) (Japan) (SC0018-SAI)</description>

--- a/hash/ekara_japan_s.xml
+++ b/hash/ekara_japan_s.xml
@@ -166,9 +166,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="sc0011">
-		<description>PostPet (Japan) (SC0011-PST)</description>
+		<description>Saiten Cartridge: PostPet (Japan) (SC0011-PST)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>
+		<info name="alt_title" value="採点カートリッジ PostPet"/>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
 				<rom name="sc0011-pst.u1" size="0x100000" crc="6cc02f14" sha1="497702bd93bdf5fbdec6921e3dddf781bc23189c"/>
@@ -213,9 +214,10 @@ license:CC0-1.0
 	</software>
 
 	<software name="sc0016">
-		<description>Saiten Cartridge: Nesshō vol. 5 (Japan) (SC0016-SAI)</description>
+		<description>Saiten Cartridge: Nesshō Vol. 5 (Japan) (SC0016-SAI)</description>
 		<year>2002</year>
 		<publisher>Takara</publisher>
+		<info name="alt_title" value="採点カートリッジ 熱唱 Vol.5"/>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
 				<rom name="sc0016-sai.u1" size="0x100000" crc="20f06e17" sha1="0f8c4ae3c175364a84ac32ae5dea6b27cac17319"/>

--- a/hash/ekara_japan_s.xml
+++ b/hash/ekara_japan_s.xml
@@ -75,7 +75,7 @@ license:CC0-1.0
 		<info name="alt_title" value="採点カートリッジ キッズチャレンジ Vol.1"/>
 		<part name="cart" interface="ekara_cart">
 			<dataarea name="rom" size="0x100000">
-				<rom name="sc0003-.u1" size="0x100000" crc="935e3445" sha1="e86949467e65d515523629ca1e8f8b47cdaaacf0"/>
+				<rom name="sc0003-sai.u1" size="0x100000" crc="935e3445" sha1="e86949467e65d515523629ca1e8f8b47cdaaacf0"/>
 			</dataarea>
 		</part>
 	</software>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -41715,6 +41715,7 @@ ht68k                           //
 
 @source:skeleton/hudson_poems.cpp
 marimba                         //
+poemgolf
 
 @source:skeleton/i7000.cpp
 i7000                           //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -41716,6 +41716,7 @@ ht68k                           //
 @source:skeleton/hudson_poems.cpp
 marimba                         //
 poembase
+poemdenj
 poemgolf
 
 @source:skeleton/i7000.cpp

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -41716,8 +41716,9 @@ ht68k                           //
 @source:skeleton/hudson_poems.cpp
 marimba                         //
 poembase
-poemdenj
 poemgolf
+poemzet
+poemzet2
 
 @source:skeleton/i7000.cpp
 i7000                           //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -41715,6 +41715,7 @@ ht68k                           //
 
 @source:skeleton/hudson_poems.cpp
 marimba                         //
+poembase
 poemgolf
 
 @source:skeleton/i7000.cpp

--- a/src/mame/skeleton/hudson_poems.cpp
+++ b/src/mame/skeleton/hudson_poems.cpp
@@ -224,7 +224,7 @@ static INPUT_PORTS_START( poemgolf )
 	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_BUTTON1 ) // O
 INPUT_PORTS_END
 
-static INPUT_PORTS_START( poemdenj )
+static INPUT_PORTS_START( poemzet )
 	PORT_START( "IN1" )
 INPUT_PORTS_END
 
@@ -363,7 +363,7 @@ void hudson_poems_state::draw_tilemap(screen_device &screen, bitmap_rgb32 &bitma
 	const int tilemap_drawheight = ((m_tilemaphigh[which] >> 16) & 0xff);
 	int tilemap_drawwidth = ((m_tilemaphigh[which] >> 0) & 0x1ff);
 
-	// 0 might be maximum poemdenj
+	// 0 might be maximum poemzet
 	if (tilemap_drawwidth == 0)
 		tilemap_drawwidth = 320;
 
@@ -874,12 +874,20 @@ ROM_START( poembase )
 	ROM_LOAD( "at24c08a.u3", 0x000000, 0x400, CRC(b83afff4) SHA1(5501e490177b69d61099cc8f1439b91320572584) )
 ROM_END
 
-ROM_START( poemdenj )
+ROM_START( poemzet )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD( "poems_denjaras.u2", 0x000000, 0x400000, CRC(278d74c2) SHA1(1bd02cce890778409151b20a048892ba3692fd9b) ) // glob with TSOP pads
 
 	ROM_REGION( 0x400, "nv", 0 )
 	ROM_LOAD( "at24c08a.u3", 0x000000, 0x400, CRC(594c7c3d) SHA1(b1ddf1d30267f10dac00064b60d8a6b594ae6fc1) )
+ROM_END
+
+ROM_START( poemzet2 )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD( "poems_oldman.u2", 0x000000, 0x400000, CRC(d721c4a9) SHA1(59d88c7f515d10d98e00ac076ebd7ce30cb0bb27) ) // glob with TSOP pads
+
+	ROM_REGION( 0x400, "nv", 0 )
+	ROM_LOAD( "at24c08a.u3", 0x000000, 0x400, CRC(5f3d5352) SHA1(94386f5703751e66d6a62e23c344ab7711aad769) )
 ROM_END
 
 } // anonymous namespace
@@ -892,6 +900,6 @@ CONS( 2004, poemgolf,     0,       0,      hudson_poems, poemgolf,     hudson_po
 // waits for 2c005d00 to become 0 (missing irq?) happens before it gets to the DMA transfers
 CONS( 2004, poembase,     0,       0,      hudson_poems, poemgolf,     hudson_poems_state, init_marimba, "Konami", "Nekketsu Pawapuro Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 
-CONS( 2004, poemdenj,     0,       0,      hudson_poems, poemdenj,     hudson_poems_state, init_marimba, "Konami", "Denjarasuji-san is in a desperate situation, let's face off in a mini-game! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+CONS( 2004, poemzet,      0,       0,      hudson_poems, poemzet,      hudson_poems_state, init_marimba, "Konami", "Zettai Zetsumei Dangerous Jiisan - Mini Game de Taiketsu ja!", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 
-
+CONS( 2005, poemzet2,     0,       0,      hudson_poems, poemzet,      hudson_poems_state, init_marimba, "Konami", "Zettai Zetsumei 2", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )

--- a/src/mame/skeleton/hudson_poems.cpp
+++ b/src/mame/skeleton/hudson_poems.cpp
@@ -656,8 +656,8 @@ void hudson_poems_state::mem_map(address_map &map)
 }
 
 static GFXDECODE_START( gfx_poems )
-	GFXDECODE_ENTRY( "maincpu", 0, gfx_8x8x4_packed_lsb, 0, 16 )
-	GFXDECODE_ENTRY( "maincpu", 0, gfx_8x8x8_raw, 0, 1 )
+	GFXDECODE_ENTRY( "maincpu", 0, gfx_8x8x4_packed_lsb, 0, 32 )
+	GFXDECODE_ENTRY( "maincpu", 0, gfx_8x8x8_raw, 0, 2 )
 
 	GFXDECODE_RAM( "mainram", 0, gfx_8x8x4_packed_lsb, 0, 32 )
 	GFXDECODE_RAM( "mainram", 0, gfx_8x8x8_raw, 0, 2 )
@@ -734,9 +734,19 @@ ROM_START( poemgolf )
 	ROM_LOAD( "at24c08a.u3", 0x000000, 0x400, CRC(55856855) SHA1(27b9b42eeea8dd06be43886e40bb2396efc88a67) )
 ROM_END
 
+ROM_START( poembase )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD( "poems_baseball.u2", 0x000000, 0x400000, CRC(105e6c37) SHA1(2a4fe66c08a57bde25047479cbd6ed9ca7c78fa2) ) // glob with TSOP pads
+
+	ROM_REGION( 0x400, "nv", 0 )
+	ROM_LOAD( "at24c08a.u3", 0x000000, 0x400, CRC(b83afff4) SHA1(5501e490177b69d61099cc8f1439b91320572584) )
+ROM_END
+
 } // anonymous namespace
 
 
 CONS( 2005, marimba,      0,       0,      hudson_poems, hudson_poems, hudson_poems_state, init_marimba, "Konami", "Marimba Tengoku (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 
-CONS( 2004, poemgolf,     0,       0,      hudson_poems, hudson_poems, hudson_poems_state, init_marimba, "Konami", "Exhilarating Golf Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+CONS( 2004, poemgolf,     0,       0,      hudson_poems, hudson_poems, hudson_poems_state, init_marimba, "Konami", "Sou-Kai Golf Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+
+CONS( 2004, poembase,     0,       0,      hudson_poems, hudson_poems, hudson_poems_state, init_marimba, "Konami", "Nekketsu Pawapuro Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )

--- a/src/mame/skeleton/hudson_poems.cpp
+++ b/src/mame/skeleton/hudson_poems.cpp
@@ -899,9 +899,9 @@ ROM_END
 CONS( 2005, marimba,      0,       0,      hudson_poems, hudson_poems, hudson_poems_state, init_marimba, "Konami", "Marimba Tengoku (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 
 // waits for 2c008f00 to become 0 (missing irq?) happens before it gets to the DMA transfers
-CONS( 2004, poemgolf,     0,       0,      hudson_poems, poemgolf,     hudson_poems_state, init_marimba, "Konami", "Sou-Kai Golf Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+CONS( 2004, poemgolf,     0,       0,      hudson_poems, poemgolf,     hudson_poems_state, init_marimba, "Konami", "Soukai Golf Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 // waits for 2c005d00 to become 0 (missing irq?) happens before it gets to the DMA transfers
-CONS( 2004, poembase,     0,       0,      hudson_poems, poemgolf,     hudson_poems_state, init_marimba, "Konami", "Nekketsu Pawapuro Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+CONS( 2004, poembase,     0,       0,      hudson_poems, poemgolf,     hudson_poems_state, init_marimba, "Konami", "Nekketsu Powerpro Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 
 CONS( 2004, poemzet,      0,       0,      hudson_poems, poemzet,      hudson_poems_state, init_marimba, "Konami", "Zettai Zetsumei Dangerous Jiisan - Mini Game de Taiketsu ja!", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 

--- a/src/mame/skeleton/hudson_poems.cpp
+++ b/src/mame/skeleton/hudson_poems.cpp
@@ -452,7 +452,8 @@ void hudson_poems_state::draw_tile8(screen_device &screen, bitmap_rgb32 &bitmap,
 
 u32 hudson_poems_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	bitmap.fill(0, cliprect);
+	pen_t const *const paldata = m_palette->pens();
+	bitmap.fill(paldata[0x100], cliprect); // poemzet 'play poems' logo (maybe lowest enabled tilemap is just opaque instead?)
 
 	for (int pri = 0x1f; pri >= 0; pri--)
 	{

--- a/src/mame/skeleton/hudson_poems.cpp
+++ b/src/mame/skeleton/hudson_poems.cpp
@@ -612,8 +612,8 @@ void hudson_poems_state::dma_trigger_w(offs_t offset, u32 data, u32 mem_mask)
 	if ((data == 0x00030001) && (m_dmamode == 0x00003210))
 	{
 		int length = m_dmalength;
-		int source = m_dmasource;
-		int dest = m_dmadest;
+		offs_t source = m_dmasource;
+		offs_t dest = m_dmadest;
 
 		while (length >= 0)
 		{
@@ -628,7 +628,7 @@ void hudson_poems_state::dma_trigger_w(offs_t offset, u32 data, u32 mem_mask)
 	else if (data == 0x00030101) // mode is not used here, but fill is
 	{
 		int length = m_dmalength;
-		int dest = m_dmadest;
+		offs_t dest = m_dmadest;
 
 		while (length >= 0)
 		{
@@ -674,7 +674,7 @@ void hudson_poems_state::dma_fill_w(offs_t offset, u32 data, u32 mem_mask)
 	COMBINE_DATA(&m_dmafill);
 }
 
-template<int Which>
+template <int Which>
 void hudson_poems_state::tilemap_map(address_map &map, u32 base)
 {
 	map(base+0x00, base+0x03).rw(FUNC(hudson_poems_state::tilemap_cfg_r<Which>), FUNC(hudson_poems_state::tilemap_cfg_w<Which>));

--- a/src/mame/skeleton/hudson_poems.cpp
+++ b/src/mame/skeleton/hudson_poems.cpp
@@ -453,10 +453,17 @@ u32 hudson_poems_state::poems_8000038_r(offs_t offset, u32 mem_mask)
 		if (m_maincpu->pc() != 0x2c000b5a)
 			logerror("%s: poems_8000038_r %08x\n", machine().describe_context(), mem_mask);
 
+	if (machine().rand() & 1)
+		return 0xffffffff;
+	else
+		return 0x00000000;
+
+	/*
 	if (m_mainram[0x1baf8/4] == 0x00000000)
 		return 0xffffffff;
 	else
 		return 0x00000000;
+	*/
 }
 
 u32 hudson_poems_state::poems_8000200_r(offs_t offset, u32 mem_mask)
@@ -719,7 +726,17 @@ ROM_START( marimba )
 	ROM_LOAD( "at24c08a.u4", 0x000000, 0x400, CRC(e128a679) SHA1(73fb551d87ed911bd469899343fd36d9d579af39) )
 ROM_END
 
+ROM_START( poemgolf )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD( "poems_golf.u2", 0x000000, 0x400000, CRC(9684a232) SHA1(8a7b97e274dfdddfb6af4df13d714947ef01f29e) ) // glob with TSOP pads
+
+	ROM_REGION( 0x400, "nv", 0 )
+	ROM_LOAD( "at24c08a.u3", 0x000000, 0x400, CRC(55856855) SHA1(27b9b42eeea8dd06be43886e40bb2396efc88a67) )
+ROM_END
+
 } // anonymous namespace
 
 
 CONS( 2005, marimba,      0,       0,      hudson_poems, hudson_poems, hudson_poems_state, init_marimba, "Konami", "Marimba Tengoku (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+
+CONS( 2004, poemgolf,     0,       0,      hudson_poems, hudson_poems, hudson_poems_state, init_marimba, "Konami", "Exhilarating Golf Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )

--- a/src/mame/skeleton/hudson_poems.cpp
+++ b/src/mame/skeleton/hudson_poems.cpp
@@ -905,4 +905,4 @@ CONS( 2004, poembase,     0,       0,      hudson_poems, poemgolf,     hudson_po
 
 CONS( 2004, poemzet,      0,       0,      hudson_poems, poemzet,      hudson_poems_state, init_marimba, "Konami", "Zettai Zetsumei Dangerous Jiisan - Mini Game de Taiketsu ja!", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 
-CONS( 2005, poemzet2,     0,       0,      hudson_poems, poemzet,      hudson_poems_state, init_marimba, "Konami", "Zettai Zetsumei 2", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+CONS( 2005, poemzet2,     0,       0,      hudson_poems, poemzet,      hudson_poems_state, init_marimba, "Konami", "Zettai Zetsumei Dangerous Jiisan Party ja! Zen-in Shuugou!!", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )

--- a/src/mame/skeleton/hudson_poems.cpp
+++ b/src/mame/skeleton/hudson_poems.cpp
@@ -224,6 +224,10 @@ static INPUT_PORTS_START( poemgolf )
 	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_BUTTON1 ) // O
 INPUT_PORTS_END
 
+static INPUT_PORTS_START( poemdenj )
+	PORT_START( "IN1" )
+INPUT_PORTS_END
+
 void hudson_poems_state::draw_sprites(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	int spritebase = (m_spritelistbase & 0x0003ffff) / 4;
@@ -340,6 +344,7 @@ void hudson_poems_state::draw_tilemap(screen_device &screen, bitmap_rgb32 &bitma
 	// contains a full 32-bit address
 	base = (m_tilemapbase[which] & 0x0003ffff) / 4;
 
+
 	// contains a full 32-bit address.  for this to work in the test mode the interrupts must be disabled as soon as test mode is entered, otherwise the pointer
 	// gets overwritten with an incorrect one.  Test mode does not require interrupts to function, although the bit we use to disable them is likely incorrect.
 	// this does NOT really seem to be tied to tilemap number, probably from a config reg
@@ -358,13 +363,16 @@ void hudson_poems_state::draw_tilemap(screen_device &screen, bitmap_rgb32 &bitma
 	const int tilemap_drawheight = ((m_tilemaphigh[which] >> 16) & 0xff);
 	int tilemap_drawwidth = ((m_tilemaphigh[which] >> 0) & 0x1ff);
 
+	// 0 might be maximum poemdenj
+	if (tilemap_drawwidth == 0)
+		tilemap_drawwidth = 320;
+
 	// clamp to size of tilemap (test mode has 256 wide tilemap in RAM, but sets full 320 width?)
 	if (tilemap_drawwidth > width)
 		tilemap_drawwidth = width;
 
 	// note m_tilemaphigh seems to be in pixels, we currently treat it as tiles
 	// these could actually be 'end pos' regs, with unknown start regs currently always set to 0
-
 	for (int y = 0; y < tilemap_drawheight / 8; y++)
 	{
 		const int ypos = (y * 8 + yscroll) & 0x1ff;
@@ -866,6 +874,14 @@ ROM_START( poembase )
 	ROM_LOAD( "at24c08a.u3", 0x000000, 0x400, CRC(b83afff4) SHA1(5501e490177b69d61099cc8f1439b91320572584) )
 ROM_END
 
+ROM_START( poemdenj )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD( "poems_denjaras.u2", 0x000000, 0x400000, CRC(278d74c2) SHA1(1bd02cce890778409151b20a048892ba3692fd9b) ) // glob with TSOP pads
+
+	ROM_REGION( 0x400, "nv", 0 )
+	ROM_LOAD( "at24c08a.u3", 0x000000, 0x400, CRC(594c7c3d) SHA1(b1ddf1d30267f10dac00064b60d8a6b594ae6fc1) )
+ROM_END
+
 } // anonymous namespace
 
 
@@ -875,3 +891,7 @@ CONS( 2005, marimba,      0,       0,      hudson_poems, hudson_poems, hudson_po
 CONS( 2004, poemgolf,     0,       0,      hudson_poems, poemgolf,     hudson_poems_state, init_marimba, "Konami", "Sou-Kai Golf Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 // waits for 2c005d00 to become 0 (missing irq?) happens before it gets to the DMA transfers
 CONS( 2004, poembase,     0,       0,      hudson_poems, poemgolf,     hudson_poems_state, init_marimba, "Konami", "Nekketsu Pawapuro Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+
+CONS( 2004, poemdenj,     0,       0,      hudson_poems, poemdenj,     hudson_poems_state, init_marimba, "Konami", "Denjarasuji-san is in a desperate situation, let's face off in a mini-game! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+
+

--- a/src/mame/skeleton/hudson_poems.cpp
+++ b/src/mame/skeleton/hudson_poems.cpp
@@ -238,7 +238,7 @@ void hudson_poems_state::draw_sprites(screen_device &screen, bitmap_rgb32 &bitma
 
 		const int x = (spriteword3 & 0x03ff);
 		const int y = (spriteword2 & 0x03ff);
-		int tilenum = spriteword1 & 0x03ff;
+		int tilenum = spriteword1 & 0x07ff;
 		const int pal = (spriteword2 & 0x7c00)>>10;
 
 		// is it selecting from multiple tile pages (which can have different bases?) (probably from a register somewhere)
@@ -248,7 +248,7 @@ void hudson_poems_state::draw_sprites(screen_device &screen, bitmap_rgb32 &bitma
 
 		/* based on code analysis of function at 006707A4
 		word0 ( 0abb bbBB ---- -dFf ) OR ( 1abb bbcc dddd dddd ) a = ?  b = alpha blend? (toggles between all bits on and off for battery logo) BB = sprite base  F = flipX f = flipY
-		word1 ( wwhh ---t tttt tttt ) - other bits are used, but pulled from ram? t = tile number?  ww = width hh = height
+		word1 ( wwhh -ttt tttt tttt ) - other bits are used, but pulled from ram? t = tile number?  ww = width hh = height
 		word2 ( 0Ppp ppyy yyyy yyyy ) P = palette bank p = palette y = ypos
 		word3 ( aabb bbxx xxxx xxxx ) x = xpos
 		*/

--- a/src/mame/skeleton/hudson_poems.cpp
+++ b/src/mame/skeleton/hudson_poems.cpp
@@ -360,10 +360,14 @@ void hudson_poems_state::draw_tilemap(screen_device &screen, bitmap_rgb32 &bitma
 	if (xscroll & 0x400)
 		xscroll -= 0x800;
 
-	const int tilemap_drawheight = ((m_tilemaphigh[which] >> 16) & 0xff);
+	int tilemap_drawheight = ((m_tilemaphigh[which] >> 16) & 0xff);
 	int tilemap_drawwidth = ((m_tilemaphigh[which] >> 0) & 0x1ff);
 
-	// 0 might be maximum poemzet
+	// 0 might be maximum, poemzet2
+	if (tilemap_drawheight == 0)
+		tilemap_drawheight = 240;
+
+	// 0 might be maximum, poemzet
 	if (tilemap_drawwidth == 0)
 		tilemap_drawwidth = 320;
 
@@ -562,7 +566,6 @@ void hudson_poems_state::unktable_w(offs_t offset, u32 data, u32 mem_mask)
 		if (m_unktableoffset < 256)
 		{
 			m_unktable[m_unktableoffset] = data & 0x0000ffff;
-			set_palette_val(m_unktableoffset);
 			m_unktableoffset++;
 		}
 	}
@@ -572,7 +575,6 @@ void hudson_poems_state::unktable_w(offs_t offset, u32 data, u32 mem_mask)
 		if (m_unktableoffset < 256)
 		{
 			m_unktable[m_unktableoffset] = (data & 0xffff0000)>>16;
-			set_palette_val(m_unktableoffset);
 			m_unktableoffset++;
 		}
 	}

--- a/src/mame/tvgames/xavix.cpp
+++ b/src/mame/tvgames/xavix.cpp
@@ -1548,6 +1548,7 @@ void xavix_cart_state::xavix_cart_ekara(machine_config &config)
 	SOFTWARE_LIST(config, "cart_list_japan_m").set_original("ekara_japan_m");
 	SOFTWARE_LIST(config, "cart_list_japan_d").set_original("ekara_japan_d");
 	SOFTWARE_LIST(config, "cart_list_japan_en").set_original("ekara_japan_en");
+	SOFTWARE_LIST(config, "cart_list_japan_kd").set_original("ekara_japan_kd");
 	SOFTWARE_LIST(config, "cart_list_japan_sp").set_original("ekara_japan_sp");
 	SOFTWARE_LIST(config, "cart_list_japan_web").set_original("ekara_japan_web");
 	SOFTWARE_LIST(config, "cart_list_japan_a").set_original("ekara_japan_a");

--- a/src/mame/tvgames/xavix.cpp
+++ b/src/mame/tvgames/xavix.cpp
@@ -1554,7 +1554,7 @@ void xavix_cart_state::xavix_cart_ekara(machine_config &config)
 	SOFTWARE_LIST(config, "cart_list_japan_a").set_original("ekara_japan_a");
 	SOFTWARE_LIST(config, "cart_list_japan_gk").set_original("ekara_japan_gk");
 	SOFTWARE_LIST(config, "cart_list_japan_bh").set_original("ekara_japan_bh");
-	SOFTWARE_LIST(config, "cart_list_japan_ac").set_original("ekara_japan_ac");
+	SOFTWARE_LIST(config, "cart_list_japan_packin").set_original("ekara_japan_packin");
 }
 
 void xavix_cart_state::xavix_cart_hikara(machine_config &config)


### PR DESCRIPTION
new software list entries
-----------
Kids' Song Best 40 (Japan) (EC0084-KSB) [Team Europe, David Haywood]
Morning Musume Special (Japan) (BX01-MOR) [Team Europe, David Haywood]
Enka-shū Dai Volume 1 (Japan) (EN-1) [Team Europe, David Haywood]
Enka-shū Dai Volume 2 (Japan) (EN-2) [Team Europe, David Haywood]
Kids' Song 20 (Japan) (KD-1) [Team Europe, David Haywood]
J-Pop Mix Mini Volume 1 (Japan) (MC0009-JPM) [Team Europe, David Haywood]
Artist Mini Volume 9 (Yamaguchi Momoe) (Japan) (MC0016-ATM) [Team Europe, David Haywood]
PostPet (Japan) (SC0011-PST) [Team Europe, David Haywood]
Saiten Cartridge: Nesshō vol. 5 (Japan) (SC0016-SAI) [Team Europe, David Haywood]

these titles aren't optimal, ideally this will be merged and the titles corrected by somebody who knows the language, along with the alt tags added.

new NOT WORKING machines
----------------
Sou-Kai Golf Champ (Japan) [Team Europe, David Haywood]
Nekketsu Pawapuro Champ (Japan) [Team Europe, David Haywood]
Zettai Zetsumei Dangerous Jiisan - Mini Game de Taiketsu ja! (Japan) [Team Europe, David Haywood]
Zettai Zetsumei Dangerous Jiisan Party ja! Zen-in Shuugou!! (Japan) [Team Europe, David Haywood]