### PR TITLE
chdman: Add support for exporting Dreamcast cues and outputting one bin per track

### DIFF
--- a/docs/source/tools/chdman.rst
+++ b/docs/source/tools/chdman.rst
@@ -319,6 +319,7 @@ Common options supported:
 Additional options:
 
 * ``--outputbin <file>`` / ``-ob <file>``
+* ``--splitbin`` / ``-sb``
 
 extractdvd
 ~~~~~~~~~~

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -97,7 +97,7 @@ constexpr int MODE_GDI = 2;
 #define OPTION_INPUT "input"
 #define OPTION_OUTPUT "output"
 #define OPTION_OUTPUT_BIN "outputbin"
-#define OPTION_OUTPUT_SPLIT "split"
+#define OPTION_OUTPUT_SPLITBIN "splitbin"
 #define OPTION_OUTPUT_FORCE "force"
 #define OPTION_INPUT_START_BYTE "inputstartbyte"
 #define OPTION_INPUT_START_HUNK "inputstarthunk"
@@ -630,7 +630,7 @@ static const option_description s_options[] =
 	{ OPTION_INPUT_PARENT,          "ip",   true, " <filename>: parent file name for input CHD" },
 	{ OPTION_OUTPUT,                "o",    true, " <filename>: output file name" },
 	{ OPTION_OUTPUT_BIN,            "ob",   true, " <filename>: output file name for binary data" },
-	{ OPTION_OUTPUT_SPLIT,          "sb",   false, ": output one binary file per track" },
+	{ OPTION_OUTPUT_SPLITBIN,       "sb",   false, ": output one binary file per track" },
 	{ OPTION_OUTPUT_FORCE,          "f",    false, ": force overwriting an existing file" },
 	{ OPTION_OUTPUT_PARENT,         "op",   true, " <filename>: parent file name for output CHD" },
 	{ OPTION_INPUT_START_BYTE,      "isb",  true, " <offset>: starting byte offset within the input" },
@@ -785,7 +785,7 @@ static const command_description s_commands[] =
 		{
 			REQUIRED OPTION_OUTPUT,
 			OPTION_OUTPUT_BIN,
-			OPTION_OUTPUT_SPLIT,
+			OPTION_OUTPUT_SPLITBIN,
 			OPTION_OUTPUT_FORCE,
 			REQUIRED OPTION_INPUT,
 			OPTION_INPUT_PARENT,
@@ -2568,11 +2568,11 @@ static void do_extract_cd(parameters_map &params)
 		default_name.erase(chop, default_name.size());
 
 	// GDIs will always output as split bin
-	bool is_splitbin = mode == MODE_GDI || params.find(OPTION_OUTPUT_SPLIT) != params.end();
+	bool is_splitbin = mode == MODE_GDI || params.find(OPTION_OUTPUT_SPLITBIN) != params.end();
 	if (!is_splitbin && cdrom->is_gdrom() && mode == MODE_CUEBIN)
 	{
 		// GD-ROM cue/bin is in Redump format which should always be split by tracks
-		util::stream_format(std::cout, "Warning: --%s is required for this specific combination of input disc type and output format, enabling automatically\n", OPTION_OUTPUT_SPLIT);
+		util::stream_format(std::cout, "Warning: --%s is required for this specific combination of input disc type and output format, enabling automatically\n", OPTION_OUTPUT_SPLITBIN);
 		is_splitbin = true;
 	}
 
@@ -2599,15 +2599,15 @@ static void do_extract_cd(parameters_map &params)
 	{
 		output_bin_file_str = output_bin_file_fnd->second;
 
-		chop = (*output_bin_file_str).find_last_of('.');
+		chop = output_bin_file_str->find_last_of('.');
 		if (chop != std::string::npos)
 		{
-			output_bin_file_ext = (*output_bin_file_str).substr(chop, (*output_bin_file_str).size() - chop);
-			(*output_bin_file_str).erase(chop, (*output_bin_file_str).size());
+			output_bin_file_ext = output_bin_file_str->substr(chop, output_bin_file_str->size() - chop);
+			output_bin_file_str->erase(chop, output_bin_file_str->size());
 		}
 	}
 
-	if ((*output_bin_file_str).find('"') != std::string::npos || output_bin_file_ext.find('"') != std::string::npos)
+	if (output_bin_file_str->find('"') != std::string::npos || output_bin_file_ext.find('"') != std::string::npos)
 		report_error(1, "Output bin filename (%s%s) must not contain quotation marks", *output_bin_file_str, output_bin_file_ext);
 
 	// print some info
@@ -2690,7 +2690,7 @@ static void do_extract_cd(parameters_map &params)
 
 			if (is_splitbin && !found_track_variable)
 			{
-				report_error(1, "A track number variable (%%t) must be specified in the output bin filename when --%s is enabled\n", OPTION_OUTPUT_SPLIT);
+				report_error(1, "A track number variable (%%t) must be specified in the output bin filename when --%s is enabled\n", OPTION_OUTPUT_SPLITBIN);
 			}
 
 			// verify output BIN file doesn't exist
@@ -2913,7 +2913,7 @@ static void do_extract_cd(parameters_map &params)
 		// delete the output files
 		output_bin_file.reset();
 		output_toc_file.reset();
-		for (auto output_bin_filename : output_bin_filenames)
+		for (auto const &output_bin_filename : output_bin_filenames)
 			osd_file::remove(output_bin_filename);
 		osd_file::remove(*output_file_str->second);
 		throw;

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -97,7 +97,7 @@ constexpr int MODE_GDI = 2;
 #define OPTION_INPUT "input"
 #define OPTION_OUTPUT "output"
 #define OPTION_OUTPUT_BIN "outputbin"
-#define OPTION_OUTPUT_SPLIT "outputsplit"
+#define OPTION_OUTPUT_SPLIT "split"
 #define OPTION_OUTPUT_FORCE "force"
 #define OPTION_INPUT_START_BYTE "inputstartbyte"
 #define OPTION_INPUT_START_HUNK "inputstarthunk"
@@ -630,7 +630,7 @@ static const option_description s_options[] =
 	{ OPTION_INPUT_PARENT,          "ip",   true, " <filename>: parent file name for input CHD" },
 	{ OPTION_OUTPUT,                "o",    true, " <filename>: output file name" },
 	{ OPTION_OUTPUT_BIN,            "ob",   true, " <filename>: output file name for binary data" },
-	{ OPTION_OUTPUT_SPLIT,          "os",   false, ": output one binary file per track" },
+	{ OPTION_OUTPUT_SPLIT,          "sb",   false, ": output one binary file per track" },
 	{ OPTION_OUTPUT_FORCE,          "f",    false, ": force overwriting an existing file" },
 	{ OPTION_OUTPUT_PARENT,         "op",   true, " <filename>: parent file name for output CHD" },
 	{ OPTION_INPUT_START_BYTE,      "isb",  true, " <offset>: starting byte offset within the input" },

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -2564,7 +2564,7 @@ static void do_extract_cd(parameters_map &params)
 
 	// split path and extension
 	int chop = default_name.find_last_of('.');
-	if (chop != -1)
+	if (chop != std::string::npos)
 		default_name.erase(chop, default_name.size());
 
 	// GDIs will always output as split bin
@@ -2600,12 +2600,15 @@ static void do_extract_cd(parameters_map &params)
 		output_bin_file_str = output_bin_file_fnd->second;
 
 		chop = (*output_bin_file_str).find_last_of('.');
-		if (chop != -1)
+		if (chop != std::string::npos)
 		{
 			output_bin_file_ext = (*output_bin_file_str).substr(chop, (*output_bin_file_str).size() - chop);
 			(*output_bin_file_str).erase(chop, (*output_bin_file_str).size());
 		}
 	}
+
+	if ((*output_bin_file_str).find('"') != std::string::npos || output_bin_file_ext.find('"') != std::string::npos)
+		report_error(1, "Output bin filename (%s%s) must not contain quotation marks", *output_bin_file_str, output_bin_file_ext);
 
 	// print some info
 	util::stream_format(std::cout, "Input CHD:    %s\n", *params.find(OPTION_INPUT)->second);

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -2795,17 +2795,14 @@ static void do_extract_cd(parameters_map &params)
 
 		for (int tracknum = 0; tracknum < toc.numtrks; tracknum++)
 		{
-			if (is_splitbin)
+			if (track_filenames[tracknum] != trackbin_name)
 			{
 				totaloutputoffs += outputoffs;
 				outputoffs = 0;
 
 				if (mode != MODE_GDI)
 					discoffs = 0;
-			}
 
-			if (track_filenames[tracknum] != trackbin_name)
-			{
 				output_bin_file.reset();
 
 				trackbin_name = track_filenames[tracknum];

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -2644,6 +2644,7 @@ static void do_extract_cd(parameters_map &params)
 			std::string::const_iterator new_trackbin_name_end = new_trackbin_name.end();
 			std::string filename_formatted = new_trackbin_name;
 			std::smatch variable_matches;
+			bool found_track_variable = false;
 
 			while (std::regex_search(new_trackbin_name_itr, new_trackbin_name_end, variable_matches, variables_regex))
 			{
@@ -2662,7 +2663,10 @@ static void do_extract_cd(parameters_map &params)
 					{
 						// track number
 						if (is_splitbin)
+						{
 							replacement = util::string_format("%" + format_part + "d", tracknum+1);
+							found_track_variable = true;
+						}
 					}
 					else
 					{
@@ -2679,6 +2683,11 @@ static void do_extract_cd(parameters_map &params)
 				}
 
 				new_trackbin_name_itr = variable_matches.suffix().first; // move past match for next loop
+			}
+
+			if (is_splitbin && !found_track_variable)
+			{
+				report_error(1, "A track number variable (%%t) must be specified in the output bin filename when --%s is enabled\n", OPTION_OUTPUT_SPLIT);
 			}
 
 			// verify output BIN file doesn't exist

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -2661,13 +2661,8 @@ static void do_extract_cd(parameters_map &params)
 					if (format_type == "t")
 					{
 						// track number
-						replacement = util::string_format("%" + format_part + "d", tracknum+1);
-
-						if (!is_splitbin)
-						{
-							util::stream_format(std::cout, "Warning: --%s not specified but track format string detected, enabling automatically\n", OPTION_OUTPUT_SPLIT);
-							is_splitbin = true;
-						}
+						if (is_splitbin)
+							replacement = util::string_format("%" + format_part + "d", tracknum+1);
 					}
 					else
 					{


### PR DESCRIPTION
The output split bins code took inspiration from from @landfillbaby's PR (https://github.com/mamedev/mame/pull/11727). I included some of their changes and did some additional refactoring, and also implemented the start of a formatting system for output filenames after some general design feedback from cuavas.

An example of the formatting system:
`chdman extractcd -i test.chd -o test.cue -ob "test %03t.bin"`
will result in the output bin filenames in the format of "test 001.bin", "test 002.bin", "test 003.bin", etc. 
And `%t` will give the track number without any additional formatting.

The output split bins is a prerequisite for implementing exporting of Dreamcast cues so the two changes have been included together. The commits are fully independent changes so I recommend looking at the specific commits separately instead of the full PR diff for reviewing.

Throwing this out as a draft PR for now to just get some feedback and additional testing.