### PR TITLE
trs/mc10.cpp: add minimum rom size and block size for cartridge rom, clean global namespace

### DIFF
--- a/src/devices/bus/mc10/mc10_cart.cpp
+++ b/src/devices/bus/mc10/mc10_cart.cpp
@@ -108,6 +108,18 @@ std::pair<std::error_condition, std::string> mc10cart_slot_device::call_load()
 				image_error::INVALIDLENGTH,
 				util::string_format("Unsupported cartridge size (must be no more than %u bytes)", m_cart->max_rom_length()));
 	}
+	else if (len < m_cart->min_rom_length())
+	{
+		return std::make_pair(
+				image_error::INVALIDLENGTH,
+				util::string_format("Unsupported cartridge size (must be at least %u bytes)", m_cart->min_rom_length()));
+	}
+	else if (len % m_cart->block_rom_length() != 0)
+	{
+		return std::make_pair(
+				image_error::INVALIDLENGTH,
+				util::string_format("Unsupported cartridge size (must be a multiple of %u bytes)", m_cart->block_rom_length()));
+	}
 
 	if (!loaded_through_softlist())
 	{
@@ -176,10 +188,20 @@ void device_mc10cart_interface::interface_pre_start()
 }
 
 /*-------------------------------------------------
-    max_rom_length
+    rom size constraints
 -------------------------------------------------*/
 
 int device_mc10cart_interface::max_rom_length() const
+{
+	return 0;
+}
+
+int device_mc10cart_interface::min_rom_length() const
+{
+	return 0;
+}
+
+int device_mc10cart_interface::block_rom_length() const
 {
 	return 0;
 }

--- a/src/devices/bus/mc10/mc10_cart.cpp
+++ b/src/devices/bus/mc10/mc10_cart.cpp
@@ -108,18 +108,6 @@ std::pair<std::error_condition, std::string> mc10cart_slot_device::call_load()
 				image_error::INVALIDLENGTH,
 				util::string_format("Unsupported cartridge size (must be no more than %u bytes)", m_cart->max_rom_length()));
 	}
-	else if (len < m_cart->min_rom_length())
-	{
-		return std::make_pair(
-				image_error::INVALIDLENGTH,
-				util::string_format("Unsupported cartridge size (must be at least %u bytes)", m_cart->min_rom_length()));
-	}
-	else if (len % m_cart->block_rom_length() != 0)
-	{
-		return std::make_pair(
-				image_error::INVALIDLENGTH,
-				util::string_format("Unsupported cartridge size (must be a multiple of %u bytes)", m_cart->block_rom_length()));
-	}
 
 	if (!loaded_through_softlist())
 	{
@@ -192,16 +180,6 @@ void device_mc10cart_interface::interface_pre_start()
 -------------------------------------------------*/
 
 int device_mc10cart_interface::max_rom_length() const
-{
-	return 0;
-}
-
-int device_mc10cart_interface::min_rom_length() const
-{
-	return 0;
-}
-
-int device_mc10cart_interface::block_rom_length() const
 {
 	return 0;
 }

--- a/src/devices/bus/mc10/mc10_cart.cpp
+++ b/src/devices/bus/mc10/mc10_cart.cpp
@@ -213,7 +213,7 @@ void mc10_cart_add_basic_devices(device_slot_interface &device)
 void alice_cart_add_basic_devices(device_slot_interface &device)
 {
 	// basic devices
-	device.option_add("alice128", ALICE_PAK_MCX128);
+	device.option_add("mcx128", MC10_PAK_MCX128);
 	device.option_add("pak", MC10_PAK);
 	device.option_add("ram", MC10_PAK_RAM);
 	device.option_add("multi", ALICE_MULTIPORTS_EXT);

--- a/src/devices/bus/mc10/mc10_cart.cpp
+++ b/src/devices/bus/mc10/mc10_cart.cpp
@@ -200,7 +200,7 @@ std::pair<std::error_condition, std::string> device_mc10cart_interface::load()
 void mc10_cart_add_basic_devices(device_slot_interface &device)
 {
 	// basic devices
-	device.option_add("mcx128", MC10_PAK_MCX128);
+	device.option_add("mcx128", MC10_PAK_MCX128).default_bios("mc10");
 	device.option_add("pak", MC10_PAK);
 	device.option_add("ram", MC10_PAK_RAM);
 	device.option_add("multi", ALICE_MULTIPORTS_EXT);
@@ -213,7 +213,7 @@ void mc10_cart_add_basic_devices(device_slot_interface &device)
 void alice_cart_add_basic_devices(device_slot_interface &device)
 {
 	// basic devices
-	device.option_add("mcx128", MC10_PAK_MCX128);
+	device.option_add("mcx128", MC10_PAK_MCX128).default_bios("alice");
 	device.option_add("pak", MC10_PAK);
 	device.option_add("ram", MC10_PAK_RAM);
 	device.option_add("multi", ALICE_MULTIPORTS_EXT);

--- a/src/devices/bus/mc10/mc10_cart.h
+++ b/src/devices/bus/mc10/mc10_cart.h
@@ -83,6 +83,9 @@ public:
 	virtual ~device_mc10cart_interface();
 
 	virtual int max_rom_length() const;
+	virtual int min_rom_length() const;
+	virtual int block_rom_length() const;
+
 	virtual std::pair<std::error_condition, std::string> load();
 
 protected:

--- a/src/devices/bus/mc10/mc10_cart.h
+++ b/src/devices/bus/mc10/mc10_cart.h
@@ -83,8 +83,6 @@ public:
 	virtual ~device_mc10cart_interface();
 
 	virtual int max_rom_length() const;
-	virtual int min_rom_length() const;
-	virtual int block_rom_length() const;
 
 	virtual std::pair<std::error_condition, std::string> load();
 

--- a/src/devices/bus/mc10/mcx128.cpp
+++ b/src/devices/bus/mc10/mcx128.cpp
@@ -75,7 +75,6 @@ protected:
 	// device_t implementation
 	virtual void device_start() override;
 	virtual void device_reset() override;
-	virtual void device_post_load() override;
 
 	virtual const tiny_rom_entry *device_rom_region() const override
 	{
@@ -287,11 +286,6 @@ void mc10_pak_mcx128_device::device_reset()
 {
 	ram_bank_cr = 0;
 	rom_map_cr = 0;
-	update_banks();
-}
-
-void mc10_pak_mcx128_device::device_post_load()
-{
 	update_banks();
 }
 

--- a/src/devices/bus/mc10/mcx128.cpp
+++ b/src/devices/bus/mc10/mcx128.cpp
@@ -43,6 +43,7 @@
 //#define VERBOSE (LOG_GENERAL)
 #include "logmacro.h"
 
+namespace {
 
 ROM_START(mc10_mcx128)
 	ROM_REGION(0x4000, "eprom", ROMREGION_ERASE00)
@@ -106,8 +107,6 @@ private:
 	void update_banks();
 
 };
-
-DEFINE_DEVICE_TYPE_PRIVATE(MC10_PAK_MCX128, device_mc10cart_interface, mc10_pak_mcx128_device, "mc10_mcx128", "Darren Atkinson's MCX-128 cartridge")
 
 //-------------------------------------------------
 //  mc10_pak_device - constructor
@@ -362,4 +361,7 @@ alice_pak_mcx128_device::alice_pak_mcx128_device(const machine_config &mconfig, 
 {
 }
 
+} // anonymous namespace
+
+DEFINE_DEVICE_TYPE_PRIVATE(MC10_PAK_MCX128, device_mc10cart_interface, mc10_pak_mcx128_device, "mc10_mcx128", "Darren Atkinson's MCX-128 cartridge")
 DEFINE_DEVICE_TYPE_PRIVATE(ALICE_PAK_MCX128, device_mc10cart_interface, alice_pak_mcx128_device, "alice_mcx128", "Darren Atkinson's MCX-128 cartridge (Alice ROM)")

--- a/src/devices/bus/mc10/mcx128.cpp
+++ b/src/devices/bus/mc10/mcx128.cpp
@@ -114,11 +114,6 @@ mc10_pak_mcx128_device::mc10_pak_mcx128_device(const machine_config &mconfig, co
 	, m_view(*this, "mcx_view")
 	, m_bank(*this, "bank%u", 0U)
 {
-	const char *driver_name = mconfig.gamedrv().name;
-	if (strcmp(driver_name, "alice") == 0)
-	 	set_default_bios_tag("alice");
-	else
-		set_default_bios_tag("mc10");
 }
 
 const tiny_rom_entry * mc10_pak_mcx128_device::device_rom_region() const

--- a/src/devices/bus/mc10/mcx128.cpp
+++ b/src/devices/bus/mc10/mcx128.cpp
@@ -45,14 +45,15 @@
 
 namespace {
 
-ROM_START(mc10_mcx128)
+ROM_START(mcx128)
 	ROM_REGION(0x4000, "eprom", ROMREGION_ERASE00)
-	ROM_LOAD("mcx128bas.rom", 0x0000, 0x4000, CRC(11202e4b) SHA1(36c30d0f198a1bffee88ef29d92f2401447a91f4))
-ROM_END
+	ROM_DEFAULT_BIOS("mc10_mcx128")
 
-ROM_START(alice_mcx128)
-	ROM_REGION(0x4000, "eprom", ROMREGION_ERASE00)
-	ROM_LOAD("alice128bas.rom", 0x0000, 0x4000, CRC(a737544a) SHA1(c8fd92705fc42deb6a0ffac6274e27fd61ecd4cc))
+	ROM_SYSTEM_BIOS(0, "mc10_mcx128", "Darren Atkinson's MCX-128 cartridge")
+	ROMX_LOAD("mcx128bas.rom", 0x0000, 0x4000, CRC(11202e4b) SHA1(36c30d0f198a1bffee88ef29d92f2401447a91f4), ROM_BIOS(0))
+
+	ROM_SYSTEM_BIOS(1, "alice_mcx128", "Darren Atkinson's MCX-128 cartridge for Alice")
+	ROMX_LOAD("alice128bas.rom", 0x0000, 0x4000, CRC(a737544a) SHA1(c8fd92705fc42deb6a0ffac6274e27fd61ecd4cc), ROM_BIOS(1))	
 ROM_END
 
 //**************************************************************************
@@ -70,17 +71,11 @@ public:
 	mc10_pak_mcx128_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
-	// construction/destruction
-	mc10_pak_mcx128_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
-
 	// device_t implementation
 	virtual void device_start() override;
 	virtual void device_reset() override;
 
-	virtual const tiny_rom_entry *device_rom_region() const override
-	{
-		return ROM_NAME(mc10_mcx128);
-	}
+	virtual const tiny_rom_entry *device_rom_region() const override;
 
 	u8 control_register_read(offs_t offset);
 	void control_register_write(offs_t offset, u8 data);
@@ -113,18 +108,24 @@ private:
 //-------------------------------------------------
 
 mc10_pak_mcx128_device::mc10_pak_mcx128_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	:mc10_pak_mcx128_device(mconfig, MC10_PAK_MCX128, tag, owner, clock)
-{
-}
-
-mc10_pak_mcx128_device::mc10_pak_mcx128_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
-	: device_t(mconfig, type, tag, owner, clock)
+	: device_t(mconfig, MC10_PAK_MCX128, tag, owner, clock)
 	, device_mc10cart_interface(mconfig, *this)
 	, m_share(*this, "ext_ram", 1024*128, ENDIANNESS_BIG)
 	, m_view(*this, "mcx_view")
 	, m_bank(*this, "bank%u", 0U)
 {
+	const char *driver_name = mconfig.gamedrv().name;
+	if (strcmp(driver_name, "alice") == 0)
+	 	set_default_bios_tag("alice_mcx128");
+	else
+		set_default_bios_tag("mc10_mcx128");
 }
+
+const tiny_rom_entry * mc10_pak_mcx128_device::device_rom_region() const
+{
+	return ROM_NAME(mcx128);
+}
+
 
 void mc10_pak_mcx128_device::view_map0(address_map &map)
 {
@@ -338,30 +339,6 @@ void mc10_pak_mcx128_device::update_banks()
 	LOG("view select: %d, bank cr: %d\n", (bank1 << 2) | (rom_map_cr & 0x03), ram_bank_cr & 0x03 );
 }
 
-class alice_pak_mcx128_device : public mc10_pak_mcx128_device
-{
-public:
-	// construction/destruction
-	alice_pak_mcx128_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
-
-protected:
-	// device-level overrides
-	virtual const tiny_rom_entry *device_rom_region() const override
-	{
-		return ROM_NAME(alice_mcx128);
-	}
-};
-
-//-------------------------------------------------
-//  mc10_pak_device - constructor
-//-------------------------------------------------
-
-alice_pak_mcx128_device::alice_pak_mcx128_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: mc10_pak_mcx128_device(mconfig, ALICE_PAK_MCX128, tag, owner, clock)
-{
-}
-
 } // anonymous namespace
 
-DEFINE_DEVICE_TYPE_PRIVATE(MC10_PAK_MCX128, device_mc10cart_interface, mc10_pak_mcx128_device, "mc10_mcx128", "Darren Atkinson's MCX-128 cartridge")
-DEFINE_DEVICE_TYPE_PRIVATE(ALICE_PAK_MCX128, device_mc10cart_interface, alice_pak_mcx128_device, "alice_mcx128", "Darren Atkinson's MCX-128 cartridge (Alice ROM)")
+DEFINE_DEVICE_TYPE_PRIVATE(MC10_PAK_MCX128, device_mc10cart_interface, mc10_pak_mcx128_device, "mcx128", "Darren Atkinson's MCX-128 cartridge")

--- a/src/devices/bus/mc10/mcx128.cpp
+++ b/src/devices/bus/mc10/mcx128.cpp
@@ -47,12 +47,12 @@ namespace {
 
 ROM_START(mcx128)
 	ROM_REGION(0x4000, "eprom", ROMREGION_ERASE00)
-	ROM_DEFAULT_BIOS("mc10_mcx128")
+	ROM_DEFAULT_BIOS("mc10")
 
-	ROM_SYSTEM_BIOS(0, "mc10_mcx128", "Darren Atkinson's MCX-128 cartridge")
+	ROM_SYSTEM_BIOS(0, "mc10", "Darren Atkinson's MCX-128 cartridge")
 	ROMX_LOAD("mcx128bas.rom", 0x0000, 0x4000, CRC(11202e4b) SHA1(36c30d0f198a1bffee88ef29d92f2401447a91f4), ROM_BIOS(0))
 
-	ROM_SYSTEM_BIOS(1, "alice_mcx128", "Darren Atkinson's MCX-128 cartridge for Alice")
+	ROM_SYSTEM_BIOS(1, "alice", "Darren Atkinson's MCX-128 cartridge for Alice")
 	ROMX_LOAD("alice128bas.rom", 0x0000, 0x4000, CRC(a737544a) SHA1(c8fd92705fc42deb6a0ffac6274e27fd61ecd4cc), ROM_BIOS(1))	
 ROM_END
 
@@ -116,9 +116,9 @@ mc10_pak_mcx128_device::mc10_pak_mcx128_device(const machine_config &mconfig, co
 {
 	const char *driver_name = mconfig.gamedrv().name;
 	if (strcmp(driver_name, "alice") == 0)
-	 	set_default_bios_tag("alice_mcx128");
+	 	set_default_bios_tag("alice");
 	else
-		set_default_bios_tag("mc10_mcx128");
+		set_default_bios_tag("mc10");
 }
 
 const tiny_rom_entry * mc10_pak_mcx128_device::device_rom_region() const

--- a/src/devices/bus/mc10/mcx128.h
+++ b/src/devices/bus/mc10/mcx128.h
@@ -9,7 +9,6 @@
 
 // device type definition
 DECLARE_DEVICE_TYPE(MC10_PAK_MCX128, device_mc10cart_interface)
-DECLARE_DEVICE_TYPE(ALICE_PAK_MCX128, device_mc10cart_interface)
 
 #endif // MAME_BUS_MC10_MC10_MCX128_H
 

--- a/src/devices/bus/mc10/multiports_ext.cpp
+++ b/src/devices/bus/mc10/multiports_ext.cpp
@@ -121,8 +121,7 @@ void mc10_multiports_ext_device::control_register_write(offs_t offset, u8 data)
 std::pair<std::error_condition, std::string> mc10_multiports_ext_device::load()
 {
 	memory_region *const romregion(memregion("^rom"));
-	if (romregion->bytes() < (0x2000 * 8))
-		return std::make_pair(image_error::INVALIDLENGTH, "Cartridge ROM must be at least 64KB");
+	assert(romregion != nullptr);
 
 	m_bank->configure_entries(0, 8, romregion->base(), 0x2000);
 

--- a/src/devices/bus/mc10/multiports_ext.cpp
+++ b/src/devices/bus/mc10/multiports_ext.cpp
@@ -54,11 +54,9 @@ protected:
 	void control_register_write(offs_t offset, u8 data);
 
 	void multiports_mem(address_map &map);
-	void update_bank();
 
 private:
 	memory_bank_creator m_bank;
-	uint8_t rom_bank_index;
 	memory_share_creator<u8> m_extention_ram;
 };
 
@@ -75,7 +73,6 @@ mc10_multiports_ext_device::mc10_multiports_ext_device(const machine_config &mco
 	: device_t(mconfig, type, tag, owner, clock)
 	, device_mc10cart_interface(mconfig, *this)
 	, m_bank(*this, "cart_bank")
-	, rom_bank_index(0)
 	, m_extention_ram(*this, "ext_ram", 1024 * 16, ENDIANNESS_BIG)
 {
 }
@@ -112,22 +109,15 @@ void mc10_multiports_ext_device::device_start()
 
 void mc10_multiports_ext_device::device_reset()
 {
-	rom_bank_index = 0;
-	update_bank();
+	m_bank->set_entry(0);
 }
 
 void mc10_multiports_ext_device::control_register_write(offs_t offset, u8 data)
 {
 	if (offset < 0x1000)
 	{
-		rom_bank_index = data & 0x07;
-		update_bank();
+		m_bank->set_entry(data & 0x07);
 	}
-}
-
-void mc10_multiports_ext_device::update_bank()
-{
-	m_bank->set_entry(rom_bank_index);
 }
 
 std::pair<std::error_condition, std::string> mc10_multiports_ext_device::load()

--- a/src/devices/bus/mc10/multiports_ext.cpp
+++ b/src/devices/bus/mc10/multiports_ext.cpp
@@ -38,6 +38,7 @@ public:
 	virtual int max_rom_length() const override;
 	virtual int min_rom_length() const override;
 	virtual int block_rom_length() const override;
+
 	virtual std::pair<std::error_condition, std::string> load() override;
 
 protected:

--- a/src/devices/bus/mc10/multiports_ext.cpp
+++ b/src/devices/bus/mc10/multiports_ext.cpp
@@ -24,7 +24,6 @@
 #include "emu.h"
 #include "multiports_ext.h"
 
-
 namespace {
 
 //**************************************************************************
@@ -109,7 +108,8 @@ void mc10_multiports_ext_device::device_start()
 
 void mc10_multiports_ext_device::device_reset()
 {
-	m_bank->set_entry(0);
+	rom_bank_index = 0;
+	update_bank();
 }
 
 void mc10_multiports_ext_device::control_register_write(offs_t offset, u8 data)

--- a/src/devices/bus/mc10/multiports_ext.cpp
+++ b/src/devices/bus/mc10/multiports_ext.cpp
@@ -87,12 +87,12 @@ int mc10_multiports_ext_device::max_rom_length() const
 
 int mc10_multiports_ext_device::min_rom_length() const
 {
-	return 1024 * 16;
+	return 1024 * 8;
 }
 
 int mc10_multiports_ext_device::block_rom_length() const
 {
-	return 1024 * 16;
+	return 1024 * 8;
 }
 
 void mc10_multiports_ext_device::multiports_mem(address_map &map)

--- a/src/devices/bus/mc10/multiports_ext.cpp
+++ b/src/devices/bus/mc10/multiports_ext.cpp
@@ -37,6 +37,8 @@ public:
 	mc10_multiports_ext_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual int max_rom_length() const override;
+	virtual int min_rom_length() const override;
+	virtual int block_rom_length() const override;
 	virtual std::pair<std::error_condition, std::string> load() override;
 
 protected:
@@ -78,6 +80,16 @@ mc10_multiports_ext_device::mc10_multiports_ext_device(const machine_config &mco
 int mc10_multiports_ext_device::max_rom_length() const
 {
 	return 1024 * 64;
+}
+
+int mc10_multiports_ext_device::min_rom_length() const
+{
+	return 1024 * 16;
+}
+
+int mc10_multiports_ext_device::block_rom_length() const
+{
+	return 1024 * 16;
 }
 
 void mc10_multiports_ext_device::multiports_mem(address_map &map)

--- a/src/devices/bus/mc10/multiports_ext.cpp
+++ b/src/devices/bus/mc10/multiports_ext.cpp
@@ -1,3 +1,6 @@
+// license:BSD-3-Clause
+// copyright-holders:S. Glaize
+
 /***************************************************************************
 
     multiports_ext.cpp

--- a/src/devices/bus/mc10/multiports_ext.cpp
+++ b/src/devices/bus/mc10/multiports_ext.cpp
@@ -115,7 +115,15 @@ void mc10_multiports_ext_device::device_reset()
 void mc10_multiports_ext_device::control_register_write(offs_t offset, u8 data)
 {
 	if (offset < 0x1000)
-		m_bank->set_entry(data & 0x07);
+	{
+		rom_bank_index = data & 0x07;
+		update_bank();
+	}
+}
+
+void mc10_multiports_ext_device::update_bank()
+{
+	m_bank->set_entry(rom_bank_index);
 }
 
 std::pair<std::error_condition, std::string> mc10_multiports_ext_device::load()

--- a/src/devices/bus/mc10/multiports_ext.cpp
+++ b/src/devices/bus/mc10/multiports_ext.cpp
@@ -3,32 +3,32 @@
 
 /***************************************************************************
 
-	multiports_ext.cpp
+    multiports_ext.cpp
 
-	Emulation of the Alice Multiports Extension
+    Emulation of the Alice Multiports Extension
 
-	Features:
-		The extension provides an extension doubler and two joystick ports.
+    Features:
+        The extension provides an extension doubler and two joystick ports.
 
-		The extension also provides (for the whole Alice family and MC-10):
-		- 16K of RAM expansion ($5000-$8FFF)
-		- 64K of ROM expansion in two possible configurations:
-			- 8K of ROM between $1000 and $2FFF, as 8 banks (Cartridge mode).
-			- 16K of ROM between $C000 and $FFFF, as 4 banks (ROM mode).
+        The extension also provides (for the whole Alice family and MC-10):
+        - 16K of RAM expansion ($5000-$8FFF)
+        - 64K of ROM expansion in two possible configurations:
+            - 8K of ROM between $1000 and $2FFF, as 8 banks (Cartridge mode).
+            - 16K of ROM between $C000 and $FFFF, as 4 banks (ROM mode).
 
-		Only the RAM/ROM expansion is emulated here.
+        Only the RAM/ROM expansion is emulated here.
 
-	Banks are selected by writing to:
-		- $1000 to $1FFF in Cartridge mode (number of bank between 0 and 7)
-		- $C000 to $CFFF in ROM mode (number of bank between 0 and 3)
+    Banks are selected by writing to:
+        - $1000 to $1FFF in Cartridge mode (number of bank between 0 and 7)
+        - $C000 to $CFFF in ROM mode (number of bank between 0 and 3)
 
 ***************************************************************************/
 
 #include "emu.h"
 #include "multiports_ext.h"
 
-namespace
-{
+
+namespace {
 
 //**************************************************************************
 //  TYPE DECLARATIONS
@@ -69,7 +69,10 @@ mc10_multiports_ext_device::mc10_multiports_ext_device(const machine_config &mco
 }
 
 mc10_multiports_ext_device::mc10_multiports_ext_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
-	: device_t(mconfig, type, tag, owner, clock), device_mc10cart_interface(mconfig, *this), m_bank(*this, "cart_bank"), m_extention_ram(*this, "ext_ram", 1024 * 16, ENDIANNESS_BIG)
+	: device_t(mconfig, type, tag, owner, clock)
+	, device_mc10cart_interface(mconfig, *this)
+	, m_bank(*this, "cart_bank")
+	, m_extention_ram(*this, "ext_ram", 1024 * 16, ENDIANNESS_BIG)
 {
 }
 

--- a/src/devices/bus/mc10/multiports_ext.cpp
+++ b/src/devices/bus/mc10/multiports_ext.cpp
@@ -3,31 +3,32 @@
 
 /***************************************************************************
 
-    multiports_ext.cpp
+	multiports_ext.cpp
 
-    Emulation of the Alice Multiports Extension
+	Emulation of the Alice Multiports Extension
 
-    Features:
-        The extension provides an extension doubler and two joystick ports.
+	Features:
+		The extension provides an extension doubler and two joystick ports.
 
-        The extension also provides (for the whole Alice family and MC-10):
-        - 16K of RAM expansion ($5000-$8FFF)
-        - 64K of ROM expansion in two possible configurations:
-            - 8K of ROM between $1000 and $2FFF, as 8 banks (Cartridge mode).
-            - 16K of ROM between $C000 and $FFFF, as 4 banks (ROM mode).
+		The extension also provides (for the whole Alice family and MC-10):
+		- 16K of RAM expansion ($5000-$8FFF)
+		- 64K of ROM expansion in two possible configurations:
+			- 8K of ROM between $1000 and $2FFF, as 8 banks (Cartridge mode).
+			- 16K of ROM between $C000 and $FFFF, as 4 banks (ROM mode).
 
-        Only the RAM/ROM expansion is emulated here.
+		Only the RAM/ROM expansion is emulated here.
 
-    Banks are selected by writing to:
-        - $1000 to $1FFF in Cartridge mode (number of bank between 0 and 7)
-        - $C000 to $CFFF in ROM mode (number of bank between 0 and 3)
+	Banks are selected by writing to:
+		- $1000 to $1FFF in Cartridge mode (number of bank between 0 and 7)
+		- $C000 to $CFFF in ROM mode (number of bank between 0 and 3)
 
 ***************************************************************************/
 
 #include "emu.h"
 #include "multiports_ext.h"
 
-namespace {
+namespace
+{
 
 //**************************************************************************
 //  TYPE DECLARATIONS
@@ -39,8 +40,6 @@ public:
 	mc10_multiports_ext_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual int max_rom_length() const override;
-	virtual int min_rom_length() const override;
-	virtual int block_rom_length() const override;
 
 	virtual std::pair<std::error_condition, std::string> load() override;
 
@@ -70,26 +69,13 @@ mc10_multiports_ext_device::mc10_multiports_ext_device(const machine_config &mco
 }
 
 mc10_multiports_ext_device::mc10_multiports_ext_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
-	: device_t(mconfig, type, tag, owner, clock)
-	, device_mc10cart_interface(mconfig, *this)
-	, m_bank(*this, "cart_bank")
-	, m_extention_ram(*this, "ext_ram", 1024 * 16, ENDIANNESS_BIG)
+	: device_t(mconfig, type, tag, owner, clock), device_mc10cart_interface(mconfig, *this), m_bank(*this, "cart_bank"), m_extention_ram(*this, "ext_ram", 1024 * 16, ENDIANNESS_BIG)
 {
 }
 
 int mc10_multiports_ext_device::max_rom_length() const
 {
 	return 1024 * 64;
-}
-
-int mc10_multiports_ext_device::min_rom_length() const
-{
-	return 1024 * 8;
-}
-
-int mc10_multiports_ext_device::block_rom_length() const
-{
-	return 1024 * 8;
 }
 
 void mc10_multiports_ext_device::multiports_mem(address_map &map)
@@ -124,6 +110,23 @@ std::pair<std::error_condition, std::string> mc10_multiports_ext_device::load()
 {
 	memory_region *const romregion(memregion("^rom"));
 	assert(romregion != nullptr);
+
+	const u32 min_rom_length = 8 * 1024;
+	const u32 block_rom_length = 8 * 1024;
+	const u32 len = romregion->bytes();
+
+	if (len < min_rom_length)
+	{
+		return std::make_pair(
+			image_error::INVALIDLENGTH,
+			util::string_format("Unsupported cartridge size (must be at least %u bytes)", min_rom_length));
+	}
+	else if (len % block_rom_length != 0)
+	{
+		return std::make_pair(
+			image_error::INVALIDLENGTH,
+			util::string_format("Unsupported cartridge size (must be a multiple of %u bytes)", block_rom_length));
+	}
 
 	m_bank->configure_entries(0, 8, romregion->base(), 0x2000);
 

--- a/src/devices/bus/mc10/multiports_ext.h
+++ b/src/devices/bus/mc10/multiports_ext.h
@@ -5,7 +5,6 @@
 
 #include "mc10_cart.h"
 
-// device type definition
 DECLARE_DEVICE_TYPE(ALICE_MULTIPORTS_EXT, device_mc10cart_interface)
 
 #endif // MAME_BUS_MC10_MC10_MULTIPORTS_EXT_H

--- a/src/devices/bus/mc10/pak.cpp
+++ b/src/devices/bus/mc10/pak.cpp
@@ -11,11 +11,34 @@
 #include "emu.h"
 #include "pak.h"
 
+
+namespace {
+
 //**************************************************************************
-//  GLOBAL VARIABLES
+//  TYPE DEFINITIONS
 //**************************************************************************
 
-DEFINE_DEVICE_TYPE(MC10_PAK, mc10_pak_device, "mc10pak", "MC-10 Program PAK")
+// ======================> mc10_pak_device
+
+class mc10_pak_device :
+		public device_t,
+		public device_mc10cart_interface
+{
+public:
+	// construction/destruction
+	mc10_pak_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	virtual int max_rom_length() const override;
+	virtual int block_rom_length() const override;
+
+	virtual std::pair<std::error_condition, std::string> load() override;
+
+protected:
+	mc10_pak_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+
+	// device_t implementation
+	virtual void device_start() override;
+};
 
 //**************************************************************************
 //  LIVE DEVICE
@@ -71,3 +94,7 @@ std::pair<std::error_condition, std::string> mc10_pak_device::load()
 
 	return std::make_pair(std::error_condition(), std::string());
 }
+
+} // anonymous namespace
+
+DEFINE_DEVICE_TYPE_PRIVATE(MC10_PAK, device_mc10cart_interface, mc10_pak_device, "mc10pak", "MC-10 Program PAK")

--- a/src/devices/bus/mc10/pak.cpp
+++ b/src/devices/bus/mc10/pak.cpp
@@ -64,8 +64,7 @@ void mc10_pak_device::device_start()
 std::pair<std::error_condition, std::string> mc10_pak_device::load()
 {
 	memory_region *const romregion(memregion("^rom"));
-	if (!romregion)
-		return std::make_pair(image_error::BADSOFTWARE, "Software item lacks 'rom' data area");
+	assert(romregion != nullptr);
 
 	// if the host has supplied a ROM space, install it
 	owning_slot().memspace().install_rom(0x5000, 0x5000 + romregion->bytes(), romregion->base());

--- a/src/devices/bus/mc10/pak.cpp
+++ b/src/devices/bus/mc10/pak.cpp
@@ -36,12 +36,17 @@ mc10_pak_device::mc10_pak_device(const machine_config &mconfig, const char *tag,
 }
 
 //-------------------------------------------------
-//  max_rom_length - device-specific startup
+//  rom constraints
 //-------------------------------------------------
 
 int mc10_pak_device::max_rom_length() const
 {
 	return 1024 * 16;
+}
+
+int mc10_pak_device::block_rom_length() const
+{
+	return 1;
 }
 
 //-------------------------------------------------

--- a/src/devices/bus/mc10/pak.cpp
+++ b/src/devices/bus/mc10/pak.cpp
@@ -29,7 +29,6 @@ public:
 	mc10_pak_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual int max_rom_length() const override;
-	virtual int block_rom_length() const override;
 
 	virtual std::pair<std::error_condition, std::string> load() override;
 
@@ -65,11 +64,6 @@ mc10_pak_device::mc10_pak_device(const machine_config &mconfig, const char *tag,
 int mc10_pak_device::max_rom_length() const
 {
 	return 1024 * 16;
-}
-
-int mc10_pak_device::block_rom_length() const
-{
-	return 1;
 }
 
 //-------------------------------------------------

--- a/src/devices/bus/mc10/pak.h
+++ b/src/devices/bus/mc10/pak.h
@@ -22,6 +22,8 @@ public:
 	mc10_pak_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual int max_rom_length() const override;
+	virtual int block_rom_length() const override;
+
 	virtual std::pair<std::error_condition, std::string> load() override;
 
 protected:

--- a/src/devices/bus/mc10/pak.h
+++ b/src/devices/bus/mc10/pak.h
@@ -7,33 +7,6 @@
 
 #include "mc10_cart.h"
 
-//**************************************************************************
-//  TYPE DEFINITIONS
-//**************************************************************************
-
-// ======================> mc10_pak_device
-
-class mc10_pak_device :
-		public device_t,
-		public device_mc10cart_interface
-{
-public:
-	// construction/destruction
-	mc10_pak_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
-
-	virtual int max_rom_length() const override;
-	virtual int block_rom_length() const override;
-
-	virtual std::pair<std::error_condition, std::string> load() override;
-
-protected:
-	mc10_pak_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
-
-	// device_t implementation
-	virtual void device_start() override;
-};
-
-// device type definitions
-DECLARE_DEVICE_TYPE(MC10_PAK, mc10_pak_device)
+DECLARE_DEVICE_TYPE(MC10_PAK, device_mc10cart_interface)
 
 #endif // MAME_BUS_MC10_MC10_PAK_H


### PR DESCRIPTION
Resolving the comments on #12080

- Clean some mentioned code aspects
- Specify the ROM minimum size and block size
- Sort includes
- Clean the global namespace
- Add license lines

Report the comments on other previously written MC10 cart devices.