### PR TITLE
Use pkgconfig to determine wayland include dir

### DIFF
--- a/scripts/src/osd/sdl_cfg.lua
+++ b/scripts/src/osd/sdl_cfg.lua
@@ -54,6 +54,11 @@ if _OPTIONS["USE_WAYLAND"]=="1" then
 	defines {
 		"SDLMAME_USE_WAYLAND",
 	}
+	if _OPTIONS["targetos"]=="linux" then
+		buildoptions {
+			backtick(pkgconfigcmd() .. " --cflags wayland-egl"),
+		}
+	end
 end
 
 if _OPTIONS["NO_USE_XINPUT"]=="1" then


### PR DESCRIPTION
Some distros (e.g. openSUSE) put the headers in /usr/include/wayland

This should fix the error reported over at bannister.org forums [1]. Unfortunately, I have no way of testing this.

[1] https://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=123347