### PR TITLE
docs: remove unnecessary repetition in othertools.rst

### DIFF
--- a/docs/source/tools/othertools.rst
+++ b/docs/source/tools/othertools.rst
@@ -21,35 +21,42 @@ pngcmp
 
 This tool is used in regression testing to compare PNG screenshot results with the runtest.cmd script found in the source archive. This script works only on Microsoft Windows.
 
+
 nltool
 ------
 
 Discrete component conversion tool.
+
 
 nlwav
 -----
 
 Discrete component conversion and testing tool.
 
+
 jedutil
 -------
 
 PAL/PLA/PLD/GAL dump handling tool. It can convert between the industry-standard JED format and MAME's proprietary packed binary format and it can show logic equations for the types of devices it knows the internal logic of.
+
 
 ldresample
 ----------
 
 This tool recompresses video data for laserdisc and VHS dumps.
 
+
 ldverify
 --------
 
 This tool is used for comparing laserdisc or VHS CHD images with the source AVI.
 
+
 romcmp
 ------
 
 This tool is used to perform basic data comparisons and integrity checks on binary dumps. With the -h switch, it can also be used to calculate hash functions.
+
 
 unidasm
 -------

--- a/docs/source/tools/othertools.rst
+++ b/docs/source/tools/othertools.rst
@@ -21,42 +21,37 @@ pngcmp
 
 This tool is used in regression testing to compare PNG screenshot results with the runtest.cmd script found in the source archive. This script works only on Microsoft Windows.
 
-
 nltool
 ------
 
-Discrete component conversion tool. Most users will not need to work with this.
+Discrete component conversion tool.
 
 nlwav
 -----
 
-Discrete component conversion and testing tool. Most users will not need to work with this.
-
+Discrete component conversion and testing tool.
 
 jedutil
 -------
 
-PAL/PLA/PLD/GAL dump handling tool. It can convert between the industry-standard JED format and MAME's proprietary packed binary format and it can show logic equations for the types of devices it knows the internal logic of. Most users will not need to work with this.
-
+PAL/PLA/PLD/GAL dump handling tool. It can convert between the industry-standard JED format and MAME's proprietary packed binary format and it can show logic equations for the types of devices it knows the internal logic of.
 
 ldresample
 ----------
 
-This tool recompresses video data for laserdisc and VHS dumps. Most users will not need to work with this.
+This tool recompresses video data for laserdisc and VHS dumps.
 
 ldverify
 --------
 
-This tool is used for comparing laserdisc or VHS CHD images with the source AVI. Most users will not need to work with this.
-
+This tool is used for comparing laserdisc or VHS CHD images with the source AVI.
 
 romcmp
 ------
 
-This tool is used to perform basic data comparisons and integrity checks on binary dumps. With the -h switch, it can also be used to calculate hash functions. Most users will not need to work with this.
-
+This tool is used to perform basic data comparisons and integrity checks on binary dumps. With the -h switch, it can also be used to calculate hash functions.
 
 unidasm
 -------
 
-Universal disassembler for many of the architectures supported in MAME. Most users will not need to work with this.
+Universal disassembler for many of the architectures supported in MAME.


### PR DESCRIPTION
Header claims "Developer-focused" tools, repeating "Most users will not need to work with this." is an unnecessary hyperbole considering all these tools expect specific domain knowledge already.