### PR TITLE
rm/rm380z.cpp: Correct floppy disk handling so double sided disks work and also add support for 8 inch disks

### DIFF
--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -185,10 +185,8 @@ void rm380z_state::rm380z_io(address_map &map)
 {
 	map.global_mask(0xff);
 	map(0x00, 0xbf).rw(FUNC(rm380z_state::rm380z_portlow_r), FUNC(rm380z_state::rm380z_portlow_w));
-	map(0xc0, 0xc3).rw(m_fdc, FUNC(fd1771_device::read), FUNC(fd1771_device::write));
-	map(0xc4, 0xc7).w(FUNC(rm380z_state::disk_0_control));
-	map(0xe0, 0xe3).rw(m_fdc, FUNC(fd1771_device::read), FUNC(fd1771_device::write));
-	map(0xe4, 0xe7).w(FUNC(rm380z_state::disk_0_control));
+	map(0xc0, 0xc3).mirror(0x20).rw(m_fdc, FUNC(fd1771_device::read), FUNC(fd1771_device::write));
+	map(0xc4, 0xc7).mirror(0x20).w(FUNC(rm380z_state::disk_0_control));
 	map(0xe8, 0xff).rw(FUNC(rm380z_state::rm380z_porthi_r), FUNC(rm380z_state::rm380z_porthi_w));
 }
 
@@ -235,13 +233,9 @@ INPUT_PORTS_END
 //
 //
 
-static void rm380z_mds_floppies(device_slot_interface &device)
+static void rm380z_floppies(device_slot_interface &device)
 {
 	device.option_add("mds", FLOPPY_525_SD);
-}
-
-static void rm380z_fds_floppies(device_slot_interface &device)
-{
 	device.option_add("fds", FLOPPY_8_DSSD);
 }
 
@@ -275,8 +269,8 @@ void rm380z_state::configure(machine_config &config)
 	/* floppy disk */
 	FD1771(config, m_fdc, 1_MHz_XTAL);
 
-	FLOPPY_CONNECTOR(config, "wd1771:0", rm380z_mds_floppies, "mds", floppy_image_device::default_mfm_floppy_formats);
-	FLOPPY_CONNECTOR(config, "wd1771:1", rm380z_mds_floppies, "mds", floppy_image_device::default_mfm_floppy_formats);
+	FLOPPY_CONNECTOR(config, m_floppy0, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
+	FLOPPY_CONNECTOR(config, m_floppy1, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
 
 	/* keyboard */
 	generic_keyboard_device &keyboard(GENERIC_KEYBOARD(config, "keyboard", 0));
@@ -304,8 +298,8 @@ void rm380z_state_cos34::configure_fds(machine_config &config)
 {
 	rm380z_state_cos34::configure(config);
 
-	FLOPPY_CONNECTOR(config.replace(), "wd1771:0", rm380z_fds_floppies, "fds", floppy_image_device::default_mfm_floppy_formats);
-	FLOPPY_CONNECTOR(config.replace(), "wd1771:1", rm380z_fds_floppies, "fds", floppy_image_device::default_mfm_floppy_formats);
+	m_floppy0->set_default_option("fds");
+	m_floppy1->set_default_option("fds");
 }
 
 void rm380z_state_cos40::configure(machine_config &config)

--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -186,8 +186,10 @@ void rm380z_state::rm380z_io(address_map &map)
 	map.global_mask(0xff);
 	map(0x00, 0xbf).rw(FUNC(rm380z_state::rm380z_portlow_r), FUNC(rm380z_state::rm380z_portlow_w));
 	map(0xc0, 0xc3).rw(m_fdc, FUNC(fd1771_device::read), FUNC(fd1771_device::write));
-	map(0xc4, 0xc4).w(FUNC(rm380z_state::disk_0_control));
-	map(0xc5, 0xff).rw(FUNC(rm380z_state::rm380z_porthi_r), FUNC(rm380z_state::rm380z_porthi_w));
+	map(0xc4, 0xc7).w(FUNC(rm380z_state::disk_0_control));
+	map(0xe0, 0xe3).rw(m_fdc, FUNC(fd1771_device::read), FUNC(fd1771_device::write));
+	map(0xe4, 0xe7).w(FUNC(rm380z_state::disk_0_control));
+	map(0xe8, 0xff).rw(FUNC(rm380z_state::rm380z_porthi_r), FUNC(rm380z_state::rm380z_porthi_w));
 }
 
 void rm480z_state::rm480z_mem(address_map &map)
@@ -233,9 +235,14 @@ INPUT_PORTS_END
 //
 //
 
-static void rm380z_floppies(device_slot_interface &device)
+static void rm380z_mds_floppies(device_slot_interface &device)
 {
-	device.option_add("sssd", FLOPPY_525_SSSD);
+	device.option_add("mds", FLOPPY_525_SD);
+}
+
+static void rm380z_fds_floppies(device_slot_interface &device)
+{
+	device.option_add("fds", FLOPPY_8_DSSD);
 }
 
 uint32_t rm380z_state::screen_update_rm380z(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
@@ -268,8 +275,8 @@ void rm380z_state::configure(machine_config &config)
 	/* floppy disk */
 	FD1771(config, m_fdc, 1_MHz_XTAL);
 
-	FLOPPY_CONNECTOR(config, "wd1771:0", rm380z_floppies, "sssd", floppy_image_device::default_mfm_floppy_formats);
-	FLOPPY_CONNECTOR(config, "wd1771:1", rm380z_floppies, "sssd", floppy_image_device::default_mfm_floppy_formats);
+	FLOPPY_CONNECTOR(config, "wd1771:0", rm380z_mds_floppies, "mds", floppy_image_device::default_mfm_floppy_formats);
+	FLOPPY_CONNECTOR(config, "wd1771:1", rm380z_mds_floppies, "mds", floppy_image_device::default_mfm_floppy_formats);
 
 	/* keyboard */
 	generic_keyboard_device &keyboard(GENERIC_KEYBOARD(config, "keyboard", 0));
@@ -291,6 +298,14 @@ void rm380z_state_cos34::configure(machine_config &config)
 
 	SN74S262(config, m_rocg, 0);
 	m_rocg->set_palette("palette");
+}
+
+void rm380z_state_cos34::configure_fds(machine_config &config)
+{
+	rm380z_state_cos34::configure(config);
+
+	FLOPPY_CONNECTOR(config.replace(), "wd1771:0", rm380z_fds_floppies, "fds", floppy_image_device::default_mfm_floppy_formats);
+	FLOPPY_CONNECTOR(config.replace(), "wd1771:1", rm380z_fds_floppies, "fds", floppy_image_device::default_mfm_floppy_formats);
 }
 
 void rm380z_state_cos40::configure(machine_config &config)
@@ -389,10 +404,10 @@ ROM_END
 
 
 /* Driver */
-//   YEAR  NAME       PARENT  COMPAT  MACHINE     INPUT      CLASS                   INIT                       COMPANY              FULLNAME                      FLAGS
-COMP(1978, rm380z,    0,      0,      configure,  rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B",          MACHINE_NO_SOUND_HW)
-COMP(1978, rm380zhrg, rm380z, 0,      configure,  rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B with HRG", MACHINE_NO_SOUND_HW)
-COMP(1978, rm380z34d, rm380z, 0,      configure,  rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4D",          MACHINE_NO_SOUND_HW)
-COMP(1978, rm380z34e, rm380z, 0,      configure,  rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4E",          MACHINE_NO_SOUND_HW)
-COMP(1981, rm480z,    rm380z, 0,      configure,  rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 1)",       MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
-COMP(1981, rm480za,   rm380z, 0,      configure,  rm380z,    rm480z_state,           driver_device::empty_init,  "Research Machines", "LINK RM-480Z (set 2)",      MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
+//   YEAR  NAME       PARENT  COMPAT  MACHINE        INPUT      CLASS                   INIT                       COMPANY              FULLNAME                      FLAGS
+COMP(1978, rm380z,    0,      0,      configure,     rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B",          MACHINE_NO_SOUND_HW)
+COMP(1978, rm380zhrg, rm380z, 0,      configure,     rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B with HRG", MACHINE_NO_SOUND_HW)
+COMP(1978, rm380z34d, rm380z, 0,      configure_fds, rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4D",          MACHINE_NO_SOUND_HW)
+COMP(1978, rm380z34e, rm380z, 0,      configure,     rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4E",          MACHINE_NO_SOUND_HW)
+COMP(1981, rm480z,    rm380z, 0,      configure,     rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 1)",       MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
+COMP(1981, rm480za,   rm380z, 0,      configure,     rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 2)",       MACHINE_NOT_WORKING | MACHINE_NO_SOUND)

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -108,6 +108,7 @@ public:
 	}
 
 	void configure(machine_config &config);
+	void configure_fds(machine_config &config);
 
 protected:
 	void machine_reset() override;

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -321,7 +321,7 @@ void rm380z_state::disk_0_control(uint8_t data)
 	{
 		// don't know how motor on is connected
 		floppy->mon_w(0);
-		floppy->ss_w(BIT(data, 5));
+		floppy->ss_w(BIT(data, 4));
 	}
 }
 


### PR DESCRIPTION
Double sided disks would not load before because the floppy drives were wrongly configured as single sided.  The wrong control port bit was also being used to select the side.  After fixing this I can load more software and access the second side of double sided disks (logical drives C: and D:).

I've also added support for 8 inch disks used by the /F firmware variants such as "COS 3.4D/F".  The "/F" refers to FDS (Full Disc System - 8") as opposed to MDS (Mini Disc System - 5.25"), which is designated by "/M".

FDS and MDS actually use different ports, so I've also updated the IO port map to include both sets.  The firmware guide shows both as being reserved for FDC use.  NB the control port address is not fully decoded and can actually be written to using 4 addresses which is why I've expanded this.

I have tested various double sided MDS disks, but have not been able to test FDS as there don't seem to be any 8" disk dumps available.  However, it does now show the "Disk not ready" message when trying to boot without a disk (previously nothing happened when trying to boot with COS 3.4D).