### PR TITLE
Add C compiler flags for Wayland EGL backend to bgfx build options

### DIFF
--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -1558,6 +1558,9 @@ end
 			defines {
 				"WL_EGL_PLATFORM=1",
 			}
+			buildoptions {
+				backtick(pkgconfigcmd() .. " --cflags wayland-egl-backend"),
+			}
 		end
 	end
 


### PR DESCRIPTION
Follow up to #12194.