### PR TITLE
util/bitstream: Fix cases where bits would be dropped when reading and writing

### DIFF
--- a/src/lib/util/bitstream.h
+++ b/src/lib/util/bitstream.h
@@ -107,7 +107,7 @@ inline uint32_t bitstream_in::peek(int numbits)
 	{
 		while (m_bits < 32)
 		{
-			int newbits = 0;
+			uint32_t newbits = 0;
 
 			if (m_doffset < m_dlength)
 			{
@@ -234,7 +234,7 @@ inline void bitstream_out::write(uint32_t newbits, int numbits)
 		// offload more bits if it'll still overflow the buffer
 		if (m_bits + numbits >= 32)
 		{
-			int rem = std::min(32 - m_bits, numbits);
+			const int rem = std::min(32 - m_bits, numbits);
 			m_buffer |= newbits >> m_bits;
 			m_bits += rem;
 			newbits <<= rem;

--- a/src/lib/util/bitstream.h
+++ b/src/lib/util/bitstream.h
@@ -40,10 +40,11 @@ public:
 private:
 	// internal state
 	uint32_t          m_buffer;       // current bit accumulator
-	int             m_bits;         // number of bits in the accumulator
+	int               m_bits;         // number of bits in the accumulator
 	const uint8_t *   m_read;         // read pointer
 	uint32_t          m_doffset;      // byte offset within the data
 	uint32_t          m_dlength;      // length of the data
+	int               m_dbitoffs;     // bit offset within current read pointer
 };
 
 
@@ -64,7 +65,7 @@ public:
 private:
 	// internal state
 	uint32_t          m_buffer;           // current bit accumulator
-	int             m_bits;             // number of bits in the accumulator
+	int               m_bits;             // number of bits in the accumulator
 	uint8_t *         m_write;            // write pointer
 	uint32_t          m_doffset;          // byte offset within the data
 	uint32_t          m_dlength;          // length of the data
@@ -85,7 +86,8 @@ inline bitstream_in::bitstream_in(const void *src, uint32_t srclength)
 		m_bits(0),
 		m_read(reinterpret_cast<const uint8_t *>(src)),
 		m_doffset(0),
-		m_dlength(srclength)
+		m_dlength(srclength),
+		m_dbitoffs(0)
 {
 }
 
@@ -103,12 +105,31 @@ inline uint32_t bitstream_in::peek(int numbits)
 	// fetch data if we need more
 	if (numbits > m_bits)
 	{
-		while (m_bits <= 24)
+		while (m_bits < 32)
 		{
+			int newbits = 0;
+
 			if (m_doffset < m_dlength)
-				m_buffer |= m_read[m_doffset] << (24 - m_bits);
-			m_doffset++;
-			m_bits += 8;
+			{
+				// adjust current data to discard any previously read partial bits
+				newbits = (m_read[m_doffset] << m_dbitoffs) & 0xff;
+			}
+
+			if (m_bits + 8 > 32)
+			{
+				// take only what can be used to fill out the rest of the buffer
+				m_dbitoffs = 32 - m_bits;
+				newbits >>= 8 - m_dbitoffs;
+				m_buffer |= newbits;
+				m_bits += m_dbitoffs;
+			}
+			else
+			{
+				m_buffer |= newbits << (24 - m_bits);
+				m_bits += 8 - m_dbitoffs;
+				m_dbitoffs = 0;
+				m_doffset++;
+			}
 		}
 	}
 
@@ -196,8 +217,11 @@ inline bitstream_out::bitstream_out(void *dest, uint32_t destlength)
 
 inline void bitstream_out::write(uint32_t newbits, int numbits)
 {
+	newbits <<= 32 - numbits;
+
 	// flush the buffer if we're going to overflow it
-	if (m_bits + numbits > 32)
+	while (m_bits + numbits >= 32 && numbits > 0)
+	{
 		while (m_bits >= 8)
 		{
 			if (m_doffset < m_dlength)
@@ -207,11 +231,19 @@ inline void bitstream_out::write(uint32_t newbits, int numbits)
 			m_bits -= 8;
 		}
 
-	// shift the bits to the top
-	if (numbits == 0)
-		newbits = 0;
-	else
-		newbits <<= 32 - numbits;
+		// offload more bits if it'll still overflow the buffer
+		if (m_bits + numbits >= 32)
+		{
+			int rem = std::min(32 - m_bits, numbits);
+			m_buffer |= newbits >> m_bits;
+			m_bits += rem;
+			newbits <<= rem;
+			numbits -= rem;
+		}
+	}
+
+	if (numbits <= 0)
+		return;
 
 	// now shift it down to account for the number of bits we already have and OR them in
 	m_buffer |= newbits >> m_bits;


### PR DESCRIPTION
Additional testing from someone else before merging would be appreciated.

In this case, the parent chunk types were using 26 bits per offset values which behaved unexpectedly resulting in some bits being dropped when reading and writing the data. I think the issue only happens when dealing with values larger than 24 bits due to the way buffering was implemented. So I've changed both `bitstream_in` and `bitstream_out` to more greedily fill its buffers, including partial reads for `bitstream_in`.

Old (can see an additional CRC error message I added to help debug, should be reproducible):
```
> ./chdman copy -i gdj_aaa_2007071100.chd -op gdj_aaa_2007100800.chd -o newchild2.chd 
chdman - MAME Compressed Hunks of Data (CHD) manager 0.262 (mame0252-3687-gb0c8802da65-dirty)
Output CHD:   newchild2.chd
Parent CHD:   gdj_aaa_2007100800.chd
Input CHD:    gdj_aaa_2007071100.chd
Compression:  lzma (LZMA), zlib (Deflate), huff (Huffman), flac (FLAC)
Hunk size:    4,096
Logical size: 40,000,000,000
Compression complete ... final ratio = 7.8%

> ./chdman info -i newchild2.chd
chdman - MAME Compressed Hunks of Data (CHD) manager 0.262 (mame0252-3687-gb0c8802da65-dirty)
CRC did not match! expected 0000f003, found 000055da
Error opening CHD file (newchild2.chd): Decompression error
Fatal error occurred: 1
```

New:
```
> ./chdman copy -i gdj_aaa_2007071100.chd -op gdj_aaa_2007100800.chd -o newchild3.chd
chdman - MAME Compressed Hunks of Data (CHD) manager 0.262 (mame0252-3658-gbaf313500d7)
Output CHD:   newchild3.chd
Parent CHD:   gdj_aaa_2007100800.chd
Input CHD:    gdj_aaa_2007071100.chd
Compression:  lzma (LZMA), zlib (Deflate), huff (Huffman), flac (FLAC)
Hunk size:    4,096
Logical size: 40,000,000,000
Compression complete ... final ratio = 7.8%

> ./chdman info -i newchild3.chd
chdman - MAME Compressed Hunks of Data (CHD) manager 0.262 (mame0252-3658-gbaf313500d7)
Input file:   newchild3.chd
File Version: 5
Logical size: 40,000,000,000 bytes
Hunk Size:    4,096 bytes
Total Hunks:  9,765,625
Unit Size:    512 bytes
Total Units:  78,125,000
Compression:  lzma (LZMA), zlib (Deflate), huff (Huffman), flac (FLAC)
CHD size:     3,137,000,409 bytes
Ratio:        7.8%
SHA1:         af76f981a86d117df0799170aa1a6babeb92fd00
Data SHA1:    f86c948f8ab9124ed04d0462c7b9b31aabd0afa4
Parent SHA1:  b32f4f09e155f2fd0fc16b0bb77331756b3928d0
Metadata:     Tag='GDDD'  Index=0  Length=37 bytes
              CYLS:156250,HEADS:10,SECS:50,BPS:512.
```


Parent CHDs just to make it easy to verify the metadata of the new child CHD looks correct:
```
> ./chdman info -i gdj_aaa_2007071100.chd
chdman - MAME Compressed Hunks of Data (CHD) manager 0.262 (mame0252-3658-gbaf313500d7)
Input file:   gdj_aaa_2007071100.chd
File Version: 5
Logical size: 40,000,000,000 bytes
Hunk Size:    4,096 bytes
Total Hunks:  9,765,625
Unit Size:    512 bytes
Total Units:  78,125,000
Compression:  lzma (LZMA), zlib (Deflate), huff (Huffman), flac (FLAC)
CHD size:     10,268,950,478 bytes
Ratio:        25.7%
SHA1:         af76f981a86d117df0799170aa1a6babeb92fd00
Data SHA1:    f86c948f8ab9124ed04d0462c7b9b31aabd0afa4
Metadata:     Tag='GDDD'  Index=0  Length=37 bytes
              CYLS:156250,HEADS:10,SECS:50,BPS:512.
              
> ./chdman info -i gdj_aaa_2007100800.chd
chdman - MAME Compressed Hunks of Data (CHD) manager 0.262 (mame0252-3658-gbaf313500d7)
Input file:   gdj_aaa_2007100800.chd
File Version: 5
Logical size: 40,000,000,000 bytes
Hunk Size:    4,096 bytes
Total Hunks:  9,765,625
Unit Size:    512 bytes
Total Units:  78,125,000
Compression:  lzma (LZMA), zlib (Deflate), huff (Huffman), flac (FLAC)
CHD size:     7,161,091,862 bytes
Ratio:        17.9%
SHA1:         b32f4f09e155f2fd0fc16b0bb77331756b3928d0
Data SHA1:    2001011370d1201129d7f43f5f8cf37752985645
Metadata:     Tag='GDDD'  Index=0  Length=37 bytes
              CYLS:156250,HEADS:10,SECS:50,BPS:512.
```