### PR TITLE
Use literal romaji for Jikkyou Powerful Pro Yakyuu game titles

### DIFF
--- a/hash/dc.xml
+++ b/hash/dc.xml
@@ -17967,7 +17967,7 @@ Has [redbook] audio
 		<rom name="track02.raw" size="1735776" md5="d09be539a7074a058159505b7f5fdcb3" sha1="db680939aae4bf61d0e588414c72a47c6dd92cdd"/>
 		<rom name="track03.bin" size="1185760800" md5="b0c73d82f36dd05235c5f2b38793c15b" sha1="8b073759e6cb0a2bc5f4e77978d7a129e22c0878"/>
 		-->
-		<description>Jikkyou Powerful Pro Yakyuu - Dreamcast Edition (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū - Dreamcast Edition (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-9507M"/>

--- a/hash/dc.xml
+++ b/hash/dc.xml
@@ -17973,6 +17973,7 @@ Has [redbook] audio
 		<info name="serial" value="T-9507M"/>
 		<info name="release" value="20000330"/>
 		<info name="alt_title" value="実況パワフルプロ野球 Dreamcast Edition"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu - Dreamcast Edition"/> <!-- often used unofficially -->
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
 				<disk name="jikkyou powerful pro yakyuu - dreamcast edition (jpn)" sha1="07e2e64eaa62690b431998750e7d3976d36db6a0"/>

--- a/hash/n64.xml
+++ b/hash/n64.xml
@@ -5867,7 +5867,7 @@ Black screen after Rare logo
 	</software>
 
 	<software name="powyak2k" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu 2000 (Japan, rev 1)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 2000 (Japan, rev 1)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NPAJ-JPN (RZ034-J1)"/>
@@ -5881,7 +5881,7 @@ Black screen after Rare logo
 	</software>
 
 	<software name="powyak2ka" cloneof="powyak2k" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu 2000 (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NPAJ-JPN (RZ034-J1)"/>
@@ -5903,7 +5903,7 @@ Black screen after Rare logo
 	</software>
 
 	<software name="powyak4" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu 4 (Japan, rev 1)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 4 (Japan, rev 1)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NP4J-JPN (RZ001-J1)"/>
@@ -5921,7 +5921,7 @@ Black screen after Rare logo
 	</software>
 
 	<software name="powyak4a" cloneof="powyak4" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu 4 (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 4 (Japan)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NP4J-JPN (RZ001-J1)"/>
@@ -5935,7 +5935,7 @@ Black screen after Rare logo
 	</software>
 
 	<software name="powyak5" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan, rev 2)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 5 (Japan, rev 2)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
 		<notes><![CDATA[
@@ -5952,7 +5952,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 	</software>
 
 	<software name="powyak5a" cloneof="powyak5" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan, rev 1)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 5 (Japan, rev 1)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
 		<notes><![CDATA[
@@ -5977,7 +5977,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 	</software>
 
 	<software name="powyak5b" cloneof="powyak5" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 5 (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
 		<notes><![CDATA[
@@ -6000,7 +6000,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 	</software>
 
 	<software name="powyak6" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan, rev 2)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 6 (Japan, rev 2)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NP6J-JPN (RZ026-J1)"/>
@@ -6014,7 +6014,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 	</software>
 
 	<software name="powyak6a" cloneof="powyak6" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan, rev 1)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 6 (Japan, rev 1)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NP6J-JPN (RZ026-J1)"/>
@@ -6028,7 +6028,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 	</software>
 
 	<software name="powyak6b" cloneof="powyak6" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 6 (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NP6J-JPN (RZ026-J1)"/>
@@ -6050,7 +6050,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 	</software>
 
 	<software name="powyk2k1" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu Basic Ban 2001 (Japan, rev 1)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū Basic Ban 2001 (Japan, rev 1)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NPEJ-JPN (RZ038-J1)"/>
@@ -6064,7 +6064,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 	</software>
 
 	<software name="powyk2k1a" cloneof="powyk2k1" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu Basic Ban 2001 (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū Basic Ban 2001 (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NPEJ-JPN (RZ038-J1)"/>

--- a/hash/n64.xml
+++ b/hash/n64.xml
@@ -5873,6 +5873,7 @@ Black screen after Rare logo
 		<info name="serial" value="NUS-NPAJ-JPN (RZ034-J1)"/>
 		<info name="release" value="20000429"/>
 		<info name="alt_title" value="実況パワフルプロ野球2000"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 2000"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<dataarea name="rom" size="0x1000000">
 				<rom name="jikkyou powerful pro yakyuu 2000 (japan) (rev a).bin" size="0x1000000" crc="4e6faa43" sha1="6f32972fe2fdce0ac051787b8253950aa36487d1" />
@@ -5887,6 +5888,7 @@ Black screen after Rare logo
 		<info name="serial" value="NUS-NPAJ-JPN (RZ034-J1)"/>
 		<info name="release" value="20000429"/>
 		<info name="alt_title" value="実況パワフルプロ野球2000"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 2000"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<feature name="pcb" value="NUS-02A-01" />
 			<feature name="u1" value="U1 [NUS-NP4J-0 02]" />
@@ -5909,6 +5911,7 @@ Black screen after Rare logo
 		<info name="serial" value="NUS-NP4J-JPN (RZ001-J1)"/>
 		<info name="release" value="19970314"/>
 		<info name="alt_title" value="実況パワフルプロ野球4"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 4"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<feature name="pcb" value="NUS-01A-02" />
 			<feature name="u1" value="U1 [NUS-NP4J-1]" /> <!-- MX23L9602-35 -->
@@ -5927,6 +5930,7 @@ Black screen after Rare logo
 		<info name="serial" value="NUS-NP4J-JPN (RZ001-J1)"/>
 		<info name="release" value="19970314"/>
 		<info name="alt_title" value="実況パワフルプロ野球4"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 4"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<dataarea name="rom" size="0xc00000">
 				<rom name="jikkyou powerful pro yakyuu 4 (japan).bin" size="0xc00000" crc="8d2540f1" sha1="73016b7c15bae869b0d868e62b433400503ef540" />
@@ -5944,6 +5948,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 		<info name="serial" value="NUS-NJ5J-JPN (RZ015-J1)"/>
 		<info name="release" value="19980326"/>
 		<info name="alt_title" value="実況パワフルプロ野球5"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 5"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<dataarea name="rom" size="0x1000000">
 				<rom name="jikkyou powerful pro yakyuu 5 (japan) (rev b).bin" size="0x1000000" crc="5b39c8b2" sha1="6105e653e99e56b6e0edf80db35031bf0f0b1881" />
@@ -5961,6 +5966,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 		<info name="serial" value="NUS-NJ5J-JPN (RZ015-J1)"/>
 		<info name="release" value="19980326"/>
 		<info name="alt_title" value="実況パワフルプロ野球5"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 5"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<feature name="pcb" value="NUS-03A-01" />
 			<feature name="u1" value="U1 [NUS-NJ5J-1]" />
@@ -5986,6 +5992,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 		<info name="serial" value="NUS-NJ5J-JPN (RZ015-J1)"/>
 		<info name="release" value="19980326"/>
 		<info name="alt_title" value="実況パワフルプロ野球5"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 5"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<feature name="pcb" value="NUS-03A-01" />
 			<feature name="u1" value="U1 [NUS-NJ5J-0]" />
@@ -6006,6 +6013,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 		<info name="serial" value="NUS-NP6J-JPN (RZ026-J1)"/>
 		<info name="release" value="19990325"/>
 		<info name="alt_title" value="実況パワフルプロ野球6"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 6"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<dataarea name="rom" size="0x1000000">
 				<rom name="jikkyou powerful pro yakyuu 6 (japan) (rev b).bin" size="0x1000000" crc="e8d4a365" sha1="be9811a86db41f5b1f4844bc004aa34d1d4bc406" />
@@ -6020,6 +6028,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 		<info name="serial" value="NUS-NP6J-JPN (RZ026-J1)"/>
 		<info name="release" value="19990325"/>
 		<info name="alt_title" value="実況パワフルプロ野球6"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 6"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<dataarea name="rom" size="0x1000000">
 				<rom name="jikkyou powerful pro yakyuu 6 (japan) (rev a).bin" size="0x1000000" crc="5b6351f1" sha1="713b5c8bf72d78b97df416923aad589ec3c8ec64" />
@@ -6034,6 +6043,7 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 		<info name="serial" value="NUS-NP6J-JPN (RZ026-J1)"/>
 		<info name="release" value="19990325"/>
 		<info name="alt_title" value="実況パワフルプロ野球6"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 6"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<feature name="pcb" value="NUS-03A-01" />
 			<feature name="u1" value="U1 [NUS-NP6J-0]" />
@@ -6050,12 +6060,13 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 	</software>
 
 	<software name="powyk2k1" supported="no">
-		<description>Jikkyou Pawafuru Puro Yakyū Basic Ban 2001 (Japan, rev 1)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū Basic-ban 2001 (Japan, rev 1)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NPEJ-JPN (RZ038-J1)"/>
 		<info name="release" value="20010329"/>
 		<info name="alt_title" value="実況パワフルプロ野球 Basic版2001"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu Basic-ban 2001"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<dataarea name="rom" size="0x1000000">
 				<rom name="jikkyou powerful pro yakyuu basic ban 2001 (japan) (rev a).bin" size="0x1000000" crc="68d57df2" sha1="897d785332af3f7f055b23e7d848e60874003bd5" />
@@ -6064,12 +6075,13 @@ Stuck vertical lines during intro (i.e. when stadiums are displayed)
 	</software>
 
 	<software name="powyk2k1a" cloneof="powyk2k1" supported="no">
-		<description>Jikkyou Pawafuru Puro Yakyū Basic Ban 2001 (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū Basic-ban 2001 (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NPEJ-JPN (RZ038-J1)"/>
 		<info name="release" value="20010329"/>
 		<info name="alt_title" value="実況パワフルプロ野球 Basic版2001"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu Basic-ban 2001"/> <!-- often used unofficially -->
 		<part name="cart" interface="n64_cart">
 			<dataarea name="rom" size="0x1000000">
 				<rom name="jikkyou powerful pro yakyuu basic ban 2001 (japan).bin" size="0x1000000" crc="4e102917" sha1="0f34cc6c6448cf4956dccdabeac0fbbd1f36dca1" />

--- a/hash/saturn.xml
+++ b/hash/saturn.xml
@@ -547,8 +547,8 @@ license:CC0-1.0
 	  Jantei: Battle Cos-Player (Japan) [T-34601G]                                          | (jantbcp)
 	  Japan Super Bass Classic '96 (Japan) [T-18707G]                                       | (jsbc96)
 	  Jikkyou Oshaberi Parodius: Forever with Me (Japan) [T-9513G]                          | (jikkparo)
-	  Jikkyou Powerful Pro Yakyuu '95 Kaimakuban (Japan) [T-9502G]                          | (powyak95)
-	  Jikkyou Powerful Pro Yakyuu S (Japan) [T-9523G]                                       | (powyaks)
+	  Jikkyou Pawafuru Puro Yakyū '95 Kaimakuban (Japan) [T-9502G]                          | (powyak95)
+	  Jikkyou Pawafuru Puro Yakyū S (Japan) [T-9523G]                                       | (powyaks)
 	  Jikuu Tantei DD: Dracula Detective: Maboroshi no Lorelei (Japan) [T-2103G]            | (jikudrac)
 	  Jinzou Ningen Hakaider: Last Judgement (Japan) [GS-9088]                              | (lastjudg)
 	  Jissen Mahjong (Japan) [T-15002G]                                                     | (jissenmj)
@@ -18401,7 +18401,7 @@ Sega logo animation draws offset [VDP2]
 
 	<!-- Identifying Jikkyou Pawerful Puroyakyu '95 (J) (T-9502G)... -->
 	<software name="powyak95" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu '95 - Kaimaku-ban (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū '95 - Kaimaku-ban (Japan)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-9502G (VS001-J1)"/>
@@ -27111,7 +27111,7 @@ Sega logo animation draws offset [VDP2]
 
 	<!-- Identifying Jikkyou Powerful Pro Yakyuu S T-9523G... -->
 	<software name="powyaks" supported="no">
-		<description>Jikkyou Powerful Pro Yakyuu S (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū S (Japan)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-9523G (VS050-J1)"/>

--- a/hash/saturn.xml
+++ b/hash/saturn.xml
@@ -18407,6 +18407,7 @@ Sega logo animation draws offset [VDP2]
 		<info name="serial" value="T-9502G (VS001-J1)"/>
 		<info name="release" value="19950728"/>
 		<info name="alt_title" value="実況パワフルプロ野球'95 開幕版"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu '95 Kaimaku-ban"/> <!-- often used unofficially -->
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
@@ -27117,6 +27118,7 @@ Sega logo animation draws offset [VDP2]
 		<info name="serial" value="T-9523G (VS050-J1)"/>
 		<info name="release" value="19971204"/>
 		<info name="alt_title" value="実況パワフルプロ野球S"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu S"/> <!-- often used unofficially -->
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">

--- a/hash/saturn.xml
+++ b/hash/saturn.xml
@@ -547,7 +547,7 @@ license:CC0-1.0
 	  Jantei: Battle Cos-Player (Japan) [T-34601G]                                          | (jantbcp)
 	  Japan Super Bass Classic '96 (Japan) [T-18707G]                                       | (jsbc96)
 	  Jikkyou Oshaberi Parodius: Forever with Me (Japan) [T-9513G]                          | (jikkparo)
-	  Jikkyou Pawafuru Puro Yakyū '95 Kaimakuban (Japan) [T-9502G]                          | (powyak95)
+	  Jikkyou Pawafuru Puro Yakyū '95 Kaimaku-ban (Japan) [T-9502G]                         | (powyak95)
 	  Jikkyou Pawafuru Puro Yakyū S (Japan) [T-9523G]                                       | (powyaks)
 	  Jikuu Tantei DD: Dracula Detective: Maboroshi no Lorelei (Japan) [T-2103G]            | (jikudrac)
 	  Jinzou Ningen Hakaider: Last Judgement (Japan) [GS-9088]                              | (lastjudg)
@@ -18401,7 +18401,7 @@ Sega logo animation draws offset [VDP2]
 
 	<!-- Identifying Jikkyou Pawerful Puroyakyu '95 (J) (T-9502G)... -->
 	<software name="powyak95" supported="no">
-		<description>Jikkyou Pawafuru Puro Yakyū '95 - Kaimaku-ban (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū '95 Kaimaku-ban (Japan)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="T-9502G (VS001-J1)"/>

--- a/hash/snes.xml
+++ b/hash/snes.xml
@@ -398,7 +398,7 @@ Beyond that last category are the roms waiting to be classified.
         <info name="serial" value="SHVC-2U" />
         <info name="release" value="19941216" />
         <info name="alt_title" value="がんばれゴエモン3 獅子重禄兵衛のからくり卍固め" />
-        <sharedfeat name="compatibility" value="NTSC"/>
+        <sharedfeat name="compatibility" value="NTSC" />
         <part name="cart" interface="snes_cart">
             <feature name="pcb" value="SHVC-1A3M-30" />
             <feature name="u1" value="U1 MASK ROM(N)" />
@@ -851,7 +851,7 @@ Beyond that last category are the roms waiting to be classified.
 		<description>Castlevania - Dracula X (USA, final prototype)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-4PV5B-01" />
 			<feature name="u1" value="U1 EPROM" />
@@ -1520,7 +1520,7 @@ Beyond that last category are the roms waiting to be classified.
 		<description>Foreman For Real (USA, final prototype)</description>
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-8PV5B-01" />
 			<feature name="u1" value="U1 4/8M EPROM(J)" />
@@ -1706,7 +1706,7 @@ Beyond that last category are the roms waiting to be classified.
 		<description>International Superstar Soccer Deluxe (Europe, prototype)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-4PV5B-01" />
 			<feature name="u1" value="U1 EPROM [D27C8001D-15]" />
@@ -1867,7 +1867,7 @@ Beyond that last category are the roms waiting to be classified.
 		<description>Joe &amp; Mac 2 - Lost in the Tropics (USA, prototype, alt)</description>
 		<year>1994</year>
 		<publisher>Data East</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2P3B-01" />
 			<feature name="u1" value="U1 EPROM(J) [TC574000AD-120]" />
@@ -1892,7 +1892,7 @@ Beyond that last category are the roms waiting to be classified.
 		<description>Jurassic Park (USA, prototype)</description>
 		<year>1993</year>
 		<publisher>Ocean</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-4PV5B-01" />
 			<feature name="u1" value="U1 EPROM [TC574000D-120]" />
@@ -2600,7 +2600,7 @@ Beyond that last category are the roms waiting to be classified.
 		<description>The Pirates of Dark Water (USA, prototype)</description>
 		<year>1994</year>
 		<publisher>Sunsoft</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2P3B-01" /> <!-- to be confirmed -->
 			<feature name="u1" value="U1 EPROM(J)" />
@@ -2880,7 +2880,7 @@ Beyond that last category are the roms waiting to be classified.
 		<description>Samurai Shodown (USA, prototype)</description>
 		<year>1994</year>
 		<publisher>Takara</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-8PV5B-01" />
 			<feature name="u1" value="U1 4/8M EPROM(J)" />
@@ -3250,7 +3250,7 @@ Beyond that last category are the roms waiting to be classified.
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SPAL-CQ" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-1" />
 			<feature name="pcb" value="SHVC-1RA3B6S-01" />
@@ -3421,7 +3421,7 @@ Beyond that last category are the roms waiting to be classified.
 		<publisher>Human Entertainment</publisher>
 		<info name="serial" value="HUMAN No. 10113" />
 		<info name="alt_title" value="スーパーファイヤープロレスリング3 ファイナルバウト" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-4PV5B-01" />
 			<feature name="u1" value="U1 EPROM" />
@@ -3482,7 +3482,7 @@ Beyond that last category are the roms waiting to be classified.
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-4M" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-4PV5B-01" />
 			<feature name="u1" value="U1 EPROM" />
@@ -3587,7 +3587,7 @@ Beyond that last category are the roms waiting to be classified.
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
 		<info name="release" value="1995" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-2" />
 			<feature name="pcb" value="SHVC-4RB3B7S-RE-01" />
@@ -3762,7 +3762,7 @@ Beyond that last category are the roms waiting to be classified.
 		<year>1993</year>
 		<publisher>Tomy</publisher>
 		<info name="alt_title" value="スーパーUNO" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2P3B-01" />
 			<feature name="u1" value="U1 EPROM(J)" />
@@ -4078,7 +4078,7 @@ Beyond that last category are the roms waiting to be classified.
 		<description>WeaponLord (USA, prototype)</description>
 		<year>1995</year>
 		<publisher>Namco</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-4QW5B-01" />
 			<feature name="u1" value="U1 1/2/4/8M EPROM(J)" />
@@ -4449,7 +4449,7 @@ Beyond that last category are the roms waiting to be classified.
 		<publisher>Konami</publisher>
 		<info name="alt_title" value="がんばれゴエモン3 獅子重禄兵衛のからくり卍固め" />
 		<!--info name="alt_title" value="RS035 がんばれゴエモン3 広報宣伝室用 SAMPLE 94 10 24 0079" /--> <!-- this is the cartridge label -->
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -4947,7 +4947,7 @@ Beyond that last category are the roms waiting to be classified.
 		<year>1994</year>
 		<publisher>ASCII Entertainment</publisher>
 		<info name="alt_title" value="ウィザップ!~暗黒の王" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -6053,7 +6053,7 @@ more investigation needed...
 		<year>1995</year>
 		<publisher>Jaleco</publisher>
 		<info name="release" value="199502xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -6271,7 +6271,7 @@ more investigation needed...
 		<publisher>Data East</publisher>
 		<info name="serial" value="SNS-N5-USA" />
 		<info name="release" value="199312xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-10" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -6556,7 +6556,7 @@ more investigation needed...
 		<publisher>Konami</publisher>
 		<info name="serial" value="SNS-ABTE-USA" />
 		<info name="release" value="199412xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -6577,7 +6577,7 @@ more investigation needed...
 		<publisher>DTMC</publisher>
 		<info name="serial" value="SNS-6F-USA" />
 		<info name="release" value="199412xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -6621,7 +6621,7 @@ more investigation needed...
 		<publisher>Ocean</publisher>
 		<info name="serial" value="SNS-AMOE-USA" />
 		<info name="release" value="199502xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -7273,7 +7273,7 @@ more investigation needed...
 		<publisher>Konami</publisher>
 		<info name="serial" value="SNS-ANCE-USA" />
 		<info name="release" value="199411xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="MJSC-1A0N-30-2" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -7434,7 +7434,7 @@ more investigation needed...
 		<publisher>Titus</publisher>
 		<info name="serial" value="M/SNS-A9-USA" />
 		<info name="release" value="199602xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -7544,7 +7544,7 @@ more investigation needed...
 		<publisher>Takara</publisher>
 		<info name="serial" value="SNS-RW-USA" />
 		<info name="release" value="199312xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-01" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -7932,7 +7932,7 @@ more investigation needed...
 		<publisher>Hot-B</publisher>
 		<info name="serial" value="SNS-AB2E-USA" />
 		<info name="release" value="199411xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-21" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -7997,7 +7997,7 @@ more investigation needed...
 		<publisher>Konami</publisher>
 		<info name="serial" value="SNSP-BJ-NOE" />
 		<info name="release" value="" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-10" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -8629,7 +8629,7 @@ more investigation needed...
 		<publisher>Konami</publisher>
 		<info name="serial" value="SNS-ABME-USA" />
 		<info name="release" value="199412xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -8719,7 +8719,7 @@ more investigation needed...
 		<publisher>Activision</publisher>
 		<info name="serial" value="SNS-BV-USA" />
 		<info name="release" value="199311xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-10" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -9725,7 +9725,7 @@ more investigation needed...
 		<publisher>Capcom</publisher>
 		<info name="serial" value="SNS-JL-USA" />
 		<info name="release" value="199406xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A0N-11" />
 			<feature name="u1" value="U1 P0" />
@@ -9797,7 +9797,7 @@ more investigation needed...
 		<publisher>Capcom</publisher>
 		<info name="serial" value="M/SNS-QM-USA" />
 		<info name="release" value="199508xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-20" />
 			<feature name="u1" value="U1 MASKROM" />
@@ -9893,7 +9893,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AC5J-JPN" />
 		<info name="release" value="19941209" />
 		<info name="alt_title" value="キャプテン翼V 覇者の称号カンピオーネ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3B-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -9978,7 +9978,7 @@ more investigation needed...
 		<publisher>Konami</publisher>
 		<info name="serial" value="M/SNS-ADZE-USA" />
 		<info name="release" value="199509xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -10284,7 +10284,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AWOJ-JPN" />
 		<info name="release" value="19950804" />
 		<info name="alt_title" value="超魔法大陸 ウォス" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -10486,7 +10486,7 @@ more investigation needed...
 		<publisher>Interplay</publisher>
 		<info name="serial" value="SNS-8C-USA" />
 		<info name="release" value="199311xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-01" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -10507,7 +10507,7 @@ more investigation needed...
 		<publisher>Interplay</publisher>
 		<info name="serial" value="SNS-7E-USA" />
 		<info name="release" value="199405xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ0N-01" />
 			<feature name="u1" value="U1 P0" />
@@ -10531,7 +10531,7 @@ more investigation needed...
 		<publisher>Interplay</publisher>
 		<info name="serial" value="SNS-ACZE-USA" />
 		<info name="release" value="199501xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ0N-20" />
 			<feature name="u1" value="U1 P0" />
@@ -10555,7 +10555,7 @@ more investigation needed...
 		<publisher>Interplay</publisher>
 		<info name="serial" value="SNS-Y5-USA" />
 		<info name="release" value="199403xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-10" />
 			<feature name="u1" value="U1 MASKROM" />
@@ -10816,7 +10816,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-KU" />
 		<info name="release" value="19930730" />
 		<info name="alt_title" value="クレヨンしんちゃん 〝嵐を呼ぶ園児〞" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A0N-01, SHVC-2A0N-10" />
 			<feature name="u1" value="U1 P0" />
@@ -10841,7 +10841,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-UE" />
 		<info name="release" value="19940527" />
 		<info name="alt_title" value="クレヨンしんちゃん2 〝大魔王の逆襲〞" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -10863,7 +10863,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AC6J-JPN" />
 		<info name="release" value="19961220" />
 		<info name="alt_title" value="クオンパ SFC" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -11054,7 +11054,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-RT" />
 		<info name="release" value="19930723" />
 		<info name="alt_title" value="第3次 スーパーロボット大戦" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A3M-10" />
 			<feature name="u1" value="U1 P0" />
@@ -11084,7 +11084,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AR4J-JPN" />
 		<info name="release" value="19950317" />
 		<info name="alt_title" value="第4次 スーパーロボット大戦" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -11456,7 +11456,7 @@ more investigation needed...
 		<publisher>Ocean</publisher>
 		<info name="serial" value="SNS-4D-USA" />
 		<info name="release" value="199312xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-YA0N-01" />
 			<feature name="u1" value="U1 P0" />
@@ -11742,7 +11742,7 @@ more investigation needed...
 		<year>1995</year>
 		<publisher>Elite Systems</publisher>
 		<info name="serial" value="SNSP-ADIP-EUR" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-1" />
 			<feature name="pcb" value="SHVC-1CA0N5S-01" />
@@ -11896,7 +11896,7 @@ more investigation needed...
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-8X-FAH, SNSP-8X-NOE" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ1M-10" />
 			<feature name="u1" value="U1 P0" />
@@ -11924,7 +11924,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-8X-USA" />
 		<info name="release" value="199411xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -11951,7 +11951,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-8X-USA, SNS-8X-USA-1 (PCMS)" />
 		<info name="release" value="199411xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -11990,7 +11990,7 @@ more investigation needed...
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-ADNP-FAH" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -12016,7 +12016,7 @@ more investigation needed...
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-ADNP-EUR" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -12044,7 +12044,7 @@ more investigation needed...
         <year>1995</year>
         <publisher>Nintendo</publisher>
         <info name="serial" value="SNSP-ADND-EUR" />
-        <sharedfeat name="compatibility" value="PAL"/>
+        <sharedfeat name="compatibility" value="PAL" />
         <part name="cart" interface="snes_cart">
             <feature name="pcb" value="SHVC-1J1M-20" />
             <feature name="u1" value="U1 MASK ROM(N)" />
@@ -12073,7 +12073,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-ADNE-USA" />
 		<info name="release" value="199512xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -12098,7 +12098,7 @@ more investigation needed...
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-A3CP-EUR" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -12124,7 +12124,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="M/SNS-A3CE-USA" />
 		<info name="release" value="199611xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -12306,7 +12306,7 @@ more investigation needed...
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="M/SNS-AD5E-USA" />
 		<info name="release" value="199507xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-20" />
 			<feature name="u1" value="U1 MASKROM" />
@@ -12373,7 +12373,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-EF" />
 		<info name="release" value="19931217" />
 		<info name="alt_title" value="ドラゴンボールZ 超武闘伝2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-10, SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -12395,7 +12395,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-EF" />
 		<info name="release" value="19931217" />
 		<info name="alt_title" value="ドラゴンボールZ 超武闘伝2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A0N-01, SHVC-2A0N-11" />
 			<feature name="u1" value="U1 P0" />
@@ -12420,7 +12420,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AZ4J-JPN" />
 		<info name="release" value="19940929" />
 		<info name="alt_title" value="ドラゴンボールZ 超武闘伝3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -12442,7 +12442,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AZ5J-JPN" />
 		<info name="release" value="19950324" />
 		<info name="alt_title" value="ドラゴンボールZ 超悟空伝 突撃編" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -13035,7 +13035,7 @@ more investigation needed...
 		<publisher>GameTek</publisher>
 		<info name="serial" value="SNS-L7-USA" />
 		<info name="release" value="199408xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-10" />
 			<feature name="u1" value="U1 MASKROM" />
@@ -13463,7 +13463,7 @@ more investigation needed...
 		<year>1995</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="SNSP-3R-EUR" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-20" />
 			<feature name="u1" value="U1 MASKROM" />
@@ -13484,7 +13484,7 @@ more investigation needed...
 		<publisher>Takara</publisher>
 		<info name="serial" value="M/SNS-3R-USA" />
 		<info name="release" value="199504xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-20" />
 			<feature name="u1" value="U1 MASKROM" />
@@ -13578,7 +13578,7 @@ more investigation needed...
 		<publisher>Data East</publisher>
 		<info name="serial" value="SNS-YH-USA" />
 		<info name="release" value="199408xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ0N-01" />
 			<feature name="u1" value="U1 P0" />
@@ -14110,7 +14110,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-J4" />
 		<info name="release" value="19940722" />
 		<info name="alt_title" value="ファイプロ女子 オールスタードリームスラム" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-10" />
 			<feature name="u1" value="U1 MASKROM" />
@@ -14236,7 +14236,7 @@ more investigation needed...
 		<publisher>Ocean</publisher>
 		<info name="serial" value="SNS-AFNE-USA" />
 		<info name="release" value="199502xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -14354,7 +14354,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AZGJ-JPN" />
 		<info name="release" value="19960223" />
 		<info name="alt_title" value="フロントミッションシリーズ ガンハザード" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -14381,7 +14381,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AZGJ-JPN" />
 		<info name="release" value="19960223" />
 		<info name="alt_title" value="フロントミッションシリーズ ガンハザード" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ3M-20" />
 			<feature name="u1" value="U1 P0" />
@@ -14689,7 +14689,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-A4GJ-JPN" />
 		<info name="release" value="19951222" />
 		<info name="alt_title" value="がんばれゴエモンきらきら道中 僕がダンサーになった理由" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -14785,7 +14785,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-3R" />
 		<info name="release" value="19940729" />
 		<info name="alt_title" value="餓狼伝説 スペシャル" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ0N-01" />
 			<feature name="u1" value="U1 P0" />
@@ -14993,7 +14993,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AGPJ-JPN" />
 		<info name="release" value="19941125" />
 		<info name="alt_title" value="極上パロディウス 過去の栄光を求めて" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -15146,7 +15146,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-4F" />
 		<info name="release" value="19941217" />
 		<info name="alt_title" value="ザ・グレイトバトルIV" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A0N-11" />
 			<feature name="u1" value="U1 P0" />
@@ -15461,7 +15461,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AHPJ-JPN" />
 		<info name="release" value="19941021" />
 		<info name="alt_title" value="必殺パチンココレクション" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -15645,7 +15645,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-HB" />
 		<info name="release" value="19930806" />
 		<info name="alt_title" value="ヒューマンベースボール" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -15796,7 +15796,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-JG-USA" />
 		<info name="release" value="199409xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -15832,7 +15832,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-JG-FRA/SFRA" />
 		<info name="release" value="19950427" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -15858,7 +15858,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-JG-NOE/SFRG" />
 		<info name="release" value="19950427" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -15884,7 +15884,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-JG-NOE/SFRG" />
 		<info name="release" value="19950427" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16075,7 +16075,7 @@ more investigation needed...
 		<year>1995</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SNSP-3U-EUR" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -16095,7 +16095,7 @@ more investigation needed...
 		<year>1995</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SNSP-AWJP-EUR" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -16214,7 +16214,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-JL" />
 		<info name="release" value="19940501" />
 		<info name="alt_title" value="J.リーグエキサイトステージ'94" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A3M-10" />
 			<feature name="u1" value="U1 P0" />
@@ -16253,7 +16253,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AJ2J-JPN" />
 		<info name="release" value="19950428" />
 		<info name="alt_title" value="J.リーグエキサイトステージ'95" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A3M-20" />
 			<feature name="u1" value="U1 P0" />
@@ -16282,7 +16282,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-JE" />
 		<info name="release" value="19930806" />
 		<info name="alt_title" value="Jリーグサッカープライムゴール" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-10, SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16304,7 +16304,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-JE" />
 		<info name="release" value="19930806" />
 		<info name="alt_title" value="Jリーグサッカープライムゴール" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-10, SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16327,7 +16327,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-2H" />
 		<info name="release" value="19940805" />
 		<info name="alt_title" value="Jリーグサッカー プライムゴール2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A0N-11" />
 			<feature name="u1" value="U1 P0" />
@@ -16352,7 +16352,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AJ3J-JPN" />
 		<info name="release" value="19950804" />
 		<info name="alt_title" value="Jリーグサッカープライムゴール3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16501,7 +16501,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AJXJ-JPN" />
 		<info name="release" value="19960913" />
 		<info name="alt_title" value="実況パワープロレスリング'96 マックス ボル テーシ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16522,13 +16522,14 @@ more investigation needed...
 	</software>
 
 	<software name="powyak98">
-		<description>Jikkyou Pawafuru Puro Yakyū - Basic Ban '98 (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū - Basic-ban '98 (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-AJ5J-JPN / RS059-J1" />
 		<info name="release" value="19980319" />
 		<info name="alt_title" value="実況パワフルプロ野球 ベーシック版'98" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu Basic-ban '98"/> <!-- often used unofficially -->
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16555,7 +16556,8 @@ more investigation needed...
 		<info name="serial" value="SHVC-AP2J-JPN" />
 		<info name="release" value="19950224" />
 		<info name="alt_title" value="実況パワフルプロ野球2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 2"/> <!-- often used unofficially -->
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BA3M-20" />
 			<feature name="u1" value="U1 P0" />
@@ -16584,7 +16586,8 @@ more investigation needed...
 		<info name="serial" value="SHVC-A3JJ-JPN" />
 		<info name="release" value="19960229" />
 		<info name="alt_title" value="実況パワフルプロ野球3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 3"/> <!-- often used unofficially -->
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16611,7 +16614,8 @@ more investigation needed...
 		<info name="serial" value="SHVC-A3JJ-JPN" />
 		<info name="release" value="19960229" />
 		<info name="alt_title" value="実況パワフルプロ野球3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 3"/> <!-- often used unofficially -->
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BA3M-20" />
 			<feature name="u1" value="U1 P0" />
@@ -16640,7 +16644,8 @@ more investigation needed...
 		<info name="serial" value="SHVC-AQ7J-JPN" />
 		<info name="release" value="19970320" />
 		<info name="alt_title" value="実況パワフルプロ野球3 '97 春" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 3 - '97 Haru"/> <!-- often used unofficially -->
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16667,7 +16672,8 @@ more investigation needed...
 		<info name="serial" value="SHVC-YX" />
 		<info name="release" value="19940311" />
 		<info name="alt_title" value="実況パワフルプロ野球'94" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 4"/> <!-- often used unofficially -->
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -16683,13 +16689,14 @@ more investigation needed...
 	</software>
 
 	<software name="powyak96a" cloneof="powyak96">
-		<description>Jikkyou Pawafuru Puro Yakyū '96 - Kaimaku Ban (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū '96 Kaimaku-ban (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-A57J-JPN" />
 		<info name="release" value="19960719" />
 		<info name="alt_title" value="実況パワフルプロ野球'96開幕版" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu '96 Kaimaku-ban" /> <!-- often used unofficially -->
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16710,13 +16717,14 @@ more investigation needed...
 	</software>
 
 	<software name="powyak96">
-		<description>Jikkyou Pawafuru Puro Yakyū '96 - Kaimaku Ban (Japan, rev. A)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū '96 Kaimaku-ban (Japan, rev. A)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-A57J-JPN" />
 		<info name="release" value="19960719" />
 		<info name="alt_title" value="実況パワフルプロ野球'96開幕版" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu '96 Kaimaku-ban" /> <!-- often used unofficially -->
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16744,7 +16752,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-3U" />
 		<info name="release" value="19941111" />
 		<info name="alt_title" value="実況ワールドサッカー パーフェクトイレブン" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-21" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16771,7 +16779,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-3U" />
 		<info name="release" value="19941111" />
 		<info name="alt_title" value="実況ワールドサッカー パーフェクトイレブン" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16799,7 +16807,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AWJJ-JPN" />
 		<info name="release" value="19950922" />
 		<info name="alt_title" value="実況ワールドサッカー2 ファイティング イレブン" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BA3M-20" />
 			<feature name="u1" value="U1 P0" />
@@ -16847,7 +16855,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-PI" />
 		<info name="release" value="19931126" />
 		<info name="alt_title" value="実戦!パチスロ必勝法!" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16874,7 +16882,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-XU" />
 		<info name="release" value="19940916" />
 		<info name="alt_title" value="実戦!パチスロ必勝法!2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-21" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -16997,7 +17005,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-5J" />
 		<info name="release" value="19940918" />
 		<info name="alt_title" value="ジャングルの王者ターちゃん 世界漫遊大格闘の巻" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -17037,7 +17045,7 @@ more investigation needed...
 		<publisher>Ocean</publisher>
 		<info name="serial" value="SNS-J8-USA" />
 		<info name="release" value="199311xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -17058,7 +17066,7 @@ more investigation needed...
 		<publisher>Ocean</publisher>
 		<info name="serial" value="SNS-J8-USA" />
 		<info name="release" value="199311xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="MAXI-1A0N-30-2" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -17135,7 +17143,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-66" />
 		<info name="release" value="19940920" />
 		<info name="alt_title" value="デザエモン" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A7M-10" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -17289,7 +17297,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-JR-USA" />
 		<info name="release" value="199403xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3B-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -17316,7 +17324,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-A9GE-USA" />
 		<info name="release" value="199606xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -17344,7 +17352,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-IX" />
 		<info name="release" value="19931210" />
 		<info name="alt_title" value="決戦!ドカポン王国IV ～伝説の勇者たち～" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -17595,7 +17603,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-CG" />
 		<info name="release" value="19940921" />
 		<info name="alt_title" value="カービィボウル" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A3M-11, SHVC-2A3M-20" />
 			<feature name="u1" value="U1 P0" />
@@ -17648,7 +17656,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-PQ-USA-1" />
 		<info name="release" value="199502xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -17668,7 +17676,7 @@ more investigation needed...
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-CG-UKV" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -18191,7 +18199,7 @@ more investigation needed...
 		<year>1994</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SNSP-LK-UKV" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -18213,7 +18221,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-LK" />
 		<info name="release" value="19940311" />
 		<info name="alt_title" value="リーサルエンフォーサーズ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -18326,7 +18334,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-5V" />
 		<info name="release" value="19940902" />
 		<info name="alt_title" value="ライブ・ア・ライブ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -18732,7 +18740,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-ZM" />
 		<info name="release" value="19940128" />
 		<info name="alt_title" value="魔神転生" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A3B-01" />
 			<feature name="u1" value="U1 P0" />
@@ -18800,7 +18808,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-ACXJ-JPN / G739139" />
 		<info name="release" value="19950914" />
 		<info name="alt_title" value="マリオのスーパーピクロス" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -18988,7 +18996,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AMVJ-JPN" />
 		<info name="release" value="19950825" />
 		<info name="alt_title" value="松方弘樹のスーパートローリン ク" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -19153,7 +19161,7 @@ more investigation needed...
 		<year>1993</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="SNSP-6M-NOE" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A0N-11" />
 			<feature name="u1" value="U1 P0" />
@@ -19177,7 +19185,7 @@ more investigation needed...
 		<publisher>Namco</publisher>
 		<info name="serial" value="SNS-6M-USA" />
 		<info name="release" value="199312xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A0N-01" />
 			<feature name="u1" value="U1 P0" />
@@ -19201,7 +19209,7 @@ more investigation needed...
 		<publisher>Konami</publisher>
 		<info name="serial" value="M/SNS-AWME-USA" />
 		<info name="release" value="199504xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -19374,7 +19382,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-NG" />
 		<info name="release" value="19941118" />
 		<info name="alt_title" value="ミリティア" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A0N-11" />
 			<feature name="u1" value="U1 P0" />
@@ -19736,7 +19744,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-MB / G723109" />
 		<info name="release" value="19940827" />
 		<info name="alt_title" value="マザー2 ギーグの逆襲" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ3M-10" />
 			<feature name="u1" value="U1 P0" />
@@ -20551,7 +20559,7 @@ more investigation needed...
 		<publisher>Gremlin Interactive</publisher>
 		<info name="serial" value="SNSP-NW-NOE" />
 		<info name="release" value="19931216" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -20572,7 +20580,7 @@ more investigation needed...
 		<publisher>GameTek</publisher>
 		<info name="serial" value="SNS-M8-USA" />
 		<info name="release" value="199307xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -21591,7 +21599,7 @@ more investigation needed...
 		<year>1996</year>
 		<publisher>Disney Interactive</publisher>
 		<info name="serial" value="SNSP-ACGP-EUR" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-20" />
 			<feature name="u1" value="U1 MASKROM" />
@@ -21612,7 +21620,7 @@ more investigation needed...
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="SNS-8P-USA" />
 		<info name="release" value="199405xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -21651,7 +21659,7 @@ more investigation needed...
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-P4-FAH/SFRA" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -21671,7 +21679,7 @@ more investigation needed...
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-P4-NOE/SFRG" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -22148,7 +22156,7 @@ more investigation needed...
 		<year>1994</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="SNSP-ER-FAH" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -22169,7 +22177,7 @@ more investigation needed...
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="SNS-ER-USA" />
 		<info name="release" value="199410xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -22450,7 +22458,7 @@ more investigation needed...
 		<year>1993</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="SNSP-VR-EUR" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -22471,7 +22479,7 @@ more investigation needed...
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="SNS-VR-USA" />
 		<info name="release" value="199311xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -22539,7 +22547,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-RN" />
 		<info name="release" value="19940103" />
 		<info name="alt_title" value="ロックンロールレーシンク" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -22879,7 +22887,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-2L" />
 		<info name="release" value="19931210" />
 		<info name="alt_title" value="ロマンシング サ・ガ2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-01, SHVC-1J3M-10" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -22906,7 +22914,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-2L" />
 		<info name="release" value="19931210" />
 		<info name="alt_title" value="ロマンシング サ・ガ2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2J3M-01, SHVC-2J3M-10" />
 			<feature name="u1" value="U1 P0" />
@@ -22935,7 +22943,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AL3J-JPN" />
 		<info name="release" value="19951111" />
 		<info name="alt_title" value="ロマンシング サ・ガ3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -22962,7 +22970,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AL3J-JPN" />
 		<info name="release" value="19951111" />
 		<info name="alt_title" value="ロマンシング サ・ガ3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -23112,7 +23120,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-RW" />
 		<info name="release" value="19931029" />
 		<info name="alt_title" value="龍虎の拳" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-10" />
 			<feature name="u1" value="U1 MASKROM" />
@@ -23185,7 +23193,7 @@ more investigation needed...
 		<publisher>Takara</publisher>
 		<info name="serial" value="SNS-A7SE-USA" />
 		<info name="release" value="199411xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ0N-01" />
 			<feature name="u1" value="U1 P0" />
@@ -23210,7 +23218,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-A7SJ-JPN" />
 		<info name="release" value="19940922" />
 		<info name="alt_title" value="サムライスピリッツ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ0N-01" />
 			<feature name="u1" value="U1 P0" />
@@ -23645,7 +23653,7 @@ more investigation needed...
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-K2-NOE/SFRG" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -23671,7 +23679,7 @@ more investigation needed...
 		<publisher>Square</publisher>
 		<info name="serial" value="SNS-K2-USA" />
 		<info name="release" value="199310xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-01" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -23697,7 +23705,7 @@ more investigation needed...
 		<publisher>Square</publisher>
 		<info name="serial" value="SNS-K2-USA" />
 		<info name="release" value="199310xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2J3M-01" />
 			<feature name="u1" value="U1 P0" />
@@ -23726,7 +23734,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-K2" />
 		<info name="release" value="19930806" />
 		<info name="alt_title" value="聖剣伝説2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3B-01" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -23753,7 +23761,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-K2" />
 		<info name="release" value="19930806" />
 		<info name="alt_title" value="聖剣伝説2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2J3M-01" />
 			<feature name="u1" value="U1 P0" />
@@ -23782,7 +23790,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-A3DJ-JPN" />
 		<info name="release" value="19950930" />
 		<info name="alt_title" value="聖剣伝説3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -23809,7 +23817,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-A3DJ-JPN" />
 		<info name="release" value="19950930" />
 		<info name="alt_title" value="聖剣伝説3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ3M-20" />
 			<feature name="u1" value="U1 P0" />
@@ -23922,7 +23930,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-KZ" />
 		<info name="release" value="19940330" />
 		<info name="alt_title" value="真・麻雀" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -24722,7 +24730,7 @@ more investigation needed...
 		<publisher>Enix</publisher>
 		<info name="serial" value="SNSP-SO-NOE/SFRG" />
 		<info name="release" value="19940127" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -24820,7 +24828,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-BT" />
 		<info name="release" value="19930621" />
 		<info name="alt_title" value="スペースバズーカ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-10" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -24842,7 +24850,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-IC" />
 		<info name="release" value="19940325" />
 		<info name="alt_title" value="スペースインベーダー ザ・オリジ ナルゲーム" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-10, SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -24989,7 +24997,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AKQJ-JPN" />
 		<info name="release" value="19960322" />
 		<info name="alt_title" value="ステイブルスター ~廐舎物語~" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A5M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -25263,7 +25271,7 @@ more investigation needed...
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="M/SNS-AS2E-USA" />
 		<info name="release" value="199503xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -25304,7 +25312,7 @@ more investigation needed...
 		<publisher>Capcom</publisher>
 		<info name="serial" value="SNS-AUZE-USA" />
 		<info name="release" value="199611xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="S-DD1" />
 			<feature name="pcb" value="SHVC-1N0N-01" />
@@ -25572,7 +25580,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AUZJ-JPN" />
 		<info name="release" value="19961220" />
 		<info name="alt_title" value="ストリートファイターZERO2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="S-DD1" />
 			<feature name="pcb" value="SHVC-1N0N-10" />
@@ -25655,7 +25663,7 @@ more investigation needed...
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-CQ-FAH, SNSP-CQ-NOE" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-1" />
 			<feature name="pcb" value="SHVC-1CA6B-01" />
@@ -25685,7 +25693,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-3D" />
 		<info name="release" value="19931001" />
 		<info name="alt_title" value="スーパー3Dベースボール" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="DSP1 A" />
 			<feature name="pcb" value="SHVC-1B3B-01" />
@@ -26254,7 +26262,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-8X / G728314" />
 		<info name="release" value="19941126" />
 		<info name="alt_title" value="スーパードンキーコンク" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26281,7 +26289,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-8X / G728314" />
 		<info name="release" value="19941126" />
 		<info name="alt_title" value="スーパードンキーコンク" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26309,7 +26317,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-ADNJ-JPN / G740814" />
 		<info name="release" value="19951121" />
 		<info name="alt_title" value="スーパードンキーコング2 ディクシー&amp;ディディー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26336,7 +26344,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-ADNJ-JPN / G740814" />
 		<info name="release" value="19951121" />
 		<info name="alt_title" value="スーパードンキーコング2 ディクシー&amp;ディディー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ1M-20" />
 			<feature name="u1" value="U1 P0" />
@@ -26365,7 +26373,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-ADNJ-JPN / G740814, SHVC-ADNJ-JPN-1 / G743669" />
 		<info name="release" value="19951121" />
 		<info name="alt_title" value="スーパードンキーコング2 ディクシー&amp;ディディー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26393,7 +26401,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-ADNJ-JPN-1 / G743669" />
 		<info name="release" value="19951121" />
 		<info name="alt_title" value="スーパードンキーコング2 ディクシー&amp;ディディー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BJ1M-20" />
 			<feature name="u1" value="U1 P0" />
@@ -26423,7 +26431,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-A3CJ-JPN" />
 		<info name="release" value="19961123" />
 		<info name="alt_title" value="スーパードンキーコング3 謎のクレミス島" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26450,7 +26458,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-A3CJ-JPN" />
 		<info name="release" value="19961123" />
 		<info name="alt_title" value="スーパードンキーコング3 謎のクレミス島" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26606,7 +26614,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-23" />
 		<info name="release" value="19941021" />
 		<info name="alt_title" value="スーパーファミリーサーキット" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-21" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26675,7 +26683,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-N6" />
 		<info name="release" value="19940304" />
 		<info name="alt_title" value="スーパーファミスタ3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26702,7 +26710,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AF4J-JPN" />
 		<info name="release" value="19950303" />
 		<info name="alt_title" value="スーパーファミスタ4" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26729,7 +26737,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AF4J-JPN" />
 		<info name="release" value="19950303" />
 		<info name="alt_title" value="スーパーファミスタ4" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26785,7 +26793,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AQQJ-JPN" />
 		<info name="release" value="19950630" />
 		<info name="alt_title" value="スーパーファイヤープロレスリング ク イーンズスペシャル" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26854,7 +26862,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-F3" />
 		<info name="release" value="19931229" />
 		<info name="alt_title" value="スーパーファイヤープロレスリング3 ファイナルバウト" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2J3M-01" />
 			<feature name="u1" value="U1 P0" />
@@ -26911,7 +26919,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-AF5J-JPN" />
 		<info name="release" value="19951222" />
 		<info name="alt_title" value="スーパーファイヤープロレスリングX" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -26985,7 +26993,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-3F" />
 		<info name="release" value="19940617" />
 		<info name="alt_title" value="スーパーフォーメーションサッ カー94 ワールドカップ・エディ ション" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A5M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -27012,7 +27020,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-A3FJ-JPN" />
 		<info name="release" value="19940922" />
 		<info name="alt_title" value="スーパーフォーメーションサッカー94 ワールドカップファイナルデータ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A5M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -27039,7 +27047,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-A95J-JPN" />
 		<info name="release" value="19950331" />
 		<info name="alt_title" value="スーパーフォーメーションサッカー'95 デッラセリエA" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2J3M-20" />
 			<feature name="u1" value="U1 P0" />
@@ -27179,7 +27187,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-ZH" />
 		<info name="release" value="19940722" />
 		<info name="alt_title" value="超原人" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2J0N-11" />
 			<feature name="u1" value="U1 P0" />
@@ -27222,7 +27230,7 @@ more investigation needed...
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="SNS-JV-USA" />
 		<info name="release" value="199404xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -27293,7 +27301,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-IG" />
 		<info name="release" value="19940408" />
 		<info name="alt_title" value="スーパー囲碁 碁王" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -27341,7 +27349,7 @@ more investigation needed...
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-ACIP-UKV" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -27493,7 +27501,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-KB" />
 		<info name="release" value="19930810" />
 		<info name="alt_title" value="スーパー競馬" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3B-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -27548,7 +27556,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-A2YJ-JPN" />
 		<info name="release" value="19960426" />
 		<info name="alt_title" value="スーパー競艇2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -27750,7 +27758,7 @@ more investigation needed...
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-4M-NOE" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-10" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -27789,7 +27797,7 @@ more investigation needed...
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-4M-FAH" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A3M-01" />
 			<feature name="u1" value="U1 P0" />
@@ -27817,7 +27825,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-4M-USA" />
 		<info name="release" value="199308xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3B-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -27858,7 +27866,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-4M-USA" />
 		<info name="release" value="199308xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A3M-10" />
 			<feature name="u1" value="U1 P0" />
@@ -27912,7 +27920,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-4M" />
 		<info name="release" value="19930714" />
 		<info name="alt_title" value="スーパーマリオコレクション" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3B-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -28273,7 +28281,7 @@ more investigation needed...
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-YI-NOE" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-2" />
 			<feature name="pcb" value="SHVC-1CB5B-20" />
@@ -28302,7 +28310,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-YI-USA, SNSN-YI-HKG" />
 		<info name="release" value="199510xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-2" /> <!-- GSU-2-SP1 -->
 			<feature name="pcb" value="SHVC-1CB5B-20" />
@@ -28332,7 +28340,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-YI / G737679" />
 		<info name="release" value="19950805" />
 		<info name="alt_title" value="スーパーマリオ ヨッシーアイラント" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-2" />
 			<feature name="pcb" value="SHVC-1CB5B-01, SHVC-1CB5B-10, SHVC-1CB5B-20" />
@@ -28589,7 +28597,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-XD" />
 		<info name="release" value="19940318" />
 		<info name="alt_title" value="スーパーナグザットオープン ゴルフで勝負だ!どらぼっちゃん" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -28876,7 +28884,7 @@ more investigation needed...
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-XP-USA-2" />
 		<info name="release" value="199411xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -29231,7 +29239,7 @@ more investigation needed...
 		<info name="serial" value="SHVC-I3" />
 		<info name="release" value="19941021" />
 		<info name="alt_title" value="スーパーラグビー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-21" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -29843,7 +29851,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-AT3J-JPN" />
 		<info name="release" value="19941216" />
 		<info name="alt_title" value="スーパーテトリス3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A1M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -29954,7 +29962,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-UN" />
 		<info name="release" value="19931112" />
 		<info name="alt_title" value="スーパーUNO" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -30062,7 +30070,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-Q7" />
 		<info name="release" value="19940729" />
 		<info name="alt_title" value="スーパー!! パチンコ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A1M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -30118,7 +30126,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-7M" />
 		<info name="release" value="19940715" />
 		<info name="alt_title" value="ソードワールドSFC2 いにし えの巨人伝説" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-21" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -30284,7 +30292,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-JV" />
 		<info name="release" value="19931126" />
 		<info name="alt_title" value="武田修宏のスーパーカップサッカー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A1M-01" />
 			<feature name="u1" value="U1 MASKROM(N)" />
@@ -30311,7 +30319,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-ATKJ-JPN" />
 		<info name="release" value="19941125" />
 		<info name="alt_title" value="武田修宏のスーパーリーグサッカー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A1M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -30405,7 +30413,7 @@ Alternate board (XL-1)
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="SNS-7T-USA" />
 		<info name="release" value="199311xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A3M-01" />
 			<feature name="u1" value="U1 P0" />
@@ -30434,7 +30442,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-AW4J-JPN" />
 		<info name="release" value="19951222" />
 		<info name="alt_title" value="テクモスーパーボウルIII ファイナルエ ディショ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A5M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -30841,7 +30849,7 @@ Alternate board (XL-1)
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-AQTF-FRA" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -30866,7 +30874,7 @@ Alternate board (XL-1)
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-AQTD-NOE" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -30891,7 +30899,7 @@ Alternate board (XL-1)
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-ATPF-EUR" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -30912,7 +30920,7 @@ Alternate board (XL-1)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-ATFE-USA-1 (PCMS)" />
 		<info name="release" value="199412xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -30933,7 +30941,7 @@ Alternate board (XL-1)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-27-USA" />
 		<info name="release" value="199408xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -31083,7 +31091,7 @@ Alternate board (XL-1)
 		<year>1995</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="SNSP-AT6P-FAH, SNSP-AT6P-FAH-1" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-30" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -31194,7 +31202,7 @@ Alternate board (XL-1)
 		<year>1994</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SNS-5Z-EUR" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -31216,7 +31224,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-AM8J-JPN" />
 		<info name="release" value="19960209" />
 		<info name="alt_title" value="ときめきメモリアル 伝説の樹の下て" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -31569,7 +31577,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-T7" />
 		<info name="release" value="19940107" />
 		<info name="alt_title" value="ツインビー レインボーベ ルアドベンチャー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -32302,7 +32310,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-CQ / G713761" />
 		<info name="release" value="19940604" />
 		<info name="alt_title" value="ワイルドトラックス" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-1" />
 			<feature name="pcb" value="SHVC-1CA6B-01" />
@@ -32472,7 +32480,7 @@ Alternate board (XL-1)
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-AXSP-EUR" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-2" />
 			<feature name="pcb" value="SHVC-1CB7B-01" />
@@ -32502,7 +32510,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-WQ" />
 		<info name="release" value="19940922" />
 		<info name="alt_title" value="ウィザップ!~暗黒の王" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -32583,7 +32591,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-6W" />
 		<info name="release" value="19940210" />
 		<info name="alt_title" value="ウルフェンシュタイン3D" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J0N-10" />
 			<feature name="u1" value="U1 MASKROM" />
@@ -32603,7 +32611,7 @@ Alternate board (XL-1)
 		<year>1994</year>
 		<publisher>GameTek</publisher>
 		<info name="serial" value="SNSP-5W-NOE" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-11" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -32630,7 +32638,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-5W" />
 		<info name="release" value="19940617" />
 		<info name="alt_title" value="ワールドカップストライ カー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="u1" value="U1 MASK ROM(N)" />
 			<feature name="u2" value="U2 64K SRAM" />
@@ -32758,7 +32766,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-WO" />
 		<info name="release" value="19930716" />
 		<info name="alt_title" value="ワールドサッカー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3B-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -32913,7 +32921,7 @@ Alternate board (XL-1)
 		<publisher>Activision</publisher>
 		<info name="serial" value="SNS-X7-USA" />
 		<info name="release" value="199402xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -33039,7 +33047,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-RH" />
 		<info name="release" value="19930714" />
 		<info name="alt_title" value="ヨッシーのロードハンティング" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -33185,7 +33193,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-AYYJ-JPN" />
 		<info name="release" value="19941222" />
 		<info name="alt_title" value="幽☆遊☆白書 特別篇" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -33207,7 +33215,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-Y2" />
 		<info name="release" value="19940610" />
 		<info name="alt_title" value="幽☆遊☆白書2 格闘の章" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A0N-20" />
 			<feature name="u1" value="U1 MASK ROM" />
@@ -33473,7 +33481,7 @@ Alternate board (XL-1)
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-ADNP-FAH" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J1M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -33753,7 +33761,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-JL" />
 		<info name="release" value="19940501" />
 		<info name="alt_title" value="J.リーグエキサイトステージ'94" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2A3M-11" />
 			<feature name="u1" value="U1 P0" />
@@ -33783,7 +33791,8 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-AP2J-JPN" />
 		<info name="release" value="19950224" />
 		<info name="alt_title" value="実況パワフルプロ野球2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 2"/> <!-- often used unofficially -->
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-BA3M-20" />
 			<feature name="u1" value="U1 P0" />
@@ -33915,7 +33924,7 @@ Alternate board (XL-1)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNS-JR-USA" />
 		<info name="release" value="199403xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-21" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -33944,7 +33953,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-QJ (KIS-4)" />
 		<info name="release" value="19940922" />
 		<info name="alt_title" value="ラリー・ニクソン スーパー・バス・フィッシング" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-2J3M-11" />
 			<feature name="u1" value="U1 P0" />
@@ -34211,7 +34220,7 @@ Alternate board (XL-1)
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-K2-FRA/SFRA" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1J3M-20" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -34561,7 +34570,7 @@ Alternate board (XL-1)
 		<info name="serial" value="SHVC-7M" />
 		<info name="release" value="19940715" />
 		<info name="alt_title" value="ソードワールドSFC2 いにし えの巨人伝説" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-21" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -34787,7 +34796,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AY2J" />
 		<info name="release" value="19960322" />
 		<info name="alt_title" value="96全国高校サッカー選手権" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -34909,7 +34918,7 @@ List of unclassified roms
 		<description>90 Minutes - European Prime Goal (Europe, prototype)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -34924,7 +34933,7 @@ List of unclassified roms
 		<description>90 Minutes - European Prime Goal (Europe)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -34954,7 +34963,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-N5" />
 		<info name="release" value="19931126" />
 		<info name="alt_title" value="abcマンデーナイトフットボール" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -35061,7 +35070,7 @@ List of unclassified roms
 		<description>ActRaiser 2 (Europe)</description>
 		<year>1993</year>
 		<publisher>Enix</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -35137,7 +35146,7 @@ List of unclassified roms
 		<description>The Adventures of Batman &amp; Robin (Europe)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -35150,7 +35159,7 @@ List of unclassified roms
 		<description>The Adventures of Dr. Franken (Europe)</description>
 		<year>1995</year>
 		<publisher>DTMC</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -35179,7 +35188,7 @@ List of unclassified roms
 		<year>1997</year>
 		<publisher>Infogrames</publisher>
 		<info name="alt_title" value="Tintin - Prisoners of the Sun (Box)" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -35262,7 +35271,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AAMJ" />
 		<info name="release" value="19951124" />
 		<info name="alt_title" value="赤川次郎 魔女たちの眠り" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -35280,7 +35289,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AAMJ" />
 		<info name="release" value="19951124" />
 		<info name="alt_title" value="赤川次郎 魔女たちの眠り" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -35315,7 +35324,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-ADZJ" />
 		<info name="release" value="19950721" />
 		<info name="alt_title" value="悪魔城ドラキュラXX" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -35403,7 +35412,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AALJ" />
 		<info name="release" value="19950915" />
 		<info name="alt_title" value="アリスのペイントアドベンチャー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -35528,7 +35537,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-A5BJ" />
 		<info name="release" value="19951208" />
 		<info name="alt_title" value="アメリカンバトルドーム" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -35622,7 +35631,7 @@ List of unclassified roms
 		<description>Animaniacs (Europe)</description>
 		<year>1994</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -35638,7 +35647,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-ANCJ" />
 		<info name="release" value="19970307" />
 		<info name="alt_title" value="アニマニアクス" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -35651,7 +35660,7 @@ List of unclassified roms
 		<description>Animaniacs (prototype 19940611)</description>
 		<year>1994</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -35825,7 +35834,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-A9" />
 		<info name="release" value="19931126" />
 		<info name="alt_title" value="アルディライトフット" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -35895,7 +35904,7 @@ List of unclassified roms
 		<description>Art of Fighting (Europe)</description>
 		<year>1994</year>
 		<publisher>Takara</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -36073,7 +36082,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AAGJ-JPN" />
 		<info name="release" value="19951201" />
 		<info name="alt_title" value="ボール・ブレット・ガン サバイバルゲー ム" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -36449,7 +36458,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-VM" />
 		<info name="release" value="19930723" />
 		<info name="alt_title" value="バズー!魔法世界" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -36674,7 +36683,7 @@ List of unclassified roms
 		<description>Biker Mice from Mars (Europe)</description>
 		<year>1994</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -36700,7 +36709,7 @@ List of unclassified roms
 		<description>BioMetal (Europe)</description>
 		<year>1993</year>
 		<publisher>Activision</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -37285,7 +37294,7 @@ List of unclassified roms
 		<description>Buck Rogers - The Arcade Game (Europe, prototype)</description>
 		<year>1993</year>
 		<publisher>Electro Brain</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -37355,7 +37364,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AYUJ-JPN" />
 		<info name="release" value="19970117" />
 		<info name="alt_title" value="BUSHI 青龍伝 ~二人の勇者 ~" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -37397,7 +37406,7 @@ List of unclassified roms
 		<description>California Games II (Europe)</description>
 		<year>1992</year>
 		<publisher>DTMC</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -37583,7 +37592,7 @@ List of unclassified roms
 		<description>Castlevania - Vampire's Kiss (Europe)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -37693,7 +37702,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AT8J-JPN" />
 		<info name="release" value="19951201" />
 		<info name="alt_title" value="ちびまる子ちゃん めざせ!南の アイランド!!" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -37709,7 +37718,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AT8J-JPN" />
 		<info name="release" value="19951201" />
 		<info name="alt_title" value="ちびまる子ちゃん めざせ!南の アイランド!!" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -37966,7 +37975,7 @@ List of unclassified roms
 		<description>Clay Fighter (Europe, prototype)</description>
 		<year>1993</year>
 		<publisher>Interplay</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -37979,7 +37988,7 @@ List of unclassified roms
 		<description>Clay Fighter (Europe)</description>
 		<year>1993</year>
 		<publisher>Interplay</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -38004,7 +38013,7 @@ List of unclassified roms
 		<description>Claymates (Europe, prototype)</description>
 		<year>1993</year>
 		<publisher>Interplay</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -38018,7 +38027,7 @@ List of unclassified roms
 		<description>Claymates (Europe, prototype, alt)</description>
 		<year>1993</year>
 		<publisher>Interplay</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -38031,7 +38040,7 @@ List of unclassified roms
 		<description>Claymates (Europe)</description>
 		<year>1993</year>
 		<publisher>Interplay</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -38071,7 +38080,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AJEJ-JPN" />
 		<info name="release" value="19950914" />
 		<info name="alt_title" value="クロックタワー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -38283,7 +38292,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-ACLJ-JPN" />
 		<info name="release" value="19950825" />
 		<info name="alt_title" value="ころんらんと" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -38411,7 +38420,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-CZ" />
 		<info name="release" value="19940826" />
 		<info name="alt_title" value="サイバーナイトII 地球帝国の野望" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -38456,7 +38465,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-RT" />
 		<info name="release" value="19930723" />
 		<info name="alt_title" value="第3次 スーパーロボット大戦" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -38474,7 +38483,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-RT" />
 		<info name="release" value="19930723" />
 		<info name="alt_title" value="第3次 スーパーロボット大戦" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -38492,7 +38501,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AR4J-JPN" />
 		<info name="release" value="19950317" />
 		<info name="alt_title" value="第4次 スーパーロボット大戦" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -38623,7 +38632,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-ADUJ-JPN" />
 		<info name="release" value="19970328" />
 		<info name="alt_title" value="ダークロウ ミーニング・オブ・テス" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="4194304">
@@ -38695,7 +38704,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-ADTJ-JPN" />
 		<info name="release" value="19950331" />
 		<info name="alt_title" value="であえ殿さま あっぱれ一番" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -38741,7 +38750,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-DZ" />
 		<info name="release" value="19930716" />
 		<info name="alt_title" value="デスブレイド" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -39012,7 +39021,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-ADRJ-JPN" />
 		<info name="release" value="19950210" />
 		<info name="alt_title" value="だるま道場" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -39205,7 +39214,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AZBJ-JPN" />
 		<info name="release" value="19961220" />
 		<info name="alt_title" value="ドナルドダックのマウイマラート" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -39218,7 +39227,7 @@ List of unclassified roms
 		<description>Donald in Maui Mallard (Europe)</description>
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -39232,7 +39241,7 @@ List of unclassified roms
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="release" value="199411xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="4194304">
@@ -39247,7 +39256,7 @@ List of unclassified roms
 		<description>Donkey Kong Country 2 - Diddy's Kong Quest (Germany)</description>
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="4194304">
@@ -39263,7 +39272,7 @@ List of unclassified roms
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
 		<info name="release" value="199512xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="4194304">
@@ -39497,7 +39506,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-BDMJ-JPN" />
 		<info name="release" value="19980601" />
 		<info name="alt_title" value="ドクターマリオ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -39512,7 +39521,7 @@ List of unclassified roms
 		<description>Dragon - The Bruce Lee Story (Europe)</description>
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -39525,7 +39534,7 @@ List of unclassified roms
 		<description>Dragon Ball Z - Chomutujeon (Korea)</description>
 		<year>1994?</year>
 		<publisher>Bandai?</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -39610,7 +39619,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-EF" />
 		<info name="release" value="19931217" />
 		<info name="alt_title" value="ドラゴンボールZ 超武闘伝2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -39626,7 +39635,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-A2ZJ-JPN" />
 		<info name="release" value="19950922" />
 		<info name="alt_title" value="ドラゴンボールZ超悟空伝 覚醒 編" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -39899,7 +39908,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AD2J-JPN" />
 		<info name="release" value="19941229" />
 		<info name="alt_title" value="デュアルオーブII" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2621440">
@@ -40090,7 +40099,7 @@ List of unclassified roms
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
 		<info name="release" value="199506xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -40352,7 +40361,7 @@ List of unclassified roms
 		<description>Eric Cantona Football Challenge (France)</description>
 		<year>1993</year>
 		<publisher>Elite Systems</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -40828,7 +40837,7 @@ List of unclassified roms
 		<description>Fatal Fury Special (Europe, prototype)</description>
 		<year>1995</year>
 		<publisher>Takara</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -40884,7 +40893,7 @@ List of unclassified roms
 		<description>Fever Pitch Soccer (Europe)</description>
 		<year>1995</year>
 		<publisher>U.S. Gold</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -40971,7 +40980,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-YH" />
 		<info name="release" value="19940527" />
 		<info name="alt_title" value="ファイターズヒストリー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2621440">
@@ -40984,7 +40993,7 @@ List of unclassified roms
 		<description>Fighter's History (USA, prototype)</description>
 		<year>1994</year>
 		<publisher>Data East</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2621440">
@@ -41000,7 +41009,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AF3J-JPN" />
 		<info name="release" value="19950217" />
 		<info name="alt_title" value="ファイターズヒストリー溝口危機一髪!!" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -41110,7 +41119,7 @@ List of unclassified roms
 		<year>1994</year>
 		<publisher>Capcom</publisher>
 		<info name="release" value="199406xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -41440,7 +41449,7 @@ List of unclassified roms
 		<description>The Flintstones (Europe)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -41508,7 +41517,7 @@ List of unclassified roms
 		<description>Foreman For Real (Europe)</description>
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -41524,7 +41533,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AFEJ-JPN" />
 		<info name="release" value="19951027" />
 		<info name="alt_title" value="フォアマン フォーリアル" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -41538,7 +41547,7 @@ List of unclassified roms
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="release" value="199510xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -41871,7 +41880,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-G9" />
 		<info name="release" value="19940128" />
 		<info name="alt_title" value="ガイアセイバー ヒーロー最大の作戦" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -41983,7 +41992,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-2U" />
 		<info name="release" value="19941216" />
 		<info name="alt_title" value="がんばれゴエモン3 獅子重禄兵衛のからくり卍固め" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -42001,7 +42010,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-2U" />
 		<info name="release" value="19941216" />
 		<info name="alt_title" value="がんばれゴエモン3 獅子重禄兵衛のからくり卍固め" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-1A3M-30" />
 			<feature name="u1" value="U1 MASK ROM(N)" />
@@ -42028,7 +42037,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-A4GJ-JPN" />
 		<info name="release" value="19951222" />
 		<info name="alt_title" value="がんばれゴエモンきらきら道中 僕がダンサーになった理由" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -42046,7 +42055,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-A4GJ-JPN" />
 		<info name="release" value="19951222" />
 		<info name="alt_title" value="がんばれゴエモンきらきら道中 僕がダンサーになった理由" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -42064,7 +42073,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-EZ" />
 		<info name="release" value="19931222" />
 		<info name="alt_title" value="がんばれ!大工の源さん" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -42311,7 +42320,7 @@ List of unclassified roms
 		<description>Get in the Hole (Japan)</description>
 		<year>1995</year>
 		<publisher>Good House</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -42437,7 +42446,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-ACKJ-JPN" />
 		<info name="release" value="19941223" />
 		<info name="alt_title" value="ゴーゴー アックマン" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1310720">
@@ -42453,7 +42462,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-R5" />
 		<info name="release" value="19930924" />
 		<info name="alt_title" value="ゴー!ゴー!ドッジリーグ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -42469,7 +42478,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-R5" />
 		<info name="release" value="19930924" />
 		<info name="alt_title" value="ゴー!ゴー!ドッジリーグ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -42554,7 +42563,7 @@ List of unclassified roms
 		<description>Gokujou Parodius (Japan, prototype)</description>
 		<year>1994</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -42567,7 +42576,7 @@ List of unclassified roms
 		<description>Gokujou Parodius (Japan, sample)</description>
 		<year>1994</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -42689,7 +42698,7 @@ List of unclassified roms
 		<description>GP-1 (Europe)</description>
 		<year>1993</year>
 		<publisher>Atlus</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -42703,7 +42712,7 @@ List of unclassified roms
 		<year>1993</year>
 		<publisher>Atlus</publisher>
 		<info name="release" value="199309xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -42717,7 +42726,7 @@ List of unclassified roms
 		<year>1994</year>
 		<publisher>Atlus</publisher>
 		<info name="release" value="199412xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -42794,7 +42803,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-K8" />
 		<info name="release" value="19940128" />
 		<info name="alt_title" value="ザ・グレイトバトル外伝2 祭だワッショイ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1310720">
@@ -42807,7 +42816,7 @@ List of unclassified roms
 		<description>The Great Battle IV (Japan, sample)</description>
 		<year>1994</year>
 		<publisher>Banpresto</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -42946,7 +42955,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AHGJ-JPN" />
 		<info name="release" value="19941118" />
 		<info name="alt_title" value="鋼" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -43069,7 +43078,7 @@ List of unclassified roms
 		<year>1994</year>
 		<publisher>Jaleco</publisher>
 		<info name="release" value="199410xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -43112,7 +43121,7 @@ List of unclassified roms
 		<description>Hanguk Pro Yagu (Korea)</description>
 		<year>1994?</year>
 		<publisher>Hyundai</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom_dsp" />
 			<dataarea name="rom" size="1572864">
@@ -43290,7 +43299,7 @@ List of unclassified roms
 		<year>1995</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="release" value="199509xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -43333,7 +43342,7 @@ List of unclassified roms
 		<description>Hebereke's Popoitto (Europe)</description>
 		<year>1995</year>
 		<publisher>Sunsoft</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -43346,7 +43355,7 @@ List of unclassified roms
 		<description>Hebereke's Popoon (Europe)</description>
 		<year>1993</year>
 		<publisher>Sunsoft</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -43626,7 +43635,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-A2HJ-JPN" />
 		<info name="release" value="19950324" />
 		<info name="alt_title" value="必殺パチンココレクション2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -43644,7 +43653,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-A3HJ-JPN" />
 		<info name="release" value="19951102" />
 		<info name="alt_title" value="必殺パチンココレクション3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -43947,7 +43956,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AFPJ-JPN" />
 		<info name="release" value="19950610" />
 		<info name="alt_title" value="本家SANKYO FEVER 実機シミュレーション" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -43963,7 +43972,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-A33J-JPN" />
 		<info name="release" value="19951215" />
 		<info name="alt_title" value="本家SANKYO FEVER 2 実機シミュレーション" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -43979,7 +43988,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-A37J-JPN" />
 		<info name="release" value="19960831" />
 		<info name="alt_title" value="本家SANKYO FEVER 3 実機シミュ レーション" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -44121,7 +44130,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AG4J-JPN" />
 		<info name="release" value="19950825" />
 		<info name="alt_title" value="ヒューマングランプリ4 F1ドリームバトル" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -44322,7 +44331,7 @@ List of unclassified roms
 		<description>The Ignition Factor (prototype)</description>
 		<year>1994</year>
 		<publisher>Jaleco</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -44336,7 +44345,7 @@ List of unclassified roms
 		<year>1995</year>
 		<publisher>Jaleco</publisher>
 		<info name="release" value="199501xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -44412,7 +44421,7 @@ List of unclassified roms
 		<description>Illusion of Time (Europe)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -44427,7 +44436,7 @@ List of unclassified roms
 		<description>Illusion of Time (Spain)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -44584,7 +44593,7 @@ List of unclassified roms
 		<year>1995</year>
 		<publisher>Konami</publisher>
 		<info name="release" value="199506xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -44598,7 +44607,7 @@ List of unclassified roms
 		<year>1995</year>
 		<publisher>Konami</publisher>
 		<info name="release" value="199511xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -44627,7 +44636,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-IT" />
 		<info name="release" value="19930326" />
 		<info name="alt_title" value="インターナショナルテニスツアー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -44641,7 +44650,7 @@ List of unclassified roms
 		<year>1993</year>
 		<publisher>Taito</publisher>
 		<info name="release" value="199311xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -44796,7 +44805,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-Q2" />
 		<info name="release" value="19940204" />
 		<info name="alt_title" value="伊藤果六段の将棋道場" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -44814,7 +44823,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-Q2" />
 		<info name="release" value="19940204" />
 		<info name="alt_title" value="伊藤果六段の将棋道場" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -44854,7 +44863,7 @@ List of unclassified roms
 		<description>J.League Excite Stage '95 (Japan, prototype)</description>
 		<year>1995</year>
 		<publisher>Epoch</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -44872,7 +44881,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AE3J-JPN" />
 		<info name="release" value="19960426" />
 		<info name="alt_title" value="Jリーグエキサイトステージ'96" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -44890,7 +44899,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AE3J-JPN" />
 		<info name="release" value="19960426" />
 		<info name="alt_title" value="Jリーグエキサイトステージ'96" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -45196,7 +45205,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AJOJ-JPN" />
 		<info name="release" value="19951215" />
 		<info name="alt_title" value="実況おしゃべりパロディウス" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="SA1" />
 			<feature name="slot" value="lorom_sa1" />
@@ -45215,7 +45224,8 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AP2J-JPN" />
 		<info name="release" value="19950224" />
 		<info name="alt_title" value="実況パワフルプロ野球2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 2"/> <!-- often used unofficially -->
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2621440">
@@ -45233,7 +45243,8 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AQ7J-JPN" />
 		<info name="release" value="19970320" />
 		<info name="alt_title" value="実況パワフルプロ野球3 '97 春" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<info name="alt_title" value="Jikkyou Powerful Pro Yakyuu 3 - '97 Haru"/> <!-- often used unofficially -->
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -45251,7 +45262,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AWJJ-JPN" />
 		<info name="release" value="19950922" />
 		<info name="alt_title" value="実況ワールドサッカー2 ファイティング イレブン" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -45266,7 +45277,7 @@ List of unclassified roms
 		<description>Jikkyou World Soccer 2 - Fighting Eleven (Japan, prototype)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -45305,7 +45316,7 @@ List of unclassified roms
 		<year>1993</year>
 		<publisher>Electro Brain</publisher>
 		<info name="release" value="199312xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -45318,7 +45329,7 @@ List of unclassified roms
 		<description>Jim Power - The Lost Dimension in 3D (enhanced version)</description>
 		<year>2015</year>
 		<publisher>Piko Interactive</publisher>
-		<sharedfeat name="developer" value="Loriciel"/>
+		<sharedfeat name="developer" value="Loriciel" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -45481,7 +45492,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-A9ZJ-JPN" />
 		<info name="release" value="19960308" />
 		<info name="alt_title" value="実戦パチンコ必勝法!2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -45533,7 +45544,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AY8J-JPN" />
 		<info name="release" value="19960405" />
 		<info name="alt_title" value="実戦!パチスロ必勝法!山佐伝説" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -45600,7 +45611,7 @@ List of unclassified roms
 		<description>Joe &amp; Mac 2 - Lost in the Tropics (USA, prototype)</description>
 		<year>1994</year>
 		<publisher>Data East</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -45614,7 +45625,7 @@ List of unclassified roms
 		<year>1994</year>
 		<publisher>Data East</publisher>
 		<info name="release" value="199404xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -45639,7 +45650,7 @@ List of unclassified roms
 		<description>Joe &amp; Mac 3 - Lost in the Tropics (Europe)</description>
 		<year>1994</year>
 		<publisher>Data East</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -45941,7 +45952,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-J8" />
 		<info name="release" value="19940624" />
 		<info name="alt_title" value="ジュラシック・パーク" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -46046,7 +46057,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AJWJ-JPN" />
 		<info name="release" value="19941223" />
 		<info name="alt_title" value="JWP女子プロレス ピュア・レッスル・クイーンズ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -46059,7 +46070,7 @@ List of unclassified roms
 		<description>K.H. Rummenigge's Player Manager (Germany)</description>
 		<year>1993</year>
 		<publisher>Imagineer</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -46074,7 +46085,7 @@ List of unclassified roms
 		<description>K.H. Rummenigge's Player Manager (Germany, Demo 20 Week Manager)</description>
 		<year>1993</year>
 		<publisher>Imagineer</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -46089,7 +46100,7 @@ List of unclassified roms
 		<description>K.H. Rummenigge's Player Manager (Germany, Demo 10 Week Manager)</description>
 		<year>1993</year>
 		<publisher>Imagineer</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -46249,7 +46260,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AVFJ-JPN" />
 		<info name="release" value="19950217" />
 		<info name="alt_title" value="柏木重孝のトップ ウォーター バッシンク" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -46397,7 +46408,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-YB" />
 		<info name="release" value="19940325" />
 		<info name="alt_title" value="剣勇伝説 ヤイバ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -46428,7 +46439,7 @@ List of unclassified roms
 		<year>1993</year>
 		<publisher>Asmik</publisher>
 		<info name="alt_title" value="決戦!ドカポン王国IV ～伝説の勇者たち～" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="0x100000">
@@ -46444,7 +46455,7 @@ List of unclassified roms
 		<year>1993</year>
 		<publisher>Asmik</publisher>
 		<info name="alt_title" value="決戦!ドカポン王国IV ～伝説の勇者たち～" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="0x100000">
@@ -46459,7 +46470,7 @@ List of unclassified roms
 		<description>Kevin Keegan's Player Manager (Europe)</description>
 		<year>1993</year>
 		<publisher>Imagineer</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -46502,7 +46513,7 @@ List of unclassified roms
 		<description>Kick Off 3 - European Challenge (Europe)</description>
 		<year>1994</year>
 		<publisher>Vic Tokai</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -46515,7 +46526,7 @@ List of unclassified roms
 		<description>Kid Klown in Crazy Chase (Europe)</description>
 		<year>1994</year>
 		<publisher>Kemco</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -46901,7 +46912,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-BKKJ-JPN" />
 		<info name="release" value="19980201 / 19990625" />
 		<info name="alt_title" value="カービィのきらきらきっす" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -46917,7 +46928,7 @@ List of unclassified roms
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
 		<info name="release" value="199502xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -46948,7 +46959,7 @@ List of unclassified roms
 		<description>Kirby's Ghost Trap (Europe)</description>
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -46964,7 +46975,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AZ6J-JPN" />
 		<info name="release" value="19950804" />
 		<info name="alt_title" value="鬼神童子 ゼンキ 烈闘雷伝" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -47024,7 +47035,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AVKJ-JPN" />
 		<info name="release" value="19950127" />
 		<info name="alt_title" value="キテレツ大百科 超時空すごろく" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1310720">
@@ -47067,7 +47078,7 @@ List of unclassified roms
 		<year>1994</year>
 		<publisher>Capcom</publisher>
 		<info name="release" value="199404xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -47199,7 +47210,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-2Z" />
 		<info name="release" value="19940128" />
 		<info name="alt_title" value="鋼鉄の騎士2 砂漠のロンメル軍団" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -47217,7 +47228,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-APZJ-JPN" />
 		<info name="release" value="19950127" />
 		<info name="alt_title" value="鋼鉄の騎士3 -激突ヨーロッパ戦線 -" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -47380,7 +47391,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-AKMJ-JPN" />
 		<info name="release" value="19950331" />
 		<info name="alt_title" value="旧約・女神転生 女神転生I, 女神転生II" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -47539,7 +47550,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-QJ (KIS-4)" />
 		<info name="release" value="19940922" />
 		<info name="alt_title" value="ラリー・ニクソン スーパー・バス・フィッシング" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -47832,7 +47843,7 @@ List of unclassified roms
 		<year>1994</year>
 		<publisher>DTMC</publisher>
 		<info name="release" value="199401xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -47846,7 +47857,7 @@ List of unclassified roms
 		<year>1994</year>
 		<publisher>Konami</publisher>
 		<info name="release" value="199401xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -47874,7 +47885,7 @@ List of unclassified roms
 		<info name="serial" value="SHVC-26" />
 		<info name="release" value="19940922" />
 		<info name="alt_title" value="リブルラブル" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="524288">
@@ -48072,7 +48083,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-7Z" />
 		<info name="release" value="19940729" />
 		<info name="alt_title" value="ロードランナー Twin ジャスティ とリバティの大冒険" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -48226,7 +48237,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Lothar Matthäus Super Soccer (Germany)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -48256,7 +48267,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Lucky Luke (Europe)</description>
 		<year>1997</year>
 		<publisher>Infogrames</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -48570,7 +48581,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AIAJ-JPN" />
 		<info name="release" value="19950310" />
 		<info name="alt_title" value="マジカルポップン" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -48780,7 +48791,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ZM" />
 		<info name="release" value="19940128" />
 		<info name="alt_title" value="魔神転生" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -48798,7 +48809,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ZM" />
 		<info name="release" value="19940128" />
 		<info name="alt_title" value="魔神転生" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -48816,7 +48827,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AZ2J-JPN" />
 		<info name="release" value="19950219" />
 		<info name="alt_title" value="魔神転生II スパイラルネメシス" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -48905,7 +48916,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Manchester United Championship Soccer (Europe)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -49033,7 +49044,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Marko's Magic Football (Europe)</description>
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -49270,7 +49281,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
 		<info name="release" value="199611xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -49467,7 +49478,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Mega Lo Mania (Europe, prototype)</description>
 		<year>1991</year>
 		<publisher>Virgin Interactive</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -49481,7 +49492,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1991</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="alt_title" value="Mega-Lo-Mania (Box)" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -49520,7 +49531,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Capcom</publisher>
 		<info name="release" value="199404xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1310720">
@@ -49687,7 +49698,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AZMJ-JPN" />
 		<info name="release" value="19950929" />
 		<info name="alt_title" value="メタルマックスリターンス" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="4194304">
@@ -49988,7 +49999,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Mighty Max (Europe)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -50001,7 +50012,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Mighty Max (USA, prototype)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -50247,7 +50258,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AK2J-JPN" />
 		<info name="release" value="19941118" />
 		<info name="alt_title" value="モンスターメーカーキッズ 王 様になりたい" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -50392,7 +50403,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AOEJ-JPN" />
 		<info name="release" value="19951215" />
 		<info name="alt_title" value="もってけoh ! ドロボー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -50808,7 +50819,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>NBA Give 'n Go (Europe)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -50822,7 +50833,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1995</year>
 		<publisher>Konami</publisher>
 		<info name="release" value="199511xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -50835,7 +50846,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>NBA Hang Time (Europe)</description>
 		<year>1996</year>
 		<publisher>Midway</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -50851,7 +50862,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1996</year>
 		<publisher>Midway</publisher>
 		<info name="release" value="199611xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -50966,7 +50977,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ANJJ-JPN" />
 		<info name="release" value="19950929" />
 		<info name="alt_title" value="NBA実況バスケット ウイニング ダンク" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -51693,7 +51704,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-NC" />
 		<info name="release" value="19930319" />
 		<info name="alt_title" value="ナイジェル・マンセルF1チャレンジ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -51708,7 +51719,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-M8-FAH" />
 		<info name="release" value="19931216" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -51723,7 +51734,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="SNSP-M8-FAH" />
 		<info name="release" value="19931216" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -51764,7 +51775,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ANRJ-JPN" />
 		<info name="release" value="19950811" />
 		<info name="alt_title" value="忍者龍剣伝 巴" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -52309,7 +52320,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Taito</publisher>
 		<info name="release" value="199410xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1310720">
@@ -52322,7 +52333,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Operation Thunderbolt (prototype)</description>
 		<year>1994</year>
 		<publisher>Taito</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -52500,7 +52511,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-APUJ-JPN" />
 		<info name="release" value="19950623" />
 		<info name="alt_title" value="P・マン" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -52543,7 +52554,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Pac-Attack (Europe)</description>
 		<year>1993</year>
 		<publisher>Namco</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -52581,7 +52592,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Pac-in-Time (Europe)</description>
 		<year>1995</year>
 		<publisher>Namco</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -52597,7 +52608,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-APTJ-JPN" />
 		<info name="release" value="19950103" />
 		<info name="alt_title" value="パックインタイム" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -52611,7 +52622,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1995</year>
 		<publisher>Namco</publisher>
 		<info name="release" value="199501xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -52624,7 +52635,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Pac-Man 2 - The New Adventures (Europe)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -52637,7 +52648,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Pac-Man 2 - The New Adventures (France)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -52650,7 +52661,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Pac-Man 2 - The New Adventures (Germany)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -52743,7 +52754,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-A2WJ-JPN" />
 		<info name="release" value="19951027" />
 		<info name="alt_title" value="パチスロ物語 パル工業スペシャル" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1310720">
@@ -53054,7 +53065,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>The Peace Keepers (prototype)</description>
 		<year>1994</year>
 		<publisher>Jaleco</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -53068,7 +53079,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Jaleco</publisher>
 		<info name="release" value="199403xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -53633,7 +53644,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ACGJ-JPN" />
 		<info name="release" value="19961220" />
 		<info name="alt_title" value="ピノキオ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -53647,7 +53658,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1996</year>
 		<publisher>Disney Interactive</publisher>
 		<info name="release" value="199611xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -53675,7 +53686,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>The Pirates of Dark Water (Europe)</description>
 		<year>1994</year>
 		<publisher>Sunsoft</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -53772,7 +53783,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Plok! (Europe)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -53788,7 +53799,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-P4" />
 		<info name="release" value="19931210" />
 		<info name="alt_title" value="プロック" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -53802,7 +53813,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1993</year>
 		<publisher>Tradewest</publisher>
 		<info name="release" value="199309xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -53891,7 +53902,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Pop'n TwinBee (Europe)</description>
 		<year>1993</year>
 		<publisher>Palcom</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -53904,7 +53915,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Pop'n TwinBee - Rainbow Bell Adventures (Europe)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -53917,7 +53928,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Pop'n TwinBee - Rainbow Bell Adventures (Germany)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -53950,7 +53961,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-IW" />
 		<info name="release" value="19940610" />
 		<info name="alt_title" value="ぽっぷるメイル" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -53968,7 +53979,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-APHJ-JPN" />
 		<info name="release" value="19950728" />
 		<info name="alt_title" value="ポポイっとへべれけ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -54006,7 +54017,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Populous II - Trials of the Olympian Gods (Europe)</description>
 		<year>1993</year>
 		<publisher>Imagineer</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -54019,7 +54030,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Populous II - Trials of the Olympian Gods (Germany)</description>
 		<year>1993</year>
 		<publisher>Imagineer</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -54202,7 +54213,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Prehistorik Man (Europe)</description>
 		<year>1996</year>
 		<publisher>Titus</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -54228,7 +54239,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1996</year>
 		<publisher>Titus</publisher>
 		<info name="release" value="199605xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -54463,7 +54474,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Jaleco</publisher>
 		<info name="release" value="199402xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -54547,7 +54558,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-PU" />
 		<info name="release" value="19930730" />
 		<info name="alt_title" value="パティームーン" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -54656,7 +54667,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>R-Type III - The Third Lightning (Europe, prototype)</description>
 		<year>1994</year>
 		<publisher>Jaleco</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -54672,7 +54683,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ER" />
 		<info name="release" value="19931210" />
 		<info name="alt_title" value="アールタイプ3 ザ・サードライトニング" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -54849,7 +54860,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
         <year>1992</year>
         <publisher>Ocean</publisher>
         <info name="serial" value="SNSP-R2-UKV" />
-        <sharedfeat name="compatibility" value="PAL"/>
+        <sharedfeat name="compatibility" value="PAL" />
         <part name="cart" interface="snes_cart">
             <feature name="pcb" value="SHVC-2J0N-01" />
             <feature name="u1" value="U1 P0" />
@@ -55170,7 +55181,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Revolution X (Europe)</description>
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -55183,7 +55194,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Revolution X (Germany)</description>
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -55199,7 +55210,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AXRJ-JPN" />
 		<info name="release" value="19960301" />
 		<info name="alt_title" value="レボリューションX" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -55213,7 +55224,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="release" value="199512xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -55468,7 +55479,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1993</year>
 		<publisher>Interplay</publisher>
 		<info name="release" value="199309xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -55591,7 +55602,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<publisher>Square</publisher>
 		<info name="serial" value="SHVC-AL9J-JPN" />
 		<info name="alt_title" value="ロマンシング サ・ガ3 体験版サンプルROM" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="4194304">
@@ -55666,7 +55677,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-R6" />
 		<info name="release" value="19931217" />
 		<info name="alt_title" value="ラッシング・ビート 修羅" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -55699,7 +55710,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-RW" />
 		<info name="release" value="19931029" />
 		<info name="alt_title" value="龍虎の拳" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -55715,7 +55726,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AAFJ-JPN" />
 		<info name="release" value="19941221" />
 		<info name="alt_title" value="龍虎の拳2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="4194304">
@@ -55793,7 +55804,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-IV" />
 		<info name="release" value="19940715" />
 		<info name="alt_title" value="サンサーラ・ナーガ2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -55808,7 +55819,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Samurai Shodown (Europe)</description>
 		<year>1994</year>
 		<publisher>Takara</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="4194304">
@@ -55821,7 +55832,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Samurai Spirits (Japan, prototype)</description>
 		<year>1994</year>
 		<publisher>Takara</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="4194304">
@@ -56068,7 +56079,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Secret of Mana (Europe, rev. A)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -56083,7 +56094,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Secret of Mana (Europe)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -56098,7 +56109,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Secret of Mana (France)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -56131,7 +56142,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AB5J-JPN" />
 		<info name="release" value="19951215" />
 		<info name="alt_title" value="聖獣魔伝 ビースト&amp;ブレイト" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2621440">
@@ -56165,7 +56176,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-G5" />
 		<info name="release" value="19930922" />
 		<info name="alt_title" value="戦国伝承" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -56469,7 +56480,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Vic Tokai</publisher>
 		<info name="release" value="199410xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -56722,7 +56733,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-XN" />
 		<info name="release" value="19951117" />
 		<info name="alt_title" value="新スタートレック~大いなる遺産IFDの謎を追え~" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2621440">
@@ -57280,7 +57291,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-XS" />
 		<info name="release" value="19941216" />
 		<info name="alt_title" value="スキーパラダイス WITH スノーボート" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -57373,7 +57384,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Smash Tennis (Europe)</description>
 		<year>1993</year>
 		<publisher>Virgin Interactive</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -57426,7 +57437,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Soccer Kid (Europe)</description>
 		<year>1994</year>
 		<publisher>Ocean</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1310720">
@@ -57466,7 +57477,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Soccer Shootout (Europe)</description>
 		<year>1994</year>
 		<publisher>Capcom</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -57616,7 +57627,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AK7J-JPN" />
 		<info name="release" value="19960329" />
 		<info name="alt_title" value="それ行け エビス丸からくり迷路 消 えたゴエモンの謎!!" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -57677,7 +57688,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-EJ (KIS-3)" />
 		<info name="release" value="19940225" />
 		<info name="alt_title" value="総合格闘技 アストラルバウト2 THE TOTAL FIGHTERS" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -57693,7 +57704,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AABJ (KIS-5)" />
 		<info name="release" value="19951020" />
 		<info name="alt_title" value="総合格闘技リングスアストラルバウト3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -57709,7 +57720,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-VO" />
 		<info name="release" value="19931029" />
 		<info name="alt_title" value="装甲騎兵ボトムズ ザ・バトリングロード" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="DSP1" />
 			<feature name="slot" value="hirom_dsp" />
@@ -57759,7 +57770,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Enix</publisher>
 		<info name="release" value="19940127" />
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -57815,7 +57826,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Space Ace (USA, prototype)</description>
 		<year>1994</year>
 		<publisher>Absolute Entertainment</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -57856,7 +57867,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Space Invaders - The Original Game (Europe)</description>
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="262144">
@@ -57870,7 +57881,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1997</year>
 		<publisher>Nintendo</publisher>
 		<info name="release" value="199711xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="262144">
@@ -57923,7 +57934,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Sparkster (Europe)</description>
 		<year>1994</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -57939,7 +57950,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ASSJ-JPN" />
 		<info name="release" value="19940915" />
 		<info name="alt_title" value="スパークスター" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -57953,7 +57964,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Konami</publisher>
 		<info name="release" value="199410xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -58056,7 +58067,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Speedy Gonzales in Los Gatos Bandidos (USA, Acclaim prototype)</description>
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -58070,7 +58081,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="release" value="199508xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -58084,7 +58095,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="release" value="199508xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -58186,7 +58197,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Spirou (Europe)</description>
 		<year>1995</year>
 		<publisher>Infogrames</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1310720">
@@ -58406,7 +58417,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Star Trek - The Next Generation - Future's Past (Europe)</description>
 		<year>1994</year>
 		<publisher>Spectrum Holobyte</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -58420,7 +58431,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Spectrum Holobyte</publisher>
 		<info name="release" value="199403xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -58681,7 +58692,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Striker (Europe, prototype)</description>
 		<year>1992</year>
 		<publisher>Elite</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -58694,7 +58705,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Striker (Europe)</description>
 		<year>1992</year>
 		<publisher>Elite</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -58708,7 +58719,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="release" value="199407xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-1" />
 			<feature name="slot" value="lorom_gsu1" />
@@ -58727,7 +58738,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-QH" />
 		<info name="release" value="19940311" />
 		<info name="alt_title" value="すごいへべれけ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1310720">
@@ -58772,7 +58783,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Sunset Riders (Europe)</description>
 		<year>1993</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -58786,7 +58797,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="release" value="199310xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -59047,7 +59058,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1995</year>
 		<publisher>Jaleco</publisher>
 		<info name="release" value="199502xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -59063,7 +59074,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Jaleco</publisher>
 		<info name="release" value="199402xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="DSP1" />
 			<feature name="slot" value="lorom_dsp" />
@@ -59277,7 +59288,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AB2J-JPN" />
 		<info name="release" value="19940923" />
 		<info name="alt_title" value="スーパーブラックバス2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -59295,7 +59306,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVA-A3SJ" />
 		<info name="release" value="19951215" />
 		<info name="alt_title" value="スーパーブラックバス3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="4194304">
@@ -59313,7 +59324,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVA-A3SJ" />
 		<info name="release" value="19951215" />
 		<info name="alt_title" value="スーパーブラックバス3" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="4194304">
@@ -59435,7 +59446,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Hudson</publisher>
 		<info name="release" value="199411xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -59653,7 +59664,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Super Conflict - The Mideast (Europe)</description>
 		<year>1993</year>
 		<publisher>Vic Tokai</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -59669,7 +59680,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1993</year>
 		<publisher>Vic Tokai</publisher>
 		<info name="release" value="199303xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -59767,7 +59778,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-7V" />
 		<info name="release" value="19940401" />
 		<info name="alt_title" value="スーパー ダブル役満" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -59783,7 +59794,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AYXJ-JPN" />
 		<info name="release" value="19970314" />
 		<info name="alt_title" value="スーパーダブル役満II" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -59891,7 +59902,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AN4J-JPN" />
 		<info name="release" value="19950707" />
 		<info name="alt_title" value="スーパーエフワンサーカス外伝" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="DSP1" />
 			<feature name="slot" value="hirom_dsp" />
@@ -59947,7 +59958,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-A25J-JPN" />
 		<info name="release" value="19980201" />
 		<info name="alt_title" value="スーパーファミリーゲレンテ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -59981,7 +59992,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-F9" />
 		<info name="release" value="19940812" />
 		<info name="alt_title" value="スーパーファイナルマッチテニス" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -59997,7 +60008,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-3E" />
 		<info name="release" value="19940204" />
 		<info name="alt_title" value="スーパーファイヤープロレスリン グ3 イージータイフ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -60013,7 +60024,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-F3" />
 		<info name="release" value="19931229" />
 		<info name="alt_title" value="スーパーファイヤープロレスリング3 ファイナルバウト" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -60032,7 +60043,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AF6J-JPN" /> <!-- NP cart: SHVC-MMSA-JPN-1 -->
 		<info name="release" value="19960329" />
 		<info name="alt_title" value="スーパーファイヤープロレスリングX プレミ アム" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 <!-- nintendo power cart -->
 		<part name="cart" interface="snes_cart">
 			<feature name="pcb" value="SHVC-MMS-02" />
@@ -60082,7 +60093,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ADEJ-JPN" />
 		<info name="release" value="19950331" />
 		<info name="alt_title" value="スーパーフォーメーションサッカー'95 デッラセリエA" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -60100,7 +60111,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-A96J-JPN" />
 		<info name="release" value="19960329" />
 		<info name="alt_title" value="スーパーフォーメーションサッカー96 ワール ドクラブエディション" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -60169,7 +60180,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AZ7J-JPN" />
 		<info name="release" value="19950728" />
 		<info name="alt_title" value="超原人2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1572864">
@@ -60267,7 +60278,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-5N" />
 		<info name="release" value="19940325" />
 		<info name="alt_title" value="スーパー五目ならべ 連珠" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -60283,7 +60294,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AGSJ-JPN" />
 		<info name="release" value="19941118" />
 		<info name="alt_title" value="スーパー 五目・将棋 ― 定跡研究 篇―" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -60491,7 +60502,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Super International Cricket (Europe, prototype)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -60581,7 +60592,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AKRJ-JPN" />
 		<info name="release" value="19950714" />
 		<info name="alt_title" value="スーパー競輪" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -60648,7 +60659,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-KJ (KIS-2)" />
 		<info name="release" value="19931008" />
 		<info name="alt_title" value="スーパー競走馬 風のシルフィード" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -60726,7 +60737,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-Q8" />
 		<info name="release" value="19941125" />
 		<info name="alt_title" value="スーパー麻雀3 辛口" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -60795,7 +60806,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-YI" />
 		<info name="release" value="19950805" />
 		<info name="alt_title" value="スーパーマリオ ヨッシーアイラント" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-2" />
 			<feature name="slot" value="lorom_gsu2" />
@@ -60814,7 +60825,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-YI" />
 		<info name="release" value="19950805" />
 		<info name="alt_title" value="スーパーマリオ ヨッシーアイラント" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-2" />
 			<feature name="slot" value="lorom_gsu2" />
@@ -60849,7 +60860,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-4M" />
 		<info name="release" value="19930714" />
 		<info name="alt_title" value="スーパーマリオコレクション" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -60864,7 +60875,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Super Mario World 2 - Yoshi's Island (Europe, rev. A)</description>
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-2" />
 			<feature name="slot" value="lorom_gsu2" />
@@ -60881,7 +60892,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
 		<info name="release" value="199510xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="GSU-2" />
 			<feature name="slot" value="lorom_gsu2" />
@@ -60900,7 +60911,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AB3J-JPN" />
 		<info name="release" value="19941223" />
 		<info name="alt_title" value="スーパー 燃えろ!!プロ野球" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -61019,7 +61030,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-8Q" />
 		<info name="release" value="19940805" />
 		<info name="alt_title" value="す~ぱ~忍者くん" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -61160,7 +61171,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Super Pinball - Behind the Mask (Europe)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -61201,7 +61212,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-APLJ-JPN" />
 		<info name="release" value="19950317" />
 		<info name="alt_title" value="スーパーピンボール2 ザ・アメイジン グ・オデッセイ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -61307,7 +61318,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Super Putty (Europe)</description>
 		<year>1993</year>
 		<publisher>U.S. Gold</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -61321,7 +61332,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1993</year>
 		<publisher>U.S. Gold</publisher>
 		<info name="release" value="199311xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -61395,7 +61406,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-A5PJ-JPN" />
 		<info name="release" value="19950421" />
 		<info name="alt_title" value="スーパーリアル麻雀PV パラダイ ス オールスター4人打ち" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -62019,7 +62030,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-UN" />
 		<info name="release" value="19931112" />
 		<info name="alt_title" value="スーパーUNO" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -62297,7 +62308,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Namco</publisher>
 		<info name="release" value="199405xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="enhancement" value="DSP1" />
 			<feature name="slot" value="hirom_dsp" />
@@ -62538,7 +62549,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ATYJ-JPN" />
 		<info name="release" value="19941125" />
 		<info name="alt_title" value="ただいま勇者募集中おかわり" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -62556,7 +62567,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-II" />
 		<info name="release" value="19940628" />
 		<info name="alt_title" value="足台拳道" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -62854,7 +62865,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-7T" />
 		<info name="release" value="19931126" />
 		<info name="alt_title" value="テクモスーパーボウル" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1572864">
@@ -62884,7 +62895,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ASBJ-JPN" />
 		<info name="release" value="19941220" />
 		<info name="alt_title" value="テクモスーパーボウルII スペシャルエ ディション" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -62900,7 +62911,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1995</year>
 		<publisher>Tecmo</publisher>
 		<info name="release" value="199501xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -62916,7 +62927,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1995</year>
 		<publisher>Tecmo</publisher>
 		<info name="release" value="199510xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -63103,7 +63114,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-LJ" />
 		<info name="release" value="19940930" />
 		<info name="alt_title" value="天龍源一郎のプロレス レヴォリューション" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -63183,7 +63194,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Terranigma (Europe)</description>
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="4194304">
@@ -63198,7 +63209,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Terranigma (Germany, rev. A)</description>
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="4194304">
@@ -63213,7 +63224,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Terranigma (Spain)</description>
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="4194304">
@@ -63228,7 +63239,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Tetris 2 (Europe)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -63242,7 +63253,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="release" value="199408xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -63271,7 +63282,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-4G" />
 		<info name="release" value="19931224" />
 		<info name="alt_title" value="テトリス 武闘外伝" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -63285,7 +63296,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1993</year>
 		<publisher>Bullet-Proof Software</publisher>
 		<info name="alt_title" value="テトリス 武闘外伝" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="0x100000">
@@ -63301,7 +63312,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-27" />
 		<info name="release" value="19940708" />
 		<info name="alt_title" value="テトリスフラッシュ" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -63317,7 +63328,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ZB" />
 		<info name="release" value="19940218" />
 		<info name="alt_title" value="鉄腕アトム" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1310720">
@@ -63615,7 +63626,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-5Z" />
 		<info name="release" value="19940930" />
 		<info name="alt_title" value="タイニー・トゥーン アドベンチャース ドタバ タ大運動会" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -63629,7 +63640,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Konami</publisher>
 		<info name="release" value="199411xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -63654,7 +63665,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Tiny Toon Adventures - Wild &amp; Wacky Sports (Europe, rev. A)</description>
 		<year>1994</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -63710,7 +63721,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AM8J-JPN" />
 		<info name="release" value="19960209" />
 		<info name="alt_title" value="ときめきメモリアル 伝説の樹の下て" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="4194304">
@@ -63829,7 +63840,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Top Gear 2 (Europe)</description>
 		<year>1993</year>
 		<publisher>Kemco</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -63843,7 +63854,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1993</year>
 		<publisher>Kemco</publisher>
 		<info name="release" value="199309xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -63891,7 +63902,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-2P" />
 		<info name="release" value="19931222" />
 		<info name="alt_title" value="トップレーサー2" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -64100,7 +64111,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-T6" />
 		<info name="release" value="19931001" />
 		<info name="alt_title" value="トリネア" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="2097152">
@@ -64365,7 +64376,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ATPJ-JPN" />
 		<info name="release" value="19941118" />
 		<info name="alt_title" value="ツヨシしっかりしなさい 対戦 ぱずるだま" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -64406,7 +64417,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-ATUJ-JPN" />
 		<info name="release" value="19950321" />
 		<info name="alt_title" value="ターフヒーロー" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -64424,7 +64435,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AYZJ-JPN" />
 		<info name="release" value="19950224" />
 		<info name="alt_title" value="ターフメモリース" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -64915,7 +64926,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AUFJ-JPN" />
 		<info name="release" value="19941216" />
 		<info name="alt_title" value="海釣り名人スズキ編" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -64930,7 +64941,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Umizuri Meijin - Suzuki Hen (Japan, prototype)</description>
 		<year>1994</year>
 		<publisher>Electronic Arts Victor</publisher>
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -65637,7 +65648,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>WeaponLord (Europe)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -65652,7 +65663,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1995</year>
 		<publisher>Namco</publisher>
 		<info name="release" value="199509xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -65769,7 +65780,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Wild Guns (USA)</description>
 		<year>1995</year>
 		<publisher>Natsume</publisher>
-		<info name="release" value="199507xx"/>
+		<info name="release" value="199507xx" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -66020,7 +66031,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Wolfenstein 3D (Europe)</description>
 		<year>1994</year>
 		<publisher>Imagineer</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -66034,7 +66045,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1994</year>
 		<publisher>Imagineer</publisher>
 		<info name="release" value="199403xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="1048576">
@@ -66390,7 +66401,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1993</year>
 		<publisher>Atlus</publisher>
 		<info name="release" value="199312xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="524288">
@@ -66531,7 +66542,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>X-Kaliber 2097 (Europe)</description>
 		<year>1994</year>
 		<publisher>Sony Interactive</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -66821,7 +66832,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Yoshi's Safari (Europe)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -66835,7 +66846,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="release" value="199309xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -66908,7 +66919,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-A5EJ-JPN" />
 		<info name="release" value="19960322" />
 		<info name="alt_title" value="イースVエキスパート" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -66926,7 +66937,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AYVJ-JPN" />
 		<info name="release" value="19951229" />
 		<info name="alt_title" value="イースV 失われた砂の都ケフィン" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="3145728">
@@ -66961,7 +66972,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-AY3J-JPN" />
 		<info name="release" value="19950324" />
 		<info name="alt_title" value="幽☆遊☆白書 ファイナル魔界最強列伝" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="hirom" />
 			<dataarea name="rom" size="3145728">
@@ -67122,7 +67133,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<info name="serial" value="SHVC-Q4" />
 		<info name="release" value="19940721" />
 		<info name="alt_title" value="ゼロヨンチャンプ ダブルアール" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
@@ -67222,7 +67233,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<description>Zombies (Europe)</description>
 		<year>1993</year>
 		<publisher>Konami</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
+		<sharedfeat name="compatibility" value="PAL" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">
@@ -67236,7 +67247,7 @@ to ensure nothing has been touched in the Retro Quest cart production in 2013/20
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="release" value="199309xx" />
-		<sharedfeat name="compatibility" value="NTSC"/>
+		<sharedfeat name="compatibility" value="NTSC" />
 		<part name="cart" interface="snes_cart">
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="1048576">

--- a/hash/snes.xml
+++ b/hash/snes.xml
@@ -16522,7 +16522,7 @@ more investigation needed...
 	</software>
 
 	<software name="powyak98">
-		<description>Jikkyou Powerful Pro Yakyuu - Basic Ban '98 (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū - Basic Ban '98 (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-AJ5J-JPN / RS059-J1" />
@@ -16549,7 +16549,7 @@ more investigation needed...
 	</software>
 
 	<software name="powyak2b" cloneof="powyak2">
-		<description>Jikkyou Powerful Pro Yakyuu 2 (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 2 (Japan)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-AP2J-JPN" />
@@ -16578,7 +16578,7 @@ more investigation needed...
 	</software>
 
 	<software name="powyak3">
-		<description>Jikkyou Powerful Pro Yakyuu 3 (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 3 (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-A3JJ-JPN" />
@@ -16605,7 +16605,7 @@ more investigation needed...
 	</software>
 
 	<software name="powyak3a" cloneof="powyak3">
-		<description>Jikkyou Powerful Pro Yakyuu 3 (Japan, alt)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 3 (Japan, alt)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-A3JJ-JPN" />
@@ -16634,7 +16634,7 @@ more investigation needed...
 	</software>
 
 	<software name="powyk397a" cloneof="powyk397">
-		<description>Jikkyou Powerful Pro Yakyuu 3 - '97 Haru (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 3 - '97 Haru (Japan)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-AQ7J-JPN" />
@@ -16661,7 +16661,7 @@ more investigation needed...
 	</software>
 
 	<software name="powyak94">
-		<description>Jikkyou Powerful Pro Yakyuu '94 (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū '94 (Japan)</description>
 		<year>1994</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-YX" />
@@ -16683,7 +16683,7 @@ more investigation needed...
 	</software>
 
 	<software name="powyak96a" cloneof="powyak96">
-		<description>Jikkyou Powerful Pro Yakyuu '96 - Kaimaku Ban (Japan)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū '96 - Kaimaku Ban (Japan)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-A57J-JPN" />
@@ -16710,7 +16710,7 @@ more investigation needed...
 	</software>
 
 	<software name="powyak96">
-		<description>Jikkyou Powerful Pro Yakyuu '96 - Kaimaku Ban (Japan, rev. A)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū '96 - Kaimaku Ban (Japan, rev. A)</description>
 		<year>1996</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-A57J-JPN" />
@@ -33777,7 +33777,7 @@ Alternate board (XL-1)
 
 	<software name="powyak2a" cloneof="powyak2">
 		<!-- single cartridge source: Yakushi~Kabuto -->
-		<description>Jikkyou Powerful Pro Yakyuu 2 (Japan, rev. A)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 2 (Japan, rev. A)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-AP2J-JPN" />
@@ -45209,7 +45209,7 @@ List of unclassified roms
 	</software>
 
 	<software name="powyak2">
-		<description>Jikkyou Powerful Pro Yakyuu 2 (Japan, rev. B)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 2 (Japan, rev. B)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-AP2J-JPN" />
@@ -45227,7 +45227,7 @@ List of unclassified roms
 	</software>
 
 	<software name="powyk397">
-		<description>Jikkyou Powerful Pro Yakyuu 3 - '97 Haru (Japan, rev. A)</description>
+		<description>Jikkyou Pawafuru Puro Yakyū 3 - '97 Haru (Japan, rev. A)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="SHVC-AQ7J-JPN" />

--- a/src/mame/konami/ksys573.cpp
+++ b/src/mame/konami/ksys573.cpp
@@ -112,8 +112,8 @@ G GunMania                                            2000.07    G?906 JA       
 P Handle Champ                                        1997.12    GQ710 JA          (no CD)
 P Hyper Bishi Bashi Champ                             1998.07    GC876 EA          (no CD)
 P Hyper Bishi Bashi Champ - 2 Player                  1999.08    GC908 JA          908    A02
-P Jikkyou Powerful Pro Yakyuu EX                      1998.04    GX802 JA          802 JA B02
-P Jikkyou Powerful Pro Yakyuu EX 98                   1998.08
+P Jikkyou Pawafuru Puro Yakyu EX                      1998.04    GX802 JA          802 JA B02
+P Jikkyou Pawafuru Puro Yakyu EX 98                   1998.08
 AA Kick & Kick                                        2001       GNA36 EA          (no CD)
 P Konami 80's Arcade Gallery                          1998.11    GC826 JA          826 JA A01
 P Konami 80's AC Special                              1998       GC826 UA          826 UA A01
@@ -6341,8 +6341,8 @@ GAME( 1997, hndlchmpj, strgchmp, konami573n, hndlchmp,  ksys573_state, empty_ini
 GAME( 1998, darkhleg,  sys573,   konami573x, konami573, ksys573_state, empty_init,    ROT0,  "Konami", "Dark Horse Legend (GX706 VER. JAA)", MACHINE_IMPERFECT_SOUND )
 GAME( 1998, fbaitbc,   sys573,   fbaitbc,    fbaitbc,   ksys573_state, empty_init,    ROT0,  "Konami", "Fisherman's Bait - A Bass Challenge (GE765 VER. UAB)", MACHINE_IMPERFECT_SOUND )
 GAME( 1998, bassangl,  fbaitbc,  fbaitbc,    fbaitbc,   ksys573_state, empty_init,    ROT0,  "Konami", "Bass Angler (GE765 VER. JAA)", MACHINE_IMPERFECT_SOUND )
-GAME( 1998, powyakex,  sys573,   konami573x, konami573, ksys573_state, empty_init,    ROT0,  "Konami", "Jikkyou Powerful Pro Yakyuu EX (GX802 VER. JAB)", MACHINE_IMPERFECT_SOUND )
-GAME( 1998, jppyex98,  sys573,   konami573x, konami573, ksys573_state, empty_init,    ROT0,  "Konami", "Jikkyou Powerful Pro Yakyuu EX '98 (GC811 VER. JAA)", MACHINE_IMPERFECT_SOUND )
+GAME( 1998, powyakex,  sys573,   konami573x, konami573, ksys573_state, empty_init,    ROT0,  "Konami", "Jikkyou Pawafuru Puro Yakyu EX (GX802 VER. JAB)", MACHINE_IMPERFECT_SOUND )
+GAME( 1998, jppyex98,  sys573,   konami573x, konami573, ksys573_state, empty_init,    ROT0,  "Konami", "Jikkyou Pawafuru Puro Yakyu EX '98 (GC811 VER. JAA)", MACHINE_IMPERFECT_SOUND )
 GAME( 1998, konam80s,  sys573,   konami573x, konami573, ksys573_state, empty_init,    ROT90, "Konami", "Konami 80's AC Special (GC826 VER. EAA)", MACHINE_IMPERFECT_SOUND )
 GAME( 1998, konam80u,  konam80s, konami573x, konami573, ksys573_state, empty_init,    ROT90, "Konami", "Konami 80's AC Special (GC826 VER. UAA)", MACHINE_IMPERFECT_SOUND )
 GAME( 1998, konam80j,  konam80s, konami573x, konami573, ksys573_state, empty_init,    ROT90, "Konami", "Konami 80's Gallery (GC826 VER. JAA)", MACHINE_IMPERFECT_SOUND )

--- a/src/mame/skeleton/hudson_poems.cpp
+++ b/src/mame/skeleton/hudson_poems.cpp
@@ -901,7 +901,7 @@ CONS( 2005, marimba,      0,       0,      hudson_poems, hudson_poems, hudson_po
 // waits for 2c008f00 to become 0 (missing irq?) happens before it gets to the DMA transfers
 CONS( 2004, poemgolf,     0,       0,      hudson_poems, poemgolf,     hudson_poems_state, init_marimba, "Konami", "Soukai Golf Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 // waits for 2c005d00 to become 0 (missing irq?) happens before it gets to the DMA transfers
-CONS( 2004, poembase,     0,       0,      hudson_poems, poemgolf,     hudson_poems_state, init_marimba, "Konami", "Nekketsu Powerpro Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
+CONS( 2004, poembase,     0,       0,      hudson_poems, poemgolf,     hudson_poems_state, init_marimba, "Konami", "Nekketsu Pawapuro Champ (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 
 CONS( 2004, poemzet,      0,       0,      hudson_poems, poemzet,      hudson_poems_state, init_marimba, "Konami", "Zettai Zetsumei Dangerous Jiisan - Mini Game de Taiketsu ja!", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_NO_SOUND )
 


### PR DESCRIPTION
Looking to solicit opinions on this.

The 実況パワフルプロ野球 franchise is usually called “Jikkyou Powerful Pro Yakyuu” in English.  However, in Japanese media, it seems to be more frequently rendered in literal romaji as “JIKKYOU PAWAFURU PURO YAKŪ”.  You can see this in the attract sequences for the games on Konami System 573, for example (e.g. `powyakex`).

“Powerful” and “Pro” are definitely loanwords from English.  The MAME convention has always been to use standard English spellings for loanwords.  Also, if we switch to literal romaji, we’ll be the odd ones out as all the other software catalogues will still be using “Jikkyou Powerful Pro Yakyuu”.

So in this case, should “JIKKYOU PAWAFURU PURO YAKŪ” be treated as an official Latin script title and used for system and software descriptions?  Or should it be treated as a pronunciation guide so we keep the conventional spellings of the loanwords?