### PR TITLE
rm/rm380z.cpp: Add COS 4.0/F firmware

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -38423,10 +38423,12 @@ rc702                           // 1979 RC702
 rc759                           // 1984 RC759
 
 @source:rm/rm380z.cpp
-rm380z                          // 1978 RM380z with COS 4.0 firmware
-rm380zhrg                       // 1978 RM380z with COS 4.0 and HRG
-rm380z34d                       // 1978 RM380z with COS 3.4 firmware and casette
-rm380z34e                       // 1978 RM380z with COS 3.4 firmware and casette
+rm380z                          // 1978 RM380z with COS 4.0/M firmware
+rm380zhrg                       // 1978 RM380z with COS 4.0/M and HRG
+rm380zf                         // 1978 RM380z with COS 4.0/F firmware
+rm380zfhrg                      // 1978 RM380z with COS 4.0/F and HRG
+rm380z34d                       // 1978 RM380z with COS 3.4/F firmware and casette
+rm380z34e                       // 1978 RM380z with COS 3.4/M firmware and casette
 rm480z                          // 1981 RM480z
 rm480za                         // 1981 RM480z
 

--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -249,7 +249,7 @@ uint32_t rm380z_state::screen_update_rm380z(screen_device &screen, bitmap_ind16 
 	return 0;
 }
 
-void rm380z_state::configure(machine_config &config)
+void rm380z_state::configure(machine_config &config, bool bFDS)
 {
 	/* basic machine hardware */
 	Z80(config, m_maincpu, 16_MHz_XTAL / 4);
@@ -268,30 +268,28 @@ void rm380z_state::configure(machine_config &config)
 	RAM(config, RAM_TAG).set_default_size("56K");
 
 	/* floppy disk */
-	FD1771(config, m_fdc, 16_MHz_XTAL / 16);
-
-	FLOPPY_CONNECTOR(config, m_floppy0, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
-	FLOPPY_CONNECTOR(config, m_floppy1, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
+	if (bFDS)
+	{
+		// FDS drives require a 2 MHz square wave clock frequency
+		FD1771(config, m_fdc, 16_MHz_XTAL / 8);
+		FLOPPY_CONNECTOR(config, m_floppy0, rm380z_floppies, "fds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
+		FLOPPY_CONNECTOR(config, m_floppy1, rm380z_floppies, "fds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
+	}
+	else
+	{
+		FD1771(config, m_fdc, 16_MHz_XTAL / 16);
+		FLOPPY_CONNECTOR(config, m_floppy0, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
+		FLOPPY_CONNECTOR(config, m_floppy1, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
+	}
 
 	/* keyboard */
 	generic_keyboard_device &keyboard(GENERIC_KEYBOARD(config, "keyboard", 0));
 	keyboard.set_keyboard_callback(FUNC(rm380z_state::keyboard_put));
 }
 
-void rm380z_state::configure_fds(machine_config &config)
+void rm380z_state_cos34::rm380z34e(machine_config &config, bool bFDS)
 {
-	configure(config);
-
-	m_floppy0->set_default_option("fds");
-	m_floppy1->set_default_option("fds");
-
-	// FDS drives require a 2 MHz square wave clock frequency
-	m_fdc->set_unscaled_clock(16_MHz_XTAL / 8);
-}
-
-void rm380z_state_cos34::configure(machine_config &config)
-{
-	rm380z_state::configure(config);
+	configure(config, bFDS);
 
 	/* cassette */
 	CASSETTE(config, m_cassette);
@@ -305,23 +303,23 @@ void rm380z_state_cos34::configure(machine_config &config)
 	m_rocg->set_palette(m_palette);
 }
 
-void rm380z_state_cos40::configure(machine_config &config)
+void rm380z_state_cos40::rm380z(machine_config &config, bool bFDS)
 {
-	rm380z_state::configure(config);
+	configure(config, bFDS);
 
 	SPEAKER_SOUND(config, m_speaker).add_route(ALL_OUTPUTS, "mono", 0.80);
 
 	m_screen->set_raw(16_MHz_XTAL, 1024, 0, 640, 312, 0, 240);
 }
 
-void rm380z_state_cos40_hrg::configure(machine_config &config)
+void rm380z_state_cos40_hrg::rm380zhrg(machine_config &config, bool bFDS)
 {
-	rm380z_state_cos40::configure(config);
+	rm380z(config, bFDS);
 
 	m_palette->set_init(FUNC(rm380z_state_cos40_hrg::palette_init)).set_entries(19);
 }
 
-void rm480z_state::configure(machine_config &config)
+void rm480z_state::rm480z(machine_config &config)
 {
 	/* basic machine hardware */
 	Z80(config, m_maincpu, 16_MHz_XTAL / 4);
@@ -417,12 +415,12 @@ ROM_END
 
 
 /* Driver */
-//   YEAR  NAME        PARENT   COMPAT  MACHINE        INPUT      CLASS                   INIT                       COMPANY              FULLNAME                        FLAGS
-COMP(1978, rm380z,     0,       0,      configure,     rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/M",          0)
-COMP(1978, rm380zhrg,  rm380z,  0,      configure,     rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/M with HRG", 0)
-COMP(1978, rm380zf,    0,       0,      configure_fds, rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/F",          0)
-COMP(1978, rm380zfhrg, rm380zf, 0,      configure_fds, rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/F with HRG", 0)
-COMP(1978, rm380z34d,  rm380z,  0,      configure_fds, rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4D/F",          MACHINE_NO_SOUND_HW)
-COMP(1978, rm380z34e,  rm380z,  0,      configure,     rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4E/M",          MACHINE_NO_SOUND_HW)
-COMP(1981, rm480z,     rm380z,  0,      configure,     rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 1)",         MACHINE_IS_SKELETON)
-COMP(1981, rm480za,    rm380z,  0,      configure,     rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 2)",         MACHINE_IS_SKELETON)
+//   YEAR  NAME        PARENT   COMPAT  MACHINE     INPUT      CLASS                   INIT                       COMPANY              FULLNAME                        FLAGS
+COMP(1978, rm380z,     0,       0,      rm380z,     rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/M",          0)
+COMP(1978, rm380zhrg,  rm380z,  0,      rm380zhrg,  rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/M with HRG", 0)
+COMP(1978, rm380zf,    0,       0,      rm380zf,    rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/F",          0)
+COMP(1978, rm380zfhrg, rm380zf, 0,      rm380zfhrg, rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/F with HRG", 0)
+COMP(1978, rm380z34d,  rm380z,  0,      rm380z34d,  rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4D/F",          MACHINE_NO_SOUND_HW)
+COMP(1978, rm380z34e,  rm380z,  0,      rm380z34e,  rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4E/M",          MACHINE_NO_SOUND_HW)
+COMP(1981, rm480z,     rm380z,  0,      rm480z,     rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 1)",         MACHINE_IS_SKELETON)
+COMP(1981, rm480za,    rm380z,  0,      rm480za,    rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 2)",         MACHINE_IS_SKELETON)

--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -278,6 +278,17 @@ void rm380z_state::configure(machine_config &config)
 	keyboard.set_keyboard_callback(FUNC(rm380z_state::keyboard_put));
 }
 
+void rm380z_state::configure_fds(machine_config &config)
+{
+	configure(config);
+
+	m_floppy0->set_default_option("fds");
+	m_floppy1->set_default_option("fds");
+
+	// FDS drives require a 2 MHz square wave clock frequency
+	m_fdc->set_unscaled_clock(16_MHz_XTAL / 8);
+}
+
 void rm380z_state_cos34::configure(machine_config &config)
 {
 	rm380z_state::configure(config);
@@ -292,17 +303,6 @@ void rm380z_state_cos34::configure(machine_config &config)
 
 	SN74S262(config, m_rocg, 0);
 	m_rocg->set_palette(m_palette);
-}
-
-void rm380z_state_cos34::configure_fds(machine_config &config)
-{
-	rm380z_state_cos34::configure(config);
-
-	m_floppy0->set_default_option("fds");
-	m_floppy1->set_default_option("fds");
-
-	// FDS drives require a 2 MHz square wave clock frequency
-	m_fdc->set_unscaled_clock(16_MHz_XTAL / 8);
 }
 
 void rm380z_state_cos40::configure(machine_config &config)
@@ -359,20 +359,36 @@ ROM_END
 
 ROM_START( rm380z ) // COS 4.0B/M
 	ROM_REGION( 0x10000, RM380Z_MAINCPU_TAG, 0 )
-	// I'm not sure of how those ROMs have been dumped. I don't know if those are good dumps or not.
-	ROM_LOAD( "cos40b-m.bin",           0x0000, 0x1000, BAD_DUMP CRC(1f0b3a5c) SHA1(0b29cb2a3b7eaa3770b34f08c4fd42844f42700f) )
-	ROM_LOAD( "cos40b-m_f600-f9ff.bin", 0x1000, 0x0400, BAD_DUMP CRC(e3397d9d) SHA1(490a0c834b0da392daf782edc7d51ca8f0668b1a) )
-	ROM_LOAD( "cos40b-m_1c00-1dff.bin", 0x1400, 0x0200, BAD_DUMP CRC(0f759f44) SHA1(9689c1c1faa62c56def999cbedbbb0c8d928dcff) )
+	ROM_LOAD( "cos40b-m.bin",           0x0000, 0x1000, CRC(1f0b3a5c) SHA1(0b29cb2a3b7eaa3770b34f08c4fd42844f42700f) )
+	ROM_LOAD( "cos40b-m_f600-f9ff.bin", 0x1000, 0x0400, CRC(e3397d9d) SHA1(490a0c834b0da392daf782edc7d51ca8f0668b1a) )
+	ROM_LOAD( "cos40b-m_1c00-1dff.bin", 0x1400, 0x0200, CRC(0f759f44) SHA1(9689c1c1faa62c56def999cbedbbb0c8d928dcff) )
 	ROM_REGION( 0x0800, "chargen", 0 )
 	ROM_LOAD( "c-gen-22.bin",           0x0000, 0x0800, CRC(1b67127f) SHA1(289a919871d30c5e832d22244bcac1dcfd544baa) )
 ROM_END
 
 ROM_START( rm380zhrg ) // COS 4.0B/M
 	ROM_REGION( 0x10000, RM380Z_MAINCPU_TAG, 0 )
-	// I'm not sure of how those ROMs have been dumped. I don't know if those are good dumps or not.
-	ROM_LOAD( "cos40b-m.bin",           0x0000, 0x1000, BAD_DUMP CRC(1f0b3a5c) SHA1(0b29cb2a3b7eaa3770b34f08c4fd42844f42700f) )
-	ROM_LOAD( "cos40b-m_f600-f9ff.bin", 0x1000, 0x0400, BAD_DUMP CRC(e3397d9d) SHA1(490a0c834b0da392daf782edc7d51ca8f0668b1a) )
-	ROM_LOAD( "cos40b-m_1c00-1dff.bin", 0x1400, 0x0200, BAD_DUMP CRC(0f759f44) SHA1(9689c1c1faa62c56def999cbedbbb0c8d928dcff) )
+	ROM_LOAD( "cos40b-m.bin",           0x0000, 0x1000, CRC(1f0b3a5c) SHA1(0b29cb2a3b7eaa3770b34f08c4fd42844f42700f) )
+	ROM_LOAD( "cos40b-m_f600-f9ff.bin", 0x1000, 0x0400, CRC(e3397d9d) SHA1(490a0c834b0da392daf782edc7d51ca8f0668b1a) )
+	ROM_LOAD( "cos40b-m_1c00-1dff.bin", 0x1400, 0x0200, CRC(0f759f44) SHA1(9689c1c1faa62c56def999cbedbbb0c8d928dcff) )
+	ROM_REGION( 0x0800, "chargen", 0 )
+	ROM_LOAD( "c-gen-22.bin",           0x0000, 0x0800, CRC(1b67127f) SHA1(289a919871d30c5e832d22244bcac1dcfd544baa) )
+ROM_END
+
+ROM_START( rm380zf ) // COS 4.0B/F
+	ROM_REGION( 0x10000, RM380Z_MAINCPU_TAG, 0 )
+	ROM_LOAD( "cos40b-f.bin",           0x0000, 0x1000, CRC(c4110957) SHA1(08d924c7a152ca102585520a987051bcad3fca3f) )
+	ROM_LOAD( "cos40b-f_f600-f9ff.bin", 0x1000, 0x0400, CRC(3b983326) SHA1(4a5273ca196cb98f9bb262f3e8f13bf22c9ca11c) )
+	ROM_LOAD( "cos40b-f_1c00-1dff.bin", 0x1400, 0x0200, CRC(0f759f44) SHA1(9689c1c1faa62c56def999cbedbbb0c8d928dcff) )
+	ROM_REGION( 0x0800, "chargen", 0 )
+	ROM_LOAD( "c-gen-22.bin",           0x0000, 0x0800, CRC(1b67127f) SHA1(289a919871d30c5e832d22244bcac1dcfd544baa) )
+ROM_END
+
+ROM_START( rm380zfhrg ) // COS 4.0B/F
+	ROM_REGION( 0x10000, RM380Z_MAINCPU_TAG, 0 )
+	ROM_LOAD( "cos40b-f.bin",           0x0000, 0x1000, CRC(c4110957) SHA1(08d924c7a152ca102585520a987051bcad3fca3f) )
+	ROM_LOAD( "cos40b-f_f600-f9ff.bin", 0x1000, 0x0400, CRC(3b983326) SHA1(4a5273ca196cb98f9bb262f3e8f13bf22c9ca11c) )
+	ROM_LOAD( "cos40b-f_1c00-1dff.bin", 0x1400, 0x0200, CRC(0f759f44) SHA1(9689c1c1faa62c56def999cbedbbb0c8d928dcff) )
 	ROM_REGION( 0x0800, "chargen", 0 )
 	ROM_LOAD( "c-gen-22.bin",           0x0000, 0x0800, CRC(1b67127f) SHA1(289a919871d30c5e832d22244bcac1dcfd544baa) )
 ROM_END
@@ -401,10 +417,12 @@ ROM_END
 
 
 /* Driver */
-//   YEAR  NAME       PARENT  COMPAT  MACHINE        INPUT      CLASS                   INIT                       COMPANY              FULLNAME                      FLAGS
-COMP(1978, rm380z,    0,      0,      configure,     rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B",          0)
-COMP(1978, rm380zhrg, rm380z, 0,      configure,     rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B with HRG", 0)
-COMP(1978, rm380z34d, rm380z, 0,      configure_fds, rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4D",          MACHINE_NO_SOUND_HW)
-COMP(1978, rm380z34e, rm380z, 0,      configure,     rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4E",          MACHINE_NO_SOUND_HW)
-COMP(1981, rm480z,    rm380z, 0,      configure,     rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 1)",       MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
-COMP(1981, rm480za,   rm380z, 0,      configure,     rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 2)",       MACHINE_NOT_WORKING | MACHINE_NO_SOUND)
+//   YEAR  NAME        PARENT   COMPAT  MACHINE        INPUT      CLASS                   INIT                       COMPANY              FULLNAME                        FLAGS
+COMP(1978, rm380z,     0,       0,      configure,     rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/M",          0)
+COMP(1978, rm380zhrg,  rm380z,  0,      configure,     rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/M with HRG", 0)
+COMP(1978, rm380zf,    rm380z,  0,      configure_fds, rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/F",          0)
+COMP(1978, rm380zfhrg, rm380zf, 0,      configure_fds, rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/F with HRG", 0)
+COMP(1978, rm380z34d,  rm380z,  0,      configure_fds, rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4D/F",          MACHINE_NO_SOUND_HW)
+COMP(1978, rm380z34e,  rm380z,  0,      configure,     rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4E/M",          MACHINE_NO_SOUND_HW)
+COMP(1981, rm480z,     rm380z,  0,      configure,     rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 1)",         MACHINE_IS_SKELETON)
+COMP(1981, rm480za,    rm380z,  0,      configure,     rm380z,    rm480z_state,           driver_device::empty_init, "Research Machines", "LINK RM-480Z (set 2)",         MACHINE_IS_SKELETON)

--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -420,7 +420,7 @@ ROM_END
 //   YEAR  NAME        PARENT   COMPAT  MACHINE        INPUT      CLASS                   INIT                       COMPANY              FULLNAME                        FLAGS
 COMP(1978, rm380z,     0,       0,      configure,     rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/M",          0)
 COMP(1978, rm380zhrg,  rm380z,  0,      configure,     rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/M with HRG", 0)
-COMP(1978, rm380zf,    rm380z,  0,      configure_fds, rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/F",          0)
+COMP(1978, rm380zf,    0,       0,      configure_fds, rm380z,    rm380z_state_cos40,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/F",          0)
 COMP(1978, rm380zfhrg, rm380zf, 0,      configure_fds, rm380zhrg, rm380z_state_cos40_hrg, driver_device::empty_init, "Research Machines", "RM-380Z, COS 4.0B/F with HRG", 0)
 COMP(1978, rm380z34d,  rm380z,  0,      configure_fds, rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4D/F",          MACHINE_NO_SOUND_HW)
 COMP(1978, rm380z34e,  rm380z,  0,      configure,     rm380z,    rm380z_state_cos34,     driver_device::empty_init, "Research Machines", "RM-380Z, COS 3.4E/M",          MACHINE_NO_SOUND_HW)

--- a/src/mame/rm/rm380z.cpp
+++ b/src/mame/rm/rm380z.cpp
@@ -249,7 +249,7 @@ uint32_t rm380z_state::screen_update_rm380z(screen_device &screen, bitmap_ind16 
 	return 0;
 }
 
-void rm380z_state::configure(machine_config &config, bool bFDS)
+void rm380z_state::base_configure(machine_config &config)
 {
 	/* basic machine hardware */
 	Z80(config, m_maincpu, 16_MHz_XTAL / 4);
@@ -268,28 +268,27 @@ void rm380z_state::configure(machine_config &config, bool bFDS)
 	RAM(config, RAM_TAG).set_default_size("56K");
 
 	/* floppy disk */
-	if (bFDS)
-	{
-		// FDS drives require a 2 MHz square wave clock frequency
-		FD1771(config, m_fdc, 16_MHz_XTAL / 8);
-		FLOPPY_CONNECTOR(config, m_floppy0, rm380z_floppies, "fds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
-		FLOPPY_CONNECTOR(config, m_floppy1, rm380z_floppies, "fds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
-	}
-	else
-	{
-		FD1771(config, m_fdc, 16_MHz_XTAL / 16);
-		FLOPPY_CONNECTOR(config, m_floppy0, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
-		FLOPPY_CONNECTOR(config, m_floppy1, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
-	}
+	FD1771(config, m_fdc, 16_MHz_XTAL / 16);
+	FLOPPY_CONNECTOR(config, m_floppy0, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
+	FLOPPY_CONNECTOR(config, m_floppy1, rm380z_floppies, "mds", floppy_image_device::default_mfm_floppy_formats).set_fixed(true);
 
 	/* keyboard */
 	generic_keyboard_device &keyboard(GENERIC_KEYBOARD(config, "keyboard", 0));
 	keyboard.set_keyboard_callback(FUNC(rm380z_state::keyboard_put));
 }
 
-void rm380z_state_cos34::rm380z34e(machine_config &config, bool bFDS)
+void rm380z_state::fds_configure()
 {
-	configure(config, bFDS);
+	// FDS drives require a 2 MHz square wave clock frequency
+	m_fdc->set_unscaled_clock(16_MHz_XTAL / 8);
+	// change media type for floppy connectors
+	m_floppy0->set_default_option("fds");
+	m_floppy1->set_default_option("fds");
+}
+
+void rm380z_state_cos34::rm380z34e(machine_config &config)
+{
+	base_configure(config);
 
 	/* cassette */
 	CASSETTE(config, m_cassette);
@@ -303,18 +302,18 @@ void rm380z_state_cos34::rm380z34e(machine_config &config, bool bFDS)
 	m_rocg->set_palette(m_palette);
 }
 
-void rm380z_state_cos40::rm380z(machine_config &config, bool bFDS)
+void rm380z_state_cos40::rm380z(machine_config &config)
 {
-	configure(config, bFDS);
+	base_configure(config);
 
 	SPEAKER_SOUND(config, m_speaker).add_route(ALL_OUTPUTS, "mono", 0.80);
 
 	m_screen->set_raw(16_MHz_XTAL, 1024, 0, 640, 312, 0, 240);
 }
 
-void rm380z_state_cos40_hrg::rm380zhrg(machine_config &config, bool bFDS)
+void rm380z_state_cos40_hrg::rm380zhrg(machine_config &config)
 {
-	rm380z(config, bFDS);
+	rm380z(config);
 
 	m_palette->set_init(FUNC(rm380z_state_cos40_hrg::palette_init)).set_entries(19);
 }

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -36,6 +36,9 @@ Research Machines RM 380Z
 // abstract base class
 class rm380z_state : public driver_device
 {
+public:
+	void configure_fds(machine_config &config);
+
 protected:
 	rm380z_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
@@ -52,7 +55,7 @@ protected:
 	static inline constexpr int RM380Z_SCREENROWS = 24;
 	static inline constexpr int RM380Z_SCREENCOLS = 40;
 
-	void configure(machine_config &config);
+	virtual void configure(machine_config &config);
 
 	void machine_reset() override;
 
@@ -110,8 +113,7 @@ public:
 	{
 	}
 
-	void configure(machine_config &config);
-	void configure_fds(machine_config &config);
+	void configure(machine_config &config) override;
 
 protected:
 	void machine_reset() override;
@@ -155,7 +157,7 @@ public:
 	{
 	}
 
-	void configure(machine_config &config);
+	void configure(machine_config &config) override;
 
 protected:
 	template <int ROWS, int COLS>
@@ -219,7 +221,7 @@ public:
 	{
 	}
 
-	void configure(machine_config &config);
+	void configure(machine_config &config) override;
 
 	DECLARE_INPUT_CHANGED_MEMBER(monitor_changed);
 
@@ -270,7 +272,7 @@ public:
 	{
 	}
 
-	void configure(machine_config &config);
+	void configure(machine_config &config) override;
 
 protected:
 	void machine_reset() override;

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -36,9 +36,6 @@ Research Machines RM 380Z
 // abstract base class
 class rm380z_state : public driver_device
 {
-public:
-	void configure_fds(machine_config &config);
-
 protected:
 	rm380z_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
@@ -55,7 +52,7 @@ protected:
 	static inline constexpr int RM380Z_SCREENROWS = 24;
 	static inline constexpr int RM380Z_SCREENCOLS = 40;
 
-	virtual void configure(machine_config &config);
+	void configure(machine_config &config, bool bFDS);
 
 	void machine_reset() override;
 
@@ -113,7 +110,8 @@ public:
 	{
 	}
 
-	void configure(machine_config &config) override;
+	void rm380z34e(machine_config &config, bool bFDS = false);
+	void rm380z34d(machine_config &config) { rm380z34e(config, true); }
 
 protected:
 	void machine_reset() override;
@@ -157,7 +155,8 @@ public:
 	{
 	}
 
-	void configure(machine_config &config) override;
+	void rm380z(machine_config &config, bool bFDS = false);
+	void rm380zf(machine_config &config) { rm380z(config, true); }
 
 protected:
 	template <int ROWS, int COLS>
@@ -221,7 +220,8 @@ public:
 	{
 	}
 
-	void configure(machine_config &config) override;
+	void rm380zhrg(machine_config &config, bool bFDS = false);
+	void rm380zfhrg(machine_config &config) { rm380zhrg(config, true); }
 
 	DECLARE_INPUT_CHANGED_MEMBER(monitor_changed);
 
@@ -272,7 +272,8 @@ public:
 	{
 	}
 
-	void configure(machine_config &config) override;
+	void rm480z(machine_config &config);
+	void rm480za(machine_config &config) { rm480z(config); }
 
 protected:
 	void machine_reset() override;

--- a/src/mame/rm/rm380z.h
+++ b/src/mame/rm/rm380z.h
@@ -52,7 +52,8 @@ protected:
 	static inline constexpr int RM380Z_SCREENROWS = 24;
 	static inline constexpr int RM380Z_SCREENCOLS = 40;
 
-	void configure(machine_config &config, bool bFDS);
+	void base_configure(machine_config &config);
+	void fds_configure();
 
 	void machine_reset() override;
 
@@ -110,8 +111,8 @@ public:
 	{
 	}
 
-	void rm380z34e(machine_config &config, bool bFDS = false);
-	void rm380z34d(machine_config &config) { rm380z34e(config, true); }
+	void rm380z34e(machine_config &config);
+	void rm380z34d(machine_config &config) { rm380z34e(config); fds_configure(); }
 
 protected:
 	void machine_reset() override;
@@ -155,8 +156,8 @@ public:
 	{
 	}
 
-	void rm380z(machine_config &config, bool bFDS = false);
-	void rm380zf(machine_config &config) { rm380z(config, true); }
+	void rm380z(machine_config &config);
+	void rm380zf(machine_config &config) { rm380z(config); fds_configure(); }
 
 protected:
 	template <int ROWS, int COLS>
@@ -220,8 +221,8 @@ public:
 	{
 	}
 
-	void rm380zhrg(machine_config &config, bool bFDS = false);
-	void rm380zfhrg(machine_config &config) { rm380zhrg(config, true); }
+	void rm380zhrg(machine_config &config);
+	void rm380zfhrg(machine_config &config) { rm380zhrg(config); fds_configure(); }
 
 	DECLARE_INPUT_CHANGED_MEMBER(monitor_changed);
 


### PR DESCRIPTION
This PR adds support for COS 4.0/F, new romset attached below:

[rm380zf.zip](https://github.com/mamedev/mame/files/14812260/rm380zf.zip)

It's basically the same as COS 4.0/M, but with some differences in the FDC code (no motor control and different timing).  The 8" disk support is useful as it allows larger CP/M programs to run using the VDU-80 display.

I have also verified that the 4.0/M roms we had are good, and made the machine descriptions clearer by adding "/M" and "/F" postfixes.
