### PR TITLE
debug/express.cpp: Fix bad iterator comparison in postfix conversion.

### DIFF
--- a/src/emu/debug/express.cpp
+++ b/src/emu/debug/express.cpp
@@ -1740,7 +1740,7 @@ void parsed_expression::infix_to_postfix()
 		else if (token->is_operator())
 		{
 			// normalize the operator based on neighbors
-			normalize_operator(*token, prev, next != m_tokenlist.end() ? &*next : nullptr, stack, was_rparen);
+			normalize_operator(*token, prev, next != origlist.end() ? &*next : nullptr, stack, was_rparen);
 			was_rparen = false;
 
 			// if the token is an opening parenthesis, push it onto the stack.


### PR DESCRIPTION
One iterator was being compared with another from the wrong container. I observed this by chance when I hit an assert in a debug MSVC build with checked iterators enabled. This bug could cause dereferencing of a past-the-end iterator in expressions ending with an operator.