### PR TITLE
f1lap has an alternate Japanese (only?) revision (currently undumped)

### DIFF
--- a/src/mame/sega/segas32.cpp
+++ b/src/mame/sega/segas32.cpp
@@ -5974,7 +5974,7 @@ GAME( 1991, f1enj,     f1en,     sega_system32_dual_direct, f1en,     segas32_ne
 
 GAME( 1993, f1lap,     0,        sega_system32_analog,      f1lap,    segas32_new_state, init_f1lap,    ROT0, "Sega",   "F1 Super Lap (World)", MACHINE_IMPERFECT_GRAPHICS )
 GAME( 1993, f1lapt,    f1lap,    sega_system32_analog,      f1lap,    segas32_new_state, init_f1lapt,   ROT0, "Sega",   "F1 Super Lap (World, Unprotected)", MACHINE_IMPERFECT_GRAPHICS ) /* Factory unprotected */
-GAME( 1993, f1lapj,    f1lap,    sega_system32_analog,      f1lap,    segas32_new_state, init_f1lap,    ROT0, "Sega",   "F1 Super Lap (Japan)", MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1993, f1lapj,    f1lap,    sega_system32_analog,      f1lap,    segas32_new_state, init_f1lap,    ROT0, "Sega",   "F1 Super Lap (Japan)", MACHINE_IMPERFECT_GRAPHICS ) /* there is an alternate revision with different team choices depending on player ID */
 
 GAME( 1992, ga2,       0,        sega_system32_ga2,         ga2,      segas32_new_state, init_ga2,      ROT0, "Sega",   "Golden Axe: The Revenge of Death Adder (World, Rev B)", MACHINE_IMPERFECT_GRAPHICS )
 GAME( 1992, ga2u,      ga2,      sega_system32_ga2,         ga2u,     segas32_new_state, init_ga2,      ROT0, "Sega",   "Golden Axe: The Revenge of Death Adder (US, Rev A)", MACHINE_IMPERFECT_GRAPHICS )


### PR DESCRIPTION
[Tweeted about this in the past.](https://twitter.com/FMecha_EXE/status/1468974622930472962)

[Another video of the alternate revision.](https://www.youtube.com/watch?v=vmEh2L3omfA)

Currently, all f1lap sets have the following:

- ID 1 has Lotus, Williams, and Minardi
- ID 2 has Ligier, McLaren, and Dallara/Scuderia Italia

In the tweet I quoted and in the YT video, these revisions have:

- ID 1 has Ferrari, Williams, and Footwork
- ID 2 has Benetton, McLaren, and Venturi/Larrousse