### PR TITLE
osd/strconv.cpp: Support UTF-8 Windows ANSI code page.

### DIFF
--- a/src/osd/strconv.cpp
+++ b/src/osd/strconv.cpp
@@ -12,6 +12,7 @@
 #include <cassert>
 // MAMEOS headers
 #include "strconv.h"
+#include "unicode.h"
 
 #if defined(SDLMAME_WIN32) || defined(OSD_WINDOWS)
 
@@ -254,10 +255,8 @@ std::string from_wstring(const WCHAR *s)
 
 int osd_uchar_from_osdchar(char32_t *uchar, const char *osdchar, size_t count)
 {
-	// FIXME: Does not handle charsets that use variable lengths encodings such
-	// as example GB18030 or UTF-8.
-	// FIXME: Assumes all characters can be converted into a single wchar_t
-	// which may not always be the case such as with surrogate pairs.
+	if (GetACP() == CP_UTF8)
+		return uchar_from_utf8(uchar, osdchar, count);
 
 	WCHAR wch;
 	CPINFO cp;

--- a/src/osd/strconv.cpp
+++ b/src/osd/strconv.cpp
@@ -5,16 +5,19 @@
 //  strconv.cpp - Win32 string conversion
 //
 //============================================================
-#if defined(SDLMAME_WIN32) || defined(OSD_WINDOWS)
-#include <windows.h>
-#endif
-#include <algorithm>
-#include <cassert>
-// MAMEOS headers
+
 #include "strconv.h"
+
 #include "unicode.h"
 
-#if defined(SDLMAME_WIN32) || defined(OSD_WINDOWS)
+#include <algorithm>
+#include <cassert>
+
+
+#if defined(_WIN32)
+
+#include <windows.h>
+
 
 namespace osd::text {
 
@@ -255,18 +258,22 @@ std::string from_wstring(const WCHAR *s)
 
 int osd_uchar_from_osdchar(char32_t *uchar, const char *osdchar, size_t count)
 {
+	// handle UTF-8 internally
 	if (GetACP() == CP_UTF8)
 		return uchar_from_utf8(uchar, osdchar, count);
 
-	WCHAR wch;
+	// FIXME: This makes multiple bad assumptions:
+	// * Assumes any character can be converted to a single wchar_t.
+	// * Assumes characters are either one byte or maximum number of bytes.
+	// * Doesn't handle nominal single-byte encodings with combining characters.
 	CPINFO cp;
-
 	if (!GetCPInfo(CP_ACP, &cp))
 		goto error;
 
 	// The multibyte char can't be bigger than the max character size
 	count = std::min(count, size_t(IsDBCSLeadByte(*osdchar) ? cp.MaxCharSize : 1));
 
+	WCHAR wch;
 	if (MultiByteToWideChar(CP_ACP, 0, osdchar, static_cast<DWORD>(count), &wch, 1) == 0)
 		goto error;
 
@@ -279,23 +286,27 @@ error:
 }
 
 
-#else
-#include "unicode.h"
+#else // _WIN32
+
 //============================================================
 //  osd_uchar_from_osdchar
 //============================================================
 
 int osd_uchar_from_osdchar(char32_t *uchar, const char *osdchar, size_t count)
 {
+	// FIXME: mbstowcs depends on global state
 	wchar_t wch;
-
 	count = mbstowcs(&wch, (char *)osdchar, 1);
-	if (count != -1)
+	if (count != size_t(-1))
+	{
 		*uchar = wch;
+		return int(count);
+	}
 	else
+	{
 		*uchar = 0;
-
-	return count;
+		return -1;
+	}
 }
 
-#endif
+#endif // _WIN32


### PR DESCRIPTION
- Defer to MAME's built-in UTF-8 decoding because MultiByteToWideChar needs the length of the code unit and once that's been determined it's convenient do the rest of the conversion and sidestep the complication of UTF-16 (surrogate pairs).
- Remove the FIXME about other variable length encodings such as GB18030. With the sole exception of UTF-8, only single- and double-character encodings are supported as the active ANSI code page. Other code pages are only usable in conversion functions and not relevant here. Source: [[MS-UCODEREF]: Supported Codepage in Windows | Microsoft Learn](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-ucoderef/28fefe92-d66c-4b03-90a9-97b473223d43).
- Remove the FIXME about surrogate pairs because these only arise in the context of Unicode inputs not representable as a single UTF-16 code unit, and as mentioned above UTF-8 (the only selectable Unicode ANSI code page) is now handled directly in MAME code.