### PR TITLE
scripts/build/verinfo.py: use a python raw string for the regular expression

### DIFF
--- a/scripts/build/verinfo.py
+++ b/scripts/build/verinfo.py
@@ -23,7 +23,7 @@ def parse_args():
 
 
 def extract_version(verinfo):
-    pattern = re.compile('\s+BARE_BUILD_VERSION\s+"(([^."]+)\.([^."]+))"')
+    pattern = re.compile(r'\s+BARE_BUILD_VERSION\s+"(([^."]+)\.([^."]+))"')
     for line in verinfo:
         match = pattern.search(line)
         if match:


### PR DESCRIPTION
so \ chars aren't treated as part of an escape sequence. (It does the right thing but it generates a warning)

```
python3 ./scripts/build/verinfo.py 
./scripts/build/verinfo.py:26: SyntaxWarning: invalid escape sequence '\s'
  pattern = re.compile('\s+BARE_BUILD_VERSION\s+"(([^."]+)\.([^."]+))"')
usage: verinfo.py [-h] [--target <target>] [--subtarget <subtarget>] [--executable <executable>] [--format <format>] [--resources <resfile>] [-o <outfile>]
                  <srcfile>
```