### PR TITLE
hash/scv.xml Fix BASIC Nyuumon entry to work properly

### DIFF
--- a/hash/scv.xml
+++ b/hash/scv.xml
@@ -89,10 +89,12 @@ Information found at http://www.rhod.fr/yeno_epoch.html
 		<year>1985</year>
 		<publisher>Epoch</publisher>
 		<part name="cart" interface="scv_cart">
-			<feature name="slot" value="rom32k" />
+			<feature name="slot" value="rom32k_ram" />
 			<dataarea name="rom" size="32768">
 				<rom name="basic.bin" size="32768" crc="ca965c2b" sha1="c68e2b81dec2c83e2aa5626c8df4011eada45245" offset="0000" />
 			</dataarea>
+			<!-- 8KB? RAM on cartridge -->
+			<dataarea name="ram" size="8192" />
 		</part>
 	</software>
 


### PR DESCRIPTION
BASIC Nyuumon contains on-cart battery-backed RAM (the cartridge includes a battery compartment for it, and http://takeda-toshiya.my.coocan.jp/scv/scv.pdf even uses it as an example of on-cart RAM), though scv.xml does not specify this, causing the title to freeze after selecting an option on its title screen.