### PR TITLE
bus/a2bus: - Add SNES MAX Super Nintendo Controller serial interface card.

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -2992,6 +2992,8 @@ if (BUSES["A2BUS"]~=null) then
 		MAME_DIR .. "src/devices/bus/a2bus/romcard.h",
 		MAME_DIR .. "src/devices/bus/a2bus/sider.cpp",
 		MAME_DIR .. "src/devices/bus/a2bus/sider.h",
+		MAME_DIR .. "src/devices/bus/a2bus/snesmax.cpp",
+		MAME_DIR .. "src/devices/bus/a2bus/snesmax.h",
 		MAME_DIR .. "src/devices/bus/a2bus/softcard3.cpp",
 		MAME_DIR .. "src/devices/bus/a2bus/softcard3.h",
 		MAME_DIR .. "src/devices/bus/a2bus/ssbapple.cpp",

--- a/src/devices/bus/a2bus/cards.cpp
+++ b/src/devices/bus/a2bus/cards.cpp
@@ -62,6 +62,7 @@
 #include "ramcard16k.h"
 #include "romcard.h"
 #include "sider.h"
+#include "snesmax.h"
 #include "softcard3.h"
 #include "ssbapple.h"
 #include "ssprite.h"
@@ -151,6 +152,7 @@ void apple2_cards(device_slot_interface &device)
 	device.option_add("grafex", A2BUS_GRAFEX);                 // Grafex card (uPD7220 graphics)
 	device.option_add("excel9", A2BUS_EXCEL9);                 // Excel-9 (6809 coprocessor)
 	device.option_add("vistaa800", A2BUS_VISTAA800);           // Vista A800 8" Disk Controller Card
+	device.option_add("snesmax", A2BUS_SNES_MAX);              // SNES MAX Joystick Card
 }
 
 void apple2e_cards(device_slot_interface &device)
@@ -231,6 +233,7 @@ void apple2e_cards(device_slot_interface &device)
 	device.option_add("pdromdrive", A2BUS_PRODOSROMDRIVE);     // ProDOS ROM Drive
 	device.option_add("superdrive", A2BUS_SUPERDRIVE);         // Apple II 3.5" Disk Controller
 	device.option_add("vistaa800", A2BUS_VISTAA800);           // Vista A800 8" Disk Controller Card
+	device.option_add("snesmax", A2BUS_SNES_MAX);              // SNES MAX Joystick Card
 }
 
 void apple2gs_cards(device_slot_interface &device)
@@ -305,6 +308,7 @@ void apple2gs_cards(device_slot_interface &device)
 	device.option_add("grafex", A2BUS_GRAFEX);                 // Grafex card (uPD7220 graphics)
 	device.option_add("pdromdrive", A2BUS_PRODOSROMDRIVE);     // ProDOS ROM Drive
 	device.option_add("superdrive", A2BUS_SUPERDRIVE);         // Apple II 3.5" Disk Controller
+	device.option_add("snesmax", A2BUS_SNES_MAX);              // SNES MAX Joystick Card
 }
 
 void apple3_cards(device_slot_interface &device)

--- a/src/devices/bus/a2bus/snesmax.cpp
+++ b/src/devices/bus/a2bus/snesmax.cpp
@@ -1,0 +1,116 @@
+// license:BSD-3-Clause
+// copyright-holders:Kelvin Sherlock
+/*********************************************************************
+
+    snesmax.cpp
+
+    SNES controller serial interface card for the Apple II by Lukazi
+    https://lukazi.blogspot.com/2021/06/game-controller-snes-max-snes.html
+
+*********************************************************************/
+
+#include "emu.h"
+#include "snesmax.h"
+#include "bus/snes_ctrl/ctrl.h"
+
+namespace {
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+class a2bus_snes_max_device:
+	public device_t,
+	public device_a2bus_card_interface
+{
+public:
+	// construction/destruction
+	a2bus_snes_max_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	a2bus_snes_max_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void device_start() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual uint8_t read_c0nx(uint8_t offset) override;
+	virtual void write_c0nx(uint8_t offset, uint8_t data) override;
+
+	required_device<snes_control_port_device> m_ctrl1;
+	required_device<snes_control_port_device> m_ctrl2;
+
+	uint32_t m_latch1;
+	uint32_t m_latch2;
+};
+
+a2bus_snes_max_device::a2bus_snes_max_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+		a2bus_snes_max_device(mconfig, A2BUS_SNES_MAX, tag, owner, clock)
+{
+}
+
+a2bus_snes_max_device::a2bus_snes_max_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+		device_t(mconfig, type, tag, owner, clock),
+		device_a2bus_card_interface(mconfig, *this),
+		m_ctrl1(*this, "ctrl1"),
+		m_ctrl2(*this, "ctrl2"),
+		m_latch1(0),
+		m_latch2(0)
+{
+}
+
+void a2bus_snes_max_device::device_add_mconfig(machine_config &config)
+{
+	SNES_CONTROL_PORT(config, m_ctrl1, snes_control_port_devices, "joypad");
+	SNES_CONTROL_PORT(config, m_ctrl2, snes_control_port_devices, "joypad");
+}
+
+void a2bus_snes_max_device::device_start()
+{
+	save_item(NAME(m_latch1));
+	save_item(NAME(m_latch2));
+}
+
+
+uint8_t a2bus_snes_max_device::read_c0nx(uint8_t offset)
+{
+	/* only data lines 6/7 are present so bits 0-5 should be floating bus. */
+	return ((m_latch1 & 0x01) << 7) | ((m_latch2 & 0x01) << 6);
+}
+
+void a2bus_snes_max_device::write_c0nx(uint8_t offset, uint8_t data)
+{
+	switch(offset & 0x01)
+	{
+	case 0:
+		/* latch */
+		m_ctrl1->port_poll();
+		m_ctrl2->port_poll();
+
+		/* bit 16 indicates if the controller is plugged in */
+		m_latch1 = m_ctrl1->get_card_device() ?  0x10000 : 0;
+		m_latch2 = m_ctrl2->get_card_device() ?  0x10000 : 0;
+
+		for (int i = 0; i < 16; ++i)
+		{
+			m_latch1 |= (m_ctrl1->read_pin4() & 1) << i;
+			m_latch2 |= (m_ctrl2->read_pin4() & 1) << i;
+		}
+		m_latch1 = ~m_latch1;
+		m_latch2 = ~m_latch2;
+		break;
+	case 1:
+		/* clock */
+		m_latch1 >>= 1;
+		m_latch2 >>= 1;
+		break;
+	}
+}
+
+} // anonymous namespace
+
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE_PRIVATE(A2BUS_SNES_MAX, device_a2bus_card_interface, a2bus_snes_max_device, "a2snesmax", "SNES MAX Joystick Card")

--- a/src/devices/bus/a2bus/snesmax.h
+++ b/src/devices/bus/a2bus/snesmax.h
@@ -1,0 +1,22 @@
+// license:BSD-3-Clause
+// copyright-holders:Kelvin Sherlock
+/*********************************************************************
+
+    snesmax.cpp
+
+    SNES digital joystick card for the Apple II by Lukazi
+    https://lukazi.blogspot.com/2021/06/game-controller-snes-max-snes.html
+
+*********************************************************************/
+
+#ifndef MAME_BUS_A2BUS_SNES_MAX_H
+#define MAME_BUS_A2BUS_SNES_MAX_H
+
+#pragma once
+
+#include "a2bus.h"
+
+// device type definition
+DECLARE_DEVICE_TYPE(A2BUS_SNES_MAX, device_a2bus_card_interface)
+
+#endif // MAME_BUS_A2BUS_SNES_MAX_H


### PR DESCRIPTION
"The SNES MAX is a serial interface card that allows an Apple II to communicate with SNES Controllers."

https://lukazi.blogspot.com/2021/06/game-controller-snes-max-snes.html

The linked example code/schematics (https://docs.google.com/open?id=1MZvEiNi_7AO1DtoYO4dpHIPd7kykrG1q) includes some test programs and patched games (although tetris refuses to work for me).

```
mame apple2ee -sl3 snesmax -flop1 Robotron_SNESMAX.dsk
```