### PR TITLE
rm/rm380z.cpp: Fix 8" disk clock frequency and minor VDU-80 display improvements

### DIFF
--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -270,8 +270,8 @@ void rm380z_state::configure(machine_config &config)
 	/* floppy disk */
 	FD1771(config, m_fdc, 1_MHz_XTAL);
 
-	FLOPPY_CONNECTOR(config, m_floppy0, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
-	FLOPPY_CONNECTOR(config, m_floppy1, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
+	FLOPPY_CONNECTOR(config, m_floppy0, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats);
+	FLOPPY_CONNECTOR(config, m_floppy1, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats);
 
 	/* keyboard */
 	generic_keyboard_device &keyboard(GENERIC_KEYBOARD(config, "keyboard", 0));

--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -268,10 +268,10 @@ void rm380z_state::configure(machine_config &config)
 	RAM(config, RAM_TAG).set_default_size("56K");
 
 	/* floppy disk */
-	FD1771(config, m_fdc, 1_MHz_XTAL);
+	FD1771(config, m_fdc, 16_MHz_XTAL / 16);
 
-	FLOPPY_CONNECTOR(config, m_floppy0, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats);
-	FLOPPY_CONNECTOR(config, m_floppy1, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats);
+	FLOPPY_CONNECTOR(config, m_floppy0, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
+	FLOPPY_CONNECTOR(config, m_floppy1, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
 
 	/* keyboard */
 	generic_keyboard_device &keyboard(GENERIC_KEYBOARD(config, "keyboard", 0));
@@ -300,6 +300,9 @@ void rm380z_state_cos34::configure_fds(machine_config &config)
 
 	m_floppy0->set_default_option("fds");
 	m_floppy1->set_default_option("fds");
+
+	// FDS drives require a 2 Mhz square wave clock frequency
+	m_fdc->set_unscaled_clock(16_MHz_XTAL / 8);
 }
 
 void rm380z_state_cos40::configure(machine_config &config)

--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -205,7 +205,7 @@ void rm480z_state::rm480z_io(address_map &map)
 	//map(0x1a, 0x1a).mirror(0xff00); // control port 2
 	//map(0x1b, 0x1b).mirror(0xff00); // control port 3 (DAC) // option
 	//map(0x1d, 0x1d).mirror(0xff00); // control port 5 (USERIO) // option
-	//map(0x20, 0x23).mirror(0xff00); // system CTC - 0=SIO4&cassin, 1=SIO2&cassio, 2=keybd int, 3=50hz int for repeat key
+	//map(0x20, 0x23).mirror(0xff00); // system CTC - 0=SIO4&cassin, 1=SIO2&cassio, 2=keybd int, 3=50Hz int for repeat key
 	//map(0x24, 0x27).mirror(0xff00); // system SIO - 0=chA network data, 1=chB SIO4 data, 2=ChA control, 3=ChB control
 	//map(0x28, 0x29).mirror(0xff02); // am9511/am9512 maths chip // option
 	//map(0x2c, 0x2f).mirror(0xff00); // z80ctc IEEE int, Maths int, RTC, RTC // option
@@ -301,7 +301,7 @@ void rm380z_state_cos34::configure_fds(machine_config &config)
 	m_floppy0->set_default_option("fds");
 	m_floppy1->set_default_option("fds");
 
-	// FDS drives require a 2 Mhz square wave clock frequency
+	// FDS drives require a 2 MHz square wave clock frequency
 	m_fdc->set_unscaled_clock(16_MHz_XTAL / 8);
 }
 

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -193,6 +193,8 @@ protected:
 	int m_videomode = RM380Z_VIDEOMODE_80COL;
 	rm380z_vram<RM380Z_SCREENROWS, RM380Z_SCREENCOLS> m_vram;
 
+	uint8_t m_fbfd = 0;
+
 	required_region_ptr<u8> m_chargen;
 	optional_device<speaker_sound_device> m_speaker;
 

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -74,14 +74,18 @@ void rm380z_state_cos40::port_write(offs_t offset, uint8_t data)
 				m_user_defined_chars[(m_character % 128) * 16 + m_character_row] = data;
 			}
 		}
-		// ignore updates while bit 4 of port 0 is set
-		// (counter is not used to set the scroll register in this case, maybe used for smooth scrolling?)
-		else if (!(m_port0 & 0x10))
+		else
 		{
-			// set scroll register (used to verticaly scroll the screen and effect vram addressing)
-			m_vram.set_scroll_register(data & 0x1f);
+			// ignore scroll updates while bit 4 (CGMUX) of port 0 is set
+			// (counter is then used for smooth scrolling which is not currently implemented)
+			if (!(m_port0 & 0x10))
+			{
+				// set scroll register (used to verticaly scroll the screen and effect vram addressing)
+				m_vram.set_scroll_register(data & 0x1f);
+			}
 			// bit 6 drives the speaker
 			m_speaker->level_w(BIT(data, 6));
+			m_fbfd = data;
 		}
 		break;
 
@@ -348,6 +352,8 @@ void rm380z_state_cos34::machine_reset()
 void rm380z_state_cos40::machine_reset()
 {
 	rm380z_state::machine_reset();
+
+	m_fbfd = 0x00;
 
 	m_vram.reset();
 	memset(m_user_defined_chars, 0, sizeof(m_user_defined_chars));

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -9,7 +9,7 @@ RM 380Z machine
 
 #include "emu.h"
 #include "rm380z.h"
-#include "formats/flopimg.h"
+
 
 /*
 
@@ -325,16 +325,6 @@ void rm380z_state::disk_0_control(uint8_t data)
 
 	if (floppy)
 	{
-		// FDS and MDS drives use a differnt square wave clock frequency
-		if (floppy->get_form_factor() == floppy_image::FF_8)
-		{
-			m_fdc->set_unscaled_clock(2_MHz_XTAL);
-		}
-		else
-		{
-			m_fdc->set_unscaled_clock(1_MHz_XTAL);
-		}
-
 		// don't know how motor on is connected
 		floppy->mon_w(0);
 		floppy->ss_w(BIT(data, 4));

--- a/src/mame/rm/rm380z_m.cpp
+++ b/src/mame/rm/rm380z_m.cpp
@@ -9,7 +9,7 @@ RM 380Z machine
 
 #include "emu.h"
 #include "rm380z.h"
-
+#include "formats/flopimg.h"
 
 /*
 
@@ -325,6 +325,16 @@ void rm380z_state::disk_0_control(uint8_t data)
 
 	if (floppy)
 	{
+		// FDS and MDS drives use a differnt square wave clock frequency
+		if (floppy->get_form_factor() == floppy_image::FF_8)
+		{
+			m_fdc->set_unscaled_clock(2_MHz_XTAL);
+		}
+		else
+		{
+			m_fdc->set_unscaled_clock(1_MHz_XTAL);
+		}
+
 		// don't know how motor on is connected
 		floppy->mon_w(0);
 		floppy->ss_w(BIT(data, 4));

--- a/src/mame/rm/rm380z_v.cpp
+++ b/src/mame/rm/rm380z_v.cpp
@@ -171,6 +171,8 @@ void rm380z_state_cos40::videoram_write(offs_t offset, uint8_t data)
 		else
 		{
 			m_vram.set_char(row, col, data);
+			// when a character is written, the corresponding attributes are cleared
+			m_vram.set_attrib(row, col, 0);
 		}
 	}
 	// else out of bounds write had no effect (see VTOUT description in firmware guide)
@@ -390,7 +392,11 @@ void rm380z_state_cos40_hrg::update_screen(bitmap_ind16 &bitmap) const
 		draw_medium_res_graphics(bitmap);
 	}
 
-	rm380z_state_cos40::update_screen(bitmap);
+	if (!(m_fbfd & 0x80))
+	{
+		// display text on top of graphics unless prevented by bit 7 of fbfd (VID INHIB)
+		rm380z_state_cos40::update_screen(bitmap);
+	}
 }
 
 void rm380z_state_cos40::update_screen(bitmap_ind16 &bitmap) const

--- a/src/mame/rm/rm380z_v.cpp
+++ b/src/mame/rm/rm380z_v.cpp
@@ -48,7 +48,7 @@ void rm380z_state_cos40_hrg::palette_init(palette_device &palette)
 	palette.set_pen_color(2, rgb_t::white());
 
 	// HRG palette (initialise to all black)
-	for (int c=3; c < 19; c++)
+	for (int c = 3; c < 19; c++)
 	{
 		palette.set_pen_color(c, rgb_t::black());
 	}
@@ -115,7 +115,7 @@ void rm380z_state_cos40::config_videomode()
 {
 	int old_mode = m_videomode;
 
-	if (m_port0 & 0x20)
+	if (BIT(m_port0, 5))
 	{
 		// 80 cols
 		m_videomode = RM380Z_VIDEOMODE_80COL;
@@ -180,7 +180,7 @@ void rm380z_state_cos40::videoram_write(offs_t offset, uint8_t data)
 
 void rm380z_state_cos40_hrg::videoram_write(offs_t offset, uint8_t data)
 {
-	if (m_hrg_port0 & 0x04)
+	if (BIT(m_hrg_port0, 2))
 	{
 		// write to HRG memory
 		m_hrg_ram[calculate_hrg_vram_index(offset)] = data;
@@ -228,7 +228,7 @@ uint8_t rm380z_state_cos40_hrg::videoram_read(offs_t offset)
 {
 	uint8_t data;
 
-	if (m_hrg_port0 & 0x04)
+	if (BIT(m_hrg_port0, 2))
 	{
 		// read from HRG memory
 		data = m_hrg_ram[calculate_hrg_vram_index(offset)];
@@ -249,7 +249,7 @@ void rm380z_state_cos40::putChar_vdu80(int charnum, int attribs, int x, int y, b
 
 	int data_pos = (charnum % 128) * 16;
 
-	for (int r=0; r < 10; r++, data_pos++)
+	for (int r = 0; r < 10; r++, data_pos++)
 	{
 		uint8_t data;
 
@@ -268,9 +268,9 @@ void rm380z_state_cos40::putChar_vdu80(int charnum, int attribs, int x, int y, b
 			data = m_user_defined_chars[data_pos];
 		}
 
-		for (int c=0; c < 8; c++, data <<= 1)
+		for (int c = 0; c < 8; c++, data <<= 1)
 		{
-			uint8_t pixel_value = (data & 0x80) ? 2 : 0;
+			uint8_t pixel_value = BIT(data, 7) ? 2 : 0;
 			if (attrRev)
 			{
 				pixel_value = !pixel_value;
@@ -293,13 +293,13 @@ void rm380z_state_cos34::putChar_vdu40(int charnum, int x, int y, bitmap_ind16 &
 	{
 		// 5x9 characters are drawn in 8x10 grid
 		// with 1 pixel gap to the left, 2 pixel gap to the right, and 1 pixel gap at the bottom
-		for (int r=0; r < 9; r++)
+		for (int r = 0; r < 9; r++)
 		{
 			uint8_t data = m_rocg->read(charnum, r);
 
-			for (int c=1; c < 6; c++, data <<= 1)
+			for (int c = 1; c < 6; c++, data <<= 1)
 			{
-				if (data & 0x40)
+				if (BIT(data, 6))
 				{
 					bitmap.pix(y * 10 + r, x * 8 + c) = 2;
 				}
@@ -313,27 +313,27 @@ void rm380z_state_cos34::putChar_vdu40(int charnum, int x, int y, bitmap_ind16 &
 
 		// discrete logic gates were used to produce a full 8x10 grid of pixels
 		// the top block is 4 pixels high, and the two lower two blocks are 3 pixels high
-		if (charnum & 0x01)
+		if (BIT(charnum, 0))
 		{
 			bitmap.plot_box(x * 8, y * 10, 4, 4, colour);
 		}
-		if (charnum & 0x02)
+		if (BIT(charnum, 1))
 		{
 			bitmap.plot_box(x * 8 + 4, y * 10, 4, 4, colour);
 		}
-		if (charnum & 0x04)
+		if (BIT(charnum, 2))
 		{
 			bitmap.plot_box(x * 8, y * 10 + 4, 4, 3, colour);
 		}
-		if (charnum & 0x08)
+		if (BIT(charnum, 3))
 		{
 			bitmap.plot_box(x * 8 + 4, y * 10 + 4, 4, 3, colour);
 		}
-		if (charnum & 0x10)
+		if (BIT(charnum, 4))
 		{
 			bitmap.plot_box(x * 8, y * 10 + 7, 4, 3, colour);
 		}
-		if (charnum & 0x20)
+		if (BIT(charnum, 5))
 		{
 			bitmap.plot_box(x * 8 + 4, y * 10 + 7, 4, 3, colour);
 		}
@@ -353,9 +353,9 @@ void rm380z_state_cos40_hrg::draw_high_res_graphics(bitmap_ind16 &bitmap) const
 		{
 			int index = ((y / 16) * 1280) + ((x / 4) << 4) + (y % 16);
 			uint8_t data = m_hrg_ram[index];
-			for (int c=0; c < 4; c++, data >>= 2)
+			for (int c = 0; c < 4; c++, data >>= 2)
 			{
-				bitmap.plot_box((x+c)*pw, y*ph, pw, ph, (data & 0x03) + 3);
+				bitmap.plot_box((x + c)*pw, y*ph, pw, ph, (data & 0x03) + 3);
 			}
 		}
 	}
@@ -392,7 +392,7 @@ void rm380z_state_cos40_hrg::update_screen(bitmap_ind16 &bitmap) const
 		draw_medium_res_graphics(bitmap);
 	}
 
-	if (!(m_fbfd & 0x80))
+	if (!BIT(m_fbfd, 7))
 	{
 		// display text on top of graphics unless prevented by bit 7 of fbfd (VID INHIB)
 		rm380z_state_cos40::update_screen(bitmap);


### PR DESCRIPTION
The RM 8" disk format is actually the IBM-3740 standard which means that generic CP/M disks in this format are compatible.  By testing these I've discovered that the FD-1771 square wave clock frequency needs to be changed for 8" disks.  This PR does that and allows such disks to load.  For example, I've just played the Infocom text adventure Zork from an 8" disk image :-)

I have also removed the slot device "fixed" restriction to allow switching between MDS and FDS drives.  It is actually possible to use FDS drives with MDS firmware if you patch the CP/M disk parameter tables, i.e boot from MDS disk in drive A:, then patch the disk parameter tables for drive B: before using with FDS disks!  I have written an assembler program to do just that.  The extra disk space allows larger CP/M programs to load which is actually very useful.  Apparently RM originally used something similar to transfer data between the two systems.

Display improvements include supporting the VID INHIB port flag which is used to control whether text is displayed with HRG or not.  There is an escape sequence for switching between these modes, which of course now works.

