### PR TITLE
util/bitstream: Adjust m_doffset based on m_dbitoffs when flushing

### DIFF
--- a/src/lib/util/bitstream.h
+++ b/src/lib/util/bitstream.h
@@ -175,6 +175,10 @@ inline uint32_t bitstream_in::read_offset() const
 		result--;
 		bits -= 8;
 	}
+
+	if (m_dbitoffs > bits)
+		result++;
+
 	return result;
 }
 
@@ -190,7 +194,11 @@ inline uint32_t bitstream_in::flush()
 		m_doffset--;
 		m_bits -= 8;
 	}
-	m_bits = m_buffer = 0;
+
+	if (m_dbitoffs > m_bits)
+		m_doffset++;
+
+	m_bits = m_buffer = m_dbitoffs = 0;
 	return m_doffset;
 }
 


### PR DESCRIPTION
Found that in addition to forgetting to clear `m_dbitoffs` when flushing resulting in data being shifted incorrectly after a flush when `m_dbitoffs` was non-0, the variable `m_doffset` would go out of sync after flushing when `m_dbitoffs` was used so that needed to be adjusted as well.

I've tested with `chdman info` to check that the 175 CHDs I have on hand can still decompress the map data still, recreated the delta CHD (`chdman copy -i ~/chd_test/gdj_aaa_2007071100.chd -op ~/chd_test/gdj_aaa_2007100800.chd -o ~/chd_test/newchild5.chd`) and verified that all of the hashes validated, and then did various tests using the `dlair` laserdisc CHD including extracting using `chdman extractld`, recreating using `chdman createld`, and verifying that the SHA1 and Data SHA1 were the same in the original CHD and the recreated CHD.