### PR TITLE
strtdriv: fixed incorrect brake pedal port mapping in harddriv.cpp

### DIFF
--- a/src/mame/atari/harddriv.cpp
+++ b/src/mame/atari/harddriv.cpp
@@ -1324,6 +1324,7 @@ static INPUT_PORTS_START( strtdriv )
 	PORT_START("mainpcb:8BADC.5")        /* b00000 - 8 bit ADC 5 - canopy */
 	PORT_BIT( 0xff, 0x80, IPT_UNUSED )
 
+	/* Placeholder ADC port for voice mic, NOT tested or verified! */
 	PORT_START("mainpcb:8BADC.6")        /* b00000 - 8 bit ADC 6 - voice mic */
 	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 

--- a/src/mame/atari/harddriv.cpp
+++ b/src/mame/atari/harddriv.cpp
@@ -1312,8 +1312,8 @@ static INPUT_PORTS_START( strtdriv )
 	PORT_START("mainpcb:8BADC.1")        /* b00000 - 8 bit ADC 1 */
 	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 
-	PORT_START("mainpcb:8BADC.2")        /* b00000 - 8 bit ADC 2 - voice mic */
-	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
+	PORT_START("mainpcb:8BADC.2")        /* b00000 - 8 bit ADC 2 - brake */
+	PORT_BIT( 0xff, 0x00, IPT_PEDAL2 ) PORT_SENSITIVITY(25) PORT_KEYDELTA(40) PORT_NAME("Brake")
 
 	PORT_START("mainpcb:8BADC.3")        /* b00000 - 8 bit ADC 3 - volume */
 	PORT_BIT( 0xff, 0x80, IPT_UNUSED )
@@ -1324,8 +1324,8 @@ static INPUT_PORTS_START( strtdriv )
 	PORT_START("mainpcb:8BADC.5")        /* b00000 - 8 bit ADC 5 - canopy */
 	PORT_BIT( 0xff, 0x80, IPT_UNUSED )
 
-	PORT_START("mainpcb:8BADC.6")        /* b00000 - 8 bit ADC 6 - brake */
-	PORT_BIT( 0xff, 0x00, IPT_PEDAL2 ) PORT_SENSITIVITY(25) PORT_KEYDELTA(40) PORT_NAME("Brake") PORT_REVERSE
+	PORT_START("mainpcb:8BADC.6")        /* b00000 - 8 bit ADC 6 - voice mic */
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_START("mainpcb:8BADC.7")        /* b00000 - 8 bit ADC 7 - seat adjust */
 	PORT_BIT( 0xff, 0x80, IPT_UNUSED )

--- a/src/mame/atari/harddriv.cpp
+++ b/src/mame/atari/harddriv.cpp
@@ -1324,8 +1324,7 @@ static INPUT_PORTS_START( strtdriv )
 	PORT_START("mainpcb:8BADC.5")        /* b00000 - 8 bit ADC 5 - canopy */
 	PORT_BIT( 0xff, 0x80, IPT_UNUSED )
 
-	/* Placeholder ADC port for voice mic, NOT tested or verified! */
-	PORT_START("mainpcb:8BADC.6")        /* b00000 - 8 bit ADC 6 - voice mic */
+	PORT_START("mainpcb:8BADC.6")        /* b00000 - 8 bit ADC 6 - ADC input for voice mic? Not verified */
 	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_START("mainpcb:8BADC.7")        /* b00000 - 8 bit ADC 7 - seat adjust */


### PR DESCRIPTION
Fixed wrongly mapped brake pedal input from 8ADC:6 to 8ADC:2 and swapped the Voice Mic function which is unused from 8ADC:2 to 8ADC:6 to avoid any conflict/loss of functionality. Steering input still needs to be fixed (if you turn to the far left of right the centre point of the steering wheel will shift and constantly pull the wheel in the opposite direction) Hard Drivin's Airborne has the same problem. Will try to fix that if I can and update the code here on GitHub.