### PR TITLE
rm/rm380z.cpp: Add sound for COS 4.0

### DIFF
--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -257,9 +257,10 @@ void rm380z_state::configure(machine_config &config)
 	m_maincpu->set_addrmap(AS_IO, &rm380z_state::rm380z_io);
 
 	/* video hardware */
+	PALETTE(config, m_palette, palette_device::MONOCHROME_HIGHLIGHT);
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_screen_update(FUNC(rm380z_state::screen_update_rm380z));
-	m_screen->set_palette("palette");
+	m_screen->set_palette(m_palette);
 
 	SPEAKER(config, "mono").front_center();
 
@@ -288,10 +289,9 @@ void rm380z_state_cos34::configure(machine_config &config)
 	m_cassette->add_route(ALL_OUTPUTS, "mono", 0.05);
 
 	m_screen->set_raw(8_MHz_XTAL, 512, 0, 320, 312, 0, 240);
-	PALETTE(config, "palette", palette_device::MONOCHROME_HIGHLIGHT);
 
 	SN74S262(config, m_rocg, 0);
-	m_rocg->set_palette("palette");
+	m_rocg->set_palette(m_palette);
 }
 
 void rm380z_state_cos34::configure_fds(machine_config &config)
@@ -306,16 +306,16 @@ void rm380z_state_cos40::configure(machine_config &config)
 {
 	rm380z_state::configure(config);
 
+	SPEAKER_SOUND(config, m_speaker).add_route(ALL_OUTPUTS, "mono", 0.80);
+
 	m_screen->set_raw(16_MHz_XTAL, 1024, 0, 640, 312, 0, 240);
-	PALETTE(config, "palette", palette_device::MONOCHROME_HIGHLIGHT);
 }
 
 void rm380z_state_cos40_hrg::configure(machine_config &config)
 {
-	rm380z_state::configure(config);
+	rm380z_state_cos40::configure(config);
 
-	m_screen->set_raw(16_MHz_XTAL, 1024, 0, 640, 312, 0, 240);
-	PALETTE(config, m_palette, FUNC(rm380z_state_cos40_hrg::palette_init), 19);
+	m_palette->set_init(FUNC(rm380z_state_cos40_hrg::palette_init)).set_entries(19);
 }
 
 void rm480z_state::configure(machine_config &config)
@@ -399,8 +399,8 @@ ROM_END
 
 /* Driver */
 //   YEAR  NAME       PARENT  COMPAT  MACHINE        INPUT      CLASS                   INIT                       COMPANY              FULLNAME                      FLAGS
-COMP(1978, rm380z,    0,      0,      configure,     rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B",          MACHINE_NO_SOUND_HW)
-COMP(1978, rm380zhrg, rm380z, 0,      configure,     rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B with HRG", MACHINE_NO_SOUND_HW)
+COMP(1978, rm380z,    0,      0,      configure,     rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B",          0)
+COMP(1978, rm380zhrg, rm380z, 0,      configure,     rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B with HRG", 0)
 COMP(1978, rm380z34d, rm380z, 0,      configure_fds, rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4D",          MACHINE_NO_SOUND_HW)
 COMP(1978, rm380z34e, rm380z, 0,      configure,     rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4E",          MACHINE_NO_SOUND_HW)
 COMP(1981, rm480z,    rm380z, 0,      configure,     rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 1)",       MACHINE_NOT_WORKING | MACHINE_NO_SOUND)

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -18,6 +18,7 @@ Research Machines RM 380Z
 #include "machine/keyboard.h"
 #include "machine/ram.h"
 #include "machine/wd_fdc.h"
+#include "sound/spkrdev.h"
 #include "video/sn74s262.h"
 
 #include "emupal.h"
@@ -40,6 +41,7 @@ protected:
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, RM380Z_MAINCPU_TAG),
 		m_screen(*this, "screen"),
+		m_palette(*this, "palette"),
 		m_messram(*this, RAM_TAG),
 		m_fdc(*this, "wd1771"),
 		m_floppy0(*this, "wd1771:0"),
@@ -90,6 +92,7 @@ protected:
 
 	required_device<cpu_device> m_maincpu;
 	optional_device<screen_device> m_screen;
+	optional_device<palette_device> m_palette;
 	optional_device<ram_device> m_messram;
 	optional_device<fd1771_device> m_fdc;
 	optional_device<floppy_connector> m_floppy0;
@@ -147,7 +150,8 @@ class rm380z_state_cos40 : public rm380z_state
 public:
 	rm380z_state_cos40(const machine_config &mconfig, device_type type, const char *tag) :
 		rm380z_state(mconfig, type, tag),
-		m_chargen(*this, "chargen")
+		m_chargen(*this, "chargen"),
+		m_speaker(*this, "speaker")
 	{
 	}
 
@@ -190,6 +194,7 @@ protected:
 	rm380z_vram<RM380Z_SCREENROWS, RM380Z_SCREENCOLS> m_vram;
 
 	required_region_ptr<u8> m_chargen;
+	optional_device<speaker_sound_device> m_speaker;
 
 private:
 	void config_videomode();
@@ -208,7 +213,6 @@ class rm380z_state_cos40_hrg : public rm380z_state_cos40
 public:
 	rm380z_state_cos40_hrg(const machine_config &mconfig, device_type type, const char *tag) :
 		rm380z_state_cos40(mconfig, type, tag),
-		m_palette(*this, "palette"),
 		m_io_display_type(*this, "display_type")
 	{
 	}
@@ -252,7 +256,6 @@ private:
 	uint8_t m_hrg_port1 = 0;
 	hrg_display_mode m_hrg_display_mode = hrg_display_mode::none;
 
-	required_device<palette_device> m_palette;
 	required_ioport m_io_display_type;
 };
 

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -81,7 +81,7 @@ void rm380z_state_cos40::port_write(offs_t offset, uint8_t data)
 			// set scroll register (used to verticaly scroll the screen and effect vram addressing)
 			m_vram.set_scroll_register(data & 0x1f);
 			// bit 6 drives the speaker
-			m_speaker->level_w(data & 0x40);
+			m_speaker->level_w(BIT(data, 6));
 		}
 		break;
 

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -80,6 +80,8 @@ void rm380z_state_cos40::port_write(offs_t offset, uint8_t data)
 		{
 			// set scroll register (used to verticaly scroll the screen and effect vram addressing)
 			m_vram.set_scroll_register(data & 0x1f);
+			// bit 6 drives the speaker
+			m_speaker->level_w(data & 0x40);
 		}
 		break;
 


### PR DESCRIPTION
This PR adds sound for COS 4.0 only as the beep control character, and escape codes to change the beep duration and frequency are not supported by COS 3.4.  The firmware guide lists these as only being implemented in COS 4.0 and later releases.

With this change <Ctrl+G> beeps, and more excitingly music is played in the "Go West" game!  It plays a recognisable rendition of "Coming 'Round the Mountain" and another tune when you reach San Francisco.  I have not found any other software with sound yet.