### PR TITLE
cpu/hcd62121: Implement missing mov instructions and timer wait

### DIFF
--- a/src/devices/cpu/hcd62121/hcd62121.h
+++ b/src/devices/cpu/hcd62121/hcd62121.h
@@ -91,6 +91,7 @@ private:
 	u8 m_dseg;
 	u8 m_sseg;
 	u8 m_f;
+	u8 m_time;
 	u16 m_lar;
 	u8 m_reg[0x80];
 


### PR DESCRIPTION
These changes bring emulation closer to the intended speed, allowing screens in CFX9850 models to be interacted without the system turning off immediately (instead of the intended 6 minutes of idle time).

George Stagg identified some missing instructions and how timers were set. In particular, that instruction 0xB3 sets the timeout for the next sleep operation at instruction 0xFE.

Concrete values for timeouts are based on test ROMs I wrote to iterate over almost all possible parameters, using a logic analyzer to get approximate durations for each timeout. If anyone is interested in checking out these timings, you can open [these traces](https://github.com/qufb/data/tree/main/cfx9850gb/dsl) in DSView, using the sigrok decoder found on the same repo.
