### PR TITLE
apple2gs_flop_clcracked.xml: added 6 dumps, used info tags for a lot of dumps [Brian Troha]

### DIFF
--- a/hash/apple2gs_flop_clcracked.xml
+++ b/hash/apple2gs_flop_clcracked.xml
@@ -10,8 +10,10 @@ license:CC0-1.0
 		<description>4th &amp; Inches (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Tony Manso, Ed Bogas, Les Pardew" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs -->
 		<!-- The Team Construction Set was sold separately, but only works with 4th & Inches so it's included as "Disk 2" -->
 		<!-- The Team Construction Set disk doesn't check itself for being an original, but runs a nibble count on the 4th & Inches disk -->
@@ -35,8 +37,10 @@ license:CC0-1.0
 		<description>Aesop's Fables (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Unicorn Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="William Demas, Joseph Hewitt IV, and June Stark" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"Aesop's Fables" is a 1988 educational program developed by William Demas, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -59,8 +63,10 @@ license:CC0-1.0
 		<description>All About America (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Unicorn Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Stanley Brewster, June Stark, and Joseph B. Hewitt IV" />
+		<info name="usage" value="Requires a 768K Apple IIgs ROM 03." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K ROM3 Apple IIgs. (crashes on ROM01 Apple IIgs?) -->
 		<!--"All About America" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -83,8 +89,9 @@ license:CC0-1.0
 		<description>Ancient Land of Ys (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Kyodai</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Ancient Land of Ys" is a 1989 fantasy role playing game developed by Kyodai and distributed by Brøderbund. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -107,8 +114,11 @@ license:CC0-1.0
 		<description>Arkanoid (version 12-Jan-89) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Taito</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Ryan Ridges and John Lund" />
+		<info name="version" value="12-Jan-89" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs -->
 		<!--"Arkanoid" is a 1988 action game developed by Ryan Ridges and John Lund, and distributed by Taito America. -->
 		<!-- The copy protection routines are not compatible with the ROM03, however the cracked version runs on any 512K Apple IIgs -->
@@ -126,8 +136,11 @@ license:CC0-1.0
 		<description>Arkanoid II: Revenge of Doh (version 29-Aug-89) (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Taito</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Ryan Ridges and John Lund" />
+		<info name="version" value="29-Aug-89" />
+		<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs ROM01 or later. -->
 		<!--"Arkanoid II" is a 1989 action game developed by Ryan Ridges and John Lund, and distributed by Taito America. -->
 		<!-- ark.s16 dated 29-Aug-89 -->
@@ -144,8 +157,11 @@ license:CC0-1.0
 		<description>Arkanoid II: Revenge of Doh (version 18-Jul-89) (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Taito</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Ryan Ridges and John Lund" />
+		<info name="version" value="18-Jul-89" />
+		<info name="usage" value="Requires a 512K Apple IIgs ROM01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs ROM01 or later. -->
 		<!--"Arkanoid II" is a 1989 action game developed by Ryan Ridges and John Lund, and distributed by Taito America. -->
 		<!-- ark.s16 dated 18-Jul-89 -->
@@ -162,9 +178,10 @@ license:CC0-1.0
 		<description>Battle Chess (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Interplay</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Jim Sproul, Todd J. Camasta, Bruce Schlickbernd, Kurt Heiden, Bill (Weez) Dugan, Thomas R. Decker, Troy P. Worrell, Michael Quarles, Rebecca Heineman, and Alan Pavlish"/>
+		<info name="programmer" value="Jim Sproul, Todd J. Camasta, Bruce Schlickbernd, Kurt Heiden, Bill (Weez) Dugan, Thomas R. Decker, Troy P. Worrell, Michael Quarles, Rebecca Heineman, and Alan Pavlish" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Battle Chess" is a 1989 board game developed by Jim Sproul, Todd J. Camasta, Bruce Schlickbernd, Kurt Heiden, Bill (Weez) Dugan, Thomas R. Decker, Troy P. Worrell, Michael Quarles, Rebecca Heineman, and Alan Pavlish, and distributed by Interplay. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -180,9 +197,11 @@ license:CC0-1.0
 		<description>Block Out (version 1.0) (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>California Dreams</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Alexander Ustaszewski, Marek Jackiewicz, Adam Skorupinski, Marcin Szostakowski, and Marcin Grzegorzewski"/>
+		<info name="programmer" value="Alexander Ustaszewski, Marek Jackiewicz, Adam Skorupinski, Marcin Szostakowski, and Marcin Grzegorzewski" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Block Out" is a 1989 action game developed by Alexander Ustaszewski, Marek Jackiewicz, Adam Skorupinski, Marcin Szostakowski, and Marcin Grzegorzewski, and distributed by California Dreams. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -198,8 +217,9 @@ license:CC0-1.0
 		<description>Bubble Ghost (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Bubble Ghost" is a 1988 action game developed by Infogrames and distributed by Accolade. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -215,8 +235,10 @@ license:CC0-1.0
 		<description>Bubble Ghost - Hard Drive compatible (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="version" value="Hard Drive compatible" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Bubble Ghost" is a 1988 action game developed by Infogrames and distributed by Accolade. -->
 		<!-- Hard coded path names were replaced with names to use current volume / directory -->
@@ -233,8 +255,12 @@ license:CC0-1.0
 		<description>Calendar Crafter (version 1.2) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>MECC</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="partno" value="A194" />
+		<info name="programmer" value="Gene Breault, Charolyn Kapplinger, Diane Portner, Steven D. Splinter, and Paul R. Wenker" />
+		<info name="version" value="1.2" />
+		<info name="usage" value="Requires a 768K Apple IIgs ROM 01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs ROM 01 or later. -->
 		<!--"Calendar Crafter" is a 1987 productivity program developed by Gene Breault, Charolyn Kapplinger, Diane Portner, Steven D. Splinter, and Paul R. Wenker, and distributed by MECC. -->
 		<!-- Protection: Bad block check for block $8 -->
@@ -250,9 +276,10 @@ license:CC0-1.0
 		<description>California Games (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Epyx</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Jimmy Huey, Dan Chang, Jenny Martin, Sheryl Knowles, Bill Bogenreif, Matt Householder, and Ron Fortier"/>
+		<info name="programmer" value="Jimmy Huey, Dan Chang, Jenny Martin, Sheryl Knowles, Bill Bogenreif, Matt Householder, and Ron Fortier" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"California Games" is a 1988 sports game developed by Jimmy Huey, Dan Chang, Jenny Martin, Sheryl Knowles, Bill Bogenreif, Matt Householder, and Ron Fortier, and distributed by Epyx. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -268,8 +295,10 @@ license:CC0-1.0
 		<description>Captain Blood (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Mindscape</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Philippe Ulrich, Didier Bouchon, Jean-Michel Jarre, Alexis Martial, and Michael Rho" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Captain Blood" is a 1989 simulation game developed by Philippe Ulrich, Didier Bouchon, Jean-Michel Jarre, Alexis Martial, and Michael Rho, and distributed by Mindscape. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -285,9 +314,10 @@ license:CC0-1.0
 		<description>Cavern Cobra (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>PBI Software</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Greg Hale and Richard L. Seaborne"/>
+		<info name="programmer" value="Greg Hale and Richard L. Seaborne" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"Cavern Cobra" is a 1987 action game developed by Greg Hale and Richard L. Seaborne, and distributed by PBI Software. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -303,8 +333,11 @@ license:CC0-1.0
 		<description>Club Backgammon (version 2.0) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>California Dreams</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Staszek Bartkowski, Jarek Olszewski, Dorota B&#x142;aszczak, Maciej Markuszewski, and Marcin Szostakowski" />
+		<info name="version" value="2.0" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Club Backgammon" is a 1988 board game developed by Staszek Bartkowski, Jarek Olszewski, Dorota Błaszczak, Maciej Markuszewski, and Marcin Szostakowski, and distributed by California Dreams. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -320,8 +353,11 @@ license:CC0-1.0
 		<description>Club Backgammon (version 1.0) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>California Dreams</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Staszek Bartkowski, Jarek Olszewski, Dorota B&#x142;aszczak, Maciej Markuszewski, and Marcin Szostakowski" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Club Backgammon" is a 1988 board game developed by Staszek Bartkowski, Jarek Olszewski, Dorota Błaszczak, Maciej Markuszewski, and Marcin Szostakowski, and distributed by California Dreams. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -337,8 +373,11 @@ license:CC0-1.0
 		<description>Cribbage King / Gin King (version 1.01) (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>The Software Toolworks</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Mark Manyen, Don Laabs, David M. Linnehan, and Elizabeth Scafati" />
+		<info name="version" value="1.01" />
+		<info name="usage" value="Requires a 1MB Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs. -->
 		<!--"Cribbage King / Gin King" is a 1989 board game developed by Mark Manyen, Don Laabs, David M. Linnehan, and Elizabeth Scafati, and distributed by The Software Toolworks. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -361,8 +400,10 @@ license:CC0-1.0
 		<description>Defender of the Crown (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Cinemaware</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Kellyn Beeck, James Sachs, Ivan Manley, Robert Jacob, Phyllis Jacob, Pat Cook, Jim Cuomo, Tom Warner, Jeff Hilbers, Steve Quinn, Richard La Barre, John Cutter, Rob Landeros, Doug Smith, Betsy Scafati, and Wayne Brockman" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"Defender of the Crown" is a 1988 adventure game developed by Kellyn Beeck, James Sachs, Ivan Manley, Robert Jacob, Phyllis Jacob, Pat Cook, Jim Cuomo, Tom Warner, Jeff Hilbers, Steve Quinn, Richard La Barre, John Cutter, Rob Landeros, Doug Smith, Betsy Scafati, and Wayne Brockman, and distributed by Cinemaware Corporation. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -385,8 +426,10 @@ license:CC0-1.0
 		<description>Déjà Vu (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>ICOM Simulations</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Fred Allen, David Marsh, Karl Roelofs, Todd Squires, Craig Erickson, Kurt Nelson, Steven Hays, Terry Schulenburg, Darin Adler, Jay Zipnick, Waldermar Horwat, Mark Waterman, and Tod Zipnick" />
+		<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs ROM01 or later. -->
 		<!--"Deja Vu" is a 1988 adventure game developed by Fred Allen, David Marsh, Karl Roelofs, Todd Squires, Craig Erickson, Kurt Nelson, Steven Hays, Terry Schulenburg, Darin Adler, Jay Zipnick, Waldermar Horwat, Mark Waterman, and Tod Zipnick, and distributed by ICOM Simulations. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -409,8 +452,10 @@ license:CC0-1.0
 		<description>Déjà Vu II: Lost in Las Vegas (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Mindscape</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Fred Allen, David Marsh, Michael Manning, Todd Squires, David Feldman, Paul Snively, Brian Baker, Karl Roelofs, Ed Dluzen, Darin Adler, Jay Zipnick, Waldemar Horwat, Julia Ulano, Tod Zipnick, and Mitch Adler" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"Déjà Vu II: Lost in Las Vegas" is a 1989 adventure game developed by Fred Allen, David Marsh, Michael Manning, Todd Squires, David Feldman, Paul Snively, Brian Baker, Karl Roelofs, Ed Dluzen, Darin Adler, Jay Zipnick, Waldemar Horwat, Julia Ulano, Tod Zipnick, and Mitch Adler, and distributed by Mindscape. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -433,8 +478,12 @@ license:CC0-1.0
 		<description>Designer Prints (version 1.0) (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>MECC</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="partno" value="A252" />
+		<info name="programmer" value="Diane Portner, Michael Stein, Brian Walker, and Paul Wenker" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 768K Apple IIgs ROM 01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs ROM 01 or later. -->
 		<!--"Designer Prints" is a 1989 desktop publishing program developed by Diane Portner, Michael Stein, Brian Walker, and Paul Wenker, and distributed by MECC. -->
 		<!-- Protection: Bad block check for block $8 -->
@@ -457,8 +506,12 @@ license:CC0-1.0
 		<description>Designer Puzzles (version 1.0) (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>MECC</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="partno" value="A223" />
+		<info name="programmer" value="Susan Gabrys, John J. Krenz, Diane Portner, and Steve Splinter" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 768K Apple IIgs ROM 01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs ROM 01 or later. -->
 		<!--"Designer Puzzles" is a 1990 desktop publishing program developed by Susan Gabrys, John J. Krenz, Diane Portner, and Steve Splinter, and distributed by MECC. -->
 		<!-- Protection: Bad block check for block $8 -->
@@ -481,8 +534,10 @@ license:CC0-1.0
 		<description>Destroyer (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Epyx</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Michael Kosaka and Chuck Sommerville" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Destroyer" is a 1987 simulation game developed by Michael Kosaka and Chuck Sommerville, and distributed by Epyx. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 - 10 separate occurrences (Yes 10!) -->
@@ -498,8 +553,11 @@ license:CC0-1.0
 		<description>Downhill Challenge (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Brøderbund Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="author" value="Christian Bertrand" />
+		<info name="programmer" value="Jean Claude Levy" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Downhill Challenge" is a 1989 sports game designed by Christian Bertrand, ported to the Apple IIgs by Jean Claude Levy, and distributed by Brøderbund Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -522,8 +580,11 @@ license:CC0-1.0
 		<description>Fantavision (version 2.1) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Brøderbund Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Scott Anderson and Ken Rosen" />
+		<info name="version" value="2.1" />
+		<info name="usage" value="Requires a 256K Apple IIgs ROM 01 or earlier." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 256K Apple IIgs ROM 01 or earlier. -->
 		<!-- NOT Compatible with the Apple IIgs ROM03. -->
 		<!--"Fantavision IIgs" is a 1987 graphics program developed by Scott Anderson and Ken Rosen, and distributed by Brøderbund Software. -->
@@ -541,8 +602,11 @@ license:CC0-1.0
 		<description>Fantavision (version 1.0) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Brøderbund Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Scott Anderson and Ken Rosen" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 256K Apple IIgs ROM 01 or earlier." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 256K Apple IIgs ROM 01 or earlier. -->
 		<!-- NOT Compatible with the Apple IIgs ROM03. -->
 		<!--"Fantavision IIgs" is a 1987 graphics program developed by Scott Anderson and Ken Rosen, and distributed by Brøderbund Software. -->
@@ -560,8 +624,10 @@ license:CC0-1.0
 		<description>Fast Break (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Steve Cartwright, Greg Hospelhorn, George Wong, Pam Levins, and Roseann Mitchell" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Fast Break" is a 1989 sports game developed by Steve Cartwright, Greg Hospelhorn, George Wong, Pam Levins, and Roseann Mitchell, and distributed by Accolade. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -577,8 +643,9 @@ license:CC0-1.0
 		<description>Final Assault (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Epyx</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Final Assault" is a 1988 sports game developed by Infogrames and distributed by Epyx. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -594,8 +661,9 @@ license:CC0-1.0
 		<description>Gauntlet (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Mindscape</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="usage" value="Requires a 256K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 256K Apple IIgs. -->
 		<!--"Gauntlet" is a 1988 action game distributed by Mindscape. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -607,12 +675,33 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="gbabsktb">
+		<description>GBA Championship Basketball: Two-on-Two (cleanly cracked)</description>
+		<year>1987</year>
+		<publisher>Activision</publisher>
+		<info name="programmer" value="Paul Terry, Jack Thornton, Scott Orr, John Cutter, Troy Lyndon, and Russell Lieblich" />
+		<info name="usage" value="Requires a 256K Apple IIgs." />
+		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2023-04-13 -->
+		<!-- It requires a 512K Apple IIgs. -->
+		<!--"GBA Championship Basketball" is a 1987 sports game developed by Paul Terry, Jack Thornton, Scott Orr, John Cutter, Troy Lyndon, and Russell Lieblich, and distributed by Activision. -->
+		<!-- Protection: Nibble count on tracks $20 & $21 -->
+
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="819264">
+				<rom name="gba championship basketball two-on-two iigs (trex crack).2mg" size="819264" crc="2a5318f2" sha1="7220908177bea5ac84c0a17064589549edaeb904"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="geometry">
 		<description>Geometry (version 1.0) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Brøderbund</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"Geometry v1.0" is a educational program teaching the concepts of geometry by Sensei Software, and publised by Brøderbund Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -641,8 +730,10 @@ license:CC0-1.0
 		<description>Gnarly Golf (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Fanfare by Britannica</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Jim Coliz Jr., Darren Bartlett, Andy Hildebrand, and Greg Thomas" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Gnarly Golf" is a 1989 miniture golf / putt game by Jim Coliz Jr & Darren Bartlett of Visual Concepts, Ltd., and distributed by Britannica Software. -->
 		<!-- Protection: Read block $63F with data markers AD AA D5 and compare read data against self generated data -->
@@ -665,9 +756,10 @@ license:CC0-1.0
 		<description>Grand Prix Circuit (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Don Mattrick, Brad Gour, Allan Johanson, Erik Kiss, Amory Wong, Rick Friesen, and Kris Hatlelid"/>
+		<info name="programmer" value="Don Mattrick, Brad Gour, Allan Johanson, Erik Kiss, Amory Wong, Rick Friesen, and Kris Hatlelid" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Grand Prix Circuit" is a 1989 racing simulation game developed by Don Mattrick, Brad Gour, Allan Johanson, Erik Kiss, Amory Wong, Rick Friesen, and Kris Hatlelid, and distributed by Accolade. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -683,8 +775,10 @@ license:CC0-1.0
 		<description>Great Western Shootout (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Britannica Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Scott Patterson and Matt Crysdale" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Great Western Shootout" is a 1989 action game developed by Scott Patterson and Matt Crysdale, and distributed by Britannica Software. -->
 		<!-- Disk 2 was a copy / back-up of the original Game Disk -->
@@ -708,8 +802,10 @@ license:CC0-1.0
 		<description>Hacker II: The Doomsday Papers (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Activision</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Steve Cartwright" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Hacker II: The Doomsday Papers" is a 1987 simulation game developed by Steve Cartwright and distributed by Activision. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -725,9 +821,10 @@ license:CC0-1.0
 		<description>Hardball! (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Dan Thompson, Ed Bogas, John Boechler, and Mike Benna"/>
+		<info name="programmer" value="Dan Thompson, Ed Bogas, John Boechler, and Mike Benna" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Hardball!" is a 1987 sports game developed by Dan Thompson, Ed Bogas, John Boechler, and Mike Benna, and distributed by Accolade. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -743,8 +840,9 @@ license:CC0-1.0
 		<description>Hostage: Rescue Mission (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Mindscape</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Hostage: Rescue Mission" is a 1990 simulation game developed by Infogrames and distributed by Mindscape. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -760,9 +858,10 @@ license:CC0-1.0
 		<description>Impossible Mission II (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Epyx</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Istvan Cseri, Gyula Horvath, Pal Komondi, and Sultan"/>
+		<info name="programmer" value="Istvan Cseri, Gyula Horvath, Pal Komondi, and Sultan" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Impossible Mission II" is a 1989 action game developed by Istvan Cseri, Gyula Horvath, Pal Komondi, and Sultan, and distributed by Epyx. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -778,11 +877,18 @@ license:CC0-1.0
 		<description>Jack Nicklaus' Greatest 18 Holes of Major Championship Golf (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Tony Manso" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Jack Nicklaus' Greatest 18 Holes of Major Championship Golf" is a 1989 sports game developed by Tony Manso and distributed by Accolade. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
+		<!-- This archive includes the four add-on disks that were available separately. -->
+		<!-- Jack Nicklaus Presents The Major Championship Courses Of 1989 (Includes: Oak Hill - U.S. Open, Royal Troon - British Open & Kemper Lakes - PGA courses) -->
+		<!-- Jack Nicklaus Presents The Major Championship Courses Of 1990 (Includes: Medinah Country Club, Shoal Creek Golf Club & St. Andrews (Old Course) courses) -->
+		<!-- Jack Nicklaus Presents The International Course Disk (Includes: St. Mellion Golf Club, St. Creek Golf Club & Australian Golf Club (Sydney) courses) -->
+		<!-- Jack Nicklaus Presents The Great Courses Of The U.S. Open (Includes: Baltusrol Golf Club, Oakmont Country Club & Pebble Beach courses) -->
 
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1 - Program disk"/>
@@ -796,14 +902,42 @@ license:CC0-1.0
 				<rom name="jack nicklaus' greatest 18 holes of major championship golf iigs - disk 2 - course disk (trex crack).2mg" size="819264" crc="600ed4ff" sha1="42dbe44b840c9512455184c64e1fc0f9b29706d4"/>
 			</dataarea>
 		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3 - Championship Courses of 1989"/>
+			<dataarea name="flop" size="819264">
+				<rom name="jack nicklaus presents the major championship courses of 1989.2mg" size="819264" crc="a307775b" sha1="d7fe58a4c7111c738214fcb250568aa88b475557"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4 - Championship Courses of 1990"/>
+			<dataarea name="flop" size="819264">
+				<rom name="jack nicklaus presents the major championship courses of 1990.2mg" size="819264" crc="188c5562" sha1="fd40796422d7233e8d5f4ea607afadae737e69a3"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 5 - U.S. Open Course disk"/>
+			<dataarea name="flop" size="819264">
+				<rom name="jack nicklaus presents the greatest courses of the u.s. open.2mg" size="819264" crc="1474fa5b" sha1="8686611bdf391237540301bd5ec475e96194e453"/>
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 6 - International Courses"/>
+			<dataarea name="flop" size="819264">
+				<rom name="jack nicklaus presents the international course Disk.2mg" size="819264" crc="6e19dc44" sha1="e8a393b2d17d98c6a63c4c38c16fb9b921ff1e92"/>
+			</dataarea>
+		</part>
 	</software>
+
 
 	<software name="jigsaw">
 		<description>Jigsaw (version 1.4 - 022988) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Britannica Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Javier Rullan Ruano and Huibert Aalbers" />
+		<info name="version" value="1.4" />
+		<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs ROM01 or later. -->
 		<!--"Jigsaw" is a 1988 board game developed by Javier Rullan Ruano and Huibert Aalbers, and distributed by Britannica Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -826,8 +960,11 @@ license:CC0-1.0
 		<description>King's Quest - Quest for the Crown (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Sierra On-Line</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="author" value="Roberta Williams, Al Lowe, Charles Tingley, Ken MacNeill, Chris Iden, Doug MacNeill, Greg Rowland, and Chris Iden" />
+		<info name="programmer" value="Carlos Escobar" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"King's Quest - Quest for the Crown" is a 1987 adventure game developed by Roberta Williams, Al Lowe, Bob Kernaghan, Robert E. Heitman, Jeff Stephenson, Chris Iden, Doug MacNeill, Margaret Lowe, Dale Carlson, Jennifer Cobb, Chad Bye, Jeremy T. Cromwell, Carlos Escobar, Annette Childs, Greg Steffen, and Ken Williams, and distributed by Sierra On-Line. -->
 		<!-- Protection: Bad block check for block $634 -->
@@ -850,8 +987,10 @@ license:CC0-1.0
 		<description>King's Quest II - Romancing The Throne (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Sierra On-Line</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Roberta Williams, Jeff Stephenson, Chris Iden, Robert Heitman, Ken Williams, Sol Ackerman, Scott Murphy, Doug MacNeill, Mark Crowe, and Al Lowe" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"King's Quest II - Romancing The Throne" is a 1987 adventure game developed by Roberta Williams, Al Lowe, Bob Kernaghan, Robert E. Heitman, Jeff Stephenson, Chris Iden, Doug MacNeill, Margaret Lowe, Dale Carlson, Jennifer Cobb, Chad Bye, Jeremy T. Cromwell, Carlos Escobar, Annette Childs, Greg Steffen, and Ken Williams, and distributed by Sierra On-Line. -->
 		<!-- Protection: Bad block check for block $634 -->
@@ -874,8 +1013,10 @@ license:CC0-1.0
 		<description>King's Quest III - To Hier is Human (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Sierra On-Line</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Roberta Williams, Al Lowe, Bob Kernaghan, Robert E. Heitman, Jeff Stephenson, Chris Iden, Doug MacNeill, Margaret Lowe, Dale Carlson, Jennifer Cobb, Chad Bye, Jeremy T. Cromwell, Carlos Escobar, Annette Childs, Greg Steffen, and Ken Williams" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"King's Quest III - To Hier is Human" is a 1988 adventure game developed by Roberta Williams, Al Lowe, Bob Kernaghan, Robert E. Heitman, Jeff Stephenson, Chris Iden, Doug MacNeill, Margaret Lowe, Dale Carlson, Jennifer Cobb, Chad Bye, Jeremy T. Cromwell, Carlos Escobar, Annette Childs, Greg Steffen, and Ken Williams, and distributed by Sierra On-Line. -->
 		<!-- Protection: Bad block check for block $634 -->
@@ -898,8 +1039,10 @@ license:CC0-1.0
 		<description>LaserForce (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Fanfare</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Javier Rullan, Huibert Aalbers, Thierry Méchain, Stéphane Renaudin, J-C. Doré, and Olivier Guichaoua" />
+		<info name="usage" value="Requires a 1.25MB Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1.25MB Apple IIgs.-->
 		<!--"LaserForce" is a 1989 action game developed by Javier Rullan, Huibert Aalbers, Thierry Méchain, Stéphane Renaudin, J-C. Doré, and Olivier Guichaoua, and distributed by Fanfare. -->
 		<!-- Protection: Read block $63F with data markers AD AA D5 and compare read data against self generated data -->
@@ -922,8 +1065,10 @@ license:CC0-1.0
 		<description>Leisure Suit Larry in the Land of the Lounge Lizards (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Sierra On-Line</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Al Lowe, Chuck Benton, Mark Crowe, Jeff Stephenson, Chris Iden, Bob Heitman, Ken Williams, and Carlos Escobar" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Leisure Suit Larry in the Land of the Lounge Lizards" is a 1987 adventure game developed by Al Lowe, Chuck Benton, Mark Crowe, Jeff Stephenson, Chris Iden, Bob Heitman, Ken Williams, and Carlos Escobar, and distributed by Sierra On-Line. -->
 		<!-- Protection: Bad block check for block $634 -->
@@ -946,8 +1091,10 @@ license:CC0-1.0
 		<description>Magical Myths (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Unicorn Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Stan Brewster, Joseph B. Hewitt IV, and June Stark" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"Magical Myths" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -970,8 +1117,11 @@ license:CC0-1.0
 		<description>Mancala (version 1.0) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>California Dreams</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Jarek Olszewski, Maciej Markuszewski, Marcin Szostakowski, and Dorota Błaszczak" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Macala" is a 1988 board game developed by Jarek Olszewski, Maciej Markuszewski, Marcin Szostakowski, and Dorota Błaszczak, and distributed by California Dreams. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -987,9 +1137,11 @@ license:CC0-1.0
 		<description>Marble Madness (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Will Harvey" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<info name="programmer" value="Will Harvey"/>
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Marble Madness" is a 1986 action game developed by Will Harvey and distributed by Electronic Arts. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -1005,9 +1157,13 @@ license:CC0-1.0
 		<description>Math Blaster Plus! (version 1.1) (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Davidson and Associates</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="author" value="Jan Davidson and Cathy Johnson" />
+		<info name="programmer" value="C.K. Haun" />
+		<info name="version" value="1.1" />
+		<info name="usage" value="Requires a 512K Apple IIgs ROM1 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- It requires a 512K Apple IIgs. -->
+		<!-- Dump released: 2021-08-13 -->
+		<!-- It requires a 512K Apple IIgs ROM1 or later. -->
 		<!--"Math Blaster Plus!" is a 1989 educational program designed by Jan Davidson and Cathy Johnson, written by C.K. Haun, and distributed by Davidson and Associates. -->
 		<!-- Protection: Bad block check for block $308 -->
 
@@ -1022,9 +1178,13 @@ license:CC0-1.0
 		<description>Math Blaster Plus! (version 1.0) (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Davidson and Associates</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="author" value="Jan Davidson and Cathy Johnson" />
+		<info name="programmer" value="C.K. Haun" />
+		<info name="version" value="1.1" />
+		<info name="usage" value="Requires a 512K Apple IIgs ROM1 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- It requires a 512K Apple IIgs. -->
+		<!-- Dump released: 2021-08-13 -->
+		<!-- It requires a 512K Apple IIgs ROM1 or later. -->
 		<!--"Math Blaster Plus!" is a 1989 educational program designed by Jan Davidson and Cathy Johnson, written by C.K. Haun, and distributed by Davidson and Associates. -->
 		<!-- Protection: Bad block check for block $308 -->
 
@@ -1039,8 +1199,10 @@ license:CC0-1.0
 		<description>Math Wizard (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Unicorn Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="William Demas, June Stark, and Joseph B. Hewitt IV" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"Math Wizard" is a 1988 educational program developed by William Demas, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -1063,8 +1225,10 @@ license:CC0-1.0
 		<description>Mavis Beacon Teaches Typing (version 1.8 21-Dec-88) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>The Software Toolworks</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="version" value="1.8" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Mavis Beacon Teaches Typing" is a 1987 educational program developed and distributed by The Software Toolworks. -->
 		<!-- mavis.s16 dated 21-Dec-88 - Currently NOT archived: v1.5 (unknown program date) -->
@@ -1088,8 +1252,10 @@ license:CC0-1.0
 		<description>Mavis Beacon Teaches Typing (version 1.2 16-Nov-87) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>The Software Toolworks</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="version" value="1.2" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Mavis Beacon Teaches Typing" is a 1987 educational program developed and distributed by The Software Toolworks. -->
 		<!-- mavis.s16 dated 16-Nov-87 -->
@@ -1113,8 +1279,10 @@ license:CC0-1.0
 		<description>Mean 18 (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Rex Bradford, George Karalias, and Mark Lesser" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Mean 18" is a 1987 sports game developed by Rex Bradford, George Karalias, and Mark Lesser, and distributed by Accolade. -->
 		<!-- This archive includes the three add-on disks that were available separately (Famous Courses Volume II, III, and IV). -->
@@ -1150,8 +1318,12 @@ license:CC0-1.0
 		<description>Mercury (version 1.0) (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>MECC</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="partno" value="A249" />
+		<info name="programmer" value="John J. Krenz, Brian Nesse, Michael Palmquist, Steve Splinter, Michael Stein, and Paul Wenker" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
 		<!--"Mercury" is a 1989 desktop publishing program developed by John J. Krenz, Brian Nesse, Michael Palmquist, Steve Splinter, Michael Stein, and Paul Wenker, and distributed by MECC. -->
 		<!-- Protection: Bad block check for block $8 -->
@@ -1174,8 +1346,11 @@ license:CC0-1.0
 		<description>Music Construction Set (version 1.0) (cleanly cracked)</description>
 		<year>1986</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Will Harvey, Jim Nitchals, and Doug Fulton" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 256K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 256K Apple IIgs. -->
 		<!--"Music Construction Set" is a 1986 audio program developed by Will Harvey, Jim Nitchals, and Doug Fulton, and distributed by Electronic Arts. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -1191,8 +1366,10 @@ license:CC0-1.0
 		<description>Neuromancer (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Interplay Productions</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Rebecca Heineman" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Neuromancer" is a 1989 adventure game developed by Rebecca Heineman and distributed by Interplay Productions. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -1208,8 +1385,10 @@ license:CC0-1.0
 		<description>Paperboy (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Mindscape</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="developer" value="Tengen" />
+		<info name="usage" value="Requires a 256K Apple IIgs ROM 01." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 256K Apple IIgs ROM 01 -->
 		<!--"Paperboy" is a 1988 action game developed by Tengen and distributed by Mindscape. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -1225,8 +1404,10 @@ license:CC0-1.0
 		<description>Pipe Dream (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Lucasfilm Games</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="developer" value="Visual Concepts" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Pipe Dream" is a 1990 board game developed by Visual Concepts and distributed by Lucasfilm Games. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -1242,9 +1423,10 @@ license:CC0-1.0
 		<description>Qix (version 1.4? 16-Jan-90) (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Taito</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Ryan Ridges and John Lund"/>
+		<info name="programmer" value="Ryan Ridges and John Lund" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Qix" is a 1990 action game developed by Ryan Ridges and John Lund, and distributed by Taito. -->
 		<!-- Purportedly this is v1.4 - qix.s16 is dated 16-Jan-90 -->
@@ -1261,8 +1443,10 @@ license:CC0-1.0
 		<description>Read and Rhyme (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Unicorn Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="William Demas" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"Read and Rhyme" is a 1988 educational program developed by William Demas and distributed by Unicorn Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -1285,8 +1469,10 @@ license:CC0-1.0
 		<description>Read-a-Rama (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Unicorn Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Stan Brewster and Joseph Hewitt" />
+		<info name="usage" value="Requires a 1MB Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs. -->
 		<!--"Read-A-Rama" is a 1989 educational program developed by Stan Brewster and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -1315,8 +1501,11 @@ license:CC0-1.0
 		<description>Reader Rabbit (version 2.3) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>The Learning Company</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Pete Rowe and Aaron Weiss" />
+		<info name="version" value="2.3" />
+		<info name="usage" value="Requires a 256K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 256K Apple IIgs. -->
 		<!--"Reader Rabbit" is a 1987 educational program developed by Pete Rowe and Aaron Weiss, and distributed by The Learning Company. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -1332,8 +1521,11 @@ license:CC0-1.0
 		<description>Reader Rabbit (version 2.2) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>The Learning Company</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Pete Rowe and Aaron Weiss" />
+		<info name="version" value="2.2" />
+		<info name="usage" value="Requires a 256K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 256K Apple IIgs. -->
 		<!--"Reader Rabbit" is a 1987 educational program developed by Pete Rowe and Aaron Weiss, and distributed by The Learning Company. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -1345,12 +1537,35 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="rrabbitb" cloneof="rrabbit">
+		<description>Reader Rabbit (Version 2.0) (cleanly cracked)</description>
+		<year>1987</year>
+		<publisher>The Learning Company</publisher>
+		<info name="programmer" value="Pete Rowe and Aaron Weiss" />
+		<info name="version" value="2.0" />
+		<info name="usage" value="Requires a 256K Apple IIgs." />
+		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2023-04-13 -->
+		<!-- It requires a 256K Apple IIgs. -->
+		<!--"Reader Rabbit" is a 1987 educational program developed by Pete Rowe and Aaron Weiss, and distributed by The Learning Company. -->
+		<!-- Protection: Bad block check for block $7 -->
+
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="819264">
+				<rom name="reader rabbit v2.0 iigs (trex crack).2mg" size="819264" crc="0d7519e3" sha1="105012eccd7f066a0c3344b8f51b111fff7fc170"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="readingme">
 		<description>Reading and Me (version 1.0) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Davidson and Associates</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Louis X. Savain and C. K. Haun" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Reading and Me" is a 1988 educational program developed by Louis X. Savain and C. K. Haun, and distributed by Davidson & Associates. -->
 		<!-- Protection: Bad block check for block $308 -->
@@ -1373,9 +1588,11 @@ license:CC0-1.0
 		<description>Sea Strike (version 1.0) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>PBI Software</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Richard L. Seaborne, Jeff A. Lefferts, and Mei-Ying Dell'Aquila"/>
+		<info name="programmer" value="Richard L. Seaborne, Jeff A. Lefferts, and Mei-Ying Dell'Aquila" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Sea Strike" is a 1987 action game developed by Richard L. Seaborne, Jeff A. Lefferts, and Mei-Ying Dell'Aquila, and distributed by PBI Software. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -1391,9 +1608,10 @@ license:CC0-1.0
 		<description>Serve and Volley (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Rick Banks, Paul Butler, Ken Shimizu, Danny Chin, Paul Battersby, Jeffrey J. Sigler, Grant Campbell, and Jay Stevens"/>
+		<info name="programmer" value="Rick Banks, Paul Butler, Ken Shimizu, Danny Chin, Paul Battersby, Jeffrey J. Sigler, Grant Campbell, and Jay Stevens" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Serve and Volley" is a 1988 sports game developed by Rick Banks, Paul Butler, Ken Shimizu, Danny Chin, Paul Battersby, Jeffrey J. Sigler, Grant Campbell, and Jay Stevens, and distributed by Accolade. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -1409,8 +1627,11 @@ license:CC0-1.0
 		<description>Shanghai (version 15-Sep-87) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Activision</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Brodie Lockard and Ivan Manley" />
+		<info name="version" value="15-Sep-87" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Shanghai" is a 1987 board game developed by Brodie Lockard and Ivan Manley, and distributed by Activision. -->
 		<!-- start.s16 dated 15-Sep-87 -->
@@ -1427,9 +1648,13 @@ license:CC0-1.0
 		<description>Shanghai (version 20-Jan-87) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Activision</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Brodie Lockard and Ivan Manley" />
+		<info name="version" value="20-Jan-87" />
+		<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier." />
 		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- It requires a 512K Apple IIgs. -->
+		<!-- Dump released: 2021-08-13 -->
+		<!-- It requires a 512K Apple IIgs ROM 01 or earlier. -->
+		<!-- NOT Compatible with the Apple IIgs ROM03. -->
 		<!--"Shanghai" is a 1987 board game developed by Brodie Lockard and Ivan Manley, and distributed by Activision. -->
 		<!-- start.s16 dated 20-Jan-87 -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -1445,8 +1670,11 @@ license:CC0-1.0
 		<description>ShowOff (version 1.1) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Brøderbund Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Serge Hervy and Jean-Claude Lévy" />
+		<info name="version" value="1.1" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"ShowOff" is a 1987 graphics program developed by Serge Hervy and Jean-Claude Lévy, and distributed by Brøderbund Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -1471,12 +1699,70 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="showoffa" cloneof="showoff">
+		<description>ShowOff (Version 1.0) (cleanly cracked)</description>
+		<year>1987</year>
+		<publisher>Brøderbund Software</publisher>
+		<info name="programmer" value="Serge Hervy and Jean-Claude Lévy" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier." />
+		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2023-04-13 -->
+		<!-- It requires a 512K Apple IIgs ROM 01 or earlier. -->
+		<!-- NOT Compatible with the Apple IIgs ROM03. -->
+		<!--"ShowOff" is a 1987 graphics program developed by Serge Hervy and Jean-Claude Lévy, and distributed by Brøderbund Software. -->
+		<!-- Protection: Nibble count on tracks $20 & $21 -->
+
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1 - Program disk"/>
+			<dataarea name="flop" size="819264">
+				<rom name="showoff v1.0 iigs - disk 1 - program (trex crack).2mg" size="819264" crc="b04c2763" sha1="f42601d9af1d1441ceac97299e12fd47cd8d5b0b"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2 - Slide show disk"/>
+			<dataarea name="flop" size="819264">
+				<rom name="showoff iigs - disk 2 - slide show (trex crack).2mg" size="819264" crc="52348475" sha1="2fc72e0fcd0c398a56e4b4ef5e247c9961bc5a8c"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3 - Graphics collection - world events"/>
+			<dataarea name="flop" size="819264">
+				<rom name="showoff iigs - disk 3 - graphics collection - world events (trex crack).2mg" size="819264" crc="fa1a5ceb" sha1="b64402b6ace256145ba3bae31682520dca7c79af"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pirates">
+		<description>Sid Meier's Pirates! (cleanly cracked)</description>
+		<year>1987</year>
+		<publisher>Microprose</publisher>
+		<info name="developer" value="Sid Meier" />
+		<info name="programmer" value="Dan Chang &amp; Ed Magnin" />
+		<info name="usage" value="Requires a 256K Apple IIgs." />
+		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2023-02-24 -->
+		<!-- It requires a 256K Apple IIgs. -->
+		<!--"Pirates!" is a 1987 simulation game developed by Sid Meier, programmed by Dan Chang & Ed Magnin, sound by Ken Lagace & Silas Warner, art by Micheal Haire, Murray Taylor & Max Remington and distributed by Microprose. -->
+		<!-- Protection: Modified ProDOS 8 and altered disk format -->
+		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
+
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="819264">
+				<rom name="sid meier's pirates iigs (trex crack).2mg" size="819264" crc="5c53623d" sha1="551eb337651bee99d235a321ed921cf10efeee66" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="slntsvce">
 		<description>Silent Service (version 925.01) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Microprose</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Sid Meier, Ed Magnin, Jim Synoski, Michael Haire, Michele Mahan, Silas Warner, Al Roireau, Larry Martin, and Edward Bever" />
+		<info name="version" value="925.01" />
+		<info name="usage" value="Requires a 256K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 256K Apple IIgs. -->
 		<!--"Silent Service" is a 1987 simulation game developed by Sid Meier, Ed Magnin, Jim Synoski, Michael Haire, Michele Mahan, Silas Warner, Al Roireau, Larry Martin, and Edward Bever, and distributed by Microprose. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -1492,8 +1778,10 @@ license:CC0-1.0
 		<description>Silpheed - Super Dogfighter (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Sierra On-Line</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="John Rettig, Stuart Goldstein, Mark Seibert, Satoshi Uesaki, Nobuyuki Ogawa, Akira Eye, Fumihito Kasatani, Nobuyuki Aoshima, Hiromi Ohba, Takeshi Miyaji, Osamu Harada, and Youichi Miyaji" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Silpheed" is a 1987 action game developed by John Rettig, Stuart Goldstein, Mark Seibert, Satoshi Uesaki, Nobuyuki Ogawa, Akira Eye, Fumihito Kasatani, Nobuyuki Aoshima, Hiromi Ohba, Takeshi Miyaji, Osamu Harada, and Youichi Miyaji, and distributed by Sierra On-Line. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -1516,8 +1804,11 @@ license:CC0-1.0
 		<description>Skate or Die (version 1.1 07-Oct-88) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Michael Kosaka, Stephen Landrum, David Bunch, and Michelle Shelfer" />
+		<info name="version" value="1.1 07-Oct-88 - ROM 03 compatible" />
+		<info name="usage" value="Requires a 512K Apple IIgs. Music requires 768K." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. Music requires 768K. -->
 		<!--"Skate or Die" is a 1988 sports game developed by Michael Kosaka, Stephen Landrum, David Bunch, and Michelle Shelfer, and distributed by Electronic Arts. -->
 		<!-- sod.sys16 dated 07-Oct-88 -->
@@ -1535,8 +1826,11 @@ license:CC0-1.0
 		<description>Skate or Die (version 1.0 12-Aug-88) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Michael Kosaka, Stephen Landrum, David Bunch, and Michelle Shelfer" />
+		<info name="version" value="1.0 12-Aug-88 - ROM 03 compatible" />
+		<info name="usage" value="Requires a 512K Apple IIgs. Music requires 768K." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. Music requires 768K. -->
 		<!--"Skate or Die" is a 1988 sports game developed by Michael Kosaka, Stephen Landrum, David Bunch, and Michelle Shelfer, and distributed by Electronic Arts. -->
 		<!-- sod.sys16 dated 12-Aug-88 -->
@@ -1556,6 +1850,7 @@ license:CC0-1.0
 		<publisher>Sierra On-Line</publisher>
 		<info name="release" value="2021-08-13"/>
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Space Quest: The Sarien Encounter" is a 1987 adventure game developed by Scott Murphy, Mark Crowe, Jeff Stephenson, Chris Iden, Sol Ackerman, and Ken Williams, and distributed by Sierra On-Line. -->
 		<!-- Protection: Bad block check for block $634 -->
@@ -1578,8 +1873,10 @@ license:CC0-1.0
 		<description>Space Quest II - Vohual's Revenge (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Sierra On-Line</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Scott Murphy, Mark Crowe, Jeff Stephenson, Chris Iden, Sol Ackerman, and Ken Williams" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Space Quest II" is a 1988 adventure game developed by Mark Crowe, Scott Murphy, Jeff Stephenson, Chris Iden, Robert Heitman, and Carlos Escobar, and distributed by Sierra On-Line. -->
 		<!-- Protection: Bad block check for block $634 -->
@@ -1602,8 +1899,10 @@ license:CC0-1.0
 		<description>Spirit of Excalibur (cleanly cracked)</description>
 		<year>1991</year>
 		<publisher>Virgin Mastertronic</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="developer" value="Synergistic Software" />
+		<info name="usage" value="Requires a 1MB Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs. -->
 		<!--"Spirit of Excalibur" is a 1991 adventure game developed by Synergistic Software and distributed by Virgin Mastertronic. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -1632,8 +1931,12 @@ license:CC0-1.0
 		<description>Storybook Weaver (version 1.0) (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>MECC</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="partno" value="A275" />
+		<info name="programmer" value="Charolyn Kapplinger, Patricia Korn, John J. Krenz, Brian S. Nesse, Jean Sharp, and Steve Zehm" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
 		<!--"Storybook Weaver" is a 1990 educational program developed by Charolyn Kapplinger, Patricia Korn, John J. Krenz, Brian S. Nesse, Jean Sharp, and Steve Zehm, and distributed by MECC. -->
 		<!-- Protection: Bad block check for block $8 -->
@@ -1656,8 +1959,12 @@ license:CC0-1.0
 		<description>Storybook Weaver - World of Adventure (version 1.0) (cleanly cracked)</description>
 		<year>1991</year>
 		<publisher>MECC</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="partno" value="A276" />
+		<info name="programmer" value="Patricia Korn, Brian S. Nesse, Dee Dee Roedel &amp; Jean Sharp" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
 		<!--"Storybook Weaver: World of Adventure" is a 1991 educational program developed by Patricia Korn, Brian S. Nesse, Dee Dee Roedel & Jean Sharp, and distributed by MECC. -->
 		<!-- Protection: Bad block check for block $8 -->
@@ -1680,8 +1987,12 @@ license:CC0-1.0
 		<description>Storybook Weaver - World of Make-Believe (version 1.0) (cleanly cracked)</description>
 		<year>1991</year>
 		<publisher>MECC</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="partno" value="A298" />
+		<info name="programmer" value="Charolyn Kapplinger, Patricia Korn, and Jean Sharp" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
 		<!--"Storybook Weaver: World of Make-Believe" is a 1991 educational program developed by Charolyn Kapplinger, Patricia Korn, and Jean Sharp, and distributed by MECC. -->
 		<!-- Protection: Bad block check for block $8 -->
@@ -1704,9 +2015,11 @@ license:CC0-1.0
 		<description>Street Sports Soccer (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Epyx</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="developer" value="Designer Software" />
+		<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier." />
 		<sharedfeat name="compatibility" value="A2GS"/>
-		<!-- It requires a 512K Apple IIgs ROM 00 or ROM 01. -->
+		<!-- Dump released: 2021-08-13 -->
+		<!-- It requires a 512K Apple IIgs ROM 01 or earlier. -->
 		<!--"Street Sports Soccer" is a 1988 sports game developed by Designer Software and distributed by Epyx. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
 
@@ -1721,8 +2034,10 @@ license:CC0-1.0
 		<description>Superstar Ice Hockey (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Mindscape</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Ed Ringler, Andrew Caldwell, Clayton Wishoff, Simon Ffinch, Ed Ringler Sr., and Chris Oke" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Superstar Ice Hockey" is a 1988 sports game developed by Ed Ringler, Andrew Caldwell, Clayton Wishoff, Simon Ffinch, Ed Ringler Sr., and Chris Oke, and distributed by Mindscape. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -1738,8 +2053,10 @@ license:CC0-1.0
 		<description>Tales From The Arabian Nights (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Unicorn Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Stanley Brewster and June Stark" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"Tales From The Arabian Nights" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -1762,9 +2079,10 @@ license:CC0-1.0
 		<description>Task Force (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Britannica Software</publisher>
-		<info name="release" value="2021-05-07"/>
-		<info name="programmer" value="Scott L. Patterson, Matthew Crysdale, and Gregory A. Thomas"/>
+		<info name="programmer" value="Scott L. Patterson, Matthew Crysdale, and Gregory A. Thomas" />
+		<info name="usage" value="Requires a 1MB Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs. -->
 		<!--"Task Force" is a 1990 action game developed by Scott L. Patterson, Matthew Crysdale, and Gregory A. Thomas, and distributed by Britannica Software. -->
 		<!-- Protection: Read block $63F with data markers AD AA D5 and compare read data against self generated data -->
@@ -1787,8 +2105,10 @@ license:CC0-1.0
 		<description>Tetris (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Spectrum HoloByte</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Roland Gustafsson, Sean B. Barger, Dan Geisler, Daniel L. Guerra, Jody Sather, Ed Bogas, Neil Cormia, Ty Roberts, and Gary Clayton" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Tetris" is a 1988 action game developed by Roland Gustafsson, Sean B. Barger, Dan Geisler, Daniel L. Guerra, Jody Sather, Ed Bogas, Neil Cormia, Ty Roberts, and Gary Clayton, and distributed by Spectrum HoloByte. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -1804,8 +2124,10 @@ license:CC0-1.0
 		<description>The Adventures of Sinbad (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Unicorn Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Curt Toumanian, Steve Quinn, Jeff Hilbers, Rob Landeros, Russ Truelove, Bill Williams, Jim Simmons, Andrew Caldwell, Douglass Sharp" />
+		<info name="usage" value="Requires a 768K Apple IIgs ROM1 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"The Adventures of Sinbad" is a 1988 educational program developed by Stanley Brewster, June Stark, and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -1828,9 +2150,10 @@ license:CC0-1.0
 		<description>The Duel: Test Drive II (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Allan Johnson, Erik Kiss, Amory Wong, Don Mattrick, Rick Friesen, Bruce Dawson, Randy Dillon, Brad Gour, Kris Hatlelid, Chris Taylor, John Boechler, Tony Lee, and Theresa Henry"/>
+		<info name="programmer" value="Allan Johnson, Erik Kiss, Amory Wong, Don Mattrick, Rick Friesen, Bruce Dawson, Randy Dillon, Brad Gour, Kris Hatlelid, Chris Taylor, John Boechler, Tony Lee, and Theresa Henry" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"The Duel: Test Drive II" is a 1989 racing simulation game developed by Allan Johnson, Erik Kiss, Amory Wong, Don Mattrick, Rick Friesen, Bruce Dawson, Randy Dillon, Brad Gour, Kris Hatlelid, Chris Taylor, John Boechler, Tony Lee, and Theresa Henry, and distributed by Accolade. -->
 		<!-- This archive includes the four add-on disks that were available separately (The Muscle Cars, The Supercars, California Challenge and European Challenge). -->
@@ -1872,8 +2195,11 @@ license:CC0-1.0
 		<description>The Fidelity Chessmaster 2100 (version 1.1 17-Nov-88) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>The Software Toolworks</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Troy Heere and Mark Manyen" />
+		<info name="version" value="1.1 17-Nov-88" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"The Fidelity Chessmaster 2100" is a 1988 board game developed by Troy Heere and Mark Manyen, and distributed by The Software Toolworks. -->
 		<!-- cm2100.s16 dated 17-Nov-88 -->
@@ -1897,8 +2223,11 @@ license:CC0-1.0
 		<description>The Fidelity Chessmaster 2100 (version 1.01 28-Sep-88) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>The Software Toolworks</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Troy Heere and Mark Manyen" />
+		<info name="version" value="1.01 28-Sep-88" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"The Fidelity Chessmaster 2100" is a 1988 board game developed by Troy Heere and Mark Manyen, and distributed by The Software Toolworks. -->
 		<!-- cm2100.s16 dated 28-Sep-88 -->
@@ -1922,8 +2251,10 @@ license:CC0-1.0
 		<description>The Graphics Studio (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Greg Hospelhorn, Peter Wickman, Richard Antaki" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"The Graphics Studio" is a 1987 graphics program developed by Greg Hospelhorn, Peter Wickman, Richard Antaki, and distributed by Accolade. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -1939,8 +2270,10 @@ license:CC0-1.0
 		<description>The Immortal (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Will Harvey, Ian Gooding, Michael Marcanted, Brett G. Durrett, and Douglas Fulton" />
+		<info name="usage" value="Requires a 1MB Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs. -->
 		<!--"The Immortal" is a 1990 roleplaying game developed by Will Harvey, Ian Gooding, Michael Marcanted, Brett G. Durrett, and Douglas Fulton, and distributed by Electronic Arts. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -1963,8 +2296,10 @@ license:CC0-1.0
 		<description>The King of Chicago (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Cinemaware</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Doug Sharp" />
+		<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs ROM01 or later. -->
 		<!--"The King of Chicago" is a 1988 adventure game developed by Doug Sharp and distributed by Cinemaware. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -1987,9 +2322,10 @@ license:CC0-1.0
 		<description>The Last Ninja (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Activision</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Jeff Silverman, John Kroeckel, J. David Koch, Erol Otus, Doug Barnett, Russell Lieblich, and Nicky Robinson"/>
+		<info name="programmer" value="Jeff Silverman, John Kroeckel, J. David Koch, Erol Otus, Doug Barnett, Russell Lieblich, and Nicky Robinson" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"The Last Ninja" is a 1988 action game developed by Jeff Silverman, John Kroeckel, J. David Koch, Erol Otus, Doug Barnett, Russell Lieblich, and Nicky Robinson, and distributed by Activision. -->
 		<!-- Protection: Bad block check for block $63F -->
@@ -2005,8 +2341,11 @@ license:CC0-1.0
 		<description>The Logic Master (version 1.5) (cleanly cracked)</description>
 		<year>1990</year>
 		<publisher>Unicorn Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="William Demas and June Stark" />
+		<info name="version" value="1.5" />
+		<info name="usage" value="Requires a 1MB Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"The Logic Master" is a 1990 educational program developed by William Demas, and June Stark, and distributed by Unicorn Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -2029,8 +2368,11 @@ license:CC0-1.0
 		<description>The Print Shop (version 1.0) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Brøderbund Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="David Balsam, Martin Kahn, Corey Kosak, Ann E. Kronen, Susan E. Schlangen, Richard Whittaker, Michelle McBride, Don Albrecht, and Leila Bronstein" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 512K Apple IIgs ROM 01 or earlier." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs ROM 01 or earlier. -->
 		<!-- NOT Compatible with the Apple IIgs ROM03. -->
 		<!--"The Print Shop IIgs" is a 1987 graphics program developed by David Balsam, Martin Kahn, Corey Kosak, Ann E. Kronen, Susan E. Schlangen, Richard Whittaker, Michelle McBride, Don Albrecht, and Leila Bronstein, and distributed by Brøderbund Software. -->
@@ -2047,8 +2389,10 @@ license:CC0-1.0
 		<description>The Third Courier (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Accolade</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Carol Manley, Ivan Manley, Mike Branham, Robert Clardy, Chris Barker, Scott Wallin, Miik Nichols, Sheldon Safir, and Mark Wallace" />
+		<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs ROM01 or later. -->
 		<!--"The Third Courier" is a 1989 adventure game developed by Carol Manley, Ivan Manley, Mike Branham, Robert Clardy, Chris Barker, Scott Wallin, Miik Nichols, Sheldon Safir, and Mark Wallace, and distributed by Accolade. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -2071,8 +2415,10 @@ license:CC0-1.0
 		<description>The Tower of Myraglen (version 1.0) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>PBI Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Richard L. Seaborne and Jeff A. Lamberts" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"The Tower of Myraglen" is a 1987 roleplaying game developed by Richard L. Seaborne and Jeff A. Lamberts, and distributed by PBI Software. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -2095,8 +2441,10 @@ license:CC0-1.0
 		<description>The Three Stooges (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Cinemaware</publisher>
-		<info name="release" value="2022-02-18"/>
+		<info name="programmer" value="John Cutter, Robert Jacob, Phyllis Jacob, Ed Magnin, Russell Truelove, Jim Simmons, and Patrick Cook" />
+		<info name="usage" value="Requires an 1.25MB Apple IIgs ROM01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1.25MB Apple IIgs ROM01 or later. -->
 		<!--"The Three Stooges" is a 1987 adventure game developed by John Cutter, Robert Jacob, Phyllis Jacob, Ed Magnin, Russell Truelove, Jim Simmons, and Patrick Cook and distributed by Cinemaware. -->
 		<!-- Protection: Bad block check for block $10D -->
@@ -2119,8 +2467,10 @@ license:CC0-1.0
 		<description>The Wonders of the Animal Kingdom (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Unicorn Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Stan Brewster, Joseph Hewitt, and June Stark" />
+		<info name="usage" value="Requires a 1MB Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs. -->
 		<!--"The Wonders of the Animal Kingdom" is a 1989 educational program developed by Stan Brewster, Joseph B. Hewitt IV, and June Stark, and distributed by Unicorn Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -2143,8 +2493,10 @@ license:CC0-1.0
 		<description>The Word Master (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Unicorn Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="William Demas and Joseph Hewitt" />
+		<info name="usage" value="Requires a 1MB Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs. -->
 		<!--"The Word Master" is a 1989 educational program developed by William Demas and Joseph B. Hewitt IV, and distributed by Unicorn Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -2160,8 +2512,11 @@ license:CC0-1.0
 		<description>Thexder (version 2.7) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Sierra On-Line</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="H. Godai, S. Uesaka, Michael D. Branham, Robert C. Clardy, John P. Conley, Lloyd Ollmann Jr., and Michael Ormsby" />
+		<info name="version" value="2.7" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Thexder" is a 1987 action game developed by H. Godai, S. Uesaka, Michael D. Branham, Robert C. Clardy, John P. Conley, Lloyd Ollmann Jr., and Michael Ormsby, and distributed by Sierra On-Line. -->
 		<!-- Protection: Bad block check for block $634 -->
@@ -2177,8 +2532,11 @@ license:CC0-1.0
 		<description>Thexder (version 1.0) (cleanly cracked) (No OS, not self booting)</description>
 		<year>1987</year>
 		<publisher>Sierra</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="H. Godai, S. Uesaka, Michael D. Branham, Robert C. Clardy, John P. Conley, Lloyd Ollmann Jr., and Michael Ormsby" />
+		<info name="version" value="1.0 - No OS, not self booting" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Thexder" is a 1987 action game developed by H. Godai, S. Uesaka, Michael D. Branham, Robert C. Clardy, John P. Conley, Lloyd Ollmann Jr., and Michael Ormsby, and distributed by Sierra On-Line. -->
 		<!-- Original release by Sierra On-Line - Did NOT come with OS and was NOT self bootable -->
@@ -2196,8 +2554,10 @@ license:CC0-1.0
 		<description>Topdraw (version 1.00A) (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Styleware Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="version" value="1.00A" />
+		<info name="usage" value="Requires a 1MB Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs. -->
 		<!--"Topdraw" is a 1987 graphics program developed by Robert Hearn and Jeff Erickson, and distributed by Styleware Software. -->
 		<!-- Topdraw later became Beagle Draw sold under the Beagle Brothers banner. Topdraw v1.01A known to exist but not currently archived -->
@@ -2214,8 +2574,11 @@ license:CC0-1.0
 		<description>TrianGo (version 1.0) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>California Dreams</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Staszek Bartkowski, Marcin Szostakowski, Maciej Markuszewski, Dorota Błaszczak" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"TrianGo" is a 1988 board game developed by Staszek Bartkowski, Marcin Szostakowski, Maciej Markuszewski, Dorota Błaszczak, and distributed by California Dreams. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -2231,9 +2594,10 @@ license:CC0-1.0
 		<description>Uninvited (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>ICOM Simulations</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Fred Allen, David Marsh, Karl Roelofs, Todd Squires, Craig Erickson, Steven Hays, Terry Schulenburg, Darin Adler, Jay Zipnick, Waldemar Horwat, Mark Waterman, Tod Zipnick, and Billy Wolf"/>
+		<info name="programmer" value="Fred Allen, David Marsh, Karl Roelofs, Todd Squires, Craig Erickson, Steven Hays, Terry Schulenburg, Darin Adler, Jay Zipnick, Waldemar Horwat, Mark Waterman, Tod Zipnick, and Billy Wolf" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs. -->
 		<!--"Uninvited" is a 1988 adventure game developed by Fred Allen, David Marsh, Karl Roelofs, Todd Squires, Craig Erickson, Steven Hays, Terry Schulenburg, Darin Adler, Jay Zipnick, Waldemar Horwat, Mark Waterman, Tod Zipnick, and Billy Wolf, and distributed by ICOM Simulations. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -2252,12 +2616,42 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="usageogr">
+		<description>USA GeoGraph (Version 1.0) (cleanly cracked)</description>
+		<year>1989</year>
+		<publisher>MECC</publisher>
+		<info name="programmer" value="Nelson Whyatt, Paul R. Wenker, Wayne Studer, Steven D. Splinter, John L. Krenz, and Charolyn Kapplinger" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
+		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2023-04-13 -->
+		<!-- It requires a 768K Apple IIgs. -->
+		<!--"USA GeoGraph" is a 1989 educational program developed by Nelson Whyatt, Paul R. Wenker, Wayne Studer, Steven D. Splinter, John L. Krenz, and Charolyn Kapplinger, and distributed by MECC Software. -->
+		<!-- Protection: Bad block check for block $8 -->
+
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1 - Program disk"/>
+			<dataarea name="flop" size="819264">
+				<rom name="usa geograph v1.0 iigs - disk 1 - program (trex crack).2mg" size="819264" crc="f968d252" sha1="ebda6798c67d277a15314b97d116f40e6b072ccd" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2 - Information disk"/>
+			<dataarea name="flop" size="819264">
+				<rom name="usa geograph v1.0 iigs - disk 2 - Information (trex crack).2mg" size="819264" crc="c5bc2c2c" sha1="6ef5b7be7d2a813387cfb4fa381c76d40d94c6ca" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="vgscraps">
 		<description>Vegas Craps (version 1.0) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>California Dreams</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Krzysztof Koziarski, Maciej Markuszewski, Marcin Szostakowski, and Dorota Błaszczak" />
+		<info name="version" value="1.0" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Vegas Gambler" is a 1988 simulation game developed by Krzysztof Koziarski, Maciej Markuszewski, Marcin Szostakowski, and Dorota Błaszczak, and distributed by California Dreams. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -2273,8 +2667,11 @@ license:CC0-1.0
 		<description>Vegas Gambler (version 1.1 25-Jul-88) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>California Dreams</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Marek Jackiewicz, Andrzej Miciłkiewicz, Marcin Szostakowski, Maciej Markuszewski, and Dorota Błaszczak" />
+		<info name="version" value="1.1 25-Jul-88" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Vegas Gambler" is a 1988 simulation game developed by Marek Jackiewicz, Andrzej Miciłkiewicz, Marcin Szostakowski, Maciej Markuszewski, and Dorota Błaszczak, and distributed by California Dreams. -->
 		<!-- gambler.sys16 dated 25-Jul-88 -->
@@ -2291,8 +2688,11 @@ license:CC0-1.0
 		<description>Vegas Gambler (version 1.0 07-Jun-88) (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>California Dreams</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Marek Jackiewicz, Andrzej Miciłkiewicz, Marcin Szostakowski, Maciej Markuszewski, and Dorota Błaszczak" />
+		<info name="version" value="1.0 07-Jun-88" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Vegas Gambler" is a 1988 simulation game developed by Marek Jackiewicz, Andrzej Miciłkiewicz, Marcin Szostakowski, Maciej Markuszewski, and Dorota Błaszczak, and distributed by California Dreams. -->
 		<!-- gambler.sys16 dated 07-Jun-88 -->
@@ -2309,8 +2709,10 @@ license:CC0-1.0
 		<description>War in Middle Earth (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Melbourne House</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Ron Harris, Robert Clardy, Alan B. Clark, Graeme Devine, Mike Branham, Lloyd Ollmann, Jr., John Conley, Jim McBride, Michael Park, David Schroeder, Michael Ormsby, Mike Christy, Ann Dickens Clardy, Marcus Streets, Mark Riley, and Mike Singleton" />
+		<info name="usage" value="Requires a 768K Apple IIgs ROM01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 768K Apple IIgs ROM01 or later. -->
 		<!--"War in Middle Earth" is a 1989 adventure game developed by Ron Harris, Robert Clardy, Alan B. Clark, Graeme Devine, Mike Branham, Lloyd Ollmann, Jr., John Conley, Jim McBride, Michael Park, David Schroeder, Michael Ormsby, Mike Christy, Ann Dickens Clardy, Marcus Streets, Mark Riley, and Mike Singleton, and distributed by Melbourne House. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -2333,8 +2735,10 @@ license:CC0-1.0
 		<description>Where in the U.S.A. is Carmen Sandiego? (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Brøderbund Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Gene Portwood, Lauren Elliot, Peter Adams, Leila Bronstein, Julie Glavin, Michelle McBride, Dan Guerra, Les Pardue, Bevan Hulfenstein, Louis Evans, and Tom Rettig" />
+		<info name="usage" value="Requires a 1MB Apple IIgs ROM 01 or later." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 1MB Apple IIgs ROM 01 or later. -->
 		<!--"Where in the U.S.A. is Carmen Sandiego?" is a 1989 educational game developed by Gene Portwood, Lauren Elliot, Peter Adams, Leila Bronstein, Julie Glavin, Michelle McBride, Dan Guerra, Les Pardue, Bevan Hulfenstein, Louis Evans, and Tom Rettig, and distributed by Brøderbund Software. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -2357,8 +2761,10 @@ license:CC0-1.0
 		<description>Where in the World is Carmen Sandiego? (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Brøderbund Software</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Gene Portwood, Lauren Elliott, Loring Vogel, Leila Bronstein, Don Albrecht, and Michelle McBride" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Where in the World is Carmen Sandiego?" is a 1989 educational game developed by Gene Portwood, Lauren Elliott, Loring Vogel, Leila Bronstein, Don Albrecht, and Michelle McBride, and distributed by Brøderbund Software. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -2381,8 +2787,10 @@ license:CC0-1.0
 		<description>Winter Games (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Epyx</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="developer" value="Westwood Studios" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Winter Games" is a 1987 sports game developed by Westwood Studios and distributed by Epyx. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -2398,8 +2806,10 @@ license:CC0-1.0
 		<description>World Games (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Epyx</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="developer" value="Westwood Studios" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"World Games" is a 1987 sports game developed by Westwood and distributed by Epyx. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->
@@ -2411,12 +2821,41 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="wldgeogr">
+		<description>World GeoGraph (Version 1.3) (cleanly cracked)</description>
+		<year>1989</year>
+		<publisher>MECC</publisher>
+		<info name="programmer" value="Charolyn Kapplinger, John L. Krenz, Diane Portner, Steven D. Splinter, Wayne Studer, Paul R. Wenker, and Nelson Whyatt" />
+		<info name="version" value="1.3" />
+		<info name="usage" value="Requires a 768K Apple IIgs." />
+		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2023-04-13 -->
+		<!-- It requires a 768K Apple IIgs. -->
+		<!--"USA GeoGraph" is a 1989 educational program developed by Charolyn Kapplinger, John L. Krenz, Diane Portner, Steven D. Splinter, Wayne Studer, Paul R. Wenker, and Nelson Whyatt, and distributed by MECC Software. -->
+		<!-- Protection: Bad block check for block $8 -->
+
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1 - Program disk"/>
+			<dataarea name="flop" size="819264">
+				<rom name="world geograph v1.3 iigs - disk 1 - program (trex crack).2mg" size="819264" crc="a296d62a" sha1="15aa6627a08b3c4f3d1c9e7651218311f07e481e" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2 - Information disk"/>
+			<dataarea name="flop" size="819264">
+				<rom name="world geograph v1.3 iigs - disk 2 - Information (trex crack).2mg" size="819264" crc="1ec2c293" sha1="6131f8ea4938f9f180e8a5f0a67d5f8f38d90e22" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="wltrgolf">
 		<description>World Tour Golf (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="author" value="Evan and Nicky Robinson and Paul Reiche III" />
+		<info name="programmer" value="John Selhorst" />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"World Tour Golf" is a 1987 sports game developed by Evan and Nicky Robinson and Paul Reiche III, ported to the Apple IIgs by John Selhorst, and distributed by Electronic Arts. -->
 		<!-- Protection: Key-Word, A manual is required to look up a letter / word or use of code wheel for a specific response -->
@@ -2432,8 +2871,10 @@ license:CC0-1.0
 		<description>Writer's Choice Elite (cleanly cracked)</description>
 		<year>1987</year>
 		<publisher>Activision</publisher>
-		<info name="release" value="2021-08-13"/>
+		<info name="programmer" value="Richard Danais, Nancy Philippine, Bernard Gallet, and Luc Barthelet" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Writer's Choice Elite" is a 1987 productivity program developed by Richard Danais, Nancy Philippine, Bernard Gallet, and Luc Barthelet, and distributed by Activision. -->
 		<!-- Protection: Bad block check for block $7 -->
@@ -2449,9 +2890,11 @@ license:CC0-1.0
 		<description>Xenocide (version 25-Sep-89) (unprotected)</description>
 		<year>1989</year>
 		<publisher>Micro Revelations</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Brian Greenstone and Dave Triplett"/>
+		<info name="programmer" value="Brian Greenstone and Dave Triplett" />
+		<info name="version" value="25-Sep-89" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Xenocide" is a 1989 action game developed by Brian Greenstone and Dave Triplett, and distributed by Micro Revelations. -->
 		<!-- xeno.sys16 dated 25-Sep-89 14:23, 63090 bytes long, 121 blocks -->
@@ -2468,9 +2911,11 @@ license:CC0-1.0
 		<description>Xenocide (version 11-Aug-89) (cleanly cracked)</description>
 		<year>1989</year>
 		<publisher>Micro Revelations</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Brian Greenstone and Dave Triplett"/>
+		<info name="programmer" value="Brian Greenstone and Dave Triplett" />
+		<info name="version" value="11-Aug-89" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Xenocide" is a 1989 action game developed by Brian Greenstone and Dave Triplett, and distributed by Micro Revelations. -->
 		<!-- xeno.sys16 dated 11-Aug-89 09:34, 65085 bytes long, 129 blocks -->
@@ -2487,9 +2932,10 @@ license:CC0-1.0
 		<description>Zany Golf (cleanly cracked)</description>
 		<year>1988</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="release" value="2021-08-13"/>
-		<info name="programmer" value="Will Harvey, Jim Nitchals, Ian Gooding, and Doug Fulton"/>
+		<info name="programmer" value="Will Harvey, Jim Nitchals, Ian Gooding, and Doug Fulton" />
+		<info name="usage" value="Requires a 512K Apple IIgs." />
 		<sharedfeat name="compatibility" value="A2GS"/>
+		<!-- Dump released: 2021-08-13 -->
 		<!-- It requires a 512K Apple IIgs. -->
 		<!--"Zany Golf" is a 1988 sports game developed by Will Harvey, Jim Nitchals, Ian Gooding, and Doug Fulton, and distributed by Electronic Arts. -->
 		<!-- Protection: Nibble count on tracks $20 & $21 -->


### PR DESCRIPTION
New working software list items
-------------------------------
GBA Championship Basketball: Two-on-Two (cleanly cracked) [Brian Troha]
Reader Rabbit (Version 2.0) (cleanly cracked) [Brian Troha]
ShowOff (Version 1.0) (cleanly cracked) [Brian Troha]
Sid Meier's Pirates! (cleanly cracked) [Brian Troha]
USA GeoGraph (Version 1.0) (cleanly cracked) [Brian Troha]
World GeoGraph (Version 1.3) (cleanly cracked) [Brian Troha]