### PR TITLE
Add -listconfigs and -config command line options.

### DIFF
--- a/src/emu/config.h
+++ b/src/emu/config.h
@@ -64,6 +64,7 @@ private:
 
 	running_machine &machine() const { return m_machine; }
 
+	void apply_command_line_configs();
 	bool attempt_load(game_driver const &system, emu_file &file, std::string_view name, config_type which_type);
 
 	bool load_xml(game_driver const &system, emu_file &file, config_type which_type);

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -212,6 +212,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_UI_MOUSE,                                   "1",         core_options::option_type::BOOLEAN,    "display UI mouse cursor" },
 	{ OPTION_LANGUAGE ";lang",                           "",          core_options::option_type::STRING,     "set UI display language" },
 	{ OPTION_NVRAM_SAVE ";nvwrite",                      "1",         core_options::option_type::BOOLEAN,    "save NVRAM data on exit" },
+	{ OPTION_CONFIG,                                     nullptr,     core_options::option_type::STRING,     "set dipswitch and configuration options"},
 
 	{ nullptr,                                           nullptr,     core_options::option_type::HEADER,     "SCRIPTING OPTIONS" },
 	{ OPTION_AUTOBOOT_COMMAND ";ab",                     nullptr,     core_options::option_type::STRING,     "command to execute after machine boot" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -172,7 +172,7 @@
 #define OPTION_UI                   "ui"
 #define OPTION_RAMSIZE              "ramsize"
 #define OPTION_NVRAM_SAVE           "nvram_save"
-#define OPTION_CONF                 "conf"
+#define OPTION_CONFIG               "config"
 
 // core comm options
 #define OPTION_COMM_LOCAL_HOST      "comm_localhost"
@@ -457,7 +457,7 @@ public:
 	ui_option ui() const { return m_ui; }
 	const char *ram_size() const { return value(OPTION_RAMSIZE); }
 	bool nvram_save() const { return bool_value(OPTION_NVRAM_SAVE); }
-	const char *conf() const { return value(OPTION_CONF); }
+	const char *config() const { return value(OPTION_CONFIG); }
 
 	// core comm options
 	const char *comm_localhost() const { return value(OPTION_COMM_LOCAL_HOST); }

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -172,6 +172,7 @@
 #define OPTION_UI                   "ui"
 #define OPTION_RAMSIZE              "ramsize"
 #define OPTION_NVRAM_SAVE           "nvram_save"
+#define OPTION_CONF                 "conf"
 
 // core comm options
 #define OPTION_COMM_LOCAL_HOST      "comm_localhost"
@@ -456,6 +457,7 @@ public:
 	ui_option ui() const { return m_ui; }
 	const char *ram_size() const { return value(OPTION_RAMSIZE); }
 	bool nvram_save() const { return bool_value(OPTION_NVRAM_SAVE); }
+	const char *conf() const { return value(OPTION_CONF); }
 
 	// core comm options
 	const char *comm_localhost() const { return value(OPTION_COMM_LOCAL_HOST); }

--- a/src/frontend/mame/clifront.h
+++ b/src/frontend/mame/clifront.h
@@ -60,6 +60,7 @@ private:
 	void listslots(const std::vector<std::string> &args);
 	void listmedia(const std::vector<std::string> &args);
 	void listsoftware(const std::vector<std::string> &args);
+	void listconfigs(const std::vector<std::string> &args);
 	void verifysoftware(const std::vector<std::string> &args);
 	void verifyroms(const std::vector<std::string> &args);
 	void verifysamples(const std::vector<std::string> &args);


### PR DESCRIPTION
The -listconfigs verb lists configuration and dipswitch ports.

Example:
```
mame gridlee -listconfigs
SYSTEM           CONFIG NAME      CONFIG VALUE     CONFIG DESCRIPTION
---------------- ---------------- ---------------- ----------------------------
gridlee          :DSW:0x03                         Bonus Life
                                  0x00             8000 points
                                  0x01             10000 points (default)
                                  0x02             12000 points
                                  0x03             14000 points
                 :DSW:0x0c                         Lives
                                  0x00             2
                                  0x04             3 (default)
                                  0x08             4
                                  0x0c             5
                 :DSW:0x10                         Free Play
                                  0x00             Off (default)
                                  0x10             On
                 :DSW:0x20                         Cabinet
                                  0x00             Upright (default)
                                  0x20             Cocktail
                 :DSW:0x40                         Reset Hall of Fame
                                  0x00             No (default)
                                  0x40             Yes
                 :DSW:0x80                         Reset Game Data
                                  0x00             No (default)
                                  0x80             Yes
                 :IN1:0x30                         Coinage
                                  0x20             2 Coins/1 Credit
                                  0x00             1 Coin/1 Credit (default)
                                  0x10             1 Coin/2 Credits
                 :IN2:0x20                         Service Mode
                                  0x20             Off (default)
                                  0x00             On
```

 And -config can be used to set options for configuration and dipswitch ports.

For instance: `mame gridlee -config :DSW:0x0c=0x0c,:IN1:0x30=0x20` will start the game with 5 lives and 2 coins/1 credit coinage.
