### PR TITLE
i186: fix dma on timer2 and timer2 as prescaler

### DIFF
--- a/src/devices/cpu/i86/i186.cpp
+++ b/src/devices/cpu/i86/i186.cpp
@@ -1258,9 +1258,9 @@ TIMER_CALLBACK_MEMBER(i80186_cpu_device::timer_elapsed)
 
 	if (which == 2)
 	{
-		if ((m_dma[0].control & (TIMER_DRQ | ST_STOP)) == TIMER_DRQ)
+		if ((m_dma[0].control & (TIMER_DRQ | ST_STOP)) == (TIMER_DRQ | ST_STOP))
 			drq_callback(0);
-		if ((m_dma[1].control & (TIMER_DRQ | ST_STOP)) == TIMER_DRQ)
+		if ((m_dma[1].control & (TIMER_DRQ | ST_STOP)) == (TIMER_DRQ | ST_STOP))
 			drq_callback(1);
 		if ((m_timer[0].control & 0x800c) == 0x8008)
 			inc_timer(0);

--- a/src/devices/cpu/i86/i186.cpp
+++ b/src/devices/cpu/i86/i186.cpp
@@ -1308,7 +1308,7 @@ TIMER_CALLBACK_MEMBER(i80186_cpu_device::timer_elapsed)
 void i80186_cpu_device::restart_timer(int which)
 {
 	timer_state *t = &m_timer[which];
-	// Only run timer 0,1 when not incremented via timer 2 pre-scaler
+	/* Only run timer 0,1 when not incremented via timer 2 pre-scaler */
 	if (which != 2 && (t->control & 0x800c) == 0x8008)
 		return;
 

--- a/src/devices/cpu/i86/i186.cpp
+++ b/src/devices/cpu/i86/i186.cpp
@@ -1308,6 +1308,10 @@ TIMER_CALLBACK_MEMBER(i80186_cpu_device::timer_elapsed)
 void i80186_cpu_device::restart_timer(int which)
 {
 	timer_state *t = &m_timer[which];
+	// Only run timer 0,1 when not incremented via timer 2 pre-scaler
+	if (which != 2 && (t->control & 0x800c) == 0x8008)
+		return;
+
 	int count = (t->control & 0x1000) ? t->maxB : t->maxA;
 	if (!(t->control & 4))
 		t->int_timer->adjust((attotime::from_hz(clock() / 8) * (count ? count : 0x10000)), which);


### PR DESCRIPTION
For the driver I'm currently writing there were two issues with the i186 emulation:
- drq_callback from timer 2 did not start dma transfer causing a blank screen
- when timer 0 or 1 use timer 2 as pre-scaler they were also incremented by their timer device, causing way too fast sequenced rhythms.

It would be good if someone familiar with the implementation would review this as I just did the changes to make it work for me - especially the pre-scaler commit.

https://github.com/orgs/mamedev/discussions/99

My WIP driver for testing can be found here  https://github.com/hjanetzek/mame/pull/2