### PR TITLE
trs/gime.cpp: Fix crash in rare circumstance

### DIFF
--- a/src/mame/trs/gime.cpp
+++ b/src/mame/trs/gime.cpp
@@ -587,14 +587,11 @@ void gime_device::update_memory(int bank)
 		is_read_only = false;
 	}
 
-	// compensate for offset
-	memory += offset;
-
 	// set the banks
 	if (memory)
 	{
-		read_bank->set_base(memory);
-		write_bank->set_base(is_read_only ? m_dummy_bank : memory);
+		read_bank->set_base(memory + offset);
+		write_bank->set_base(is_read_only ? m_dummy_bank : memory + offset);
 	}
 	else
 	{


### PR DESCRIPTION
A zero in `memory` was being used as a flag for a dummy memory bank. Adding the `offset` before checking the condition could cause unallocated memory to be referenced.