### PR TITLE
casio/cfx9850.cpp: Various fixes

### DIFF
--- a/src/devices/cpu/hcd62121/hcd62121.cpp
+++ b/src/devices/cpu/hcd62121/hcd62121.cpp
@@ -39,7 +39,7 @@ enum
 	HCD62121_R70, HCD62121_R74, HCD62121_R78, HCD62121_R7C
 };
 
-
+// TODO - Max value stored with "movb reg,f" is 0x3f, is bit 5 set in other instructions?
 constexpr u8 FLAG_CL = 0x10;
 constexpr u8 FLAG_Z = 0x08;
 constexpr u8 FLAG_C = 0x04;
@@ -62,11 +62,15 @@ hcd62121_cpu_device::hcd62121_cpu_device(const machine_config &mconfig, const ch
 	, m_sseg(0)
 	, m_f(0)
 	, m_time(0)
+	, m_time_op(0)
+	, m_is_timer_started(false)
+	, m_is_infinite_timeout(false)
 	, m_lar(0)
 	, m_opt(0)
 	, m_port(0)
 	, m_program(nullptr)
 	, m_icount(0)
+	, m_cycles_until_timeout(0)
 	, m_kol_cb(*this)
 	, m_koh_cb(*this)
 	, m_port_cb(*this)
@@ -81,6 +85,14 @@ device_memory_interface::space_config_vector hcd62121_cpu_device::memory_space_c
 	return space_config_vector {
 		std::make_pair(AS_PROGRAM, &m_program_config)
 	};
+}
+
+TIMER_CALLBACK_MEMBER(hcd62121_cpu_device::timer_tick)
+{
+	// TODO - Only stores seconds? How can it stop/reset?
+	if (m_is_timer_started) {
+		m_time = (m_time + 1) % 60;
+	}
 }
 
 u8 hcd62121_cpu_device::read_op()
@@ -136,6 +148,33 @@ void hcd62121_cpu_device::write_reg(int size, u8 op1)
 			m_reg[(op1 + i) & 0x7f] = m_temp1[i];
 	}
 }
+
+
+void hcd62121_cpu_device::read_ireg(int size, u8 op1)
+{
+	u16 ad = m_reg[(0x40 | op1) & 0x7f ] | (m_reg[(0x40 | (op1 + 1)) & 0x7f] << 8);
+
+	for (int i = 0; i < size; i++)
+	{
+		m_temp1[i] = m_program->read_byte((m_dseg << 16) | ad);
+		ad += (op1 & 0x40) ? -1 : 1;
+	}
+	m_lar = ad;
+}
+
+
+void hcd62121_cpu_device::write_ireg(int size, u8 op1)
+{
+	u16 ad = m_reg[(0x40 | op1) & 0x7f] | (m_reg[(0x40 | (op1 + 1)) & 0x7f] << 8);
+
+	for (int i = 0; i < size; i++)
+	{
+		m_program->write_byte((m_dseg << 16) | ad, m_temp1[i]);
+		ad += (op1 & 0x40) ? -1 : 1;
+	}
+	m_lar = ad;
+}
+
 
 void hcd62121_cpu_device::read_regreg(int size, u8 op1, u8 op2, bool copy_extend_immediate)
 {
@@ -307,6 +346,9 @@ void hcd62121_cpu_device::device_start()
 {
 	m_program = &space(AS_PROGRAM);
 
+	m_timer = timer_alloc(FUNC(hcd62121_cpu_device::timer_tick), this);
+	m_timer->adjust(attotime::from_seconds(1), 0, attotime::from_seconds(1));
+
 	save_item(NAME(m_prev_pc));
 	save_item(NAME(m_sp));
 	save_item(NAME(m_ip));
@@ -336,38 +378,38 @@ void hcd62121_cpu_device::device_start()
 	state_add(HCD62121_DSIZE, "DSIZE", m_dsize).callimport().callexport().formatstr("%02X");
 	state_add(HCD62121_F,     "F",     m_f    ).callimport().callexport().formatstr("%02X");
 
-	state_add(HCD62121_R00, "R00", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R04, "R04", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R08, "R08", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R0C, "R0C", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R10, "R10", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R14, "R14", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R18, "R18", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R1C, "R1C", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R20, "R20", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R24, "R24", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R28, "R28", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R2C, "R2C", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R30, "R30", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R34, "R34", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R38, "R38", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R3C, "R3C", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R40, "R40", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R44, "R44", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R48, "R48", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R4C, "R4C", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R50, "R50", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R54, "R54", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R58, "R58", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R5C, "R5C", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R60, "R60", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R64, "R64", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R68, "R68", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R6C, "R6C", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R70, "R70", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R74, "R74", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R78, "R78", m_reg[0x00]).callimport().callexport().formatstr("%8s");
-	state_add(HCD62121_R7C, "R7C", m_reg[0x00]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R00, "R00", *(u32*)&m_reg[0x00]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R04, "R04", *(u32*)&m_reg[0x04]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R08, "R08", *(u32*)&m_reg[0x08]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R0C, "R0C", *(u32*)&m_reg[0x0C]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R10, "R10", *(u32*)&m_reg[0x10]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R14, "R14", *(u32*)&m_reg[0x14]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R18, "R18", *(u32*)&m_reg[0x18]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R1C, "R1C", *(u32*)&m_reg[0x1C]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R20, "R20", *(u32*)&m_reg[0x20]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R24, "R24", *(u32*)&m_reg[0x24]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R28, "R28", *(u32*)&m_reg[0x28]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R2C, "R2C", *(u32*)&m_reg[0x2C]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R30, "R30", *(u32*)&m_reg[0x30]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R34, "R34", *(u32*)&m_reg[0x34]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R38, "R38", *(u32*)&m_reg[0x38]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R3C, "R3C", *(u32*)&m_reg[0x3C]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R40, "R40", *(u32*)&m_reg[0x40]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R44, "R44", *(u32*)&m_reg[0x44]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R48, "R48", *(u32*)&m_reg[0x48]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R4C, "R4C", *(u32*)&m_reg[0x4C]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R50, "R50", *(u32*)&m_reg[0x50]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R54, "R54", *(u32*)&m_reg[0x54]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R58, "R58", *(u32*)&m_reg[0x58]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R5C, "R5C", *(u32*)&m_reg[0x5C]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R60, "R60", *(u32*)&m_reg[0x60]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R64, "R64", *(u32*)&m_reg[0x64]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R68, "R68", *(u32*)&m_reg[0x68]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R6C, "R6C", *(u32*)&m_reg[0x6C]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R70, "R70", *(u32*)&m_reg[0x70]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R74, "R74", *(u32*)&m_reg[0x74]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R78, "R78", *(u32*)&m_reg[0x78]).callimport().callexport().formatstr("%8s");
+	state_add(HCD62121_R7C, "R7C", *(u32*)&m_reg[0x7C]).callimport().callexport().formatstr("%8s");
 
 	set_icountptr(m_icount);
 }
@@ -514,6 +556,8 @@ void hcd62121_cpu_device::device_reset()
 	m_sseg = 0;
 	m_lar = 0;
 	m_f = 0;
+	m_time = 0;
+	m_time_op = 0;
 	m_dsize = 0;
 	m_opt = 0;
 	m_port = 0;
@@ -522,6 +566,9 @@ void hcd62121_cpu_device::device_reset()
 	{
 		elem = 0;
 	}
+
+	m_is_timer_started = false;
+	m_is_infinite_timeout = false;
 }
 
 
@@ -810,6 +857,20 @@ void hcd62121_cpu_device::execute_run()
 {
 	do
 	{
+		if (m_ki_cb() != 0) {
+			m_cycles_until_timeout = 0;
+			m_is_infinite_timeout = false;
+		} else if (m_is_infinite_timeout) {
+			m_icount = 0;
+		} else if (m_cycles_until_timeout > 0) {
+			int cycles_to_consume = std::min(m_cycles_until_timeout, m_icount);
+			m_cycles_until_timeout -= cycles_to_consume;
+			m_icount -= cycles_to_consume;
+		}
+		if (m_icount <= 0) {
+			break;
+		}
+
 		offs_t pc = (m_cseg << 16) | m_ip;
 
 		debugger_instruction_hook(pc);
@@ -1152,6 +1213,87 @@ void hcd62121_cpu_device::execute_run()
 			}
 			break;
 
+		case 0x40:      /* shrb/shlb ir1,8 */
+		case 0x41:      /* shrw/shlw ir1,8 */
+		case 0x42:      /* shrq/shlq ir1,8 */
+		case 0x43:      /* shrt/shlt ir1,8 */
+			{
+				int size = datasize(op);
+				u8 reg1 = read_op();
+
+				// TODO - read_ireg should support reading this
+				if (reg1 & 0x80) {
+					read_ireg(size, (reg1 & 0x7f) - size + 1);
+					for (int i=0; i < size - 1; i++) {
+						m_temp1[i] = m_temp1[i + 1];
+					}
+					m_temp1[size-1] = 0;
+					write_ireg(size, (reg1 & 0x7f) - size + 1);
+				}
+				else
+				{
+					read_ireg(size, reg1);
+					for (int i = size-1; i > 0; i--) {
+						m_temp1[i] = m_temp1[i - 1];
+					}
+					m_temp1[0] = 0;
+					write_ireg(size, reg1);
+				}
+			}
+			break;
+
+		case 0x44:      /* mskb ir1,r2 */
+		case 0x45:      /* mskw ir1,r2 */
+		case 0x46:      /* mskq ir1,r2 */
+		case 0x47:      /* mskt ir1,r2 */
+			{
+				int size = datasize(op);
+				u8 reg1 = read_op();
+				u8 reg2 = read_op();
+
+				read_iregreg(size, reg1, reg2, true);
+
+				op_msk(size);
+			}
+			break;
+
+		case 0x48:      /* shrb/shlb ir1,4 */
+		case 0x49:      /* shrw/shlw ir1,4 */
+		case 0x4A:      /* shrq/shlq ir1,4 */
+		case 0x4B:      /* shrt/shlt ir1,4 */
+			/* Nibble shift */
+			{
+				int size = datasize(op);
+				u8 reg1 = read_op();
+				u8 d1 = 0, d2 = 0;
+
+				read_ireg(size, reg1);
+
+				if (reg1 & 0x80)
+				{
+					// shift right
+					for (int i = 0; i < size; i++)
+					{
+						d1 = (m_temp1[i] & 0x0f) << 4;
+						m_temp1[i] = (m_temp1[i] >> 4) | d2;
+						d2 = d1;
+					}
+				}
+				else
+				{
+					// shift left
+					for (int i = 0; i < size; i++)
+					{
+						d1 = (m_temp1[i] & 0xf0) >> 4;
+						m_temp1[i] = (m_temp1[i] << 4) | d2;
+						d2 = d1;
+					}
+				}
+
+				write_ireg(size, reg1);
+			}
+			break;
+
 		case 0x4C:      /* testb ir1,r2 */
 		case 0x4D:      /* testw ir1,r2 */
 		case 0x4E:      /* testq ir1,r2 */
@@ -1232,6 +1374,41 @@ void hcd62121_cpu_device::execute_run()
 			}
 			break;
 
+		case 0x60:      /* shrb ir1,1 */
+		case 0x61:      /* shrw ir1,1 */
+		case 0x62:      /* shrq ir1,1 */
+		case 0x63:      /* shrt ir1,1 */
+			{
+				int size = datasize(op);
+				u8 reg1 = read_op();
+				u8 d1 = 0, d2 = 0;
+				bool zero_high = true;
+				bool zero_low = true;
+
+				read_ireg(size, reg1);
+
+				d2 = 0;
+				set_cl_flag ((m_temp1[0] & (1U<<4)) != 0U);
+				for (int i = 0; i < size; i++)
+				{
+					d1 = (m_temp1[i] & 0x01) << 7;
+					m_temp1[i] = (m_temp1[i] >> 1) | d2;
+					d2 = d1;
+					if (m_temp1[i] & 0xf0)
+						zero_high = false;
+					if (m_temp1[i] & 0x0f)
+						zero_low = false;
+				}
+
+				write_ireg(size, reg1);
+
+				set_zero_flag(zero_high && zero_low);
+				set_zh_flag(zero_high);
+				set_zl_flag(zero_low);
+				set_carry_flag (d2 != 0);
+			}
+			break;
+
 		case 0x64:      /* orb ir1,r2 */
 		case 0x65:      /* orb ir1,r2 */
 		case 0x66:      /* orb ir1,r2 */
@@ -1249,6 +1426,40 @@ void hcd62121_cpu_device::execute_run()
 			}
 			break;
 
+		case 0x68:      /* shlb ir1,1 */
+		case 0x69:      /* shlw ir1,1 */
+		case 0x6A:      /* shlq ir1,1 */
+		case 0x6B:      /* shlt ir1,1 */
+			{
+				int size = datasize(op);
+				u8 reg1 = read_op();
+				u8 d1 = 0, d2 = 0;
+				bool zero_high = true;
+				bool zero_low = true;
+
+				read_ireg(size, reg1);
+
+				set_cl_flag ((m_temp1[0] & (1U<<3)) != 0U);
+				for (int i = 0; i < size; i++)
+				{
+					d1 = (m_temp1[i] & 0x80) >> 7;
+					m_temp1[i] = (m_temp1[i] << 1) | d2;
+					d2 = d1;
+
+					if (m_temp1[i] & 0xf0)
+						zero_high = false;
+					if (m_temp1[i] & 0x0f)
+						zero_low = false;
+				}
+
+				write_ireg(size, reg1);
+				set_zero_flag(zero_high && zero_low);
+				set_zh_flag(zero_high);
+				set_zl_flag(zero_low);
+				set_carry_flag (d2 != 0);
+			}
+			break;
+
 		case 0x6C:      /* andb ir1,r2 */
 		case 0x6D:      /* andw ir1,r2 */
 		case 0x6E:      /* andq ir1,r2 */
@@ -1261,6 +1472,23 @@ void hcd62121_cpu_device::execute_run()
 				read_iregreg(size, reg1, reg2, true);
 
 				op_and(size);
+
+				write_iregreg(size, reg1, reg2);
+			}
+			break;
+
+		case 0x70:      /* subbb ir1,r2 */
+		case 0x71:      /* subbw ir1,r2 */
+		case 0x72:      /* subbq ir1,r2 */
+		case 0x73:      /* subbt ir1,r2 */
+			{
+				int size = datasize(op);
+				u8 reg1 = read_op();
+				u8 reg2 = read_op();
+
+				read_iregreg(size, reg1, reg2, false);
+
+				op_subb(size);
 
 				write_iregreg(size, reg1, reg2);
 			}
@@ -1443,7 +1671,9 @@ void hcd62121_cpu_device::execute_run()
 			}
 			break;
 
+		case 0xB0:      /* unk_B0 reg/i8 */
 		case 0xB1:      /* unk_B1 reg/i8 - PORTx control/direction? */
+		case 0xB2:      /* unk_B2 reg/i8 */
 			logerror("%02x:%04x: unimplemented instruction %02x encountered\n", m_cseg, m_ip-1, op);
 			read_op();
 			break;
@@ -1452,7 +1682,8 @@ void hcd62121_cpu_device::execute_run()
 			{
 				u8 arg = read_op();
 
-				m_time = arg;
+				m_time_op = arg;
+				m_is_timer_started = true;
 			}
 			break;
 
@@ -1478,7 +1709,6 @@ void hcd62121_cpu_device::execute_run()
 			break;
 
 		case 0xBB:      /* jmpcl a16 */
-			logerror("%02x:%04x: unimplemented instruction %02x encountered\n", m_cseg, m_ip-1, op);
 			{
 				u8 a1 = read_op();
 				u8 a2 = read_op();
@@ -1489,7 +1719,6 @@ void hcd62121_cpu_device::execute_run()
 			break;
 
 		case 0xBF:      /* jmpncl a16 */
-			logerror("%02x:%04x: unimplemented instruction %02x encountered\n", m_cseg, m_ip-1, op);
 			{
 				u8 a1 = read_op();
 				u8 a2 = read_op();
@@ -1499,10 +1728,17 @@ void hcd62121_cpu_device::execute_run()
 			}
 			break;
 
-		//case 0xC0:      /* movb reg,i8 */  // TODO - test
+		/*
+		    These instructions do not modify any general purpose registers or memory,
+		    but might be implemented on other CPUs with the same instruction set.
+		*/
+		case 0xC0:      /* nop reg,i8 */
+		case 0xC2:      /* nop reg,i8 */
+		case 0xC3:      /* nop reg,i8 */
+			logerror("%02x:%04x: nop instruction %02x %02x,%02x\n", m_cseg, m_ip-1, op, read_op(), read_op());
+			break;
+
 		case 0xC1:      /* movw reg,i16 */
-		//case 0xC2:      /* movw reg,i64 */ // TODO - test
-		//case 0xC3:      /* movw reg,i80 */ // TODO - test
 			{
 				int size = datasize(op);
 				u8 reg = read_op();
@@ -1580,7 +1816,7 @@ void hcd62121_cpu_device::execute_run()
 		case 0xCC:      /* swapb ir1,r2 */
 		case 0xCD:      /* swapw ir1,r2 */
 		case 0xCE:      /* swapq ir1,r2 */
-		case 0xCF:      /* swapt ir1,r2? */
+		case 0xCF:      /* swapt ir1,r2 */
 			{
 				int size = datasize(op);
 				u8 reg1 = read_op();
@@ -1601,7 +1837,8 @@ void hcd62121_cpu_device::execute_run()
 
 				write_iregreg(size, reg1, reg2);
 				write_iregreg2(size, reg1, reg2);
-				// TODO - are flags affected?
+
+				m_f = 0;
 			}
 			break;
 
@@ -1705,6 +1942,10 @@ void hcd62121_cpu_device::execute_run()
 			}
 			break;
 
+		case 0xE5:      /* movb reg,TIME */
+			m_reg[read_op() & 0x7f] = m_time;
+			break;
+
 		case 0xE6:      /* movb reg,PORT */
 			m_reg[read_op() & 0x7f] = m_port;
 			break;
@@ -1761,18 +2002,19 @@ void hcd62121_cpu_device::execute_run()
 		case 0xF1:      /* unk_F1 reg/i8 (out?) */
 		case 0xF3:      /* unk_F3 reg/i8 (out?) */
 		case 0xF5:      /* unk_F5 reg/i8 (out?) */
+		case 0xF6:      /* unk_F6 reg/i8 (out?) */
 		case 0xF7:      /* timer_ctrl i8 */
 			logerror("%02x:%04x: unimplemented instruction %02x encountered\n", m_cseg, m_ip-1, op);
 			read_op();
 			break;
 
 		case 0xFC:      /* unk_FC - disable interrupts/stop timer?? */
-		case 0xFD:      /* unk_FD */
 			logerror("%02x:%04x: unimplemented instruction %02x encountered\n", m_cseg, m_ip-1, op);
 			break;
 
+		case 0xFD:      /* timer_wait_low (no X1 clock, address or data bus activity) */
 		case 0xFE:      /* timer_wait */
-			if (m_time & 0x01) {
+			if (m_time_op & 0x01) {
 				/*
 				    When timer control is set with operand 0xC0, the CPU periodically reads
 				    from external RAM (address range 0x7c00..0x7fff) at an interval of
@@ -1787,8 +2029,12 @@ void hcd62121_cpu_device::execute_run()
 				    the timer wait execution.
 				*/
 				const u64 TIMER_STATE_READ_CYCLES = 832 + 64;
-				u64 cycles_until_timeout = 0;
-				switch (m_time) {
+				switch (m_time_op) {
+					case 0x01:
+					case 0x03:
+						// Likely only timeouts on KO enabled input.
+						m_is_infinite_timeout = true;
+						break;
 					case 0x11:
 					case 0x13:
 					case 0x15:
@@ -1846,7 +2092,7 @@ void hcd62121_cpu_device::execute_run()
 					case 0xdd:
 					case 0xdf:
 						// Approximately 814.32us
-						cycles_until_timeout = 0x4 * TIMER_STATE_READ_CYCLES;
+						m_cycles_until_timeout = 0x4 * TIMER_STATE_READ_CYCLES;
 						break;
 					case 0x21:
 					case 0x23:
@@ -1873,7 +2119,7 @@ void hcd62121_cpu_device::execute_run()
 					case 0xad:
 					case 0xaf:
 						// Approximately 1.63ms
-						cycles_until_timeout = 0x8 * TIMER_STATE_READ_CYCLES;
+						m_cycles_until_timeout = 0x8 * TIMER_STATE_READ_CYCLES;
 						break;
 					case 0x05:
 					case 0x07:
@@ -1888,34 +2134,33 @@ void hcd62121_cpu_device::execute_run()
 					case 0xcd:
 					case 0xcf:
 						// Approximately 209.34ms
-						cycles_until_timeout = 0x400 * TIMER_STATE_READ_CYCLES;
+						m_cycles_until_timeout = 0x400 * TIMER_STATE_READ_CYCLES;
 						break;
 					case 0x49:
 					case 0x4b:
 					case 0xc9:
 					case 0xcb:
 						// Approximately 837.61ms
-						cycles_until_timeout = 0x1000 * TIMER_STATE_READ_CYCLES;
+						m_cycles_until_timeout = 0x1000 * TIMER_STATE_READ_CYCLES;
 						break;
 					case 0x41:
 					case 0x43:
 					case 0xc1:
 					case 0xc3:
 						// Approximately 1.68s
-						cycles_until_timeout = 0x2000 * TIMER_STATE_READ_CYCLES;
+						m_cycles_until_timeout = 0x2000 * TIMER_STATE_READ_CYCLES;
 						break;
 					case 0x81:
 					case 0x83:
 						// Approximately 100.58s
-						cycles_until_timeout = 0x7a800 * TIMER_STATE_READ_CYCLES;
+						m_cycles_until_timeout = 0x7a800 * TIMER_STATE_READ_CYCLES;
 						break;
 					default:
-						logerror("%02x:%04x: unimplemented timer value %02x encountered\n", m_cseg, m_ip-1, m_time);
+						logerror("%02x:%04x: unimplemented timer value %02x encountered\n", m_cseg, m_ip-1, m_time_op);
 						break;
 				}
-				m_icount -= cycles_until_timeout;
 			} else {
-				logerror("%02x:%04x: wait for disabled timer? value %02x\n", m_cseg, m_ip-1, m_time);
+				logerror("%02x:%04x: wait for disabled timer? value %02x\n", m_cseg, m_ip-1, m_time_op);
 			}
 			break;
 

--- a/src/devices/cpu/hcd62121/hcd62121.cpp
+++ b/src/devices/cpu/hcd62121/hcd62121.cpp
@@ -22,6 +22,7 @@ TODO:
 #include "emu.h"
 #include "hcd62121.h"
 #include "hcd62121d.h"
+#include "multibyte.h"
 
 
 enum
@@ -419,309 +420,30 @@ void hcd62121_cpu_device::device_start()
 	set_icountptr(m_icount);
 }
 
+
 void hcd62121_cpu_device::state_import(const device_state_entry &entry)
 {
-	switch (entry.index())
+	if ((entry.index() >= HCD62121_R00) && (entry.index() <= HCD62121_R7C))
 	{
-		case HCD62121_R00:
-			m_reg[0x00] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x01] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x02] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x03] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R04:
-			m_reg[0x04] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x05] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x06] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x07] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R08:
-			m_reg[0x08] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x09] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x0A] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x0B] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R0C:
-			m_reg[0x0C] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x0D] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x0E] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x0F] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R10:
-			m_reg[0x10] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x11] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x12] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x13] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R14:
-			m_reg[0x14] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x15] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x16] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x17] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R18:
-			m_reg[0x18] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x19] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x1A] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x1B] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R1C:
-			m_reg[0x1C] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x1D] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x1E] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x1F] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R20:
-			m_reg[0x20] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x21] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x22] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x23] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R24:
-			m_reg[0x24] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x25] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x26] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x27] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R28:
-			m_reg[0x28] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x29] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x2A] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x2B] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R2C:
-			m_reg[0x2C] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x2D] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x2E] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x2F] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R30:
-			m_reg[0x30] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x31] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x32] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x33] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R34:
-			m_reg[0x34] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x35] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x36] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x37] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R38:
-			m_reg[0x38] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x39] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x3A] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x3B] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R3C:
-			m_reg[0x3C] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x3D] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x3E] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x3F] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R40:
-			m_reg[0x40] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x41] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x42] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x43] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R44:
-			m_reg[0x44] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x45] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x46] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x47] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R48:
-			m_reg[0x48] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x49] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x4A] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x4B] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R4C:
-			m_reg[0x4C] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x4D] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x4E] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x4F] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R50:
-			m_reg[0x50] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x51] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x52] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x53] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R54:
-			m_reg[0x54] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x55] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x56] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x57] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R58:
-			m_reg[0x58] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x59] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x5A] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x5B] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R5C:
-			m_reg[0x5C] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x5D] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x5E] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x5F] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R60:
-			m_reg[0x60] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x61] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x62] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x63] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R64:
-			m_reg[0x64] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x65] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x66] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x67] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R68:
-			m_reg[0x68] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x69] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x6A] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x6B] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R6C:
-			m_reg[0x6C] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x6D] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x6E] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x6F] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R70:
-			m_reg[0x70] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x71] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x72] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x73] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R74:
-			m_reg[0x74] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x75] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x76] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x77] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R78:
-			m_reg[0x78] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x79] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x7A] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x7B] = m_debugger_temp & 0xff;
-			break;
-		case HCD62121_R7C:
-			m_reg[0x7C] = (m_debugger_temp >> 24) & 0xff;
-			m_reg[0x7D] = (m_debugger_temp >> 16) & 0xff;
-			m_reg[0x7E] = (m_debugger_temp >> 8) & 0xff;
-			m_reg[0x7F] = m_debugger_temp & 0xff;
-			break;
+		put_u32be(&m_reg[(entry.index() - HCD62121_R00) * 4], m_debugger_temp);
 	}
 }
 
+
 void hcd62121_cpu_device::state_export(const device_state_entry &entry)
-{
-	switch (entry.index())
+{   if ((entry.index() >= HCD62121_R00) && (entry.index() <= HCD62121_R7C))
 	{
-		case STATE_GENPC:
-		case STATE_GENPCBASE:
-			m_rtemp = (m_cseg << 16) | m_ip;
-			break;
-		case HCD62121_R00:
-			m_debugger_temp = (m_reg[0x00] << 24) | (m_reg[0x01] << 16) | (m_reg[0x02] << 8) | m_reg[0x03];
-			break;
-		case HCD62121_R04:
-			m_debugger_temp = (m_reg[0x04] << 24) | (m_reg[0x05] << 16) | (m_reg[0x06] << 8) | m_reg[0x07];
-			break;
-		case HCD62121_R08:
-			m_debugger_temp = (m_reg[0x08] << 24) | (m_reg[0x09] << 16) | (m_reg[0x0A] << 8) | m_reg[0x0B];
-			break;
-		case HCD62121_R0C:
-			m_debugger_temp = (m_reg[0x0C] << 24) | (m_reg[0x0D] << 16) | (m_reg[0x0E] << 8) | m_reg[0x0F];
-			break;
-		case HCD62121_R10:
-			m_debugger_temp = (m_reg[0x10] << 24) | (m_reg[0x11] << 16) | (m_reg[0x12] << 8) | m_reg[0x13];
-			break;
-		case HCD62121_R14:
-			m_debugger_temp = (m_reg[0x14] << 24) | (m_reg[0x15] << 16) | (m_reg[0x16] << 8) | m_reg[0x17];
-			break;
-		case HCD62121_R18:
-			m_debugger_temp = (m_reg[0x18] << 24) | (m_reg[0x19] << 16) | (m_reg[0x1A] << 8) | m_reg[0x1B];
-			break;
-		case HCD62121_R1C:
-			m_debugger_temp = (m_reg[0x1C] << 24) | (m_reg[0x1D] << 16) | (m_reg[0x1E] << 8) | m_reg[0x1F];
-			break;
-		case HCD62121_R20:
-			m_debugger_temp = (m_reg[0x20] << 24) | (m_reg[0x21] << 16) | (m_reg[0x22] << 8) | m_reg[0x23];
-			break;
-		case HCD62121_R24:
-			m_debugger_temp = (m_reg[0x24] << 24) | (m_reg[0x25] << 16) | (m_reg[0x26] << 8) | m_reg[0x27];
-			break;
-		case HCD62121_R28:
-			m_debugger_temp = (m_reg[0x28] << 24) | (m_reg[0x29] << 16) | (m_reg[0x2A] << 8) | m_reg[0x2B];
-			break;
-		case HCD62121_R2C:
-			m_debugger_temp = (m_reg[0x2C] << 24) | (m_reg[0x2D] << 16) | (m_reg[0x2E] << 8) | m_reg[0x2F];
-			break;
-		case HCD62121_R30:
-			m_debugger_temp = (m_reg[0x30] << 24) | (m_reg[0x31] << 16) | (m_reg[0x32] << 8) | m_reg[0x33];
-			break;
-		case HCD62121_R34:
-			m_debugger_temp = (m_reg[0x34] << 24) | (m_reg[0x35] << 16) | (m_reg[0x36] << 8) | m_reg[0x37];
-			break;
-		case HCD62121_R38:
-			m_debugger_temp = (m_reg[0x38] << 24) | (m_reg[0x39] << 16) | (m_reg[0x3A] << 8) | m_reg[0x3B];
-			break;
-		case HCD62121_R3C:
-			m_debugger_temp = (m_reg[0x3C] << 24) | (m_reg[0x3D] << 16) | (m_reg[0x3E] << 8) | m_reg[0x3F];
-			break;
-		case HCD62121_R40:
-			m_debugger_temp = (m_reg[0x40] << 24) | (m_reg[0x41] << 16) | (m_reg[0x42] << 8) | m_reg[0x43];
-			break;
-		case HCD62121_R44:
-			m_debugger_temp = (m_reg[0x44] << 24) | (m_reg[0x45] << 16) | (m_reg[0x46] << 8) | m_reg[0x47];
-			break;
-		case HCD62121_R48:
-			m_debugger_temp = (m_reg[0x48] << 24) | (m_reg[0x49] << 16) | (m_reg[0x4A] << 8) | m_reg[0x4B];
-			break;
-		case HCD62121_R4C:
-			m_debugger_temp = (m_reg[0x4C] << 24) | (m_reg[0x4D] << 16) | (m_reg[0x4E] << 8) | m_reg[0x4F];
-			break;
-		case HCD62121_R50:
-			m_debugger_temp = (m_reg[0x50] << 24) | (m_reg[0x51] << 16) | (m_reg[0x52] << 8) | m_reg[0x53];
-			break;
-		case HCD62121_R54:
-			m_debugger_temp = (m_reg[0x54] << 24) | (m_reg[0x55] << 16) | (m_reg[0x56] << 8) | m_reg[0x57];
-			break;
-		case HCD62121_R58:
-			m_debugger_temp = (m_reg[0x58] << 24) | (m_reg[0x59] << 16) | (m_reg[0x5A] << 8) | m_reg[0x5B];
-			break;
-		case HCD62121_R5C:
-			m_debugger_temp = (m_reg[0x5C] << 24) | (m_reg[0x5D] << 16) | (m_reg[0x5E] << 8) | m_reg[0x5F];
-			break;
-		case HCD62121_R60:
-			m_debugger_temp = (m_reg[0x60] << 24) | (m_reg[0x61] << 16) | (m_reg[0x62] << 8) | m_reg[0x63];
-			break;
-		case HCD62121_R64:
-			m_debugger_temp = (m_reg[0x64] << 24) | (m_reg[0x65] << 16) | (m_reg[0x66] << 8) | m_reg[0x67];
-			break;
-		case HCD62121_R68:
-			m_debugger_temp = (m_reg[0x68] << 24) | (m_reg[0x69] << 16) | (m_reg[0x6A] << 8) | m_reg[0x6B];
-			break;
-		case HCD62121_R6C:
-			m_debugger_temp = (m_reg[0x6C] << 24) | (m_reg[0x6D] << 16) | (m_reg[0x6E] << 8) | m_reg[0x6F];
-			break;
-		case HCD62121_R70:
-			m_debugger_temp = (m_reg[0x70] << 24) | (m_reg[0x71] << 16) | (m_reg[0x72] << 8) | m_reg[0x73];
-			break;
-		case HCD62121_R74:
-			m_debugger_temp = (m_reg[0x74] << 24) | (m_reg[0x75] << 16) | (m_reg[0x76] << 8) | m_reg[0x77];
-			break;
-		case HCD62121_R78:
-			m_debugger_temp = (m_reg[0x78] << 24) | (m_reg[0x79] << 16) | (m_reg[0x7A] << 8) | m_reg[0x7B];
-			break;
-		case HCD62121_R7C:
-			m_debugger_temp = (m_reg[0x7C] << 24) | (m_reg[0x7D] << 16) | (m_reg[0x7E] << 8) | m_reg[0x7F];
-			break;
+		m_debugger_temp = get_u32be(&m_reg[(entry.index() - HCD62121_R00) * 4]);
+	}
+	else
+	{
+		switch (entry.index())
+		{
+			case STATE_GENPC:
+			case STATE_GENPCBASE:
+				m_rtemp = (m_cseg << 16) | m_ip;
+				break;
+		}
 	}
 }
 
@@ -868,8 +590,6 @@ void hcd62121_cpu_device::device_reset()
 	{
 		elem = 0;
 	}
-
-	m_debugger_temp = 0;
 }
 
 

--- a/src/devices/cpu/hcd62121/hcd62121.cpp
+++ b/src/devices/cpu/hcd62121/hcd62121.cpp
@@ -21,7 +21,9 @@ TODO:
 
 #include "emu.h"
 #include "hcd62121.h"
+
 #include "hcd62121d.h"
+
 #include "multibyte.h"
 
 
@@ -431,7 +433,8 @@ void hcd62121_cpu_device::state_import(const device_state_entry &entry)
 
 
 void hcd62121_cpu_device::state_export(const device_state_entry &entry)
-{   if ((entry.index() >= HCD62121_R00) && (entry.index() <= HCD62121_R7C))
+{
+	if ((entry.index() >= HCD62121_R00) && (entry.index() <= HCD62121_R7C))
 	{
 		m_debugger_temp = get_u32be(&m_reg[(entry.index() - HCD62121_R00) * 4]);
 	}
@@ -463,9 +466,7 @@ void hcd62121_cpu_device::state_string_export(const device_state_entry &entry, s
 				m_f & FLAG_CL ? "CL":"__",
 				m_f & FLAG_ZL ? "ZL":"__",
 				m_f & FLAG_C ? 'C':'_',
-				m_f & FLAG_Z ? 'Z':'_'
-			);
-
+				m_f & FLAG_Z ? 'Z':'_');
 			break;
 
 		case HCD62121_R00:

--- a/src/devices/cpu/hcd62121/hcd62121.h
+++ b/src/devices/cpu/hcd62121/hcd62121.h
@@ -55,10 +55,13 @@ protected:
 	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
 
 private:
+	TIMER_CALLBACK_MEMBER(timer_tick);
 	u8 read_op();
 	u8 datasize(u8 op);
 	void read_reg(int size, u8 op1);
 	void write_reg(int size, u8 op1);
+	void read_ireg(int size, u8 op1);
+	void write_ireg(int size, u8 op1);
 	void read_regreg(int size, u8 op1, u8 op2, bool copy_extend_immediate);
 	void write_regreg(int size, u8 op1, u8 op2);
 	void read_iregreg(int size, u8 op1, u8 op2, bool copy_extend_immediate);
@@ -92,6 +95,10 @@ private:
 	u8 m_sseg;
 	u8 m_f;
 	u8 m_time;
+	u8 m_time_op;
+	bool m_is_timer_started;
+	bool m_is_infinite_timeout;
+	emu_timer *m_timer;
 	u16 m_lar;
 	u8 m_reg[0x80];
 
@@ -108,6 +115,7 @@ private:
 	address_space *m_program;
 
 	int m_icount;
+	int m_cycles_until_timeout;
 
 	devcb_write8 m_kol_cb;
 	devcb_write8 m_koh_cb;

--- a/src/devices/cpu/hcd62121/hcd62121.h
+++ b/src/devices/cpu/hcd62121/hcd62121.h
@@ -48,6 +48,7 @@ protected:
 	virtual space_config_vector memory_space_config() const override;
 
 	// device_state_interface overrides
+	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
 	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
@@ -96,6 +97,7 @@ private:
 	u8 m_f;
 	u8 m_time;
 	u8 m_time_op;
+	s32 m_cycles_until_timeout;
 	bool m_is_timer_started;
 	bool m_is_infinite_timeout;
 	emu_timer *m_timer;
@@ -112,10 +114,11 @@ private:
 	u8 m_temp2[0x10];
 	u32 m_rtemp;
 
+	u32 m_debugger_temp;
+
 	address_space *m_program;
 
 	int m_icount;
-	int m_cycles_until_timeout;
 
 	devcb_write8 m_kol_cb;
 	devcb_write8 m_koh_cb;

--- a/src/devices/cpu/hcd62121/hcd62121d.cpp
+++ b/src/devices/cpu/hcd62121/hcd62121d.cpp
@@ -117,18 +117,18 @@ const hcd62121_disassembler::dasm hcd62121_disassembler::ops[256] =
 	{ "callnc",  ARG_A16,    ARG_NONE }, { "callnz",  ARG_A16,    ARG_NONE },
 
 	/* 0xb0 */
-	{ "unB0?",   ARG_NONE,   ARG_NONE }, { "unB1?",   ARG_I8,     ARG_NONE },
-	{ "unB2?",   ARG_NONE,   ARG_NONE }, { "unB3?",   ARG_I8,     ARG_NONE },
-	{ "out",     ARG_KHI,    ARG_REG  }, { "out",     ARG_KHI,    ARG_I8   },
-	{ "out",     ARG_KLO,    ARG_REG  }, { "out",     ARG_KLO,    ARG_I8   },
-	{ "unB8?",   ARG_NONE,   ARG_NONE }, { "unB9?",   ARG_I8,     ARG_NONE },
-	{ "unBA?",   ARG_NONE,   ARG_NONE }, { "jmpcl",   ARG_A16,    ARG_NONE },
-	{ "unBC?",   ARG_I8,     ARG_NONE }, { "unBD?",   ARG_NONE,   ARG_NONE },
-	{ "unBE?",   ARG_NONE,   ARG_NONE }, { "jmpncl",  ARG_A16,    ARG_NONE },
+	{ "unB0?",   ARG_I8,     ARG_NONE }, { "unB1?",     ARG_I8,     ARG_NONE },
+	{ "unB2?",   ARG_I8,     ARG_NONE }, { "timer_set", ARG_I8,     ARG_NONE },
+	{ "out",     ARG_KHI,    ARG_REG  }, { "out",       ARG_KHI,    ARG_I8   },
+	{ "out",     ARG_KLO,    ARG_REG  }, { "out",       ARG_KLO,    ARG_I8   },
+	{ "unB8?",   ARG_NONE,   ARG_NONE }, { "unB9?",     ARG_I8,     ARG_NONE },
+	{ "unBA?",   ARG_NONE,   ARG_NONE }, { "jmpcl",     ARG_A16,    ARG_NONE },
+	{ "unBC?",   ARG_I8,     ARG_NONE }, { "unBD?",     ARG_NONE,   ARG_NONE },
+	{ "unBE?",   ARG_NONE,   ARG_NONE }, { "jmpncl",    ARG_A16,    ARG_NONE },
 
 	/* 0xc0 */
 	{ "movb",    ARG_REG,    ARG_I8   }, { "movw",    ARG_REG,    ARG_I16  },
-	{ "movq",    ARG_REG,    ARG_I64  }, { "movt",    ARG_REG,    ARG_I80  },
+	{ "movq",    ARG_REG,    ARG_I8   }, { "movt",    ARG_REG,    ARG_I8   },
 	{ "movb",    ARG_ILR,    ARG_ILR  }, { "movw",    ARG_ILR,    ARG_ILR  },
 	{ "movq",    ARG_ILR,    ARG_ILR  }, { "movt",    ARG_ILR,    ARG_ILR  },
 	{ "unC8?",   ARG_NONE,   ARG_NONE }, { "unC9?",   ARG_NONE,   ARG_NONE },
@@ -149,7 +149,7 @@ const hcd62121_disassembler::dasm hcd62121_disassembler::ops[256] =
 	/* 0xe0 */
 	{ "in0",     ARG_REG,    ARG_NONE }, { "movb",    ARG_REG,    ARG_OPT  },
 	{ "in",      ARG_REG,    ARG_KI   }, { "movb",    ARG_REG,    ARG_DSZ  },
-	{ "movb",    ARG_REG,    ARG_F    }, { "unE5?",   ARG_I8,     ARG_NONE },
+	{ "movb",    ARG_REG,    ARG_F    }, { "movb",    ARG_REG,    ARG_TIME },
 	{ "movb",    ARG_REG,    ARG_PORT }, { "unE7?",   ARG_I8,     ARG_NONE },
 	{ "movw",    ARG_REG,    ARG_LAR  }, { "movw?",   ARG_REG,    ARG_LAR  },
 	{ "movw",    ARG_REG,    ARG_PC   }, { "movw",    ARG_REG,    ARG_SP   },
@@ -157,14 +157,14 @@ const hcd62121_disassembler::dasm hcd62121_disassembler::ops[256] =
 	{ "movb",    ARG_REG,    ARG_CS   }, { "movb",    ARG_REG,    ARG_SS   },
 
 	/* 0xf0 */
-	{ "movb",    ARG_OPT,    ARG_REG  }, { "unF1?",   ARG_I8,     ARG_NONE },
-	{ "movb",    ARG_PORT,   ARG_REG  }, { "unF3?",   ARG_I8,     ARG_NONE },
-	{ "unF4?",   ARG_I8,     ARG_NONE }, { "unF5?",   ARG_I8,     ARG_NONE },
-	{ "unF6?",   ARG_I8,     ARG_NONE }, { "unF7?",   ARG_I8,     ARG_NONE },
-	{ "unF8?",   ARG_NONE,   ARG_NONE }, { "unF9?",   ARG_NONE,   ARG_NONE },
-	{ "unFA?",   ARG_NONE,   ARG_NONE }, { "unFb?",   ARG_NONE,   ARG_NONE },
-	{ "unFC?",   ARG_NONE,   ARG_NONE }, { "unFD?",   ARG_NONE,   ARG_NONE },
-	{ "unFE?",   ARG_NONE,   ARG_NONE }, { "nop",     ARG_NONE,   ARG_NONE }
+	{ "movb",       ARG_OPT,    ARG_REG  }, { "unF1?",          ARG_I8,     ARG_NONE },
+	{ "movb",       ARG_PORT,   ARG_REG  }, { "unF3?",          ARG_I8,     ARG_NONE },
+	{ "unF4?",      ARG_I8,     ARG_NONE }, { "unF5?",          ARG_I8,     ARG_NONE },
+	{ "unF6?",      ARG_I8,     ARG_NONE }, { "timer_ctrl",     ARG_I8,     ARG_NONE },
+	{ "unF8?",      ARG_NONE,   ARG_NONE }, { "unF9?",          ARG_NONE,   ARG_NONE },
+	{ "unFA?",      ARG_NONE,   ARG_NONE }, { "unFb?",          ARG_NONE,   ARG_NONE },
+	{ "unFC?",      ARG_NONE,   ARG_NONE }, { "timer_wait_low", ARG_NONE,   ARG_NONE },
+	{ "timer_wait", ARG_NONE,   ARG_NONE }, { "nop",            ARG_NONE,   ARG_NONE }
 };
 
 u32 hcd62121_disassembler::opcode_alignment() const
@@ -186,9 +186,9 @@ offs_t hcd62121_disassembler::disassemble(std::ostream &stream, offs_t pc, const
 
 	/* Special cases for shift and rotate instructions */
 	if (inst->arg2 == ARG_S4 || inst->arg2 == ARG_S8)
-		util::stream_format(stream, "%c%c%c%c    ", inst->str[0], inst->str[1], (opcodes.r8(pc) & 0x80) ? 'r' : 'l', inst->str[3]);
+		util::stream_format(stream, "%c%c%c%c        ", inst->str[0], inst->str[1], (opcodes.r8(pc) & 0x80) ? 'r' : 'l', inst->str[3]);
 	else
-		util::stream_format(stream, "%-8s", inst->str);
+		util::stream_format(stream, "%-12s", inst->str);
 
 	switch(inst->arg1)
 	{
@@ -318,8 +318,8 @@ offs_t hcd62121_disassembler::disassemble(std::ostream &stream, offs_t pc, const
 	case ARG_PORT:
 		util::stream_format(stream, "PORT");
 		break;
-	case ARG_TIM:
-		util::stream_format(stream, "TIM?");
+	case ARG_TIME:
+		util::stream_format(stream, "TIME");
 		break;
 	case ARG_KLO:
 		util::stream_format(stream, "KOL");
@@ -408,8 +408,8 @@ offs_t hcd62121_disassembler::disassemble(std::ostream &stream, offs_t pc, const
 	case ARG_PORT:
 		util::stream_format(stream, ",PORT");
 		break;
-	case ARG_TIM:
-		util::stream_format(stream, ",TIM?");
+	case ARG_TIME:
+		util::stream_format(stream, ",TIME");
 		break;
 	case ARG_KI:
 		util::stream_format(stream, ",KI");

--- a/src/devices/cpu/hcd62121/hcd62121d.h
+++ b/src/devices/cpu/hcd62121/hcd62121d.h
@@ -47,7 +47,7 @@ private:
 		ARG_DSZ,       /* dsize register? */
 		ARG_OPT,       /* OPTx (output) pins */
 		ARG_PORT,      /* PORTx (output) pins */
-		ARG_TIM,       /* timing related register? */
+		ARG_TIME,      /* timing related register */
 		ARG_KLO,       /* KO1 - KO8 output lines */
 		ARG_KHI,       /* KO9 - KO14(?) output lines */
 		ARG_KI,        /* K input lines */


### PR DESCRIPTION
- Fix CFX9850GB `display_ram` mapping, this one doesn't write to segment 0x60;
- Debugger edits to register values were all being incorrectly applied to the first register, now they should go to the corresponding set of 4 registers;
- Implement TIME register;
- Add more instructions tested on hardware;
- Fix swap flags, they are always cleared regardless of values;
- Fix timer so that it expires on KO enabled key input;
- Add an infinite timer variant, which seems to only be used along with the low power variant of `timer_wait`;
- Prefer more accurate palette taken from an [online Casio manual](https://support.casio.com/storage/en/manual/pdf/EN/004/fx_plus_ch_intro_EN.pdf), although it isn't clear what contrast levels they used for those screenshots;