### PR TITLE
Revert "video/mc6845.cpp: Restore support for zero active width/height configuration"

### DIFF
--- a/src/devices/video/mc6845.h
+++ b/src/devices/video/mc6845.h
@@ -204,8 +204,8 @@ protected:
 	/* These computed are used to define the screen parameters for a driver */
 	uint16_t  m_horiz_pix_total;
 	uint16_t  m_vert_pix_total;
-	uint16_t  m_visible_width;
-	uint16_t  m_visible_height;
+	uint16_t  m_max_visible_x;
+	uint16_t  m_max_visible_y;
 	uint16_t  m_hsync_on_pos;
 	uint16_t  m_hsync_off_pos;
 	uint16_t  m_vsync_on_pos;

--- a/src/mame/commodore/cbm2.cpp
+++ b/src/mame/commodore/cbm2.cpp
@@ -1422,9 +1422,6 @@ INPUT_PORTS_END
 
 MC6845_UPDATE_ROW( cbm2_state::crtc_update_row )
 {
-	if (!de)
-		return;
-
 	pen_t const *const pen = m_palette->pens();
 
 	int x = 0;

--- a/src/mame/heathkit/tlb.cpp
+++ b/src/mame/heathkit/tlb.cpp
@@ -19,6 +19,8 @@
       - 49/50 row mode only shows half the screen.
       - In 49/50 row mode, character descenders are cut off.
       - Screen saver does not disable the screen
+    - With superset slot option
+      - Screensaver freezes the screen instead of blanking the screen
 
   Not Implemented (yet)
     - With SigmaSoft IGC
@@ -908,7 +910,6 @@ ROM_START( h19 )
 	ROM_LOAD( "2716_444-37_h19keyb.u445", 0x0000, 0x0800, CRC(5c3e6972) SHA1(df49ce64ae48652346a91648c58178a34fb37d3c))
 ROM_END
 
-
 ROM_START( super19 )
 	// Super-19 ROM
 	ROM_REGION( 0x1000, "maincpu", ROMREGION_ERASEFF )
@@ -922,7 +923,6 @@ ROM_START( super19 )
 	ROM_REGION( 0x0800, "keyboard", 0 )
 	ROM_LOAD( "2716_444-37_h19keyb.u445", 0x0000, 0x0800, CRC(5c3e6972) SHA1(df49ce64ae48652346a91648c58178a34fb37d3c))
 ROM_END
-
 
 ROM_START( superset )
 	// SuperSet ROM
@@ -941,7 +941,6 @@ ROM_START( superset )
 	ROM_REGION( 0x0800, "keyboard", 0 )
 	ROM_LOAD( "2716_101-422_superset_kbd.u445", 0x0000, 0x0800, CRC(549d15b3) SHA1(981962e5e05bbdc5a66b0e86870853ce5596e877))
 ROM_END
-
 
 ROM_START( watz19 )
 	ROM_REGION( 0x1000, "maincpu", ROMREGION_ERASEFF )
@@ -963,7 +962,6 @@ ROM_START( watz19 )
 	ROM_LOAD( "keybd.u445", 0x0000, 0x0800, CRC(58dc8217) SHA1(1b23705290bdf9fc6342065c6a528c04bff67b13))
 ROM_END
 
-
 ROM_START( ultra19 )
 	// Ultra ROM
 	ROM_REGION( 0x1000, "maincpu", ROMREGION_ERASEFF )
@@ -977,7 +975,6 @@ ROM_START( ultra19 )
 	ROM_REGION( 0x0800, "keyboard", 0 )
 	ROM_LOAD( "2716_h19_ultra_keyboard.u445", 0x0000, 0x0800, CRC(76130c92) SHA1(ca39c602af48505139d2750a084b5f8f0e662ff7))
 ROM_END
-
 
 ROM_START( gp19 )
 	// GP-19 ROMs
@@ -994,7 +991,6 @@ ROM_START( gp19 )
 	ROM_REGION( 0x0800, "keyboard", 0 )
 	ROM_LOAD( "2716_444-37_h19keyb.u445", 0x0000, 0x0800, CRC(5c3e6972) SHA1(df49ce64ae48652346a91648c58178a34fb37d3c))
 ROM_END
-
 
 ROM_START( imaginator )
 	// Program code
@@ -1136,7 +1132,6 @@ ioport_constructor heath_super19_tlb_device::device_input_ports() const
 {
 	return INPUT_PORTS_NAME(super19);
 }
-
 
 /**
  * Superset ROM
@@ -1285,7 +1280,6 @@ void heath_superset_tlb_device::out2_internal(int data)
 	m_selected_char_set = (m_selected_char_set & 0x0a) | (data & 0x01);
 }
 
-
 /**
  * Watzman ROM
  *
@@ -1305,7 +1299,6 @@ ioport_constructor heath_watz_tlb_device::device_input_ports() const
 {
 	return INPUT_PORTS_NAME(watz19);
 }
-
 
 /**
  * UltraROM
@@ -1344,7 +1337,6 @@ ioport_constructor heath_ultra_tlb_device::device_input_ports() const
 {
 	return INPUT_PORTS_NAME(ultra19);
 }
-
 
 /**
  * Northwest Digital Systems GP-19 add-in board
@@ -1441,6 +1433,7 @@ void heath_gp19_tlb_device::latch_u5_w(uint8_t data)
 		m_crtc->set_clock(GP19_DOT_CLOCK_2 / 8);
 	}
 }
+
 
 MC6845_UPDATE_ROW(heath_gp19_tlb_device::crtc_update_row)
 {


### PR DESCRIPTION
Reverts mamedev/mame#12007

This is a case of attempting to fix the symptom rather than the issue, and it breaks all systems that use 6845-family CRTCs with "show borders" set.