### PR TITLE
megadriv.xml: Added and corrected info on the Sega Game Toshokan games

### DIFF
--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -60,23 +60,25 @@ Known undumped pirates
   * Shizen Mahjong / Competition Mahjong (by Sachen, apparently dumped but hoarded)
   * Magic 7 Block - 百変七巧板
 
-Sega Game Toshokan games could be downloaded via the Mega Modem while a subscription was active. The existing dumps were either extracted from Sega's B-Club! game rental service or ripped from the Game no Kanzume compilations.
-Known missing entries from the Sega Game Toshokan service:
-	Columns (1991)
-	Flicky (1990)
-	Kinetic Connection ① Nei Second (1991)
-	Kinetic Connection ② Ohana Batake (1991)
-	Kinetic Connection ③ Shirogane wa Warau yo (1991)
-	Kinetic Connection ④ Mogura no Oasobi (1991)
-	Kinetic Connection ⑤ Lightning Nei (1991)
-	Pyramid Magic Editor (1991)
-	Pyramid Magic Editor (1991)
-	Pyramid Magic Soushuuhen (1992)
-	Pyramid Magic Yokokuhen (1990)
-	Sega Music Collection Phantasy Star III (1991)
-	Sega Music Collection Bonanza Brothers (1991)
-	Sega Music Collection Sonic The Hedgehog (1991)
-	Taiketsu! Columns (1991)
+Sega Game Toshokan games could be downloaded via the Mega Modem while a subscription was active. The existing dumps were either extracted from Sega's B-Club! game rental service or ripped from the Game no Kanzume compilations released on the Mega-CD.
+
+Known missing entries from the Sega Game Toshokan service
+
+  * Columns (1991)
+  * Flicky (1990)
+  * Kinetic Connection ① Nei Second (1991)
+  * Kinetic Connection ② Ohana Batake (1991)
+  * Kinetic Connection ③ Shirogane wa Warau yo (1991)
+  * Kinetic Connection ④ Mogura no Oasobi (1991)
+  * Kinetic Connection ⑤ Lightning Nei (1991)
+  * Pyramid Magic Editor (1991)
+  * Pyramid Magic Editor (1991)
+  * Pyramid Magic Soushuuhen (1992)
+  * Pyramid Magic Yokokuhen (1990)
+  * Sega Music Collection Phantasy Star III (1991)
+  * Sega Music Collection Bonanza Brothers (1991)
+  * Sega Music Collection Sonic The Hedgehog (1991)
+  * Taiketsu! Columns (1991)
 
 TODO:
 - Phantasy Star (serial G-4534, pstarjmd) is actually a SMS cart in MD shell,

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -25827,7 +25827,6 @@ Red screen
 		<year>1991</year>
 		<publisher>Sega</publisher>
 		<info name="alt_title" value="RIDDLE WIRED クイズ独占企業の崩壊 8月 VOL. 1"/>
-		<info name="alt_title" value="クイズ リドル･ワイアード ８月 VOL.1 (Sega Game Toshokan menu)"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
 				<rom name="riddle wired (jpn) (sn).bin" size="262144" crc="fae3d720" sha1="662ffc946978030125dc1274aeec5196bc9a721b"/>

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -79,30 +79,30 @@ Known missing entries from the Sega Game Toshokan service
   * Pyramid Magic Editor (1991)
   * Pyramid Magic Soushuuhen (1992)
   * Pyramid Magic Yokokuhen (1990)
-  * Riddle Wired - Hachigatsu Vol. 2 (1991)
-  * Riddle Wired - Hachigatsu Vol. 3 (1991)
-  * Riddle Wired - Hachigatsu Vol. 4 (1991)
-  * Riddle Wired - Hachigatsu Vol. 5 (1991)
-  * Riddle Wired - Kugatsu Vol. 1 (1991)
-  * Riddle Wired - Kugatsu Vol. 2 (1991)
-  * Riddle Wired - Juugatsu Vol. 1 (1991)
-  * Riddle Wired - Juugatsu Vol. 2 (1991)
-  * Riddle Wired - Juuichigatsu Vol. 1 (1991)
-  * Riddle Wired - Juuichigatsu Vol. 2 (1991)
-  * Riddle Wired - Juunigatsu Vol. 1 (1991)
-  * Riddle Wired - Juunigatsu Vol. 2 (1991)
-  * Riddle Wired - Ichigatsu Vol. 1 (1992)
-  * Riddle Wired - Ichigatsu Vol. 2 (1992)
-  * Riddle Wired - Nigatsu Vol. 1 (1992)
-  * Riddle Wired - Nigatsu Vol. 2 (1992)
-  * Riddle Wired - Sangatsu Vol. 1 (1992)
-  * Riddle Wired - Sangatsu Vol. 2 (1992)
-  * Riddle Wired - Shigatsu Vol. 1 (1992)
-  * Riddle Wired - Shigatsu Vol. 2 (1992)
-  * Riddle Wired - Gogatsu Vol. 1 (1992)
-  * Riddle Wired - Gogatsu Vol. 2 (1992)
-  * Riddle Wired - Rokugatsu Vol. 1 (1992)
-  * Riddle Wired - Rokugatsu Vol. 2 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 8-gatsu Vol. 2 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 8-gatsu Vol. 3 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 8-gatsu Vol. 4 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 8-gatsu Vol. 5 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 9-gatsu Vol. 1 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 9-gatsu Vol. 2 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 10-gatsu Vol. 1 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 10-gatsu Vol. 2 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 11-gatsu Vol. 1 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 11-gatsu Vol. 2 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 12-gatsu Vol. 1 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 12-gatsu Vol. 2 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 1-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 1-gatsu Vol. 2 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 2-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 2-gatsu Vol. 2 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 3-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 3-gatsu Vol. 2 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 4-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 4-gatsu Vol. 2 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 5-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 5-gatsu Vol. 2 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 6-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 6-gatsu Vol. 2 (1992)
   * Sega Music Collection Phantasy Star III (1991)
   * Sega Music Collection Bonanza Brothers (1991)
   * Sega Music Collection Sonic The Hedgehog (1991)
@@ -25823,10 +25823,11 @@ Red screen
 	</software>
 
 	<software name="riddle81">
-		<description>Riddle Wired - Hachigatsu Vol. 1 (Japan, Sega Game Toshokan)</description>
+		<description>Riddle Wired - Quiz Dokusen Kigyou no Houkai 8-gatsu Vol. 1 (Japan, Sega Game Toshokan)</description>
 		<year>1991</year>
 		<publisher>Sega</publisher>
-		<info name="alt_title" value="クイズ リドル･ワイアード ８月 VOL.1"/>
+		<info name="alt_title" value="RIDDLE WIRED クイズ独占企業の崩壊 8月 VOL. 1"/>
+		<info name="alt_title" value="クイズ リドル･ワイアード ８月 VOL.1 (Sega Game Toshokan menu)"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
 				<rom name="riddle wired (jpn) (sn).bin" size="262144" crc="fae3d720" sha1="662ffc946978030125dc1274aeec5196bc9a721b"/>

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -66,15 +66,40 @@ Known missing entries from the Sega Game Toshokan service
 
   * Columns (1991)
   * Flicky (1990)
-  * Kinetic Connection ① Nei Second (1991)
+  * Kinetic Connection ① Nei Sword (1991)
   * Kinetic Connection ② Ohana Batake (1991)
   * Kinetic Connection ③ Shirogane wa Warau yo (1991)
   * Kinetic Connection ④ Mogura no Oasobi (1991)
   * Kinetic Connection ⑤ Lightning Nei (1991)
+  * Phantasy Star II - Nei's Adventure (2008) (Sega Ages 2500 Series Vol. 32)
   * Pyramid Magic Editor (1991)
   * Pyramid Magic Editor (1991)
   * Pyramid Magic Soushuuhen (1992)
   * Pyramid Magic Yokokuhen (1990)
+  * Riddle Wired - Hachigatsu Vol. 2 (1991)
+  * Riddle Wired - Hachigatsu Vol. 3 (1991)
+  * Riddle Wired - Hachigatsu Vol. 4 (1991)
+  * Riddle Wired - Hachigatsu Vol. 5 (1991)
+  * Riddle Wired - Kugatsu Vol. 1 (1991)
+  * Riddle Wired - Kugatsu Vol. 2 (1991)
+  * Riddle Wired - Juugatsu Vol. 1 (1991)
+  * Riddle Wired - Juugatsu Vol. 2 (1991)
+  * Riddle Wired - Juuichigatsu Vol. 1 (1991)
+  * Riddle Wired - Juuichigatsu Vol. 2 (1991)
+  * Riddle Wired - Juunigatsu Vol. 1 (1991)
+  * Riddle Wired - Juunigatsu Vol. 2 (1991)
+  * Riddle Wired - Ichigatsu Vol. 1 (1992)
+  * Riddle Wired - Ichigatsu Vol. 2 (1992)
+  * Riddle Wired - Nigatsu Vol. 1 (1992)
+  * Riddle Wired - Nigatsu Vol. 2 (1992)
+  * Riddle Wired - Sangatsu Vol. 1 (1992)
+  * Riddle Wired - Sangatsu Vol. 2 (1992)
+  * Riddle Wired - Shigatsu Vol. 1 (1992)
+  * Riddle Wired - Shigatsu Vol. 2 (1992)
+  * Riddle Wired - Gogatsu Vol. 1 (1992)
+  * Riddle Wired - Gogatsu Vol. 2 (1992)
+  * Riddle Wired - Rokugatsu Vol. 1 (1992)
+  * Riddle Wired - Rokugatsu Vol. 2 (1992)
   * Sega Music Collection Phantasy Star III (1991)
   * Sega Music Collection Bonanza Brothers (1991)
   * Sega Music Collection Sonic The Hedgehog (1991)
@@ -25795,9 +25820,10 @@ Red screen
 	</software>
 
 	<software name="riddle">
-		<description>Riddle Wired (Japan, Sega Game Toshokan)</description>
+		<description>Riddle Wired - Hachigatsu Vol. 1 (Japan, Sega Game Toshokan)</description>
 		<year>1991</year>
 		<publisher>Sega</publisher>
+		<info name="alt_title" value="クイズ リドル･ワイアード ８月 VOL.1"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
 				<rom name="riddle wired (jpn) (sn).bin" size="262144" crc="fae3d720" sha1="662ffc946978030125dc1274aeec5196bc9a721b"/>

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -60,6 +60,24 @@ Known undumped pirates
   * Shizen Mahjong / Competition Mahjong (by Sachen, apparently dumped but hoarded)
   * Magic 7 Block - 百変七巧板
 
+Sega Game Toshokan games could be downloaded via the Mega Modem while a subscription was active. The existing dumps were either extracted from Sega's B-Club! game rental service or ripped from the Game no Kanzume compilations.
+Known missing entries from the Sega Game Toshokan service:
+	Columns (1991)
+	Flicky (1990)
+	Kinetic Connection ① Nei Second (1991)
+	Kinetic Connection ② Ohana Batake (1991)
+	Kinetic Connection ③ Shirogane wa Warau yo (1991)
+	Kinetic Connection ④ Mogura no Oasobi (1991)
+	Kinetic Connection ⑤ Lightning Nei (1991)
+	Pyramid Magic Editor (1991)
+	Pyramid Magic Editor (1991)
+	Pyramid Magic Soushuuhen (1992)
+	Pyramid Magic Yokokuhen (1990)
+	Sega Music Collection Phantasy Star III (1991)
+	Sega Music Collection Bonanza Brothers (1991)
+	Sega Music Collection Sonic The Hedgehog (1991)
+	Taiketsu! Columns (1991)
+
 TODO:
 - Phantasy Star (serial G-4534, pstarjmd) is actually a SMS cart in MD shell,
   which works in the MD thanks to VDP compatibility mode.
@@ -10115,8 +10133,8 @@ but dumps still have to be confirmed.
 	</software>
 
 	<software name="16tongnk" cloneof="16ton">
-		<description>16t (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>16t (Japan, ripped from Game no Kanzume Vol. 2)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -15576,7 +15594,7 @@ https://bootleggames.fandom.com/wiki/Chaoji_Dafuweng
 
 	<software name="dokidoki">
 		<description>Ikazuse! Koi no Doki Doki Penguin Land MD (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1992</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -15586,8 +15604,8 @@ https://bootleggames.fandom.com/wiki/Chaoji_Dafuweng
 	</software>
 
 	<software name="dokidokignk" cloneof="dokidoki">
-		<description>Ikazuse! Koi no Doki Doki Penguin Land MD (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Ikazuse! Koi no Doki Doki Penguin Land MD (Japan, ripped from Game no Kanzume Vol. 2)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -17029,7 +17047,7 @@ https://segaretro.org/Elitserien_96
 
 	<software name="labdeath" cloneof="fatallab">
 		<description>Shi no Meikyuu - Labyrinth of Death (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1990</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -17039,8 +17057,8 @@ https://segaretro.org/Elitserien_96
 	</software>
 
 	<software name="labdeathgnk" cloneof="fatallab">
-		<description>Shi no Meikyuu - Labyrinth of Death (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Shi no Meikyuu - Labyrinth of Death (Japan, ripped from Game no Kanzume Vol. 2)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="131072">
@@ -17665,12 +17683,12 @@ https://segaretro.org/Feng_Shen_Ying_Jie_Chuan
 	</software>
 
 	<software name="gamenko">
-		<description>Game no Kandume Otokuyou (Japan)</description>
+		<description>Game no Kanzume Otokuyou (Japan, Sega Channel)</description>
 		<year>1995</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="3145728">
-				<rom name="game no kandume otokuyou (jpn).bin" size="3145728" crc="cdad7e6b" sha1="31c66bd13abf4ae8271c09ec5286a0ee0289dbbc"/>
+				<rom name="game no kanzume otokuyou (jpn).bin" size="3145728" crc="cdad7e6b" sha1="31c66bd13abf4ae8271c09ec5286a0ee0289dbbc"/>
 			</dataarea>
 		</part>
 	</software>
@@ -18544,8 +18562,8 @@ Unemulated [Sega Mega Modem] features
 	</software>
 
 	<software name="hypermgnk" cloneof="hyperm">
-		<description>Hyper Marbles (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Hyper Marbles (Japan, ripped from Game no Kanzume Vol. 1)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -23768,8 +23786,8 @@ Black screen at intro
 	</software>
 
 	<software name="paddlegnk" cloneof="paddle">
-		<description>Paddle Fighter (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Paddle Fighter (Japan, ripped from Game no Kanzume Vol. 1)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -24101,7 +24119,7 @@ Black screen at intro
 
 	<software name="ps2aa">
 		<description>Phantasy Star II - Amia's Adventure (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1990</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -24134,7 +24152,7 @@ Black screen at intro
 
 	<software name="ps2ad">
 		<description>Phantasy Star II - Kinds's Adventure (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1990</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -24167,7 +24185,7 @@ Black screen at intro
 
 	<software name="ps2ag">
 		<description>Phantasy Star II - Shilka's Adventure (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1990</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -25052,7 +25070,7 @@ Black screen
 
 	<software name="putter">
 		<description>Putter Golf (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1990</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -25062,8 +25080,8 @@ Black screen
 	</software>
 
 	<software name="puttergnk" cloneof="putter">
-		<description>Putter Golf (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Putter Golf (Japan, ripped from Game no Kanzume Vol. 2)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -25168,8 +25186,8 @@ Black screen
 	</software>
 
 	<software name="pyramidgnk" cloneof="pyramid">
-		<description>Pyramid Magic (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Pyramid Magic (Japan, ripped from Game no Kanzume Vol. 1)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -25819,7 +25819,7 @@ Red screen
 		</part>
 	</software>
 
-	<software name="riddle">
+	<software name="riddle81">
 		<description>Riddle Wired - Hachigatsu Vol. 1 (Japan, Sega Game Toshokan)</description>
 		<year>1991</year>
 		<publisher>Sega</publisher>

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -60,7 +60,10 @@ Known undumped pirates
   * Shizen Mahjong / Competition Mahjong (by Sachen, apparently dumped but hoarded)
   * Magic 7 Block - 百変七巧板
 
-Sega Game Toshokan games could be downloaded via the Mega Modem while a subscription was active. The existing dumps were either extracted from Sega's B-Club! game rental service or ripped from the Game no Kanzume compilations released on the Mega-CD.
+Sega Game Toshokan games could be downloaded via the Mega Modem while a
+subscription was active. The existing dumps were either extracted from
+Sega's B-Club! game rental service or ripped from the Game no Kanzume
+compilations released on the Mega-CD.
 
 Known missing entries from the Sega Game Toshokan service
 


### PR DESCRIPTION
- Added list of known missing Sega Game Toshokan games.
- Added the specific titles of the collections where some of these dumps come from.
- Corrected Kandume -> Kanzume.
- Added proper years for all of their entries according to Sega's website.
- Added full "serialized" title to existing Riddle Wired entry.