### PR TITLE
machine/icd2061a: Fix out of bounds array access

### DIFF
--- a/src/devices/machine/icd2061a.cpp
+++ b/src/devices/machine/icd2061a.cpp
@@ -24,10 +24,14 @@
 
 #define LOG_PINS (1 << 1)
 #define LOG_STATE (1 << 2)
+#define LOG_TODO (1 << 3)
 
-// #define VERBOSE (LOG_GENERAL | LOG_PINS | LOG_STATE)
+// #define VERBOSE (LOG_GENERAL | LOG_PINS | LOG_STATE | LOG_TODO)
+#define VERBOSE (LOG_TODO)
 
 #include "logmacro.h"
+
+#define LOGTODO(...)   LOGMASKED(LOG_TODO, __VA_ARGS__)
 
 
 DEFINE_DEVICE_TYPE(ICD2061A, icd2061a_device, "icd2061a", "IC Designs 2061A Dual Programmable Graphics Clock Generator")
@@ -168,6 +172,8 @@ TIMER_CALLBACK_MEMBER( icd2061a_device::update_clock_callback )
 		const int m = BIT(m_regs[MREG], 7, 3); // post-vco divisor
 		const int q = BIT(m_regs[MREG], 0, 7) + 2; // q counter value
 		m_reg_clocks[MREG] = (clock() * m_prescale[a] * (p / double(q))) / (1 << m);
+	} else {
+		LOGTODO("unimplemented mclkout selected %d\n", m_mclkout_select);
 	}
 
 	if (m_reg_clocks[MREG] != m_mclkout_clock) {
@@ -198,6 +204,8 @@ TIMER_CALLBACK_MEMBER( icd2061a_device::update_clock_callback )
 		const int m = BIT(m_regs[m_vclkout_select], 7, 3); // post-vco divisor
 		const int q = BIT(m_regs[m_vclkout_select], 0, 7) + 2; // q counter value
 		vclkout_clock = m_reg_clocks[m_vclkout_select] = (clock() * m_prescale[a] * (p / double(q))) / (1 << m);
+	} else {
+		LOGTODO("unimplemented vclkout selected %d\n", m_vclkout_select);
 	}
 
 	if (vclkout_clock != m_vclkout_clock) {

--- a/src/devices/machine/icd2061a.cpp
+++ b/src/devices/machine/icd2061a.cpp
@@ -189,18 +189,21 @@ TIMER_CALLBACK_MEMBER( icd2061a_device::update_clock_callback )
 	else if (m_outdis == 1 && m_pwrdwn == 1 && m_sel1 == 1 && (m_intclk == 1 || m_sel0 == 1))
 		m_vclkout_select = VCLKOUT_REG2;
 
+	uint32_t vclkout_clock = m_vclkout_clock;
 	if (m_vclkout_select == VCLKOUT_FEATCLK) {
-		m_reg_clocks[m_vclkout_select] = m_featclock;
+		vclkout_clock = m_featclock;
 	} else if (m_vclkout_select >= VCLKOUT_REG0 && m_vclkout_select <= VCLKOUT_REG2) {
 		const int a = BIT(m_regs[m_vclkout_select], 21, 2); // register addr
 		const int p = BIT(m_regs[m_vclkout_select], 10, 7) + 3; // p counter value
 		const int m = BIT(m_regs[m_vclkout_select], 7, 3); // post-vco divisor
 		const int q = BIT(m_regs[m_vclkout_select], 0, 7) + 2; // q counter value
-		m_reg_clocks[m_vclkout_select] = (clock() * m_prescale[a] * (p / double(q))) / (1 << m);
+		vclkout_clock = m_reg_clocks[m_vclkout_select] = (clock() * m_prescale[a] * (p / double(q))) / (1 << m);
 	}
 
-	m_vclkout_changed_cb(m_reg_clocks[m_vclkout_select]);
-	m_vclkout_clock = m_reg_clocks[m_vclkout_select];
+	if (vclkout_clock != m_vclkout_clock) {
+		m_vclkout_clock = vclkout_clock;
+		m_vclkout_changed_cb(vclkout_clock);
+	}
 }
 
 void icd2061a_device::update_clock()


### PR DESCRIPTION
Just to be sure I checked and all other usages of `m_reg_clocks` are using constants instead of variables. `truckk` and `ujlnow` are both still booting so code-wise it's working as expected (they rely on the feature clock working properly to even boot).

cc: @happppp 